### PR TITLE
link: Update build script to include rpath into LC_RPATH

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -209,7 +209,9 @@ func buildAllPkgs(prog llssa.Program, initial []*packages.Package, mode Mode, ve
 				dir, lib := filepath.Split(linkFile)
 				command := " -l " + lib
 				if dir != "" {
-					command += " -L " + dir[:len(dir)-1]
+					dir = dir[:len(dir)-1]
+					command += " -L " + dir
+					command += " -Wl,-rpath," + dir
 				}
 				if isSingleLinkFile(pkg.ExportFile) {
 					pkg.ExportFile = command + " " + pkg.ExportFile


### PR DESCRIPTION
Add library path into `LC_RPATH`, don't need to update global rpath.

```
$ otool -lL callpy 
Load command 16
          cmd LC_RPATH
      cmdsize 56
         path /Users/lijie/miniforge3/envs/py312/lib (offset 12)
...
 datasize 536
        @rpath/libpython3.12.dylib (compatibility version 3.12.0, current version 3.12.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1336.0.0)
```

Before:
```
 ./callpy            
dyld[13582]: Library not loaded: @rpath/libpython3.12.dylib
  Referenced from: <FC4DE790-C3E6-305A-BD65-4FFB8CB042F8> /Users/lijie/source/goplus/llgo/_pydemo/callpy/callpy
  Reason: no LC_RPATH's found
[1]    13582 abort      ./callpy
```

After:
```
./callpy            
sqrt(2) = 1.414214
```