### PR TITLE
build: support pkg-config and link args

### DIFF
--- a/py/python.go
+++ b/py/python.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	LLGoPackage = "link: $LLGO_LIB_PYTHON"
+	LLGoPackage = "link: $LLGO_LIB_PYTHON; $(pkg-config --libs python3-embed)"
 )
 
 // -----------------------------------------------------------------------------

--- a/xtool/clang/check/check.go
+++ b/xtool/clang/check/check.go
@@ -1,0 +1,26 @@
+package check
+
+import (
+	"errors"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+func CheckLinkArgs(args string) error {
+	cmdArgs := strings.Split(args, " ")
+	cmd := exec.Command("clang")
+	nul := "/dev/null"
+	if runtime.GOOS == "windows" {
+		nul = "NUL"
+	}
+	cmd.Args = append(cmd.Args, cmdArgs...)
+	cmd.Args = append(cmd.Args, "-x", "c", "-o", nul, "-")
+	src := "int main() {return 0;}"
+	srcIn := strings.NewReader(src)
+	cmd.Stdin = srcIn
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return errors.New(string(out))
+	}
+	return nil
+}

--- a/xtool/env/env.go
+++ b/xtool/env/env.go
@@ -1,0 +1,32 @@
+package env
+
+import (
+	"os"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+func ExpandEnv(s string) string {
+	return expandEnvWithCmd(s)
+}
+
+func expandEnvWithCmd(s string) string {
+	re := regexp.MustCompile(`\$\(([^)]+)\)`)
+	expanded := re.ReplaceAllStringFunc(s, func(m string) string {
+		cmd := re.FindStringSubmatch(m)[1]
+		var out []byte
+		var err error
+		if runtime.GOOS == "windows" {
+			out, err = exec.Command("cmd", "/C", cmd).Output()
+		} else {
+			out, err = exec.Command("sh", "-c", cmd).Output()
+		}
+		if err != nil {
+			return ""
+		}
+		return strings.TrimSpace(string(out))
+	})
+	return os.Expand(expanded, os.Getenv)
+}


### PR DESCRIPTION
Supports alternatives of external library linking.

```LLGoPackage = "link: $LLGO_LIB_PYTHON; $(pkg-config --libs python3-embed); -lpython3"```
