### PR TITLE
readme:lld-17 download on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
 sudo apt-get update  # execute if needed
 sudo apt-get install libgc-dev
 sudo apt-get install --no-install-recommends llvm-17-dev
+sudo apt-get install lld-17
 go install -v ./...
 ```
 


### PR DESCRIPTION
Fix #336
brew installs LLVM with its own lld
```bash
brew install llvm@17
❯ which ld.lld 
/opt/homebrew/opt/llvm@17/bin/ld.lld
```
However, `apt-get install --no-install-recommends llvm-17-dev` does not carry this lld，additional downloads are required, Otherwise, the #336 problem will occur
