### PR TITLE
link:not exist method warning

### DIFF
--- a/cl/import.go
+++ b/cl/import.go
@@ -270,7 +270,7 @@ func (p *context) initLink(line string, prefix int, f func(inPkgName string) (fu
 			} else {
 				panic(line + ": no specified call convention. eg. //go:linkname Printf C.printf")
 			}
-		} else if c := inPkgName[0]; c >= 'A' && c <= 'Z' {
+		} else {
 			fmt.Fprintln(os.Stderr, "==>", line)
 			fmt.Fprintf(os.Stderr, "llgo: linkname %s not found and ignored\n", inPkgName)
 		}


### PR DESCRIPTION
fix #435 
Removes the check that only throws an error when a function does not exist.

When using the erroneous example from #435, a warning message will be displayed:
```go
// Should be Lua_State, not Lua_Stage

// llgo:link (*Lua_Stage).PushInteger C.lua_pushinteger
func (L *Lua_State) PushInteger(n Integer) {}
```
Running the code will result in the following warning being correctly output:
```bash
❯ llgo run .
==> // llgo:link (*Lua_Stage).PushInteger C.lua_pushinteger
llgo: linkname (*Lua_Stage).PushInteger not found and ignored
```