### PR TITLE
cmd: change "llgo run" to use a temp dir for binaries

### DIFF
--- a/cmd/internal/run/run.go
+++ b/cmd/internal/run/run.go
@@ -19,6 +19,8 @@ package run
 
 import (
 	"errors"
+	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/goplus/llgo/cmd/internal/base"
@@ -57,8 +59,16 @@ func runCmpTest(cmd *base.Command, args []string) {
 func runCmdEx(cmd *base.Command, args []string, mode build.Mode) {
 	args, runArgs, err := parseRunArgs(args)
 	check(err)
+
+	tempBinPath, err := os.MkdirTemp("", "llgo-run-")
+	if err != nil {
+		panic(fmt.Errorf("os.MkdirTemp failed: %v", err))
+	}
+	defer os.RemoveAll(tempBinPath) // NOTE: this will not work if os.Exit is called; remove it manually if needed
+
 	conf := build.NewDefaultConf(mode)
 	conf.RunArgs = runArgs
+	conf.BinPath = tempBinPath
 	build.Do(args, conf)
 }
 

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -401,6 +401,7 @@ func linkMainPkg(pkg *packages.Package, pkgs []*aPackage, llFiles []string, conf
 		cmd.Stderr = os.Stderr
 		cmd.Run()
 		if s := cmd.ProcessState; s != nil {
+			os.RemoveAll(conf.BinPath) // remove temp dir before exit
 			os.Exit(s.ExitCode())
 		}
 	case ModeCmpTest:


### PR DESCRIPTION
Changed "llgo run" to generate binaries in a temp dir instead of GOBIN. The temp dir is automatically removed after execution, mimicking the behavior of "go run".