### PR TITLE
llgo/c/lua:link style

### DIFF
--- a/c/lua/_demo/coroutine/coroutine.go
+++ b/c/lua/_demo/coroutine/coroutine.go
@@ -6,28 +6,28 @@ import (
 )
 
 func coroutineFunc(L *lua.State) {
-	L.LoadString(c.Str(`
+	L.Loadstring(c.Str(`
 	function coro_func()
 	   for i = 1, 5 do
 	       coroutine.yield(i)
 	   end
 	end
 	`))
-	L.PCall(0, 0, 0)
-	L.GetGlobal(c.Str("coro_func"))
+	L.Pcall(0, 0, 0)
+	L.Getglobal(c.Str("coro_func"))
 }
 
 func main() {
-	L := lua.NewState()
+	L := lua.Newstate()
 	defer L.Close()
 
-	L.OpenLibs()
+	L.Openlibs()
 
 	coroutineFunc(L) // Load and get the coroutine function
 
-	co := L.NewThread() // Create a new coroutine/thread
-	L.PushValue(-2)     // Move the function to the top of the stack
-	L.XMove(co, 1)      // Move the function to the new coroutine
+	co := L.Newthread() // Create a new coroutine/thread
+	L.Pushvalue(-2)     // Move the function to the top of the stack
+	L.Xmove(co, 1)      // Move the function to the new coroutine
 
 	var nres c.Int
 	var status c.Int
@@ -38,12 +38,12 @@ func main() {
 		status = co.Resume(nil, 0, &nres)
 		c.Printf(c.Str("Resuming coroutine %d...\n"), status)
 		if status == lua.YIELD {
-			yieldValue := co.ToInteger(-1)
+			yieldValue := co.Tointeger(-1)
 			c.Printf(c.Str("Yield value: %d\n"), yieldValue)
 			co.Pop(1) // Clean up the stack
 
 			// Check if the coroutine is yieldable
-			if co.IsYieldable() != 0 {
+			if co.Isyieldable() != 0 {
 				c.Printf(c.Str("Coroutine is yieldable.\n"))
 			} else {
 				c.Printf(c.Str("Coroutine is not yieldable.\n"))

--- a/c/lua/_demo/error/error.go
+++ b/c/lua/_demo/error/error.go
@@ -8,11 +8,11 @@ import (
 )
 
 func main() {
-	L := lua.NewState()
+	L := lua.Newstate()
 	defer L.Close()
-	L.OpenLibs()
-	if res := L.LoadString(c.Str("function doubleNumber(x) ! return x * 2 end")); res != lua.OK {
-		c.Printf(c.Str("error: %s\n"), L.ToString(-1))
+	L.Openlibs()
+	if res := L.Loadstring(c.Str("function doubleNumber(x) ! return x * 2 end")); res != lua.OK {
+		c.Printf(c.Str("error: %s\n"), L.Tostring(-1))
 	}
 }
 

--- a/c/lua/_demo/funccall-concat/funccall.go
+++ b/c/lua/_demo/funccall-concat/funccall.go
@@ -8,21 +8,21 @@ import (
 )
 
 func main() {
-	L := lua.NewState()
+	L := lua.Newstate()
 	defer L.Close()
 
-	L.OpenLibs()
-	if res := L.DoString(c.Str("function combineParams(num, str) return 'Result: ' .. str .. '  ' .. num end")); res != lua.OK {
-		c.Printf(c.Str("error: %s\n"), L.ToString(-1))
+	L.Openlibs()
+	if res := L.Dostring(c.Str("function combineParams(num, str) return 'Result: ' .. str .. '  ' .. num end")); res != lua.OK {
+		c.Printf(c.Str("error: %s\n"), L.Tostring(-1))
 	}
-	L.GetGlobal(c.Str("combineParams"))
-	L.PushNumber(3.14159)
-	L.PushString(c.Str("Hello, World!"))
-	if res := L.PCall(2, 1, 0); res != lua.OK {
-		c.Printf(c.Str("error: %s\n"), L.ToString(-1))
+	L.Getglobal(c.Str("combineParams"))
+	L.Pushnumber(3.14159)
+	L.Pushstring(c.Str("Hello, World!"))
+	if res := L.Pcall(2, 1, 0); res != lua.OK {
+		c.Printf(c.Str("error: %s\n"), L.Tostring(-1))
 	}
-	if res := L.IsString(-1); res != 0 {
-		result := L.ToString(-1)
+	if res := L.Isstring(-1); res != 0 {
+		result := L.Tostring(-1)
 		c.Printf(result)
 	}
 }

--- a/c/lua/_demo/funccall-number/funccall.go
+++ b/c/lua/_demo/funccall-number/funccall.go
@@ -8,29 +8,29 @@ import (
 )
 
 func main() {
-	L := lua.NewState()
+	L := lua.Newstate()
 	defer L.Close()
 
-	L.OpenLibs()
-	if res := L.LoadString(c.Str("function doubleNumber(x) return x * 2 end")); res != lua.OK {
-		c.Printf(c.Str("error: %s\n"), L.ToString(-1))
+	L.Openlibs()
+	if res := L.Loadstring(c.Str("function doubleNumber(x) return x * 2 end")); res != lua.OK {
+		c.Printf(c.Str("error: %s\n"), L.Tostring(-1))
 	}
-	if res := L.PCall(0, 0, 0); res != lua.OK {
-		c.Printf(c.Str("error: %s\n"), L.ToString(-1))
-	}
-
-	L.GetGlobal(c.Str("doubleNumber"))
-	L.PushNumber(10)
-
-	if res := L.PCall(1, 1, 0); res != lua.OK {
-		c.Printf(c.Str("error: %s\n"), L.ToString(-1))
+	if res := L.Pcall(0, 0, 0); res != lua.OK {
+		c.Printf(c.Str("error: %s\n"), L.Tostring(-1))
 	}
 
-	if res := L.IsNumber(-1); res != 0 {
-		result := L.ToInteger(-1)
+	L.Getglobal(c.Str("doubleNumber"))
+	L.Pushnumber(10)
+
+	if res := L.Pcall(1, 1, 0); res != lua.OK {
+		c.Printf(c.Str("error: %s\n"), L.Tostring(-1))
+	}
+
+	if res := L.Isnumber(-1); res != 0 {
+		result := L.Tointeger(-1)
 		c.Printf(c.Str("result: %lld\n"), result)
 	} else {
-		c.Printf(c.Str("error: %s\n"), L.ToString(-1))
+		c.Printf(c.Str("error: %s\n"), L.Tostring(-1))
 	}
 }
 

--- a/c/lua/_demo/funccall-string/funccall.go
+++ b/c/lua/_demo/funccall-string/funccall.go
@@ -8,10 +8,10 @@ import (
 )
 
 func main() {
-	L := lua.NewState()
+	L := lua.Newstate()
 	defer L.Close()
 
-	L.OpenLibs()
+	L.Openlibs()
 	code := c.Str(
 		`function processStrings(a, b, c)
 	print('Received string a: ' .. a)
@@ -20,22 +20,22 @@ func main() {
 	return a .. b .. c
 end`)
 
-	if res := L.DoString(code); res != lua.OK {
-		c.Printf(c.Str("error: %s\n"), L.ToString(-1))
+	if res := L.Dostring(code); res != lua.OK {
+		c.Printf(c.Str("error: %s\n"), L.Tostring(-1))
 	}
 
-	L.GetGlobal(c.Str("processStrings"))
+	L.Getglobal(c.Str("processStrings"))
 
-	L.PushString(c.Str("Hello, World!"))
-	L.PushLString(c.Str(`Hello Lua In LLGO`), 17)
-	L.PushFString(c.Str(`Hello %s In %d`), c.Str("LLGO"), 2024)
+	L.Pushstring(c.Str("Hello, World!"))
+	L.Pushlstring(c.Str(`Hello Lua In LLGO`), 17)
+	L.Pushfstring(c.Str(`Hello %s In %d`), c.Str("LLGO"), 2024)
 
-	if res := L.PCall(3, 1, 0); res != lua.OK {
-		c.Printf(c.Str("error: %s\n"), L.ToString(-1))
+	if res := L.Pcall(3, 1, 0); res != lua.OK {
+		c.Printf(c.Str("error: %s\n"), L.Tostring(-1))
 	}
 
-	if res := L.IsString(-1); res != 0 {
-		result := L.ToString(-1)
+	if res := L.Isstring(-1); res != 0 {
+		result := L.Tostring(-1)
 		c.Printf(c.Str("result: %s\n"), result)
 	}
 }

--- a/c/lua/_demo/hello/hello.go
+++ b/c/lua/_demo/hello/hello.go
@@ -8,10 +8,14 @@ import (
 )
 
 func main() {
-	L := lua.NewState()
+	L := lua.Newstate()
 	defer L.Close()
-	L.OpenLibs()
-	if res := L.DoString(c.Str("print('hello world')")); res != lua.OK {
+	L.Openlibs()
+	if res := L.Dostring(c.Str("print('hello world')")); res != lua.OK {
 		println("error")
 	}
 }
+
+/* Expected output:
+hello world
+*/

--- a/c/lua/_demo/loadcall/loadcall.go
+++ b/c/lua/_demo/loadcall/loadcall.go
@@ -8,15 +8,19 @@ import (
 )
 
 func main() {
-	L := lua.NewState()
+	L := lua.Newstate()
 	defer L.Close()
 
-	L.OpenLibs()
-	if res := L.LoadString(c.Str("print('hello world')")); res != lua.OK {
+	L.Openlibs()
+	if res := L.Loadstring(c.Str("print('hello world')")); res != lua.OK {
 		println("error")
 	}
-	if res := L.PCall(0, 0, 0); res != lua.OK {
+	if res := L.Pcall(0, 0, 0); res != lua.OK {
 		println("error")
 	}
 
 }
+
+/* Expected output:
+hello world
+*/

--- a/c/lua/_demo/stack/stack.go
+++ b/c/lua/_demo/stack/stack.go
@@ -7,24 +7,24 @@ import (
 
 // printStack prints the current stack of the given Lua state.
 func printStack(L *lua.State, stateName *c.Char) {
-	top := L.GetTop()
+	top := L.Gettop()
 	c.Printf(c.Str("%s stack (top=%d):"), stateName, top)
 	for i := 1; i <= int(top); i++ {
-		c.Printf(c.Str("%s "), L.ToString(c.Int(i)))
+		c.Printf(c.Str("%s "), L.Tostring(c.Int(i)))
 	}
 	c.Printf(c.Str("\n"))
 }
 
 func main() {
 	// Create a new Lua state and open libraries
-	L := lua.NewState()
+	L := lua.Newstate()
 	defer L.Close()
-	L.OpenLibs()
+	L.Openlibs()
 
 	// Push initial values onto the stack
-	L.PushString(c.Str("Hello"))
-	L.PushString(c.Str("LLGO"))
-	L.PushNumber(2024)
+	L.Pushstring(c.Str("Hello"))
+	L.Pushstring(c.Str("LLGO"))
+	L.Pushnumber(2024)
 
 	// Print initial stack
 	c.Printf(c.Str("Initial stack:\n"))
@@ -32,11 +32,11 @@ func main() {
 
 	// Use absindex to ensure the index is positive
 	idx := -2
-	absIdx := L.AbsIndex(c.Int(idx))
+	absIdx := L.Absindex(c.Int(idx))
 	c.Printf(c.Str("Absolute index of 'LLGO': %d\n"), absIdx)
 
 	// Copy 'LLGO' to the top of the stack
-	L.PushValue(absIdx)
+	L.Pushvalue(absIdx)
 	c.Printf(c.Str("\nAfter pushing 'LLGO' to the top:\n"))
 	printStack(L, c.Str("L1"))
 
@@ -51,29 +51,54 @@ func main() {
 	printStack(L, c.Str("L1"))
 
 	// Check if we can grow the stack
-	if L.CheckStack(c.Int(2)) == 0 {
+	if L.Checkstack(c.Int(2)) == 0 {
 		c.Printf(c.Str("Cannot grow stack\n"))
 		return
 	}
 
 	// Push additional elements
-	L.PushNumber(3.14)
-	L.PushString(c.Str("Lua"))
+	L.Pushnumber(3.14)
+	L.Pushstring(c.Str("Lua"))
 	c.Printf(c.Str("\nAfter pushing more elements:\n"))
 	printStack(L, c.Str("L1"))
 
 	// Set the top of the stack, clearing extra elements
-	L.SetTop(c.Int(5))
+	L.Settop(c.Int(5))
 	c.Printf(c.Str("\nAfter setting top to 5:\n"))
 	printStack(L, c.Str("L1"))
 
 	// Create a second Lua state
-	L1 := lua.NewState()
+	L1 := lua.Newstate()
 	defer L1.Close()
 
 	// Move two elements to the new state
-	L.XMove(L1, c.Int(2))
+	L.Xmove(L1, c.Int(2))
 	c.Printf(c.Str("\nAfter moving two elements to L1:\n"))
 	printStack(L, c.Str("L1"))
 	printStack(L1, c.Str("L2"))
 }
+
+/* Expected output:
+Initial stack:
+L1 stack (top=3):Hello LLGO 2024.0
+Absolute index of 'LLGO': 2
+
+After pushing 'LLGO' to the top:
+L1 stack (top=4):Hello LLGO 2024.0 LLGO
+
+After rotating the stack:
+L1 stack (top=4):LLGO 2024.0 LLGO Hello
+
+After copying the top element to index 2:
+L1 stack (top=4):LLGO Hello LLGO Hello
+
+After pushing more elements:
+L1 stack (top=6):LLGO Hello LLGO Hello 3.14 Lua
+
+After setting top to 5:
+L1 stack (top=5):LLGO Hello LLGO Hello 3.14
+
+After moving two elements to L1:
+L1 stack (top=3):LLGO Hello LLGO
+L2 stack (top=2):Hello 3.14
+*/

--- a/c/lua/_demo/table/table.go
+++ b/c/lua/_demo/table/table.go
@@ -6,10 +6,10 @@ import (
 )
 
 func printTable(L *lua.State) {
-	L.PushNil()
+	L.Pushnil()
 	for L.Next(-2) != 0 {
-		key := L.ToString(-2)
-		value := L.ToString(-1)
+		key := L.Tostring(-2)
+		value := L.Tostring(-1)
 		c.Printf(c.Str("%s - %s\n"), key, value)
 		L.Pop(1)
 	}
@@ -17,31 +17,31 @@ func printTable(L *lua.State) {
 }
 
 func main() {
-	L := lua.NewState()
+	L := lua.Newstate()
 	defer L.Close()
 
-	L.OpenLibs()
+	L.Openlibs()
 
-	L.NewTable()
+	L.Newtable()
 
-	L.PushString(c.Str("name"))
-	L.PushString(c.Str("John"))
-	L.SetTable(-3)
+	L.Pushstring(c.Str("name"))
+	L.Pushstring(c.Str("John"))
+	L.Settable(-3)
 
-	L.PushString(c.Str("age"))
-	L.PushNumber(30)
-	L.SetTable(-3)
+	L.Pushstring(c.Str("age"))
+	L.Pushnumber(30)
+	L.Settable(-3)
 
-	L.PushString(c.Str("John Doe"))
-	L.SetField(-2, c.Str("fullname"))
+	L.Pushstring(c.Str("John Doe"))
+	L.Setfield(-2, c.Str("fullname"))
 
-	L.GetField(-1, c.Str("name"))
-	c.Printf(c.Str("%s\n"), L.ToString(-1))
+	L.Getfield(-1, c.Str("name"))
+	c.Printf(c.Str("%s\n"), L.Tostring(-1))
 	L.Pop(1)
 
-	L.PushString(c.Str("age"))
-	L.GetTable(-2)
-	age := int(L.ToNumber(-1))
+	L.Pushstring(c.Str("age"))
+	L.Gettable(-2)
+	age := int(L.Tonumber(-1))
 	c.Printf(c.Str("Age: %d\n"), age)
 	L.Pop(1)
 
@@ -49,3 +49,12 @@ func main() {
 	printTable(L)
 
 }
+
+/* Expected output:
+John
+Age: 30
+All entries in the table:
+age - 30.0
+fullname - John Doe
+name - John
+*/

--- a/c/lua/lauxlib.go
+++ b/c/lua/lauxlib.go
@@ -16,16 +16,16 @@ import (
 
 // /* predefined references */
 
-// llgo:link (*State).LoadFilex C.luaL_loadfilex
-func (L *State) LoadFilex(filename *c.Char, mode *c.Char) c.Int { return 0 }
+// llgo:link (*State).Loadfilex C.luaL_loadfilex
+func (L *State) Loadfilex(filename *c.Char, mode *c.Char) c.Int { return 0 }
 
-func (L *State) LoadFile(filename *c.Char) c.Int { return L.LoadFilex(filename, nil) }
+func (L *State) Loadfile(filename *c.Char) c.Int { return L.Loadfilex(filename, nil) }
 
-// llgo:link (*State).LoadString C.luaL_loadstring
-func (L *State) LoadString(s *c.Char) c.Int { return 0 }
+// llgo:link (*State).Loadstring C.luaL_loadstring
+func (L *State) Loadstring(s *c.Char) c.Int { return 0 }
 
-//go:linkname NewState C.luaL_newstate
-func NewState() *State
+//go:linkname Newstate C.luaL_newstate
+func Newstate() *State
 
 // /*
 // ** ===============================================================
@@ -33,18 +33,18 @@ func NewState() *State
 // ** ===============================================================
 // */
 
-func (L *State) DoFile(filename *c.Char) c.Int {
-	if loadResult := L.LoadFile(filename); loadResult != 0 {
+func (L *State) Dofile(filename *c.Char) c.Int {
+	if loadResult := L.Loadfile(filename); loadResult != 0 {
 		return loadResult
 	}
-	return L.PCall(c.Int(0), c.Int(MULTRET), c.Int(0))
+	return L.Pcall(c.Int(0), c.Int(MULTRET), c.Int(0))
 }
 
-func (L *State) DoString(str *c.Char) c.Int {
-	if loadResult := L.LoadString(str); loadResult != 0 {
+func (L *State) Dostring(str *c.Char) c.Int {
+	if loadResult := L.Loadstring(str); loadResult != 0 {
 		return loadResult
 	}
-	return L.PCall(c.Int(0), c.Int(MULTRET), c.Int(0))
+	return L.Pcall(c.Int(0), c.Int(MULTRET), c.Int(0))
 }
 
 // /*

--- a/c/lua/lua.go
+++ b/c/lua/lua.go
@@ -146,8 +146,8 @@ func (L *State) Close() {}
 // State *(lua_newstate) (lua_Alloc f, void *ud);
 // State *(lua_newthread) (State *L);
 
-// llgo:link (*State).NewThread C.lua_newthread
-func (L *State) NewThread() *State { return nil }
+// llgo:link (*State).Newthread C.lua_newthread
+func (L *State) Newthread() *State { return nil }
 
 // int        (lua_closethread) (State *L, State *from);
 // int        (lua_resetthread) (State *L);  /* Deprecated! */
@@ -158,17 +158,17 @@ func (L *State) NewThread() *State { return nil }
 // ** basic stack manipulation
 // */
 
-// llgo:link (*State).AbsIndex C.lua_absindex
-func (L *State) AbsIndex(idx c.Int) c.Int { return 0 }
+// llgo:link (*State).Absindex C.lua_absindex
+func (L *State) Absindex(idx c.Int) c.Int { return 0 }
 
-// llgo:link (*State).GetTop C.lua_gettop
-func (L *State) GetTop() c.Int { return 0 }
+// llgo:link (*State).Gettop C.lua_gettop
+func (L *State) Gettop() c.Int { return 0 }
 
-// llgo:link (*State).SetTop C.lua_settop
-func (L *State) SetTop(idx c.Int) {}
+// llgo:link (*State).Settop C.lua_settop
+func (L *State) Settop(idx c.Int) {}
 
-// llgo:link (*State).PushValue C.lua_pushvalue
-func (L *State) PushValue(idx c.Int) {}
+// llgo:link (*State).Pushvalue C.lua_pushvalue
+func (L *State) Pushvalue(idx c.Int) {}
 
 // llgo:link (*State).Rotate C.lua_rotate
 func (L *State) Rotate(idx c.Int, n c.Int) {}
@@ -176,44 +176,44 @@ func (L *State) Rotate(idx c.Int, n c.Int) {}
 // llgo:link (*State).Copy C.lua_copy
 func (L *State) Copy(fromidx c.Int, toidx c.Int) {}
 
-// llgo:link (*State).CheckStack C.lua_checkstack
-func (L *State) CheckStack(n c.Int) c.Int { return 0 }
+// llgo:link (*State).Checkstack C.lua_checkstack
+func (L *State) Checkstack(n c.Int) c.Int { return 0 }
 
-// llgo:link (*State).XMove C.lua_xmove
-func (L *State) XMove(to *State, n c.Int) {}
+// llgo:link (*State).Xmove C.lua_xmove
+func (L *State) Xmove(to *State, n c.Int) {}
 
 // /*
 // ** access functions (stack -> C)
 // */
 // LUA_API int             (lua_isinteger) (State *L, int idx);
-// llgo:link (*State).IsInteger C.lua_isinteger
-func (L *State) IsInteger(idx c.Int) c.Int { return 0 }
+// llgo:link (*State).Isinteger C.lua_isinteger
+func (L *State) Isinteger(idx c.Int) c.Int { return 0 }
 
-// llgo:link (*State).IsNumber C.lua_isnumber
-func (L *State) IsNumber(idx c.Int) c.Int { return 0 }
+// llgo:link (*State).Isnumber C.lua_isnumber
+func (L *State) Isnumber(idx c.Int) c.Int { return 0 }
 
-// llgo:link (*State).IsString C.lua_isstring
-func (L *State) IsString(idx c.Int) c.Int { return 0 }
+// llgo:link (*State).Isstring C.lua_isstring
+func (L *State) Isstring(idx c.Int) c.Int { return 0 }
 
 // TODO(zzy):add to demo
 // llgo:link (*State).Type C.lua_type
 func (L *State) Type(idx c.Int) c.Int { return 0 }
 
 // TODO(zzy)
-// llgo:link (*State).TypeName C.lua_typename
-func (L *State) TypeName(tp c.Int) *c.Char { return nil }
+// llgo:link (*State).Typename C.lua_typename
+func (L *State) Typename(tp c.Int) *c.Char { return nil }
 
-// llgo:link (*State).ToNumberx C.lua_tonumberx
-func (L *State) ToNumberx(idx c.Int, isnum *c.Int) Number { return 0 }
+// llgo:link (*State).Tonumberx C.lua_tonumberx
+func (L *State) Tonumberx(idx c.Int, isnum *c.Int) Number { return 0 }
 
-// llgo:link (*State).ToIntegerx C.lua_tointegerx
-func (L *State) ToIntegerx(idx c.Int, isnum *c.Int) Integer { return 0 }
+// llgo:link (*State).Tointegerx C.lua_tointegerx
+func (L *State) Tointegerx(idx c.Int, isnum *c.Int) Integer { return 0 }
 
-// llgo:link (*State).ToBoolean C.lua_toboolean
-func (L *State) ToBoolean(idx c.Int) bool { return false }
+// llgo:link (*State).Toboolean C.lua_toboolean
+func (L *State) Toboolean(idx c.Int) bool { return false }
 
-// llgo:link (*State).ToLString C.lua_tolstring
-func (L *State) ToLString(idx c.Int, len *c.Ulong) *c.Char { return nil }
+// llgo:link (*State).Tolstring C.lua_tolstring
+func (L *State) Tolstring(idx c.Int, len *c.Ulong) *c.Char { return nil }
 
 // LUA_API int             (lua_iscfunction) (State *L, int idx);
 // LUA_API int             (lua_isuserdata) (State *L, int idx);
@@ -231,30 +231,30 @@ func (L *State) ToLString(idx c.Int, len *c.Ulong) *c.Char { return nil }
 // /*
 // ** push functions (C -> stack)
 // */
-// llgo:link (*State).PushNil C.lua_pushnil
-func (L *State) PushNil() {}
+// llgo:link (*State).Pushnil C.lua_pushnil
+func (L *State) Pushnil() {}
 
-// llgo:link (*State).PushNumber C.lua_pushnumber
-func (L *State) PushNumber(n Number) {}
+// llgo:link (*State).Pushnumber C.lua_pushnumber
+func (L *State) Pushnumber(n Number) {}
 
-// llgo:link (*State).PushInteger C.lua_pushinteger
-func (L *State) PushInteger(n Integer) {}
+// llgo:link (*State).Pushinteger C.lua_pushinteger
+func (L *State) Pushinteger(n Integer) {}
 
-// llgo:link (*State).PushString C.lua_pushstring
-func (L *State) PushString(s *c.Char) *c.Char {
+// llgo:link (*State).Pushstring C.lua_pushstring
+func (L *State) Pushstring(s *c.Char) *c.Char {
 	return nil
 }
 
-// llgo:link (*State).PushLString C.lua_pushlstring
-func (L *State) PushLString(s *c.Char, len c.Ulong) *c.Char {
+// llgo:link (*State).Pushlstring C.lua_pushlstring
+func (L *State) Pushlstring(s *c.Char, len c.Ulong) *c.Char {
 	return nil
 }
 
-// llgo:link (*State).PushFString C.lua_pushfstring
-func (L *State) PushFString(format *c.Char, __llgo_va_list ...any) *c.Char { return nil }
+// llgo:link (*State).Pushfstring C.lua_pushfstring
+func (L *State) Pushfstring(format *c.Char, __llgo_va_list ...any) *c.Char { return nil }
 
-// llgo:link (*State).PushBoolean C.lua_pushboolean
-func (L *State) PushBoolean(b c.Int) {}
+// llgo:link (*State).Pushboolean C.lua_pushboolean
+func (L *State) Pushboolean(b c.Int) {}
 
 //const char *(lua_pushvfstring) (State *L, const char *fmt,va_list argp);
 //void  (lua_pushcclosure) (State *L, lua_CFunction fn, int n);
@@ -265,17 +265,17 @@ func (L *State) PushBoolean(b c.Int) {}
 // ** get functions (Lua -> stack)
 // */
 
-// llgo:link (*State).GetGlobal C.lua_getglobal
-func (L *State) GetGlobal(name *c.Char) c.Int { return 0 }
+// llgo:link (*State).Getglobal C.lua_getglobal
+func (L *State) Getglobal(name *c.Char) c.Int { return 0 }
 
-// llgo:link (*State).GetTable C.lua_gettable
-func (L *State) GetTable(idx c.Int) c.Int { return 0 }
+// llgo:link (*State).Gettable C.lua_gettable
+func (L *State) Gettable(idx c.Int) c.Int { return 0 }
 
-// llgo:link (*State).GetField C.lua_getfield
-func (L *State) GetField(idx c.Int, k *c.Char) c.Int { return 0 }
+// llgo:link (*State).Getfield C.lua_getfield
+func (L *State) Getfield(idx c.Int, k *c.Char) c.Int { return 0 }
 
-// llgo:link (*State).CreateTable C.lua_createtable
-func (L *State) CreateTable(narr c.Int, nrec c.Int) {}
+// llgo:link (*State).Createtable C.lua_createtable
+func (L *State) Createtable(narr c.Int, nrec c.Int) {}
 
 // LUA_API int (lua_geti) (State *L, int idx, lua_Integer n);
 // LUA_API int (lua_rawget) (State *L, int idx);
@@ -291,14 +291,14 @@ func (L *State) CreateTable(narr c.Int, nrec c.Int) {}
 // */
 
 // TODO(zzy):add to demo
-// llgo:link (*State).SetGlobal C.lua_setglobal
-func (L *State) SetGlobal(name *c.Char) {}
+// llgo:link (*State).Setglobal C.lua_setglobal
+func (L *State) Setglobal(name *c.Char) {}
 
-// llgo:link (*State).SetTable C.lua_settable
-func (L *State) SetTable(idx c.Int) {}
+// llgo:link (*State).Settable C.lua_settable
+func (L *State) Settable(idx c.Int) {}
 
-// llgo:link (*State).SetField C.lua_setfield
-func (L *State) SetField(idx c.Int, k *c.Char) {}
+// llgo:link (*State).Setfield C.lua_setfield
+func (L *State) Setfield(idx c.Int, k *c.Char) {}
 
 //void  (lua_seti) (State *L, int idx, lua_Integer n);
 //void  (lua_rawset) (State *L, int idx);
@@ -311,13 +311,13 @@ func (L *State) SetField(idx c.Int, k *c.Char) {}
 // ** 'load' and 'call' functions (load and run Lua code)
 // */
 
-// llgo:link (*State).PCallk C.lua_pcallk
-func (L *State) PCallk(nargs c.Int, nresults c.Int, errfunc c.Int, ctx KContext, k *KFunction) c.Int {
+// llgo:link (*State).Pcallk C.lua_pcallk
+func (L *State) Pcallk(nargs c.Int, nresults c.Int, errfunc c.Int, ctx KContext, k *KFunction) c.Int {
 	return 0
 }
 
-func (L *State) PCall(nargs c.Int, nresults c.Int, errfunc c.Int) c.Int {
-	return L.PCallk(nargs, nresults, errfunc, KContext(c.Int(0)), nil)
+func (L *State) Pcall(nargs c.Int, nresults c.Int, errfunc c.Int) c.Int {
+	return L.Pcallk(nargs, nresults, errfunc, KContext(c.Int(0)), nil)
 }
 
 // void  (lua_callk) (State *L, int nargs, int nresults, lua_KContext ctx, lua_KFunction k);
@@ -337,8 +337,8 @@ func (L *State) Resume(from *State, narg c.Int, nres *c.Int) c.Int { return 0 }
 // llgo:link (*State).Status C.lua_status
 func (L *State) Status() c.Int { return 0 }
 
-// llgo:link (*State).IsYieldable C.lua_isyieldable
-func (L *State) IsYieldable() c.Int { return 0 }
+// llgo:link (*State).Isyieldable C.lua_isyieldable
+func (L *State) Isyieldable() c.Int { return 0 }
 
 // TODO(zzy)
 // int  (lua_yieldk)     (State *L, int nresults, lua_KContext ctx, lua_KFunction k);
@@ -396,19 +396,19 @@ func (L *State) Next(idx c.Int) c.Int { return 0 }
 // ** ===============================================================
 // */
 
-func (L *State) ToNumber(idx c.Int) Number    { return L.ToNumberx(idx, nil) }
-func (L *State) ToString(idx c.Int) *c.Char   { return L.ToLString(idx, nil) }
-func (L *State) ToInteger(idx c.Int) Integer  { return L.ToIntegerx(idx, nil) }
-func (L *State) Pop(n c.Int)                  { L.SetTop(-(n) - 1) }
-func (L *State) NewTable()                    { L.CreateTable(0, 0) }
-func (L *State) IsFunction(n c.Int) bool      { return L.Type(n) == c.Int(FUNCTION) }
-func (L *State) IsTable(n c.Int) bool         { return L.Type(n) == c.Int(TABLE) }
-func (L *State) IsLightUserData(n c.Int) bool { return L.Type(n) == c.Int(LIGHTUSERDATA) }
-func (L *State) IsNil(n c.Int) bool           { return L.Type(n) == c.Int(NIL) }
-func (L *State) IsBoolean(n c.Int) bool       { return L.Type(n) == c.Int(BOOLEAN) }
-func (L *State) IsThread(n c.Int) bool        { return L.Type(n) == c.Int(THREAD) }
-func (L *State) IsNone(n c.Int) bool          { return L.Type(n) == c.Int(NONE) }
-func (L *State) IsNoneOrNil(n c.Int) bool     { return L.Type(n) <= 0 }
+func (L *State) Tonumber(idx c.Int) Number    { return L.Tonumberx(idx, nil) }
+func (L *State) Tostring(idx c.Int) *c.Char   { return L.Tolstring(idx, nil) }
+func (L *State) Tointeger(idx c.Int) Integer  { return L.Tointegerx(idx, nil) }
+func (L *State) Pop(n c.Int)                  { L.Settop(-(n) - 1) }
+func (L *State) Newtable()                    { L.Createtable(0, 0) }
+func (L *State) Isfunction(n c.Int) bool      { return L.Type(n) == c.Int(FUNCTION) }
+func (L *State) Istable(n c.Int) bool         { return L.Type(n) == c.Int(TABLE) }
+func (L *State) Islightuserdata(n c.Int) bool { return L.Type(n) == c.Int(LIGHTUSERDATA) }
+func (L *State) Isnil(n c.Int) bool           { return L.Type(n) == c.Int(NIL) }
+func (L *State) Isboolean(n c.Int) bool       { return L.Type(n) == c.Int(BOOLEAN) }
+func (L *State) Isthread(n c.Int) bool        { return L.Type(n) == c.Int(THREAD) }
+func (L *State) Isnone(n c.Int) bool          { return L.Type(n) == c.Int(NONE) }
+func (L *State) Isnoneornil(n c.Int) bool     { return L.Type(n) <= 0 }
 
 // #define lua_getextraspace(L)	((void *)((char *)(L) - LUA_EXTRASPACE))
 

--- a/c/lua/lualib.go
+++ b/c/lua/lualib.go
@@ -4,5 +4,5 @@ import (
 	_ "unsafe"
 )
 
-// llgo:link (*State).OpenLibs C.luaL_openlibs
-func (L *State) OpenLibs() {}
+// llgo:link (*State).Openlibs C.luaL_openlibs
+func (L *State) Openlibs() {}


### PR DESCRIPTION
For macros, they are also considered to be generated by automated tools, and the naming convention is consistent with that of general functions.
```c
#define lua_tonumber(L,i)	lua_tonumberx(L,(i),NULL)
#define lua_tointeger(L,i)	lua_tointegerx(L,(i),NULL)
#define lua_pop(L,n)		lua_settop(L, -(n)-1)
```