### PR TITLE
build(macOS): change full library paths to @rpath

### DIFF
--- a/xtool/llvm/install_name_tool/rpath.go
+++ b/xtool/llvm/install_name_tool/rpath.go
@@ -54,7 +54,7 @@ type Change struct {
 
 // Change changes dependent shared library install name.
 func (p *Cmd) Change(target string, chgs ...Change) error {
-	args := make([]string, len(chgs)*3+1)
+	args := make([]string, 0, len(chgs)*3+1)
 	for _, chg := range chgs {
 		args = append(args, "-change", chg.Old, chg.New)
 	}
@@ -64,7 +64,7 @@ func (p *Cmd) Change(target string, chgs ...Change) error {
 
 // ChangeToRpath changes dependent shared library install name to @rpath.
 func (p *Cmd) ChangeToRpath(target string, dylibDeps ...string) error {
-	args := make([]string, len(dylibDeps)*3+1)
+	args := make([]string, 0, len(dylibDeps)*3+1)
 	for _, dep := range dylibDeps {
 		args = append(args, "-change", dep, "@rpath/"+filepath.Base(dep))
 	}


### PR DESCRIPTION
```sh
$ otool -L hello
hello:
        @rpath/libgc.1.dylib (compatibility version 7.0.0, current version 7.3.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1345.100.2)
$ otool -l hello | grep LC_RPATH -A2
          cmd LC_RPATH
      cmdsize 32
         path @loader_path (offset 12)
--
          cmd LC_RPATH
      cmdsize 32
         path @loader_path/../lib (offset 12)
--
          cmd LC_RPATH
      cmdsize 56
         path /opt/homebrew/Cellar/bdw-gc/8.2.6/lib (offset 12)
--
          cmd LC_RPATH
      cmdsize 48
         path /opt/homebrew/opt/bdw-gc/lib (offset 12)
```