### PR TITLE
build: fix unsafe.Sizeof for llgo:type C

### DIFF
--- a/cl/_testrt/qsortfn/out.ll
+++ b/cl/_testrt/qsortfn/out.ll
@@ -263,31 +263,25 @@ _llgo_0:
   store i64 23, ptr %4, align 4
   store i64 2, ptr %5, align 4
   store i64 7, ptr %6, align 4
-  %7 = alloca { ptr, ptr }, align 8
-  %8 = getelementptr inbounds { ptr, ptr }, ptr %7, i32 0, i32 0
-  store ptr @"__llgo_stub.main.sort3a$1", ptr %8, align 8
-  %9 = getelementptr inbounds { ptr, ptr }, ptr %7, i32 0, i32 1
-  store ptr null, ptr %9, align 8
-  %10 = load { ptr, ptr }, ptr %7, align 8
-  %11 = getelementptr inbounds i64, ptr %1, i64 0
-  call void @qsort(ptr %11, i64 5, i64 8, { ptr, ptr } %10)
-  %12 = load [5 x i64], ptr %1, align 4
+  %7 = getelementptr inbounds i64, ptr %1, i64 0
+  call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort3a$1")
+  %8 = load [5 x i64], ptr %1, align 4
   br label %_llgo_1
 
 _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-  %13 = phi i64 [ -1, %_llgo_0 ], [ %14, %_llgo_2 ]
-  %14 = add i64 %13, 1
-  %15 = icmp slt i64 %14, 5
-  br i1 %15, label %_llgo_2, label %_llgo_3
+  %9 = phi i64 [ -1, %_llgo_0 ], [ %10, %_llgo_2 ]
+  %10 = add i64 %9, 1
+  %11 = icmp slt i64 %10, 5
+  br i1 %11, label %_llgo_2, label %_llgo_3
 
 _llgo_2:                                          ; preds = %_llgo_1
-  %16 = icmp slt i64 %14, 0
-  %17 = icmp sge i64 %14, 5
-  %18 = or i1 %17, %16
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %18)
-  %19 = getelementptr inbounds i64, ptr %1, i64 %14
-  %20 = load i64, ptr %19, align 4
-  %21 = call i32 (ptr, ...) @printf(ptr @9, i64 %20)
+  %12 = icmp slt i64 %10, 0
+  %13 = icmp sge i64 %10, 5
+  %14 = or i1 %13, %12
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %14)
+  %15 = getelementptr inbounds i64, ptr %1, i64 %10
+  %16 = load i64, ptr %15, align 4
+  %17 = call i32 (ptr, ...) @printf(ptr @9, i64 %16)
   br label %_llgo_1
 
 _llgo_3:                                          ; preds = %_llgo_1
@@ -318,30 +312,24 @@ _llgo_0:
   store i64 2, ptr %5, align 4
   store i64 7, ptr %6, align 4
   %7 = getelementptr inbounds i64, ptr %1, i64 0
-  %8 = alloca { ptr, ptr }, align 8
-  %9 = getelementptr inbounds { ptr, ptr }, ptr %8, i32 0, i32 0
-  store ptr @"__llgo_stub.main.sort3b$1", ptr %9, align 8
-  %10 = getelementptr inbounds { ptr, ptr }, ptr %8, i32 0, i32 1
-  store ptr null, ptr %10, align 8
-  %11 = load { ptr, ptr }, ptr %8, align 8
-  call void @qsort(ptr %7, i64 5, i64 8, { ptr, ptr } %11)
-  %12 = load [5 x i64], ptr %1, align 4
+  call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort3b$1")
+  %8 = load [5 x i64], ptr %1, align 4
   br label %_llgo_1
 
 _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-  %13 = phi i64 [ -1, %_llgo_0 ], [ %14, %_llgo_2 ]
-  %14 = add i64 %13, 1
-  %15 = icmp slt i64 %14, 5
-  br i1 %15, label %_llgo_2, label %_llgo_3
+  %9 = phi i64 [ -1, %_llgo_0 ], [ %10, %_llgo_2 ]
+  %10 = add i64 %9, 1
+  %11 = icmp slt i64 %10, 5
+  br i1 %11, label %_llgo_2, label %_llgo_3
 
 _llgo_2:                                          ; preds = %_llgo_1
-  %16 = icmp slt i64 %14, 0
-  %17 = icmp sge i64 %14, 5
-  %18 = or i1 %17, %16
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %18)
-  %19 = getelementptr inbounds i64, ptr %1, i64 %14
-  %20 = load i64, ptr %19, align 4
-  %21 = call i32 (ptr, ...) @printf(ptr @11, i64 %20)
+  %12 = icmp slt i64 %10, 0
+  %13 = icmp sge i64 %10, 5
+  %14 = or i1 %13, %12
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %14)
+  %15 = getelementptr inbounds i64, ptr %1, i64 %10
+  %16 = load i64, ptr %15, align 4
+  %17 = call i32 (ptr, ...) @printf(ptr @11, i64 %16)
   br label %_llgo_1
 
 _llgo_3:                                          ; preds = %_llgo_1
@@ -371,31 +359,25 @@ _llgo_0:
   store i64 23, ptr %4, align 4
   store i64 2, ptr %5, align 4
   store i64 7, ptr %6, align 4
-  %7 = alloca { ptr, ptr }, align 8
-  %8 = getelementptr inbounds { ptr, ptr }, ptr %7, i32 0, i32 0
-  store ptr @"__llgo_stub.main.sort4a$1", ptr %8, align 8
-  %9 = getelementptr inbounds { ptr, ptr }, ptr %7, i32 0, i32 1
-  store ptr null, ptr %9, align 8
-  %10 = load { ptr, ptr }, ptr %7, align 8
-  %11 = getelementptr inbounds i64, ptr %1, i64 0
-  call void @qsort(ptr %11, i64 5, i64 8, { ptr, ptr } %10)
-  %12 = load [5 x i64], ptr %1, align 4
+  %7 = getelementptr inbounds i64, ptr %1, i64 0
+  call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort4a$1")
+  %8 = load [5 x i64], ptr %1, align 4
   br label %_llgo_1
 
 _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-  %13 = phi i64 [ -1, %_llgo_0 ], [ %14, %_llgo_2 ]
-  %14 = add i64 %13, 1
-  %15 = icmp slt i64 %14, 5
-  br i1 %15, label %_llgo_2, label %_llgo_3
+  %9 = phi i64 [ -1, %_llgo_0 ], [ %10, %_llgo_2 ]
+  %10 = add i64 %9, 1
+  %11 = icmp slt i64 %10, 5
+  br i1 %11, label %_llgo_2, label %_llgo_3
 
 _llgo_2:                                          ; preds = %_llgo_1
-  %16 = icmp slt i64 %14, 0
-  %17 = icmp sge i64 %14, 5
-  %18 = or i1 %17, %16
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %18)
-  %19 = getelementptr inbounds i64, ptr %1, i64 %14
-  %20 = load i64, ptr %19, align 4
-  %21 = call i32 (ptr, ...) @printf(ptr @13, i64 %20)
+  %12 = icmp slt i64 %10, 0
+  %13 = icmp sge i64 %10, 5
+  %14 = or i1 %13, %12
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %14)
+  %15 = getelementptr inbounds i64, ptr %1, i64 %10
+  %16 = load i64, ptr %15, align 4
+  %17 = call i32 (ptr, ...) @printf(ptr @13, i64 %16)
   br label %_llgo_1
 
 _llgo_3:                                          ; preds = %_llgo_1
@@ -473,31 +455,25 @@ _llgo_0:
   store i64 23, ptr %4, align 4
   store i64 2, ptr %5, align 4
   store i64 7, ptr %6, align 4
-  %7 = alloca { ptr, ptr }, align 8
-  %8 = getelementptr inbounds { ptr, ptr }, ptr %7, i32 0, i32 0
-  store ptr @"__llgo_stub.main.sort5a$1", ptr %8, align 8
-  %9 = getelementptr inbounds { ptr, ptr }, ptr %7, i32 0, i32 1
-  store ptr null, ptr %9, align 8
-  %10 = load { ptr, ptr }, ptr %7, align 8
-  %11 = getelementptr inbounds i64, ptr %1, i64 0
-  call void @qsort(ptr %11, i64 5, i64 8, { ptr, ptr } %10)
-  %12 = load [5 x i64], ptr %1, align 4
+  %7 = getelementptr inbounds i64, ptr %1, i64 0
+  call void @qsort(ptr %7, i64 5, i64 8, ptr @"main.sort5a$1")
+  %8 = load [5 x i64], ptr %1, align 4
   br label %_llgo_1
 
 _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-  %13 = phi i64 [ -1, %_llgo_0 ], [ %14, %_llgo_2 ]
-  %14 = add i64 %13, 1
-  %15 = icmp slt i64 %14, 5
-  br i1 %15, label %_llgo_2, label %_llgo_3
+  %9 = phi i64 [ -1, %_llgo_0 ], [ %10, %_llgo_2 ]
+  %10 = add i64 %9, 1
+  %11 = icmp slt i64 %10, 5
+  br i1 %11, label %_llgo_2, label %_llgo_3
 
 _llgo_2:                                          ; preds = %_llgo_1
-  %16 = icmp slt i64 %14, 0
-  %17 = icmp sge i64 %14, 5
-  %18 = or i1 %17, %16
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %18)
-  %19 = getelementptr inbounds i64, ptr %1, i64 %14
-  %20 = load i64, ptr %19, align 4
-  %21 = call i32 (ptr, ...) @printf(ptr @17, i64 %20)
+  %12 = icmp slt i64 %10, 0
+  %13 = icmp sge i64 %10, 5
+  %14 = or i1 %13, %12
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %14)
+  %15 = getelementptr inbounds i64, ptr %1, i64 %10
+  %16 = load i64, ptr %15, align 4
+  %17 = call i32 (ptr, ...) @printf(ptr @17, i64 %16)
   br label %_llgo_1
 
 _llgo_3:                                          ; preds = %_llgo_1
@@ -570,27 +546,3 @@ declare ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64)
 declare void @qsort(ptr, i64, i64, ptr)
 
 declare void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1)
-
-define linkonce i32 @"__llgo_stub.main.sort3a$1"(ptr %0, ptr %1, ptr %2) {
-_llgo_0:
-  %3 = tail call i32 @"main.sort3a$1"(ptr %1, ptr %2)
-  ret i32 %3
-}
-
-define linkonce i32 @"__llgo_stub.main.sort3b$1"(ptr %0, ptr %1, ptr %2) {
-_llgo_0:
-  %3 = tail call i32 @"main.sort3b$1"(ptr %1, ptr %2)
-  ret i32 %3
-}
-
-define linkonce i32 @"__llgo_stub.main.sort4a$1"(ptr %0, ptr %1, ptr %2) {
-_llgo_0:
-  %3 = tail call i32 @"main.sort4a$1"(ptr %1, ptr %2)
-  ret i32 %3
-}
-
-define linkonce i32 @"__llgo_stub.main.sort5a$1"(ptr %0, ptr %1, ptr %2) {
-_llgo_0:
-  %3 = tail call i32 @"main.sort5a$1"(ptr %1, ptr %2)
-  ret i32 %3
-}

--- a/cl/_testrt/unsafe/in.go
+++ b/cl/_testrt/unsafe/in.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"unsafe"
+)
+
+//llgo:type C
+type T func()
+
+type M struct {
+	v  int
+	fn T
+}
+
+type N struct {
+	v  int
+	fn func()
+}
+
+func main() {
+	if unsafe.Sizeof(*(*T)(nil)) != unsafe.Sizeof(0) {
+		panic("error")
+	}
+	if unsafe.Sizeof(*(*M)(nil)) != unsafe.Sizeof([2]int{}) {
+		panic("error")
+	}
+	if unsafe.Sizeof(*(*N)(nil)) != unsafe.Sizeof([3]int{}) {
+		panic("error")
+	}
+}

--- a/cl/_testrt/unsafe/out.ll
+++ b/cl/_testrt/unsafe/out.ll
@@ -1,0 +1,123 @@
+; ModuleID = 'main'
+source_filename = "main"
+
+%"github.com/goplus/llgo/internal/runtime.String" = type { ptr, i64 }
+%"github.com/goplus/llgo/internal/runtime.eface" = type { ptr, ptr }
+
+@"main.init$guard" = global i1 false, align 1
+@__llgo_argc = global i32 0, align 4
+@__llgo_argv = global ptr null, align 8
+@0 = private unnamed_addr constant [5 x i8] c"error", align 1
+@_llgo_string = linkonce global ptr null, align 8
+
+define void @main.init() {
+_llgo_0:
+  %0 = load i1, ptr @"main.init$guard", align 1
+  br i1 %0, label %_llgo_2, label %_llgo_1
+
+_llgo_1:                                          ; preds = %_llgo_0
+  store i1 true, ptr @"main.init$guard", align 1
+  call void @"main.init$after"()
+  br label %_llgo_2
+
+_llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+  ret void
+}
+
+define i32 @main(i32 %0, ptr %1) {
+_llgo_0:
+  store i32 %0, ptr @__llgo_argc, align 4
+  store ptr %1, ptr @__llgo_argv, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.init"()
+  call void @main.init()
+  br i1 false, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  %2 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 0
+  store ptr @0, ptr %3, align 8
+  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 1
+  store i64 5, ptr %4, align 4
+  %5 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
+  %6 = load ptr, ptr @_llgo_string, align 8
+  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %5, ptr %7, align 8
+  %8 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, i32 0, i32 0
+  store ptr %6, ptr %9, align 8
+  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, i32 0, i32 1
+  store ptr %7, ptr %10, align 8
+  %11 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %11)
+  unreachable
+
+_llgo_2:                                          ; preds = %_llgo_0
+  br i1 false, label %_llgo_3, label %_llgo_4
+
+_llgo_3:                                          ; preds = %_llgo_2
+  %12 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %12, i32 0, i32 0
+  store ptr @0, ptr %13, align 8
+  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %12, i32 0, i32 1
+  store i64 5, ptr %14, align 4
+  %15 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %12, align 8
+  %16 = load ptr, ptr @_llgo_string, align 8
+  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %15, ptr %17, align 8
+  %18 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %19 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %18, i32 0, i32 0
+  store ptr %16, ptr %19, align 8
+  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %18, i32 0, i32 1
+  store ptr %17, ptr %20, align 8
+  %21 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %18, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %21)
+  unreachable
+
+_llgo_4:                                          ; preds = %_llgo_2
+  br i1 false, label %_llgo_5, label %_llgo_6
+
+_llgo_5:                                          ; preds = %_llgo_4
+  %22 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %22, i32 0, i32 0
+  store ptr @0, ptr %23, align 8
+  %24 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %22, i32 0, i32 1
+  store i64 5, ptr %24, align 4
+  %25 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %22, align 8
+  %26 = load ptr, ptr @_llgo_string, align 8
+  %27 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %25, ptr %27, align 8
+  %28 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %29 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %28, i32 0, i32 0
+  store ptr %26, ptr %29, align 8
+  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %28, i32 0, i32 1
+  store ptr %27, ptr %30, align 8
+  %31 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %28, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %31)
+  unreachable
+
+_llgo_6:                                          ; preds = %_llgo_4
+  ret i32 0
+}
+
+declare void @"github.com/goplus/llgo/internal/runtime.init"()
+
+define void @"main.init$after"() {
+_llgo_0:
+  %0 = load ptr, ptr @_llgo_string, align 8
+  %1 = icmp eq ptr %0, null
+  br i1 %1, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  store ptr %2, ptr @_llgo_string, align 8
+  br label %_llgo_2
+
+_llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+  ret void
+}
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64)
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64)
+
+declare void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface")

--- a/cl/import.go
+++ b/cl/import.go
@@ -196,8 +196,6 @@ func (p *context) initFiles(pkgPath string, files []*ast.File) {
 							p.collectSkipNames(line)
 						}
 					}
-				case token.TYPE:
-					handleTypeDecl(p.prog, p.goTyps, decl)
 				}
 			}
 		}
@@ -568,9 +566,7 @@ func handleTypeDecl(prog llssa.Program, pkg *types.Package, decl *ast.GenDecl) {
 	if len(decl.Specs) == 1 {
 		if bg := typeBackground(decl.Doc); bg != "" {
 			inPkgName := decl.Specs[0].(*ast.TypeSpec).Name.Name
-			if obj := pkg.Scope().Lookup(inPkgName); obj != nil {
-				prog.Type(obj.Type(), toBackground(bg))
-			}
+			prog.SetTypeBackground(pkg.Path()+"."+inPkgName, toBackground(bg))
 		}
 	}
 }

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -236,6 +236,10 @@ func (p Program) SetRuntime(runtime any) {
 	}
 }
 
+func (p Program) SetTypeBackground(fullName string, bg Background) {
+	p.gocvt.typbg[fullName] = bg
+}
+
 func (p Program) runtime() *types.Package {
 	if p.rt == nil {
 		p.rt = p.rtget()

--- a/ssa/type_cvt.go
+++ b/ssa/type_cvt.go
@@ -26,12 +26,14 @@ import (
 // -----------------------------------------------------------------------------
 
 type goTypes struct {
-	typs map[unsafe.Pointer]unsafe.Pointer
+	typs  map[unsafe.Pointer]unsafe.Pointer
+	typbg map[string]Background
 }
 
 func newGoTypes() goTypes {
 	typs := make(map[unsafe.Pointer]unsafe.Pointer)
-	return goTypes{typs}
+	typbk := make(map[string]Background)
+	return goTypes{typs, typbk}
 }
 
 type Background int
@@ -93,6 +95,9 @@ func (p goTypes) cvtType(typ types.Type) (raw types.Type, cvt bool) {
 	case *types.Struct:
 		return p.cvtStruct(t)
 	case *types.Named:
+		if p.typbg[t.String()] == InC {
+			break
+		}
 		return p.cvtNamed(t)
 	case *types.Signature:
 		return p.cvtClosure(t), true


### PR DESCRIPTION
unsafe.Sizeof 在 types.check 中转换为整数值，所以在 types.check 之前预先分析 []*ast.File 查找 llgo:type C 标志，用来判断 prog.TypesSize.Sizeof 和 prog.gocvt.cvtType 。

- internal/packages
  `func (Deduper).SetPreload(fn func(pkg *types.Package, syntax []*ast.File)) `
  `func (Deduper).SetPkgPath(fn func(path, name string) string)`
- internal/build
  `deduper.SetPreload` for check `llgo:type C` before types.check
- ssa
 ` (Program).SetTypeBackground(fullName string, bg Background)`
  use the `goTypes.typbg` map for types.Sizes and `goTypes.cvtType`
- internal/llgen
 use  `internal/packages.Deduper.SetPkgPath` for custome pkgPath.

