### PR TITLE
env:fix incorrect extra line breaks & subcmd match

### DIFF
--- a/cl/_testlibc/demangle/in.go
+++ b/cl/_testlibc/demangle/in.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"github.com/goplus/llgo/c"
+	"github.com/goplus/llgo/cpp/llvm"
+)
+
+func main() {
+	mangledName := "__ZNK9INIReader10ParseErrorEv"
+	if name := llvm.ItaniumDemangle(mangledName, true); name != nil {
+		c.Printf(c.Str("%s\n"), name)
+	} else {
+		println("Failed to demangle")
+	}
+}

--- a/cl/_testlibc/demangle/out.ll
+++ b/cl/_testlibc/demangle/out.ll
@@ -1,0 +1,69 @@
+; ModuleID = 'main'
+source_filename = "main"
+
+%"github.com/goplus/llgo/internal/runtime.String" = type { ptr, i64 }
+
+@"main.init$guard" = global i1 false, align 1
+@__llgo_argc = global i32 0, align 4
+@__llgo_argv = global ptr null, align 8
+@0 = private unnamed_addr constant [29 x i8] c"__ZNK9INIReader10ParseErrorEv", align 1
+@1 = private unnamed_addr constant [4 x i8] c"%s\0A\00", align 1
+@2 = private unnamed_addr constant [18 x i8] c"Failed to demangle", align 1
+
+define void @main.init() {
+_llgo_0:
+  %0 = load i1, ptr @"main.init$guard", align 1
+  br i1 %0, label %_llgo_2, label %_llgo_1
+
+_llgo_1:                                          ; preds = %_llgo_0
+  store i1 true, ptr @"main.init$guard", align 1
+  br label %_llgo_2
+
+_llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+  ret void
+}
+
+define i32 @main(i32 %0, ptr %1) {
+_llgo_0:
+  store i32 %0, ptr @__llgo_argc, align 4
+  store ptr %1, ptr @__llgo_argv, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.init"()
+  call void @main.init()
+  %2 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 0
+  store ptr @0, ptr %3, align 8
+  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 1
+  store i64 29, ptr %4, align 4
+  %5 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
+  %6 = call ptr @_ZN4llvm15itaniumDemangleENSt3__117basic_string_viewIcNS0_11char_traitsIcEEEEb(%"github.com/goplus/llgo/internal/runtime.String" %5, i1 true)
+  %7 = icmp ne ptr %6, null
+  br i1 %7, label %_llgo_1, label %_llgo_3
+
+_llgo_1:                                          ; preds = %_llgo_0
+  %8 = call i32 (ptr, ...) @printf(ptr @1, ptr %6)
+  br label %_llgo_2
+
+_llgo_2:                                          ; preds = %_llgo_3, %_llgo_1
+  ret i32 0
+
+_llgo_3:                                          ; preds = %_llgo_0
+  %9 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %9, i32 0, i32 0
+  store ptr @2, ptr %10, align 8
+  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %9, i32 0, i32 1
+  store i64 18, ptr %11, align 4
+  %12 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %9, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %12)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
+  br label %_llgo_2
+}
+
+declare void @"github.com/goplus/llgo/internal/runtime.init"()
+
+declare ptr @_ZN4llvm15itaniumDemangleENSt3__117basic_string_viewIcNS0_11char_traitsIcEEEEb(%"github.com/goplus/llgo/internal/runtime.String", i1)
+
+declare i32 @printf(ptr, ...)
+
+declare void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String")
+
+declare void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8)

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -283,7 +283,7 @@ func buildAllPkgs(ctx *context, initial []*packages.Package, verbose bool) (pkgs
 				for _, param := range altParts {
 					param = strings.TrimSpace(param)
 					if strings.ContainsRune(param, '$') {
-						expd = strings.TrimSpace(env.ExpandEnv(param))
+						expd = env.ExpandEnv(param)
 						ctx.nLibdir++
 					} else {
 						expd = param

--- a/xtool/env/env.go
+++ b/xtool/env/env.go
@@ -35,7 +35,7 @@ func ExpandEnv(s string) string {
 
 func expandEnvWithCmd(s string) string {
 	expanded := reSubcmd.ReplaceAllStringFunc(s, func(m string) string {
-		subcmd := strings.TrimSpace(s[2 : len(s)-1])
+		subcmd := strings.TrimSpace(m[2 : len(m)-1])
 
 		args := parseSubcmd(subcmd)
 
@@ -55,9 +55,9 @@ func expandEnvWithCmd(s string) string {
 			return ""
 		}
 
-		return string(out)
+		return strings.Replace(strings.TrimSpace(string(out)), "\n", " ", -1)
 	})
-	return os.Expand(expanded, os.Getenv)
+	return strings.TrimSpace(os.Expand(expanded, os.Getenv))
 }
 
 func parseSubcmd(s string) []string {


### PR DESCRIPTION
fix the issue of clang command errors caused by extra line breaks introduced by `exec.Command(cmd, args[1:]...).Output()`

----
This problematic command has an extra line break.
```
clang [-I/opt/homebrew/Cellar/llvm/18.1.8/include  -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-emit-llvm -S -o /Users/zhangzhiyang/Library/Caches/go-build/56/5656941ebcccc22e088ca01e3b2d684aeba7737dc870cdab6d55dc63162bcb83-d.llcursor.cpp.ll -c /Users/zhangzhiyang/Documents/Code/goplus/llgo/c/clang/_wrap/cursor.cpp]
```
![企业微信截图_11c77aba-3fd6-460a-b5d4-3df58c67f169](https://github.com/user-attachments/assets/033f05be-2015-45b0-b0e3-8e05813a4deb)
