### PR TITLE
fix describe mismatch in pthread.h

### DIFF
--- a/c/pthread/sync/sync.go
+++ b/c/pthread/sync/sync.go
@@ -76,14 +76,18 @@ func (m *Mutex) Init(attr *MutexAttr) c.Int { return 0 }
 // llgo:link (*Mutex).Destroy C.pthread_mutex_destroy
 func (m *Mutex) Destroy() {}
 
-// llgo:link (*Mutex).Lock C.pthread_mutex_lock
-func (m *Mutex) Lock() {}
+func (m *Mutex) Lock() { m.lockInternal() }
+
+// llgo:link (*Mutex).lockInternal C.pthread_mutex_lock
+func (m *Mutex) lockInternal() c.Int { return 0 }
 
 // llgo:link (*Mutex).TryLock C.pthread_mutex_trylock
 func (m *Mutex) TryLock() c.Int { return 0 }
 
-// llgo:link (*Mutex).Unlock C.pthread_mutex_unlock
-func (m *Mutex) Unlock() {}
+func (m *Mutex) Unlock() { m.unlockInternal() }
+
+// llgo:link (*Mutex).unlockInternal C.pthread_mutex_unlock
+func (m *Mutex) unlockInternal() c.Int { return 0 }
 
 // -----------------------------------------------------------------------------
 


### PR DESCRIPTION
mismatched function describe in generated ll file against pthread.h

```llvm
declare void @pthread_mutex_lock(ptr)
declare void @pthread_mutex_unlock(ptr) 
```
in pthread.h

```c
int pthread_mutex_lock(pthread_mutex_t *);
int pthread_mutex_unlock(pthread_mutex_t *);
```

So change link lock and unlock to private method and call Lock and Unlock by private method
