### PR TITLE
build: fix `sigsetjmp` issues and ensure required libs on Linux

### DIFF
--- a/c/setjmp/setjmp.go
+++ b/c/setjmp/setjmp.go
@@ -44,9 +44,6 @@ func Longjmp(env *JmpBuf, val c.Int)
 
 // -----------------------------------------------------------------------------
 
-//go:linkname Sigsetjmp C.sigsetjmp
-func Sigsetjmp(env *SigjmpBuf, savemask c.Int) c.Int
-
 //go:linkname Siglongjmp C.siglongjmp
 func Siglongjmp(env *SigjmpBuf, val c.Int)
 

--- a/c/setjmp/setjmp_linux.go
+++ b/c/setjmp/setjmp_linux.go
@@ -1,0 +1,12 @@
+//go:build linux
+
+package setjmp
+
+import (
+	_ "unsafe"
+
+	"github.com/goplus/llgo/c"
+)
+
+//go:linkname Sigsetjmp C.__sigsetjmp
+func Sigsetjmp(env *SigjmpBuf, savemask c.Int) c.Int

--- a/c/setjmp/setjmp_other.go
+++ b/c/setjmp/setjmp_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package setjmp
+
+import (
+	_ "unsafe"
+
+	"github.com/goplus/llgo/c"
+)
+
+//go:linkname Sigsetjmp C.sigsetjmp
+func Sigsetjmp(env *SigjmpBuf, savemask c.Int) c.Int

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -356,6 +356,8 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, llFiles 
 			"-rpath", "$ORIGIN",
 			"-rpath", "$ORIGIN/../lib",
 			"-Xlinker", "--gc-sections",
+			"-lm",
+			"-latomic",
 			"-lpthread", // libpthread is built-in since glibc 2.34 (2021-08-01); we need to support earlier versions.
 		)
 	}


### PR DESCRIPTION
1. Handle `sigsetjmp` platform differences:
   - Separate `sigsetjmp` linkage to platform-specific files.
   - Use `__sigsetjmp` on Linux to handle `sigsetjmp` being a macro.
   - Maintain original implementation for Darwin.

2. Ensure linking of required libs:
   - Explicitly link against fundamental libs (e.g., libm, libatomic).
   - Address the fact that typical Linux linkers don't link these by default.