### PR TITLE
build: replicate macOS `-dead_strip` optimization on Linux

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -361,6 +361,8 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, llFiles 
 			args,
 			"-rpath", "$ORIGIN",
 			"-rpath", "$ORIGIN/../lib",
+			"-fdata-sections",
+			"-ffunction-sections",
 			"-Xlinker", "--gc-sections",
 			"-lm",
 			"-latomic",


### PR DESCRIPTION
Added `-fdata-sections` and `-ffunction-sections` compiler flags to work with `--gc-sections` on Linux. This combination achieves similar dead code elimination as macOS's `-dead_strip`, reducing binary size and resolving undefined symbol issues. Ensures consistent optimization across macOS and Linux builds.