### PR TITLE
llcppg:ast info design

### DIFF
--- a/chore/llcppg/ast/ast.go
+++ b/chore/llcppg/ast/ast.go
@@ -1,0 +1,67 @@
+package ast
+
+import "strings"
+
+type AccessSpecifier int
+
+const (
+	Public AccessSpecifier = iota
+	Protected
+	Private
+)
+
+type Node interface {
+	// other info, if needed
+}
+
+type NamedType interface {
+	Node
+	TypeName() string
+	Namespace() []string
+	FullName() string
+}
+
+type BaseType struct {
+	Name      string
+	namespace []string
+}
+
+func (b *BaseType) TypeName() string {
+	return b.Name
+}
+
+func (b *BaseType) Namespace() []string {
+	return b.namespace
+}
+
+func (b *BaseType) FullName() string {
+	return strings.Join(append(b.Namespace(), b.TypeName()), "::")
+}
+
+type Macro interface {
+	Node
+	MacroName() string
+}
+
+type File struct {
+	Name   string
+	Defs   []*TypeDef // structs, functions, classes
+	Macros []*Macro
+}
+
+// ConstantMacro represents a constant macro definition
+// For This Usage: #define OK 1 , Map to Go: const OK = 1
+type ConstantMacro struct {
+	Name  string
+	Value string
+}
+
+// GenericMacro represents other types of macro definitions
+// (Consider whether to retain collection of these)
+type GenericMacro struct {
+	Name       string
+	Definition string
+}
+
+func (c *ConstantMacro) MacroName() string { return c.Name }
+func (g *GenericMacro) MacroName() string  { return g.Name }

--- a/chore/llcppg/ast/def.go
+++ b/chore/llcppg/ast/def.go
@@ -1,0 +1,54 @@
+package ast
+
+// TypeDef interface represents a type definition
+type TypeDef interface {
+	NamedType
+}
+
+// Represents a base class in inheritance
+type BaseClass struct {
+	Type   TypeUse
+	Access AccessSpecifier // Access specifier affects visibility of derived class fields, but not memory layout
+}
+
+type ClassDef struct {
+	BaseType
+	BaseClasses []*BaseClass
+	Fields      []*Field
+	Methods     []*MethodDef
+}
+
+type StructDef struct {
+	BaseType
+	Fields []*Field
+}
+
+type FunctionDef struct {
+	BaseType
+	ReturnType *Field
+	Params     []*Field
+	Symbol     string
+}
+
+type MethodDef struct {
+	FunctionDef
+	Class      TypeUse // Class to which this method belongs
+	Access     AccessSpecifier
+	IsVirtual  bool //  Whether it's a virtual function
+	IsOverride bool //  Whether it's an overriding function
+}
+
+type Field struct {
+	Names []string
+	Type  TypeUse
+}
+
+type EnumDef struct {
+	BaseType
+	Values []*EnumValue
+}
+
+type EnumValue struct {
+	Name  string
+	Value int64
+}

--- a/chore/llcppg/ast/use.go
+++ b/chore/llcppg/ast/use.go
@@ -1,0 +1,29 @@
+package ast
+
+type TypeUse interface {
+	NamedType
+}
+
+// a basic type usage
+type BasicTypeUse struct {
+	BaseType
+}
+
+// a custom type usage
+type CustomTypeUse struct {
+	BaseType
+}
+
+// a pointer type usage
+type PointerTypeUse struct {
+	BaseType TypeUse
+}
+
+func (t *PointerTypeUse) TypeName() string {
+	return t.BaseType.TypeName() + "*"
+}
+
+// fully qualified name of the pointer type
+func (t *PointerTypeUse) FullName() string {
+	return t.BaseType.FullName() + "*"
+}


### PR DESCRIPTION
The design focuses on extracting essential structural information.

- Namespaces: Retain sufficient namespace information without nested node representation
- Macros: Process only simple constant definition macros, to collect definitions similar to enumerations, such as #define OK 1.
- Type: Clear differentiation of type definitions and uses, facilitating code generation