### PR TITLE
[WIP] llcppg:ast info design

### DIFF
--- a/chore/llcppg/ast/ast.go
+++ b/chore/llcppg/ast/ast.go
@@ -1,0 +1,62 @@
+package ast
+
+import (
+	"go/ast"
+	"go/token"
+)
+
+// decl
+type (
+	// #include
+	// #define()
+	// typedef(namespace)
+	// struct(namespace)
+	// class(namespace)
+	GenDecl struct {
+	}
+
+	// keep use FuncType
+	CFuncDecl struct {
+		// receiver is not need
+		Doc      *ast.CommentGroup
+		Name     *ast.Ident
+		Type     *ast.FuncType
+		Body     *ast.BlockStmt
+		IsInline bool
+	}
+	CMethodDecl struct {
+		CFuncDecl
+		IsConstructor bool
+		IsDestructor  bool
+	}
+)
+
+func (d *CFuncDecl) Pos() token.Pos { return d.Type.Pos() }
+func (d *CFuncDecl) End() token.Pos {
+	if d.Body != nil {
+		return d.Body.End()
+	}
+	return d.Type.End()
+}
+func (*CFuncDecl) declNode() {}
+
+// expression
+type (
+	// for aaa::bbb
+	NamespaceExpr struct {
+		X   ast.Expr
+		Sel *ast.Ident
+	}
+	Variadic struct {
+		Ellipsis token.Pos // position of "..."
+	}
+)
+
+func (x *NamespaceExpr) Pos() token.Pos { return x.X.Pos() }
+func (x *Variadic) Pos() token.Pos      { return x.Ellipsis }
+
+func (x *NamespaceExpr) End() token.Pos { return x.Sel.End() }
+func (x *Variadic) End() token.Pos      { return x.Ellipsis + 3 }
+
+func (*NamespaceExpr) exprNode() {}
+func (*Variadic) exprNode()      {}


### PR DESCRIPTION
**目前主要思考方向为直接扩展go的ast的节点表达，并保留整体的go的ast树结构，用于描述足够的c语言信息**

正在考虑是否应该直接复用一些基础结构,比如在Go的AST设计中，所有的类型都会实现Node接口，其存储了这个节点在FileSet 中的偏移量（这部分也是之前没有考虑到的多文件的实现，还不明确是否需要构建一个尽可能相同的FileSet）

### namespace
**NamespaceExpr**
由于C语言中的标识符支持通过命名空间进行嵌套，类似于Go语言中的Selector表达式，设计了一个NamespaceExpr结构体用于表述命名空间的嵌套访问：
```go
type NamespaceExpr struct {
    X   *ast.Expr  // 命名空间前缀表达式
    Sel *ast.Ident // 选择的标识符
}
```
对于namespace的存储，还有一个设计，即更扁平的作为Ident属性的namespace
**QualifiedIdent**
```go
QualifiedIdent struct {
    Namespaces []*ast.Ident
    Name       *ast.Ident
}
```
### FuncDecl
在Go语言中，函数和方法的声明区分为Method和Func，主要差异在于Recv字段。对于C++语言，函数声明与方法声明的差异就比较大了，所以现有的FuncDecl并不足以描述，需要扩展

- 类方法支持public、protected、private等访问修饰符，这些修饰符决定了方法的可见性和是否暴露于动态链接库中。
- 类方法可能包括构造函数和析构函数，这影响到方法是否需要重载或包装。

### Field & FieldList
在Go中，每一个Field后面可以跟一个Tag，虽然C语言中不需要此标签，但其存在不影响结构的完整表达：
```
type Field struct {
    Doc     *CommentGroup 
    Names   []*Ident     
    Type    Expr         
    Tag     *BasicLit    
    Comment *CommentGroup 
}
```
### 可变参数表达
在设计对C语言的printf函数等可变参数函数的表示时，参考Ellipsis表达式：
```
type Ellipsis struct {
    Ellipsis token.Pos 
    Elt      Expr    
}
```
但是直接使用Ellipsis会导致多余的Elt信息，需要进行考虑，对于描述C语言的参数列表，没有什么额外的好处，所以单独使用了一个可变参数的表达
```go
Variadic struct {
    Ellipsis token.Pos // position of "..."
}
```