### PR TITLE
perf(lib/sync): avoid using `defer`

### DIFF
--- a/internal/lib/sync/sync.go
+++ b/internal/lib/sync/sync.go
@@ -98,11 +98,11 @@ type Once struct {
 func (o *Once) Do(f func()) {
 	if !o.done {
 		o.m.Lock()
-		defer o.m.Unlock()
 		if !o.done {
 			o.done = true
 			f()
 		}
+		o.m.Unlock()
 	}
 }
 


### PR DESCRIPTION
```diff
11d10
< %"github.com/goplus/llgo/internal/runtime.Defer" = type { ptr, i64, ptr, ptr, ptr }
51d49
< @__llgo_defer = linkonce global i32 0, align 4
133,151c131
<   %4 = load i32, ptr @__llgo_defer, align 4
<   %5 = call ptr @pthread_getspecific(i32 %4)
<   %6 = alloca i8, i64 196, align 1
<   %7 = alloca i8, i64 40, align 1
<   %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Defer", ptr %7, i32 0, i32 0
<   store ptr %6, ptr %8, align 8
<   %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Defer", ptr %7, i32 0, i32 1
<   store i64 0, ptr %9, align 4
<   %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Defer", ptr %7, i32 0, i32 2
<   store ptr %5, ptr %10, align 8
<   %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Defer", ptr %7, i32 0, i32 3
<   store ptr blockaddress(@"sync.(*Once).Do", %_llgo_6), ptr %11, align 8
<   %12 = call i32 @pthread_setspecific(i32 %4, ptr %7)
<   %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Defer", ptr %7, i32 0, i32 1
<   %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Defer", ptr %7, i32 0, i32 3
<   %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Defer", ptr %7, i32 0, i32 4
<   %16 = call i32 @sigsetjmp(ptr %6, i32 0)
<   %17 = icmp eq i32 %16, 0
<   br i1 %17, label %_llgo_5, label %_llgo_8
---
>   br i1 %3, label %_llgo_2, label %_llgo_1
153,162c133,138
< _llgo_1:                                          ; preds = %_llgo_5
<   %18 = getelementptr inbounds %sync.Once, ptr %0, i32 0, i32 0
<   call void @"sync.(*Mutex).Lock"(ptr %18)
<   %19 = getelementptr inbounds %sync.Once, ptr %0, i32 0, i32 0
<   %20 = load i64, ptr %13, align 4
<   %21 = or i64 %20, 1
<   store i64 %21, ptr %13, align 4
<   %22 = getelementptr inbounds %sync.Once, ptr %0, i32 0, i32 1
<   %23 = load i1, ptr %22, align 1
<   br i1 %23, label %_llgo_2, label %_llgo_4
---
> _llgo_1:                                          ; preds = %_llgo_0
>   %4 = getelementptr inbounds %sync.Once, ptr %0, i32 0, i32 0
>   call void @"sync.(*Mutex).Lock"(ptr %4)
>   %5 = getelementptr inbounds %sync.Once, ptr %0, i32 0, i32 1
>   %6 = load i1, ptr %5, align 1
>   br i1 %6, label %_llgo_4, label %_llgo_3
164,168c140
< _llgo_2:                                          ; preds = %_llgo_4, %_llgo_1, %_llgo_5
<   store ptr blockaddress(@"sync.(*Once).Do", %_llgo_9), ptr %15, align 8
<   br label %_llgo_6
< 
< _llgo_3:                                          ; preds = %_llgo_7
---
> _llgo_2:                                          ; preds = %_llgo_4, %_llgo_0
171,180c143,149
< _llgo_4:                                          ; preds = %_llgo_1
<   %24 = getelementptr inbounds %sync.Once, ptr %0, i32 0, i32 1
<   store i1 true, ptr %24, align 1
<   %25 = extractvalue { ptr, ptr } %1, 1
<   %26 = extractvalue { ptr, ptr } %1, 0
<   call void %26(ptr %25)
<   br label %_llgo_2
< 
< _llgo_5:                                          ; preds = %_llgo_0
<   br i1 %3, label %_llgo_2, label %_llgo_1
---
> _llgo_3:                                          ; preds = %_llgo_1
>   %7 = getelementptr inbounds %sync.Once, ptr %0, i32 0, i32 1
>   store i1 true, ptr %7, align 1
>   %8 = extractvalue { ptr, ptr } %1, 1
>   %9 = extractvalue { ptr, ptr } %1, 0
>   call void %9(ptr %8)
>   br label %_llgo_4
182,210c151,154
< _llgo_6:                                          ; preds = %_llgo_8, %_llgo_2
<   store ptr blockaddress(@"sync.(*Once).Do", %_llgo_7), ptr %14, align 8
<   %27 = load i64, ptr %13, align 4
<   %28 = and i64 %27, 1
<   %29 = icmp ne i64 %28, 0
<   br i1 %29, label %_llgo_10, label %_llgo_11
< 
< _llgo_7:                                          ; preds = %_llgo_8, %_llgo_11
<   call void @"github.com/goplus/llgo/internal/runtime.Rethrow"(ptr %5)
<   br label %_llgo_3
< 
< _llgo_8:                                          ; preds = %_llgo_0
<   store ptr blockaddress(@"sync.(*Once).Do", %_llgo_7), ptr %15, align 8
<   %30 = load ptr, ptr %14, align 8
<   indirectbr ptr %30, [label %_llgo_7, label %_llgo_6]
< 
< _llgo_9:                                          ; preds = %_llgo_11
<   ret void
< 
< _llgo_10:                                         ; preds = %_llgo_6
<   call void @pthread_mutex_unlock(ptr %19)
<   br label %_llgo_11
< 
< _llgo_11:                                         ; preds = %_llgo_10, %_llgo_6
<   %31 = load %"github.com/goplus/llgo/internal/runtime.Defer", ptr %7, align 8
<   %32 = extractvalue %"github.com/goplus/llgo/internal/runtime.Defer" %31, 2
<   %33 = call i32 @pthread_setspecific(i32 %4, ptr %32)
<   %34 = load ptr, ptr %15, align 8
<   indirectbr ptr %34, [label %_llgo_7, label %_llgo_9]
---
> _llgo_4:                                          ; preds = %_llgo_3, %_llgo_1
>   %10 = getelementptr inbounds %sync.Once, ptr %0, i32 0, i32 0
>   call void @pthread_mutex_unlock(ptr %10)
>   br label %_llgo_2
982,990d925
<   %304 = load i32, ptr @__llgo_defer, align 4
<   %305 = icmp eq i32 %304, 0
<   br i1 %305, label %_llgo_33, label %_llgo_34
< 
< _llgo_33:                                         ; preds = %_llgo_32
<   %306 = call i32 @pthread_key_create(ptr @__llgo_defer, ptr null)
<   br label %_llgo_34
< 
< _llgo_34:                                         ; preds = %_llgo_33, %_llgo_32
1036,1043d970
< declare ptr @pthread_getspecific(i32)
< 
< declare i32 @pthread_setspecific(i32, ptr)
< 
< declare i32 @sigsetjmp(ptr, i32)
< 
< declare void @"github.com/goplus/llgo/internal/runtime.Rethrow"(ptr)
< 
1057,1058d983
< 
< declare i32 @pthread_key_create(ptr, ptr)
```