### PR TITLE
fix(c/os): add missing `clearenv` for macOS

### DIFF
--- a/c/os/_os/os.c
+++ b/c/os/_os/os.c
@@ -1,0 +1,9 @@
+#include <stdlib.h>
+
+int llgo_clearenv() {
+	extern char **environ;
+	if (environ != NULL) {
+		*environ = NULL;
+	}
+	return 0;
+}

--- a/c/os/os.go
+++ b/c/os/os.go
@@ -28,7 +28,8 @@ import (
 )
 
 const (
-	LLGoPackage = "decl"
+	LLGoFiles   = "_os/os.c"
+	LLGoPackage = "link"
 )
 
 const (
@@ -149,9 +150,6 @@ func Putenv(env *c.Char) c.Int
 
 //go:linkname Unsetenv C.unsetenv
 func Unsetenv(name *c.Char) c.Int
-
-//go:linkname Clearenv C.clearenv
-func Clearenv()
 
 // -----------------------------------------------------------------------------
 

--- a/c/os/os_linux.go
+++ b/c/os/os_linux.go
@@ -1,0 +1,24 @@
+//go:build linux
+
+/*
+ * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package os
+
+import "C"
+
+//go:linkname Clearenv C.clearenv
+func Clearenv()

--- a/c/os/os_other.go
+++ b/c/os/os_other.go
@@ -1,0 +1,24 @@
+//go:build !linux
+
+/*
+ * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package os
+
+import "C"
+
+//go:linkname Clearenv C.llgo_clearenv
+func Clearenv()


### PR DESCRIPTION
Without `-Xlinker -dead_strip`:

```sh
$ llgo build .
# llgotest
ld64.lld: error: undefined symbol: clearenv
>>> referenced by /var/folders/fh/f39_dzqn0p31th82dvpr1b_w0000gn/T/a7c5a3b89e966e97f2920bb4f709118d21529514a1aac919c229474ffb89c93a-d-6958e0.o:(symbol syscall.Clearenv+0x13c)
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

---

The libc on macOS lacks `clearenv`, so this patch adds an implementation.