### PR TITLE
cpp/std: fix std::string def

### DIFF
--- a/cpp/std/string.go
+++ b/cpp/std/string.go
@@ -31,7 +31,7 @@ type StringView = string
 
 // String represents a C++ std::string object.
 type String struct {
-	Unused [3]uintptr
+	Unused [3 * unsafe.Sizeof(0)]byte
 }
 
 // llgo:link (*String).InitEmpty C.stdStringInitEmpty


### PR DESCRIPTION
std::string
```
    struct __long
    {
        pointer   __data_;
        size_type __size_;
        size_type __cap_;
    };

    struct __short
    {
        union
        {
            unsigned char __size_;
            value_type __lx;
        };
        value_type __data_[__min_cap];
    };
```