### PR TITLE
c/clang:marco content

### DIFF
--- a/c/clang/_demo/symboldump/symboldump.go
+++ b/c/clang/_demo/symboldump/symboldump.go
@@ -59,6 +59,7 @@ func printMarcoInfo(cursor clang.Cursor) {
 	for _, tok := range tokensSlice {
 		tokStr := context.unit.Token(tok)
 		c.Printf(c.Str("%s "), tokStr.CStr())
+		tokStr.Dispose()
 	}
 
 	c.Printf(c.Str("\n"))

--- a/c/clang/clang.go
+++ b/c/clang/clang.go
@@ -1360,7 +1360,6 @@ type SourceRange struct {
 /**
  * Describes a kind of token.
  */
-
 type TokenKind c.Int
 
 const (
@@ -1471,6 +1470,16 @@ func (c Cursor) Argument(index c.Uint) (arg Cursor) {
 	return
 }
 
+/**
+ * Retrieve the physical location of the source constructor referenced
+ * by the given cursor.
+ *
+ * The location of a declaration is typically the location of the name of that
+ * declaration, where the name of that declaration would occur if it is
+ * unnamed, or some keyword that introduces that particular declaration.
+ * The location of a reference is where that reference occurs within the
+ * source code.
+ */
 // llgo:link (*Cursor).wrapLocation C.wrap_clang_getCursorLocation
 func (c *Cursor) wrapLocation(loc *SourceLocation) {}
 
@@ -1518,7 +1527,7 @@ func (c Cursor) Extent() (loc SourceRange) {
 // llgo:link (*TranslationUnit).wrapTokenize C.wrap_clang_tokenize
 func (t *TranslationUnit) wrapTokenize(ran *SourceRange, tokens **Token, numTokens *c.Uint) {}
 
-func (t TranslationUnit) Tokenize(ran SourceRange, tokens **Token, numTokens *c.Uint) {
+func (t *TranslationUnit) Tokenize(ran SourceRange, tokens **Token, numTokens *c.Uint) {
 	t.wrapTokenize(&ran, tokens, numTokens)
 }
 
@@ -1533,7 +1542,7 @@ func (*TranslationUnit) wrapToken(token *Token) (ret String) {
 	return
 }
 
-func (c TranslationUnit) Token(token Token) (ret String) {
+func (c *TranslationUnit) Token(token Token) (ret String) {
 	return c.wrapToken(&token)
 }
 


### PR DESCRIPTION
Fixed macro content output incompleteness caused by incorrect address passing in value methods. Macro content is now displaying fully, including previously missing operators and symbols.

```bash
#define MAX(a, b) ((a) > (b) ? (a) : (b))
#define ABS(x) ((x) < 0 ? -(x) : (x))
#define COMPUTE(x, y) (MAX(ABS(x), ABS(y)))
```

```bash
./test.h:19:9
Marco Name: MAX
Content: MAX ( a , b ) ( ( a ) > ( b ) ? ( a ) : ( b ) )
--------------------------------
./test.h:20:9
Marco Name: ABS
Content: ABS ( x ) ( ( x ) < 0 ? - ( x ) : ( x ) )
--------------------------------
./test.h:21:9
Marco Name: COMPUTE
Content: COMPUTE ( x , y ) ( MAX ( ABS ( x ) , ABS ( y ) ) )
--------------------------------
```