### PR TITLE
castdump:array,typedef,pointer,funcproto,enum & builtin type

### DIFF
--- a/c/clang/_wrap/cursor.cpp
+++ b/c/clang/_wrap/cursor.cpp
@@ -31,7 +31,17 @@ void wrap_clang_getTranslationUnitCursor(CXTranslationUnit uint, CXCursor *cur) 
 
 void wrap_clang_getCursorType(CXCursor *cur, CXType *typ) { *typ = clang_getCursorType(*cur); }
 
+void wrap_clang_getPointeeType(CXType *pointerTyp, CXType *pointeeTyp) {
+    *pointeeTyp = clang_getPointeeType(*pointerTyp);
+}
+
+void wrap_clang_getArrayElementType(CXType *arrayTyp, CXType *elemTyp) {
+    *elemTyp = clang_getArrayElementType(*arrayTyp);
+}
+
 void wrap_clang_getCursorResultType(CXCursor *cur, CXType *typ) { *typ = clang_getCursorResultType(*cur); }
+
+void wrap_clang_getCanonicalType(CXType *typ, CXType *canonicalType) { *canonicalType = clang_getCanonicalType(*typ); }
 
 CXString wrap_clang_getTypeSpelling(CXType *typ) { return clang_getTypeSpelling(*typ); }
 

--- a/c/clang/clang.go
+++ b/c/clang/clang.go
@@ -1322,6 +1322,14 @@ type Cursor struct {
 type TypeKind c.Int
 
 /**
+ * Retrieve the spelling of a given CXTypeKind.
+ */
+// llgo:link TypeKind.String C.clang_getTypeKindSpelling
+func (TypeKind) String() (ret String) {
+	return
+}
+
+/**
  * Describes the kind of type
  */
 const (
@@ -1778,6 +1786,44 @@ func (t *Type) wrapString() (ret String) {
 
 func (t Type) String() (ret String) {
 	return t.wrapString()
+}
+
+/**
+ * For pointer types, returns the type of the pointee.
+ */
+// llgo:link (*Type).wrapPointeeType C.wrap_clang_getPointeeType
+func (t *Type) wrapPointeeType(ret *Type) { return }
+
+func (t Type) PointeeType() (ret Type) {
+	t.wrapPointeeType(&ret)
+	return
+}
+
+/**
+ * Return the element type of an array type.
+ *
+ * If a non-array type is passed in, an invalid type is returned.
+ */
+// llgo:link (*Type).wrapArrayElementType C.wrap_clang_getArrayElementType
+func (t *Type) wrapArrayElementType(ret *Type) { return }
+func (t Type) ArrayElementType() (ret Type) {
+	t.wrapArrayElementType(&ret)
+	return
+}
+
+/**
+ * Return the canonical type for a CXType.
+ *
+ * Clang's type system explicitly models typedefs and all the ways
+ * a specific type can be represented.  The canonical type is the underlying
+ * type with all the "sugar" removed.  For example, if 'T' is a typedef
+ * for 'int', the canonical type for 'T' would be 'int'.
+ */
+// llgo:link (*Type).wrapCanonicalType C.wrap_clang_getCanonicalType
+func (t *Type) wrapCanonicalType(ret *Type) { return }
+func (t Type) CanonicalType() (ret Type) {
+	t.wrapCanonicalType(&ret)
+	return
 }
 
 //llgo:link File.FileName C.clang_getFileName

--- a/chore/_xtool/castdump/castdump.go
+++ b/chore/_xtool/castdump/castdump.go
@@ -14,19 +14,18 @@ type Data struct {
 	Unit  *clang.TranslationUnit
 }
 
+var accessMap = map[clang.CXXAccessSpecifier]string{
+	clang.CXXInvalidAccessSpecifier: "invalid",
+	clang.CXXPublic:                 "public",
+	clang.CXXProtected:              "protected",
+	clang.CXXPrivate:                "private",
+}
+
 func accessToString(spec clang.CXXAccessSpecifier) string {
-	switch spec {
-	case clang.CXXInvalidAccessSpecifier:
-		return "invalid"
-	case clang.CXXPublic:
-		return "public"
-	case clang.CXXProtected:
-		return "protected"
-	case clang.CXXPrivate:
-		return "private"
-	default:
-		return "unkown"
+	if str, ok := accessMap[spec]; ok {
+		return str
 	}
+	return "unknown"
 }
 
 func visit(cursor, parent clang.Cursor, ClientData c.Pointer) clang.ChildVisitResult {


### PR DESCRIPTION
1. For nodes with types, their type trees are recursively output. Currently supported types include array, typedef, pointer, funcproto, enum, and builtin types.
2. For enum types, although they are complex types, it's not possible to obtain their more fundamental underlying 
types. 


- [ ] The parsed void type causes an additional line break.

```
ClassDecl: INIReader(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:42:7)
   <ComplexType|Record>: INIReader
      CXXAccessSpecifier:  public(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:43:3)
      CXXConstructor: INIReader (Symbol: __ZN9INIReaderC1ERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEE)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:46:22)
      <ComplexType|FunctionProto>: void (const std::string &)
                  <ComplexType|LValueReference>: const std::string &
         attribute(visibility): default
         ParmDecl: filename(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:46:51)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:46:43)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
      CXXConstructor: INIReader (Symbol: __ZN9INIReaderC1EPKcm)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:50:22)
      <ComplexType|FunctionProto>: void (const char *, size_t)
                  <ComplexType|Pointer>: const char *
            <BuiltinType|Char_S>: const char
         <ComplexType|Elaborated>: size_t
         attribute(visibility): default
         ParmDecl: buffer(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:50:44)
         <ComplexType|Pointer>: const char *
            <BuiltinType|Char_S>: const char
         ParmDecl: buffer_size(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:50:59)
         <ComplexType|Elaborated>: size_t
            TypeRef: size_t(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:50:52)
            <ComplexType|Typedef>: size_t
               <BuiltinType|ULong>: unsigned long
      CXXMethod: ParseError (Symbol: __ZNK9INIReader10ParseErrorEv)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:54:17)
      <ComplexType|FunctionProto>: int () const
         <BuiltinType|Int>: int
         attribute(visibility): default
      CXXMethod: Get (Symbol: __ZNK9INIReader3GetERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_S8_)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:57:25)
      <ComplexType|FunctionProto>: std::string (const std::string &, const std::string &, const std::string &) const
         <ComplexType|Elaborated>: std::string
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         attribute(visibility): default
         NamespaceRef: std
         TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:57:18)
         <ComplexType|Typedef>: std::string
            <ComplexType|Record>: std::basic_string<char>
         ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:57:48)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:57:40)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: name(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:57:76)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:57:68)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: default_value(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:58:48)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:58:40)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
      CXXMethod: GetString (Symbol: __ZNK9INIReader9GetStringERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_S8_)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:62:25)
      <ComplexType|FunctionProto>: std::string (const std::string &, const std::string &, const std::string &) const
         <ComplexType|Elaborated>: std::string
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         attribute(visibility): default
         NamespaceRef: std
         TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:62:18)
         <ComplexType|Typedef>: std::string
            <ComplexType|Record>: std::basic_string<char>
         ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:62:54)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:62:46)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: name(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:62:82)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:62:74)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: default_value(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:63:54)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:63:46)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
      CXXMethod: GetInteger (Symbol: __ZNK9INIReader10GetIntegerERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_l)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:67:18)
      <ComplexType|FunctionProto>: long (const std::string &, const std::string &, long) const
         <BuiltinType|Long>: long
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         <BuiltinType|Long>: long
         attribute(visibility): default
         ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:67:48)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:67:40)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: name(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:67:76)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:67:68)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: default_value(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:67:87)
         <BuiltinType|Long>: long
      CXXMethod: GetInteger64 (Symbol: __ZNK9INIReader12GetInteger64ERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_x)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:71:21)
      <ComplexType|FunctionProto>: int64_t (const std::string &, const std::string &, int64_t) const
         <ComplexType|Elaborated>: int64_t
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|Elaborated>: int64_t
         attribute(visibility): default
         TypeRef: int64_t(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:71:13)
         <ComplexType|Typedef>: int64_t
            <BuiltinType|LongLong>: long long
         ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:71:53)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:71:45)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: name(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:71:81)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:71:73)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: default_value(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:71:95)
         <ComplexType|Elaborated>: int64_t
            TypeRef: int64_t(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:71:87)
            <ComplexType|Typedef>: int64_t
               <BuiltinType|LongLong>: long long
      CXXMethod: GetUnsigned (Symbol: __ZNK9INIReader11GetUnsignedERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_m)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:75:27)
      <ComplexType|FunctionProto>: unsigned long (const std::string &, const std::string &, unsigned long) const
         <BuiltinType|ULong>: unsigned long
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         <BuiltinType|ULong>: unsigned long
         attribute(visibility): default
         ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:75:58)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:75:50)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: name(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:75:86)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:75:78)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: default_value(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:76:53)
         <BuiltinType|ULong>: unsigned long
      CXXMethod: GetUnsigned64 (Symbol: __ZNK9INIReader13GetUnsigned64ERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_y)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:80:22)
      <ComplexType|FunctionProto>: uint64_t (const std::string &, const std::string &, uint64_t) const
         <ComplexType|Elaborated>: uint64_t
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|Elaborated>: uint64_t
         attribute(visibility): default
         TypeRef: uint64_t(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:80:13)
         <ComplexType|Typedef>: uint64_t
            <BuiltinType|ULongLong>: unsigned long long
         ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:80:55)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:80:47)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: name(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:80:83)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:80:75)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: default_value(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:80:98)
         <ComplexType|Elaborated>: uint64_t
            TypeRef: uint64_t(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:80:89)
            <ComplexType|Typedef>: uint64_t
               <BuiltinType|ULongLong>: unsigned long long
      CXXMethod: GetReal (Symbol: __ZNK9INIReader7GetRealERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_d)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:85:20)
      <ComplexType|FunctionProto>: double (const std::string &, const std::string &, double) const
         <BuiltinType|Double>: double
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         <BuiltinType|Double>: double
         attribute(visibility): default
         ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:85:47)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:85:39)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: name(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:85:75)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:85:67)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: default_value(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:85:88)
         <BuiltinType|Double>: double
      CXXMethod: GetBoolean (Symbol: __ZNK9INIReader10GetBooleanERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_b)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:90:18)
      <ComplexType|FunctionProto>: bool (const std::string &, const std::string &, bool) const
         <BuiltinType|Bool>: bool
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         <BuiltinType|Bool>: bool
         attribute(visibility): default
         ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:90:48)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:90:40)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: name(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:90:76)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:90:68)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: default_value(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:90:87)
         <BuiltinType|Bool>: bool
      CXXMethod: HasSection (Symbol: __ZNK9INIReader10HasSectionERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEE)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:94:18)
      <ComplexType|FunctionProto>: bool (const std::string &) const
         <BuiltinType|Bool>: bool
         <ComplexType|LValueReference>: const std::string &
         attribute(visibility): default
         ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:94:48)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:94:40)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
      CXXMethod: HasValue (Symbol: __ZNK9INIReader8HasValueERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:97:18)
      <ComplexType|FunctionProto>: bool (const std::string &, const std::string &) const
         <BuiltinType|Bool>: bool
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         attribute(visibility): default
         ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:97:46)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:97:38)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: name(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:97:74)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:97:66)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
      CXXAccessSpecifier:  private(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:99:3)
      FieldDecl: _error(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:100:9)
      <BuiltinType|Int>: int
      FieldDecl: _values(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:101:40)
      <BuiltinType|Int>: int
      CXXMethod: MakeKey (Symbol: __ZN9INIReader7MakeKeyERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:102:24)
      <ComplexType|FunctionProto>: std::string (const std::string &, const std::string &)
         <ComplexType|Elaborated>: std::string
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         NamespaceRef: std
         TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:102:17)
         <ComplexType|Typedef>: std::string
            <ComplexType|Record>: std::basic_string<char>
         ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:102:51)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:102:43)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: name(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:102:79)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:102:71)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
      CXXMethod: ValueHandler (Symbol: __ZN9INIReader12ValueHandlerEPvPKcS2_S2_)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:103:16)
      <ComplexType|FunctionProto>: int (void *, const char *, const char *, const char *)
         <BuiltinType|Int>: int
         <ComplexType|Pointer>: void *
                     <ComplexType|Pointer>: const char *
            <BuiltinType|Char_S>: const char
         <ComplexType|Pointer>: const char *
            <BuiltinType|Char_S>: const char
         <ComplexType|Pointer>: const char *
            <BuiltinType|Char_S>: const char
         ParmDecl: user(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:103:35)
         <ComplexType|Pointer>: void *
                     ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:103:53)
         <ComplexType|Pointer>: const char *
            <BuiltinType|Char_S>: const char
         ParmDecl: name(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:103:74)
         <ComplexType|Pointer>: const char *
            <BuiltinType|Char_S>: const char
         ParmDecl: value(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:103:92)
         <ComplexType|Pointer>: const char *
            <BuiltinType|Char_S>: const char
```