### PR TITLE
castdump:funcproto type & computed enum value

### DIFF
--- a/c/clang/_wrap/cursor.cpp
+++ b/c/clang/_wrap/cursor.cpp
@@ -31,6 +31,16 @@ void wrap_clang_getTranslationUnitCursor(CXTranslationUnit uint, CXCursor *cur) 
 
 void wrap_clang_getCursorType(CXCursor *cur, CXType *typ) { *typ = clang_getCursorType(*cur); }
 
+void wrap_clang_getCursorResultType(CXCursor *cur, CXType *typ) { *typ = clang_getCursorResultType(*cur); }
+
+void wrap_clang_getResultType(CXType *typ, CXType *resultTyp) { *resultTyp = clang_getResultType(*typ); }
+
+int wrap_clang_getNumArgTypes(CXType *typ) { return clang_getNumArgTypes(*typ); }
+
+void wrap_clang_getArgType(CXType *typ, unsigned i, CXType *argTyp) { *argTyp = clang_getArgType(*typ, i); }
+
+long long wrap_clang_getEnumConstantDeclValue(CXCursor *cur) { return clang_getEnumConstantDeclValue(*cur); }
+
 void wrap_clang_getPointeeType(CXType *pointerTyp, CXType *pointeeTyp) {
     *pointeeTyp = clang_getPointeeType(*pointerTyp);
 }
@@ -38,8 +48,6 @@ void wrap_clang_getPointeeType(CXType *pointerTyp, CXType *pointeeTyp) {
 void wrap_clang_getArrayElementType(CXType *arrayTyp, CXType *elemTyp) {
     *elemTyp = clang_getArrayElementType(*arrayTyp);
 }
-
-void wrap_clang_getCursorResultType(CXCursor *cur, CXType *typ) { *typ = clang_getCursorResultType(*cur); }
 
 void wrap_clang_getCanonicalType(CXType *typ, CXType *canonicalType) { *canonicalType = clang_getCanonicalType(*typ); }
 

--- a/c/clang/clang.go
+++ b/c/clang/clang.go
@@ -1609,6 +1609,22 @@ func (c Cursor) ResultType() (ret Type) {
 }
 
 /**
+ * Retrieve the integer value of an enum constant declaration as a signed
+ *  long long.
+ *
+ * If the cursor does not reference an enum constant declaration, LLONG_MIN is
+ * returned. Since this is also potentially a valid constant value, the kind of
+ * the cursor must be verified before calling this function.
+ */
+// llgo:link (*Cursor).wrapEnumConstantDeclValue C.wrap_clang_getEnumConstantDeclValue
+func (*Cursor) wrapEnumConstantDeclValue() (ret c.LongLong) {
+	return 0
+}
+func (c Cursor) EnumConstantDeclValue() (ret c.LongLong) {
+	return c.wrapEnumConstantDeclValue()
+}
+
+/**
  * Retrieve the number of non-variadic arguments associated with a given
  * cursor.
  *
@@ -1789,6 +1805,47 @@ func (t Type) String() (ret String) {
 }
 
 /**
+ * Retrieve the return type associated with a function type.
+ *
+ * If a non-function type is passed in, an invalid type is returned.
+ */
+// llgo:link (*Type).wrapResultType C.wrap_clang_getResultType
+func (t *Type) wrapResultType(ret *Type) { return }
+
+func (t Type) ResultType() (ret Type) {
+	t.wrapResultType(&ret)
+	return
+}
+
+/**
+ * Retrieve the number of non-variadic parameters associated with a
+ * function type.
+ *
+ * If a non-function type is passed in, -1 is returned.
+ */
+// llgo:link (*Type).wrapNumArgTypes C.wrap_clang_getNumArgTypes
+func (t *Type) wrapNumArgTypes() (num c.Int) { return 0 }
+
+func (t Type) NumArgTypes() (num c.Int) {
+	return t.wrapNumArgTypes()
+}
+
+// void wrap_clang_getArgType(CXType *typ, unsigned i, CXType *argTyp) { *argTyp = clang_getArgType(*typ, i); }
+/**
+ * Retrieve the type of a parameter of a function type.
+ *
+ * If a non-function type is passed in or the function does not have enough
+ * parameters, an invalid type is returned.
+ */
+// llgo:link (*Type).wrapArgType C.wrap_clang_getArgType
+func (t *Type) wrapArgType(index c.Uint, argTyp *Type) { return }
+
+func (t Type) ArgType(index c.Uint) (ret Type) {
+	t.wrapArgType(index, &ret)
+	return
+}
+
+/**
  * For pointer types, returns the type of the pointee.
  */
 // llgo:link (*Type).wrapPointeeType C.wrap_clang_getPointeeType
@@ -1806,6 +1863,7 @@ func (t Type) PointeeType() (ret Type) {
  */
 // llgo:link (*Type).wrapArrayElementType C.wrap_clang_getArrayElementType
 func (t *Type) wrapArrayElementType(ret *Type) { return }
+
 func (t Type) ArrayElementType() (ret Type) {
 	t.wrapArrayElementType(&ret)
 	return
@@ -1821,6 +1879,7 @@ func (t Type) ArrayElementType() (ret Type) {
  */
 // llgo:link (*Type).wrapCanonicalType C.wrap_clang_getCanonicalType
 func (t *Type) wrapCanonicalType(ret *Type) { return }
+
 func (t Type) CanonicalType() (ret Type) {
 	t.wrapCanonicalType(&ret)
 	return


### PR DESCRIPTION
```
 ClassDecl: INIReader(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:42:7)
   <ComplexType|Record>: INIReader
      CXXAccessSpecifier:  public(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:43:3)
      CXXConstructor: INIReader (Symbol: __ZN9INIReaderC1ERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEE)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:46:22)
      <ComplexType|FunctionProto>: void (const std::string &)
         <BuiltinType|Void>: void
         <ComplexType|LValueReference>: const std::string &
         attribute(visibility): default
         ParmDecl: filename(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:46:51)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:46:43)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
      CXXConstructor: INIReader (Symbol: __ZN9INIReaderC1EPKcm)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:50:22)
      <ComplexType|FunctionProto>: void (const char *, size_t)
         <BuiltinType|Void>: void
         <ComplexType|Pointer>: const char *
            <BuiltinType|Char_S>: const char
         <ComplexType|Elaborated>: size_t
         attribute(visibility): default
         ParmDecl: buffer(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:50:44)
         <ComplexType|Pointer>: const char *
            <BuiltinType|Char_S>: const char
         ParmDecl: buffer_size(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:50:59)
         <ComplexType|Elaborated>: size_t
            TypeRef: size_t(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:50:52)
            <ComplexType|Typedef>: size_t
               <BuiltinType|ULong>: unsigned long
      CXXMethod: ParseError (Symbol: __ZNK9INIReader10ParseErrorEv)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:54:17)
      <ComplexType|FunctionProto>: int () const
         <BuiltinType|Int>: int
         attribute(visibility): default
      CXXMethod: Get (Symbol: __ZNK9INIReader3GetERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_S8_)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:57:25)
      <ComplexType|FunctionProto>: std::string (const std::string &, const std::string &, const std::string &) const
         <ComplexType|Elaborated>: std::string
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         attribute(visibility): default
         NamespaceRef: std
         TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:57:18)
         <ComplexType|Typedef>: std::string
            <ComplexType|Record>: std::basic_string<char>
         ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:57:48)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:57:40)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: name(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:57:76)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:57:68)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: default_value(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:58:48)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:58:40)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
      CXXMethod: GetString (Symbol: __ZNK9INIReader9GetStringERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_S8_)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:62:25)
      <ComplexType|FunctionProto>: std::string (const std::string &, const std::string &, const std::string &) const
         <ComplexType|Elaborated>: std::string
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         attribute(visibility): default
         NamespaceRef: std
         TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:62:18)
         <ComplexType|Typedef>: std::string
            <ComplexType|Record>: std::basic_string<char>
         ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:62:54)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:62:46)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: name(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:62:82)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:62:74)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: default_value(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:63:54)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:63:46)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
      CXXMethod: GetInteger (Symbol: __ZNK9INIReader10GetIntegerERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_l)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:67:18)
      <ComplexType|FunctionProto>: long (const std::string &, const std::string &, long) const
         <BuiltinType|Long>: long
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         <BuiltinType|Long>: long
         attribute(visibility): default
         ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:67:48)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:67:40)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: name(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:67:76)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:67:68)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: default_value(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:67:87)
         <BuiltinType|Long>: long
      CXXMethod: GetInteger64 (Symbol: __ZNK9INIReader12GetInteger64ERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_x)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:71:21)
      <ComplexType|FunctionProto>: int64_t (const std::string &, const std::string &, int64_t) const
         <ComplexType|Elaborated>: int64_t
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|Elaborated>: int64_t
         attribute(visibility): default
         TypeRef: int64_t(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:71:13)
         <ComplexType|Typedef>: int64_t
            <BuiltinType|LongLong>: long long
         ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:71:53)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:71:45)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: name(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:71:81)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:71:73)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: default_value(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:71:95)
         <ComplexType|Elaborated>: int64_t
            TypeRef: int64_t(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:71:87)
            <ComplexType|Typedef>: int64_t
               <BuiltinType|LongLong>: long long
      CXXMethod: GetUnsigned (Symbol: __ZNK9INIReader11GetUnsignedERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_m)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:75:27)
      <ComplexType|FunctionProto>: unsigned long (const std::string &, const std::string &, unsigned long) const
         <BuiltinType|ULong>: unsigned long
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         <BuiltinType|ULong>: unsigned long
         attribute(visibility): default
         ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:75:58)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:75:50)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: name(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:75:86)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:75:78)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: default_value(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:76:53)
         <BuiltinType|ULong>: unsigned long
      CXXMethod: GetUnsigned64 (Symbol: __ZNK9INIReader13GetUnsigned64ERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_y)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:80:22)
      <ComplexType|FunctionProto>: uint64_t (const std::string &, const std::string &, uint64_t) const
         <ComplexType|Elaborated>: uint64_t
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|Elaborated>: uint64_t
         attribute(visibility): default
         TypeRef: uint64_t(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:80:13)
         <ComplexType|Typedef>: uint64_t
            <BuiltinType|ULongLong>: unsigned long long
         ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:80:55)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:80:47)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: name(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:80:83)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:80:75)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: default_value(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:80:98)
         <ComplexType|Elaborated>: uint64_t
            TypeRef: uint64_t(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:80:89)
            <ComplexType|Typedef>: uint64_t
               <BuiltinType|ULongLong>: unsigned long long
      CXXMethod: GetReal (Symbol: __ZNK9INIReader7GetRealERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_d)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:85:20)
      <ComplexType|FunctionProto>: double (const std::string &, const std::string &, double) const
         <BuiltinType|Double>: double
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         <BuiltinType|Double>: double
         attribute(visibility): default
         ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:85:47)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:85:39)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: name(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:85:75)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:85:67)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: default_value(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:85:88)
         <BuiltinType|Double>: double
      CXXMethod: GetBoolean (Symbol: __ZNK9INIReader10GetBooleanERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_b)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:90:18)
      <ComplexType|FunctionProto>: bool (const std::string &, const std::string &, bool) const
         <BuiltinType|Bool>: bool
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         <BuiltinType|Bool>: bool
         attribute(visibility): default
         ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:90:48)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:90:40)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: name(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:90:76)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:90:68)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: default_value(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:90:87)
         <BuiltinType|Bool>: bool
      CXXMethod: HasSection (Symbol: __ZNK9INIReader10HasSectionERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEE)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:94:18)
      <ComplexType|FunctionProto>: bool (const std::string &) const
         <BuiltinType|Bool>: bool
         <ComplexType|LValueReference>: const std::string &
         attribute(visibility): default
         ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:94:48)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:94:40)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
      CXXMethod: HasValue (Symbol: __ZNK9INIReader8HasValueERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:97:18)
      <ComplexType|FunctionProto>: bool (const std::string &, const std::string &) const
         <BuiltinType|Bool>: bool
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         attribute(visibility): default
         ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:97:46)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:97:38)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: name(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:97:74)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:97:66)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
      CXXAccessSpecifier:  private(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:99:3)
      FieldDecl: _error(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:100:9)
      <BuiltinType|Int>: int
      FieldDecl: _values(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:101:40)
      <BuiltinType|Int>: int
      CXXMethod: MakeKey (Symbol: __ZN9INIReader7MakeKeyERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:102:24)
      <ComplexType|FunctionProto>: std::string (const std::string &, const std::string &)
         <ComplexType|Elaborated>: std::string
         <ComplexType|LValueReference>: const std::string &
         <ComplexType|LValueReference>: const std::string &
         NamespaceRef: std
         TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:102:17)
         <ComplexType|Typedef>: std::string
            <ComplexType|Record>: std::basic_string<char>
         ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:102:51)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:102:43)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
         ParmDecl: name(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:102:79)
         <ComplexType|LValueReference>: const std::string &
            NamespaceRef: std
            TypeRef: std::string(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:102:71)
            <ComplexType|Typedef>: std::string
               <ComplexType|Record>: std::basic_string<char>
      CXXMethod: ValueHandler (Symbol: __ZN9INIReader12ValueHandlerEPvPKcS2_S2_)(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:103:16)
      <ComplexType|FunctionProto>: int (void *, const char *, const char *, const char *)
         <BuiltinType|Int>: int
         <ComplexType|Pointer>: void *
            <BuiltinType|Void>: void
         <ComplexType|Pointer>: const char *
            <BuiltinType|Char_S>: const char
         <ComplexType|Pointer>: const char *
            <BuiltinType|Char_S>: const char
         <ComplexType|Pointer>: const char *
            <BuiltinType|Char_S>: const char
         ParmDecl: user(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:103:35)
         <ComplexType|Pointer>: void *
            <BuiltinType|Void>: void
         ParmDecl: section(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:103:53)
         <ComplexType|Pointer>: const char *
            <BuiltinType|Char_S>: const char
         ParmDecl: name(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:103:74)
         <ComplexType|Pointer>: const char *
            <BuiltinType|Char_S>: const char
         ParmDecl: value(Loc:/opt/homebrew/Cellar/inih/58/include/INIReader.h:103:92)
         <ComplexType|Pointer>: const char *
            <BuiltinType|Char_S>: const char
```