### PR TITLE
llcppg/ast:builtin type

### DIFF
--- a/chore/llcppg/ast/ast.go
+++ b/chore/llcppg/ast/ast.go
@@ -63,11 +63,18 @@ func (*BasicLit) exprNode() {}
 type TypeKind uint
 
 const (
-	Int TypeKind = iota
-	Char
-	Float
-	Complex
+	Void TypeKind = iota
 	Bool
+	Char
+	Char16
+	Char32
+	WChar
+	Int
+	Int128
+	Float
+	Float16
+	Float128
+	Complex
 )
 
 type TypeFlag uint


### PR DESCRIPTION
* remove complex, it's more likely an expr;
*  not concern with Objective-C,Accum,IBM128,BFloat16,  it's not part of standard C or C++


- [ ] uncertain whether CXType_Overload and CXType_Dependent need to be included in the builtin types




| Type                 | TypeFlag             | TypeKind |
| -------------------- | -------------------- | -------- |
| CXType\_Void         |                      | Void     |
| CXType\_Bool         |                      | Bool     |
| CXType\_Char\_U      | Unsigned             | Char     |
| CXType\_UChar        | Unsigned             | Char     |
| CXType\_Char16       |                      | Char16          |
| CXType\_Char32       |                      |  Char32        |
| CXType\_UShort       | Unsigned \| Short    | Int      |
| CXType\_UInt         | Unsigned             | Int      |
| CXType\_ULong        | Unsigned \| Long     | Int      |
| CXType\_ULongLong    | Unsigned \| LongLong | Int      |
| CXType\_UInt128      | Unsigned             | Int128      |
| CXType\_Char\_S      | Signed               | Char     |
| CXType\_SChar        | Signed               | Char     |
| CXType\_WChar        |                      |    WChar      |
| CXType\_Short        | Short      | Int      |
| CXType\_Int          |             | Int      |
| CXType\_Long         |  Long       | Int      |
| CXType\_LongLong     | LongLong   | Int      |
| CXType\_Int128       |               | Int128      |
| CXType\_Float        |                      | Float    |
| CXType\_Double       | Double               | Float    |
| CXType\_LongDouble   | Long \| Double       | Float    |
| CXType\_NullPtr      |                      |  NullPtr        |
| CXType\_Overload     |                      |          |
| CXType\_Dependent    |                      |          |
| CXType\_ObjCId       |                      |          |
| CXType\_ObjCClass    |                      |          |
| CXType\_ObjCSel      |                      |          |
| CXType\_Float128     |                      |  Float128        |
| CXType\_Half         |                      |    Float16        |
| CXType\_Float16      |                      |  Float16        |
| CXType\_ShortAccum   |                      |          |
| CXType\_Accum        |                      |          |
| CXType\_LongAccum    |                      |          |
| CXType\_UShortAccum  |                      |          |
| CXType\_UAccum       |                      |          |
| CXType\_ULongAccum   |                      |          |
| CXType\_BFloat16     |                      |        |
| CXType\_Ibm128       |                      |         |

