### PR TITLE
feat(py): Add more method to tuple object

### DIFF
--- a/py/tuple.go
+++ b/py/tuple.go
@@ -32,8 +32,22 @@ func NewTuple(len uintptr) *Object
 // llgo:link (*Object).TupleLen C.PyTuple_Size
 func (t *Object) TupleLen() uintptr { return 0 }
 
-// Return the object at position pos in the tuple pointed to by p. If pos is
+// Return the object at position pos in the tuple pointed to t. If pos is
 // negative or out of bounds, return nil and set an IndexError exception.
 //
 // llgo:link (*Object).TupleItem C.PyTuple_GetItem
 func (t *Object) TupleItem(index uintptr) *Object { return nil }
+
+// Insert a reference to object o at position pos of the tuple pointed to by t.
+// Return 0 on success. If pos is out of bounds, return -1 and set an
+// IndexError exception.
+//
+// llgo:link (*Object).TupleSetItem C.PyTuple_SetItem
+func (t *Object) TupleSetItem(index int, o *Object) int { return 0 }
+
+// Return the slice of the tuple pointed to by t between low and high,
+// or NULL on failure. This is the equivalent of the Python expression
+// p[low:high]. Indexing from the end of the tuple is not supported.
+//
+// llgo:link (*Object).TupleSlice C.PyTuple_GetSlice
+func (l *Object) TupleSlice(low, high int) *Object { return nil }


### PR DESCRIPTION
Works as expected:

```go
package main

import (
	"github.com/goplus/llgo/py"
	"github.com/goplus/llgo/py/std"
)

func main() {
	t := py.NewTuple(3)
	t.TupleSetItem(0, py.Str("111"))
	t.TupleSetItem(1, py.Str("222"))
	t.TupleSetItem(2, py.Str("333"))
	std.Print(t)
	s := t.TupleSlice(1, 3)
	std.Print(s)
}
```

```
$ ./llgo build -o a a.go
# command-line-arguments

$ ./a 
('111', '222', '333')
('222', '333')
```