### PR TITLE
cmptest: add support for comparison with `llgo.expect` files

### DIFF
--- a/cmd/internal/run/run.go
+++ b/cmd/internal/run/run.go
@@ -37,8 +37,8 @@ var Cmd = &base.Command{
 
 // llgo cmptest
 var CmpTestCmd = &base.Command{
-	UsageLine: "llgo cmptest [build flags] package [arguments...]",
-	Short:     "Compile programs by llgo and go, run them and do comparative tests (stdout/stderr/exitcode)",
+	UsageLine: "llgo cmptest [-genexpect] [build flags] package [arguments...]",
+	Short:     "Compile and run with llgo, compare result (stdout/stderr/exitcode) with go or llgo.expect; generate llgo.expect file if -genexpect is specified",
 }
 
 func init() {
@@ -55,9 +55,13 @@ func runCmpTest(cmd *base.Command, args []string) {
 }
 
 func runCmdEx(cmd *base.Command, args []string, mode build.Mode) {
+	conf := build.NewDefaultConf(mode)
+	if mode == build.ModeCmpTest && len(args) > 0 && args[0] == "-genexpect" {
+		conf.GenExpect = true
+		args = args[1:]
+	}
 	args, runArgs, err := parseRunArgs(args)
 	check(err)
-	conf := build.NewDefaultConf(mode)
 	conf.RunArgs = runArgs
 	build.Do(args, conf)
 }

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -64,11 +64,12 @@ func needLLFile(mode Mode) bool {
 }
 
 type Config struct {
-	BinPath string
-	AppExt  string   // ".exe" on Windows, empty on Unix
-	OutFile string   // only valid for ModeBuild when len(pkgs) == 1
-	RunArgs []string // only valid for ModeRun
-	Mode    Mode
+	BinPath   string
+	AppExt    string   // ".exe" on Windows, empty on Unix
+	OutFile   string   // only valid for ModeBuild when len(pkgs) == 1
+	RunArgs   []string // only valid for ModeRun
+	GenExpect bool     // only valid for ModeCmpTest
+	Mode      Mode
 }
 
 func NewDefaultConf(mode Mode) *Config {
@@ -462,7 +463,7 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, llFiles 
 			os.Exit(s.ExitCode())
 		}
 	case ModeCmpTest:
-		cmpTest("", pkgPath, app, conf.RunArgs)
+		cmpTest(filepath.Dir(pkg.GoFiles[0]), pkgPath, app, conf.GenExpect, conf.RunArgs)
 	}
 	return
 }


### PR DESCRIPTION
Fixes #671