### PR TITLE
fix(py): Change uintptr to int in container types

### DIFF
--- a/py/dict.go
+++ b/py/dict.go
@@ -58,6 +58,6 @@ func (d *Object) DictGetItem(key *Object) *Object { return nil }
 // Return the number of items in the dictionary.
 //
 // llgo:link (*Object).DictSize C.PyDict_Size
-func (d *Object) DictSize() uintptr { return 0 }
+func (d *Object) DictSize() int { return 0 }
 
 // -----------------------------------------------------------------------------

--- a/py/list.go
+++ b/py/list.go
@@ -30,32 +30,32 @@ func List(__llgo_va_list ...any) *Object
 // Return a new list of length len on success, or nil on failure.
 //
 //go:linkname NewList C.PyList_New
-func NewList(len uintptr) *Object
+func NewList(len int) *Object
 
 // Return the length of the list object in list; this is equivalent to len(list)
 // on a list object.
 //
 // llgo:link (*Object).ListLen C.PyList_Size
-func (l *Object) ListLen() uintptr { return 0 }
+func (l *Object) ListLen() int { return 0 }
 
 // Return the object at position index in the list pointed to by list. The position
 // must be non-negative; indexing from the end of the list is not supported. If index
 // is out of bounds (<0 or >=len(list)), return nil and set an IndexError exception.
 //
 // llgo:link (*Object).ListItem C.PyList_GetItem
-func (l *Object) ListItem(index uintptr) *Object { return nil }
+func (l *Object) ListItem(index int) *Object { return nil }
 
 // Set the item at index index in list to item. Return 0 on success. If index is out
 // of bounds, return -1 and set an IndexError exception.
 //
 // llgo:link (*Object).ListSetItem C.PyList_SetItem
-func (l *Object) ListSetItem(index uintptr, item *Object) c.Int { return 0 }
+func (l *Object) ListSetItem(index int, item *Object) c.Int { return 0 }
 
 // Insert the item item into list list in front of index index. Return 0 if successful;
 // return -1 and set an exception if unsuccessful. Analogous to list.insert(index, item).
 //
 // llgo:link (*Object).ListInsert C.PyList_Insert
-func (l *Object) ListInsert(index uintptr, item *Object) c.Int { return 0 }
+func (l *Object) ListInsert(index int, item *Object) c.Int { return 0 }
 
 // Append the object item at the end of list list. Return 0 if successful; return -1
 // and set an exception if unsuccessful. Analogous to list.append(item).
@@ -68,7 +68,7 @@ func (l *Object) ListAppend(item *Object) c.Int { return 0 }
 // Indexing from the end of the list is not supported.
 //
 // llgo:link (*Object).ListSlice C.PyList_GetSlice
-func (l *Object) ListSlice(low, high uintptr) *Object { return nil }
+func (l *Object) ListSlice(low, high int) *Object { return nil }
 
 // Set the slice of list between low and high to the contents of itemlist. Analogous
 // to list[low:high] = itemlist. The itemlist may be NULL, indicating the assignment
@@ -76,7 +76,7 @@ func (l *Object) ListSlice(low, high uintptr) *Object { return nil }
 // from the end of the list is not supported.
 //
 // llgo:link (*Object).ListSetSlice C.PyList_SetSlice
-func (l *Object) ListSetSlice(low, high uintptr, itemlist *Object) c.Int { return 0 }
+func (l *Object) ListSetSlice(low, high int, itemlist *Object) c.Int { return 0 }
 
 // Sort the items of list in place. Return 0 on success, -1 on failure. This is equivalent
 // to list.sort().

--- a/py/tuple.go
+++ b/py/tuple.go
@@ -25,18 +25,18 @@ import (
 // Return a new tuple object of size len, or nil on failure.
 //
 //go:linkname NewTuple C.PyTuple_New
-func NewTuple(len uintptr) *Object
+func NewTuple(len int) *Object
 
 // Take a pointer to a tuple object, and return the size of that tuple.
 //
 // llgo:link (*Object).TupleLen C.PyTuple_Size
-func (t *Object) TupleLen() uintptr { return 0 }
+func (t *Object) TupleLen() int { return 0 }
 
 // Return the object at position pos in the tuple pointed to t. If pos is
 // negative or out of bounds, return nil and set an IndexError exception.
 //
 // llgo:link (*Object).TupleItem C.PyTuple_GetItem
-func (t *Object) TupleItem(index uintptr) *Object { return nil }
+func (t *Object) TupleItem(index int) *Object { return nil }
 
 // Insert a reference to object o at position pos of the tuple pointed to by t.
 // Return 0 on success. If pos is out of bounds, return -1 and set an


### PR DESCRIPTION
These functions using `Py_ssize_t` types, which is [just C's `ssize_t`](https://peps.python.org/pep-0353/), and it's **Signed** SIZE Type, which size is just the word size (32bit on 32bit CPU). So I think we should change it to go's `int` type.