### PR TITLE
feat(py): Add Python tuple constructor helper

### DIFF
--- a/cl/_testpy/max/in.go
+++ b/cl/_testpy/max/in.go
@@ -12,4 +12,8 @@ func main() {
 	list := py.List(3.0, 9.0, 23.0, 100.0)
 	y := std.Max(std.Iter(list))
 	std.Print(y)
+
+	tuple := py.Tuple(1.0, 2.0, 3.0)
+	z := std.Max(std.Iter(tuple))
+	std.Print(z)
 }

--- a/cl/_testpy/max/out.ll
+++ b/cl/_testpy/max/out.ll
@@ -58,6 +58,19 @@ _llgo_0:
   %22 = call ptr (ptr, ...) @PyObject_CallFunctionObjArgs(ptr %21, ptr %20, ptr null)
   %23 = load ptr, ptr @__llgo_py.builtins.print, align 8
   %24 = call ptr (ptr, ...) @PyObject_CallFunctionObjArgs(ptr %23, ptr %22, ptr null)
+  %25 = call ptr @PyTuple_New(i64 3)
+  %26 = call ptr @PyFloat_FromDouble(double 1.000000e+00)
+  %27 = call i32 @PyTuple_SetItem(ptr %25, i64 0, ptr %26)
+  %28 = call ptr @PyFloat_FromDouble(double 2.000000e+00)
+  %29 = call i32 @PyTuple_SetItem(ptr %25, i64 1, ptr %28)
+  %30 = call ptr @PyFloat_FromDouble(double 3.000000e+00)
+  %31 = call i32 @PyTuple_SetItem(ptr %25, i64 2, ptr %30)
+  %32 = load ptr, ptr @__llgo_py.builtins.iter, align 8
+  %33 = call ptr @PyObject_CallOneArg(ptr %32, ptr %25)
+  %34 = load ptr, ptr @__llgo_py.builtins.max, align 8
+  %35 = call ptr (ptr, ...) @PyObject_CallFunctionObjArgs(ptr %34, ptr %33, ptr null)
+  %36 = load ptr, ptr @__llgo_py.builtins.print, align 8
+  %37 = call ptr (ptr, ...) @PyObject_CallFunctionObjArgs(ptr %36, ptr %35, ptr null)
   ret i32 0
 }
 
@@ -74,6 +87,10 @@ declare ptr @PyList_New(i64)
 declare i32 @PyList_SetItem(ptr, i64, ptr)
 
 declare ptr @PyObject_CallOneArg(ptr, ptr)
+
+declare ptr @PyTuple_New(i64)
+
+declare i32 @PyTuple_SetItem(ptr, i64, ptr)
 
 declare void @llgoLoadPyModSyms(ptr, ...)
 

--- a/cl/import.go
+++ b/cl/import.go
@@ -391,8 +391,9 @@ const (
 
 	llgoFuncAddr = llgoInstrBase + 0xd
 
-	llgoPyList = llgoInstrBase + 0x10
-	llgoPyStr  = llgoInstrBase + 0x11
+	llgoPyList  = llgoInstrBase + 0x10
+	llgoPyStr   = llgoInstrBase + 0x11
+	llgoPyTuple = llgoInstrBase + 0x12
 
 	llgoAtomicLoad    = llgoInstrBase + 0x1d
 	llgoAtomicStore   = llgoInstrBase + 0x1e

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -216,6 +216,7 @@ var llgoInstrs = map[string]int{
 	"funcAddr":    llgoFuncAddr,
 	"pystr":       llgoPyStr,
 	"pyList":      llgoPyList,
+	"pyTuple":     llgoPyTuple,
 	"sigjmpbuf":   llgoSigjmpbuf,
 	"sigsetjmp":   llgoSigsetjmp,
 	"siglongjmp":  llgoSiglongjmp,
@@ -354,6 +355,9 @@ func (p *context) call(b llssa.Builder, act llssa.DoAction, call *ssa.CallCommon
 		case llgoPyList:
 			args := p.compileValues(b, args, fnHasVArg)
 			ret = b.PyList(args...)
+		case llgoPyTuple:
+			args := p.compileValues(b, args, fnHasVArg)
+			ret = b.PyTuple(args...)
 		case llgoPyStr:
 			ret = pystr(b, args)
 		case llgoCstr:

--- a/py/tuple.go
+++ b/py/tuple.go
@@ -22,6 +22,9 @@ import (
 
 // https://docs.python.org/3/c-api/tuple.html
 
+//go:linkname Tuple llgo.pyTuple
+func Tuple(__llgo_va_list ...any) *Object
+
 // Return a new tuple object of size len, or nil on failure.
 //
 //go:linkname NewTuple C.PyTuple_New

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -169,6 +169,8 @@ type aProgram struct {
 	pyImpTy      *types.Signature
 	pyNewList    *types.Signature
 	pyListSetI   *types.Signature
+	pyNewTuple   *types.Signature
+	pyTupleSetI  *types.Signature
 	floatFromDbl *types.Signature
 	callNoArgs   *types.Signature
 	callOneArg   *types.Signature

--- a/ssa/python.go
+++ b/ssa/python.go
@@ -347,14 +347,14 @@ func (b Builder) PyNewTuple(n Expr) (ret Expr) {
 	return b.Call(fn, n)
 }
 
-// PyListSetItem(list *Object, index uintptr, item *Object) c.Int
+// PyTupleSetItem(list *Object, index uintptr, item *Object) c.Int
 func (b Builder) PyTupleSetItem(list, index, item Expr) (ret Expr) {
 	prog := b.Prog
 	fn := b.Pkg.pyFunc("PyTuple_SetItem", prog.tyTupleSetItem())
 	return b.Call(fn, list, index, item)
 }
 
-// PyList(args ...Expr) *Object
+// PyTuple(args ...Expr) *Object
 func (b Builder) PyTuple(args ...Expr) (ret Expr) {
 	prog := b.Prog
 	n := len(args)


### PR DESCRIPTION
Add a `py.Tuple` constructor which is similar to the exist `py.List`. Usage:

```
package main

import (
	"github.com/goplus/llgo/py"
	"github.com/goplus/llgo/py/std"
)

func main() {
	t := py.Tuple(py.Str("foo"), py.Str("bar"), py.Str("baz"))
	std.Print(t)
}
```

```
$ ./llgo build -o a a.go
# command-line-arguments
$ ./a 
('foo', 'bar', 'baz')
```