### PR TITLE
gc: fix missing pthread registration causing unknown thread error

### DIFF
--- a/c/pthread/_pthread/pthread_gc.c
+++ b/c/pthread/_pthread/pthread_gc.c
@@ -1,0 +1,11 @@
+#define GC_THREADS
+#include <gc.h>
+#include <pthread.h>
+
+int llgoPthreadCreate(pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine)(void *), void *arg) {
+    return GC_pthread_create(thread, attr, start_routine, arg);
+}
+
+int llgoPthreadJoin(pthread_t thread, void **retval) {
+    return GC_pthread_join(thread, retval);
+}

--- a/c/pthread/_pthread/pthread_nogc.c
+++ b/c/pthread/_pthread/pthread_nogc.c
@@ -1,0 +1,9 @@
+#include <pthread.h>
+
+int llgoPthreadCreate(pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine)(void *), void *arg) {
+    return pthread_create(thread, attr, start_routine, arg);
+}
+
+int llgoPthreadJoin(pthread_t thread, void **retval) {
+    return pthread_join(thread, retval);
+}

--- a/c/pthread/pthread.go
+++ b/c/pthread/pthread.go
@@ -22,10 +22,6 @@ import (
 	"github.com/goplus/llgo/c"
 )
 
-const (
-	LLGoPackage = "decl"
-)
-
 func __noop__() c.Int {
 	return 0
 }
@@ -65,7 +61,7 @@ type Thread = *aThread
 //
 // See https://man7.org/linux/man-pages/man3/pthread_create.3.html
 //
-//go:linkname Create C.pthread_create
+//go:linkname Create C.llgoPthreadCreate
 func Create(pthread *Thread, attr *Attr, routine func(c.Pointer) c.Pointer, arg c.Pointer) c.Int
 
 // The pthread_join() function waits for the thread specified by
@@ -86,7 +82,7 @@ func Create(pthread *Thread, attr *Attr, routine func(c.Pointer) c.Pointer, arg 
 //
 // See https://man7.org/linux/man-pages/man3/pthread_join.3.html
 //
-//go:linkname Join C.pthread_join
+//go:linkname Join C.llgoPthreadJoin
 func Join(thread Thread, retval *c.Pointer) c.Int
 
 // The pthread_exit() function terminates the calling thread and

--- a/c/pthread/pthread_gc.go
+++ b/c/pthread/pthread_gc.go
@@ -1,0 +1,25 @@
+//go:build !nogc
+// +build !nogc
+
+/*
+ * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pthread
+
+const (
+	LLGoFiles   = "$(pkg-config --cflags bdw-gc): _pthread/pthread_gc.c"
+	LLGoPackage = "link: $(pkg-config --libs bdw-gc); -lgc"
+)

--- a/c/pthread/pthread_nogc.go
+++ b/c/pthread/pthread_nogc.go
@@ -1,0 +1,25 @@
+//go:build nogc
+// +build nogc
+
+/*
+ * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pthread
+
+const (
+	LLGoFiles   = "_pthread/pthread_nogc.c"
+	LLGoPackage = "link"
+)

--- a/cl/_testgo/goroutine/out.ll
+++ b/cl/_testgo/goroutine/out.ll
@@ -51,7 +51,7 @@ _llgo_0:
   %15 = getelementptr inbounds { { ptr, ptr }, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %13, i32 0, i32 1
   store %"github.com/goplus/llgo/internal/runtime.String" %12, ptr %15, align 8
   %16 = alloca i8, i64 8, align 1
-  %17 = call i32 @pthread_create(ptr %16, ptr null, ptr @"main._llgo_routine$1", ptr %13)
+  %17 = call i32 @llgoPthreadCreate(ptr %16, ptr null, ptr @"main._llgo_routine$1", ptr %13)
   br label %_llgo_3
 
 _llgo_1:                                          ; preds = %_llgo_3
@@ -104,7 +104,7 @@ _llgo_0:
 
 declare void @free(ptr)
 
-declare i32 @pthread_create(ptr, ptr, ptr, ptr)
+declare i32 @llgoPthreadCreate(ptr, ptr, ptr, ptr)
 
 declare void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String")
 

--- a/ssa/goroutine.go
+++ b/ssa/goroutine.go
@@ -51,7 +51,7 @@ func (p Program) tyPthreadCreate() *types.Signature {
 }
 
 func (b Builder) pthreadCreate(pp, attr, routine, arg Expr) Expr {
-	fn := b.Pkg.cFunc("pthread_create", b.Prog.tyPthreadCreate())
+	fn := b.Pkg.cFunc("llgoPthreadCreate", b.Prog.tyPthreadCreate())
 	return b.Call(fn, pp, attr, routine, arg)
 }
 


### PR DESCRIPTION
- Use `GC_pthread_create` instead of `pthread_create` when GC is enabled.