### PR TITLE
llcppg/ast:scoping for Tagexpr

### DIFF
--- a/chore/llcppg/ast/ast.go
+++ b/chore/llcppg/ast/ast.go
@@ -130,10 +130,10 @@ const (
 	Class
 )
 
-// struct/union/enum/class Name
+// struct/union/enum/class (A::B::)Name
 type TagExpr struct {
 	Tag  Tag
-	Name *Ident
+	Name Expr // ScopingExpr, Ident
 }
 
 func (*TagExpr) exprNode() {}


### PR DESCRIPTION
To Describe  a  `Fully Qualified Name Declaration with Struct Tag`,like follow
```c++
struct outer::inner::MyStruct s;
```
```
&TagExpr{
    Tag: Struct,
    Name: &ScopingExpr{
        Parent: &Ident{Name: "outer"},
        X: &ScopingExpr{
            Parent: &Ident{Name: "inner"},
            X: &Ident{Name: "MyStruct"},
        },
    },
}

```