### PR TITLE
llcppg/ast:func mangle name

### DIFF
--- a/chore/llcppg/ast/ast.go
+++ b/chore/llcppg/ast/ast.go
@@ -317,10 +317,11 @@ func (*EnumTypeDecl) declNode() {}
 // Ret Name(Params);
 type FuncDecl struct {
 	DeclBase
-	Name     *Ident
-	Type     *FuncType
-	IsInline bool
-	IsStatic bool
+	Name        *Ident
+	MangledName string // C: same as Name, C++: mangled
+	Type        *FuncType
+	IsInline    bool
+	IsStatic    bool
 
 	// Class method specific fields
 	IsConst       bool // const member function


### PR DESCRIPTION
 In C header files, this is not mangled and matches the Name. In C++, it's mangled according to C++ name mangling rules.