### PR TITLE
castdump:use UnderlyingType instead CanonicalType in typedef

### DIFF
--- a/chore/_xtool/castdump/castdump.go
+++ b/chore/_xtool/castdump/castdump.go
@@ -61,7 +61,9 @@ func printType(t clang.Type, data *Data) {
 	case clang.TypeIncompleteArray, clang.TypeVariableArray, clang.TypeDependentSizedArray, clang.TypeConstantArray:
 		printType(t.ArrayElementType(), data)
 	case clang.TypeTypedef:
-		printType(t.CanonicalType(), data)
+		printType(t.TypeDeclaration().TypedefDeclUnderlyingType(), data)
+	case clang.TypeElaborated:
+		printType(t.NamedType(), data)
 	case clang.TypeFunctionProto:
 		printType(t.ResultType(), data)
 		for i := 0; i < int(t.NumArgTypes()); i++ {


### PR DESCRIPTION
```cpp
typedef struct A {
    int x;
} *MyStruct;
```
```Diff
   StructDecl: A(Loc:./a.h:1:16)
   <ComplexType|Record>: A
      FieldDecl: x(Loc:./a.h:2:9)
      <BuiltinType|Int>: int
   TypedefDecl: MyStruct(Loc:./a.h:3:4)
   <ComplexType|Typedef>: MyStruct
-     <ComplexType|Pointer>: A *
-        <ComplexType|Record>: A
+     <ComplexType|Pointer>: struct A *
+        <ComplexType|Elaborated>: struct A
+           <ComplexType|Record>: A
      StructDecl: A(Loc:./a.h:1:16)
      <ComplexType|Record>: A
         FieldDecl: x(Loc:./a.h:2:9)
         <BuiltinType|Int>: int
```

在更新之前，对于Typedef是使用CanonicalType获得原始类型的，该类型即是Typedef 对应的UnderlyingType  Desugar后的类型，而在libclang的树中，应该使用UnderlyingType访问Typedef对应的类型。

对于一个复杂类型的引用会保留 elaborated类型，该类型保留了引用复杂类型时的信息，比如对于一个声明的结构体，可以区分是通过struct a引用，还是直接通过 a 名称引用  
```
/**
 * Return the canonical type for a CXType.
 *
 * Clang's type system explicitly models typedefs and all the ways
 * a specific type can be represented.  The canonical type is the underlying
 * type with all the "sugar" removed.  For example, if 'T' is a typedef
 * for 'int', the canonical type for 'T' would be 'int'.
 */
CINDEX_LINKAGE CXType clang_getCanonicalType(CXType T);
```