### PR TITLE
llcppg/ast:elaborate type's uid

### DIFF
--- a/chore/llcppg/ast/ast.go
+++ b/chore/llcppg/ast/ast.go
@@ -247,6 +247,7 @@ func (*FuncType) exprNode() {}
 // ------------------------------------------------
 
 type RecordType struct {
+	Uid     string // Unified Symbol Resolution (USR)
 	Tag     Tag
 	Fields  *FieldList
 	Methods []*FuncDecl
@@ -298,6 +299,7 @@ type EnumItem struct {
 func (*EnumItem) exprNode() {}
 
 type EnumType struct {
+	Uid   string // Unified Symbol Resolution (USR)
 	Items []*EnumItem
 }
 


### PR DESCRIPTION
When a typedef assigns multiple aliases to the same anonymous RecordType or EnumType, it creates a corresponding number of embedded RecordTypes or EnumTypes. However, these actually point to the same underlying type. A uid (Unique Identifier) attribute is added to these ElaboratedTypes, expected to be represented using the Unified Symbol Resolution (USR) format.
#### Example
```c
typedef struct { int x; int y; } Point, *PointPtr;
```
#### Related Api
```c
/**
 * Retrieve a Unified Symbol Resolution (USR) for the entity referenced
 * by the given cursor.
 *
 * A Unified Symbol Resolution (USR) is a string that identifies a particular
 * entity (function, class, variable, etc.) within a program. USRs can be
 * compared across translation units to determine, e.g., when references in
 * one translation refer to an entity defined in another translation unit.
 */
CINDEX_LINKAGE CXString clang_getCursorUSR(CXCursor);
```