### PR TITLE
llcppsymg:parse c / c++ &  output  func proto

### DIFF
--- a/chore/_xtool/llcppsymg/clangutils/clangutils.go
+++ b/chore/_xtool/llcppsymg/clangutils/clangutils.go
@@ -1,0 +1,72 @@
+package clangutils
+
+import (
+	"errors"
+	"unsafe"
+
+	"github.com/goplus/llgo/c"
+	"github.com/goplus/llgo/c/clang"
+)
+
+type Config struct {
+	File  string
+	Temp  bool
+	Args  []string
+	IsCpp bool
+	Index *clang.Index
+}
+
+func CreateTranslationUnit(config *Config) (*clang.Index, *clang.TranslationUnit, error) {
+	// default use the c/c++ standard of clang; c:gnu17 c++:gnu++17
+	// https://clang.llvm.org/docs/CommandGuide/clang.html
+	defaultArgs := []string{"-x", "c"}
+	if config.IsCpp {
+		defaultArgs = []string{"-x", "c++"}
+	}
+	allArgs := append(defaultArgs, config.Args...)
+
+	cArgs := make([]*c.Char, len(allArgs))
+	for i, arg := range allArgs {
+		cArgs[i] = c.AllocaCStr(arg)
+	}
+
+	var index *clang.Index
+	if config.Index != nil {
+		index = config.Index
+	} else {
+		index = clang.CreateIndex(0, 0)
+	}
+
+	var unit *clang.TranslationUnit
+
+	if config.Temp {
+		content := c.AllocaCStr(config.File)
+		tempFile := &clang.UnsavedFile{
+			Filename: c.Str("temp.h"),
+			Contents: content,
+			Length:   c.Ulong(c.Strlen(content)),
+		}
+
+		unit = index.ParseTranslationUnit(
+			tempFile.Filename,
+			unsafe.SliceData(cArgs), c.Int(len(cArgs)),
+			tempFile, 1,
+			clang.DetailedPreprocessingRecord,
+		)
+
+	} else {
+		cFile := c.AllocaCStr(config.File)
+		unit = index.ParseTranslationUnit(
+			cFile,
+			unsafe.SliceData(cArgs), c.Int(len(cArgs)),
+			nil, 0,
+			clang.DetailedPreprocessingRecord,
+		)
+	}
+
+	if unit == nil {
+		return nil, nil, errors.New("failed to parse translation unit")
+	}
+
+	return index, unit, nil
+}

--- a/chore/_xtool/llcppsymg/clangutils/clangutils.go
+++ b/chore/_xtool/llcppsymg/clangutils/clangutils.go
@@ -70,3 +70,16 @@ func CreateTranslationUnit(config *Config) (*clang.Index, *clang.TranslationUnit
 
 	return index, unit, nil
 }
+
+// Traverse up the semantic parents
+func BuildScopingParts(cursor clang.Cursor) []string {
+	var parts []string
+	for cursor.IsNull() != 1 && cursor.Kind != clang.CursorTranslationUnit {
+		name := cursor.String()
+		qualified := c.GoString(name.CStr())
+		parts = append([]string{qualified}, parts...)
+		cursor = cursor.SemanticParent()
+		name.Dispose()
+	}
+	return parts
+}

--- a/chore/_xtool/llcppsymg/llcppsymg.go
+++ b/chore/_xtool/llcppsymg/llcppsymg.go
@@ -61,7 +61,7 @@ func main() {
 	check(err)
 
 	filepaths := genHeaderFilePath(conf.CFlags, conf.Include)
-	headerInfos, err := parse.ParseHeaderFile(filepaths, conf.TrimPrefixes)
+	headerInfos, err := parse.ParseHeaderFile(filepaths, conf.TrimPrefixes, conf.Cplusplus)
 	check(err)
 
 	symbolInfo := getCommonSymbols(symbols, headerInfos, conf.TrimPrefixes)

--- a/chore/_xtool/llcppsymg/parse/parse.go
+++ b/chore/_xtool/llcppsymg/parse/parse.go
@@ -53,9 +53,35 @@ func (c *Context) removePrefix(str string) string {
 	return str
 }
 
-func (c *Context) genGoName(name string) string {
-	class := c.removePrefix(c.className)
+func toTitle(s string) string {
+	if s == "" {
+		return ""
+	}
+	return strings.ToUpper(s[:1]) + strings.ToLower(s[1:])
+}
+
+func toCamel(originName string) string {
+	if originName == "" {
+		return ""
+	}
+	subs := strings.Split(string(originName), "_")
+	name := ""
+	for _, sub := range subs {
+		name += toTitle(sub)
+	}
+	return name
+}
+
+// 1. remove prefix from config
+// 2. convert to camel case
+func (c *Context) toGoName(name string) string {
 	name = c.removePrefix(name)
+	return toCamel(name)
+}
+
+func (c *Context) genGoName(name string) string {
+	class := c.toGoName(c.className)
+	name = c.toGoName(name)
 
 	var baseName string
 	if class == "" {

--- a/chore/_xtool/llcppsymg/parse/parse.go
+++ b/chore/_xtool/llcppsymg/parse/parse.go
@@ -134,14 +134,14 @@ func visit(cursor, parent clang.Cursor, clientData c.Pointer) clang.ChildVisitRe
 }
 
 func ParseHeaderFile(filepaths []string, prefixes []string, isCpp bool) (map[string]string, error) {
-
 	context = newContext(prefixes)
-
+	index := clang.CreateIndex(0, 0)
 	for _, filename := range filepaths {
-		index, unit, err := clangutils.CreateTranslationUnit(&clangutils.Config{
+		_, unit, err := clangutils.CreateTranslationUnit(&clangutils.Config{
 			File:  filename,
 			Temp:  false,
 			IsCpp: isCpp,
+			Index: index,
 		})
 		if err != nil {
 			return nil, errors.New("Unable to parse translation unit for file " + filename)
@@ -151,7 +151,7 @@ func ParseHeaderFile(filepaths []string, prefixes []string, isCpp bool) (map[str
 		context.setCurrentFile(filename)
 		clang.VisitChildren(cursor, visit, nil)
 		unit.Dispose()
-		index.Dispose()
 	}
+	index.Dispose()
 	return context.symbolMap, nil
 }


### PR DESCRIPTION
* 将`llcppsymg.symb.json`的函数原型输出修改为通过libclang中获得头文件中函数签名以及向上递归语法父级来构建，之前的实现方式是通过`manglename`直接`demangle`来获取的函数签名，但这个形式输出的内容实际上并不易读，比如一个 `const std:string &`,会输出为` std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&`,对于使用该工具的用户来说，并不直观
**C++**
```json
  {
    "mangle": "_ZN9INIReader12ValueHandlerEPvPKcS2_S2_",
    "c++": "INIReader::ValueHandler(void*, char const*, char const*, char const*)",
    "go": "(*Reader).ValueHandler"
  },
  {
    "mangle": "_ZN9INIReader7MakeKeyERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_",
    "c++": "INIReader::MakeKey(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)",
    "go": "(*Reader).MakeKey"
  },
```
而通过libclang通过头文件获得函数签名的方式，不但能保留足够的信息，对于这种string也会输出为 `const std:string &`，并且对于C语言的符号来说，并不包含函数参数，所以也不能通过`Demangle`的方式导出原型`,所以将这个函数原型字段更新为通过libclang访问头文件构建，对于同样的两个函数，表现为如下，并支持C语言的函数原型输出
```json

  {
    "mangle": "_ZN9INIReader12ValueHandlerEPvPKcS2_S2_",
    "c++": "INIReader::ValueHandler(void *, const char *, const char *, const char *)",
    "go": "(*Reader).ValueHandler"
  },
  {
    "mangle": "_ZN9INIReader7MakeKeyERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEES8_",
    "c++": "INIReader::MakeKey(const std::string &, const std::string &)",
    "go": "(*Reader).MakeKey"
  }
```
* 将符号表中的GoFuncName 去除指定前缀，并将连字符命名的函数名生成为大驼峰格式

#### C语言第三方库的llcppsymg
`llcppg.cfg`
```json
{
  "name": "sqlite",
  "cflags": "-I/opt/homebrew/opt/sqlite/include",
  "include": ["sqlite3.h"],
  "libs": "-L/opt/homebrew/opt/sqlite/lib -lsqlite3",
  "trimPrefixes": ["sqlite3_"],
  "cplusplus":false
}
```
output `llcppg.symb.json`
[llcppg.symb.json](https://github.com/user-attachments/files/17069007/llcppg.symb.json)
```json
[
  {
    "mangle": "sqlite3_aggregate_context",
    "c++": "sqlite3_aggregate_context(sqlite3_context *, int)",
    "go": "AggregateContext"
  },
  {
    "mangle": "sqlite3_aggregate_count",
    "c++": "sqlite3_aggregate_count(sqlite3_context *)",
    "go": "AggregateCount"
  },
  {
    "mangle": "sqlite3_auto_extension",
    "c++": "sqlite3_auto_extension(void (*)(void))",
    "go": "AutoExtension"
  },
  {
    "mangle": "sqlite3_autovacuum_pages",
    "c++": "sqlite3_autovacuum_pages(sqlite3 *, unsigned int (*)(void *, const char *, unsigned int, unsigned int, unsigned int), void *, void (*)(void *))",
    "go": "AutovacuumPages"
  },
  {
    "mangle": "sqlite3_backup_finish",
    "c++": "sqlite3_backup_finish(sqlite3_backup *)",
    "go": "BackupFinish"
  },
.........
]

```

