### PR TITLE
[wip] ssa/abi: build.TypeName pub for named has typeargs

### DIFF
--- a/ssa/abi/abi.go
+++ b/ssa/abi/abi.go
@@ -167,7 +167,7 @@ func (b *Builder) TypeName(t types.Type) (ret string, pub bool) {
 	case *types.Named:
 		o := t.Obj()
 		pkg := o.Pkg()
-		return "_llgo_" + FullName(pkg, NamedName(t)), (pkg == nil || o.Exported())
+		return "_llgo_" + FullName(pkg, NamedName(t)), (pkg == nil || o.Exported() || t.TypeArgs() != nil)
 	case *types.Interface:
 		if t.Empty() {
 			return "_llgo_any", true


### PR DESCRIPTION
fix abi for unexport generic type in diffrent package.
https://github.com/cpunion/llgo/blob/interface-bug/x/async/_demo/all/all.go 