### PR TITLE
ssa: fix gocvt named recurs for typeargs. support sync.Map

### DIFF
--- a/_demo/async/async/async.go
+++ b/_demo/async/async/async.go
@@ -1,0 +1,31 @@
+package async
+
+import (
+	_ "unsafe"
+)
+
+type Void = [0]byte
+
+type Future[T any] interface {
+	Then(cb func(T))
+}
+
+type future[T any] struct {
+	cb func(func(T))
+}
+
+func (f *future[T]) Then(cb func(T)) {
+	f.cb(cb)
+}
+
+func Async[T any](fn func(func(T))) Future[T] {
+	return &future[T]{fn}
+}
+
+func Run[T any](future Future[T]) T {
+	var ret T
+	future.Then(func(v T) {
+		ret = v
+	})
+	return ret
+}

--- a/_demo/async/main.go
+++ b/_demo/async/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"time"
+
+	"github.com/goplus/llgo/_demo/async/async"
+	"github.com/goplus/llgo/_demo/async/timeout"
+)
+
+func Sleep(i int, d time.Duration) async.Future[int] {
+	return async.Async(func(resolve func(int)) {
+		timeout.Timeout(d).Then(func(async.Void) {
+			resolve(i)
+		})
+	})
+}
+
+func main() {
+	async.Run(async.Async(func(resolve func(async.Void)) {
+		println("read file")
+		defer resolve(async.Void{})
+	}))
+}

--- a/_demo/async/timeout/timeout.go
+++ b/_demo/async/timeout/timeout.go
@@ -1,0 +1,16 @@
+package timeout
+
+import (
+	"time"
+
+	"github.com/goplus/llgo/_demo/async/async"
+)
+
+func Timeout(d time.Duration) async.Future[async.Void] {
+	return async.Async(func(resolve func(async.Void)) {
+		go func() {
+			time.Sleep(d)
+			resolve(async.Void{})
+		}()
+	})
+}

--- a/cl/_testgo/syncmap/in.go
+++ b/cl/_testgo/syncmap/in.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+func main() {
+	var m sync.Map
+	m.Store(1, "hello")
+	m.Store("1", 100)
+	v, ok := m.Load("1")
+	fmt.Println(v, ok)
+	m.Range(func(k, v interface{}) bool {
+		fmt.Printf("%#v %v\n", k, v)
+		return true
+	})
+}

--- a/cl/_testgo/syncmap/out.ll
+++ b/cl/_testgo/syncmap/out.ll
@@ -1,0 +1,225 @@
+; ModuleID = 'main'
+source_filename = "main"
+
+%"github.com/goplus/llgo/internal/runtime.eface" = type { ptr, ptr }
+%"github.com/goplus/llgo/internal/runtime.String" = type { ptr, i64 }
+%"github.com/goplus/llgo/internal/runtime.Slice" = type { ptr, i64, i64 }
+%"github.com/goplus/llgo/internal/runtime.iface" = type { ptr, ptr }
+
+@"main.init$guard" = global i1 false, align 1
+@__llgo_argc = global i32 0, align 4
+@__llgo_argv = global ptr null, align 8
+@_llgo_int = linkonce global ptr null, align 8
+@0 = private unnamed_addr constant [5 x i8] c"hello", align 1
+@_llgo_string = linkonce global ptr null, align 8
+@1 = private unnamed_addr constant [1 x i8] c"1", align 1
+@_llgo_bool = linkonce global ptr null, align 8
+@2 = private unnamed_addr constant [7 x i8] c"%#v %v\0A", align 1
+
+define void @main.init() {
+_llgo_0:
+  %0 = load i1, ptr @"main.init$guard", align 1
+  br i1 %0, label %_llgo_2, label %_llgo_1
+
+_llgo_1:                                          ; preds = %_llgo_0
+  store i1 true, ptr @"main.init$guard", align 1
+  call void @fmt.init()
+  call void @sync.init()
+  call void @"main.init$after"()
+  br label %_llgo_2
+
+_llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+  ret void
+}
+
+define i32 @main(i32 %0, ptr %1) {
+_llgo_0:
+  store i32 %0, ptr @__llgo_argc, align 4
+  store ptr %1, ptr @__llgo_argv, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.init"()
+  call void @main.init()
+  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
+  %3 = load ptr, ptr @_llgo_int, align 8
+  %4 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %4, i32 0, i32 0
+  store ptr %3, ptr %5, align 8
+  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %4, i32 0, i32 1
+  store ptr inttoptr (i64 1 to ptr), ptr %6, align 8
+  %7 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %4, align 8
+  %8 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %8, i32 0, i32 0
+  store ptr @0, ptr %9, align 8
+  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %8, i32 0, i32 1
+  store i64 5, ptr %10, align 4
+  %11 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %8, align 8
+  %12 = load ptr, ptr @_llgo_string, align 8
+  %13 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %11, ptr %13, align 8
+  %14 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %14, i32 0, i32 0
+  store ptr %12, ptr %15, align 8
+  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %14, i32 0, i32 1
+  store ptr %13, ptr %16, align 8
+  %17 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %14, align 8
+  call void @"sync.(*Map).Store"(ptr %2, %"github.com/goplus/llgo/internal/runtime.eface" %7, %"github.com/goplus/llgo/internal/runtime.eface" %17)
+  %18 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %19 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %18, i32 0, i32 0
+  store ptr @1, ptr %19, align 8
+  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %18, i32 0, i32 1
+  store i64 1, ptr %20, align 4
+  %21 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %18, align 8
+  %22 = load ptr, ptr @_llgo_string, align 8
+  %23 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %21, ptr %23, align 8
+  %24 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %24, i32 0, i32 0
+  store ptr %22, ptr %25, align 8
+  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %24, i32 0, i32 1
+  store ptr %23, ptr %26, align 8
+  %27 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %24, align 8
+  %28 = load ptr, ptr @_llgo_int, align 8
+  %29 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %29, i32 0, i32 0
+  store ptr %28, ptr %30, align 8
+  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %29, i32 0, i32 1
+  store ptr inttoptr (i64 100 to ptr), ptr %31, align 8
+  %32 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %29, align 8
+  call void @"sync.(*Map).Store"(ptr %2, %"github.com/goplus/llgo/internal/runtime.eface" %27, %"github.com/goplus/llgo/internal/runtime.eface" %32)
+  %33 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %33, i32 0, i32 0
+  store ptr @1, ptr %34, align 8
+  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %33, i32 0, i32 1
+  store i64 1, ptr %35, align 4
+  %36 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %33, align 8
+  %37 = load ptr, ptr @_llgo_string, align 8
+  %38 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %36, ptr %38, align 8
+  %39 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %40 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %39, i32 0, i32 0
+  store ptr %37, ptr %40, align 8
+  %41 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %39, i32 0, i32 1
+  store ptr %38, ptr %41, align 8
+  %42 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %39, align 8
+  %43 = call { %"github.com/goplus/llgo/internal/runtime.eface", i1 } @"sync.(*Map).Load"(ptr %2, %"github.com/goplus/llgo/internal/runtime.eface" %42)
+  %44 = extractvalue { %"github.com/goplus/llgo/internal/runtime.eface", i1 } %43, 0
+  %45 = extractvalue { %"github.com/goplus/llgo/internal/runtime.eface", i1 } %43, 1
+  %46 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
+  %47 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %46, i64 0
+  store %"github.com/goplus/llgo/internal/runtime.eface" %44, ptr %47, align 8
+  %48 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %46, i64 1
+  %49 = load ptr, ptr @_llgo_bool, align 8
+  %50 = sext i1 %45 to i64
+  %51 = inttoptr i64 %50 to ptr
+  %52 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %53 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %52, i32 0, i32 0
+  store ptr %49, ptr %53, align 8
+  %54 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %52, i32 0, i32 1
+  store ptr %51, ptr %54, align 8
+  %55 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %52, align 8
+  store %"github.com/goplus/llgo/internal/runtime.eface" %55, ptr %48, align 8
+  %56 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %56, i32 0, i32 0
+  store ptr %46, ptr %57, align 8
+  %58 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %56, i32 0, i32 1
+  store i64 2, ptr %58, align 4
+  %59 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %56, i32 0, i32 2
+  store i64 2, ptr %59, align 4
+  %60 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %56, align 8
+  %61 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @fmt.Println(%"github.com/goplus/llgo/internal/runtime.Slice" %60)
+  %62 = alloca { ptr, ptr }, align 8
+  %63 = getelementptr inbounds { ptr, ptr }, ptr %62, i32 0, i32 0
+  store ptr @"__llgo_stub.main.main$1", ptr %63, align 8
+  %64 = getelementptr inbounds { ptr, ptr }, ptr %62, i32 0, i32 1
+  store ptr null, ptr %64, align 8
+  %65 = load { ptr, ptr }, ptr %62, align 8
+  call void @"sync.(*Map).Range"(ptr %2, { ptr, ptr } %65)
+  ret i32 0
+}
+
+define i1 @"main.main$1"(%"github.com/goplus/llgo/internal/runtime.eface" %0, %"github.com/goplus/llgo/internal/runtime.eface" %1) {
+_llgo_0:
+  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
+  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %2, i64 0
+  store %"github.com/goplus/llgo/internal/runtime.eface" %0, ptr %3, align 8
+  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %2, i64 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %1, ptr %4, align 8
+  %5 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %5, i32 0, i32 0
+  store ptr %2, ptr %6, align 8
+  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %5, i32 0, i32 1
+  store i64 2, ptr %7, align 4
+  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %5, i32 0, i32 2
+  store i64 2, ptr %8, align 4
+  %9 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %5, align 8
+  %10 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %10, i32 0, i32 0
+  store ptr @2, ptr %11, align 8
+  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %10, i32 0, i32 1
+  store i64 7, ptr %12, align 4
+  %13 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %10, align 8
+  %14 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @fmt.Printf(%"github.com/goplus/llgo/internal/runtime.String" %13, %"github.com/goplus/llgo/internal/runtime.Slice" %9)
+  ret i1 true
+}
+
+declare void @fmt.init()
+
+declare void @sync.init()
+
+declare void @"github.com/goplus/llgo/internal/runtime.init"()
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64)
+
+declare void @"sync.(*Map).Store"(ptr, %"github.com/goplus/llgo/internal/runtime.eface", %"github.com/goplus/llgo/internal/runtime.eface")
+
+define void @"main.init$after"() {
+_llgo_0:
+  %0 = load ptr, ptr @_llgo_int, align 8
+  %1 = icmp eq ptr %0, null
+  br i1 %1, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  store ptr %2, ptr @_llgo_int, align 8
+  br label %_llgo_2
+
+_llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+  %3 = load ptr, ptr @_llgo_string, align 8
+  %4 = icmp eq ptr %3, null
+  br i1 %4, label %_llgo_3, label %_llgo_4
+
+_llgo_3:                                          ; preds = %_llgo_2
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  store ptr %5, ptr @_llgo_string, align 8
+  br label %_llgo_4
+
+_llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
+  %6 = load ptr, ptr @_llgo_bool, align 8
+  %7 = icmp eq ptr %6, null
+  br i1 %7, label %_llgo_5, label %_llgo_6
+
+_llgo_5:                                          ; preds = %_llgo_4
+  %8 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 33)
+  store ptr %8, ptr @_llgo_bool, align 8
+  br label %_llgo_6
+
+_llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
+  ret void
+}
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64)
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64)
+
+declare { %"github.com/goplus/llgo/internal/runtime.eface", i1 } @"sync.(*Map).Load"(ptr, %"github.com/goplus/llgo/internal/runtime.eface")
+
+declare { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @fmt.Println(%"github.com/goplus/llgo/internal/runtime.Slice")
+
+declare void @"sync.(*Map).Range"(ptr, { ptr, ptr })
+
+define linkonce i1 @"__llgo_stub.main.main$1"(ptr %0, %"github.com/goplus/llgo/internal/runtime.eface" %1, %"github.com/goplus/llgo/internal/runtime.eface" %2) {
+_llgo_0:
+  %3 = tail call i1 @"main.main$1"(%"github.com/goplus/llgo/internal/runtime.eface" %1, %"github.com/goplus/llgo/internal/runtime.eface" %2)
+  ret i1 %3
+}
+
+declare { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @fmt.Printf(%"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.Slice")

--- a/cl/_testgo/tprecurfn/in.go
+++ b/cl/_testgo/tprecurfn/in.go
@@ -1,0 +1,11 @@
+package main
+
+type My[T any] struct {
+	fn   func(n T)
+	next *My[T]
+}
+
+func main() {
+	m := &My[int]{next: &My[int]{fn: func(n int) { println(n) }}}
+	m.next.fn(100)
+}

--- a/cl/_testgo/tprecurfn/out.ll
+++ b/cl/_testgo/tprecurfn/out.ll
@@ -1,0 +1,70 @@
+; ModuleID = 'main'
+source_filename = "main"
+
+%"main.My[int]" = type { { ptr, ptr }, ptr }
+
+@"main.init$guard" = global i1 false, align 1
+@__llgo_argc = global i32 0, align 4
+@__llgo_argv = global ptr null, align 8
+
+define void @main.init() {
+_llgo_0:
+  %0 = load i1, ptr @"main.init$guard", align 1
+  br i1 %0, label %_llgo_2, label %_llgo_1
+
+_llgo_1:                                          ; preds = %_llgo_0
+  store i1 true, ptr @"main.init$guard", align 1
+  br label %_llgo_2
+
+_llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+  ret void
+}
+
+define i32 @main(i32 %0, ptr %1) {
+_llgo_0:
+  store i32 %0, ptr @__llgo_argc, align 4
+  store ptr %1, ptr @__llgo_argv, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.init"()
+  call void @main.init()
+  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
+  %3 = getelementptr inbounds %"main.My[int]", ptr %2, i32 0, i32 1
+  %4 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
+  %5 = getelementptr inbounds %"main.My[int]", ptr %4, i32 0, i32 0
+  %6 = alloca { ptr, ptr }, align 8
+  %7 = getelementptr inbounds { ptr, ptr }, ptr %6, i32 0, i32 0
+  store ptr @"__llgo_stub.main.main$1", ptr %7, align 8
+  %8 = getelementptr inbounds { ptr, ptr }, ptr %6, i32 0, i32 1
+  store ptr null, ptr %8, align 8
+  %9 = load { ptr, ptr }, ptr %6, align 8
+  store { ptr, ptr } %9, ptr %5, align 8
+  store ptr %4, ptr %3, align 8
+  %10 = getelementptr inbounds %"main.My[int]", ptr %2, i32 0, i32 1
+  %11 = load ptr, ptr %10, align 8
+  %12 = getelementptr inbounds %"main.My[int]", ptr %11, i32 0, i32 0
+  %13 = load { ptr, ptr }, ptr %12, align 8
+  %14 = extractvalue { ptr, ptr } %13, 1
+  %15 = extractvalue { ptr, ptr } %13, 0
+  call void %15(ptr %14, i64 100)
+  ret i32 0
+}
+
+define void @"main.main$1"(i64 %0) {
+_llgo_0:
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %0)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
+  ret void
+}
+
+declare void @"github.com/goplus/llgo/internal/runtime.init"()
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64)
+
+define linkonce void @"__llgo_stub.main.main$1"(ptr %0, i64 %1) {
+_llgo_0:
+  tail call void @"main.main$1"(i64 %1)
+  ret void
+}
+
+declare void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64)
+
+declare void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8)

--- a/cl/_testrt/abinamed/out.ll
+++ b/cl/_testrt/abinamed/out.ll
@@ -511,5883 +511,5885 @@ _llgo_1:                                          ; preds = %_llgo_0
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-  %7 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %7, i32 0, i32 0
-  store ptr @0, ptr %8, align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %7, i32 0, i32 1
-  store i64 6, ptr %9, align 4
-  %10 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %7, align 8
-  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %10, i64 25, i64 48, i64 0, i64 0)
-  %12 = load ptr, ptr @"*_llgo_main.T", align 8
-  %13 = icmp eq ptr %12, null
-  br i1 %13, label %_llgo_3, label %_llgo_4
+  %7 = load ptr, ptr @_llgo_main.T, align 8
+  %8 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %8, i32 0, i32 0
+  store ptr @0, ptr %9, align 8
+  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %8, i32 0, i32 1
+  store i64 6, ptr %10, align 4
+  %11 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %8, align 8
+  %12 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %11, i64 25, i64 48, i64 0, i64 0)
+  %13 = load ptr, ptr @"*_llgo_main.T", align 8
+  %14 = icmp eq ptr %13, null
+  br i1 %14, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %11)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %14)
-  store ptr %14, ptr @"*_llgo_main.T", align 8
+  %15 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %12)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %15)
+  store ptr %15, ptr @"*_llgo_main.T", align 8
   br label %_llgo_4
 
 _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
-  %15 = load ptr, ptr @"*_llgo_main.T", align 8
-  %16 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %16, i32 0, i32 0
-  store ptr @1, ptr %17, align 8
-  %18 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %16, i32 0, i32 1
-  store i64 40, ptr %18, align 4
-  %19 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %16, align 8
-  %20 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %19, i64 25, i64 80, i64 0, i64 22)
-  %21 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %22 = icmp eq ptr %21, null
-  br i1 %22, label %_llgo_5, label %_llgo_6
+  %16 = load ptr, ptr @"*_llgo_main.T", align 8
+  %17 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %18 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %17, i32 0, i32 0
+  store ptr @1, ptr %18, align 8
+  %19 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %17, i32 0, i32 1
+  store i64 40, ptr %19, align 4
+  %20 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %17, align 8
+  %21 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %20, i64 25, i64 80, i64 0, i64 22)
+  %22 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %23 = icmp eq ptr %22, null
+  br i1 %23, label %_llgo_5, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_4
-  store ptr %20, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  store ptr %21, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %23 = load ptr, ptr @_llgo_uintptr, align 8
-  %24 = icmp eq ptr %23, null
-  br i1 %24, label %_llgo_7, label %_llgo_8
+  %24 = load ptr, ptr @_llgo_uintptr, align 8
+  %25 = icmp eq ptr %24, null
+  br i1 %25, label %_llgo_7, label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_6
-  %25 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
-  store ptr %25, ptr @_llgo_uintptr, align 8
+  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
+  store ptr %26, ptr @_llgo_uintptr, align 8
   br label %_llgo_8
 
 _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
-  %26 = load ptr, ptr @_llgo_uintptr, align 8
-  %27 = load ptr, ptr @_llgo_uint32, align 8
-  %28 = icmp eq ptr %27, null
-  br i1 %28, label %_llgo_9, label %_llgo_10
+  %27 = load ptr, ptr @_llgo_uintptr, align 8
+  %28 = load ptr, ptr @_llgo_uint32, align 8
+  %29 = icmp eq ptr %28, null
+  br i1 %29, label %_llgo_9, label %_llgo_10
 
 _llgo_9:                                          ; preds = %_llgo_8
-  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 42)
-  store ptr %29, ptr @_llgo_uint32, align 8
+  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 42)
+  store ptr %30, ptr @_llgo_uint32, align 8
   br label %_llgo_10
 
 _llgo_10:                                         ; preds = %_llgo_9, %_llgo_8
-  %30 = load ptr, ptr @_llgo_uint32, align 8
-  %31 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %31, i32 0, i32 0
-  store ptr @2, ptr %32, align 8
-  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %31, i32 0, i32 1
-  store i64 41, ptr %33, align 4
-  %34 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %31, align 8
-  %35 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %34, i64 8, i64 1, i64 0, i64 0)
-  %36 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.TFlag", align 8
-  %37 = icmp eq ptr %36, null
-  br i1 %37, label %_llgo_11, label %_llgo_12
+  %31 = load ptr, ptr @_llgo_uint32, align 8
+  %32 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %32, i32 0, i32 0
+  store ptr @2, ptr %33, align 8
+  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %32, i32 0, i32 1
+  store i64 41, ptr %34, align 4
+  %35 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %32, align 8
+  %36 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %35, i64 8, i64 1, i64 0, i64 0)
+  %37 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.TFlag", align 8
+  %38 = icmp eq ptr %37, null
+  br i1 %38, label %_llgo_11, label %_llgo_12
 
 _llgo_11:                                         ; preds = %_llgo_10
-  store ptr %35, ptr @"_llgo_github.com/goplus/llgo/internal/abi.TFlag", align 8
+  store ptr %36, ptr @"_llgo_github.com/goplus/llgo/internal/abi.TFlag", align 8
   br label %_llgo_12
 
 _llgo_12:                                         ; preds = %_llgo_11, %_llgo_10
-  %38 = load ptr, ptr @_llgo_uint8, align 8
-  %39 = icmp eq ptr %38, null
-  br i1 %39, label %_llgo_13, label %_llgo_14
+  %39 = load ptr, ptr @_llgo_uint8, align 8
+  %40 = icmp eq ptr %39, null
+  br i1 %40, label %_llgo_13, label %_llgo_14
 
 _llgo_13:                                         ; preds = %_llgo_12
-  %40 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  store ptr %40, ptr @_llgo_uint8, align 8
+  %41 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  store ptr %41, ptr @_llgo_uint8, align 8
   br label %_llgo_14
 
 _llgo_14:                                         ; preds = %_llgo_13, %_llgo_12
-  %41 = load ptr, ptr @_llgo_uint8, align 8
-  br i1 %37, label %_llgo_15, label %_llgo_16
+  %42 = load ptr, ptr @_llgo_uint8, align 8
+  br i1 %38, label %_llgo_15, label %_llgo_16
 
 _llgo_15:                                         ; preds = %_llgo_14
-  %42 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %42, i32 0, i32 0
-  store ptr @3, ptr %43, align 8
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %42, i32 0, i32 1
-  store i64 35, ptr %44, align 4
-  %45 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %42, align 8
-  %46 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %47 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %46, i32 0, i32 0
-  store ptr @4, ptr %47, align 8
-  %48 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %46, i32 0, i32 1
-  store i64 5, ptr %48, align 4
-  %49 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %46, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %35, %"github.com/goplus/llgo/internal/runtime.String" %45, %"github.com/goplus/llgo/internal/runtime.String" %49, ptr %41, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  %43 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %43, i32 0, i32 0
+  store ptr @3, ptr %44, align 8
+  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %43, i32 0, i32 1
+  store i64 35, ptr %45, align 4
+  %46 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %43, align 8
+  %47 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %48 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %47, i32 0, i32 0
+  store ptr @4, ptr %48, align 8
+  %49 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %47, i32 0, i32 1
+  store i64 5, ptr %49, align 4
+  %50 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %47, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %36, %"github.com/goplus/llgo/internal/runtime.String" %46, %"github.com/goplus/llgo/internal/runtime.String" %50, ptr %42, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
   br label %_llgo_16
 
 _llgo_16:                                         ; preds = %_llgo_15, %_llgo_14
-  %50 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.TFlag", align 8
-  %51 = load ptr, ptr @_llgo_Pointer, align 8
-  %52 = icmp eq ptr %51, null
-  br i1 %52, label %_llgo_17, label %_llgo_18
+  %51 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.TFlag", align 8
+  %52 = load ptr, ptr @_llgo_Pointer, align 8
+  %53 = icmp eq ptr %52, null
+  br i1 %53, label %_llgo_17, label %_llgo_18
 
 _llgo_17:                                         ; preds = %_llgo_16
-  %53 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %53)
-  store ptr %53, ptr @_llgo_Pointer, align 8
+  %54 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %54)
+  store ptr %54, ptr @_llgo_Pointer, align 8
   br label %_llgo_18
 
 _llgo_18:                                         ; preds = %_llgo_17, %_llgo_16
-  %54 = load ptr, ptr @_llgo_Pointer, align 8
-  %55 = load ptr, ptr @_llgo_bool, align 8
-  %56 = icmp eq ptr %55, null
-  br i1 %56, label %_llgo_19, label %_llgo_20
+  %55 = load ptr, ptr @_llgo_Pointer, align 8
+  %56 = load ptr, ptr @_llgo_bool, align 8
+  %57 = icmp eq ptr %56, null
+  br i1 %57, label %_llgo_19, label %_llgo_20
 
 _llgo_19:                                         ; preds = %_llgo_18
-  %57 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 33)
-  store ptr %57, ptr @_llgo_bool, align 8
+  %58 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 33)
+  store ptr %58, ptr @_llgo_bool, align 8
   br label %_llgo_20
 
 _llgo_20:                                         ; preds = %_llgo_19, %_llgo_18
-  %58 = load ptr, ptr @_llgo_bool, align 8
-  %59 = load ptr, ptr @_llgo_Pointer, align 8
+  %59 = load ptr, ptr @_llgo_bool, align 8
   %60 = load ptr, ptr @_llgo_Pointer, align 8
   %61 = load ptr, ptr @_llgo_Pointer, align 8
-  %62 = load ptr, ptr @_llgo_bool, align 8
-  %63 = load ptr, ptr @"_llgo_func$QUW0mAalenD4Bc6QsairPZ_HOMzGmcNs0GCyMzTNFig", align 8
-  %64 = icmp eq ptr %63, null
-  br i1 %64, label %_llgo_21, label %_llgo_22
+  %62 = load ptr, ptr @_llgo_Pointer, align 8
+  %63 = load ptr, ptr @_llgo_bool, align 8
+  %64 = load ptr, ptr @"_llgo_func$QUW0mAalenD4Bc6QsairPZ_HOMzGmcNs0GCyMzTNFig", align 8
+  %65 = icmp eq ptr %64, null
+  br i1 %65, label %_llgo_21, label %_llgo_22
 
 _llgo_21:                                         ; preds = %_llgo_20
-  %65 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %66 = getelementptr ptr, ptr %65, i64 0
-  store ptr %59, ptr %66, align 8
-  %67 = getelementptr ptr, ptr %65, i64 1
+  %66 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %67 = getelementptr ptr, ptr %66, i64 0
   store ptr %60, ptr %67, align 8
-  %68 = getelementptr ptr, ptr %65, i64 2
+  %68 = getelementptr ptr, ptr %66, i64 1
   store ptr %61, ptr %68, align 8
-  %69 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %70 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %69, i32 0, i32 0
-  store ptr %65, ptr %70, align 8
-  %71 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %69, i32 0, i32 1
-  store i64 3, ptr %71, align 4
-  %72 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %69, i32 0, i32 2
+  %69 = getelementptr ptr, ptr %66, i64 2
+  store ptr %62, ptr %69, align 8
+  %70 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %71 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %70, i32 0, i32 0
+  store ptr %66, ptr %71, align 8
+  %72 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %70, i32 0, i32 1
   store i64 3, ptr %72, align 4
-  %73 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %69, align 8
-  %74 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %75 = getelementptr ptr, ptr %74, i64 0
-  store ptr %62, ptr %75, align 8
-  %76 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %77 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %76, i32 0, i32 0
-  store ptr %74, ptr %77, align 8
-  %78 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %76, i32 0, i32 1
-  store i64 1, ptr %78, align 4
-  %79 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %76, i32 0, i32 2
+  %73 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %70, i32 0, i32 2
+  store i64 3, ptr %73, align 4
+  %74 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %70, align 8
+  %75 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %76 = getelementptr ptr, ptr %75, i64 0
+  store ptr %63, ptr %76, align 8
+  %77 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %78 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %77, i32 0, i32 0
+  store ptr %75, ptr %78, align 8
+  %79 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %77, i32 0, i32 1
   store i64 1, ptr %79, align 4
-  %80 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %76, align 8
-  %81 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %73, %"github.com/goplus/llgo/internal/runtime.Slice" %80, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %81)
-  store ptr %81, ptr @"_llgo_func$QUW0mAalenD4Bc6QsairPZ_HOMzGmcNs0GCyMzTNFig", align 8
+  %80 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %77, i32 0, i32 2
+  store i64 1, ptr %80, align 4
+  %81 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %77, align 8
+  %82 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %74, %"github.com/goplus/llgo/internal/runtime.Slice" %81, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %82)
+  store ptr %82, ptr @"_llgo_func$QUW0mAalenD4Bc6QsairPZ_HOMzGmcNs0GCyMzTNFig", align 8
   br label %_llgo_22
 
 _llgo_22:                                         ; preds = %_llgo_21, %_llgo_20
-  %82 = load ptr, ptr @"_llgo_func$QUW0mAalenD4Bc6QsairPZ_HOMzGmcNs0GCyMzTNFig", align 8
-  %83 = load ptr, ptr @_llgo_Pointer, align 8
+  %83 = load ptr, ptr @"_llgo_func$QUW0mAalenD4Bc6QsairPZ_HOMzGmcNs0GCyMzTNFig", align 8
   %84 = load ptr, ptr @_llgo_Pointer, align 8
   %85 = load ptr, ptr @_llgo_Pointer, align 8
-  %86 = load ptr, ptr @_llgo_bool, align 8
-  %87 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %88 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %87, i32 0, i32 0
-  store ptr @5, ptr %88, align 8
-  %89 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %87, i32 0, i32 1
-  store i64 1, ptr %89, align 4
-  %90 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %87, align 8
-  %91 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %92 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %91, i32 0, i32 0
-  store ptr null, ptr %92, align 8
-  %93 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %91, i32 0, i32 1
-  store i64 0, ptr %93, align 4
-  %94 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %91, align 8
-  %95 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %96 = getelementptr ptr, ptr %95, i64 0
-  store ptr %83, ptr %96, align 8
-  %97 = getelementptr ptr, ptr %95, i64 1
+  %86 = load ptr, ptr @_llgo_Pointer, align 8
+  %87 = load ptr, ptr @_llgo_bool, align 8
+  %88 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %89 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %88, i32 0, i32 0
+  store ptr @5, ptr %89, align 8
+  %90 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %88, i32 0, i32 1
+  store i64 1, ptr %90, align 4
+  %91 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %88, align 8
+  %92 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %93 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %92, i32 0, i32 0
+  store ptr null, ptr %93, align 8
+  %94 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %92, i32 0, i32 1
+  store i64 0, ptr %94, align 4
+  %95 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %92, align 8
+  %96 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %97 = getelementptr ptr, ptr %96, i64 0
   store ptr %84, ptr %97, align 8
-  %98 = getelementptr ptr, ptr %95, i64 2
+  %98 = getelementptr ptr, ptr %96, i64 1
   store ptr %85, ptr %98, align 8
-  %99 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %100 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %99, i32 0, i32 0
-  store ptr %95, ptr %100, align 8
-  %101 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %99, i32 0, i32 1
-  store i64 3, ptr %101, align 4
-  %102 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %99, i32 0, i32 2
+  %99 = getelementptr ptr, ptr %96, i64 2
+  store ptr %86, ptr %99, align 8
+  %100 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %101 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %100, i32 0, i32 0
+  store ptr %96, ptr %101, align 8
+  %102 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %100, i32 0, i32 1
   store i64 3, ptr %102, align 4
-  %103 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %99, align 8
-  %104 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %105 = getelementptr ptr, ptr %104, i64 0
-  store ptr %86, ptr %105, align 8
-  %106 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %107 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %106, i32 0, i32 0
-  store ptr %104, ptr %107, align 8
-  %108 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %106, i32 0, i32 1
-  store i64 1, ptr %108, align 4
-  %109 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %106, i32 0, i32 2
+  %103 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %100, i32 0, i32 2
+  store i64 3, ptr %103, align 4
+  %104 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %100, align 8
+  %105 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %106 = getelementptr ptr, ptr %105, i64 0
+  store ptr %87, ptr %106, align 8
+  %107 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %108 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %107, i32 0, i32 0
+  store ptr %105, ptr %108, align 8
+  %109 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %107, i32 0, i32 1
   store i64 1, ptr %109, align 4
-  %110 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %106, align 8
-  %111 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %103, %"github.com/goplus/llgo/internal/runtime.Slice" %110, i1 false)
-  %112 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %90, ptr %111, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %94, i1 false)
-  %113 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %114 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %113, i32 0, i32 0
-  store ptr @6, ptr %114, align 8
-  %115 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %113, i32 0, i32 1
-  store i64 4, ptr %115, align 4
-  %116 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %113, align 8
-  %117 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %118 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %117, i32 0, i32 0
-  store ptr null, ptr %118, align 8
-  %119 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %117, i32 0, i32 1
-  store i64 0, ptr %119, align 4
-  %120 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %117, align 8
-  %121 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %122 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %116, ptr %121, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %120, i1 false)
-  %123 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %124 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %123, i32 0, i32 0
-  store ptr @7, ptr %124, align 8
-  %125 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %123, i32 0, i32 1
-  store i64 4, ptr %125, align 4
-  %126 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %123, align 8
-  %127 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %128 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %127, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %112, ptr %128, align 8
-  %129 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %127, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %122, ptr %129, align 8
-  %130 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %131 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %130, i32 0, i32 0
-  store ptr %127, ptr %131, align 8
-  %132 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %130, i32 0, i32 1
-  store i64 2, ptr %132, align 4
-  %133 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %130, i32 0, i32 2
+  %110 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %107, i32 0, i32 2
+  store i64 1, ptr %110, align 4
+  %111 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %107, align 8
+  %112 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %104, %"github.com/goplus/llgo/internal/runtime.Slice" %111, i1 false)
+  %113 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %91, ptr %112, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %95, i1 false)
+  %114 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %115 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %114, i32 0, i32 0
+  store ptr @6, ptr %115, align 8
+  %116 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %114, i32 0, i32 1
+  store i64 4, ptr %116, align 4
+  %117 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %114, align 8
+  %118 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %119 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %118, i32 0, i32 0
+  store ptr null, ptr %119, align 8
+  %120 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %118, i32 0, i32 1
+  store i64 0, ptr %120, align 4
+  %121 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %118, align 8
+  %122 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %123 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %117, ptr %122, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %121, i1 false)
+  %124 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %125 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %124, i32 0, i32 0
+  store ptr @7, ptr %125, align 8
+  %126 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %124, i32 0, i32 1
+  store i64 4, ptr %126, align 4
+  %127 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %124, align 8
+  %128 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %129 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %128, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %113, ptr %129, align 8
+  %130 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %128, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %123, ptr %130, align 8
+  %131 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %132 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %131, i32 0, i32 0
+  store ptr %128, ptr %132, align 8
+  %133 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %131, i32 0, i32 1
   store i64 2, ptr %133, align 4
-  %134 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %130, align 8
-  %135 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %126, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %134)
-  store ptr %135, ptr @"main.struct$p9hq6rduefaRA0UGJ6DazYUtteEOtDFu7UHk5jhDUV4", align 8
-  %136 = load ptr, ptr @"main.struct$p9hq6rduefaRA0UGJ6DazYUtteEOtDFu7UHk5jhDUV4", align 8
-  %137 = load ptr, ptr @_llgo_byte, align 8
-  %138 = icmp eq ptr %137, null
-  br i1 %138, label %_llgo_23, label %_llgo_24
+  %134 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %131, i32 0, i32 2
+  store i64 2, ptr %134, align 4
+  %135 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %131, align 8
+  %136 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %127, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %135)
+  store ptr %136, ptr @"main.struct$p9hq6rduefaRA0UGJ6DazYUtteEOtDFu7UHk5jhDUV4", align 8
+  %137 = load ptr, ptr @"main.struct$p9hq6rduefaRA0UGJ6DazYUtteEOtDFu7UHk5jhDUV4", align 8
+  %138 = load ptr, ptr @_llgo_byte, align 8
+  %139 = icmp eq ptr %138, null
+  br i1 %139, label %_llgo_23, label %_llgo_24
 
 _llgo_23:                                         ; preds = %_llgo_22
-  %139 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  store ptr %139, ptr @_llgo_byte, align 8
+  %140 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  store ptr %140, ptr @_llgo_byte, align 8
   br label %_llgo_24
 
 _llgo_24:                                         ; preds = %_llgo_23, %_llgo_22
-  %140 = load ptr, ptr @_llgo_byte, align 8
-  %141 = load ptr, ptr @"*_llgo_byte", align 8
-  %142 = icmp eq ptr %141, null
-  br i1 %142, label %_llgo_25, label %_llgo_26
+  %141 = load ptr, ptr @_llgo_byte, align 8
+  %142 = load ptr, ptr @"*_llgo_byte", align 8
+  %143 = icmp eq ptr %142, null
+  br i1 %143, label %_llgo_25, label %_llgo_26
 
 _llgo_25:                                         ; preds = %_llgo_24
-  %143 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %144 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %143)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %144)
-  store ptr %144, ptr @"*_llgo_byte", align 8
+  %144 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %145 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %144)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %145)
+  store ptr %145, ptr @"*_llgo_byte", align 8
   br label %_llgo_26
 
 _llgo_26:                                         ; preds = %_llgo_25, %_llgo_24
-  %145 = load ptr, ptr @"*_llgo_byte", align 8
-  %146 = load ptr, ptr @_llgo_string, align 8
-  %147 = icmp eq ptr %146, null
-  br i1 %147, label %_llgo_27, label %_llgo_28
+  %146 = load ptr, ptr @"*_llgo_byte", align 8
+  %147 = load ptr, ptr @_llgo_string, align 8
+  %148 = icmp eq ptr %147, null
+  br i1 %148, label %_llgo_27, label %_llgo_28
 
 _llgo_27:                                         ; preds = %_llgo_26
-  %148 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  store ptr %148, ptr @_llgo_string, align 8
+  %149 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  store ptr %149, ptr @_llgo_string, align 8
   br label %_llgo_28
 
 _llgo_28:                                         ; preds = %_llgo_27, %_llgo_26
-  %149 = load ptr, ptr @_llgo_string, align 8
-  %150 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %151 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %150, i32 0, i32 0
-  store ptr @1, ptr %151, align 8
-  %152 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %150, i32 0, i32 1
-  store i64 40, ptr %152, align 4
-  %153 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %150, align 8
-  %154 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %153, i64 25, i64 80, i64 0, i64 22)
-  %155 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %156 = icmp eq ptr %155, null
-  br i1 %156, label %_llgo_29, label %_llgo_30
+  %150 = load ptr, ptr @_llgo_string, align 8
+  %151 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %152 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %153 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %152, i32 0, i32 0
+  store ptr @1, ptr %153, align 8
+  %154 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %152, i32 0, i32 1
+  store i64 40, ptr %154, align 4
+  %155 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %152, align 8
+  %156 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %155, i64 25, i64 72, i64 0, i64 22)
+  %157 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %158 = icmp eq ptr %157, null
+  br i1 %158, label %_llgo_29, label %_llgo_30
 
 _llgo_29:                                         ; preds = %_llgo_28
-  %157 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %154)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %157)
-  store ptr %157, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %159 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %156)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %159)
+  store ptr %159, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
   br label %_llgo_30
 
 _llgo_30:                                         ; preds = %_llgo_29, %_llgo_28
-  %158 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %159 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %160 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %159, i32 0, i32 0
-  store ptr @2, ptr %160, align 8
-  %161 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %159, i32 0, i32 1
-  store i64 41, ptr %161, align 4
-  %162 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %159, align 8
-  %163 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %162, i64 8, i64 1, i64 0, i64 0)
-  %164 = load ptr, ptr @_llgo_Pointer, align 8
-  %165 = load ptr, ptr @_llgo_Pointer, align 8
+  %160 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %161 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %162 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %161, i32 0, i32 0
+  store ptr @2, ptr %162, align 8
+  %163 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %161, i32 0, i32 1
+  store i64 41, ptr %163, align 4
+  %164 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %161, align 8
+  %165 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %164, i64 8, i64 1, i64 0, i64 0)
   %166 = load ptr, ptr @_llgo_Pointer, align 8
-  %167 = load ptr, ptr @_llgo_bool, align 8
-  %168 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %169 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %168, i32 0, i32 0
-  store ptr @1, ptr %169, align 8
-  %170 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %168, i32 0, i32 1
-  store i64 40, ptr %170, align 4
-  %171 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %168, align 8
-  %172 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %171, i64 25, i64 80, i64 0, i64 22)
-  %173 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %174 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %173, i32 0, i32 0
-  store ptr @8, ptr %174, align 8
-  %175 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %173, i32 0, i32 1
-  store i64 5, ptr %175, align 4
-  %176 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %173, align 8
-  %177 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %178 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %177, i32 0, i32 0
-  store ptr null, ptr %178, align 8
-  %179 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %177, i32 0, i32 1
-  store i64 0, ptr %179, align 4
-  %180 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %177, align 8
-  %181 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
-  %182 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %176, ptr %181, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %180, i1 false)
-  %183 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %184 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %183, i32 0, i32 0
-  store ptr @9, ptr %184, align 8
-  %185 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %183, i32 0, i32 1
-  store i64 8, ptr %185, align 4
-  %186 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %183, align 8
-  %187 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %188 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %187, i32 0, i32 0
-  store ptr null, ptr %188, align 8
-  %189 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %187, i32 0, i32 1
-  store i64 0, ptr %189, align 4
-  %190 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %187, align 8
-  %191 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
-  %192 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %186, ptr %191, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %190, i1 false)
-  %193 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %194 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %193, i32 0, i32 0
-  store ptr @10, ptr %194, align 8
-  %195 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %193, i32 0, i32 1
-  store i64 4, ptr %195, align 4
-  %196 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %193, align 8
-  %197 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %198 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %197, i32 0, i32 0
-  store ptr null, ptr %198, align 8
-  %199 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %197, i32 0, i32 1
-  store i64 0, ptr %199, align 4
-  %200 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %197, align 8
-  %201 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 42)
-  %202 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %196, ptr %201, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %200, i1 false)
-  %203 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %204 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %203, i32 0, i32 0
-  store ptr @4, ptr %204, align 8
-  %205 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %203, i32 0, i32 1
-  store i64 5, ptr %205, align 4
-  %206 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %203, align 8
-  %207 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %208 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %207, i32 0, i32 0
-  store ptr null, ptr %208, align 8
-  %209 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %207, i32 0, i32 1
-  store i64 0, ptr %209, align 4
-  %210 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %207, align 8
-  %211 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %206, ptr %163, i64 20, %"github.com/goplus/llgo/internal/runtime.String" %210, i1 false)
-  %212 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %213 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %212, i32 0, i32 0
-  store ptr @11, ptr %213, align 8
-  %214 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %212, i32 0, i32 1
-  store i64 6, ptr %214, align 4
-  %215 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %212, align 8
-  %216 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %217 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %216, i32 0, i32 0
-  store ptr null, ptr %217, align 8
-  %218 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %216, i32 0, i32 1
-  store i64 0, ptr %218, align 4
-  %219 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %216, align 8
-  %220 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %221 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %215, ptr %220, i64 21, %"github.com/goplus/llgo/internal/runtime.String" %219, i1 false)
-  %222 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %223 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %222, i32 0, i32 0
-  store ptr @12, ptr %223, align 8
-  %224 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %222, i32 0, i32 1
-  store i64 11, ptr %224, align 4
-  %225 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %222, align 8
-  %226 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %227 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %226, i32 0, i32 0
-  store ptr null, ptr %227, align 8
-  %228 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %226, i32 0, i32 1
-  store i64 0, ptr %228, align 4
-  %229 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %226, align 8
-  %230 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %231 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %225, ptr %230, i64 22, %"github.com/goplus/llgo/internal/runtime.String" %229, i1 false)
-  %232 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %233 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %232, i32 0, i32 0
-  store ptr @13, ptr %233, align 8
-  %234 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %232, i32 0, i32 1
-  store i64 5, ptr %234, align 4
-  %235 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %232, align 8
-  %236 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %237 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %236, i32 0, i32 0
-  store ptr null, ptr %237, align 8
-  %238 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %236, i32 0, i32 1
-  store i64 0, ptr %238, align 4
-  %239 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %236, align 8
-  %240 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %241 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %235, ptr %240, i64 23, %"github.com/goplus/llgo/internal/runtime.String" %239, i1 false)
-  %242 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %243 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %242, i32 0, i32 0
-  store ptr @14, ptr %243, align 8
-  %244 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %242, i32 0, i32 1
-  store i64 5, ptr %244, align 4
-  %245 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %242, align 8
-  %246 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %247 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %246, i32 0, i32 0
-  store ptr null, ptr %247, align 8
-  %248 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %246, i32 0, i32 1
-  store i64 0, ptr %248, align 4
-  %249 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %246, align 8
-  %250 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %251 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %250, i32 0, i32 0
-  store ptr @5, ptr %251, align 8
-  %252 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %250, i32 0, i32 1
-  store i64 1, ptr %252, align 4
-  %253 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %250, align 8
-  %254 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %255 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %254, i32 0, i32 0
-  store ptr null, ptr %255, align 8
-  %256 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %254, i32 0, i32 1
-  store i64 0, ptr %256, align 4
-  %257 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %254, align 8
-  %258 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %259 = getelementptr ptr, ptr %258, i64 0
-  store ptr %164, ptr %259, align 8
-  %260 = getelementptr ptr, ptr %258, i64 1
-  store ptr %165, ptr %260, align 8
-  %261 = getelementptr ptr, ptr %258, i64 2
+  %167 = load ptr, ptr @_llgo_Pointer, align 8
+  %168 = load ptr, ptr @_llgo_Pointer, align 8
+  %169 = load ptr, ptr @_llgo_bool, align 8
+  %170 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %171 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %170, i32 0, i32 0
+  store ptr @1, ptr %171, align 8
+  %172 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %170, i32 0, i32 1
+  store i64 40, ptr %172, align 4
+  %173 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %170, align 8
+  %174 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %173, i64 25, i64 72, i64 0, i64 22)
+  %175 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %176 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %175, i32 0, i32 0
+  store ptr @8, ptr %176, align 8
+  %177 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %175, i32 0, i32 1
+  store i64 5, ptr %177, align 4
+  %178 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %175, align 8
+  %179 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %180 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %179, i32 0, i32 0
+  store ptr null, ptr %180, align 8
+  %181 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %179, i32 0, i32 1
+  store i64 0, ptr %181, align 4
+  %182 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %179, align 8
+  %183 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
+  %184 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %178, ptr %183, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %182, i1 false)
+  %185 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %186 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %185, i32 0, i32 0
+  store ptr @9, ptr %186, align 8
+  %187 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %185, i32 0, i32 1
+  store i64 8, ptr %187, align 4
+  %188 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %185, align 8
+  %189 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %190 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %189, i32 0, i32 0
+  store ptr null, ptr %190, align 8
+  %191 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %189, i32 0, i32 1
+  store i64 0, ptr %191, align 4
+  %192 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %189, align 8
+  %193 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
+  %194 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %188, ptr %193, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %192, i1 false)
+  %195 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %196 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %195, i32 0, i32 0
+  store ptr @10, ptr %196, align 8
+  %197 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %195, i32 0, i32 1
+  store i64 4, ptr %197, align 4
+  %198 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %195, align 8
+  %199 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %200 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %199, i32 0, i32 0
+  store ptr null, ptr %200, align 8
+  %201 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %199, i32 0, i32 1
+  store i64 0, ptr %201, align 4
+  %202 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %199, align 8
+  %203 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 42)
+  %204 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %198, ptr %203, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %202, i1 false)
+  %205 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %206 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %205, i32 0, i32 0
+  store ptr @4, ptr %206, align 8
+  %207 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %205, i32 0, i32 1
+  store i64 5, ptr %207, align 4
+  %208 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %205, align 8
+  %209 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %210 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %209, i32 0, i32 0
+  store ptr null, ptr %210, align 8
+  %211 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %209, i32 0, i32 1
+  store i64 0, ptr %211, align 4
+  %212 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %209, align 8
+  %213 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %208, ptr %165, i64 20, %"github.com/goplus/llgo/internal/runtime.String" %212, i1 false)
+  %214 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %215 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %214, i32 0, i32 0
+  store ptr @11, ptr %215, align 8
+  %216 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %214, i32 0, i32 1
+  store i64 6, ptr %216, align 4
+  %217 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %214, align 8
+  %218 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %219 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %218, i32 0, i32 0
+  store ptr null, ptr %219, align 8
+  %220 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %218, i32 0, i32 1
+  store i64 0, ptr %220, align 4
+  %221 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %218, align 8
+  %222 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %223 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %217, ptr %222, i64 21, %"github.com/goplus/llgo/internal/runtime.String" %221, i1 false)
+  %224 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %225 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %224, i32 0, i32 0
+  store ptr @12, ptr %225, align 8
+  %226 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %224, i32 0, i32 1
+  store i64 11, ptr %226, align 4
+  %227 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %224, align 8
+  %228 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %229 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %228, i32 0, i32 0
+  store ptr null, ptr %229, align 8
+  %230 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %228, i32 0, i32 1
+  store i64 0, ptr %230, align 4
+  %231 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %228, align 8
+  %232 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %233 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %227, ptr %232, i64 22, %"github.com/goplus/llgo/internal/runtime.String" %231, i1 false)
+  %234 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %235 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %234, i32 0, i32 0
+  store ptr @13, ptr %235, align 8
+  %236 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %234, i32 0, i32 1
+  store i64 5, ptr %236, align 4
+  %237 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %234, align 8
+  %238 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %239 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %238, i32 0, i32 0
+  store ptr null, ptr %239, align 8
+  %240 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %238, i32 0, i32 1
+  store i64 0, ptr %240, align 4
+  %241 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %238, align 8
+  %242 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %243 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %237, ptr %242, i64 23, %"github.com/goplus/llgo/internal/runtime.String" %241, i1 false)
+  %244 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %245 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %244, i32 0, i32 0
+  store ptr @14, ptr %245, align 8
+  %246 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %244, i32 0, i32 1
+  store i64 5, ptr %246, align 4
+  %247 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %244, align 8
+  %248 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %249 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %248, i32 0, i32 0
+  store ptr null, ptr %249, align 8
+  %250 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %248, i32 0, i32 1
+  store i64 0, ptr %250, align 4
+  %251 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %248, align 8
+  %252 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %253 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %252, i32 0, i32 0
+  store ptr @5, ptr %253, align 8
+  %254 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %252, i32 0, i32 1
+  store i64 1, ptr %254, align 4
+  %255 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %252, align 8
+  %256 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %257 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %256, i32 0, i32 0
+  store ptr null, ptr %257, align 8
+  %258 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %256, i32 0, i32 1
+  store i64 0, ptr %258, align 4
+  %259 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %256, align 8
+  %260 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %261 = getelementptr ptr, ptr %260, i64 0
   store ptr %166, ptr %261, align 8
-  %262 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %263 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %262, i32 0, i32 0
-  store ptr %258, ptr %263, align 8
-  %264 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %262, i32 0, i32 1
-  store i64 3, ptr %264, align 4
-  %265 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %262, i32 0, i32 2
-  store i64 3, ptr %265, align 4
-  %266 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %262, align 8
-  %267 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %268 = getelementptr ptr, ptr %267, i64 0
-  store ptr %167, ptr %268, align 8
-  %269 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %270 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %269, i32 0, i32 0
-  store ptr %267, ptr %270, align 8
-  %271 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %269, i32 0, i32 1
-  store i64 1, ptr %271, align 4
-  %272 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %269, i32 0, i32 2
-  store i64 1, ptr %272, align 4
-  %273 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %269, align 8
-  %274 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %266, %"github.com/goplus/llgo/internal/runtime.Slice" %273, i1 false)
-  %275 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %253, ptr %274, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %257, i1 false)
-  %276 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %277 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %276, i32 0, i32 0
-  store ptr @6, ptr %277, align 8
-  %278 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %276, i32 0, i32 1
-  store i64 4, ptr %278, align 4
-  %279 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %276, align 8
-  %280 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %281 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %280, i32 0, i32 0
-  store ptr null, ptr %281, align 8
-  %282 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %280, i32 0, i32 1
-  store i64 0, ptr %282, align 4
-  %283 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %280, align 8
-  %284 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %285 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %279, ptr %284, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %283, i1 false)
-  %286 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %287 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %286, i32 0, i32 0
-  store ptr @7, ptr %287, align 8
-  %288 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %286, i32 0, i32 1
-  store i64 4, ptr %288, align 4
-  %289 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %286, align 8
-  %290 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %291 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %290, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %275, ptr %291, align 8
-  %292 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %290, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %285, ptr %292, align 8
-  %293 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %294 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %293, i32 0, i32 0
-  store ptr %290, ptr %294, align 8
-  %295 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %293, i32 0, i32 1
-  store i64 2, ptr %295, align 4
-  %296 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %293, i32 0, i32 2
-  store i64 2, ptr %296, align 4
-  %297 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %293, align 8
-  %298 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %289, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %297)
-  %299 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %245, ptr %298, i64 24, %"github.com/goplus/llgo/internal/runtime.String" %249, i1 false)
-  %300 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %301 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %300, i32 0, i32 0
-  store ptr @15, ptr %301, align 8
-  %302 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %300, i32 0, i32 1
-  store i64 6, ptr %302, align 4
-  %303 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %300, align 8
-  %304 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %305 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %304, i32 0, i32 0
-  store ptr null, ptr %305, align 8
-  %306 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %304, i32 0, i32 1
-  store i64 0, ptr %306, align 4
-  %307 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %304, align 8
-  %308 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %309 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %308)
-  %310 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %303, ptr %309, i64 40, %"github.com/goplus/llgo/internal/runtime.String" %307, i1 false)
-  %311 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %312 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %311, i32 0, i32 0
-  store ptr @16, ptr %312, align 8
-  %313 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %311, i32 0, i32 1
-  store i64 4, ptr %313, align 4
-  %314 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %311, align 8
-  %315 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %316 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %315, i32 0, i32 0
-  store ptr null, ptr %316, align 8
-  %317 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %315, i32 0, i32 1
-  store i64 0, ptr %317, align 4
-  %318 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %315, align 8
-  %319 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %320 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %314, ptr %319, i64 48, %"github.com/goplus/llgo/internal/runtime.String" %318, i1 false)
-  %321 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %322 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %321, i32 0, i32 0
-  store ptr @17, ptr %322, align 8
-  %323 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %321, i32 0, i32 1
-  store i64 10, ptr %323, align 4
-  %324 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %321, align 8
-  %325 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %326 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %325, i32 0, i32 0
-  store ptr null, ptr %326, align 8
-  %327 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %325, i32 0, i32 1
-  store i64 0, ptr %327, align 4
-  %328 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %325, align 8
-  %329 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %172)
-  %330 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %324, ptr %329, i64 64, %"github.com/goplus/llgo/internal/runtime.String" %328, i1 false)
-  %331 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %332 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %331, i32 0, i32 0
-  store ptr @7, ptr %332, align 8
-  %333 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %331, i32 0, i32 1
-  store i64 4, ptr %333, align 4
-  %334 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %331, align 8
-  %335 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 616)
-  %336 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %335, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %182, ptr %336, align 8
-  %337 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %335, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %192, ptr %337, align 8
-  %338 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %335, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %202, ptr %338, align 8
-  %339 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %335, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %211, ptr %339, align 8
-  %340 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %335, i64 4
-  store %"github.com/goplus/llgo/internal/abi.StructField" %221, ptr %340, align 8
-  %341 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %335, i64 5
-  store %"github.com/goplus/llgo/internal/abi.StructField" %231, ptr %341, align 8
-  %342 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %335, i64 6
-  store %"github.com/goplus/llgo/internal/abi.StructField" %241, ptr %342, align 8
-  %343 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %335, i64 7
-  store %"github.com/goplus/llgo/internal/abi.StructField" %299, ptr %343, align 8
-  %344 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %335, i64 8
-  store %"github.com/goplus/llgo/internal/abi.StructField" %310, ptr %344, align 8
-  %345 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %335, i64 9
-  store %"github.com/goplus/llgo/internal/abi.StructField" %320, ptr %345, align 8
-  %346 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %335, i64 10
-  store %"github.com/goplus/llgo/internal/abi.StructField" %330, ptr %346, align 8
-  %347 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %348 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %347, i32 0, i32 0
-  store ptr %335, ptr %348, align 8
-  %349 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %347, i32 0, i32 1
-  store i64 11, ptr %349, align 4
-  %350 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %347, i32 0, i32 2
-  store i64 11, ptr %350, align 4
-  %351 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %347, align 8
-  %352 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %334, i64 72, %"github.com/goplus/llgo/internal/runtime.Slice" %351)
-  store ptr %352, ptr @"main.struct$13P_TvKNXommvK6tKt3eRNnJqTcPEFYrHagFiHeRpb0", align 8
-  %353 = load ptr, ptr @"main.struct$13P_TvKNXommvK6tKt3eRNnJqTcPEFYrHagFiHeRpb0", align 8
-  br i1 %22, label %_llgo_31, label %_llgo_32
+  %262 = getelementptr ptr, ptr %260, i64 1
+  store ptr %167, ptr %262, align 8
+  %263 = getelementptr ptr, ptr %260, i64 2
+  store ptr %168, ptr %263, align 8
+  %264 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %265 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %264, i32 0, i32 0
+  store ptr %260, ptr %265, align 8
+  %266 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %264, i32 0, i32 1
+  store i64 3, ptr %266, align 4
+  %267 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %264, i32 0, i32 2
+  store i64 3, ptr %267, align 4
+  %268 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %264, align 8
+  %269 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %270 = getelementptr ptr, ptr %269, i64 0
+  store ptr %169, ptr %270, align 8
+  %271 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %272 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %271, i32 0, i32 0
+  store ptr %269, ptr %272, align 8
+  %273 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %271, i32 0, i32 1
+  store i64 1, ptr %273, align 4
+  %274 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %271, i32 0, i32 2
+  store i64 1, ptr %274, align 4
+  %275 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %271, align 8
+  %276 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %268, %"github.com/goplus/llgo/internal/runtime.Slice" %275, i1 false)
+  %277 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %255, ptr %276, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %259, i1 false)
+  %278 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %279 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %278, i32 0, i32 0
+  store ptr @6, ptr %279, align 8
+  %280 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %278, i32 0, i32 1
+  store i64 4, ptr %280, align 4
+  %281 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %278, align 8
+  %282 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %283 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %282, i32 0, i32 0
+  store ptr null, ptr %283, align 8
+  %284 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %282, i32 0, i32 1
+  store i64 0, ptr %284, align 4
+  %285 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %282, align 8
+  %286 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %287 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %281, ptr %286, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %285, i1 false)
+  %288 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %289 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %288, i32 0, i32 0
+  store ptr @7, ptr %289, align 8
+  %290 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %288, i32 0, i32 1
+  store i64 4, ptr %290, align 4
+  %291 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %288, align 8
+  %292 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %293 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %292, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %277, ptr %293, align 8
+  %294 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %292, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %287, ptr %294, align 8
+  %295 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %296 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %295, i32 0, i32 0
+  store ptr %292, ptr %296, align 8
+  %297 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %295, i32 0, i32 1
+  store i64 2, ptr %297, align 4
+  %298 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %295, i32 0, i32 2
+  store i64 2, ptr %298, align 4
+  %299 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %295, align 8
+  %300 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %291, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %299)
+  %301 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %247, ptr %300, i64 24, %"github.com/goplus/llgo/internal/runtime.String" %251, i1 false)
+  %302 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %303 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %302, i32 0, i32 0
+  store ptr @15, ptr %303, align 8
+  %304 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %302, i32 0, i32 1
+  store i64 6, ptr %304, align 4
+  %305 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %302, align 8
+  %306 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %307 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %306, i32 0, i32 0
+  store ptr null, ptr %307, align 8
+  %308 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %306, i32 0, i32 1
+  store i64 0, ptr %308, align 4
+  %309 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %306, align 8
+  %310 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %311 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %310)
+  %312 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %305, ptr %311, i64 40, %"github.com/goplus/llgo/internal/runtime.String" %309, i1 false)
+  %313 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %314 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %313, i32 0, i32 0
+  store ptr @16, ptr %314, align 8
+  %315 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %313, i32 0, i32 1
+  store i64 4, ptr %315, align 4
+  %316 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %313, align 8
+  %317 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %318 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %317, i32 0, i32 0
+  store ptr null, ptr %318, align 8
+  %319 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %317, i32 0, i32 1
+  store i64 0, ptr %319, align 4
+  %320 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %317, align 8
+  %321 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %322 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %316, ptr %321, i64 48, %"github.com/goplus/llgo/internal/runtime.String" %320, i1 false)
+  %323 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %324 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %323, i32 0, i32 0
+  store ptr @17, ptr %324, align 8
+  %325 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %323, i32 0, i32 1
+  store i64 10, ptr %325, align 4
+  %326 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %323, align 8
+  %327 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %328 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %327, i32 0, i32 0
+  store ptr null, ptr %328, align 8
+  %329 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %327, i32 0, i32 1
+  store i64 0, ptr %329, align 4
+  %330 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %327, align 8
+  %331 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %174)
+  %332 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %326, ptr %331, i64 64, %"github.com/goplus/llgo/internal/runtime.String" %330, i1 false)
+  %333 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %334 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %333, i32 0, i32 0
+  store ptr @7, ptr %334, align 8
+  %335 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %333, i32 0, i32 1
+  store i64 4, ptr %335, align 4
+  %336 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %333, align 8
+  %337 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 616)
+  %338 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %337, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %184, ptr %338, align 8
+  %339 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %337, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %194, ptr %339, align 8
+  %340 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %337, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %204, ptr %340, align 8
+  %341 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %337, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %213, ptr %341, align 8
+  %342 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %337, i64 4
+  store %"github.com/goplus/llgo/internal/abi.StructField" %223, ptr %342, align 8
+  %343 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %337, i64 5
+  store %"github.com/goplus/llgo/internal/abi.StructField" %233, ptr %343, align 8
+  %344 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %337, i64 6
+  store %"github.com/goplus/llgo/internal/abi.StructField" %243, ptr %344, align 8
+  %345 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %337, i64 7
+  store %"github.com/goplus/llgo/internal/abi.StructField" %301, ptr %345, align 8
+  %346 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %337, i64 8
+  store %"github.com/goplus/llgo/internal/abi.StructField" %312, ptr %346, align 8
+  %347 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %337, i64 9
+  store %"github.com/goplus/llgo/internal/abi.StructField" %322, ptr %347, align 8
+  %348 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %337, i64 10
+  store %"github.com/goplus/llgo/internal/abi.StructField" %332, ptr %348, align 8
+  %349 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %350 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %349, i32 0, i32 0
+  store ptr %337, ptr %350, align 8
+  %351 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %349, i32 0, i32 1
+  store i64 11, ptr %351, align 4
+  %352 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %349, i32 0, i32 2
+  store i64 11, ptr %352, align 4
+  %353 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %349, align 8
+  %354 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %336, i64 72, %"github.com/goplus/llgo/internal/runtime.Slice" %353)
+  store ptr %354, ptr @"main.struct$13P_TvKNXommvK6tKt3eRNnJqTcPEFYrHagFiHeRpb0", align 8
+  %355 = load ptr, ptr @"main.struct$13P_TvKNXommvK6tKt3eRNnJqTcPEFYrHagFiHeRpb0", align 8
+  br i1 %23, label %_llgo_31, label %_llgo_32
 
 _llgo_31:                                         ; preds = %_llgo_30
-  %354 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %355 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %354, i32 0, i32 0
-  store ptr @18, ptr %355, align 8
-  %356 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %354, i32 0, i32 1
-  store i64 5, ptr %356, align 4
-  %357 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %354, align 8
-  %358 = load ptr, ptr @_llgo_int, align 8
-  %359 = icmp eq ptr %358, null
-  br i1 %359, label %_llgo_33, label %_llgo_34
+  %356 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %357 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %356, i32 0, i32 0
+  store ptr @18, ptr %357, align 8
+  %358 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %356, i32 0, i32 1
+  store i64 5, ptr %358, align 4
+  %359 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %356, align 8
+  %360 = load ptr, ptr @_llgo_int, align 8
+  %361 = icmp eq ptr %360, null
+  br i1 %361, label %_llgo_33, label %_llgo_34
 
 _llgo_32:                                         ; preds = %_llgo_42, %_llgo_30
-  %360 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %361 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %362 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %363 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %362, i32 0, i32 0
-  store ptr @0, ptr %363, align 8
-  %364 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %362, i32 0, i32 1
-  store i64 6, ptr %364, align 4
-  %365 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %362, align 8
-  %366 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %365, i64 25, i64 48, i64 0, i64 0)
-  %367 = load ptr, ptr @"[]_llgo_main.T", align 8
-  %368 = icmp eq ptr %367, null
-  br i1 %368, label %_llgo_149, label %_llgo_150
+  %362 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %363 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %364 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %365 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %364, i32 0, i32 0
+  store ptr @0, ptr %365, align 8
+  %366 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %364, i32 0, i32 1
+  store i64 6, ptr %366, align 4
+  %367 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %364, align 8
+  %368 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %367, i64 25, i64 48, i64 0, i64 0)
+  %369 = load ptr, ptr @"[]_llgo_main.T", align 8
+  %370 = icmp eq ptr %369, null
+  br i1 %370, label %_llgo_149, label %_llgo_150
 
 _llgo_33:                                         ; preds = %_llgo_31
-  %369 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  store ptr %369, ptr @_llgo_int, align 8
+  %371 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  store ptr %371, ptr @_llgo_int, align 8
   br label %_llgo_34
 
 _llgo_34:                                         ; preds = %_llgo_33, %_llgo_31
-  %370 = load ptr, ptr @_llgo_int, align 8
-  %371 = load ptr, ptr @_llgo_int, align 8
-  %372 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %373 = icmp eq ptr %372, null
-  br i1 %373, label %_llgo_35, label %_llgo_36
+  %372 = load ptr, ptr @_llgo_int, align 8
+  %373 = load ptr, ptr @_llgo_int, align 8
+  %374 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %375 = icmp eq ptr %374, null
+  br i1 %375, label %_llgo_35, label %_llgo_36
 
 _llgo_35:                                         ; preds = %_llgo_34
-  %374 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %375 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %376 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %375, i32 0, i32 0
-  store ptr %374, ptr %376, align 8
-  %377 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %375, i32 0, i32 1
-  store i64 0, ptr %377, align 4
-  %378 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %375, i32 0, i32 2
-  store i64 0, ptr %378, align 4
-  %379 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %375, align 8
-  %380 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %381 = getelementptr ptr, ptr %380, i64 0
-  store ptr %371, ptr %381, align 8
-  %382 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %383 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %382, i32 0, i32 0
-  store ptr %380, ptr %383, align 8
-  %384 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %382, i32 0, i32 1
-  store i64 1, ptr %384, align 4
-  %385 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %382, i32 0, i32 2
-  store i64 1, ptr %385, align 4
-  %386 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %382, align 8
-  %387 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %379, %"github.com/goplus/llgo/internal/runtime.Slice" %386, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %387)
-  store ptr %387, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %376 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %377 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %378 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %377, i32 0, i32 0
+  store ptr %376, ptr %378, align 8
+  %379 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %377, i32 0, i32 1
+  store i64 0, ptr %379, align 4
+  %380 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %377, i32 0, i32 2
+  store i64 0, ptr %380, align 4
+  %381 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %377, align 8
+  %382 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %383 = getelementptr ptr, ptr %382, i64 0
+  store ptr %373, ptr %383, align 8
+  %384 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %385 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %384, i32 0, i32 0
+  store ptr %382, ptr %385, align 8
+  %386 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %384, i32 0, i32 1
+  store i64 1, ptr %386, align 4
+  %387 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %384, i32 0, i32 2
+  store i64 1, ptr %387, align 4
+  %388 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %384, align 8
+  %389 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %381, %"github.com/goplus/llgo/internal/runtime.Slice" %388, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %389)
+  store ptr %389, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
   br label %_llgo_36
 
 _llgo_36:                                         ; preds = %_llgo_35, %_llgo_34
-  %388 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %389 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %390 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %389, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %357, ptr %390, align 8
-  %391 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %389, i32 0, i32 1
-  store ptr %388, ptr %391, align 8
-  %392 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %389, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Align", ptr %392, align 8
-  %393 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %389, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Align", ptr %393, align 8
-  %394 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %389, align 8
-  %395 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %396 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %395, i32 0, i32 0
-  store ptr @19, ptr %396, align 8
-  %397 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %395, i32 0, i32 1
-  store i64 9, ptr %397, align 4
-  %398 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %395, align 8
-  %399 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %400 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %399, i32 0, i32 0
-  store ptr @20, ptr %400, align 8
-  %401 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %399, i32 0, i32 1
-  store i64 45, ptr %401, align 4
-  %402 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %399, align 8
-  %403 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %402, i64 25, i64 104, i64 0, i64 20)
-  %404 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
-  %405 = icmp eq ptr %404, null
-  br i1 %405, label %_llgo_37, label %_llgo_38
+  %390 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %391 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %392 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %391, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %359, ptr %392, align 8
+  %393 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %391, i32 0, i32 1
+  store ptr %390, ptr %393, align 8
+  %394 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %391, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Align", ptr %394, align 8
+  %395 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %391, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Align", ptr %395, align 8
+  %396 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %391, align 8
+  %397 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %398 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %397, i32 0, i32 0
+  store ptr @19, ptr %398, align 8
+  %399 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %397, i32 0, i32 1
+  store i64 9, ptr %399, align 4
+  %400 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %397, align 8
+  %401 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %402 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %401, i32 0, i32 0
+  store ptr @20, ptr %402, align 8
+  %403 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %401, i32 0, i32 1
+  store i64 45, ptr %403, align 4
+  %404 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %401, align 8
+  %405 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %404, i64 25, i64 104, i64 0, i64 20)
+  %406 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  %407 = icmp eq ptr %406, null
+  br i1 %407, label %_llgo_37, label %_llgo_38
 
 _llgo_37:                                         ; preds = %_llgo_36
-  store ptr %403, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  store ptr %405, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
   br label %_llgo_38
 
 _llgo_38:                                         ; preds = %_llgo_37, %_llgo_36
-  %406 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %407 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %408 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %409 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %408, i32 0, i32 0
-  store ptr @1, ptr %409, align 8
-  %410 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %408, i32 0, i32 1
-  store i64 40, ptr %410, align 4
-  %411 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %408, align 8
-  %412 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %411, i64 25, i64 80, i64 0, i64 22)
-  %413 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %414 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %413, i32 0, i32 0
-  store ptr @1, ptr %414, align 8
-  %415 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %413, i32 0, i32 1
-  store i64 40, ptr %415, align 4
-  %416 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %413, align 8
-  %417 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %416, i64 25, i64 80, i64 0, i64 22)
-  %418 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %419 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %418, i32 0, i32 0
-  store ptr @1, ptr %419, align 8
-  %420 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %418, i32 0, i32 1
-  store i64 40, ptr %420, align 4
-  %421 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %418, align 8
-  %422 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %421, i64 25, i64 80, i64 0, i64 22)
-  %423 = load ptr, ptr @"_llgo_struct$eLreYy_0Tx9Ip-rgTmC6_uCvf27HVl_zBUTfLS0WYaY", align 8
-  %424 = icmp eq ptr %423, null
-  br i1 %424, label %_llgo_39, label %_llgo_40
+  %408 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %409 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %410 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %411 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %410, i32 0, i32 0
+  store ptr @1, ptr %411, align 8
+  %412 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %410, i32 0, i32 1
+  store i64 40, ptr %412, align 4
+  %413 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %410, align 8
+  %414 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %413, i64 25, i64 80, i64 0, i64 22)
+  %415 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %416 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %415, i32 0, i32 0
+  store ptr @1, ptr %416, align 8
+  %417 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %415, i32 0, i32 1
+  store i64 40, ptr %417, align 4
+  %418 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %415, align 8
+  %419 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %418, i64 25, i64 80, i64 0, i64 22)
+  %420 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %421 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %420, i32 0, i32 0
+  store ptr @1, ptr %421, align 8
+  %422 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %420, i32 0, i32 1
+  store i64 40, ptr %422, align 4
+  %423 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %420, align 8
+  %424 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %423, i64 25, i64 80, i64 0, i64 22)
+  %425 = load ptr, ptr @"_llgo_struct$eLreYy_0Tx9Ip-rgTmC6_uCvf27HVl_zBUTfLS0WYaY", align 8
+  %426 = icmp eq ptr %425, null
+  br i1 %426, label %_llgo_39, label %_llgo_40
 
 _llgo_39:                                         ; preds = %_llgo_38
-  %425 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %426 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %425, i32 0, i32 0
-  store ptr @21, ptr %426, align 8
-  %427 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %425, i32 0, i32 1
-  store i64 4, ptr %427, align 4
-  %428 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %425, align 8
-  %429 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %430 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %429, i32 0, i32 0
-  store ptr null, ptr %430, align 8
-  %431 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %429, i32 0, i32 1
-  store i64 0, ptr %431, align 4
-  %432 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %429, align 8
-  %433 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %428, ptr %412, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %432, i1 true)
-  %434 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %435 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %434, i32 0, i32 0
-  store ptr @22, ptr %435, align 8
-  %436 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %434, i32 0, i32 1
-  store i64 4, ptr %436, align 4
-  %437 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %434, align 8
-  %438 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %439 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %438, i32 0, i32 0
-  store ptr null, ptr %439, align 8
-  %440 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %438, i32 0, i32 1
-  store i64 0, ptr %440, align 4
-  %441 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %438, align 8
-  %442 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %417)
-  %443 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %437, ptr %442, i64 72, %"github.com/goplus/llgo/internal/runtime.String" %441, i1 false)
-  %444 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %445 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %444, i32 0, i32 0
-  store ptr @23, ptr %445, align 8
-  %446 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %444, i32 0, i32 1
-  store i64 5, ptr %446, align 4
-  %447 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %444, align 8
-  %448 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %449 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %448, i32 0, i32 0
-  store ptr null, ptr %449, align 8
-  %450 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %448, i32 0, i32 1
-  store i64 0, ptr %450, align 4
-  %451 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %448, align 8
-  %452 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %422)
-  %453 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %447, ptr %452, i64 80, %"github.com/goplus/llgo/internal/runtime.String" %451, i1 false)
-  %454 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %455 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %454, i32 0, i32 0
-  store ptr @24, ptr %455, align 8
-  %456 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %454, i32 0, i32 1
-  store i64 3, ptr %456, align 4
-  %457 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %454, align 8
-  %458 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %459 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %458, i32 0, i32 0
-  store ptr null, ptr %459, align 8
-  %460 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %458, i32 0, i32 1
-  store i64 0, ptr %460, align 4
-  %461 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %458, align 8
-  %462 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
-  %463 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %457, ptr %462, i64 88, %"github.com/goplus/llgo/internal/runtime.String" %461, i1 false)
-  %464 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %465 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %464, i32 0, i32 0
-  store ptr @7, ptr %465, align 8
-  %466 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %464, i32 0, i32 1
-  store i64 4, ptr %466, align 4
-  %467 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %464, align 8
-  %468 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
-  %469 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %468, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %433, ptr %469, align 8
-  %470 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %468, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %443, ptr %470, align 8
-  %471 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %468, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %453, ptr %471, align 8
-  %472 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %468, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %463, ptr %472, align 8
-  %473 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %474 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %473, i32 0, i32 0
-  store ptr %468, ptr %474, align 8
-  %475 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %473, i32 0, i32 1
-  store i64 4, ptr %475, align 4
-  %476 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %473, i32 0, i32 2
-  store i64 4, ptr %476, align 4
-  %477 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %473, align 8
-  %478 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %467, i64 96, %"github.com/goplus/llgo/internal/runtime.Slice" %477)
-  store ptr %478, ptr @"_llgo_struct$eLreYy_0Tx9Ip-rgTmC6_uCvf27HVl_zBUTfLS0WYaY", align 8
+  %427 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %428 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %427, i32 0, i32 0
+  store ptr @21, ptr %428, align 8
+  %429 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %427, i32 0, i32 1
+  store i64 4, ptr %429, align 4
+  %430 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %427, align 8
+  %431 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %432 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %431, i32 0, i32 0
+  store ptr null, ptr %432, align 8
+  %433 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %431, i32 0, i32 1
+  store i64 0, ptr %433, align 4
+  %434 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %431, align 8
+  %435 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %430, ptr %414, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %434, i1 true)
+  %436 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %437 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %436, i32 0, i32 0
+  store ptr @22, ptr %437, align 8
+  %438 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %436, i32 0, i32 1
+  store i64 4, ptr %438, align 4
+  %439 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %436, align 8
+  %440 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %441 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %440, i32 0, i32 0
+  store ptr null, ptr %441, align 8
+  %442 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %440, i32 0, i32 1
+  store i64 0, ptr %442, align 4
+  %443 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %440, align 8
+  %444 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %419)
+  %445 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %439, ptr %444, i64 72, %"github.com/goplus/llgo/internal/runtime.String" %443, i1 false)
+  %446 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %447 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %446, i32 0, i32 0
+  store ptr @23, ptr %447, align 8
+  %448 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %446, i32 0, i32 1
+  store i64 5, ptr %448, align 4
+  %449 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %446, align 8
+  %450 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %451 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %450, i32 0, i32 0
+  store ptr null, ptr %451, align 8
+  %452 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %450, i32 0, i32 1
+  store i64 0, ptr %452, align 4
+  %453 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %450, align 8
+  %454 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %424)
+  %455 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %449, ptr %454, i64 80, %"github.com/goplus/llgo/internal/runtime.String" %453, i1 false)
+  %456 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %457 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %456, i32 0, i32 0
+  store ptr @24, ptr %457, align 8
+  %458 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %456, i32 0, i32 1
+  store i64 3, ptr %458, align 4
+  %459 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %456, align 8
+  %460 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %461 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %460, i32 0, i32 0
+  store ptr null, ptr %461, align 8
+  %462 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %460, i32 0, i32 1
+  store i64 0, ptr %462, align 4
+  %463 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %460, align 8
+  %464 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
+  %465 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %459, ptr %464, i64 88, %"github.com/goplus/llgo/internal/runtime.String" %463, i1 false)
+  %466 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %467 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %466, i32 0, i32 0
+  store ptr @7, ptr %467, align 8
+  %468 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %466, i32 0, i32 1
+  store i64 4, ptr %468, align 4
+  %469 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %466, align 8
+  %470 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
+  %471 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %470, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %435, ptr %471, align 8
+  %472 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %470, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %445, ptr %472, align 8
+  %473 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %470, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %455, ptr %473, align 8
+  %474 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %470, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %465, ptr %474, align 8
+  %475 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %476 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %475, i32 0, i32 0
+  store ptr %470, ptr %476, align 8
+  %477 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %475, i32 0, i32 1
+  store i64 4, ptr %477, align 4
+  %478 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %475, i32 0, i32 2
+  store i64 4, ptr %478, align 4
+  %479 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %475, align 8
+  %480 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %469, i64 96, %"github.com/goplus/llgo/internal/runtime.Slice" %479)
+  store ptr %480, ptr @"_llgo_struct$eLreYy_0Tx9Ip-rgTmC6_uCvf27HVl_zBUTfLS0WYaY", align 8
   br label %_llgo_40
 
 _llgo_40:                                         ; preds = %_llgo_39, %_llgo_38
-  %479 = load ptr, ptr @"_llgo_struct$eLreYy_0Tx9Ip-rgTmC6_uCvf27HVl_zBUTfLS0WYaY", align 8
-  br i1 %405, label %_llgo_41, label %_llgo_42
+  %481 = load ptr, ptr @"_llgo_struct$eLreYy_0Tx9Ip-rgTmC6_uCvf27HVl_zBUTfLS0WYaY", align 8
+  br i1 %407, label %_llgo_41, label %_llgo_42
 
 _llgo_41:                                         ; preds = %_llgo_40
-  %480 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %481 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %480, i32 0, i32 0
-  store ptr @18, ptr %481, align 8
-  %482 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %480, i32 0, i32 1
-  store i64 5, ptr %482, align 4
-  %483 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %480, align 8
-  %484 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %485 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %486 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %485, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %483, ptr %486, align 8
-  %487 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %485, i32 0, i32 1
-  store ptr %484, ptr %487, align 8
-  %488 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %485, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Align", ptr %488, align 8
-  %489 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %485, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Align", ptr %489, align 8
-  %490 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %485, align 8
-  %491 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %492 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %491, i32 0, i32 0
-  store ptr @19, ptr %492, align 8
-  %493 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %491, i32 0, i32 1
-  store i64 9, ptr %493, align 4
-  %494 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %491, align 8
-  %495 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %496 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %495, i32 0, i32 0
-  store ptr @20, ptr %496, align 8
-  %497 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %495, i32 0, i32 1
-  store i64 45, ptr %497, align 4
-  %498 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %495, align 8
-  %499 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %498, i64 25, i64 104, i64 0, i64 20)
-  %500 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
-  %501 = icmp eq ptr %500, null
-  br i1 %501, label %_llgo_43, label %_llgo_44
+  %482 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %483 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %482, i32 0, i32 0
+  store ptr @18, ptr %483, align 8
+  %484 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %482, i32 0, i32 1
+  store i64 5, ptr %484, align 4
+  %485 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %482, align 8
+  %486 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %487 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %488 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %487, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %485, ptr %488, align 8
+  %489 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %487, i32 0, i32 1
+  store ptr %486, ptr %489, align 8
+  %490 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %487, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Align", ptr %490, align 8
+  %491 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %487, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Align", ptr %491, align 8
+  %492 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %487, align 8
+  %493 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %494 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %493, i32 0, i32 0
+  store ptr @19, ptr %494, align 8
+  %495 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %493, i32 0, i32 1
+  store i64 9, ptr %495, align 4
+  %496 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %493, align 8
+  %497 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %498 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %497, i32 0, i32 0
+  store ptr @20, ptr %498, align 8
+  %499 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %497, i32 0, i32 1
+  store i64 45, ptr %499, align 4
+  %500 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %497, align 8
+  %501 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %500, i64 25, i64 104, i64 0, i64 20)
+  %502 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  %503 = icmp eq ptr %502, null
+  br i1 %503, label %_llgo_43, label %_llgo_44
 
 _llgo_42:                                         ; preds = %_llgo_148, %_llgo_40
-  %502 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
-  %503 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
-  %504 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
-  %505 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %506 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %505, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %398, ptr %506, align 8
-  %507 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %505, i32 0, i32 1
-  store ptr %504, ptr %507, align 8
-  %508 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %505, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).ArrayType", ptr %508, align 8
-  %509 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %505, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).ArrayType", ptr %509, align 8
-  %510 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %505, align 8
-  %511 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %512 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %511, i32 0, i32 0
-  store ptr @25, ptr %512, align 8
-  %513 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %511, i32 0, i32 1
-  store i64 7, ptr %513, align 4
-  %514 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %511, align 8
-  %515 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
-  %516 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %517 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %516, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %514, ptr %517, align 8
-  %518 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %516, i32 0, i32 1
-  store ptr %515, ptr %518, align 8
-  %519 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %516, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).ChanDir", ptr %519, align 8
-  %520 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %516, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).ChanDir", ptr %520, align 8
-  %521 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %516, align 8
-  %522 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %523 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %522, i32 0, i32 0
-  store ptr @27, ptr %523, align 8
-  %524 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %522, i32 0, i32 1
-  store i64 6, ptr %524, align 4
-  %525 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %522, align 8
-  %526 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %527 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %528 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %529 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %528, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %525, ptr %529, align 8
-  %530 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %528, i32 0, i32 1
-  store ptr %527, ptr %530, align 8
-  %531 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %528, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Common", ptr %531, align 8
-  %532 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %528, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Common", ptr %532, align 8
-  %533 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %528, align 8
-  %534 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %535 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %534, i32 0, i32 0
-  store ptr @22, ptr %535, align 8
-  %536 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %534, i32 0, i32 1
-  store i64 4, ptr %536, align 4
-  %537 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %534, align 8
-  %538 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %539 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %540 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %541 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %540, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %537, ptr %541, align 8
-  %542 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %540, i32 0, i32 1
-  store ptr %539, ptr %542, align 8
-  %543 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %540, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Elem", ptr %543, align 8
-  %544 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %540, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Elem", ptr %544, align 8
-  %545 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %540, align 8
-  %546 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %547 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %546, i32 0, i32 0
-  store ptr @28, ptr %547, align 8
-  %548 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %546, i32 0, i32 1
-  store i64 15, ptr %548, align 4
-  %549 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %546, align 8
-  %550 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %551 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
-  %552 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %553 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %552, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %549, ptr %553, align 8
-  %554 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %552, i32 0, i32 1
-  store ptr %551, ptr %554, align 8
-  %555 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %552, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).ExportedMethods", ptr %555, align 8
-  %556 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %552, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).ExportedMethods", ptr %556, align 8
-  %557 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %552, align 8
-  %558 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %559 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %558, i32 0, i32 0
-  store ptr @33, ptr %559, align 8
-  %560 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %558, i32 0, i32 1
-  store i64 10, ptr %560, align 4
-  %561 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %558, align 8
-  %562 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %563 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %564 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %563, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %561, ptr %564, align 8
-  %565 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %563, i32 0, i32 1
-  store ptr %562, ptr %565, align 8
-  %566 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %563, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).FieldAlign", ptr %566, align 8
-  %567 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %563, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).FieldAlign", ptr %567, align 8
-  %568 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %563, align 8
-  %569 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %570 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %569, i32 0, i32 0
-  store ptr @34, ptr %570, align 8
-  %571 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %569, i32 0, i32 1
-  store i64 8, ptr %571, align 4
-  %572 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %569, align 8
-  %573 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %574 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
-  %575 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %576 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %575, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %572, ptr %576, align 8
-  %577 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %575, i32 0, i32 1
-  store ptr %574, ptr %577, align 8
-  %578 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %575, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).FuncType", ptr %578, align 8
-  %579 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %575, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).FuncType", ptr %579, align 8
-  %580 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %575, align 8
-  %581 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %582 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %581, i32 0, i32 0
-  store ptr @35, ptr %582, align 8
-  %583 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %581, i32 0, i32 1
-  store i64 7, ptr %583, align 4
-  %584 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %581, align 8
-  %585 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %586 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %587 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %586, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %584, ptr %587, align 8
-  %588 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %586, i32 0, i32 1
-  store ptr %585, ptr %588, align 8
-  %589 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %586, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).HasName", ptr %589, align 8
-  %590 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %586, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).HasName", ptr %590, align 8
-  %591 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %586, align 8
-  %592 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %593 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %592, i32 0, i32 0
-  store ptr @36, ptr %593, align 8
-  %594 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %592, i32 0, i32 1
-  store i64 10, ptr %594, align 4
-  %595 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %592, align 8
-  %596 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %597 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %598 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %597, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %595, ptr %598, align 8
-  %599 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %597, i32 0, i32 1
-  store ptr %596, ptr %599, align 8
-  %600 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %597, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).IfaceIndir", ptr %600, align 8
-  %601 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %597, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).IfaceIndir", ptr %601, align 8
-  %602 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %597, align 8
-  %603 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %604 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %603, i32 0, i32 0
-  store ptr @37, ptr %604, align 8
-  %605 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %603, i32 0, i32 1
-  store i64 13, ptr %605, align 4
-  %606 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %603, align 8
-  %607 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
-  %608 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
-  %609 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %610 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %609, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %606, ptr %610, align 8
-  %611 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %609, i32 0, i32 1
-  store ptr %608, ptr %611, align 8
-  %612 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %609, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).InterfaceType", ptr %612, align 8
-  %613 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %609, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).InterfaceType", ptr %613, align 8
-  %614 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %609, align 8
-  %615 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %616 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %615, i32 0, i32 0
-  store ptr @48, ptr %616, align 8
-  %617 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %615, i32 0, i32 1
-  store i64 13, ptr %617, align 4
-  %618 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %615, align 8
-  %619 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %620 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %621 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %620, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %618, ptr %621, align 8
-  %622 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %620, i32 0, i32 1
-  store ptr %619, ptr %622, align 8
-  %623 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %620, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).IsDirectIface", ptr %623, align 8
-  %624 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %620, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).IsDirectIface", ptr %624, align 8
-  %625 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %620, align 8
-  %626 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %627 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %626, i32 0, i32 0
-  store ptr @49, ptr %627, align 8
-  %628 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %626, i32 0, i32 1
-  store i64 3, ptr %628, align 4
-  %629 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %626, align 8
-  %630 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %631 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %632 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %633 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %632, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %629, ptr %633, align 8
-  %634 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %632, i32 0, i32 1
-  store ptr %631, ptr %634, align 8
-  %635 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %632, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Key", ptr %635, align 8
-  %636 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %632, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Key", ptr %636, align 8
-  %637 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %632, align 8
-  %638 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %639 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %638, i32 0, i32 0
-  store ptr @50, ptr %639, align 8
-  %640 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %638, i32 0, i32 1
-  store i64 4, ptr %640, align 4
-  %641 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %638, align 8
-  %642 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
-  %643 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %644 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %643, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %641, ptr %644, align 8
-  %645 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %643, i32 0, i32 1
-  store ptr %642, ptr %645, align 8
-  %646 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %643, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Kind", ptr %646, align 8
-  %647 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %643, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Kind", ptr %647, align 8
-  %648 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %643, align 8
-  %649 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %650 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %649, i32 0, i32 0
-  store ptr @24, ptr %650, align 8
-  %651 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %649, i32 0, i32 1
-  store i64 3, ptr %651, align 4
-  %652 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %649, align 8
-  %653 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %654 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %655 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %654, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %652, ptr %655, align 8
-  %656 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %654, i32 0, i32 1
-  store ptr %653, ptr %656, align 8
-  %657 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %654, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Len", ptr %657, align 8
-  %658 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %654, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Len", ptr %658, align 8
-  %659 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %654, align 8
-  %660 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %661 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %660, i32 0, i32 0
-  store ptr @53, ptr %661, align 8
-  %662 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %660, i32 0, i32 1
-  store i64 7, ptr %662, align 4
-  %663 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %660, align 8
-  %664 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
-  %665 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
-  %666 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %667 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %666, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %663, ptr %667, align 8
-  %668 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %666, i32 0, i32 1
-  store ptr %665, ptr %668, align 8
-  %669 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %666, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).MapType", ptr %669, align 8
-  %670 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %666, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).MapType", ptr %670, align 8
-  %671 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %666, align 8
-  %672 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %673 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %672, i32 0, i32 0
-  store ptr @65, ptr %673, align 8
-  %674 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %672, i32 0, i32 1
-  store i64 9, ptr %674, align 4
-  %675 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %672, align 8
-  %676 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %677 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %678 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %677, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %675, ptr %678, align 8
-  %679 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %677, i32 0, i32 1
-  store ptr %676, ptr %679, align 8
-  %680 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %677, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).NumMethod", ptr %680, align 8
-  %681 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %677, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).NumMethod", ptr %681, align 8
-  %682 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %677, align 8
-  %683 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %684 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %683, i32 0, i32 0
-  store ptr @66, ptr %684, align 8
-  %685 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %683, i32 0, i32 1
-  store i64 8, ptr %685, align 4
-  %686 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %683, align 8
-  %687 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %688 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %689 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %688, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %686, ptr %689, align 8
-  %690 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %688, i32 0, i32 1
-  store ptr %687, ptr %690, align 8
-  %691 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %688, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Pointers", ptr %691, align 8
-  %692 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %688, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Pointers", ptr %692, align 8
-  %693 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %688, align 8
-  %694 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %695 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %694, i32 0, i32 0
-  store ptr @68, ptr %695, align 8
-  %696 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %694, i32 0, i32 1
-  store i64 4, ptr %696, align 4
-  %697 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %694, align 8
-  %698 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
-  %699 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %700 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %699, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %697, ptr %700, align 8
-  %701 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %699, i32 0, i32 1
-  store ptr %698, ptr %701, align 8
-  %702 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %699, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Size", ptr %702, align 8
-  %703 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %699, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Size", ptr %703, align 8
-  %704 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %699, align 8
-  %705 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %706 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %705, i32 0, i32 0
-  store ptr @52, ptr %706, align 8
-  %707 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %705, i32 0, i32 1
-  store i64 6, ptr %707, align 4
-  %708 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %705, align 8
-  %709 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %710 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %711 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %710, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %708, ptr %711, align 8
-  %712 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %710, i32 0, i32 1
-  store ptr %709, ptr %712, align 8
-  %713 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %710, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).String", ptr %713, align 8
-  %714 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %710, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).String", ptr %714, align 8
-  %715 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %710, align 8
-  %716 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %717 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %716, i32 0, i32 0
-  store ptr @69, ptr %717, align 8
-  %718 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %716, i32 0, i32 1
-  store i64 10, ptr %718, align 4
-  %719 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %716, align 8
-  %720 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
-  %721 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
-  %722 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %723 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %722, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %719, ptr %723, align 8
-  %724 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %722, i32 0, i32 1
-  store ptr %721, ptr %724, align 8
-  %725 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %722, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType", ptr %725, align 8
-  %726 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %722, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType", ptr %726, align 8
-  %727 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %722, align 8
-  %728 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %729 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %728, i32 0, i32 0
-  store ptr @79, ptr %729, align 8
-  %730 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %728, i32 0, i32 1
-  store i64 8, ptr %730, align 4
-  %731 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %728, align 8
-  %732 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
-  %733 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %734 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %733, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %731, ptr %734, align 8
-  %735 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %733, i32 0, i32 1
-  store ptr %732, ptr %735, align 8
-  %736 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %733, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Uncommon", ptr %736, align 8
-  %737 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %733, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Uncommon", ptr %737, align 8
-  %738 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %733, align 8
-  %739 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 880)
-  %740 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %739, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %394, ptr %740, align 8
-  %741 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %739, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %510, ptr %741, align 8
-  %742 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %739, i64 2
-  store %"github.com/goplus/llgo/internal/abi.Method" %521, ptr %742, align 8
-  %743 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %739, i64 3
-  store %"github.com/goplus/llgo/internal/abi.Method" %533, ptr %743, align 8
-  %744 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %739, i64 4
-  store %"github.com/goplus/llgo/internal/abi.Method" %545, ptr %744, align 8
-  %745 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %739, i64 5
-  store %"github.com/goplus/llgo/internal/abi.Method" %557, ptr %745, align 8
-  %746 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %739, i64 6
-  store %"github.com/goplus/llgo/internal/abi.Method" %568, ptr %746, align 8
-  %747 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %739, i64 7
-  store %"github.com/goplus/llgo/internal/abi.Method" %580, ptr %747, align 8
-  %748 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %739, i64 8
-  store %"github.com/goplus/llgo/internal/abi.Method" %591, ptr %748, align 8
-  %749 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %739, i64 9
-  store %"github.com/goplus/llgo/internal/abi.Method" %602, ptr %749, align 8
-  %750 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %739, i64 10
-  store %"github.com/goplus/llgo/internal/abi.Method" %614, ptr %750, align 8
-  %751 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %739, i64 11
-  store %"github.com/goplus/llgo/internal/abi.Method" %625, ptr %751, align 8
-  %752 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %739, i64 12
-  store %"github.com/goplus/llgo/internal/abi.Method" %637, ptr %752, align 8
-  %753 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %739, i64 13
-  store %"github.com/goplus/llgo/internal/abi.Method" %648, ptr %753, align 8
-  %754 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %739, i64 14
-  store %"github.com/goplus/llgo/internal/abi.Method" %659, ptr %754, align 8
-  %755 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %739, i64 15
-  store %"github.com/goplus/llgo/internal/abi.Method" %671, ptr %755, align 8
-  %756 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %739, i64 16
-  store %"github.com/goplus/llgo/internal/abi.Method" %682, ptr %756, align 8
-  %757 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %739, i64 17
-  store %"github.com/goplus/llgo/internal/abi.Method" %693, ptr %757, align 8
-  %758 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %739, i64 18
-  store %"github.com/goplus/llgo/internal/abi.Method" %704, ptr %758, align 8
-  %759 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %739, i64 19
-  store %"github.com/goplus/llgo/internal/abi.Method" %715, ptr %759, align 8
-  %760 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %739, i64 20
-  store %"github.com/goplus/llgo/internal/abi.Method" %727, ptr %760, align 8
-  %761 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %739, i64 21
-  store %"github.com/goplus/llgo/internal/abi.Method" %738, ptr %761, align 8
-  %762 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %763 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %762, i32 0, i32 0
-  store ptr %739, ptr %763, align 8
-  %764 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %762, i32 0, i32 1
-  store i64 22, ptr %764, align 4
-  %765 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %762, i32 0, i32 2
-  store i64 22, ptr %765, align 4
-  %766 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %762, align 8
-  %767 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %768 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %767, i32 0, i32 0
-  store ptr @3, ptr %768, align 8
-  %769 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %767, i32 0, i32 1
-  store i64 35, ptr %769, align 4
-  %770 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %767, align 8
-  %771 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %772 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %771, i32 0, i32 0
-  store ptr @21, ptr %772, align 8
-  %773 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %771, i32 0, i32 1
-  store i64 4, ptr %773, align 4
-  %774 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %771, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %20, %"github.com/goplus/llgo/internal/runtime.String" %770, %"github.com/goplus/llgo/internal/runtime.String" %774, ptr %353, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %766)
+  %504 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  %505 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  %506 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
+  %507 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %508 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %507, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %400, ptr %508, align 8
+  %509 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %507, i32 0, i32 1
+  store ptr %506, ptr %509, align 8
+  %510 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %507, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).ArrayType", ptr %510, align 8
+  %511 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %507, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).ArrayType", ptr %511, align 8
+  %512 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %507, align 8
+  %513 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %514 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %513, i32 0, i32 0
+  store ptr @25, ptr %514, align 8
+  %515 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %513, i32 0, i32 1
+  store i64 7, ptr %515, align 4
+  %516 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %513, align 8
+  %517 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
+  %518 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %519 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %518, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %516, ptr %519, align 8
+  %520 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %518, i32 0, i32 1
+  store ptr %517, ptr %520, align 8
+  %521 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %518, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).ChanDir", ptr %521, align 8
+  %522 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %518, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).ChanDir", ptr %522, align 8
+  %523 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %518, align 8
+  %524 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %525 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %524, i32 0, i32 0
+  store ptr @27, ptr %525, align 8
+  %526 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %524, i32 0, i32 1
+  store i64 6, ptr %526, align 4
+  %527 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %524, align 8
+  %528 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %529 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %530 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %531 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %530, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %527, ptr %531, align 8
+  %532 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %530, i32 0, i32 1
+  store ptr %529, ptr %532, align 8
+  %533 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %530, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Common", ptr %533, align 8
+  %534 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %530, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Common", ptr %534, align 8
+  %535 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %530, align 8
+  %536 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %537 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %536, i32 0, i32 0
+  store ptr @22, ptr %537, align 8
+  %538 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %536, i32 0, i32 1
+  store i64 4, ptr %538, align 4
+  %539 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %536, align 8
+  %540 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %541 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %542 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %543 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %542, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %539, ptr %543, align 8
+  %544 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %542, i32 0, i32 1
+  store ptr %541, ptr %544, align 8
+  %545 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %542, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Elem", ptr %545, align 8
+  %546 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %542, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Elem", ptr %546, align 8
+  %547 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %542, align 8
+  %548 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %549 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %548, i32 0, i32 0
+  store ptr @28, ptr %549, align 8
+  %550 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %548, i32 0, i32 1
+  store i64 15, ptr %550, align 4
+  %551 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %548, align 8
+  %552 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %553 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
+  %554 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %555 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %554, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %551, ptr %555, align 8
+  %556 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %554, i32 0, i32 1
+  store ptr %553, ptr %556, align 8
+  %557 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %554, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).ExportedMethods", ptr %557, align 8
+  %558 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %554, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).ExportedMethods", ptr %558, align 8
+  %559 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %554, align 8
+  %560 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %561 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %560, i32 0, i32 0
+  store ptr @33, ptr %561, align 8
+  %562 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %560, i32 0, i32 1
+  store i64 10, ptr %562, align 4
+  %563 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %560, align 8
+  %564 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %565 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %566 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %565, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %563, ptr %566, align 8
+  %567 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %565, i32 0, i32 1
+  store ptr %564, ptr %567, align 8
+  %568 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %565, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).FieldAlign", ptr %568, align 8
+  %569 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %565, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).FieldAlign", ptr %569, align 8
+  %570 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %565, align 8
+  %571 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %572 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %571, i32 0, i32 0
+  store ptr @34, ptr %572, align 8
+  %573 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %571, i32 0, i32 1
+  store i64 8, ptr %573, align 4
+  %574 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %571, align 8
+  %575 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %576 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
+  %577 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %578 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %577, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %574, ptr %578, align 8
+  %579 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %577, i32 0, i32 1
+  store ptr %576, ptr %579, align 8
+  %580 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %577, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).FuncType", ptr %580, align 8
+  %581 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %577, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).FuncType", ptr %581, align 8
+  %582 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %577, align 8
+  %583 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %584 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %583, i32 0, i32 0
+  store ptr @35, ptr %584, align 8
+  %585 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %583, i32 0, i32 1
+  store i64 7, ptr %585, align 4
+  %586 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %583, align 8
+  %587 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %588 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %589 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %588, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %586, ptr %589, align 8
+  %590 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %588, i32 0, i32 1
+  store ptr %587, ptr %590, align 8
+  %591 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %588, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).HasName", ptr %591, align 8
+  %592 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %588, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).HasName", ptr %592, align 8
+  %593 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %588, align 8
+  %594 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %595 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %594, i32 0, i32 0
+  store ptr @36, ptr %595, align 8
+  %596 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %594, i32 0, i32 1
+  store i64 10, ptr %596, align 4
+  %597 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %594, align 8
+  %598 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %599 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %600 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %599, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %597, ptr %600, align 8
+  %601 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %599, i32 0, i32 1
+  store ptr %598, ptr %601, align 8
+  %602 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %599, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).IfaceIndir", ptr %602, align 8
+  %603 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %599, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).IfaceIndir", ptr %603, align 8
+  %604 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %599, align 8
+  %605 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %606 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %605, i32 0, i32 0
+  store ptr @37, ptr %606, align 8
+  %607 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %605, i32 0, i32 1
+  store i64 13, ptr %607, align 4
+  %608 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %605, align 8
+  %609 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  %610 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
+  %611 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %612 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %611, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %608, ptr %612, align 8
+  %613 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %611, i32 0, i32 1
+  store ptr %610, ptr %613, align 8
+  %614 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %611, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).InterfaceType", ptr %614, align 8
+  %615 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %611, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).InterfaceType", ptr %615, align 8
+  %616 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %611, align 8
+  %617 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %618 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %617, i32 0, i32 0
+  store ptr @48, ptr %618, align 8
+  %619 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %617, i32 0, i32 1
+  store i64 13, ptr %619, align 4
+  %620 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %617, align 8
+  %621 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %622 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %623 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %622, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %620, ptr %623, align 8
+  %624 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %622, i32 0, i32 1
+  store ptr %621, ptr %624, align 8
+  %625 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %622, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).IsDirectIface", ptr %625, align 8
+  %626 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %622, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).IsDirectIface", ptr %626, align 8
+  %627 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %622, align 8
+  %628 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %629 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %628, i32 0, i32 0
+  store ptr @49, ptr %629, align 8
+  %630 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %628, i32 0, i32 1
+  store i64 3, ptr %630, align 4
+  %631 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %628, align 8
+  %632 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %633 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %634 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %635 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %634, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %631, ptr %635, align 8
+  %636 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %634, i32 0, i32 1
+  store ptr %633, ptr %636, align 8
+  %637 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %634, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Key", ptr %637, align 8
+  %638 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %634, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Key", ptr %638, align 8
+  %639 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %634, align 8
+  %640 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %641 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %640, i32 0, i32 0
+  store ptr @50, ptr %641, align 8
+  %642 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %640, i32 0, i32 1
+  store i64 4, ptr %642, align 4
+  %643 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %640, align 8
+  %644 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
+  %645 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %646 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %645, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %643, ptr %646, align 8
+  %647 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %645, i32 0, i32 1
+  store ptr %644, ptr %647, align 8
+  %648 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %645, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Kind", ptr %648, align 8
+  %649 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %645, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Kind", ptr %649, align 8
+  %650 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %645, align 8
+  %651 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %652 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %651, i32 0, i32 0
+  store ptr @24, ptr %652, align 8
+  %653 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %651, i32 0, i32 1
+  store i64 3, ptr %653, align 4
+  %654 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %651, align 8
+  %655 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %656 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %657 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %656, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %654, ptr %657, align 8
+  %658 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %656, i32 0, i32 1
+  store ptr %655, ptr %658, align 8
+  %659 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %656, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Len", ptr %659, align 8
+  %660 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %656, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Len", ptr %660, align 8
+  %661 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %656, align 8
+  %662 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %663 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %662, i32 0, i32 0
+  store ptr @53, ptr %663, align 8
+  %664 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %662, i32 0, i32 1
+  store i64 7, ptr %664, align 4
+  %665 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %662, align 8
+  %666 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  %667 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
+  %668 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %669 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %668, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %665, ptr %669, align 8
+  %670 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %668, i32 0, i32 1
+  store ptr %667, ptr %670, align 8
+  %671 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %668, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).MapType", ptr %671, align 8
+  %672 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %668, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).MapType", ptr %672, align 8
+  %673 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %668, align 8
+  %674 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %675 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %674, i32 0, i32 0
+  store ptr @65, ptr %675, align 8
+  %676 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %674, i32 0, i32 1
+  store i64 9, ptr %676, align 4
+  %677 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %674, align 8
+  %678 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %679 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %680 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %679, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %677, ptr %680, align 8
+  %681 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %679, i32 0, i32 1
+  store ptr %678, ptr %681, align 8
+  %682 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %679, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).NumMethod", ptr %682, align 8
+  %683 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %679, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).NumMethod", ptr %683, align 8
+  %684 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %679, align 8
+  %685 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %686 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %685, i32 0, i32 0
+  store ptr @66, ptr %686, align 8
+  %687 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %685, i32 0, i32 1
+  store i64 8, ptr %687, align 4
+  %688 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %685, align 8
+  %689 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %690 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %691 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %690, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %688, ptr %691, align 8
+  %692 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %690, i32 0, i32 1
+  store ptr %689, ptr %692, align 8
+  %693 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %690, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Pointers", ptr %693, align 8
+  %694 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %690, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Pointers", ptr %694, align 8
+  %695 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %690, align 8
+  %696 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %697 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %696, i32 0, i32 0
+  store ptr @68, ptr %697, align 8
+  %698 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %696, i32 0, i32 1
+  store i64 4, ptr %698, align 4
+  %699 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %696, align 8
+  %700 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
+  %701 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %702 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %701, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %699, ptr %702, align 8
+  %703 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %701, i32 0, i32 1
+  store ptr %700, ptr %703, align 8
+  %704 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %701, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Size", ptr %704, align 8
+  %705 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %701, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Size", ptr %705, align 8
+  %706 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %701, align 8
+  %707 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %708 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %707, i32 0, i32 0
+  store ptr @52, ptr %708, align 8
+  %709 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %707, i32 0, i32 1
+  store i64 6, ptr %709, align 4
+  %710 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %707, align 8
+  %711 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %712 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %713 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %712, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %710, ptr %713, align 8
+  %714 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %712, i32 0, i32 1
+  store ptr %711, ptr %714, align 8
+  %715 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %712, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).String", ptr %715, align 8
+  %716 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %712, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).String", ptr %716, align 8
+  %717 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %712, align 8
+  %718 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %719 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %718, i32 0, i32 0
+  store ptr @69, ptr %719, align 8
+  %720 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %718, i32 0, i32 1
+  store i64 10, ptr %720, align 4
+  %721 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %718, align 8
+  %722 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  %723 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
+  %724 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %725 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %724, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %721, ptr %725, align 8
+  %726 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %724, i32 0, i32 1
+  store ptr %723, ptr %726, align 8
+  %727 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %724, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType", ptr %727, align 8
+  %728 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %724, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType", ptr %728, align 8
+  %729 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %724, align 8
+  %730 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %731 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %730, i32 0, i32 0
+  store ptr @79, ptr %731, align 8
+  %732 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %730, i32 0, i32 1
+  store i64 8, ptr %732, align 4
+  %733 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %730, align 8
+  %734 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
+  %735 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %736 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %735, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %733, ptr %736, align 8
+  %737 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %735, i32 0, i32 1
+  store ptr %734, ptr %737, align 8
+  %738 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %735, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Uncommon", ptr %738, align 8
+  %739 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %735, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Uncommon", ptr %739, align 8
+  %740 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %735, align 8
+  %741 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 880)
+  %742 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %741, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %396, ptr %742, align 8
+  %743 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %741, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %512, ptr %743, align 8
+  %744 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %741, i64 2
+  store %"github.com/goplus/llgo/internal/abi.Method" %523, ptr %744, align 8
+  %745 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %741, i64 3
+  store %"github.com/goplus/llgo/internal/abi.Method" %535, ptr %745, align 8
+  %746 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %741, i64 4
+  store %"github.com/goplus/llgo/internal/abi.Method" %547, ptr %746, align 8
+  %747 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %741, i64 5
+  store %"github.com/goplus/llgo/internal/abi.Method" %559, ptr %747, align 8
+  %748 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %741, i64 6
+  store %"github.com/goplus/llgo/internal/abi.Method" %570, ptr %748, align 8
+  %749 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %741, i64 7
+  store %"github.com/goplus/llgo/internal/abi.Method" %582, ptr %749, align 8
+  %750 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %741, i64 8
+  store %"github.com/goplus/llgo/internal/abi.Method" %593, ptr %750, align 8
+  %751 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %741, i64 9
+  store %"github.com/goplus/llgo/internal/abi.Method" %604, ptr %751, align 8
+  %752 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %741, i64 10
+  store %"github.com/goplus/llgo/internal/abi.Method" %616, ptr %752, align 8
+  %753 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %741, i64 11
+  store %"github.com/goplus/llgo/internal/abi.Method" %627, ptr %753, align 8
+  %754 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %741, i64 12
+  store %"github.com/goplus/llgo/internal/abi.Method" %639, ptr %754, align 8
+  %755 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %741, i64 13
+  store %"github.com/goplus/llgo/internal/abi.Method" %650, ptr %755, align 8
+  %756 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %741, i64 14
+  store %"github.com/goplus/llgo/internal/abi.Method" %661, ptr %756, align 8
+  %757 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %741, i64 15
+  store %"github.com/goplus/llgo/internal/abi.Method" %673, ptr %757, align 8
+  %758 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %741, i64 16
+  store %"github.com/goplus/llgo/internal/abi.Method" %684, ptr %758, align 8
+  %759 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %741, i64 17
+  store %"github.com/goplus/llgo/internal/abi.Method" %695, ptr %759, align 8
+  %760 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %741, i64 18
+  store %"github.com/goplus/llgo/internal/abi.Method" %706, ptr %760, align 8
+  %761 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %741, i64 19
+  store %"github.com/goplus/llgo/internal/abi.Method" %717, ptr %761, align 8
+  %762 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %741, i64 20
+  store %"github.com/goplus/llgo/internal/abi.Method" %729, ptr %762, align 8
+  %763 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %741, i64 21
+  store %"github.com/goplus/llgo/internal/abi.Method" %740, ptr %763, align 8
+  %764 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %765 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %764, i32 0, i32 0
+  store ptr %741, ptr %765, align 8
+  %766 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %764, i32 0, i32 1
+  store i64 22, ptr %766, align 4
+  %767 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %764, i32 0, i32 2
+  store i64 22, ptr %767, align 4
+  %768 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %764, align 8
+  %769 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %770 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %769, i32 0, i32 0
+  store ptr @3, ptr %770, align 8
+  %771 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %769, i32 0, i32 1
+  store i64 35, ptr %771, align 4
+  %772 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %769, align 8
+  %773 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %774 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %773, i32 0, i32 0
+  store ptr @21, ptr %774, align 8
+  %775 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %773, i32 0, i32 1
+  store i64 4, ptr %775, align 4
+  %776 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %773, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %21, %"github.com/goplus/llgo/internal/runtime.String" %772, %"github.com/goplus/llgo/internal/runtime.String" %776, ptr %355, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %768)
   br label %_llgo_32
 
 _llgo_43:                                         ; preds = %_llgo_41
-  %775 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %499)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %775)
-  store ptr %775, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  %777 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %501)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %777)
+  store ptr %777, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
   br label %_llgo_44
 
 _llgo_44:                                         ; preds = %_llgo_43, %_llgo_41
-  %776 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
-  %777 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
-  %778 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
-  %779 = icmp eq ptr %778, null
-  br i1 %779, label %_llgo_45, label %_llgo_46
+  %778 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  %779 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  %780 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
+  %781 = icmp eq ptr %780, null
+  br i1 %781, label %_llgo_45, label %_llgo_46
 
 _llgo_45:                                         ; preds = %_llgo_44
-  %780 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %781 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %782 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %781, i32 0, i32 0
-  store ptr %780, ptr %782, align 8
-  %783 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %781, i32 0, i32 1
-  store i64 0, ptr %783, align 4
-  %784 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %781, i32 0, i32 2
-  store i64 0, ptr %784, align 4
-  %785 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %781, align 8
-  %786 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %787 = getelementptr ptr, ptr %786, i64 0
-  store ptr %777, ptr %787, align 8
-  %788 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %789 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %788, i32 0, i32 0
-  store ptr %786, ptr %789, align 8
-  %790 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %788, i32 0, i32 1
-  store i64 1, ptr %790, align 4
-  %791 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %788, i32 0, i32 2
-  store i64 1, ptr %791, align 4
-  %792 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %788, align 8
-  %793 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %785, %"github.com/goplus/llgo/internal/runtime.Slice" %792, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %793)
-  store ptr %793, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
+  %782 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %783 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %784 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %783, i32 0, i32 0
+  store ptr %782, ptr %784, align 8
+  %785 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %783, i32 0, i32 1
+  store i64 0, ptr %785, align 4
+  %786 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %783, i32 0, i32 2
+  store i64 0, ptr %786, align 4
+  %787 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %783, align 8
+  %788 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %789 = getelementptr ptr, ptr %788, i64 0
+  store ptr %779, ptr %789, align 8
+  %790 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %791 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %790, i32 0, i32 0
+  store ptr %788, ptr %791, align 8
+  %792 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %790, i32 0, i32 1
+  store i64 1, ptr %792, align 4
+  %793 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %790, i32 0, i32 2
+  store i64 1, ptr %793, align 4
+  %794 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %790, align 8
+  %795 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %787, %"github.com/goplus/llgo/internal/runtime.Slice" %794, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %795)
+  store ptr %795, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
   br label %_llgo_46
 
 _llgo_46:                                         ; preds = %_llgo_45, %_llgo_44
-  %794 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
-  %795 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %796 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %795, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %494, ptr %796, align 8
-  %797 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %795, i32 0, i32 1
-  store ptr %794, ptr %797, align 8
-  %798 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %795, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ArrayType", ptr %798, align 8
-  %799 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %795, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ArrayType", ptr %799, align 8
-  %800 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %795, align 8
-  %801 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %802 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %801, i32 0, i32 0
-  store ptr @25, ptr %802, align 8
-  %803 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %801, i32 0, i32 1
-  store i64 7, ptr %803, align 4
-  %804 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %801, align 8
-  %805 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %806 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %805, i32 0, i32 0
-  store ptr @26, ptr %806, align 8
-  %807 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %805, i32 0, i32 1
-  store i64 43, ptr %807, align 4
-  %808 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %805, align 8
-  %809 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %808, i64 2, i64 8, i64 0, i64 0)
-  %810 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ChanDir", align 8
-  %811 = icmp eq ptr %810, null
-  br i1 %811, label %_llgo_47, label %_llgo_48
+  %796 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
+  %797 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %798 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %797, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %496, ptr %798, align 8
+  %799 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %797, i32 0, i32 1
+  store ptr %796, ptr %799, align 8
+  %800 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %797, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ArrayType", ptr %800, align 8
+  %801 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %797, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ArrayType", ptr %801, align 8
+  %802 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %797, align 8
+  %803 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %804 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %803, i32 0, i32 0
+  store ptr @25, ptr %804, align 8
+  %805 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %803, i32 0, i32 1
+  store i64 7, ptr %805, align 4
+  %806 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %803, align 8
+  %807 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %808 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %807, i32 0, i32 0
+  store ptr @26, ptr %808, align 8
+  %809 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %807, i32 0, i32 1
+  store i64 43, ptr %809, align 4
+  %810 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %807, align 8
+  %811 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %810, i64 2, i64 8, i64 0, i64 0)
+  %812 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ChanDir", align 8
+  %813 = icmp eq ptr %812, null
+  br i1 %813, label %_llgo_47, label %_llgo_48
 
 _llgo_47:                                         ; preds = %_llgo_46
-  store ptr %809, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ChanDir", align 8
+  store ptr %811, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ChanDir", align 8
   br label %_llgo_48
 
 _llgo_48:                                         ; preds = %_llgo_47, %_llgo_46
-  %812 = load ptr, ptr @_llgo_int, align 8
-  br i1 %811, label %_llgo_49, label %_llgo_50
+  %814 = load ptr, ptr @_llgo_int, align 8
+  br i1 %813, label %_llgo_49, label %_llgo_50
 
 _llgo_49:                                         ; preds = %_llgo_48
-  %813 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %814 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %813, i32 0, i32 0
-  store ptr @3, ptr %814, align 8
-  %815 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %813, i32 0, i32 1
-  store i64 35, ptr %815, align 4
-  %816 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %813, align 8
-  %817 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %818 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %817, i32 0, i32 0
-  store ptr @25, ptr %818, align 8
-  %819 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %817, i32 0, i32 1
-  store i64 7, ptr %819, align 4
-  %820 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %817, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %809, %"github.com/goplus/llgo/internal/runtime.String" %816, %"github.com/goplus/llgo/internal/runtime.String" %820, ptr %812, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  %815 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %816 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %815, i32 0, i32 0
+  store ptr @3, ptr %816, align 8
+  %817 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %815, i32 0, i32 1
+  store i64 35, ptr %817, align 4
+  %818 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %815, align 8
+  %819 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %820 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %819, i32 0, i32 0
+  store ptr @25, ptr %820, align 8
+  %821 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %819, i32 0, i32 1
+  store i64 7, ptr %821, align 4
+  %822 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %819, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %811, %"github.com/goplus/llgo/internal/runtime.String" %818, %"github.com/goplus/llgo/internal/runtime.String" %822, ptr %814, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
   br label %_llgo_50
 
 _llgo_50:                                         ; preds = %_llgo_49, %_llgo_48
-  %821 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ChanDir", align 8
-  %822 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ChanDir", align 8
-  %823 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
-  %824 = icmp eq ptr %823, null
-  br i1 %824, label %_llgo_51, label %_llgo_52
+  %823 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ChanDir", align 8
+  %824 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ChanDir", align 8
+  %825 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
+  %826 = icmp eq ptr %825, null
+  br i1 %826, label %_llgo_51, label %_llgo_52
 
 _llgo_51:                                         ; preds = %_llgo_50
-  %825 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %826 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %827 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %826, i32 0, i32 0
-  store ptr %825, ptr %827, align 8
-  %828 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %826, i32 0, i32 1
-  store i64 0, ptr %828, align 4
-  %829 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %826, i32 0, i32 2
-  store i64 0, ptr %829, align 4
-  %830 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %826, align 8
-  %831 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %832 = getelementptr ptr, ptr %831, i64 0
-  store ptr %822, ptr %832, align 8
-  %833 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %834 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %833, i32 0, i32 0
-  store ptr %831, ptr %834, align 8
-  %835 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %833, i32 0, i32 1
-  store i64 1, ptr %835, align 4
-  %836 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %833, i32 0, i32 2
-  store i64 1, ptr %836, align 4
-  %837 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %833, align 8
-  %838 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %830, %"github.com/goplus/llgo/internal/runtime.Slice" %837, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %838)
-  store ptr %838, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
+  %827 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %828 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %829 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %828, i32 0, i32 0
+  store ptr %827, ptr %829, align 8
+  %830 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %828, i32 0, i32 1
+  store i64 0, ptr %830, align 4
+  %831 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %828, i32 0, i32 2
+  store i64 0, ptr %831, align 4
+  %832 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %828, align 8
+  %833 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %834 = getelementptr ptr, ptr %833, i64 0
+  store ptr %824, ptr %834, align 8
+  %835 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %836 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %835, i32 0, i32 0
+  store ptr %833, ptr %836, align 8
+  %837 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %835, i32 0, i32 1
+  store i64 1, ptr %837, align 4
+  %838 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %835, i32 0, i32 2
+  store i64 1, ptr %838, align 4
+  %839 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %835, align 8
+  %840 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %832, %"github.com/goplus/llgo/internal/runtime.Slice" %839, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %840)
+  store ptr %840, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
   br label %_llgo_52
 
 _llgo_52:                                         ; preds = %_llgo_51, %_llgo_50
-  %839 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
-  %840 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %841 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %840, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %804, ptr %841, align 8
-  %842 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %840, i32 0, i32 1
-  store ptr %839, ptr %842, align 8
-  %843 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %840, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ChanDir", ptr %843, align 8
-  %844 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %840, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ChanDir", ptr %844, align 8
-  %845 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %840, align 8
-  %846 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %847 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %846, i32 0, i32 0
-  store ptr @27, ptr %847, align 8
-  %848 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %846, i32 0, i32 1
-  store i64 6, ptr %848, align 4
-  %849 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %846, align 8
-  %850 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %851 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %852 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %853 = icmp eq ptr %852, null
-  br i1 %853, label %_llgo_53, label %_llgo_54
+  %841 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
+  %842 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %843 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %842, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %806, ptr %843, align 8
+  %844 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %842, i32 0, i32 1
+  store ptr %841, ptr %844, align 8
+  %845 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %842, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ChanDir", ptr %845, align 8
+  %846 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %842, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ChanDir", ptr %846, align 8
+  %847 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %842, align 8
+  %848 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %849 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %848, i32 0, i32 0
+  store ptr @27, ptr %849, align 8
+  %850 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %848, i32 0, i32 1
+  store i64 6, ptr %850, align 4
+  %851 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %848, align 8
+  %852 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %853 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %854 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %855 = icmp eq ptr %854, null
+  br i1 %855, label %_llgo_53, label %_llgo_54
 
 _llgo_53:                                         ; preds = %_llgo_52
-  %854 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %855 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %856 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %855, i32 0, i32 0
-  store ptr %854, ptr %856, align 8
-  %857 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %855, i32 0, i32 1
-  store i64 0, ptr %857, align 4
-  %858 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %855, i32 0, i32 2
-  store i64 0, ptr %858, align 4
-  %859 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %855, align 8
-  %860 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %861 = getelementptr ptr, ptr %860, i64 0
-  store ptr %851, ptr %861, align 8
-  %862 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %863 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %862, i32 0, i32 0
-  store ptr %860, ptr %863, align 8
-  %864 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %862, i32 0, i32 1
-  store i64 1, ptr %864, align 4
-  %865 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %862, i32 0, i32 2
-  store i64 1, ptr %865, align 4
-  %866 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %862, align 8
-  %867 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %859, %"github.com/goplus/llgo/internal/runtime.Slice" %866, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %867)
-  store ptr %867, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %856 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %857 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %858 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %857, i32 0, i32 0
+  store ptr %856, ptr %858, align 8
+  %859 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %857, i32 0, i32 1
+  store i64 0, ptr %859, align 4
+  %860 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %857, i32 0, i32 2
+  store i64 0, ptr %860, align 4
+  %861 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %857, align 8
+  %862 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %863 = getelementptr ptr, ptr %862, i64 0
+  store ptr %853, ptr %863, align 8
+  %864 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %865 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %864, i32 0, i32 0
+  store ptr %862, ptr %865, align 8
+  %866 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %864, i32 0, i32 1
+  store i64 1, ptr %866, align 4
+  %867 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %864, i32 0, i32 2
+  store i64 1, ptr %867, align 4
+  %868 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %864, align 8
+  %869 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %861, %"github.com/goplus/llgo/internal/runtime.Slice" %868, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %869)
+  store ptr %869, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
   br label %_llgo_54
 
 _llgo_54:                                         ; preds = %_llgo_53, %_llgo_52
-  %868 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %869 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %870 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %869, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %849, ptr %870, align 8
-  %871 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %869, i32 0, i32 1
-  store ptr %868, ptr %871, align 8
-  %872 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %869, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Common", ptr %872, align 8
-  %873 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %869, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Common", ptr %873, align 8
-  %874 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %869, align 8
-  %875 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %876 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %875, i32 0, i32 0
-  store ptr @28, ptr %876, align 8
-  %877 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %875, i32 0, i32 1
-  store i64 15, ptr %877, align 4
-  %878 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %875, align 8
-  %879 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %880 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %879, i32 0, i32 0
-  store ptr @29, ptr %880, align 8
-  %881 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %879, i32 0, i32 1
-  store i64 42, ptr %881, align 4
-  %882 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %879, align 8
-  %883 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %882, i64 25, i64 40, i64 0, i64 3)
-  %884 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %885 = icmp eq ptr %884, null
-  br i1 %885, label %_llgo_55, label %_llgo_56
+  %870 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %871 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %872 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %871, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %851, ptr %872, align 8
+  %873 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %871, i32 0, i32 1
+  store ptr %870, ptr %873, align 8
+  %874 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %871, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Common", ptr %874, align 8
+  %875 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %871, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Common", ptr %875, align 8
+  %876 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %871, align 8
+  %877 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %878 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %877, i32 0, i32 0
+  store ptr @28, ptr %878, align 8
+  %879 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %877, i32 0, i32 1
+  store i64 15, ptr %879, align 4
+  %880 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %877, align 8
+  %881 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %882 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %881, i32 0, i32 0
+  store ptr @29, ptr %882, align 8
+  %883 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %881, i32 0, i32 1
+  store i64 42, ptr %883, align 4
+  %884 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %881, align 8
+  %885 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %884, i64 25, i64 40, i64 0, i64 3)
+  %886 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %887 = icmp eq ptr %886, null
+  br i1 %887, label %_llgo_55, label %_llgo_56
 
 _llgo_55:                                         ; preds = %_llgo_54
-  store ptr %883, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  store ptr %885, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
   br label %_llgo_56
 
 _llgo_56:                                         ; preds = %_llgo_55, %_llgo_54
-  %886 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %887 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %886, i32 0, i32 0
-  store ptr @30, ptr %887, align 8
-  %888 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %886, i32 0, i32 1
-  store i64 44, ptr %888, align 4
-  %889 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %886, align 8
-  %890 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %889, i64 25, i64 128, i64 0, i64 23)
-  %891 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %892 = icmp eq ptr %891, null
-  br i1 %892, label %_llgo_57, label %_llgo_58
+  %888 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %889 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %888, i32 0, i32 0
+  store ptr @30, ptr %889, align 8
+  %890 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %888, i32 0, i32 1
+  store i64 44, ptr %890, align 4
+  %891 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %888, align 8
+  %892 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %891, i64 25, i64 128, i64 0, i64 23)
+  %893 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %894 = icmp eq ptr %893, null
+  br i1 %894, label %_llgo_57, label %_llgo_58
 
 _llgo_57:                                         ; preds = %_llgo_56
-  store ptr %890, ptr @"_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  store ptr %892, ptr @"_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
   br label %_llgo_58
 
 _llgo_58:                                         ; preds = %_llgo_57, %_llgo_56
-  %893 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %894 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %895 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %894, i32 0, i32 0
-  store ptr @1, ptr %895, align 8
-  %896 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %894, i32 0, i32 1
-  store i64 40, ptr %896, align 4
-  %897 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %894, align 8
-  %898 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %897, i64 25, i64 80, i64 0, i64 22)
-  %899 = load ptr, ptr @"[]*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %900 = icmp eq ptr %899, null
-  br i1 %900, label %_llgo_59, label %_llgo_60
+  %895 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %896 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %897 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %896, i32 0, i32 0
+  store ptr @1, ptr %897, align 8
+  %898 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %896, i32 0, i32 1
+  store i64 40, ptr %898, align 4
+  %899 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %896, align 8
+  %900 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %899, i64 25, i64 80, i64 0, i64 22)
+  %901 = load ptr, ptr @"[]*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %902 = icmp eq ptr %901, null
+  br i1 %902, label %_llgo_59, label %_llgo_60
 
 _llgo_59:                                         ; preds = %_llgo_58
-  %901 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %898)
-  %902 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %901)
-  store ptr %902, ptr @"[]*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %903 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %900)
+  %904 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %903)
+  store ptr %904, ptr @"[]*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
   br label %_llgo_60
 
 _llgo_60:                                         ; preds = %_llgo_59, %_llgo_58
-  %903 = load ptr, ptr @"[]*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %904 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
   %905 = load ptr, ptr @"[]*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %906 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %907 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %906, i32 0, i32 0
-  store ptr @1, ptr %907, align 8
-  %908 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %906, i32 0, i32 1
-  store i64 40, ptr %908, align 4
-  %909 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %906, align 8
-  %910 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %909, i64 25, i64 80, i64 0, i64 22)
-  %911 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %912 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %911, i32 0, i32 0
-  store ptr @1, ptr %912, align 8
-  %913 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %911, i32 0, i32 1
-  store i64 40, ptr %913, align 4
-  %914 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %911, align 8
-  %915 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %914, i64 25, i64 80, i64 0, i64 22)
-  %916 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %917 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %916, i32 0, i32 0
-  store ptr @1, ptr %917, align 8
-  %918 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %916, i32 0, i32 1
-  store i64 40, ptr %918, align 4
-  %919 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %916, align 8
-  %920 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %919, i64 25, i64 80, i64 0, i64 22)
-  %921 = load ptr, ptr @"_llgo_struct$wRu7InfmQeSkq7akLN3soDNninnS1dQajawdYvmHbzw", align 8
-  %922 = icmp eq ptr %921, null
-  br i1 %922, label %_llgo_61, label %_llgo_62
+  %906 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %907 = load ptr, ptr @"[]*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %908 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %909 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %908, i32 0, i32 0
+  store ptr @1, ptr %909, align 8
+  %910 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %908, i32 0, i32 1
+  store i64 40, ptr %910, align 4
+  %911 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %908, align 8
+  %912 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %911, i64 25, i64 80, i64 0, i64 22)
+  %913 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %914 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %913, i32 0, i32 0
+  store ptr @1, ptr %914, align 8
+  %915 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %913, i32 0, i32 1
+  store i64 40, ptr %915, align 4
+  %916 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %913, align 8
+  %917 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %916, i64 25, i64 80, i64 0, i64 22)
+  %918 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %919 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %918, i32 0, i32 0
+  store ptr @1, ptr %919, align 8
+  %920 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %918, i32 0, i32 1
+  store i64 40, ptr %920, align 4
+  %921 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %918, align 8
+  %922 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %921, i64 25, i64 80, i64 0, i64 22)
+  %923 = load ptr, ptr @"_llgo_struct$wRu7InfmQeSkq7akLN3soDNninnS1dQajawdYvmHbzw", align 8
+  %924 = icmp eq ptr %923, null
+  br i1 %924, label %_llgo_61, label %_llgo_62
 
 _llgo_61:                                         ; preds = %_llgo_60
-  %923 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %924 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %923, i32 0, i32 0
-  store ptr @21, ptr %924, align 8
-  %925 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %923, i32 0, i32 1
-  store i64 4, ptr %925, align 4
-  %926 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %923, align 8
-  %927 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %928 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %927, i32 0, i32 0
-  store ptr null, ptr %928, align 8
-  %929 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %927, i32 0, i32 1
-  store i64 0, ptr %929, align 4
-  %930 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %927, align 8
-  %931 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %926, ptr %910, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %930, i1 true)
-  %932 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %933 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %932, i32 0, i32 0
-  store ptr @31, ptr %933, align 8
-  %934 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %932, i32 0, i32 1
-  store i64 2, ptr %934, align 4
-  %935 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %932, align 8
-  %936 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %937 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %936, i32 0, i32 0
-  store ptr null, ptr %937, align 8
-  %938 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %936, i32 0, i32 1
-  store i64 0, ptr %938, align 4
-  %939 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %936, align 8
-  %940 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %915)
-  %941 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %940)
-  %942 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %935, ptr %941, i64 72, %"github.com/goplus/llgo/internal/runtime.String" %939, i1 false)
-  %943 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %944 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %943, i32 0, i32 0
-  store ptr @32, ptr %944, align 8
-  %945 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %943, i32 0, i32 1
-  store i64 3, ptr %945, align 4
-  %946 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %943, align 8
-  %947 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %948 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %947, i32 0, i32 0
-  store ptr null, ptr %948, align 8
-  %949 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %947, i32 0, i32 1
-  store i64 0, ptr %949, align 4
-  %950 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %947, align 8
-  %951 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %920)
-  %952 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %951)
-  %953 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %946, ptr %952, i64 96, %"github.com/goplus/llgo/internal/runtime.String" %950, i1 false)
-  %954 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %955 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %954, i32 0, i32 0
-  store ptr @7, ptr %955, align 8
-  %956 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %954, i32 0, i32 1
-  store i64 4, ptr %956, align 4
-  %957 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %954, align 8
-  %958 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 168)
-  %959 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %958, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %931, ptr %959, align 8
-  %960 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %958, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %942, ptr %960, align 8
-  %961 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %958, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %953, ptr %961, align 8
-  %962 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %963 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %962, i32 0, i32 0
-  store ptr %958, ptr %963, align 8
-  %964 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %962, i32 0, i32 1
-  store i64 3, ptr %964, align 4
-  %965 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %962, i32 0, i32 2
-  store i64 3, ptr %965, align 4
-  %966 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %962, align 8
-  %967 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %957, i64 120, %"github.com/goplus/llgo/internal/runtime.Slice" %966)
-  store ptr %967, ptr @"_llgo_struct$wRu7InfmQeSkq7akLN3soDNninnS1dQajawdYvmHbzw", align 8
+  %925 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %926 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %925, i32 0, i32 0
+  store ptr @21, ptr %926, align 8
+  %927 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %925, i32 0, i32 1
+  store i64 4, ptr %927, align 4
+  %928 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %925, align 8
+  %929 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %930 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %929, i32 0, i32 0
+  store ptr null, ptr %930, align 8
+  %931 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %929, i32 0, i32 1
+  store i64 0, ptr %931, align 4
+  %932 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %929, align 8
+  %933 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %928, ptr %912, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %932, i1 true)
+  %934 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %935 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %934, i32 0, i32 0
+  store ptr @31, ptr %935, align 8
+  %936 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %934, i32 0, i32 1
+  store i64 2, ptr %936, align 4
+  %937 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %934, align 8
+  %938 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %939 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %938, i32 0, i32 0
+  store ptr null, ptr %939, align 8
+  %940 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %938, i32 0, i32 1
+  store i64 0, ptr %940, align 4
+  %941 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %938, align 8
+  %942 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %917)
+  %943 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %942)
+  %944 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %937, ptr %943, i64 72, %"github.com/goplus/llgo/internal/runtime.String" %941, i1 false)
+  %945 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %946 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %945, i32 0, i32 0
+  store ptr @32, ptr %946, align 8
+  %947 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %945, i32 0, i32 1
+  store i64 3, ptr %947, align 4
+  %948 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %945, align 8
+  %949 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %950 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %949, i32 0, i32 0
+  store ptr null, ptr %950, align 8
+  %951 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %949, i32 0, i32 1
+  store i64 0, ptr %951, align 4
+  %952 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %949, align 8
+  %953 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %922)
+  %954 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %953)
+  %955 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %948, ptr %954, i64 96, %"github.com/goplus/llgo/internal/runtime.String" %952, i1 false)
+  %956 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %957 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %956, i32 0, i32 0
+  store ptr @7, ptr %957, align 8
+  %958 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %956, i32 0, i32 1
+  store i64 4, ptr %958, align 4
+  %959 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %956, align 8
+  %960 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 168)
+  %961 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %960, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %933, ptr %961, align 8
+  %962 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %960, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %944, ptr %962, align 8
+  %963 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %960, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %955, ptr %963, align 8
+  %964 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %965 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %964, i32 0, i32 0
+  store ptr %960, ptr %965, align 8
+  %966 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %964, i32 0, i32 1
+  store i64 3, ptr %966, align 4
+  %967 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %964, i32 0, i32 2
+  store i64 3, ptr %967, align 4
+  %968 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %964, align 8
+  %969 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %959, i64 120, %"github.com/goplus/llgo/internal/runtime.Slice" %968)
+  store ptr %969, ptr @"_llgo_struct$wRu7InfmQeSkq7akLN3soDNninnS1dQajawdYvmHbzw", align 8
   br label %_llgo_62
 
 _llgo_62:                                         ; preds = %_llgo_61, %_llgo_60
-  %968 = load ptr, ptr @"_llgo_struct$wRu7InfmQeSkq7akLN3soDNninnS1dQajawdYvmHbzw", align 8
-  br i1 %892, label %_llgo_63, label %_llgo_64
+  %970 = load ptr, ptr @"_llgo_struct$wRu7InfmQeSkq7akLN3soDNninnS1dQajawdYvmHbzw", align 8
+  br i1 %894, label %_llgo_63, label %_llgo_64
 
 _llgo_63:                                         ; preds = %_llgo_62
-  %969 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %970 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %969, i32 0, i32 0
-  store ptr @18, ptr %970, align 8
-  %971 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %969, i32 0, i32 1
-  store i64 5, ptr %971, align 4
-  %972 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %969, align 8
-  %973 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %974 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %975 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %974, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %972, ptr %975, align 8
-  %976 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %974, i32 0, i32 1
-  store ptr %973, ptr %976, align 8
-  %977 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %974, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Align", ptr %977, align 8
-  %978 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %974, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Align", ptr %978, align 8
-  %979 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %974, align 8
-  %980 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %981 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %980, i32 0, i32 0
-  store ptr @19, ptr %981, align 8
-  %982 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %980, i32 0, i32 1
-  store i64 9, ptr %982, align 4
-  %983 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %980, align 8
-  %984 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
-  %985 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
-  %986 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %987 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %986, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %983, ptr %987, align 8
-  %988 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %986, i32 0, i32 1
-  store ptr %985, ptr %988, align 8
-  %989 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %986, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ArrayType", ptr %989, align 8
-  %990 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %986, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ArrayType", ptr %990, align 8
-  %991 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %986, align 8
-  %992 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %993 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %992, i32 0, i32 0
-  store ptr @25, ptr %993, align 8
-  %994 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %992, i32 0, i32 1
-  store i64 7, ptr %994, align 4
-  %995 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %992, align 8
-  %996 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
-  %997 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %998 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %997, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %995, ptr %998, align 8
-  %999 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %997, i32 0, i32 1
-  store ptr %996, ptr %999, align 8
-  %1000 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %997, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ChanDir", ptr %1000, align 8
-  %1001 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %997, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ChanDir", ptr %1001, align 8
-  %1002 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %997, align 8
-  %1003 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1004 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1003, i32 0, i32 0
-  store ptr @27, ptr %1004, align 8
-  %1005 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1003, i32 0, i32 1
-  store i64 6, ptr %1005, align 4
-  %1006 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1003, align 8
-  %1007 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %1008 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %1009 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1010 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1009, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1006, ptr %1010, align 8
-  %1011 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1009, i32 0, i32 1
-  store ptr %1008, ptr %1011, align 8
-  %1012 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1009, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Common", ptr %1012, align 8
-  %1013 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1009, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Common", ptr %1013, align 8
-  %1014 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1009, align 8
-  %1015 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1016 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1015, i32 0, i32 0
-  store ptr @22, ptr %1016, align 8
-  %1017 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1015, i32 0, i32 1
-  store i64 4, ptr %1017, align 4
-  %1018 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1015, align 8
-  %1019 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %1020 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %1021 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1022 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1021, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1018, ptr %1022, align 8
-  %1023 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1021, i32 0, i32 1
-  store ptr %1020, ptr %1023, align 8
-  %1024 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1021, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Elem", ptr %1024, align 8
-  %1025 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1021, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Elem", ptr %1025, align 8
-  %1026 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1021, align 8
-  %1027 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1028 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1027, i32 0, i32 0
-  store ptr @28, ptr %1028, align 8
-  %1029 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1027, i32 0, i32 1
-  store i64 15, ptr %1029, align 4
-  %1030 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1027, align 8
-  %1031 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1032 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1031, i32 0, i32 0
-  store ptr @29, ptr %1032, align 8
-  %1033 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1031, i32 0, i32 1
-  store i64 42, ptr %1033, align 4
-  %1034 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1031, align 8
-  %1035 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1034, i64 25, i64 40, i64 0, i64 3)
-  %1036 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %1037 = icmp eq ptr %1036, null
-  br i1 %1037, label %_llgo_65, label %_llgo_66
+  %971 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %972 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %971, i32 0, i32 0
+  store ptr @18, ptr %972, align 8
+  %973 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %971, i32 0, i32 1
+  store i64 5, ptr %973, align 4
+  %974 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %971, align 8
+  %975 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %976 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %977 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %976, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %974, ptr %977, align 8
+  %978 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %976, i32 0, i32 1
+  store ptr %975, ptr %978, align 8
+  %979 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %976, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Align", ptr %979, align 8
+  %980 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %976, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Align", ptr %980, align 8
+  %981 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %976, align 8
+  %982 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %983 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %982, i32 0, i32 0
+  store ptr @19, ptr %983, align 8
+  %984 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %982, i32 0, i32 1
+  store i64 9, ptr %984, align 4
+  %985 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %982, align 8
+  %986 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  %987 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
+  %988 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %989 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %988, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %985, ptr %989, align 8
+  %990 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %988, i32 0, i32 1
+  store ptr %987, ptr %990, align 8
+  %991 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %988, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ArrayType", ptr %991, align 8
+  %992 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %988, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ArrayType", ptr %992, align 8
+  %993 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %988, align 8
+  %994 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %995 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %994, i32 0, i32 0
+  store ptr @25, ptr %995, align 8
+  %996 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %994, i32 0, i32 1
+  store i64 7, ptr %996, align 4
+  %997 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %994, align 8
+  %998 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
+  %999 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1000 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %999, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %997, ptr %1000, align 8
+  %1001 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %999, i32 0, i32 1
+  store ptr %998, ptr %1001, align 8
+  %1002 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %999, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ChanDir", ptr %1002, align 8
+  %1003 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %999, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ChanDir", ptr %1003, align 8
+  %1004 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %999, align 8
+  %1005 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1006 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1005, i32 0, i32 0
+  store ptr @27, ptr %1006, align 8
+  %1007 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1005, i32 0, i32 1
+  store i64 6, ptr %1007, align 4
+  %1008 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1005, align 8
+  %1009 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %1010 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %1011 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1012 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1011, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1008, ptr %1012, align 8
+  %1013 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1011, i32 0, i32 1
+  store ptr %1010, ptr %1013, align 8
+  %1014 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1011, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Common", ptr %1014, align 8
+  %1015 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1011, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Common", ptr %1015, align 8
+  %1016 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1011, align 8
+  %1017 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1018 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1017, i32 0, i32 0
+  store ptr @22, ptr %1018, align 8
+  %1019 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1017, i32 0, i32 1
+  store i64 4, ptr %1019, align 4
+  %1020 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1017, align 8
+  %1021 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %1022 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %1023 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1024 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1023, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1020, ptr %1024, align 8
+  %1025 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1023, i32 0, i32 1
+  store ptr %1022, ptr %1025, align 8
+  %1026 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1023, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Elem", ptr %1026, align 8
+  %1027 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1023, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Elem", ptr %1027, align 8
+  %1028 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1023, align 8
+  %1029 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1030 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1029, i32 0, i32 0
+  store ptr @28, ptr %1030, align 8
+  %1031 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1029, i32 0, i32 1
+  store i64 15, ptr %1031, align 4
+  %1032 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1029, align 8
+  %1033 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1034 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1033, i32 0, i32 0
+  store ptr @29, ptr %1034, align 8
+  %1035 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1033, i32 0, i32 1
+  store i64 42, ptr %1035, align 4
+  %1036 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1033, align 8
+  %1037 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1036, i64 25, i64 40, i64 0, i64 3)
+  %1038 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %1039 = icmp eq ptr %1038, null
+  br i1 %1039, label %_llgo_65, label %_llgo_66
 
 _llgo_64:                                         ; preds = %_llgo_90, %_llgo_62
-  %1038 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %1039 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %1040 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1041 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1040, i32 0, i32 0
-  store ptr @30, ptr %1041, align 8
-  %1042 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1040, i32 0, i32 1
-  store i64 44, ptr %1042, align 4
-  %1043 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1040, align 8
-  %1044 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1043, i64 25, i64 128, i64 0, i64 23)
-  %1045 = load ptr, ptr @"_llgo_struct$SDp3TNnYnxb26MhB1v8VMbmY71BX77YOaY7lgS1cFx0", align 8
-  %1046 = icmp eq ptr %1045, null
-  br i1 %1046, label %_llgo_145, label %_llgo_146
+  %1040 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %1041 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %1042 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1043 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1042, i32 0, i32 0
+  store ptr @30, ptr %1043, align 8
+  %1044 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1042, i32 0, i32 1
+  store i64 44, ptr %1044, align 4
+  %1045 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1042, align 8
+  %1046 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1045, i64 25, i64 128, i64 0, i64 23)
+  %1047 = load ptr, ptr @"_llgo_struct$SDp3TNnYnxb26MhB1v8VMbmY71BX77YOaY7lgS1cFx0", align 8
+  %1048 = icmp eq ptr %1047, null
+  br i1 %1048, label %_llgo_145, label %_llgo_146
 
 _llgo_65:                                         ; preds = %_llgo_63
-  %1047 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %1035)
-  store ptr %1047, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %1049 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %1037)
+  store ptr %1049, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
   br label %_llgo_66
 
 _llgo_66:                                         ; preds = %_llgo_65, %_llgo_63
-  %1048 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %1049 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %1050 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
-  %1051 = icmp eq ptr %1050, null
-  br i1 %1051, label %_llgo_67, label %_llgo_68
+  %1050 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %1051 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %1052 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
+  %1053 = icmp eq ptr %1052, null
+  br i1 %1053, label %_llgo_67, label %_llgo_68
 
 _llgo_67:                                         ; preds = %_llgo_66
-  %1052 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %1053 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1054 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1053, i32 0, i32 0
-  store ptr %1052, ptr %1054, align 8
-  %1055 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1053, i32 0, i32 1
-  store i64 0, ptr %1055, align 4
-  %1056 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1053, i32 0, i32 2
-  store i64 0, ptr %1056, align 4
-  %1057 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1053, align 8
-  %1058 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %1059 = getelementptr ptr, ptr %1058, i64 0
-  store ptr %1049, ptr %1059, align 8
-  %1060 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1061 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1060, i32 0, i32 0
-  store ptr %1058, ptr %1061, align 8
-  %1062 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1060, i32 0, i32 1
-  store i64 1, ptr %1062, align 4
-  %1063 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1060, i32 0, i32 2
-  store i64 1, ptr %1063, align 4
-  %1064 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1060, align 8
-  %1065 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1057, %"github.com/goplus/llgo/internal/runtime.Slice" %1064, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1065)
-  store ptr %1065, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
+  %1054 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %1055 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1056 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1055, i32 0, i32 0
+  store ptr %1054, ptr %1056, align 8
+  %1057 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1055, i32 0, i32 1
+  store i64 0, ptr %1057, align 4
+  %1058 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1055, i32 0, i32 2
+  store i64 0, ptr %1058, align 4
+  %1059 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1055, align 8
+  %1060 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %1061 = getelementptr ptr, ptr %1060, i64 0
+  store ptr %1051, ptr %1061, align 8
+  %1062 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1063 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1062, i32 0, i32 0
+  store ptr %1060, ptr %1063, align 8
+  %1064 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1062, i32 0, i32 1
+  store i64 1, ptr %1064, align 4
+  %1065 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1062, i32 0, i32 2
+  store i64 1, ptr %1065, align 4
+  %1066 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1062, align 8
+  %1067 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1059, %"github.com/goplus/llgo/internal/runtime.Slice" %1066, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1067)
+  store ptr %1067, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
   br label %_llgo_68
 
 _llgo_68:                                         ; preds = %_llgo_67, %_llgo_66
-  %1066 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
-  %1067 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1068 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1030, ptr %1068, align 8
-  %1069 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i32 0, i32 1
-  store ptr %1066, ptr %1069, align 8
-  %1070 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ExportedMethods", ptr %1070, align 8
-  %1071 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ExportedMethods", ptr %1071, align 8
-  %1072 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, align 8
-  %1073 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1074 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1073, i32 0, i32 0
-  store ptr @33, ptr %1074, align 8
-  %1075 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1073, i32 0, i32 1
-  store i64 10, ptr %1075, align 4
-  %1076 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1073, align 8
-  %1077 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %1078 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1079 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1078, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1076, ptr %1079, align 8
-  %1080 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1078, i32 0, i32 1
-  store ptr %1077, ptr %1080, align 8
-  %1081 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1078, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).FieldAlign", ptr %1081, align 8
-  %1082 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1078, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).FieldAlign", ptr %1082, align 8
-  %1083 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1078, align 8
-  %1084 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1085 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1084, i32 0, i32 0
-  store ptr @34, ptr %1085, align 8
-  %1086 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1084, i32 0, i32 1
-  store i64 8, ptr %1086, align 4
-  %1087 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1084, align 8
-  %1088 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1089 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1088, i32 0, i32 0
-  store ptr @30, ptr %1089, align 8
-  %1090 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1088, i32 0, i32 1
-  store i64 44, ptr %1090, align 4
-  %1091 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1088, align 8
-  %1092 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1091, i64 25, i64 128, i64 0, i64 23)
-  %1093 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %1094 = icmp eq ptr %1093, null
-  br i1 %1094, label %_llgo_69, label %_llgo_70
+  %1068 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
+  %1069 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1070 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1069, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1032, ptr %1070, align 8
+  %1071 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1069, i32 0, i32 1
+  store ptr %1068, ptr %1071, align 8
+  %1072 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1069, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ExportedMethods", ptr %1072, align 8
+  %1073 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1069, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ExportedMethods", ptr %1073, align 8
+  %1074 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1069, align 8
+  %1075 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1076 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1075, i32 0, i32 0
+  store ptr @33, ptr %1076, align 8
+  %1077 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1075, i32 0, i32 1
+  store i64 10, ptr %1077, align 4
+  %1078 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1075, align 8
+  %1079 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %1080 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1081 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1080, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1078, ptr %1081, align 8
+  %1082 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1080, i32 0, i32 1
+  store ptr %1079, ptr %1082, align 8
+  %1083 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1080, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).FieldAlign", ptr %1083, align 8
+  %1084 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1080, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).FieldAlign", ptr %1084, align 8
+  %1085 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1080, align 8
+  %1086 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1087 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1086, i32 0, i32 0
+  store ptr @34, ptr %1087, align 8
+  %1088 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1086, i32 0, i32 1
+  store i64 8, ptr %1088, align 4
+  %1089 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1086, align 8
+  %1090 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1091 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1090, i32 0, i32 0
+  store ptr @30, ptr %1091, align 8
+  %1092 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1090, i32 0, i32 1
+  store i64 44, ptr %1092, align 4
+  %1093 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1090, align 8
+  %1094 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1093, i64 25, i64 128, i64 0, i64 23)
+  %1095 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %1096 = icmp eq ptr %1095, null
+  br i1 %1096, label %_llgo_69, label %_llgo_70
 
 _llgo_69:                                         ; preds = %_llgo_68
-  %1095 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1092)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1095)
-  store ptr %1095, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %1097 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1094)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1097)
+  store ptr %1097, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
   br label %_llgo_70
 
 _llgo_70:                                         ; preds = %_llgo_69, %_llgo_68
-  %1096 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %1097 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %1098 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
-  %1099 = icmp eq ptr %1098, null
-  br i1 %1099, label %_llgo_71, label %_llgo_72
+  %1098 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %1099 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %1100 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
+  %1101 = icmp eq ptr %1100, null
+  br i1 %1101, label %_llgo_71, label %_llgo_72
 
 _llgo_71:                                         ; preds = %_llgo_70
-  %1100 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %1101 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1102 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1101, i32 0, i32 0
-  store ptr %1100, ptr %1102, align 8
-  %1103 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1101, i32 0, i32 1
-  store i64 0, ptr %1103, align 4
-  %1104 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1101, i32 0, i32 2
-  store i64 0, ptr %1104, align 4
-  %1105 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1101, align 8
-  %1106 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %1107 = getelementptr ptr, ptr %1106, i64 0
-  store ptr %1097, ptr %1107, align 8
-  %1108 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1109 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1108, i32 0, i32 0
-  store ptr %1106, ptr %1109, align 8
-  %1110 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1108, i32 0, i32 1
-  store i64 1, ptr %1110, align 4
-  %1111 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1108, i32 0, i32 2
-  store i64 1, ptr %1111, align 4
-  %1112 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1108, align 8
-  %1113 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1105, %"github.com/goplus/llgo/internal/runtime.Slice" %1112, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1113)
-  store ptr %1113, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
+  %1102 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %1103 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1104 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1103, i32 0, i32 0
+  store ptr %1102, ptr %1104, align 8
+  %1105 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1103, i32 0, i32 1
+  store i64 0, ptr %1105, align 4
+  %1106 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1103, i32 0, i32 2
+  store i64 0, ptr %1106, align 4
+  %1107 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1103, align 8
+  %1108 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %1109 = getelementptr ptr, ptr %1108, i64 0
+  store ptr %1099, ptr %1109, align 8
+  %1110 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1111 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1110, i32 0, i32 0
+  store ptr %1108, ptr %1111, align 8
+  %1112 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1110, i32 0, i32 1
+  store i64 1, ptr %1112, align 4
+  %1113 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1110, i32 0, i32 2
+  store i64 1, ptr %1113, align 4
+  %1114 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1110, align 8
+  %1115 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1107, %"github.com/goplus/llgo/internal/runtime.Slice" %1114, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1115)
+  store ptr %1115, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
   br label %_llgo_72
 
 _llgo_72:                                         ; preds = %_llgo_71, %_llgo_70
-  %1114 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
-  %1115 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1116 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1115, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1087, ptr %1116, align 8
-  %1117 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1115, i32 0, i32 1
-  store ptr %1114, ptr %1117, align 8
-  %1118 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1115, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).FuncType", ptr %1118, align 8
-  %1119 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1115, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).FuncType", ptr %1119, align 8
-  %1120 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1115, align 8
-  %1121 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1122 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1121, i32 0, i32 0
-  store ptr @35, ptr %1122, align 8
-  %1123 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1121, i32 0, i32 1
-  store i64 7, ptr %1123, align 4
-  %1124 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1121, align 8
-  %1125 = load ptr, ptr @_llgo_bool, align 8
-  %1126 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %1127 = icmp eq ptr %1126, null
-  br i1 %1127, label %_llgo_73, label %_llgo_74
+  %1116 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
+  %1117 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1118 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1117, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1089, ptr %1118, align 8
+  %1119 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1117, i32 0, i32 1
+  store ptr %1116, ptr %1119, align 8
+  %1120 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1117, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).FuncType", ptr %1120, align 8
+  %1121 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1117, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).FuncType", ptr %1121, align 8
+  %1122 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1117, align 8
+  %1123 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1124 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1123, i32 0, i32 0
+  store ptr @35, ptr %1124, align 8
+  %1125 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1123, i32 0, i32 1
+  store i64 7, ptr %1125, align 4
+  %1126 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1123, align 8
+  %1127 = load ptr, ptr @_llgo_bool, align 8
+  %1128 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1129 = icmp eq ptr %1128, null
+  br i1 %1129, label %_llgo_73, label %_llgo_74
 
 _llgo_73:                                         ; preds = %_llgo_72
-  %1128 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %1129 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1130 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1129, i32 0, i32 0
-  store ptr %1128, ptr %1130, align 8
-  %1131 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1129, i32 0, i32 1
-  store i64 0, ptr %1131, align 4
-  %1132 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1129, i32 0, i32 2
-  store i64 0, ptr %1132, align 4
-  %1133 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1129, align 8
-  %1134 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %1135 = getelementptr ptr, ptr %1134, i64 0
-  store ptr %1125, ptr %1135, align 8
-  %1136 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1137 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1136, i32 0, i32 0
-  store ptr %1134, ptr %1137, align 8
-  %1138 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1136, i32 0, i32 1
-  store i64 1, ptr %1138, align 4
-  %1139 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1136, i32 0, i32 2
-  store i64 1, ptr %1139, align 4
-  %1140 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1136, align 8
-  %1141 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1133, %"github.com/goplus/llgo/internal/runtime.Slice" %1140, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1141)
-  store ptr %1141, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1130 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %1131 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1132 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1131, i32 0, i32 0
+  store ptr %1130, ptr %1132, align 8
+  %1133 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1131, i32 0, i32 1
+  store i64 0, ptr %1133, align 4
+  %1134 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1131, i32 0, i32 2
+  store i64 0, ptr %1134, align 4
+  %1135 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1131, align 8
+  %1136 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %1137 = getelementptr ptr, ptr %1136, i64 0
+  store ptr %1127, ptr %1137, align 8
+  %1138 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1139 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1138, i32 0, i32 0
+  store ptr %1136, ptr %1139, align 8
+  %1140 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1138, i32 0, i32 1
+  store i64 1, ptr %1140, align 4
+  %1141 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1138, i32 0, i32 2
+  store i64 1, ptr %1141, align 4
+  %1142 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1138, align 8
+  %1143 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1135, %"github.com/goplus/llgo/internal/runtime.Slice" %1142, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1143)
+  store ptr %1143, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
   br label %_llgo_74
 
 _llgo_74:                                         ; preds = %_llgo_73, %_llgo_72
-  %1142 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %1143 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1144 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1143, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1124, ptr %1144, align 8
-  %1145 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1143, i32 0, i32 1
-  store ptr %1142, ptr %1145, align 8
-  %1146 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1143, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).HasName", ptr %1146, align 8
-  %1147 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1143, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).HasName", ptr %1147, align 8
-  %1148 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1143, align 8
-  %1149 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1150 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1149, i32 0, i32 0
-  store ptr @36, ptr %1150, align 8
-  %1151 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1149, i32 0, i32 1
-  store i64 10, ptr %1151, align 4
-  %1152 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1149, align 8
-  %1153 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %1154 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1155 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1154, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1152, ptr %1155, align 8
-  %1156 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1154, i32 0, i32 1
-  store ptr %1153, ptr %1156, align 8
-  %1157 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1154, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).IfaceIndir", ptr %1157, align 8
-  %1158 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1154, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).IfaceIndir", ptr %1158, align 8
-  %1159 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1154, align 8
-  %1160 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1161 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1160, i32 0, i32 0
-  store ptr @37, ptr %1161, align 8
-  %1162 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1160, i32 0, i32 1
-  store i64 13, ptr %1162, align 4
-  %1163 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1160, align 8
-  %1164 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1165 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1164, i32 0, i32 0
-  store ptr @38, ptr %1165, align 8
-  %1166 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1164, i32 0, i32 1
-  store i64 49, ptr %1166, align 4
-  %1167 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1164, align 8
-  %1168 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1167, i64 25, i64 120, i64 0, i64 22)
-  %1169 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
-  %1170 = icmp eq ptr %1169, null
-  br i1 %1170, label %_llgo_75, label %_llgo_76
+  %1144 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1145 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1146 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1145, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1126, ptr %1146, align 8
+  %1147 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1145, i32 0, i32 1
+  store ptr %1144, ptr %1147, align 8
+  %1148 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1145, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).HasName", ptr %1148, align 8
+  %1149 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1145, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).HasName", ptr %1149, align 8
+  %1150 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1145, align 8
+  %1151 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1152 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1151, i32 0, i32 0
+  store ptr @36, ptr %1152, align 8
+  %1153 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1151, i32 0, i32 1
+  store i64 10, ptr %1153, align 4
+  %1154 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1151, align 8
+  %1155 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1156 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1157 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1156, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1154, ptr %1157, align 8
+  %1158 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1156, i32 0, i32 1
+  store ptr %1155, ptr %1158, align 8
+  %1159 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1156, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).IfaceIndir", ptr %1159, align 8
+  %1160 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1156, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).IfaceIndir", ptr %1160, align 8
+  %1161 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1156, align 8
+  %1162 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1163 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1162, i32 0, i32 0
+  store ptr @37, ptr %1163, align 8
+  %1164 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1162, i32 0, i32 1
+  store i64 13, ptr %1164, align 4
+  %1165 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1162, align 8
+  %1166 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1167 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1166, i32 0, i32 0
+  store ptr @38, ptr %1167, align 8
+  %1168 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1166, i32 0, i32 1
+  store i64 49, ptr %1168, align 4
+  %1169 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1166, align 8
+  %1170 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1169, i64 25, i64 120, i64 0, i64 22)
+  %1171 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  %1172 = icmp eq ptr %1171, null
+  br i1 %1172, label %_llgo_75, label %_llgo_76
 
 _llgo_75:                                         ; preds = %_llgo_74
-  store ptr %1168, ptr @"_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  store ptr %1170, ptr @"_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
   br label %_llgo_76
 
 _llgo_76:                                         ; preds = %_llgo_75, %_llgo_74
-  %1171 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1172 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1171, i32 0, i32 0
-  store ptr @39, ptr %1172, align 8
-  %1173 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1171, i32 0, i32 1
-  store i64 43, ptr %1173, align 4
-  %1174 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1171, align 8
-  %1175 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1174, i64 25, i64 24, i64 0, i64 3)
-  %1176 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %1177 = icmp eq ptr %1176, null
-  br i1 %1177, label %_llgo_77, label %_llgo_78
+  %1173 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1174 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1173, i32 0, i32 0
+  store ptr @39, ptr %1174, align 8
+  %1175 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1173, i32 0, i32 1
+  store i64 43, ptr %1175, align 4
+  %1176 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1173, align 8
+  %1177 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1176, i64 25, i64 24, i64 0, i64 3)
+  %1178 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
+  %1179 = icmp eq ptr %1178, null
+  br i1 %1179, label %_llgo_77, label %_llgo_78
 
 _llgo_77:                                         ; preds = %_llgo_76
-  store ptr %1175, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
+  store ptr %1177, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
   br label %_llgo_78
 
 _llgo_78:                                         ; preds = %_llgo_77, %_llgo_76
-  %1178 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %1179 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1180 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1179, i32 0, i32 0
-  store ptr @30, ptr %1180, align 8
-  %1181 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1179, i32 0, i32 1
-  store i64 44, ptr %1181, align 4
-  %1182 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1179, align 8
-  %1183 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1182, i64 25, i64 128, i64 0, i64 23)
-  %1184 = load ptr, ptr @"_llgo_struct$-SVMNS9vOT5F9q4yodRiL9MFhdPf0tfZ2Cx2o7KjSDw", align 8
-  %1185 = icmp eq ptr %1184, null
-  br i1 %1185, label %_llgo_79, label %_llgo_80
+  %1180 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %1181 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1182 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1181, i32 0, i32 0
+  store ptr @30, ptr %1182, align 8
+  %1183 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1181, i32 0, i32 1
+  store i64 44, ptr %1183, align 4
+  %1184 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1181, align 8
+  %1185 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1184, i64 25, i64 128, i64 0, i64 23)
+  %1186 = load ptr, ptr @"_llgo_struct$-SVMNS9vOT5F9q4yodRiL9MFhdPf0tfZ2Cx2o7KjSDw", align 8
+  %1187 = icmp eq ptr %1186, null
+  br i1 %1187, label %_llgo_79, label %_llgo_80
 
 _llgo_79:                                         ; preds = %_llgo_78
-  %1186 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1187 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1186, i32 0, i32 0
-  store ptr @40, ptr %1187, align 8
-  %1188 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1186, i32 0, i32 1
-  store i64 5, ptr %1188, align 4
-  %1189 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1186, align 8
-  %1190 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1191 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1190, i32 0, i32 0
-  store ptr null, ptr %1191, align 8
-  %1192 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1190, i32 0, i32 1
-  store i64 0, ptr %1192, align 4
-  %1193 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1190, align 8
-  %1194 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %1195 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1189, ptr %1194, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %1193, i1 false)
-  %1196 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1197 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1196, i32 0, i32 0
-  store ptr @41, ptr %1197, align 8
-  %1198 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1196, i32 0, i32 1
-  store i64 4, ptr %1198, align 4
-  %1199 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1196, align 8
-  %1200 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1201 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1200, i32 0, i32 0
-  store ptr null, ptr %1201, align 8
-  %1202 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1200, i32 0, i32 1
-  store i64 0, ptr %1202, align 4
-  %1203 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1200, align 8
-  %1204 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1183)
-  %1205 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1199, ptr %1204, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %1203, i1 false)
-  %1206 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1207 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1206, i32 0, i32 0
-  store ptr @7, ptr %1207, align 8
-  %1208 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1206, i32 0, i32 1
-  store i64 4, ptr %1208, align 4
-  %1209 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1206, align 8
-  %1210 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %1211 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1210, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %1195, ptr %1211, align 8
-  %1212 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1210, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %1205, ptr %1212, align 8
-  %1213 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1214 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1213, i32 0, i32 0
-  store ptr %1210, ptr %1214, align 8
-  %1215 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1213, i32 0, i32 1
-  store i64 2, ptr %1215, align 4
-  %1216 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1213, i32 0, i32 2
-  store i64 2, ptr %1216, align 4
-  %1217 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1213, align 8
-  %1218 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %1209, i64 24, %"github.com/goplus/llgo/internal/runtime.Slice" %1217)
-  store ptr %1218, ptr @"_llgo_struct$-SVMNS9vOT5F9q4yodRiL9MFhdPf0tfZ2Cx2o7KjSDw", align 8
+  %1188 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1189 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1188, i32 0, i32 0
+  store ptr @40, ptr %1189, align 8
+  %1190 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1188, i32 0, i32 1
+  store i64 5, ptr %1190, align 4
+  %1191 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1188, align 8
+  %1192 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1193 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1192, i32 0, i32 0
+  store ptr null, ptr %1193, align 8
+  %1194 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1192, i32 0, i32 1
+  store i64 0, ptr %1194, align 4
+  %1195 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1192, align 8
+  %1196 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %1197 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1191, ptr %1196, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %1195, i1 false)
+  %1198 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1199 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1198, i32 0, i32 0
+  store ptr @41, ptr %1199, align 8
+  %1200 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1198, i32 0, i32 1
+  store i64 4, ptr %1200, align 4
+  %1201 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1198, align 8
+  %1202 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1203 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1202, i32 0, i32 0
+  store ptr null, ptr %1203, align 8
+  %1204 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1202, i32 0, i32 1
+  store i64 0, ptr %1204, align 4
+  %1205 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1202, align 8
+  %1206 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1185)
+  %1207 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1201, ptr %1206, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %1205, i1 false)
+  %1208 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1209 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1208, i32 0, i32 0
+  store ptr @7, ptr %1209, align 8
+  %1210 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1208, i32 0, i32 1
+  store i64 4, ptr %1210, align 4
+  %1211 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1208, align 8
+  %1212 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %1213 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1212, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1197, ptr %1213, align 8
+  %1214 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1212, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1207, ptr %1214, align 8
+  %1215 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1216 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1215, i32 0, i32 0
+  store ptr %1212, ptr %1216, align 8
+  %1217 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1215, i32 0, i32 1
+  store i64 2, ptr %1217, align 4
+  %1218 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1215, i32 0, i32 2
+  store i64 2, ptr %1218, align 4
+  %1219 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1215, align 8
+  %1220 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %1211, i64 24, %"github.com/goplus/llgo/internal/runtime.Slice" %1219)
+  store ptr %1220, ptr @"_llgo_struct$-SVMNS9vOT5F9q4yodRiL9MFhdPf0tfZ2Cx2o7KjSDw", align 8
   br label %_llgo_80
 
 _llgo_80:                                         ; preds = %_llgo_79, %_llgo_78
-  %1219 = load ptr, ptr @"_llgo_struct$-SVMNS9vOT5F9q4yodRiL9MFhdPf0tfZ2Cx2o7KjSDw", align 8
-  br i1 %1177, label %_llgo_81, label %_llgo_82
+  %1221 = load ptr, ptr @"_llgo_struct$-SVMNS9vOT5F9q4yodRiL9MFhdPf0tfZ2Cx2o7KjSDw", align 8
+  br i1 %1179, label %_llgo_81, label %_llgo_82
 
 _llgo_81:                                         ; preds = %_llgo_80
-  %1220 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1221 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1220, i32 0, i32 0
-  store ptr @42, ptr %1221, align 8
-  %1222 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1220, i32 0, i32 1
-  store i64 8, ptr %1222, align 4
-  %1223 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1220, align 8
-  %1224 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %1225 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1226 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1225, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1223, ptr %1226, align 8
-  %1227 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1225, i32 0, i32 1
-  store ptr %1224, ptr %1227, align 8
-  %1228 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1225, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).Exported", ptr %1228, align 8
-  %1229 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1225, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).Exported", ptr %1229, align 8
-  %1230 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1225, align 8
-  %1231 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1232 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1231, i32 0, i32 0
-  store ptr @43, ptr %1232, align 8
-  %1233 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1231, i32 0, i32 1
-  store i64 4, ptr %1233, align 4
-  %1234 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1231, align 8
-  %1235 = load ptr, ptr @_llgo_string, align 8
-  %1236 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %1237 = icmp eq ptr %1236, null
-  br i1 %1237, label %_llgo_83, label %_llgo_84
+  %1222 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1223 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1222, i32 0, i32 0
+  store ptr @42, ptr %1223, align 8
+  %1224 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1222, i32 0, i32 1
+  store i64 8, ptr %1224, align 4
+  %1225 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1222, align 8
+  %1226 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1227 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1228 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1227, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1225, ptr %1228, align 8
+  %1229 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1227, i32 0, i32 1
+  store ptr %1226, ptr %1229, align 8
+  %1230 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1227, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).Exported", ptr %1230, align 8
+  %1231 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1227, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).Exported", ptr %1231, align 8
+  %1232 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1227, align 8
+  %1233 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1234 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1233, i32 0, i32 0
+  store ptr @43, ptr %1234, align 8
+  %1235 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1233, i32 0, i32 1
+  store i64 4, ptr %1235, align 4
+  %1236 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1233, align 8
+  %1237 = load ptr, ptr @_llgo_string, align 8
+  %1238 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %1239 = icmp eq ptr %1238, null
+  br i1 %1239, label %_llgo_83, label %_llgo_84
 
 _llgo_82:                                         ; preds = %_llgo_84, %_llgo_80
-  %1238 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %1239 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1240 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1239, i32 0, i32 0
-  store ptr @39, ptr %1240, align 8
-  %1241 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1239, i32 0, i32 1
-  store i64 43, ptr %1241, align 4
-  %1242 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1239, align 8
-  %1243 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1242, i64 25, i64 24, i64 0, i64 3)
-  %1244 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %1245 = icmp eq ptr %1244, null
-  br i1 %1245, label %_llgo_85, label %_llgo_86
+  %1240 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
+  %1241 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1242 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1241, i32 0, i32 0
+  store ptr @39, ptr %1242, align 8
+  %1243 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1241, i32 0, i32 1
+  store i64 43, ptr %1243, align 4
+  %1244 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1241, align 8
+  %1245 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1244, i64 25, i64 24, i64 0, i64 3)
+  %1246 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
+  %1247 = icmp eq ptr %1246, null
+  br i1 %1247, label %_llgo_85, label %_llgo_86
 
 _llgo_83:                                         ; preds = %_llgo_81
-  %1246 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %1247 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1248 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1247, i32 0, i32 0
-  store ptr %1246, ptr %1248, align 8
-  %1249 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1247, i32 0, i32 1
-  store i64 0, ptr %1249, align 4
-  %1250 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1247, i32 0, i32 2
-  store i64 0, ptr %1250, align 4
-  %1251 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1247, align 8
-  %1252 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %1253 = getelementptr ptr, ptr %1252, i64 0
-  store ptr %1235, ptr %1253, align 8
-  %1254 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1255 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1254, i32 0, i32 0
-  store ptr %1252, ptr %1255, align 8
-  %1256 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1254, i32 0, i32 1
-  store i64 1, ptr %1256, align 4
-  %1257 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1254, i32 0, i32 2
-  store i64 1, ptr %1257, align 4
-  %1258 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1254, align 8
-  %1259 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1251, %"github.com/goplus/llgo/internal/runtime.Slice" %1258, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1259)
-  store ptr %1259, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %1248 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %1249 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1250 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1249, i32 0, i32 0
+  store ptr %1248, ptr %1250, align 8
+  %1251 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1249, i32 0, i32 1
+  store i64 0, ptr %1251, align 4
+  %1252 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1249, i32 0, i32 2
+  store i64 0, ptr %1252, align 4
+  %1253 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1249, align 8
+  %1254 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %1255 = getelementptr ptr, ptr %1254, i64 0
+  store ptr %1237, ptr %1255, align 8
+  %1256 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1257 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1256, i32 0, i32 0
+  store ptr %1254, ptr %1257, align 8
+  %1258 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1256, i32 0, i32 1
+  store i64 1, ptr %1258, align 4
+  %1259 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1256, i32 0, i32 2
+  store i64 1, ptr %1259, align 4
+  %1260 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1256, align 8
+  %1261 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1253, %"github.com/goplus/llgo/internal/runtime.Slice" %1260, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1261)
+  store ptr %1261, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
   br label %_llgo_84
 
 _llgo_84:                                         ; preds = %_llgo_83, %_llgo_81
-  %1260 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %1261 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1262 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1261, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1234, ptr %1262, align 8
-  %1263 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1261, i32 0, i32 1
-  store ptr %1260, ptr %1263, align 8
-  %1264 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1261, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).Name", ptr %1264, align 8
-  %1265 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1261, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).Name", ptr %1265, align 8
-  %1266 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1261, align 8
-  %1267 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1268 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1267, i32 0, i32 0
-  store ptr @44, ptr %1268, align 8
-  %1269 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1267, i32 0, i32 1
-  store i64 7, ptr %1269, align 4
-  %1270 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1267, align 8
-  %1271 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %1272 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1273 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1272, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1270, ptr %1273, align 8
-  %1274 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1272, i32 0, i32 1
-  store ptr %1271, ptr %1274, align 8
-  %1275 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1272, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).PkgPath", ptr %1275, align 8
-  %1276 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1272, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).PkgPath", ptr %1276, align 8
-  %1277 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1272, align 8
-  %1278 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 120)
-  %1279 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1278, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %1230, ptr %1279, align 8
-  %1280 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1278, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %1266, ptr %1280, align 8
-  %1281 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1278, i64 2
-  store %"github.com/goplus/llgo/internal/abi.Method" %1277, ptr %1281, align 8
-  %1282 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1283 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1282, i32 0, i32 0
-  store ptr %1278, ptr %1283, align 8
-  %1284 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1282, i32 0, i32 1
-  store i64 3, ptr %1284, align 4
-  %1285 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1282, i32 0, i32 2
-  store i64 3, ptr %1285, align 4
-  %1286 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1282, align 8
-  %1287 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1288 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1287, i32 0, i32 0
-  store ptr @3, ptr %1288, align 8
-  %1289 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1287, i32 0, i32 1
-  store i64 35, ptr %1289, align 4
-  %1290 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1287, align 8
-  %1291 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1292 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1291, i32 0, i32 0
-  store ptr @45, ptr %1292, align 8
-  %1293 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1291, i32 0, i32 1
-  store i64 7, ptr %1293, align 4
-  %1294 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1291, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %1175, %"github.com/goplus/llgo/internal/runtime.String" %1290, %"github.com/goplus/llgo/internal/runtime.String" %1294, ptr %1219, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %1286)
+  %1262 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %1263 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1264 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1263, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1236, ptr %1264, align 8
+  %1265 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1263, i32 0, i32 1
+  store ptr %1262, ptr %1265, align 8
+  %1266 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1263, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).Name", ptr %1266, align 8
+  %1267 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1263, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).Name", ptr %1267, align 8
+  %1268 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1263, align 8
+  %1269 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1270 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1269, i32 0, i32 0
+  store ptr @44, ptr %1270, align 8
+  %1271 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1269, i32 0, i32 1
+  store i64 7, ptr %1271, align 4
+  %1272 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1269, align 8
+  %1273 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %1274 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1275 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1274, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1272, ptr %1275, align 8
+  %1276 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1274, i32 0, i32 1
+  store ptr %1273, ptr %1276, align 8
+  %1277 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1274, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).PkgPath", ptr %1277, align 8
+  %1278 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1274, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).PkgPath", ptr %1278, align 8
+  %1279 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1274, align 8
+  %1280 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 120)
+  %1281 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1280, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %1232, ptr %1281, align 8
+  %1282 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1280, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %1268, ptr %1282, align 8
+  %1283 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1280, i64 2
+  store %"github.com/goplus/llgo/internal/abi.Method" %1279, ptr %1283, align 8
+  %1284 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1285 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1284, i32 0, i32 0
+  store ptr %1280, ptr %1285, align 8
+  %1286 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1284, i32 0, i32 1
+  store i64 3, ptr %1286, align 4
+  %1287 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1284, i32 0, i32 2
+  store i64 3, ptr %1287, align 4
+  %1288 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1284, align 8
+  %1289 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1290 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1289, i32 0, i32 0
+  store ptr @3, ptr %1290, align 8
+  %1291 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1289, i32 0, i32 1
+  store i64 35, ptr %1291, align 4
+  %1292 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1289, align 8
+  %1293 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1294 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1293, i32 0, i32 0
+  store ptr @45, ptr %1294, align 8
+  %1295 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1293, i32 0, i32 1
+  store i64 7, ptr %1295, align 4
+  %1296 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1293, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %1177, %"github.com/goplus/llgo/internal/runtime.String" %1292, %"github.com/goplus/llgo/internal/runtime.String" %1296, ptr %1221, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %1288)
   br label %_llgo_82
 
 _llgo_85:                                         ; preds = %_llgo_82
-  %1295 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %1243)
-  store ptr %1295, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
+  %1297 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %1245)
+  store ptr %1297, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
   br label %_llgo_86
 
 _llgo_86:                                         ; preds = %_llgo_85, %_llgo_82
-  %1296 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %1297 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1298 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1297, i32 0, i32 0
-  store ptr @1, ptr %1298, align 8
-  %1299 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1297, i32 0, i32 1
-  store i64 40, ptr %1299, align 4
-  %1300 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1297, align 8
-  %1301 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1300, i64 25, i64 80, i64 0, i64 22)
-  %1302 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1303 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1302, i32 0, i32 0
-  store ptr @39, ptr %1303, align 8
-  %1304 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1302, i32 0, i32 1
-  store i64 43, ptr %1304, align 4
-  %1305 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1302, align 8
-  %1306 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1305, i64 25, i64 24, i64 0, i64 3)
-  %1307 = load ptr, ptr @"_llgo_struct$mWxYYevLxpL1wQyiQtAy4OszkqTlHtrmEcPpzW9Air4", align 8
-  %1308 = icmp eq ptr %1307, null
-  br i1 %1308, label %_llgo_87, label %_llgo_88
+  %1298 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
+  %1299 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1300 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1299, i32 0, i32 0
+  store ptr @1, ptr %1300, align 8
+  %1301 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1299, i32 0, i32 1
+  store i64 40, ptr %1301, align 4
+  %1302 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1299, align 8
+  %1303 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1302, i64 25, i64 80, i64 0, i64 22)
+  %1304 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1305 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1304, i32 0, i32 0
+  store ptr @39, ptr %1305, align 8
+  %1306 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1304, i32 0, i32 1
+  store i64 43, ptr %1306, align 4
+  %1307 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1304, align 8
+  %1308 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1307, i64 25, i64 24, i64 0, i64 3)
+  %1309 = load ptr, ptr @"_llgo_struct$mWxYYevLxpL1wQyiQtAy4OszkqTlHtrmEcPpzW9Air4", align 8
+  %1310 = icmp eq ptr %1309, null
+  br i1 %1310, label %_llgo_87, label %_llgo_88
 
 _llgo_87:                                         ; preds = %_llgo_86
-  %1309 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1310 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1309, i32 0, i32 0
-  store ptr @21, ptr %1310, align 8
-  %1311 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1309, i32 0, i32 1
-  store i64 4, ptr %1311, align 4
-  %1312 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1309, align 8
-  %1313 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1314 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1313, i32 0, i32 0
-  store ptr null, ptr %1314, align 8
-  %1315 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1313, i32 0, i32 1
-  store i64 0, ptr %1315, align 4
-  %1316 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1313, align 8
-  %1317 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1312, ptr %1301, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %1316, i1 true)
-  %1318 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1319 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1318, i32 0, i32 0
-  store ptr @46, ptr %1319, align 8
-  %1320 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1318, i32 0, i32 1
-  store i64 8, ptr %1320, align 4
-  %1321 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1318, align 8
-  %1322 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1323 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1322, i32 0, i32 0
-  store ptr null, ptr %1323, align 8
-  %1324 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1322, i32 0, i32 1
-  store i64 0, ptr %1324, align 4
-  %1325 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1322, align 8
-  %1326 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %1327 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1321, ptr %1326, i64 72, %"github.com/goplus/llgo/internal/runtime.String" %1325, i1 false)
-  %1328 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1329 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1328, i32 0, i32 0
-  store ptr @47, ptr %1329, align 8
-  %1330 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1328, i32 0, i32 1
-  store i64 7, ptr %1330, align 4
-  %1331 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1328, align 8
-  %1332 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1333 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1332, i32 0, i32 0
-  store ptr null, ptr %1333, align 8
-  %1334 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1332, i32 0, i32 1
-  store i64 0, ptr %1334, align 4
-  %1335 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1332, align 8
-  %1336 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %1306)
-  %1337 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1331, ptr %1336, i64 88, %"github.com/goplus/llgo/internal/runtime.String" %1335, i1 false)
-  %1338 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1339 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1338, i32 0, i32 0
-  store ptr @7, ptr %1339, align 8
-  %1340 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1338, i32 0, i32 1
-  store i64 4, ptr %1340, align 4
-  %1341 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1338, align 8
-  %1342 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 168)
-  %1343 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1342, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %1317, ptr %1343, align 8
-  %1344 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1342, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %1327, ptr %1344, align 8
-  %1345 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1342, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %1337, ptr %1345, align 8
-  %1346 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1347 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1346, i32 0, i32 0
-  store ptr %1342, ptr %1347, align 8
-  %1348 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1346, i32 0, i32 1
-  store i64 3, ptr %1348, align 4
-  %1349 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1346, i32 0, i32 2
-  store i64 3, ptr %1349, align 4
-  %1350 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1346, align 8
-  %1351 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %1341, i64 112, %"github.com/goplus/llgo/internal/runtime.Slice" %1350)
-  store ptr %1351, ptr @"_llgo_struct$mWxYYevLxpL1wQyiQtAy4OszkqTlHtrmEcPpzW9Air4", align 8
+  %1311 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1312 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1311, i32 0, i32 0
+  store ptr @21, ptr %1312, align 8
+  %1313 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1311, i32 0, i32 1
+  store i64 4, ptr %1313, align 4
+  %1314 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1311, align 8
+  %1315 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1316 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1315, i32 0, i32 0
+  store ptr null, ptr %1316, align 8
+  %1317 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1315, i32 0, i32 1
+  store i64 0, ptr %1317, align 4
+  %1318 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1315, align 8
+  %1319 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1314, ptr %1303, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %1318, i1 true)
+  %1320 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1321 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1320, i32 0, i32 0
+  store ptr @46, ptr %1321, align 8
+  %1322 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1320, i32 0, i32 1
+  store i64 8, ptr %1322, align 4
+  %1323 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1320, align 8
+  %1324 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1325 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1324, i32 0, i32 0
+  store ptr null, ptr %1325, align 8
+  %1326 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1324, i32 0, i32 1
+  store i64 0, ptr %1326, align 4
+  %1327 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1324, align 8
+  %1328 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %1329 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1323, ptr %1328, i64 72, %"github.com/goplus/llgo/internal/runtime.String" %1327, i1 false)
+  %1330 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1331 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1330, i32 0, i32 0
+  store ptr @47, ptr %1331, align 8
+  %1332 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1330, i32 0, i32 1
+  store i64 7, ptr %1332, align 4
+  %1333 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1330, align 8
+  %1334 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1335 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1334, i32 0, i32 0
+  store ptr null, ptr %1335, align 8
+  %1336 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1334, i32 0, i32 1
+  store i64 0, ptr %1336, align 4
+  %1337 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1334, align 8
+  %1338 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %1308)
+  %1339 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1333, ptr %1338, i64 88, %"github.com/goplus/llgo/internal/runtime.String" %1337, i1 false)
+  %1340 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1341 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1340, i32 0, i32 0
+  store ptr @7, ptr %1341, align 8
+  %1342 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1340, i32 0, i32 1
+  store i64 4, ptr %1342, align 4
+  %1343 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1340, align 8
+  %1344 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 168)
+  %1345 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1344, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1319, ptr %1345, align 8
+  %1346 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1344, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1329, ptr %1346, align 8
+  %1347 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1344, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1339, ptr %1347, align 8
+  %1348 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1349 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1348, i32 0, i32 0
+  store ptr %1344, ptr %1349, align 8
+  %1350 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1348, i32 0, i32 1
+  store i64 3, ptr %1350, align 4
+  %1351 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1348, i32 0, i32 2
+  store i64 3, ptr %1351, align 4
+  %1352 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1348, align 8
+  %1353 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %1343, i64 112, %"github.com/goplus/llgo/internal/runtime.Slice" %1352)
+  store ptr %1353, ptr @"_llgo_struct$mWxYYevLxpL1wQyiQtAy4OszkqTlHtrmEcPpzW9Air4", align 8
   br label %_llgo_88
 
 _llgo_88:                                         ; preds = %_llgo_87, %_llgo_86
-  %1352 = load ptr, ptr @"_llgo_struct$mWxYYevLxpL1wQyiQtAy4OszkqTlHtrmEcPpzW9Air4", align 8
-  br i1 %1170, label %_llgo_89, label %_llgo_90
+  %1354 = load ptr, ptr @"_llgo_struct$mWxYYevLxpL1wQyiQtAy4OszkqTlHtrmEcPpzW9Air4", align 8
+  br i1 %1172, label %_llgo_89, label %_llgo_90
 
 _llgo_89:                                         ; preds = %_llgo_88
-  %1353 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1354 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1353, i32 0, i32 0
-  store ptr @18, ptr %1354, align 8
-  %1355 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1353, i32 0, i32 1
-  store i64 5, ptr %1355, align 4
-  %1356 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1353, align 8
-  %1357 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %1358 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1359 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1358, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1356, ptr %1359, align 8
-  %1360 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1358, i32 0, i32 1
-  store ptr %1357, ptr %1360, align 8
-  %1361 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1358, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Align", ptr %1361, align 8
-  %1362 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1358, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Align", ptr %1362, align 8
-  %1363 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1358, align 8
-  %1364 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1365 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1364, i32 0, i32 0
-  store ptr @19, ptr %1365, align 8
-  %1366 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1364, i32 0, i32 1
-  store i64 9, ptr %1366, align 4
-  %1367 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1364, align 8
-  %1368 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
-  %1369 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
-  %1370 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1371 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1370, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1367, ptr %1371, align 8
-  %1372 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1370, i32 0, i32 1
-  store ptr %1369, ptr %1372, align 8
-  %1373 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1370, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ArrayType", ptr %1373, align 8
-  %1374 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1370, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ArrayType", ptr %1374, align 8
-  %1375 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1370, align 8
-  %1376 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1377 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1376, i32 0, i32 0
-  store ptr @25, ptr %1377, align 8
-  %1378 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1376, i32 0, i32 1
-  store i64 7, ptr %1378, align 4
-  %1379 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1376, align 8
-  %1380 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
-  %1381 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1382 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1381, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1379, ptr %1382, align 8
-  %1383 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1381, i32 0, i32 1
-  store ptr %1380, ptr %1383, align 8
-  %1384 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1381, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ChanDir", ptr %1384, align 8
-  %1385 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1381, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ChanDir", ptr %1385, align 8
-  %1386 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1381, align 8
-  %1387 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1388 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1387, i32 0, i32 0
-  store ptr @27, ptr %1388, align 8
-  %1389 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1387, i32 0, i32 1
-  store i64 6, ptr %1389, align 4
-  %1390 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1387, align 8
-  %1391 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %1392 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %1393 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1394 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1393, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1390, ptr %1394, align 8
-  %1395 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1393, i32 0, i32 1
-  store ptr %1392, ptr %1395, align 8
-  %1396 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1393, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Common", ptr %1396, align 8
-  %1397 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1393, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Common", ptr %1397, align 8
-  %1398 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1393, align 8
-  %1399 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1400 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1399, i32 0, i32 0
-  store ptr @22, ptr %1400, align 8
-  %1401 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1399, i32 0, i32 1
-  store i64 4, ptr %1401, align 4
-  %1402 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1399, align 8
-  %1403 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %1404 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %1405 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1406 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1405, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1402, ptr %1406, align 8
-  %1407 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1405, i32 0, i32 1
-  store ptr %1404, ptr %1407, align 8
-  %1408 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1405, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Elem", ptr %1408, align 8
-  %1409 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1405, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Elem", ptr %1409, align 8
-  %1410 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1405, align 8
-  %1411 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1412 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1411, i32 0, i32 0
-  store ptr @28, ptr %1412, align 8
-  %1413 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1411, i32 0, i32 1
-  store i64 15, ptr %1413, align 4
-  %1414 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1411, align 8
-  %1415 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %1416 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
-  %1417 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1418 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1417, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1414, ptr %1418, align 8
-  %1419 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1417, i32 0, i32 1
-  store ptr %1416, ptr %1419, align 8
-  %1420 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1417, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ExportedMethods", ptr %1420, align 8
-  %1421 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1417, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ExportedMethods", ptr %1421, align 8
-  %1422 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1417, align 8
-  %1423 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1424 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1423, i32 0, i32 0
-  store ptr @33, ptr %1424, align 8
-  %1425 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1423, i32 0, i32 1
-  store i64 10, ptr %1425, align 4
-  %1426 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1423, align 8
-  %1427 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %1428 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1429 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1428, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1426, ptr %1429, align 8
-  %1430 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1428, i32 0, i32 1
-  store ptr %1427, ptr %1430, align 8
-  %1431 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1428, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).FieldAlign", ptr %1431, align 8
-  %1432 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1428, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).FieldAlign", ptr %1432, align 8
-  %1433 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1428, align 8
-  %1434 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1435 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1434, i32 0, i32 0
-  store ptr @34, ptr %1435, align 8
-  %1436 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1434, i32 0, i32 1
-  store i64 8, ptr %1436, align 4
-  %1437 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1434, align 8
-  %1438 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %1439 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
-  %1440 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1441 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1440, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1437, ptr %1441, align 8
-  %1442 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1440, i32 0, i32 1
-  store ptr %1439, ptr %1442, align 8
-  %1443 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1440, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).FuncType", ptr %1443, align 8
-  %1444 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1440, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).FuncType", ptr %1444, align 8
-  %1445 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1440, align 8
-  %1446 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1447 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1446, i32 0, i32 0
-  store ptr @35, ptr %1447, align 8
-  %1448 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1446, i32 0, i32 1
-  store i64 7, ptr %1448, align 4
-  %1449 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1446, align 8
-  %1450 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %1451 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1452 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1451, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1449, ptr %1452, align 8
-  %1453 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1451, i32 0, i32 1
-  store ptr %1450, ptr %1453, align 8
-  %1454 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1451, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).HasName", ptr %1454, align 8
-  %1455 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1451, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).HasName", ptr %1455, align 8
-  %1456 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1451, align 8
-  %1457 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1458 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1457, i32 0, i32 0
-  store ptr @36, ptr %1458, align 8
-  %1459 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1457, i32 0, i32 1
-  store i64 10, ptr %1459, align 4
-  %1460 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1457, align 8
-  %1461 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %1462 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1463 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1462, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1460, ptr %1463, align 8
-  %1464 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1462, i32 0, i32 1
-  store ptr %1461, ptr %1464, align 8
-  %1465 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1462, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).IfaceIndir", ptr %1465, align 8
-  %1466 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1462, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).IfaceIndir", ptr %1466, align 8
-  %1467 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1462, align 8
-  %1468 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1469 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1468, i32 0, i32 0
-  store ptr @37, ptr %1469, align 8
-  %1470 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1468, i32 0, i32 1
-  store i64 13, ptr %1470, align 4
-  %1471 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1468, align 8
-  %1472 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1473 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1472, i32 0, i32 0
-  store ptr @38, ptr %1473, align 8
-  %1474 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1472, i32 0, i32 1
-  store i64 49, ptr %1474, align 4
-  %1475 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1472, align 8
-  %1476 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1475, i64 25, i64 120, i64 0, i64 22)
-  %1477 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
-  %1478 = icmp eq ptr %1477, null
-  br i1 %1478, label %_llgo_91, label %_llgo_92
+  %1355 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1356 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1355, i32 0, i32 0
+  store ptr @18, ptr %1356, align 8
+  %1357 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1355, i32 0, i32 1
+  store i64 5, ptr %1357, align 4
+  %1358 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1355, align 8
+  %1359 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %1360 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1361 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1360, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1358, ptr %1361, align 8
+  %1362 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1360, i32 0, i32 1
+  store ptr %1359, ptr %1362, align 8
+  %1363 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1360, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Align", ptr %1363, align 8
+  %1364 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1360, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Align", ptr %1364, align 8
+  %1365 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1360, align 8
+  %1366 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1367 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1366, i32 0, i32 0
+  store ptr @19, ptr %1367, align 8
+  %1368 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1366, i32 0, i32 1
+  store i64 9, ptr %1368, align 4
+  %1369 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1366, align 8
+  %1370 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  %1371 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
+  %1372 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1373 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1372, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1369, ptr %1373, align 8
+  %1374 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1372, i32 0, i32 1
+  store ptr %1371, ptr %1374, align 8
+  %1375 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1372, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ArrayType", ptr %1375, align 8
+  %1376 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1372, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ArrayType", ptr %1376, align 8
+  %1377 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1372, align 8
+  %1378 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1379 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1378, i32 0, i32 0
+  store ptr @25, ptr %1379, align 8
+  %1380 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1378, i32 0, i32 1
+  store i64 7, ptr %1380, align 4
+  %1381 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1378, align 8
+  %1382 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
+  %1383 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1384 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1383, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1381, ptr %1384, align 8
+  %1385 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1383, i32 0, i32 1
+  store ptr %1382, ptr %1385, align 8
+  %1386 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1383, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ChanDir", ptr %1386, align 8
+  %1387 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1383, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ChanDir", ptr %1387, align 8
+  %1388 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1383, align 8
+  %1389 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1390 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1389, i32 0, i32 0
+  store ptr @27, ptr %1390, align 8
+  %1391 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1389, i32 0, i32 1
+  store i64 6, ptr %1391, align 4
+  %1392 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1389, align 8
+  %1393 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %1394 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %1395 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1396 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1395, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1392, ptr %1396, align 8
+  %1397 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1395, i32 0, i32 1
+  store ptr %1394, ptr %1397, align 8
+  %1398 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1395, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Common", ptr %1398, align 8
+  %1399 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1395, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Common", ptr %1399, align 8
+  %1400 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1395, align 8
+  %1401 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1402 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1401, i32 0, i32 0
+  store ptr @22, ptr %1402, align 8
+  %1403 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1401, i32 0, i32 1
+  store i64 4, ptr %1403, align 4
+  %1404 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1401, align 8
+  %1405 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %1406 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %1407 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1408 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1407, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1404, ptr %1408, align 8
+  %1409 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1407, i32 0, i32 1
+  store ptr %1406, ptr %1409, align 8
+  %1410 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1407, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Elem", ptr %1410, align 8
+  %1411 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1407, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Elem", ptr %1411, align 8
+  %1412 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1407, align 8
+  %1413 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1414 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1413, i32 0, i32 0
+  store ptr @28, ptr %1414, align 8
+  %1415 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1413, i32 0, i32 1
+  store i64 15, ptr %1415, align 4
+  %1416 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1413, align 8
+  %1417 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %1418 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
+  %1419 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1420 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1419, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1416, ptr %1420, align 8
+  %1421 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1419, i32 0, i32 1
+  store ptr %1418, ptr %1421, align 8
+  %1422 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1419, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ExportedMethods", ptr %1422, align 8
+  %1423 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1419, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ExportedMethods", ptr %1423, align 8
+  %1424 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1419, align 8
+  %1425 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1426 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1425, i32 0, i32 0
+  store ptr @33, ptr %1426, align 8
+  %1427 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1425, i32 0, i32 1
+  store i64 10, ptr %1427, align 4
+  %1428 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1425, align 8
+  %1429 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %1430 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1431 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1430, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1428, ptr %1431, align 8
+  %1432 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1430, i32 0, i32 1
+  store ptr %1429, ptr %1432, align 8
+  %1433 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1430, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).FieldAlign", ptr %1433, align 8
+  %1434 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1430, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).FieldAlign", ptr %1434, align 8
+  %1435 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1430, align 8
+  %1436 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1437 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1436, i32 0, i32 0
+  store ptr @34, ptr %1437, align 8
+  %1438 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1436, i32 0, i32 1
+  store i64 8, ptr %1438, align 4
+  %1439 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1436, align 8
+  %1440 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %1441 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
+  %1442 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1443 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1442, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1439, ptr %1443, align 8
+  %1444 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1442, i32 0, i32 1
+  store ptr %1441, ptr %1444, align 8
+  %1445 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1442, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).FuncType", ptr %1445, align 8
+  %1446 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1442, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).FuncType", ptr %1446, align 8
+  %1447 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1442, align 8
+  %1448 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1449 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1448, i32 0, i32 0
+  store ptr @35, ptr %1449, align 8
+  %1450 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1448, i32 0, i32 1
+  store i64 7, ptr %1450, align 4
+  %1451 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1448, align 8
+  %1452 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1453 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1454 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1453, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1451, ptr %1454, align 8
+  %1455 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1453, i32 0, i32 1
+  store ptr %1452, ptr %1455, align 8
+  %1456 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1453, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).HasName", ptr %1456, align 8
+  %1457 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1453, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).HasName", ptr %1457, align 8
+  %1458 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1453, align 8
+  %1459 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1460 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1459, i32 0, i32 0
+  store ptr @36, ptr %1460, align 8
+  %1461 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1459, i32 0, i32 1
+  store i64 10, ptr %1461, align 4
+  %1462 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1459, align 8
+  %1463 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1464 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1465 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1464, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1462, ptr %1465, align 8
+  %1466 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1464, i32 0, i32 1
+  store ptr %1463, ptr %1466, align 8
+  %1467 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1464, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).IfaceIndir", ptr %1467, align 8
+  %1468 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1464, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).IfaceIndir", ptr %1468, align 8
+  %1469 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1464, align 8
+  %1470 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1471 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1470, i32 0, i32 0
+  store ptr @37, ptr %1471, align 8
+  %1472 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1470, i32 0, i32 1
+  store i64 13, ptr %1472, align 4
+  %1473 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1470, align 8
+  %1474 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1475 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1474, i32 0, i32 0
+  store ptr @38, ptr %1475, align 8
+  %1476 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1474, i32 0, i32 1
+  store i64 49, ptr %1476, align 4
+  %1477 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1474, align 8
+  %1478 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1477, i64 25, i64 120, i64 0, i64 22)
+  %1479 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  %1480 = icmp eq ptr %1479, null
+  br i1 %1480, label %_llgo_91, label %_llgo_92
 
 _llgo_90:                                         ; preds = %_llgo_110, %_llgo_88
-  %1479 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
-  %1480 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
-  %1481 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
-  %1482 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1483 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1482, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1163, ptr %1483, align 8
-  %1484 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1482, i32 0, i32 1
-  store ptr %1481, ptr %1484, align 8
-  %1485 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1482, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).InterfaceType", ptr %1485, align 8
-  %1486 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1482, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).InterfaceType", ptr %1486, align 8
-  %1487 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1482, align 8
-  %1488 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1489 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1488, i32 0, i32 0
-  store ptr @48, ptr %1489, align 8
-  %1490 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1488, i32 0, i32 1
-  store i64 13, ptr %1490, align 4
-  %1491 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1488, align 8
-  %1492 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %1493 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1494 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1493, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1491, ptr %1494, align 8
-  %1495 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1493, i32 0, i32 1
-  store ptr %1492, ptr %1495, align 8
-  %1496 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1493, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).IsDirectIface", ptr %1496, align 8
-  %1497 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1493, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).IsDirectIface", ptr %1497, align 8
-  %1498 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1493, align 8
-  %1499 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1500 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1499, i32 0, i32 0
-  store ptr @49, ptr %1500, align 8
-  %1501 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1499, i32 0, i32 1
-  store i64 3, ptr %1501, align 4
-  %1502 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1499, align 8
-  %1503 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %1504 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %1505 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1506 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1505, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1502, ptr %1506, align 8
-  %1507 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1505, i32 0, i32 1
-  store ptr %1504, ptr %1507, align 8
-  %1508 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1505, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Key", ptr %1508, align 8
-  %1509 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1505, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Key", ptr %1509, align 8
-  %1510 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1505, align 8
-  %1511 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1512 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1511, i32 0, i32 0
-  store ptr @50, ptr %1512, align 8
-  %1513 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1511, i32 0, i32 1
-  store i64 4, ptr %1513, align 4
-  %1514 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1511, align 8
-  %1515 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
-  %1516 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1517 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1516, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1514, ptr %1517, align 8
-  %1518 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1516, i32 0, i32 1
-  store ptr %1515, ptr %1518, align 8
-  %1519 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1516, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Kind", ptr %1519, align 8
-  %1520 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1516, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Kind", ptr %1520, align 8
-  %1521 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1516, align 8
-  %1522 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1523 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1522, i32 0, i32 0
-  store ptr @24, ptr %1523, align 8
-  %1524 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1522, i32 0, i32 1
-  store i64 3, ptr %1524, align 4
-  %1525 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1522, align 8
-  %1526 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %1527 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1528 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1527, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1525, ptr %1528, align 8
-  %1529 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1527, i32 0, i32 1
-  store ptr %1526, ptr %1529, align 8
-  %1530 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1527, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Len", ptr %1530, align 8
-  %1531 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1527, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Len", ptr %1531, align 8
-  %1532 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1527, align 8
-  %1533 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1534 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1533, i32 0, i32 0
-  store ptr @53, ptr %1534, align 8
-  %1535 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1533, i32 0, i32 1
-  store i64 7, ptr %1535, align 4
-  %1536 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1533, align 8
-  %1537 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
-  %1538 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
-  %1539 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1540 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1539, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1536, ptr %1540, align 8
-  %1541 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1539, i32 0, i32 1
-  store ptr %1538, ptr %1541, align 8
-  %1542 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1539, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).MapType", ptr %1542, align 8
-  %1543 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1539, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).MapType", ptr %1543, align 8
-  %1544 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1539, align 8
-  %1545 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1546 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1545, i32 0, i32 0
-  store ptr @65, ptr %1546, align 8
-  %1547 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1545, i32 0, i32 1
-  store i64 9, ptr %1547, align 4
-  %1548 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1545, align 8
-  %1549 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %1550 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1551 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1550, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1548, ptr %1551, align 8
-  %1552 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1550, i32 0, i32 1
-  store ptr %1549, ptr %1552, align 8
-  %1553 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1550, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).NumMethod", ptr %1553, align 8
-  %1554 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1550, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).NumMethod", ptr %1554, align 8
-  %1555 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1550, align 8
-  %1556 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1557 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1556, i32 0, i32 0
-  store ptr @66, ptr %1557, align 8
-  %1558 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1556, i32 0, i32 1
-  store i64 8, ptr %1558, align 4
-  %1559 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1556, align 8
-  %1560 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %1561 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1562 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1561, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1559, ptr %1562, align 8
-  %1563 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1561, i32 0, i32 1
-  store ptr %1560, ptr %1563, align 8
-  %1564 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1561, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Pointers", ptr %1564, align 8
-  %1565 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1561, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Pointers", ptr %1565, align 8
-  %1566 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1561, align 8
-  %1567 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1568 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1567, i32 0, i32 0
-  store ptr @68, ptr %1568, align 8
-  %1569 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1567, i32 0, i32 1
-  store i64 4, ptr %1569, align 4
-  %1570 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1567, align 8
-  %1571 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
-  %1572 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1573 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1572, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1570, ptr %1573, align 8
-  %1574 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1572, i32 0, i32 1
-  store ptr %1571, ptr %1574, align 8
-  %1575 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1572, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Size", ptr %1575, align 8
-  %1576 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1572, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Size", ptr %1576, align 8
-  %1577 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1572, align 8
-  %1578 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1579 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1578, i32 0, i32 0
-  store ptr @52, ptr %1579, align 8
-  %1580 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1578, i32 0, i32 1
-  store i64 6, ptr %1580, align 4
-  %1581 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1578, align 8
-  %1582 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %1583 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1584 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1583, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1581, ptr %1584, align 8
-  %1585 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1583, i32 0, i32 1
-  store ptr %1582, ptr %1585, align 8
-  %1586 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1583, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).String", ptr %1586, align 8
-  %1587 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1583, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).String", ptr %1587, align 8
-  %1588 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1583, align 8
-  %1589 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1590 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1589, i32 0, i32 0
-  store ptr @69, ptr %1590, align 8
-  %1591 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1589, i32 0, i32 1
-  store i64 10, ptr %1591, align 4
-  %1592 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1589, align 8
-  %1593 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
-  %1594 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
-  %1595 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1596 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1595, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1592, ptr %1596, align 8
-  %1597 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1595, i32 0, i32 1
-  store ptr %1594, ptr %1597, align 8
-  %1598 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1595, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).StructType", ptr %1598, align 8
-  %1599 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1595, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).StructType", ptr %1599, align 8
-  %1600 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1595, align 8
-  %1601 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1602 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1601, i32 0, i32 0
-  store ptr @79, ptr %1602, align 8
-  %1603 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1601, i32 0, i32 1
-  store i64 8, ptr %1603, align 4
-  %1604 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1601, align 8
-  %1605 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
-  %1606 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1607 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1606, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1604, ptr %1607, align 8
-  %1608 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1606, i32 0, i32 1
-  store ptr %1605, ptr %1608, align 8
-  %1609 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1606, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Uncommon", ptr %1609, align 8
-  %1610 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1606, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Uncommon", ptr %1610, align 8
-  %1611 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1606, align 8
-  %1612 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1613 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1612, i32 0, i32 0
-  store ptr @85, ptr %1613, align 8
-  %1614 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1612, i32 0, i32 1
-  store i64 8, ptr %1614, align 4
-  %1615 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1612, align 8
-  %1616 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %1617 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1618 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1617, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1615, ptr %1618, align 8
-  %1619 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1617, i32 0, i32 1
-  store ptr %1616, ptr %1619, align 8
-  %1620 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1617, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Variadic", ptr %1620, align 8
-  %1621 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1617, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Variadic", ptr %1621, align 8
-  %1622 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1617, align 8
-  %1623 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 920)
-  %1624 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1623, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %979, ptr %1624, align 8
-  %1625 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1623, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %991, ptr %1625, align 8
-  %1626 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1623, i64 2
-  store %"github.com/goplus/llgo/internal/abi.Method" %1002, ptr %1626, align 8
-  %1627 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1623, i64 3
-  store %"github.com/goplus/llgo/internal/abi.Method" %1014, ptr %1627, align 8
-  %1628 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1623, i64 4
-  store %"github.com/goplus/llgo/internal/abi.Method" %1026, ptr %1628, align 8
-  %1629 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1623, i64 5
-  store %"github.com/goplus/llgo/internal/abi.Method" %1072, ptr %1629, align 8
-  %1630 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1623, i64 6
-  store %"github.com/goplus/llgo/internal/abi.Method" %1083, ptr %1630, align 8
-  %1631 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1623, i64 7
-  store %"github.com/goplus/llgo/internal/abi.Method" %1120, ptr %1631, align 8
-  %1632 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1623, i64 8
-  store %"github.com/goplus/llgo/internal/abi.Method" %1148, ptr %1632, align 8
-  %1633 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1623, i64 9
-  store %"github.com/goplus/llgo/internal/abi.Method" %1159, ptr %1633, align 8
-  %1634 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1623, i64 10
-  store %"github.com/goplus/llgo/internal/abi.Method" %1487, ptr %1634, align 8
-  %1635 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1623, i64 11
-  store %"github.com/goplus/llgo/internal/abi.Method" %1498, ptr %1635, align 8
-  %1636 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1623, i64 12
-  store %"github.com/goplus/llgo/internal/abi.Method" %1510, ptr %1636, align 8
-  %1637 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1623, i64 13
-  store %"github.com/goplus/llgo/internal/abi.Method" %1521, ptr %1637, align 8
-  %1638 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1623, i64 14
-  store %"github.com/goplus/llgo/internal/abi.Method" %1532, ptr %1638, align 8
-  %1639 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1623, i64 15
-  store %"github.com/goplus/llgo/internal/abi.Method" %1544, ptr %1639, align 8
-  %1640 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1623, i64 16
-  store %"github.com/goplus/llgo/internal/abi.Method" %1555, ptr %1640, align 8
-  %1641 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1623, i64 17
-  store %"github.com/goplus/llgo/internal/abi.Method" %1566, ptr %1641, align 8
-  %1642 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1623, i64 18
-  store %"github.com/goplus/llgo/internal/abi.Method" %1577, ptr %1642, align 8
-  %1643 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1623, i64 19
-  store %"github.com/goplus/llgo/internal/abi.Method" %1588, ptr %1643, align 8
-  %1644 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1623, i64 20
-  store %"github.com/goplus/llgo/internal/abi.Method" %1600, ptr %1644, align 8
-  %1645 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1623, i64 21
-  store %"github.com/goplus/llgo/internal/abi.Method" %1611, ptr %1645, align 8
-  %1646 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1623, i64 22
-  store %"github.com/goplus/llgo/internal/abi.Method" %1622, ptr %1646, align 8
-  %1647 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1648 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1647, i32 0, i32 0
-  store ptr %1623, ptr %1648, align 8
-  %1649 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1647, i32 0, i32 1
-  store i64 23, ptr %1649, align 4
-  %1650 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1647, i32 0, i32 2
-  store i64 23, ptr %1650, align 4
-  %1651 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1647, align 8
-  %1652 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1653 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1652, i32 0, i32 0
-  store ptr @3, ptr %1653, align 8
-  %1654 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1652, i32 0, i32 1
-  store i64 35, ptr %1654, align 4
-  %1655 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1652, align 8
-  %1656 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1657 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1656, i32 0, i32 0
-  store ptr @34, ptr %1657, align 8
-  %1658 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1656, i32 0, i32 1
-  store i64 8, ptr %1658, align 4
-  %1659 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1656, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %890, %"github.com/goplus/llgo/internal/runtime.String" %1655, %"github.com/goplus/llgo/internal/runtime.String" %1659, ptr %968, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %1651)
+  %1481 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  %1482 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  %1483 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
+  %1484 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1485 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1484, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1165, ptr %1485, align 8
+  %1486 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1484, i32 0, i32 1
+  store ptr %1483, ptr %1486, align 8
+  %1487 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1484, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).InterfaceType", ptr %1487, align 8
+  %1488 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1484, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).InterfaceType", ptr %1488, align 8
+  %1489 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1484, align 8
+  %1490 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1491 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1490, i32 0, i32 0
+  store ptr @48, ptr %1491, align 8
+  %1492 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1490, i32 0, i32 1
+  store i64 13, ptr %1492, align 4
+  %1493 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1490, align 8
+  %1494 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1495 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1496 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1495, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1493, ptr %1496, align 8
+  %1497 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1495, i32 0, i32 1
+  store ptr %1494, ptr %1497, align 8
+  %1498 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1495, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).IsDirectIface", ptr %1498, align 8
+  %1499 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1495, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).IsDirectIface", ptr %1499, align 8
+  %1500 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1495, align 8
+  %1501 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1502 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1501, i32 0, i32 0
+  store ptr @49, ptr %1502, align 8
+  %1503 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1501, i32 0, i32 1
+  store i64 3, ptr %1503, align 4
+  %1504 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1501, align 8
+  %1505 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %1506 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %1507 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1508 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1507, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1504, ptr %1508, align 8
+  %1509 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1507, i32 0, i32 1
+  store ptr %1506, ptr %1509, align 8
+  %1510 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1507, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Key", ptr %1510, align 8
+  %1511 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1507, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Key", ptr %1511, align 8
+  %1512 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1507, align 8
+  %1513 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1514 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1513, i32 0, i32 0
+  store ptr @50, ptr %1514, align 8
+  %1515 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1513, i32 0, i32 1
+  store i64 4, ptr %1515, align 4
+  %1516 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1513, align 8
+  %1517 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
+  %1518 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1519 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1518, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1516, ptr %1519, align 8
+  %1520 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1518, i32 0, i32 1
+  store ptr %1517, ptr %1520, align 8
+  %1521 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1518, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Kind", ptr %1521, align 8
+  %1522 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1518, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Kind", ptr %1522, align 8
+  %1523 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1518, align 8
+  %1524 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1525 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1524, i32 0, i32 0
+  store ptr @24, ptr %1525, align 8
+  %1526 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1524, i32 0, i32 1
+  store i64 3, ptr %1526, align 4
+  %1527 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1524, align 8
+  %1528 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %1529 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1530 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1529, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1527, ptr %1530, align 8
+  %1531 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1529, i32 0, i32 1
+  store ptr %1528, ptr %1531, align 8
+  %1532 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1529, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Len", ptr %1532, align 8
+  %1533 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1529, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Len", ptr %1533, align 8
+  %1534 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1529, align 8
+  %1535 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1536 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1535, i32 0, i32 0
+  store ptr @53, ptr %1536, align 8
+  %1537 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1535, i32 0, i32 1
+  store i64 7, ptr %1537, align 4
+  %1538 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1535, align 8
+  %1539 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  %1540 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
+  %1541 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1542 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1541, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1538, ptr %1542, align 8
+  %1543 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1541, i32 0, i32 1
+  store ptr %1540, ptr %1543, align 8
+  %1544 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1541, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).MapType", ptr %1544, align 8
+  %1545 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1541, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).MapType", ptr %1545, align 8
+  %1546 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1541, align 8
+  %1547 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1548 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1547, i32 0, i32 0
+  store ptr @65, ptr %1548, align 8
+  %1549 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1547, i32 0, i32 1
+  store i64 9, ptr %1549, align 4
+  %1550 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1547, align 8
+  %1551 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %1552 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1553 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1552, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1550, ptr %1553, align 8
+  %1554 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1552, i32 0, i32 1
+  store ptr %1551, ptr %1554, align 8
+  %1555 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1552, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).NumMethod", ptr %1555, align 8
+  %1556 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1552, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).NumMethod", ptr %1556, align 8
+  %1557 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1552, align 8
+  %1558 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1559 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1558, i32 0, i32 0
+  store ptr @66, ptr %1559, align 8
+  %1560 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1558, i32 0, i32 1
+  store i64 8, ptr %1560, align 4
+  %1561 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1558, align 8
+  %1562 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1563 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1564 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1563, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1561, ptr %1564, align 8
+  %1565 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1563, i32 0, i32 1
+  store ptr %1562, ptr %1565, align 8
+  %1566 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1563, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Pointers", ptr %1566, align 8
+  %1567 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1563, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Pointers", ptr %1567, align 8
+  %1568 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1563, align 8
+  %1569 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1570 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1569, i32 0, i32 0
+  store ptr @68, ptr %1570, align 8
+  %1571 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1569, i32 0, i32 1
+  store i64 4, ptr %1571, align 4
+  %1572 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1569, align 8
+  %1573 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
+  %1574 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1575 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1572, ptr %1575, align 8
+  %1576 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i32 0, i32 1
+  store ptr %1573, ptr %1576, align 8
+  %1577 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Size", ptr %1577, align 8
+  %1578 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Size", ptr %1578, align 8
+  %1579 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, align 8
+  %1580 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1581 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1580, i32 0, i32 0
+  store ptr @52, ptr %1581, align 8
+  %1582 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1580, i32 0, i32 1
+  store i64 6, ptr %1582, align 4
+  %1583 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1580, align 8
+  %1584 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %1585 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1586 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1585, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1583, ptr %1586, align 8
+  %1587 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1585, i32 0, i32 1
+  store ptr %1584, ptr %1587, align 8
+  %1588 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1585, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).String", ptr %1588, align 8
+  %1589 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1585, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).String", ptr %1589, align 8
+  %1590 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1585, align 8
+  %1591 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1592 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1591, i32 0, i32 0
+  store ptr @69, ptr %1592, align 8
+  %1593 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1591, i32 0, i32 1
+  store i64 10, ptr %1593, align 4
+  %1594 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1591, align 8
+  %1595 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  %1596 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
+  %1597 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1598 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1597, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1594, ptr %1598, align 8
+  %1599 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1597, i32 0, i32 1
+  store ptr %1596, ptr %1599, align 8
+  %1600 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1597, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).StructType", ptr %1600, align 8
+  %1601 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1597, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).StructType", ptr %1601, align 8
+  %1602 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1597, align 8
+  %1603 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1604 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1603, i32 0, i32 0
+  store ptr @79, ptr %1604, align 8
+  %1605 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1603, i32 0, i32 1
+  store i64 8, ptr %1605, align 4
+  %1606 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1603, align 8
+  %1607 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
+  %1608 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1609 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1608, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1606, ptr %1609, align 8
+  %1610 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1608, i32 0, i32 1
+  store ptr %1607, ptr %1610, align 8
+  %1611 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1608, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Uncommon", ptr %1611, align 8
+  %1612 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1608, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Uncommon", ptr %1612, align 8
+  %1613 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1608, align 8
+  %1614 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1615 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1614, i32 0, i32 0
+  store ptr @85, ptr %1615, align 8
+  %1616 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1614, i32 0, i32 1
+  store i64 8, ptr %1616, align 4
+  %1617 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1614, align 8
+  %1618 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1619 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1620 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1619, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1617, ptr %1620, align 8
+  %1621 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1619, i32 0, i32 1
+  store ptr %1618, ptr %1621, align 8
+  %1622 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1619, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Variadic", ptr %1622, align 8
+  %1623 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1619, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Variadic", ptr %1623, align 8
+  %1624 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1619, align 8
+  %1625 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 920)
+  %1626 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1625, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %981, ptr %1626, align 8
+  %1627 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1625, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %993, ptr %1627, align 8
+  %1628 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1625, i64 2
+  store %"github.com/goplus/llgo/internal/abi.Method" %1004, ptr %1628, align 8
+  %1629 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1625, i64 3
+  store %"github.com/goplus/llgo/internal/abi.Method" %1016, ptr %1629, align 8
+  %1630 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1625, i64 4
+  store %"github.com/goplus/llgo/internal/abi.Method" %1028, ptr %1630, align 8
+  %1631 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1625, i64 5
+  store %"github.com/goplus/llgo/internal/abi.Method" %1074, ptr %1631, align 8
+  %1632 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1625, i64 6
+  store %"github.com/goplus/llgo/internal/abi.Method" %1085, ptr %1632, align 8
+  %1633 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1625, i64 7
+  store %"github.com/goplus/llgo/internal/abi.Method" %1122, ptr %1633, align 8
+  %1634 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1625, i64 8
+  store %"github.com/goplus/llgo/internal/abi.Method" %1150, ptr %1634, align 8
+  %1635 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1625, i64 9
+  store %"github.com/goplus/llgo/internal/abi.Method" %1161, ptr %1635, align 8
+  %1636 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1625, i64 10
+  store %"github.com/goplus/llgo/internal/abi.Method" %1489, ptr %1636, align 8
+  %1637 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1625, i64 11
+  store %"github.com/goplus/llgo/internal/abi.Method" %1500, ptr %1637, align 8
+  %1638 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1625, i64 12
+  store %"github.com/goplus/llgo/internal/abi.Method" %1512, ptr %1638, align 8
+  %1639 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1625, i64 13
+  store %"github.com/goplus/llgo/internal/abi.Method" %1523, ptr %1639, align 8
+  %1640 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1625, i64 14
+  store %"github.com/goplus/llgo/internal/abi.Method" %1534, ptr %1640, align 8
+  %1641 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1625, i64 15
+  store %"github.com/goplus/llgo/internal/abi.Method" %1546, ptr %1641, align 8
+  %1642 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1625, i64 16
+  store %"github.com/goplus/llgo/internal/abi.Method" %1557, ptr %1642, align 8
+  %1643 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1625, i64 17
+  store %"github.com/goplus/llgo/internal/abi.Method" %1568, ptr %1643, align 8
+  %1644 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1625, i64 18
+  store %"github.com/goplus/llgo/internal/abi.Method" %1579, ptr %1644, align 8
+  %1645 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1625, i64 19
+  store %"github.com/goplus/llgo/internal/abi.Method" %1590, ptr %1645, align 8
+  %1646 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1625, i64 20
+  store %"github.com/goplus/llgo/internal/abi.Method" %1602, ptr %1646, align 8
+  %1647 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1625, i64 21
+  store %"github.com/goplus/llgo/internal/abi.Method" %1613, ptr %1647, align 8
+  %1648 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1625, i64 22
+  store %"github.com/goplus/llgo/internal/abi.Method" %1624, ptr %1648, align 8
+  %1649 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1650 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1649, i32 0, i32 0
+  store ptr %1625, ptr %1650, align 8
+  %1651 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1649, i32 0, i32 1
+  store i64 23, ptr %1651, align 4
+  %1652 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1649, i32 0, i32 2
+  store i64 23, ptr %1652, align 4
+  %1653 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1649, align 8
+  %1654 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1655 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1654, i32 0, i32 0
+  store ptr @3, ptr %1655, align 8
+  %1656 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1654, i32 0, i32 1
+  store i64 35, ptr %1656, align 4
+  %1657 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1654, align 8
+  %1658 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1659 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1658, i32 0, i32 0
+  store ptr @34, ptr %1659, align 8
+  %1660 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1658, i32 0, i32 1
+  store i64 8, ptr %1660, align 4
+  %1661 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1658, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %892, %"github.com/goplus/llgo/internal/runtime.String" %1657, %"github.com/goplus/llgo/internal/runtime.String" %1661, ptr %970, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %1653)
   br label %_llgo_64
 
 _llgo_91:                                         ; preds = %_llgo_89
-  %1660 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1476)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1660)
-  store ptr %1660, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  %1662 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1478)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1662)
+  store ptr %1662, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
   br label %_llgo_92
 
 _llgo_92:                                         ; preds = %_llgo_91, %_llgo_89
-  %1661 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
-  %1662 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
-  %1663 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
-  %1664 = icmp eq ptr %1663, null
-  br i1 %1664, label %_llgo_93, label %_llgo_94
+  %1663 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  %1664 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  %1665 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
+  %1666 = icmp eq ptr %1665, null
+  br i1 %1666, label %_llgo_93, label %_llgo_94
 
 _llgo_93:                                         ; preds = %_llgo_92
-  %1665 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %1666 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1667 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1666, i32 0, i32 0
-  store ptr %1665, ptr %1667, align 8
-  %1668 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1666, i32 0, i32 1
-  store i64 0, ptr %1668, align 4
-  %1669 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1666, i32 0, i32 2
-  store i64 0, ptr %1669, align 4
-  %1670 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1666, align 8
-  %1671 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %1672 = getelementptr ptr, ptr %1671, i64 0
-  store ptr %1662, ptr %1672, align 8
-  %1673 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1674 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1673, i32 0, i32 0
-  store ptr %1671, ptr %1674, align 8
-  %1675 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1673, i32 0, i32 1
-  store i64 1, ptr %1675, align 4
-  %1676 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1673, i32 0, i32 2
-  store i64 1, ptr %1676, align 4
-  %1677 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1673, align 8
-  %1678 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1670, %"github.com/goplus/llgo/internal/runtime.Slice" %1677, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1678)
-  store ptr %1678, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
+  %1667 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %1668 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1669 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1668, i32 0, i32 0
+  store ptr %1667, ptr %1669, align 8
+  %1670 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1668, i32 0, i32 1
+  store i64 0, ptr %1670, align 4
+  %1671 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1668, i32 0, i32 2
+  store i64 0, ptr %1671, align 4
+  %1672 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1668, align 8
+  %1673 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %1674 = getelementptr ptr, ptr %1673, i64 0
+  store ptr %1664, ptr %1674, align 8
+  %1675 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1676 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1675, i32 0, i32 0
+  store ptr %1673, ptr %1676, align 8
+  %1677 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1675, i32 0, i32 1
+  store i64 1, ptr %1677, align 4
+  %1678 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1675, i32 0, i32 2
+  store i64 1, ptr %1678, align 4
+  %1679 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1675, align 8
+  %1680 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1672, %"github.com/goplus/llgo/internal/runtime.Slice" %1679, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1680)
+  store ptr %1680, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
   br label %_llgo_94
 
 _llgo_94:                                         ; preds = %_llgo_93, %_llgo_92
-  %1679 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
-  %1680 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1681 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1680, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1471, ptr %1681, align 8
-  %1682 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1680, i32 0, i32 1
-  store ptr %1679, ptr %1682, align 8
-  %1683 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1680, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).InterfaceType", ptr %1683, align 8
-  %1684 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1680, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).InterfaceType", ptr %1684, align 8
-  %1685 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1680, align 8
-  %1686 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1687 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1686, i32 0, i32 0
-  store ptr @48, ptr %1687, align 8
-  %1688 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1686, i32 0, i32 1
-  store i64 13, ptr %1688, align 4
-  %1689 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1686, align 8
-  %1690 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %1691 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1692 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1691, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1689, ptr %1692, align 8
-  %1693 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1691, i32 0, i32 1
-  store ptr %1690, ptr %1693, align 8
-  %1694 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1691, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).IsDirectIface", ptr %1694, align 8
-  %1695 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1691, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).IsDirectIface", ptr %1695, align 8
-  %1696 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1691, align 8
-  %1697 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1698 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1697, i32 0, i32 0
-  store ptr @49, ptr %1698, align 8
-  %1699 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1697, i32 0, i32 1
-  store i64 3, ptr %1699, align 4
-  %1700 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1697, align 8
-  %1701 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %1702 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %1703 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1704 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1703, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1700, ptr %1704, align 8
-  %1705 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1703, i32 0, i32 1
-  store ptr %1702, ptr %1705, align 8
-  %1706 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1703, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Key", ptr %1706, align 8
-  %1707 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1703, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Key", ptr %1707, align 8
-  %1708 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1703, align 8
-  %1709 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1710 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1709, i32 0, i32 0
-  store ptr @50, ptr %1710, align 8
-  %1711 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1709, i32 0, i32 1
-  store i64 4, ptr %1711, align 4
-  %1712 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1709, align 8
-  %1713 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1714 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1713, i32 0, i32 0
-  store ptr @51, ptr %1714, align 8
-  %1715 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1713, i32 0, i32 1
-  store i64 40, ptr %1715, align 4
-  %1716 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1713, align 8
-  %1717 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1716, i64 7, i64 8, i64 1, i64 1)
-  %1718 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Kind", align 8
-  %1719 = icmp eq ptr %1718, null
-  br i1 %1719, label %_llgo_95, label %_llgo_96
+  %1681 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
+  %1682 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1683 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1682, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1473, ptr %1683, align 8
+  %1684 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1682, i32 0, i32 1
+  store ptr %1681, ptr %1684, align 8
+  %1685 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1682, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).InterfaceType", ptr %1685, align 8
+  %1686 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1682, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).InterfaceType", ptr %1686, align 8
+  %1687 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1682, align 8
+  %1688 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1689 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1688, i32 0, i32 0
+  store ptr @48, ptr %1689, align 8
+  %1690 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1688, i32 0, i32 1
+  store i64 13, ptr %1690, align 4
+  %1691 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1688, align 8
+  %1692 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1693 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1694 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1693, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1691, ptr %1694, align 8
+  %1695 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1693, i32 0, i32 1
+  store ptr %1692, ptr %1695, align 8
+  %1696 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1693, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).IsDirectIface", ptr %1696, align 8
+  %1697 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1693, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).IsDirectIface", ptr %1697, align 8
+  %1698 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1693, align 8
+  %1699 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1700 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1699, i32 0, i32 0
+  store ptr @49, ptr %1700, align 8
+  %1701 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1699, i32 0, i32 1
+  store i64 3, ptr %1701, align 4
+  %1702 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1699, align 8
+  %1703 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %1704 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %1705 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1706 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1705, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1702, ptr %1706, align 8
+  %1707 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1705, i32 0, i32 1
+  store ptr %1704, ptr %1707, align 8
+  %1708 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1705, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Key", ptr %1708, align 8
+  %1709 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1705, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Key", ptr %1709, align 8
+  %1710 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1705, align 8
+  %1711 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1712 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1711, i32 0, i32 0
+  store ptr @50, ptr %1712, align 8
+  %1713 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1711, i32 0, i32 1
+  store i64 4, ptr %1713, align 4
+  %1714 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1711, align 8
+  %1715 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1716 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1715, i32 0, i32 0
+  store ptr @51, ptr %1716, align 8
+  %1717 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1715, i32 0, i32 1
+  store i64 40, ptr %1717, align 4
+  %1718 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1715, align 8
+  %1719 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1718, i64 7, i64 8, i64 1, i64 1)
+  %1720 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Kind", align 8
+  %1721 = icmp eq ptr %1720, null
+  br i1 %1721, label %_llgo_95, label %_llgo_96
 
 _llgo_95:                                         ; preds = %_llgo_94
-  store ptr %1717, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Kind", align 8
+  store ptr %1719, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Kind", align 8
   br label %_llgo_96
 
 _llgo_96:                                         ; preds = %_llgo_95, %_llgo_94
-  %1720 = load ptr, ptr @_llgo_uint, align 8
-  %1721 = icmp eq ptr %1720, null
-  br i1 %1721, label %_llgo_97, label %_llgo_98
+  %1722 = load ptr, ptr @_llgo_uint, align 8
+  %1723 = icmp eq ptr %1722, null
+  br i1 %1723, label %_llgo_97, label %_llgo_98
 
 _llgo_97:                                         ; preds = %_llgo_96
-  %1722 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 39)
-  store ptr %1722, ptr @_llgo_uint, align 8
+  %1724 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 39)
+  store ptr %1724, ptr @_llgo_uint, align 8
   br label %_llgo_98
 
 _llgo_98:                                         ; preds = %_llgo_97, %_llgo_96
-  %1723 = load ptr, ptr @_llgo_uint, align 8
-  br i1 %1719, label %_llgo_99, label %_llgo_100
+  %1725 = load ptr, ptr @_llgo_uint, align 8
+  br i1 %1721, label %_llgo_99, label %_llgo_100
 
 _llgo_99:                                         ; preds = %_llgo_98
-  %1724 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1725 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1724, i32 0, i32 0
-  store ptr @52, ptr %1725, align 8
-  %1726 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1724, i32 0, i32 1
-  store i64 6, ptr %1726, align 4
-  %1727 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1724, align 8
-  %1728 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %1729 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1730 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1729, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1727, ptr %1730, align 8
-  %1731 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1729, i32 0, i32 1
-  store ptr %1728, ptr %1731, align 8
-  %1732 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1729, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Kind).String", ptr %1732, align 8
-  %1733 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1729, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Kind).String", ptr %1733, align 8
-  %1734 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1729, align 8
-  %1735 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1736 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1735, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1727, ptr %1736, align 8
-  %1737 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1735, i32 0, i32 1
-  store ptr %1728, ptr %1737, align 8
-  %1738 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1735, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Kind).String", ptr %1738, align 8
-  %1739 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1735, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.Kind.String", ptr %1739, align 8
-  %1740 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1735, align 8
-  %1741 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %1742 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1741, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %1740, ptr %1742, align 8
-  %1743 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1744 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1743, i32 0, i32 0
-  store ptr %1741, ptr %1744, align 8
-  %1745 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1743, i32 0, i32 1
-  store i64 1, ptr %1745, align 4
-  %1746 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1743, i32 0, i32 2
-  store i64 1, ptr %1746, align 4
-  %1747 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1743, align 8
-  %1748 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %1749 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1748, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %1734, ptr %1749, align 8
-  %1750 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1751 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1750, i32 0, i32 0
-  store ptr %1748, ptr %1751, align 8
-  %1752 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1750, i32 0, i32 1
-  store i64 1, ptr %1752, align 4
-  %1753 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1750, i32 0, i32 2
-  store i64 1, ptr %1753, align 4
-  %1754 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1750, align 8
-  %1755 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1756 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1755, i32 0, i32 0
-  store ptr @3, ptr %1756, align 8
-  %1757 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1755, i32 0, i32 1
-  store i64 35, ptr %1757, align 4
-  %1758 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1755, align 8
-  %1759 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1760 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1759, i32 0, i32 0
-  store ptr @50, ptr %1760, align 8
-  %1761 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1759, i32 0, i32 1
-  store i64 4, ptr %1761, align 4
-  %1762 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1759, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %1717, %"github.com/goplus/llgo/internal/runtime.String" %1758, %"github.com/goplus/llgo/internal/runtime.String" %1762, ptr %1723, %"github.com/goplus/llgo/internal/runtime.Slice" %1747, %"github.com/goplus/llgo/internal/runtime.Slice" %1754)
+  %1726 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1727 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1726, i32 0, i32 0
+  store ptr @52, ptr %1727, align 8
+  %1728 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1726, i32 0, i32 1
+  store i64 6, ptr %1728, align 4
+  %1729 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1726, align 8
+  %1730 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %1731 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1732 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1731, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1729, ptr %1732, align 8
+  %1733 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1731, i32 0, i32 1
+  store ptr %1730, ptr %1733, align 8
+  %1734 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1731, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Kind).String", ptr %1734, align 8
+  %1735 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1731, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Kind).String", ptr %1735, align 8
+  %1736 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1731, align 8
+  %1737 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1738 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1737, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1729, ptr %1738, align 8
+  %1739 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1737, i32 0, i32 1
+  store ptr %1730, ptr %1739, align 8
+  %1740 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1737, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Kind).String", ptr %1740, align 8
+  %1741 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1737, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.Kind.String", ptr %1741, align 8
+  %1742 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1737, align 8
+  %1743 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %1744 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1743, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %1742, ptr %1744, align 8
+  %1745 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1746 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1745, i32 0, i32 0
+  store ptr %1743, ptr %1746, align 8
+  %1747 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1745, i32 0, i32 1
+  store i64 1, ptr %1747, align 4
+  %1748 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1745, i32 0, i32 2
+  store i64 1, ptr %1748, align 4
+  %1749 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1745, align 8
+  %1750 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %1751 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1750, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %1736, ptr %1751, align 8
+  %1752 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1753 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1752, i32 0, i32 0
+  store ptr %1750, ptr %1753, align 8
+  %1754 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1752, i32 0, i32 1
+  store i64 1, ptr %1754, align 4
+  %1755 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1752, i32 0, i32 2
+  store i64 1, ptr %1755, align 4
+  %1756 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1752, align 8
+  %1757 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1758 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1757, i32 0, i32 0
+  store ptr @3, ptr %1758, align 8
+  %1759 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1757, i32 0, i32 1
+  store i64 35, ptr %1759, align 4
+  %1760 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1757, align 8
+  %1761 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1762 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1761, i32 0, i32 0
+  store ptr @50, ptr %1762, align 8
+  %1763 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1761, i32 0, i32 1
+  store i64 4, ptr %1763, align 4
+  %1764 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1761, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %1719, %"github.com/goplus/llgo/internal/runtime.String" %1760, %"github.com/goplus/llgo/internal/runtime.String" %1764, ptr %1725, %"github.com/goplus/llgo/internal/runtime.Slice" %1749, %"github.com/goplus/llgo/internal/runtime.Slice" %1756)
   br label %_llgo_100
 
 _llgo_100:                                        ; preds = %_llgo_99, %_llgo_98
-  %1763 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Kind", align 8
-  %1764 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Kind", align 8
-  %1765 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
-  %1766 = icmp eq ptr %1765, null
-  br i1 %1766, label %_llgo_101, label %_llgo_102
+  %1765 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Kind", align 8
+  %1766 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Kind", align 8
+  %1767 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
+  %1768 = icmp eq ptr %1767, null
+  br i1 %1768, label %_llgo_101, label %_llgo_102
 
 _llgo_101:                                        ; preds = %_llgo_100
-  %1767 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %1768 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1769 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1768, i32 0, i32 0
-  store ptr %1767, ptr %1769, align 8
-  %1770 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1768, i32 0, i32 1
-  store i64 0, ptr %1770, align 4
-  %1771 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1768, i32 0, i32 2
-  store i64 0, ptr %1771, align 4
-  %1772 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1768, align 8
-  %1773 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %1774 = getelementptr ptr, ptr %1773, i64 0
-  store ptr %1764, ptr %1774, align 8
-  %1775 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1776 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1775, i32 0, i32 0
-  store ptr %1773, ptr %1776, align 8
-  %1777 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1775, i32 0, i32 1
-  store i64 1, ptr %1777, align 4
-  %1778 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1775, i32 0, i32 2
-  store i64 1, ptr %1778, align 4
-  %1779 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1775, align 8
-  %1780 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1772, %"github.com/goplus/llgo/internal/runtime.Slice" %1779, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1780)
-  store ptr %1780, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
+  %1769 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %1770 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1771 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1770, i32 0, i32 0
+  store ptr %1769, ptr %1771, align 8
+  %1772 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1770, i32 0, i32 1
+  store i64 0, ptr %1772, align 4
+  %1773 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1770, i32 0, i32 2
+  store i64 0, ptr %1773, align 4
+  %1774 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1770, align 8
+  %1775 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %1776 = getelementptr ptr, ptr %1775, i64 0
+  store ptr %1766, ptr %1776, align 8
+  %1777 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1778 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1777, i32 0, i32 0
+  store ptr %1775, ptr %1778, align 8
+  %1779 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1777, i32 0, i32 1
+  store i64 1, ptr %1779, align 4
+  %1780 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1777, i32 0, i32 2
+  store i64 1, ptr %1780, align 4
+  %1781 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1777, align 8
+  %1782 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1774, %"github.com/goplus/llgo/internal/runtime.Slice" %1781, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1782)
+  store ptr %1782, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
   br label %_llgo_102
 
 _llgo_102:                                        ; preds = %_llgo_101, %_llgo_100
-  %1781 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
-  %1782 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1783 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1782, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1712, ptr %1783, align 8
-  %1784 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1782, i32 0, i32 1
-  store ptr %1781, ptr %1784, align 8
-  %1785 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1782, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Kind", ptr %1785, align 8
-  %1786 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1782, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Kind", ptr %1786, align 8
-  %1787 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1782, align 8
-  %1788 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1789 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1788, i32 0, i32 0
-  store ptr @24, ptr %1789, align 8
-  %1790 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1788, i32 0, i32 1
-  store i64 3, ptr %1790, align 4
-  %1791 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1788, align 8
-  %1792 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %1793 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1794 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1793, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1791, ptr %1794, align 8
-  %1795 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1793, i32 0, i32 1
-  store ptr %1792, ptr %1795, align 8
-  %1796 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1793, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Len", ptr %1796, align 8
-  %1797 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1793, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Len", ptr %1797, align 8
-  %1798 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1793, align 8
-  %1799 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1800 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1799, i32 0, i32 0
-  store ptr @53, ptr %1800, align 8
-  %1801 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1799, i32 0, i32 1
-  store i64 7, ptr %1801, align 4
-  %1802 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1799, align 8
-  %1803 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1804 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1803, i32 0, i32 0
-  store ptr @54, ptr %1804, align 8
-  %1805 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1803, i32 0, i32 1
-  store i64 43, ptr %1805, align 4
-  %1806 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1803, align 8
-  %1807 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1806, i64 25, i64 136, i64 0, i64 25)
-  %1808 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
-  %1809 = icmp eq ptr %1808, null
-  br i1 %1809, label %_llgo_103, label %_llgo_104
+  %1783 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
+  %1784 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1785 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1784, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1714, ptr %1785, align 8
+  %1786 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1784, i32 0, i32 1
+  store ptr %1783, ptr %1786, align 8
+  %1787 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1784, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Kind", ptr %1787, align 8
+  %1788 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1784, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Kind", ptr %1788, align 8
+  %1789 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1784, align 8
+  %1790 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1791 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1790, i32 0, i32 0
+  store ptr @24, ptr %1791, align 8
+  %1792 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1790, i32 0, i32 1
+  store i64 3, ptr %1792, align 4
+  %1793 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1790, align 8
+  %1794 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %1795 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %1796 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1795, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1793, ptr %1796, align 8
+  %1797 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1795, i32 0, i32 1
+  store ptr %1794, ptr %1797, align 8
+  %1798 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1795, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Len", ptr %1798, align 8
+  %1799 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1795, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Len", ptr %1799, align 8
+  %1800 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1795, align 8
+  %1801 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1802 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1801, i32 0, i32 0
+  store ptr @53, ptr %1802, align 8
+  %1803 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1801, i32 0, i32 1
+  store i64 7, ptr %1803, align 4
+  %1804 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1801, align 8
+  %1805 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1806 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1805, i32 0, i32 0
+  store ptr @54, ptr %1806, align 8
+  %1807 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1805, i32 0, i32 1
+  store i64 43, ptr %1807, align 4
+  %1808 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1805, align 8
+  %1809 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1808, i64 25, i64 136, i64 0, i64 25)
+  %1810 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  %1811 = icmp eq ptr %1810, null
+  br i1 %1811, label %_llgo_103, label %_llgo_104
 
 _llgo_103:                                        ; preds = %_llgo_102
-  store ptr %1807, ptr @"_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  store ptr %1809, ptr @"_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
   br label %_llgo_104
 
 _llgo_104:                                        ; preds = %_llgo_103, %_llgo_102
-  %1810 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %1811 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
   %1812 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %1813 = load ptr, ptr @_llgo_Pointer, align 8
-  %1814 = load ptr, ptr @_llgo_Pointer, align 8
-  %1815 = load ptr, ptr @_llgo_uintptr, align 8
-  %1816 = load ptr, ptr @_llgo_uintptr, align 8
-  %1817 = load ptr, ptr @"_llgo_func$cAvVsWLgvZTNybpI-5Hj9CeBwW9xcw6i77GFRvp83mY", align 8
-  %1818 = icmp eq ptr %1817, null
-  br i1 %1818, label %_llgo_105, label %_llgo_106
+  %1813 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %1814 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %1815 = load ptr, ptr @_llgo_Pointer, align 8
+  %1816 = load ptr, ptr @_llgo_Pointer, align 8
+  %1817 = load ptr, ptr @_llgo_uintptr, align 8
+  %1818 = load ptr, ptr @_llgo_uintptr, align 8
+  %1819 = load ptr, ptr @"_llgo_func$cAvVsWLgvZTNybpI-5Hj9CeBwW9xcw6i77GFRvp83mY", align 8
+  %1820 = icmp eq ptr %1819, null
+  br i1 %1820, label %_llgo_105, label %_llgo_106
 
 _llgo_105:                                        ; preds = %_llgo_104
-  %1819 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %1820 = getelementptr ptr, ptr %1819, i64 0
-  store ptr %1813, ptr %1820, align 8
-  %1821 = getelementptr ptr, ptr %1819, i64 1
-  store ptr %1814, ptr %1821, align 8
-  %1822 = getelementptr ptr, ptr %1819, i64 2
+  %1821 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %1822 = getelementptr ptr, ptr %1821, i64 0
   store ptr %1815, ptr %1822, align 8
-  %1823 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1824 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1823, i32 0, i32 0
-  store ptr %1819, ptr %1824, align 8
-  %1825 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1823, i32 0, i32 1
-  store i64 3, ptr %1825, align 4
-  %1826 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1823, i32 0, i32 2
-  store i64 3, ptr %1826, align 4
-  %1827 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1823, align 8
-  %1828 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %1829 = getelementptr ptr, ptr %1828, i64 0
-  store ptr %1816, ptr %1829, align 8
-  %1830 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1831 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1830, i32 0, i32 0
-  store ptr %1828, ptr %1831, align 8
-  %1832 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1830, i32 0, i32 1
-  store i64 1, ptr %1832, align 4
-  %1833 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1830, i32 0, i32 2
-  store i64 1, ptr %1833, align 4
-  %1834 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1830, align 8
-  %1835 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1827, %"github.com/goplus/llgo/internal/runtime.Slice" %1834, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1835)
-  store ptr %1835, ptr @"_llgo_func$cAvVsWLgvZTNybpI-5Hj9CeBwW9xcw6i77GFRvp83mY", align 8
+  %1823 = getelementptr ptr, ptr %1821, i64 1
+  store ptr %1816, ptr %1823, align 8
+  %1824 = getelementptr ptr, ptr %1821, i64 2
+  store ptr %1817, ptr %1824, align 8
+  %1825 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1826 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1825, i32 0, i32 0
+  store ptr %1821, ptr %1826, align 8
+  %1827 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1825, i32 0, i32 1
+  store i64 3, ptr %1827, align 4
+  %1828 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1825, i32 0, i32 2
+  store i64 3, ptr %1828, align 4
+  %1829 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1825, align 8
+  %1830 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %1831 = getelementptr ptr, ptr %1830, i64 0
+  store ptr %1818, ptr %1831, align 8
+  %1832 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1833 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1832, i32 0, i32 0
+  store ptr %1830, ptr %1833, align 8
+  %1834 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1832, i32 0, i32 1
+  store i64 1, ptr %1834, align 4
+  %1835 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1832, i32 0, i32 2
+  store i64 1, ptr %1835, align 4
+  %1836 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1832, align 8
+  %1837 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1829, %"github.com/goplus/llgo/internal/runtime.Slice" %1836, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1837)
+  store ptr %1837, ptr @"_llgo_func$cAvVsWLgvZTNybpI-5Hj9CeBwW9xcw6i77GFRvp83mY", align 8
   br label %_llgo_106
 
 _llgo_106:                                        ; preds = %_llgo_105, %_llgo_104
-  %1836 = load ptr, ptr @"_llgo_func$cAvVsWLgvZTNybpI-5Hj9CeBwW9xcw6i77GFRvp83mY", align 8
-  %1837 = load ptr, ptr @_llgo_Pointer, align 8
-  %1838 = load ptr, ptr @_llgo_Pointer, align 8
-  %1839 = load ptr, ptr @_llgo_uintptr, align 8
-  %1840 = load ptr, ptr @_llgo_uintptr, align 8
-  %1841 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1842 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1841, i32 0, i32 0
-  store ptr @5, ptr %1842, align 8
-  %1843 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1841, i32 0, i32 1
-  store i64 1, ptr %1843, align 4
-  %1844 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1841, align 8
-  %1845 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1846 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1845, i32 0, i32 0
-  store ptr null, ptr %1846, align 8
-  %1847 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1845, i32 0, i32 1
-  store i64 0, ptr %1847, align 4
-  %1848 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1845, align 8
-  %1849 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %1850 = getelementptr ptr, ptr %1849, i64 0
-  store ptr %1837, ptr %1850, align 8
-  %1851 = getelementptr ptr, ptr %1849, i64 1
-  store ptr %1838, ptr %1851, align 8
-  %1852 = getelementptr ptr, ptr %1849, i64 2
+  %1838 = load ptr, ptr @"_llgo_func$cAvVsWLgvZTNybpI-5Hj9CeBwW9xcw6i77GFRvp83mY", align 8
+  %1839 = load ptr, ptr @_llgo_Pointer, align 8
+  %1840 = load ptr, ptr @_llgo_Pointer, align 8
+  %1841 = load ptr, ptr @_llgo_uintptr, align 8
+  %1842 = load ptr, ptr @_llgo_uintptr, align 8
+  %1843 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1844 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1843, i32 0, i32 0
+  store ptr @5, ptr %1844, align 8
+  %1845 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1843, i32 0, i32 1
+  store i64 1, ptr %1845, align 4
+  %1846 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1843, align 8
+  %1847 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1848 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1847, i32 0, i32 0
+  store ptr null, ptr %1848, align 8
+  %1849 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1847, i32 0, i32 1
+  store i64 0, ptr %1849, align 4
+  %1850 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1847, align 8
+  %1851 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %1852 = getelementptr ptr, ptr %1851, i64 0
   store ptr %1839, ptr %1852, align 8
-  %1853 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1854 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1853, i32 0, i32 0
-  store ptr %1849, ptr %1854, align 8
-  %1855 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1853, i32 0, i32 1
-  store i64 3, ptr %1855, align 4
-  %1856 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1853, i32 0, i32 2
-  store i64 3, ptr %1856, align 4
-  %1857 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1853, align 8
-  %1858 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %1859 = getelementptr ptr, ptr %1858, i64 0
-  store ptr %1840, ptr %1859, align 8
-  %1860 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1861 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1860, i32 0, i32 0
-  store ptr %1858, ptr %1861, align 8
-  %1862 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1860, i32 0, i32 1
-  store i64 1, ptr %1862, align 4
-  %1863 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1860, i32 0, i32 2
-  store i64 1, ptr %1863, align 4
-  %1864 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1860, align 8
-  %1865 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1857, %"github.com/goplus/llgo/internal/runtime.Slice" %1864, i1 false)
-  %1866 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1844, ptr %1865, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %1848, i1 false)
-  %1867 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1868 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1867, i32 0, i32 0
-  store ptr @6, ptr %1868, align 8
-  %1869 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1867, i32 0, i32 1
-  store i64 4, ptr %1869, align 4
-  %1870 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1867, align 8
-  %1871 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1872 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1871, i32 0, i32 0
-  store ptr null, ptr %1872, align 8
-  %1873 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1871, i32 0, i32 1
-  store i64 0, ptr %1873, align 4
-  %1874 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1871, align 8
-  %1875 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %1876 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1870, ptr %1875, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %1874, i1 false)
-  %1877 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1878 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1877, i32 0, i32 0
-  store ptr @7, ptr %1878, align 8
-  %1879 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1877, i32 0, i32 1
-  store i64 4, ptr %1879, align 4
-  %1880 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1877, align 8
-  %1881 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %1882 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1881, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %1866, ptr %1882, align 8
-  %1883 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1881, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %1876, ptr %1883, align 8
-  %1884 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1885 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1884, i32 0, i32 0
-  store ptr %1881, ptr %1885, align 8
-  %1886 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1884, i32 0, i32 1
-  store i64 2, ptr %1886, align 4
-  %1887 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1884, i32 0, i32 2
-  store i64 2, ptr %1887, align 4
-  %1888 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1884, align 8
-  %1889 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %1880, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %1888)
-  store ptr %1889, ptr @"main.struct$uDDWukIj6_GRAIQyJjrj0CZt1Ru2uIDU1N9fcbR_jCg", align 8
-  %1890 = load ptr, ptr @"main.struct$uDDWukIj6_GRAIQyJjrj0CZt1Ru2uIDU1N9fcbR_jCg", align 8
-  %1891 = load ptr, ptr @_llgo_uint16, align 8
-  %1892 = icmp eq ptr %1891, null
-  br i1 %1892, label %_llgo_107, label %_llgo_108
+  %1853 = getelementptr ptr, ptr %1851, i64 1
+  store ptr %1840, ptr %1853, align 8
+  %1854 = getelementptr ptr, ptr %1851, i64 2
+  store ptr %1841, ptr %1854, align 8
+  %1855 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1856 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1855, i32 0, i32 0
+  store ptr %1851, ptr %1856, align 8
+  %1857 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1855, i32 0, i32 1
+  store i64 3, ptr %1857, align 4
+  %1858 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1855, i32 0, i32 2
+  store i64 3, ptr %1858, align 4
+  %1859 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1855, align 8
+  %1860 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %1861 = getelementptr ptr, ptr %1860, i64 0
+  store ptr %1842, ptr %1861, align 8
+  %1862 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1863 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1862, i32 0, i32 0
+  store ptr %1860, ptr %1863, align 8
+  %1864 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1862, i32 0, i32 1
+  store i64 1, ptr %1864, align 4
+  %1865 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1862, i32 0, i32 2
+  store i64 1, ptr %1865, align 4
+  %1866 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1862, align 8
+  %1867 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1859, %"github.com/goplus/llgo/internal/runtime.Slice" %1866, i1 false)
+  %1868 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1846, ptr %1867, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %1850, i1 false)
+  %1869 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1870 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1869, i32 0, i32 0
+  store ptr @6, ptr %1870, align 8
+  %1871 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1869, i32 0, i32 1
+  store i64 4, ptr %1871, align 4
+  %1872 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1869, align 8
+  %1873 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1874 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1873, i32 0, i32 0
+  store ptr null, ptr %1874, align 8
+  %1875 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1873, i32 0, i32 1
+  store i64 0, ptr %1875, align 4
+  %1876 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1873, align 8
+  %1877 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %1878 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1872, ptr %1877, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %1876, i1 false)
+  %1879 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1880 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1879, i32 0, i32 0
+  store ptr @7, ptr %1880, align 8
+  %1881 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1879, i32 0, i32 1
+  store i64 4, ptr %1881, align 4
+  %1882 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1879, align 8
+  %1883 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %1884 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1883, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1868, ptr %1884, align 8
+  %1885 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1883, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1878, ptr %1885, align 8
+  %1886 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1887 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1886, i32 0, i32 0
+  store ptr %1883, ptr %1887, align 8
+  %1888 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1886, i32 0, i32 1
+  store i64 2, ptr %1888, align 4
+  %1889 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1886, i32 0, i32 2
+  store i64 2, ptr %1889, align 4
+  %1890 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1886, align 8
+  %1891 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %1882, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %1890)
+  store ptr %1891, ptr @"main.struct$uDDWukIj6_GRAIQyJjrj0CZt1Ru2uIDU1N9fcbR_jCg", align 8
+  %1892 = load ptr, ptr @"main.struct$uDDWukIj6_GRAIQyJjrj0CZt1Ru2uIDU1N9fcbR_jCg", align 8
+  %1893 = load ptr, ptr @_llgo_uint16, align 8
+  %1894 = icmp eq ptr %1893, null
+  br i1 %1894, label %_llgo_107, label %_llgo_108
 
 _llgo_107:                                        ; preds = %_llgo_106
-  %1893 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 41)
-  store ptr %1893, ptr @_llgo_uint16, align 8
+  %1895 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 41)
+  store ptr %1895, ptr @_llgo_uint16, align 8
   br label %_llgo_108
 
 _llgo_108:                                        ; preds = %_llgo_107, %_llgo_106
-  %1894 = load ptr, ptr @_llgo_uint16, align 8
-  %1895 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1896 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1895, i32 0, i32 0
-  store ptr @1, ptr %1896, align 8
-  %1897 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1895, i32 0, i32 1
-  store i64 40, ptr %1897, align 4
-  %1898 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1895, align 8
-  %1899 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1898, i64 25, i64 80, i64 0, i64 22)
-  %1900 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1901 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1900, i32 0, i32 0
-  store ptr @1, ptr %1901, align 8
-  %1902 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1900, i32 0, i32 1
-  store i64 40, ptr %1902, align 4
-  %1903 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1900, align 8
-  %1904 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1903, i64 25, i64 80, i64 0, i64 22)
-  %1905 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1906 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1905, i32 0, i32 0
-  store ptr @1, ptr %1906, align 8
-  %1907 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1905, i32 0, i32 1
-  store i64 40, ptr %1907, align 4
-  %1908 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1905, align 8
-  %1909 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1908, i64 25, i64 80, i64 0, i64 22)
-  %1910 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1911 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1910, i32 0, i32 0
-  store ptr @1, ptr %1911, align 8
-  %1912 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1910, i32 0, i32 1
-  store i64 40, ptr %1912, align 4
-  %1913 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1910, align 8
-  %1914 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1913, i64 25, i64 80, i64 0, i64 22)
-  %1915 = load ptr, ptr @_llgo_Pointer, align 8
-  %1916 = load ptr, ptr @_llgo_Pointer, align 8
-  %1917 = load ptr, ptr @_llgo_uintptr, align 8
-  %1918 = load ptr, ptr @_llgo_uintptr, align 8
-  %1919 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1920 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1919, i32 0, i32 0
-  store ptr @21, ptr %1920, align 8
-  %1921 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1919, i32 0, i32 1
-  store i64 4, ptr %1921, align 4
-  %1922 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1919, align 8
-  %1923 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1924 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1923, i32 0, i32 0
-  store ptr null, ptr %1924, align 8
-  %1925 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1923, i32 0, i32 1
-  store i64 0, ptr %1925, align 4
-  %1926 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1923, align 8
-  %1927 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1922, ptr %1899, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %1926, i1 true)
-  %1928 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1929 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1928, i32 0, i32 0
-  store ptr @49, ptr %1929, align 8
-  %1930 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1928, i32 0, i32 1
-  store i64 3, ptr %1930, align 4
-  %1931 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1928, align 8
-  %1932 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1933 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1932, i32 0, i32 0
-  store ptr null, ptr %1933, align 8
-  %1934 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1932, i32 0, i32 1
-  store i64 0, ptr %1934, align 4
-  %1935 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1932, align 8
-  %1936 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1904)
-  %1937 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1931, ptr %1936, i64 72, %"github.com/goplus/llgo/internal/runtime.String" %1935, i1 false)
-  %1938 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1939 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1938, i32 0, i32 0
-  store ptr @22, ptr %1939, align 8
-  %1940 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1938, i32 0, i32 1
-  store i64 4, ptr %1940, align 4
-  %1941 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1938, align 8
-  %1942 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1943 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1942, i32 0, i32 0
-  store ptr null, ptr %1943, align 8
-  %1944 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1942, i32 0, i32 1
-  store i64 0, ptr %1944, align 4
-  %1945 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1942, align 8
-  %1946 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1909)
-  %1947 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1941, ptr %1946, i64 80, %"github.com/goplus/llgo/internal/runtime.String" %1945, i1 false)
-  %1948 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1949 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1948, i32 0, i32 0
-  store ptr @55, ptr %1949, align 8
-  %1950 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1948, i32 0, i32 1
-  store i64 6, ptr %1950, align 4
-  %1951 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1948, align 8
-  %1952 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1953 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1952, i32 0, i32 0
-  store ptr null, ptr %1953, align 8
-  %1954 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1952, i32 0, i32 1
-  store i64 0, ptr %1954, align 4
-  %1955 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1952, align 8
-  %1956 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1914)
-  %1957 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1951, ptr %1956, i64 88, %"github.com/goplus/llgo/internal/runtime.String" %1955, i1 false)
-  %1958 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1959 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1958, i32 0, i32 0
-  store ptr @56, ptr %1959, align 8
-  %1960 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1958, i32 0, i32 1
-  store i64 6, ptr %1960, align 4
-  %1961 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1958, align 8
-  %1962 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1963 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1962, i32 0, i32 0
-  store ptr null, ptr %1963, align 8
-  %1964 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1962, i32 0, i32 1
-  store i64 0, ptr %1964, align 4
-  %1965 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1962, align 8
-  %1966 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1967 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1966, i32 0, i32 0
-  store ptr @5, ptr %1967, align 8
-  %1968 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1966, i32 0, i32 1
-  store i64 1, ptr %1968, align 4
-  %1969 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1966, align 8
-  %1970 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1971 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1970, i32 0, i32 0
-  store ptr null, ptr %1971, align 8
-  %1972 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1970, i32 0, i32 1
-  store i64 0, ptr %1972, align 4
-  %1973 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1970, align 8
-  %1974 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %1975 = getelementptr ptr, ptr %1974, i64 0
-  store ptr %1915, ptr %1975, align 8
-  %1976 = getelementptr ptr, ptr %1974, i64 1
-  store ptr %1916, ptr %1976, align 8
-  %1977 = getelementptr ptr, ptr %1974, i64 2
+  %1896 = load ptr, ptr @_llgo_uint16, align 8
+  %1897 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1898 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1897, i32 0, i32 0
+  store ptr @1, ptr %1898, align 8
+  %1899 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1897, i32 0, i32 1
+  store i64 40, ptr %1899, align 4
+  %1900 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1897, align 8
+  %1901 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1900, i64 25, i64 80, i64 0, i64 22)
+  %1902 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1903 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1902, i32 0, i32 0
+  store ptr @1, ptr %1903, align 8
+  %1904 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1902, i32 0, i32 1
+  store i64 40, ptr %1904, align 4
+  %1905 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1902, align 8
+  %1906 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1905, i64 25, i64 80, i64 0, i64 22)
+  %1907 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1908 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1907, i32 0, i32 0
+  store ptr @1, ptr %1908, align 8
+  %1909 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1907, i32 0, i32 1
+  store i64 40, ptr %1909, align 4
+  %1910 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1907, align 8
+  %1911 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1910, i64 25, i64 80, i64 0, i64 22)
+  %1912 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1913 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1912, i32 0, i32 0
+  store ptr @1, ptr %1913, align 8
+  %1914 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1912, i32 0, i32 1
+  store i64 40, ptr %1914, align 4
+  %1915 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1912, align 8
+  %1916 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1915, i64 25, i64 80, i64 0, i64 22)
+  %1917 = load ptr, ptr @_llgo_Pointer, align 8
+  %1918 = load ptr, ptr @_llgo_Pointer, align 8
+  %1919 = load ptr, ptr @_llgo_uintptr, align 8
+  %1920 = load ptr, ptr @_llgo_uintptr, align 8
+  %1921 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1922 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1921, i32 0, i32 0
+  store ptr @21, ptr %1922, align 8
+  %1923 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1921, i32 0, i32 1
+  store i64 4, ptr %1923, align 4
+  %1924 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1921, align 8
+  %1925 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1926 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1925, i32 0, i32 0
+  store ptr null, ptr %1926, align 8
+  %1927 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1925, i32 0, i32 1
+  store i64 0, ptr %1927, align 4
+  %1928 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1925, align 8
+  %1929 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1924, ptr %1901, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %1928, i1 true)
+  %1930 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1931 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1930, i32 0, i32 0
+  store ptr @49, ptr %1931, align 8
+  %1932 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1930, i32 0, i32 1
+  store i64 3, ptr %1932, align 4
+  %1933 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1930, align 8
+  %1934 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1935 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1934, i32 0, i32 0
+  store ptr null, ptr %1935, align 8
+  %1936 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1934, i32 0, i32 1
+  store i64 0, ptr %1936, align 4
+  %1937 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1934, align 8
+  %1938 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1906)
+  %1939 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1933, ptr %1938, i64 72, %"github.com/goplus/llgo/internal/runtime.String" %1937, i1 false)
+  %1940 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1941 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1940, i32 0, i32 0
+  store ptr @22, ptr %1941, align 8
+  %1942 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1940, i32 0, i32 1
+  store i64 4, ptr %1942, align 4
+  %1943 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1940, align 8
+  %1944 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1945 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1944, i32 0, i32 0
+  store ptr null, ptr %1945, align 8
+  %1946 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1944, i32 0, i32 1
+  store i64 0, ptr %1946, align 4
+  %1947 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1944, align 8
+  %1948 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1911)
+  %1949 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1943, ptr %1948, i64 80, %"github.com/goplus/llgo/internal/runtime.String" %1947, i1 false)
+  %1950 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1951 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1950, i32 0, i32 0
+  store ptr @55, ptr %1951, align 8
+  %1952 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1950, i32 0, i32 1
+  store i64 6, ptr %1952, align 4
+  %1953 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1950, align 8
+  %1954 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1955 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1954, i32 0, i32 0
+  store ptr null, ptr %1955, align 8
+  %1956 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1954, i32 0, i32 1
+  store i64 0, ptr %1956, align 4
+  %1957 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1954, align 8
+  %1958 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1916)
+  %1959 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1953, ptr %1958, i64 88, %"github.com/goplus/llgo/internal/runtime.String" %1957, i1 false)
+  %1960 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1961 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1960, i32 0, i32 0
+  store ptr @56, ptr %1961, align 8
+  %1962 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1960, i32 0, i32 1
+  store i64 6, ptr %1962, align 4
+  %1963 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1960, align 8
+  %1964 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1965 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1964, i32 0, i32 0
+  store ptr null, ptr %1965, align 8
+  %1966 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1964, i32 0, i32 1
+  store i64 0, ptr %1966, align 4
+  %1967 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1964, align 8
+  %1968 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1969 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1968, i32 0, i32 0
+  store ptr @5, ptr %1969, align 8
+  %1970 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1968, i32 0, i32 1
+  store i64 1, ptr %1970, align 4
+  %1971 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1968, align 8
+  %1972 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1973 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1972, i32 0, i32 0
+  store ptr null, ptr %1973, align 8
+  %1974 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1972, i32 0, i32 1
+  store i64 0, ptr %1974, align 4
+  %1975 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1972, align 8
+  %1976 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %1977 = getelementptr ptr, ptr %1976, i64 0
   store ptr %1917, ptr %1977, align 8
-  %1978 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1979 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1978, i32 0, i32 0
-  store ptr %1974, ptr %1979, align 8
-  %1980 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1978, i32 0, i32 1
-  store i64 3, ptr %1980, align 4
-  %1981 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1978, i32 0, i32 2
-  store i64 3, ptr %1981, align 4
-  %1982 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1978, align 8
-  %1983 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %1984 = getelementptr ptr, ptr %1983, i64 0
-  store ptr %1918, ptr %1984, align 8
-  %1985 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1986 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1985, i32 0, i32 0
-  store ptr %1983, ptr %1986, align 8
-  %1987 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1985, i32 0, i32 1
-  store i64 1, ptr %1987, align 4
-  %1988 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1985, i32 0, i32 2
-  store i64 1, ptr %1988, align 4
-  %1989 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1985, align 8
-  %1990 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1982, %"github.com/goplus/llgo/internal/runtime.Slice" %1989, i1 false)
-  %1991 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1969, ptr %1990, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %1973, i1 false)
-  %1992 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1993 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1992, i32 0, i32 0
-  store ptr @6, ptr %1993, align 8
-  %1994 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1992, i32 0, i32 1
-  store i64 4, ptr %1994, align 4
-  %1995 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1992, align 8
-  %1996 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1997 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1996, i32 0, i32 0
-  store ptr null, ptr %1997, align 8
-  %1998 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1996, i32 0, i32 1
-  store i64 0, ptr %1998, align 4
-  %1999 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1996, align 8
-  %2000 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %2001 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1995, ptr %2000, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %1999, i1 false)
-  %2002 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2003 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2002, i32 0, i32 0
-  store ptr @7, ptr %2003, align 8
-  %2004 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2002, i32 0, i32 1
-  store i64 4, ptr %2004, align 4
-  %2005 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2002, align 8
-  %2006 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %2007 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2006, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %1991, ptr %2007, align 8
-  %2008 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2006, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2001, ptr %2008, align 8
-  %2009 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2010 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2009, i32 0, i32 0
-  store ptr %2006, ptr %2010, align 8
-  %2011 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2009, i32 0, i32 1
-  store i64 2, ptr %2011, align 4
-  %2012 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2009, i32 0, i32 2
-  store i64 2, ptr %2012, align 4
-  %2013 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2009, align 8
-  %2014 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %2005, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %2013)
-  %2015 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1961, ptr %2014, i64 96, %"github.com/goplus/llgo/internal/runtime.String" %1965, i1 false)
-  %2016 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2017 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2016, i32 0, i32 0
-  store ptr @57, ptr %2017, align 8
-  %2018 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2016, i32 0, i32 1
-  store i64 7, ptr %2018, align 4
-  %2019 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2016, align 8
-  %2020 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2021 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2020, i32 0, i32 0
-  store ptr null, ptr %2021, align 8
-  %2022 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2020, i32 0, i32 1
-  store i64 0, ptr %2022, align 4
-  %2023 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2020, align 8
-  %2024 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %2025 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2019, ptr %2024, i64 112, %"github.com/goplus/llgo/internal/runtime.String" %2023, i1 false)
-  %2026 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2027 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2026, i32 0, i32 0
-  store ptr @58, ptr %2027, align 8
-  %2028 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2026, i32 0, i32 1
-  store i64 9, ptr %2028, align 4
-  %2029 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2026, align 8
-  %2030 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2031 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2030, i32 0, i32 0
-  store ptr null, ptr %2031, align 8
-  %2032 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2030, i32 0, i32 1
-  store i64 0, ptr %2032, align 4
-  %2033 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2030, align 8
-  %2034 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %2035 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2029, ptr %2034, i64 113, %"github.com/goplus/llgo/internal/runtime.String" %2033, i1 false)
-  %2036 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2037 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2036, i32 0, i32 0
-  store ptr @59, ptr %2037, align 8
-  %2038 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2036, i32 0, i32 1
-  store i64 10, ptr %2038, align 4
-  %2039 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2036, align 8
-  %2040 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2041 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2040, i32 0, i32 0
-  store ptr null, ptr %2041, align 8
-  %2042 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2040, i32 0, i32 1
-  store i64 0, ptr %2042, align 4
-  %2043 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2040, align 8
-  %2044 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 41)
-  %2045 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2039, ptr %2044, i64 114, %"github.com/goplus/llgo/internal/runtime.String" %2043, i1 false)
-  %2046 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2047 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2046, i32 0, i32 0
-  store ptr @60, ptr %2047, align 8
-  %2048 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2046, i32 0, i32 1
-  store i64 5, ptr %2048, align 4
-  %2049 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2046, align 8
-  %2050 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2051 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2050, i32 0, i32 0
-  store ptr null, ptr %2051, align 8
-  %2052 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2050, i32 0, i32 1
-  store i64 0, ptr %2052, align 4
-  %2053 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2050, align 8
-  %2054 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 42)
-  %2055 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2049, ptr %2054, i64 116, %"github.com/goplus/llgo/internal/runtime.String" %2053, i1 false)
-  %2056 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2057 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2056, i32 0, i32 0
-  store ptr @7, ptr %2057, align 8
-  %2058 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2056, i32 0, i32 1
-  store i64 4, ptr %2058, align 4
-  %2059 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2056, align 8
-  %2060 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 504)
-  %2061 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2060, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %1927, ptr %2061, align 8
-  %2062 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2060, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %1937, ptr %2062, align 8
-  %2063 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2060, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %1947, ptr %2063, align 8
-  %2064 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2060, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %1957, ptr %2064, align 8
-  %2065 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2060, i64 4
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2015, ptr %2065, align 8
-  %2066 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2060, i64 5
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2025, ptr %2066, align 8
-  %2067 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2060, i64 6
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2035, ptr %2067, align 8
-  %2068 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2060, i64 7
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2045, ptr %2068, align 8
-  %2069 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2060, i64 8
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2055, ptr %2069, align 8
-  %2070 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2071 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2070, i32 0, i32 0
-  store ptr %2060, ptr %2071, align 8
-  %2072 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2070, i32 0, i32 1
-  store i64 9, ptr %2072, align 4
-  %2073 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2070, i32 0, i32 2
-  store i64 9, ptr %2073, align 4
-  %2074 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2070, align 8
-  %2075 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %2059, i64 120, %"github.com/goplus/llgo/internal/runtime.Slice" %2074)
-  store ptr %2075, ptr @"main.struct$Yk42tBqeO4BzIoRAwt__cbPj2UwIDCP07Kg_SR7sBZM", align 8
-  %2076 = load ptr, ptr @"main.struct$Yk42tBqeO4BzIoRAwt__cbPj2UwIDCP07Kg_SR7sBZM", align 8
-  br i1 %1809, label %_llgo_109, label %_llgo_110
+  %1978 = getelementptr ptr, ptr %1976, i64 1
+  store ptr %1918, ptr %1978, align 8
+  %1979 = getelementptr ptr, ptr %1976, i64 2
+  store ptr %1919, ptr %1979, align 8
+  %1980 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1981 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1980, i32 0, i32 0
+  store ptr %1976, ptr %1981, align 8
+  %1982 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1980, i32 0, i32 1
+  store i64 3, ptr %1982, align 4
+  %1983 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1980, i32 0, i32 2
+  store i64 3, ptr %1983, align 4
+  %1984 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1980, align 8
+  %1985 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %1986 = getelementptr ptr, ptr %1985, i64 0
+  store ptr %1920, ptr %1986, align 8
+  %1987 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %1988 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1987, i32 0, i32 0
+  store ptr %1985, ptr %1988, align 8
+  %1989 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1987, i32 0, i32 1
+  store i64 1, ptr %1989, align 4
+  %1990 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1987, i32 0, i32 2
+  store i64 1, ptr %1990, align 4
+  %1991 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1987, align 8
+  %1992 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1984, %"github.com/goplus/llgo/internal/runtime.Slice" %1991, i1 false)
+  %1993 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1971, ptr %1992, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %1975, i1 false)
+  %1994 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1995 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1994, i32 0, i32 0
+  store ptr @6, ptr %1995, align 8
+  %1996 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1994, i32 0, i32 1
+  store i64 4, ptr %1996, align 4
+  %1997 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1994, align 8
+  %1998 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1999 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1998, i32 0, i32 0
+  store ptr null, ptr %1999, align 8
+  %2000 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1998, i32 0, i32 1
+  store i64 0, ptr %2000, align 4
+  %2001 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1998, align 8
+  %2002 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %2003 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1997, ptr %2002, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %2001, i1 false)
+  %2004 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2005 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2004, i32 0, i32 0
+  store ptr @7, ptr %2005, align 8
+  %2006 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2004, i32 0, i32 1
+  store i64 4, ptr %2006, align 4
+  %2007 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2004, align 8
+  %2008 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %2009 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2008, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1993, ptr %2009, align 8
+  %2010 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2008, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %2003, ptr %2010, align 8
+  %2011 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %2012 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2011, i32 0, i32 0
+  store ptr %2008, ptr %2012, align 8
+  %2013 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2011, i32 0, i32 1
+  store i64 2, ptr %2013, align 4
+  %2014 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2011, i32 0, i32 2
+  store i64 2, ptr %2014, align 4
+  %2015 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2011, align 8
+  %2016 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %2007, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %2015)
+  %2017 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1963, ptr %2016, i64 96, %"github.com/goplus/llgo/internal/runtime.String" %1967, i1 false)
+  %2018 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2019 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2018, i32 0, i32 0
+  store ptr @57, ptr %2019, align 8
+  %2020 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2018, i32 0, i32 1
+  store i64 7, ptr %2020, align 4
+  %2021 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2018, align 8
+  %2022 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2023 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2022, i32 0, i32 0
+  store ptr null, ptr %2023, align 8
+  %2024 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2022, i32 0, i32 1
+  store i64 0, ptr %2024, align 4
+  %2025 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2022, align 8
+  %2026 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %2027 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2021, ptr %2026, i64 112, %"github.com/goplus/llgo/internal/runtime.String" %2025, i1 false)
+  %2028 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2029 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2028, i32 0, i32 0
+  store ptr @58, ptr %2029, align 8
+  %2030 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2028, i32 0, i32 1
+  store i64 9, ptr %2030, align 4
+  %2031 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2028, align 8
+  %2032 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2033 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2032, i32 0, i32 0
+  store ptr null, ptr %2033, align 8
+  %2034 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2032, i32 0, i32 1
+  store i64 0, ptr %2034, align 4
+  %2035 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2032, align 8
+  %2036 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %2037 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2031, ptr %2036, i64 113, %"github.com/goplus/llgo/internal/runtime.String" %2035, i1 false)
+  %2038 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2039 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2038, i32 0, i32 0
+  store ptr @59, ptr %2039, align 8
+  %2040 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2038, i32 0, i32 1
+  store i64 10, ptr %2040, align 4
+  %2041 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2038, align 8
+  %2042 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2043 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2042, i32 0, i32 0
+  store ptr null, ptr %2043, align 8
+  %2044 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2042, i32 0, i32 1
+  store i64 0, ptr %2044, align 4
+  %2045 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2042, align 8
+  %2046 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 41)
+  %2047 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2041, ptr %2046, i64 114, %"github.com/goplus/llgo/internal/runtime.String" %2045, i1 false)
+  %2048 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2049 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2048, i32 0, i32 0
+  store ptr @60, ptr %2049, align 8
+  %2050 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2048, i32 0, i32 1
+  store i64 5, ptr %2050, align 4
+  %2051 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2048, align 8
+  %2052 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2053 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2052, i32 0, i32 0
+  store ptr null, ptr %2053, align 8
+  %2054 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2052, i32 0, i32 1
+  store i64 0, ptr %2054, align 4
+  %2055 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2052, align 8
+  %2056 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 42)
+  %2057 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2051, ptr %2056, i64 116, %"github.com/goplus/llgo/internal/runtime.String" %2055, i1 false)
+  %2058 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2059 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2058, i32 0, i32 0
+  store ptr @7, ptr %2059, align 8
+  %2060 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2058, i32 0, i32 1
+  store i64 4, ptr %2060, align 4
+  %2061 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2058, align 8
+  %2062 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 504)
+  %2063 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2062, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1929, ptr %2063, align 8
+  %2064 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2062, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1939, ptr %2064, align 8
+  %2065 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2062, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1949, ptr %2065, align 8
+  %2066 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2062, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1959, ptr %2066, align 8
+  %2067 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2062, i64 4
+  store %"github.com/goplus/llgo/internal/abi.StructField" %2017, ptr %2067, align 8
+  %2068 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2062, i64 5
+  store %"github.com/goplus/llgo/internal/abi.StructField" %2027, ptr %2068, align 8
+  %2069 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2062, i64 6
+  store %"github.com/goplus/llgo/internal/abi.StructField" %2037, ptr %2069, align 8
+  %2070 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2062, i64 7
+  store %"github.com/goplus/llgo/internal/abi.StructField" %2047, ptr %2070, align 8
+  %2071 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2062, i64 8
+  store %"github.com/goplus/llgo/internal/abi.StructField" %2057, ptr %2071, align 8
+  %2072 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %2073 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2072, i32 0, i32 0
+  store ptr %2062, ptr %2073, align 8
+  %2074 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2072, i32 0, i32 1
+  store i64 9, ptr %2074, align 4
+  %2075 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2072, i32 0, i32 2
+  store i64 9, ptr %2075, align 4
+  %2076 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2072, align 8
+  %2077 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %2061, i64 120, %"github.com/goplus/llgo/internal/runtime.Slice" %2076)
+  store ptr %2077, ptr @"main.struct$Yk42tBqeO4BzIoRAwt__cbPj2UwIDCP07Kg_SR7sBZM", align 8
+  %2078 = load ptr, ptr @"main.struct$Yk42tBqeO4BzIoRAwt__cbPj2UwIDCP07Kg_SR7sBZM", align 8
+  br i1 %1811, label %_llgo_109, label %_llgo_110
 
 _llgo_109:                                        ; preds = %_llgo_108
-  %2077 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2078 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2077, i32 0, i32 0
-  store ptr @18, ptr %2078, align 8
-  %2079 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2077, i32 0, i32 1
-  store i64 5, ptr %2079, align 4
-  %2080 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2077, align 8
-  %2081 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %2082 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2083 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2082, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2080, ptr %2083, align 8
-  %2084 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2082, i32 0, i32 1
-  store ptr %2081, ptr %2084, align 8
-  %2085 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2082, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Align", ptr %2085, align 8
-  %2086 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2082, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Align", ptr %2086, align 8
-  %2087 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2082, align 8
-  %2088 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2089 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2088, i32 0, i32 0
-  store ptr @19, ptr %2089, align 8
-  %2090 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2088, i32 0, i32 1
-  store i64 9, ptr %2090, align 4
-  %2091 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2088, align 8
-  %2092 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
-  %2093 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
-  %2094 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2095 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2094, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2091, ptr %2095, align 8
-  %2096 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2094, i32 0, i32 1
-  store ptr %2093, ptr %2096, align 8
-  %2097 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2094, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ArrayType", ptr %2097, align 8
-  %2098 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2094, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ArrayType", ptr %2098, align 8
-  %2099 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2094, align 8
-  %2100 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2101 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2100, i32 0, i32 0
-  store ptr @25, ptr %2101, align 8
-  %2102 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2100, i32 0, i32 1
-  store i64 7, ptr %2102, align 4
-  %2103 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2100, align 8
-  %2104 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
-  %2105 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2106 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2105, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2103, ptr %2106, align 8
-  %2107 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2105, i32 0, i32 1
-  store ptr %2104, ptr %2107, align 8
-  %2108 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2105, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ChanDir", ptr %2108, align 8
-  %2109 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2105, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ChanDir", ptr %2109, align 8
-  %2110 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2105, align 8
-  %2111 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2112 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2111, i32 0, i32 0
-  store ptr @27, ptr %2112, align 8
-  %2113 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2111, i32 0, i32 1
-  store i64 6, ptr %2113, align 4
-  %2114 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2111, align 8
-  %2115 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %2116 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %2117 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2118 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2117, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2114, ptr %2118, align 8
-  %2119 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2117, i32 0, i32 1
-  store ptr %2116, ptr %2119, align 8
-  %2120 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2117, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Common", ptr %2120, align 8
-  %2121 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2117, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Common", ptr %2121, align 8
-  %2122 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2117, align 8
-  %2123 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2124 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2123, i32 0, i32 0
-  store ptr @28, ptr %2124, align 8
-  %2125 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2123, i32 0, i32 1
-  store i64 15, ptr %2125, align 4
-  %2126 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2123, align 8
-  %2127 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %2128 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
-  %2129 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2130 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2129, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2126, ptr %2130, align 8
-  %2131 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2129, i32 0, i32 1
-  store ptr %2128, ptr %2131, align 8
-  %2132 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2129, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ExportedMethods", ptr %2132, align 8
-  %2133 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2129, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ExportedMethods", ptr %2133, align 8
-  %2134 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2129, align 8
-  %2135 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2136 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2135, i32 0, i32 0
-  store ptr @33, ptr %2136, align 8
-  %2137 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2135, i32 0, i32 1
-  store i64 10, ptr %2137, align 4
-  %2138 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2135, align 8
-  %2139 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %2140 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2141 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2140, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2138, ptr %2141, align 8
-  %2142 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2140, i32 0, i32 1
-  store ptr %2139, ptr %2142, align 8
-  %2143 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2140, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).FieldAlign", ptr %2143, align 8
-  %2144 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2140, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).FieldAlign", ptr %2144, align 8
-  %2145 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2140, align 8
-  %2146 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2147 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2146, i32 0, i32 0
-  store ptr @34, ptr %2147, align 8
-  %2148 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2146, i32 0, i32 1
-  store i64 8, ptr %2148, align 4
-  %2149 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2146, align 8
-  %2150 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %2151 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
-  %2152 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2153 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2152, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2149, ptr %2153, align 8
-  %2154 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2152, i32 0, i32 1
-  store ptr %2151, ptr %2154, align 8
-  %2155 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2152, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).FuncType", ptr %2155, align 8
-  %2156 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2152, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).FuncType", ptr %2156, align 8
-  %2157 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2152, align 8
-  %2158 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2159 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2158, i32 0, i32 0
-  store ptr @35, ptr %2159, align 8
-  %2160 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2158, i32 0, i32 1
-  store i64 7, ptr %2160, align 4
-  %2161 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2158, align 8
-  %2162 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2163 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2164 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2163, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2161, ptr %2164, align 8
-  %2165 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2163, i32 0, i32 1
-  store ptr %2162, ptr %2165, align 8
-  %2166 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2163, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).HasName", ptr %2166, align 8
-  %2167 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2163, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).HasName", ptr %2167, align 8
-  %2168 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2163, align 8
-  %2169 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2170 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2169, i32 0, i32 0
-  store ptr @61, ptr %2170, align 8
-  %2171 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2169, i32 0, i32 1
-  store i64 14, ptr %2171, align 4
-  %2172 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2169, align 8
-  %2173 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2174 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2175 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2174, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2172, ptr %2175, align 8
-  %2176 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2174, i32 0, i32 1
-  store ptr %2173, ptr %2176, align 8
-  %2177 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2174, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).HashMightPanic", ptr %2177, align 8
-  %2178 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2174, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).HashMightPanic", ptr %2178, align 8
-  %2179 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2174, align 8
-  %2180 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2181 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2180, i32 0, i32 0
-  store ptr @36, ptr %2181, align 8
-  %2182 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2180, i32 0, i32 1
-  store i64 10, ptr %2182, align 4
-  %2183 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2180, align 8
-  %2184 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2185 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2186 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2185, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2183, ptr %2186, align 8
-  %2187 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2185, i32 0, i32 1
-  store ptr %2184, ptr %2187, align 8
-  %2188 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2185, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IfaceIndir", ptr %2188, align 8
-  %2189 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2185, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IfaceIndir", ptr %2189, align 8
-  %2190 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2185, align 8
-  %2191 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2192 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2191, i32 0, i32 0
-  store ptr @62, ptr %2192, align 8
-  %2193 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2191, i32 0, i32 1
-  store i64 12, ptr %2193, align 4
-  %2194 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2191, align 8
-  %2195 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2196 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2197 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2196, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2194, ptr %2197, align 8
-  %2198 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2196, i32 0, i32 1
-  store ptr %2195, ptr %2198, align 8
-  %2199 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2196, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IndirectElem", ptr %2199, align 8
-  %2200 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2196, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IndirectElem", ptr %2200, align 8
-  %2201 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2196, align 8
-  %2202 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2203 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2202, i32 0, i32 0
-  store ptr @63, ptr %2203, align 8
-  %2204 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2202, i32 0, i32 1
-  store i64 11, ptr %2204, align 4
-  %2205 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2202, align 8
-  %2206 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2207 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2208 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2207, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2205, ptr %2208, align 8
-  %2209 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2207, i32 0, i32 1
-  store ptr %2206, ptr %2209, align 8
-  %2210 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2207, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IndirectKey", ptr %2210, align 8
-  %2211 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2207, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IndirectKey", ptr %2211, align 8
-  %2212 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2207, align 8
-  %2213 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2214 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2213, i32 0, i32 0
-  store ptr @37, ptr %2214, align 8
-  %2215 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2213, i32 0, i32 1
-  store i64 13, ptr %2215, align 4
-  %2216 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2213, align 8
-  %2217 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
-  %2218 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
-  %2219 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2220 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2219, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2216, ptr %2220, align 8
-  %2221 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2219, i32 0, i32 1
-  store ptr %2218, ptr %2221, align 8
-  %2222 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2219, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).InterfaceType", ptr %2222, align 8
-  %2223 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2219, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).InterfaceType", ptr %2223, align 8
-  %2224 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2219, align 8
-  %2225 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2226 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2225, i32 0, i32 0
-  store ptr @48, ptr %2226, align 8
-  %2227 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2225, i32 0, i32 1
-  store i64 13, ptr %2227, align 4
-  %2228 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2225, align 8
-  %2229 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2230 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2231 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2230, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2228, ptr %2231, align 8
-  %2232 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2230, i32 0, i32 1
-  store ptr %2229, ptr %2232, align 8
-  %2233 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2230, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IsDirectIface", ptr %2233, align 8
-  %2234 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2230, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IsDirectIface", ptr %2234, align 8
-  %2235 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2230, align 8
-  %2236 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2237 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2236, i32 0, i32 0
-  store ptr @50, ptr %2237, align 8
-  %2238 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2236, i32 0, i32 1
-  store i64 4, ptr %2238, align 4
-  %2239 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2236, align 8
-  %2240 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
-  %2241 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2242 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2241, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2239, ptr %2242, align 8
-  %2243 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2241, i32 0, i32 1
-  store ptr %2240, ptr %2243, align 8
-  %2244 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2241, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Kind", ptr %2244, align 8
-  %2245 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2241, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Kind", ptr %2245, align 8
-  %2246 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2241, align 8
-  %2247 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2248 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2247, i32 0, i32 0
-  store ptr @24, ptr %2248, align 8
-  %2249 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2247, i32 0, i32 1
-  store i64 3, ptr %2249, align 4
-  %2250 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2247, align 8
-  %2251 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %2252 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2253 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2252, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2250, ptr %2253, align 8
-  %2254 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2252, i32 0, i32 1
-  store ptr %2251, ptr %2254, align 8
-  %2255 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2252, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Len", ptr %2255, align 8
-  %2256 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2252, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Len", ptr %2256, align 8
-  %2257 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2252, align 8
-  %2258 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2259 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2258, i32 0, i32 0
-  store ptr @53, ptr %2259, align 8
-  %2260 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2258, i32 0, i32 1
-  store i64 7, ptr %2260, align 4
-  %2261 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2258, align 8
-  %2262 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2263 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2262, i32 0, i32 0
-  store ptr @54, ptr %2263, align 8
-  %2264 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2262, i32 0, i32 1
-  store i64 43, ptr %2264, align 4
-  %2265 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2262, align 8
-  %2266 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2265, i64 25, i64 136, i64 0, i64 25)
-  %2267 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
-  %2268 = icmp eq ptr %2267, null
-  br i1 %2268, label %_llgo_111, label %_llgo_112
+  %2079 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2080 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2079, i32 0, i32 0
+  store ptr @18, ptr %2080, align 8
+  %2081 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2079, i32 0, i32 1
+  store i64 5, ptr %2081, align 4
+  %2082 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2079, align 8
+  %2083 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %2084 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2085 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2084, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2082, ptr %2085, align 8
+  %2086 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2084, i32 0, i32 1
+  store ptr %2083, ptr %2086, align 8
+  %2087 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2084, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Align", ptr %2087, align 8
+  %2088 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2084, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Align", ptr %2088, align 8
+  %2089 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2084, align 8
+  %2090 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2091 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2090, i32 0, i32 0
+  store ptr @19, ptr %2091, align 8
+  %2092 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2090, i32 0, i32 1
+  store i64 9, ptr %2092, align 4
+  %2093 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2090, align 8
+  %2094 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  %2095 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
+  %2096 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2097 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2096, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2093, ptr %2097, align 8
+  %2098 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2096, i32 0, i32 1
+  store ptr %2095, ptr %2098, align 8
+  %2099 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2096, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ArrayType", ptr %2099, align 8
+  %2100 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2096, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ArrayType", ptr %2100, align 8
+  %2101 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2096, align 8
+  %2102 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2103 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2102, i32 0, i32 0
+  store ptr @25, ptr %2103, align 8
+  %2104 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2102, i32 0, i32 1
+  store i64 7, ptr %2104, align 4
+  %2105 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2102, align 8
+  %2106 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
+  %2107 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2108 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2107, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2105, ptr %2108, align 8
+  %2109 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2107, i32 0, i32 1
+  store ptr %2106, ptr %2109, align 8
+  %2110 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2107, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ChanDir", ptr %2110, align 8
+  %2111 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2107, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ChanDir", ptr %2111, align 8
+  %2112 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2107, align 8
+  %2113 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2114 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2113, i32 0, i32 0
+  store ptr @27, ptr %2114, align 8
+  %2115 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2113, i32 0, i32 1
+  store i64 6, ptr %2115, align 4
+  %2116 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2113, align 8
+  %2117 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %2118 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %2119 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2120 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2119, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2116, ptr %2120, align 8
+  %2121 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2119, i32 0, i32 1
+  store ptr %2118, ptr %2121, align 8
+  %2122 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2119, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Common", ptr %2122, align 8
+  %2123 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2119, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Common", ptr %2123, align 8
+  %2124 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2119, align 8
+  %2125 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2126 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2125, i32 0, i32 0
+  store ptr @28, ptr %2126, align 8
+  %2127 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2125, i32 0, i32 1
+  store i64 15, ptr %2127, align 4
+  %2128 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2125, align 8
+  %2129 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %2130 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
+  %2131 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2132 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2131, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2128, ptr %2132, align 8
+  %2133 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2131, i32 0, i32 1
+  store ptr %2130, ptr %2133, align 8
+  %2134 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2131, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ExportedMethods", ptr %2134, align 8
+  %2135 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2131, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ExportedMethods", ptr %2135, align 8
+  %2136 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2131, align 8
+  %2137 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2138 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2137, i32 0, i32 0
+  store ptr @33, ptr %2138, align 8
+  %2139 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2137, i32 0, i32 1
+  store i64 10, ptr %2139, align 4
+  %2140 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2137, align 8
+  %2141 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %2142 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2143 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2142, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2140, ptr %2143, align 8
+  %2144 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2142, i32 0, i32 1
+  store ptr %2141, ptr %2144, align 8
+  %2145 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2142, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).FieldAlign", ptr %2145, align 8
+  %2146 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2142, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).FieldAlign", ptr %2146, align 8
+  %2147 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2142, align 8
+  %2148 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2149 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2148, i32 0, i32 0
+  store ptr @34, ptr %2149, align 8
+  %2150 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2148, i32 0, i32 1
+  store i64 8, ptr %2150, align 4
+  %2151 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2148, align 8
+  %2152 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %2153 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
+  %2154 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2155 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2154, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2151, ptr %2155, align 8
+  %2156 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2154, i32 0, i32 1
+  store ptr %2153, ptr %2156, align 8
+  %2157 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2154, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).FuncType", ptr %2157, align 8
+  %2158 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2154, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).FuncType", ptr %2158, align 8
+  %2159 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2154, align 8
+  %2160 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2161 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2160, i32 0, i32 0
+  store ptr @35, ptr %2161, align 8
+  %2162 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2160, i32 0, i32 1
+  store i64 7, ptr %2162, align 4
+  %2163 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2160, align 8
+  %2164 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %2165 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2166 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2165, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2163, ptr %2166, align 8
+  %2167 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2165, i32 0, i32 1
+  store ptr %2164, ptr %2167, align 8
+  %2168 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2165, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).HasName", ptr %2168, align 8
+  %2169 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2165, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).HasName", ptr %2169, align 8
+  %2170 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2165, align 8
+  %2171 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2172 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2171, i32 0, i32 0
+  store ptr @61, ptr %2172, align 8
+  %2173 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2171, i32 0, i32 1
+  store i64 14, ptr %2173, align 4
+  %2174 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2171, align 8
+  %2175 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %2176 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2177 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2176, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2174, ptr %2177, align 8
+  %2178 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2176, i32 0, i32 1
+  store ptr %2175, ptr %2178, align 8
+  %2179 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2176, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).HashMightPanic", ptr %2179, align 8
+  %2180 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2176, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).HashMightPanic", ptr %2180, align 8
+  %2181 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2176, align 8
+  %2182 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2183 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2182, i32 0, i32 0
+  store ptr @36, ptr %2183, align 8
+  %2184 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2182, i32 0, i32 1
+  store i64 10, ptr %2184, align 4
+  %2185 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2182, align 8
+  %2186 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %2187 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2188 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2187, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2185, ptr %2188, align 8
+  %2189 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2187, i32 0, i32 1
+  store ptr %2186, ptr %2189, align 8
+  %2190 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2187, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IfaceIndir", ptr %2190, align 8
+  %2191 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2187, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IfaceIndir", ptr %2191, align 8
+  %2192 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2187, align 8
+  %2193 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2194 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2193, i32 0, i32 0
+  store ptr @62, ptr %2194, align 8
+  %2195 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2193, i32 0, i32 1
+  store i64 12, ptr %2195, align 4
+  %2196 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2193, align 8
+  %2197 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %2198 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2199 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2198, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2196, ptr %2199, align 8
+  %2200 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2198, i32 0, i32 1
+  store ptr %2197, ptr %2200, align 8
+  %2201 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2198, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IndirectElem", ptr %2201, align 8
+  %2202 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2198, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IndirectElem", ptr %2202, align 8
+  %2203 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2198, align 8
+  %2204 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2205 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2204, i32 0, i32 0
+  store ptr @63, ptr %2205, align 8
+  %2206 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2204, i32 0, i32 1
+  store i64 11, ptr %2206, align 4
+  %2207 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2204, align 8
+  %2208 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %2209 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2210 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2209, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2207, ptr %2210, align 8
+  %2211 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2209, i32 0, i32 1
+  store ptr %2208, ptr %2211, align 8
+  %2212 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2209, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IndirectKey", ptr %2212, align 8
+  %2213 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2209, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IndirectKey", ptr %2213, align 8
+  %2214 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2209, align 8
+  %2215 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2216 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2215, i32 0, i32 0
+  store ptr @37, ptr %2216, align 8
+  %2217 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2215, i32 0, i32 1
+  store i64 13, ptr %2217, align 4
+  %2218 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2215, align 8
+  %2219 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  %2220 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
+  %2221 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2222 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2221, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2218, ptr %2222, align 8
+  %2223 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2221, i32 0, i32 1
+  store ptr %2220, ptr %2223, align 8
+  %2224 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2221, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).InterfaceType", ptr %2224, align 8
+  %2225 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2221, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).InterfaceType", ptr %2225, align 8
+  %2226 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2221, align 8
+  %2227 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2228 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2227, i32 0, i32 0
+  store ptr @48, ptr %2228, align 8
+  %2229 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2227, i32 0, i32 1
+  store i64 13, ptr %2229, align 4
+  %2230 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2227, align 8
+  %2231 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %2232 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2233 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2232, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2230, ptr %2233, align 8
+  %2234 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2232, i32 0, i32 1
+  store ptr %2231, ptr %2234, align 8
+  %2235 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2232, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IsDirectIface", ptr %2235, align 8
+  %2236 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2232, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IsDirectIface", ptr %2236, align 8
+  %2237 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2232, align 8
+  %2238 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2239 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2238, i32 0, i32 0
+  store ptr @50, ptr %2239, align 8
+  %2240 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2238, i32 0, i32 1
+  store i64 4, ptr %2240, align 4
+  %2241 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2238, align 8
+  %2242 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
+  %2243 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2244 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2243, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2241, ptr %2244, align 8
+  %2245 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2243, i32 0, i32 1
+  store ptr %2242, ptr %2245, align 8
+  %2246 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2243, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Kind", ptr %2246, align 8
+  %2247 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2243, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Kind", ptr %2247, align 8
+  %2248 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2243, align 8
+  %2249 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2250 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2249, i32 0, i32 0
+  store ptr @24, ptr %2250, align 8
+  %2251 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2249, i32 0, i32 1
+  store i64 3, ptr %2251, align 4
+  %2252 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2249, align 8
+  %2253 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %2254 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2255 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2254, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2252, ptr %2255, align 8
+  %2256 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2254, i32 0, i32 1
+  store ptr %2253, ptr %2256, align 8
+  %2257 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2254, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Len", ptr %2257, align 8
+  %2258 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2254, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Len", ptr %2258, align 8
+  %2259 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2254, align 8
+  %2260 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2261 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2260, i32 0, i32 0
+  store ptr @53, ptr %2261, align 8
+  %2262 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2260, i32 0, i32 1
+  store i64 7, ptr %2262, align 4
+  %2263 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2260, align 8
+  %2264 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2265 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2264, i32 0, i32 0
+  store ptr @54, ptr %2265, align 8
+  %2266 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2264, i32 0, i32 1
+  store i64 43, ptr %2266, align 4
+  %2267 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2264, align 8
+  %2268 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2267, i64 25, i64 136, i64 0, i64 25)
+  %2269 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  %2270 = icmp eq ptr %2269, null
+  br i1 %2270, label %_llgo_111, label %_llgo_112
 
 _llgo_110:                                        ; preds = %_llgo_130, %_llgo_108
-  %2269 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
-  %2270 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
-  %2271 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
-  %2272 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2273 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2272, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1802, ptr %2273, align 8
-  %2274 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2272, i32 0, i32 1
-  store ptr %2271, ptr %2274, align 8
-  %2275 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2272, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).MapType", ptr %2275, align 8
-  %2276 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2272, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).MapType", ptr %2276, align 8
-  %2277 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2272, align 8
-  %2278 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2279 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2278, i32 0, i32 0
-  store ptr @65, ptr %2279, align 8
-  %2280 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2278, i32 0, i32 1
-  store i64 9, ptr %2280, align 4
-  %2281 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2278, align 8
-  %2282 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %2283 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2284 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2283, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2281, ptr %2284, align 8
-  %2285 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2283, i32 0, i32 1
-  store ptr %2282, ptr %2285, align 8
-  %2286 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2283, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).NumMethod", ptr %2286, align 8
-  %2287 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2283, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).NumMethod", ptr %2287, align 8
-  %2288 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2283, align 8
-  %2289 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2290 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2289, i32 0, i32 0
-  store ptr @66, ptr %2290, align 8
-  %2291 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2289, i32 0, i32 1
-  store i64 8, ptr %2291, align 4
-  %2292 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2289, align 8
-  %2293 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2294 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2295 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2294, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2292, ptr %2295, align 8
-  %2296 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2294, i32 0, i32 1
-  store ptr %2293, ptr %2296, align 8
-  %2297 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2294, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Pointers", ptr %2297, align 8
-  %2298 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2294, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Pointers", ptr %2298, align 8
-  %2299 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2294, align 8
-  %2300 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2301 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2300, i32 0, i32 0
-  store ptr @68, ptr %2301, align 8
-  %2302 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2300, i32 0, i32 1
-  store i64 4, ptr %2302, align 4
-  %2303 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2300, align 8
-  %2304 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
-  %2305 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2306 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2305, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2303, ptr %2306, align 8
-  %2307 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2305, i32 0, i32 1
-  store ptr %2304, ptr %2307, align 8
-  %2308 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2305, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Size", ptr %2308, align 8
-  %2309 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2305, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Size", ptr %2309, align 8
-  %2310 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2305, align 8
-  %2311 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2312 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2311, i32 0, i32 0
-  store ptr @52, ptr %2312, align 8
-  %2313 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2311, i32 0, i32 1
-  store i64 6, ptr %2313, align 4
-  %2314 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2311, align 8
-  %2315 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %2316 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2317 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2316, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2314, ptr %2317, align 8
-  %2318 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2316, i32 0, i32 1
-  store ptr %2315, ptr %2318, align 8
-  %2319 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2316, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).String", ptr %2319, align 8
-  %2320 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2316, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).String", ptr %2320, align 8
-  %2321 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2316, align 8
-  %2322 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2323 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2322, i32 0, i32 0
-  store ptr @69, ptr %2323, align 8
-  %2324 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2322, i32 0, i32 1
-  store i64 10, ptr %2324, align 4
-  %2325 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2322, align 8
-  %2326 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
-  %2327 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
-  %2328 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2329 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2328, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2325, ptr %2329, align 8
-  %2330 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2328, i32 0, i32 1
-  store ptr %2327, ptr %2330, align 8
-  %2331 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2328, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).StructType", ptr %2331, align 8
-  %2332 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2328, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).StructType", ptr %2332, align 8
-  %2333 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2328, align 8
-  %2334 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2335 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2334, i32 0, i32 0
-  store ptr @79, ptr %2335, align 8
-  %2336 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2334, i32 0, i32 1
-  store i64 8, ptr %2336, align 4
-  %2337 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2334, align 8
-  %2338 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
-  %2339 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2340 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2339, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2337, ptr %2340, align 8
-  %2341 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2339, i32 0, i32 1
-  store ptr %2338, ptr %2341, align 8
-  %2342 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2339, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Uncommon", ptr %2342, align 8
-  %2343 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2339, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Uncommon", ptr %2343, align 8
-  %2344 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2339, align 8
-  %2345 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 880)
-  %2346 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2345, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %1363, ptr %2346, align 8
-  %2347 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2345, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %1375, ptr %2347, align 8
-  %2348 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2345, i64 2
-  store %"github.com/goplus/llgo/internal/abi.Method" %1386, ptr %2348, align 8
-  %2349 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2345, i64 3
-  store %"github.com/goplus/llgo/internal/abi.Method" %1398, ptr %2349, align 8
-  %2350 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2345, i64 4
-  store %"github.com/goplus/llgo/internal/abi.Method" %1410, ptr %2350, align 8
-  %2351 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2345, i64 5
-  store %"github.com/goplus/llgo/internal/abi.Method" %1422, ptr %2351, align 8
-  %2352 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2345, i64 6
-  store %"github.com/goplus/llgo/internal/abi.Method" %1433, ptr %2352, align 8
-  %2353 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2345, i64 7
-  store %"github.com/goplus/llgo/internal/abi.Method" %1445, ptr %2353, align 8
-  %2354 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2345, i64 8
-  store %"github.com/goplus/llgo/internal/abi.Method" %1456, ptr %2354, align 8
-  %2355 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2345, i64 9
-  store %"github.com/goplus/llgo/internal/abi.Method" %1467, ptr %2355, align 8
-  %2356 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2345, i64 10
-  store %"github.com/goplus/llgo/internal/abi.Method" %1685, ptr %2356, align 8
-  %2357 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2345, i64 11
-  store %"github.com/goplus/llgo/internal/abi.Method" %1696, ptr %2357, align 8
-  %2358 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2345, i64 12
-  store %"github.com/goplus/llgo/internal/abi.Method" %1708, ptr %2358, align 8
-  %2359 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2345, i64 13
-  store %"github.com/goplus/llgo/internal/abi.Method" %1787, ptr %2359, align 8
-  %2360 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2345, i64 14
-  store %"github.com/goplus/llgo/internal/abi.Method" %1798, ptr %2360, align 8
-  %2361 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2345, i64 15
-  store %"github.com/goplus/llgo/internal/abi.Method" %2277, ptr %2361, align 8
-  %2362 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2345, i64 16
-  store %"github.com/goplus/llgo/internal/abi.Method" %2288, ptr %2362, align 8
-  %2363 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2345, i64 17
-  store %"github.com/goplus/llgo/internal/abi.Method" %2299, ptr %2363, align 8
-  %2364 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2345, i64 18
-  store %"github.com/goplus/llgo/internal/abi.Method" %2310, ptr %2364, align 8
-  %2365 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2345, i64 19
-  store %"github.com/goplus/llgo/internal/abi.Method" %2321, ptr %2365, align 8
-  %2366 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2345, i64 20
-  store %"github.com/goplus/llgo/internal/abi.Method" %2333, ptr %2366, align 8
-  %2367 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2345, i64 21
-  store %"github.com/goplus/llgo/internal/abi.Method" %2344, ptr %2367, align 8
-  %2368 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2369 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2368, i32 0, i32 0
-  store ptr %2345, ptr %2369, align 8
-  %2370 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2368, i32 0, i32 1
-  store i64 22, ptr %2370, align 4
-  %2371 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2368, i32 0, i32 2
-  store i64 22, ptr %2371, align 4
-  %2372 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2368, align 8
-  %2373 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2374 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2373, i32 0, i32 0
-  store ptr @3, ptr %2374, align 8
-  %2375 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2373, i32 0, i32 1
-  store i64 35, ptr %2375, align 4
-  %2376 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2373, align 8
-  %2377 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2378 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2377, i32 0, i32 0
-  store ptr @37, ptr %2378, align 8
-  %2379 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2377, i32 0, i32 1
-  store i64 13, ptr %2379, align 4
-  %2380 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2377, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %1168, %"github.com/goplus/llgo/internal/runtime.String" %2376, %"github.com/goplus/llgo/internal/runtime.String" %2380, ptr %1352, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %2372)
+  %2271 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  %2272 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  %2273 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
+  %2274 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2275 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2274, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %1804, ptr %2275, align 8
+  %2276 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2274, i32 0, i32 1
+  store ptr %2273, ptr %2276, align 8
+  %2277 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2274, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).MapType", ptr %2277, align 8
+  %2278 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2274, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).MapType", ptr %2278, align 8
+  %2279 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2274, align 8
+  %2280 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2281 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2280, i32 0, i32 0
+  store ptr @65, ptr %2281, align 8
+  %2282 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2280, i32 0, i32 1
+  store i64 9, ptr %2282, align 4
+  %2283 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2280, align 8
+  %2284 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %2285 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2286 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2285, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2283, ptr %2286, align 8
+  %2287 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2285, i32 0, i32 1
+  store ptr %2284, ptr %2287, align 8
+  %2288 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2285, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).NumMethod", ptr %2288, align 8
+  %2289 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2285, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).NumMethod", ptr %2289, align 8
+  %2290 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2285, align 8
+  %2291 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2292 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2291, i32 0, i32 0
+  store ptr @66, ptr %2292, align 8
+  %2293 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2291, i32 0, i32 1
+  store i64 8, ptr %2293, align 4
+  %2294 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2291, align 8
+  %2295 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %2296 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2297 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2296, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2294, ptr %2297, align 8
+  %2298 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2296, i32 0, i32 1
+  store ptr %2295, ptr %2298, align 8
+  %2299 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2296, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Pointers", ptr %2299, align 8
+  %2300 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2296, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Pointers", ptr %2300, align 8
+  %2301 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2296, align 8
+  %2302 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2303 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2302, i32 0, i32 0
+  store ptr @68, ptr %2303, align 8
+  %2304 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2302, i32 0, i32 1
+  store i64 4, ptr %2304, align 4
+  %2305 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2302, align 8
+  %2306 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
+  %2307 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2308 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2307, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2305, ptr %2308, align 8
+  %2309 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2307, i32 0, i32 1
+  store ptr %2306, ptr %2309, align 8
+  %2310 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2307, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Size", ptr %2310, align 8
+  %2311 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2307, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Size", ptr %2311, align 8
+  %2312 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2307, align 8
+  %2313 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2314 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2313, i32 0, i32 0
+  store ptr @52, ptr %2314, align 8
+  %2315 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2313, i32 0, i32 1
+  store i64 6, ptr %2315, align 4
+  %2316 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2313, align 8
+  %2317 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %2318 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2319 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2318, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2316, ptr %2319, align 8
+  %2320 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2318, i32 0, i32 1
+  store ptr %2317, ptr %2320, align 8
+  %2321 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2318, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).String", ptr %2321, align 8
+  %2322 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2318, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).String", ptr %2322, align 8
+  %2323 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2318, align 8
+  %2324 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2325 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2324, i32 0, i32 0
+  store ptr @69, ptr %2325, align 8
+  %2326 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2324, i32 0, i32 1
+  store i64 10, ptr %2326, align 4
+  %2327 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2324, align 8
+  %2328 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  %2329 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
+  %2330 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2331 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2330, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2327, ptr %2331, align 8
+  %2332 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2330, i32 0, i32 1
+  store ptr %2329, ptr %2332, align 8
+  %2333 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2330, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).StructType", ptr %2333, align 8
+  %2334 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2330, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).StructType", ptr %2334, align 8
+  %2335 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2330, align 8
+  %2336 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2337 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2336, i32 0, i32 0
+  store ptr @79, ptr %2337, align 8
+  %2338 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2336, i32 0, i32 1
+  store i64 8, ptr %2338, align 4
+  %2339 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2336, align 8
+  %2340 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
+  %2341 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2342 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2341, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2339, ptr %2342, align 8
+  %2343 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2341, i32 0, i32 1
+  store ptr %2340, ptr %2343, align 8
+  %2344 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2341, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Uncommon", ptr %2344, align 8
+  %2345 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2341, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Uncommon", ptr %2345, align 8
+  %2346 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2341, align 8
+  %2347 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 880)
+  %2348 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2347, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %1365, ptr %2348, align 8
+  %2349 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2347, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %1377, ptr %2349, align 8
+  %2350 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2347, i64 2
+  store %"github.com/goplus/llgo/internal/abi.Method" %1388, ptr %2350, align 8
+  %2351 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2347, i64 3
+  store %"github.com/goplus/llgo/internal/abi.Method" %1400, ptr %2351, align 8
+  %2352 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2347, i64 4
+  store %"github.com/goplus/llgo/internal/abi.Method" %1412, ptr %2352, align 8
+  %2353 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2347, i64 5
+  store %"github.com/goplus/llgo/internal/abi.Method" %1424, ptr %2353, align 8
+  %2354 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2347, i64 6
+  store %"github.com/goplus/llgo/internal/abi.Method" %1435, ptr %2354, align 8
+  %2355 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2347, i64 7
+  store %"github.com/goplus/llgo/internal/abi.Method" %1447, ptr %2355, align 8
+  %2356 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2347, i64 8
+  store %"github.com/goplus/llgo/internal/abi.Method" %1458, ptr %2356, align 8
+  %2357 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2347, i64 9
+  store %"github.com/goplus/llgo/internal/abi.Method" %1469, ptr %2357, align 8
+  %2358 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2347, i64 10
+  store %"github.com/goplus/llgo/internal/abi.Method" %1687, ptr %2358, align 8
+  %2359 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2347, i64 11
+  store %"github.com/goplus/llgo/internal/abi.Method" %1698, ptr %2359, align 8
+  %2360 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2347, i64 12
+  store %"github.com/goplus/llgo/internal/abi.Method" %1710, ptr %2360, align 8
+  %2361 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2347, i64 13
+  store %"github.com/goplus/llgo/internal/abi.Method" %1789, ptr %2361, align 8
+  %2362 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2347, i64 14
+  store %"github.com/goplus/llgo/internal/abi.Method" %1800, ptr %2362, align 8
+  %2363 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2347, i64 15
+  store %"github.com/goplus/llgo/internal/abi.Method" %2279, ptr %2363, align 8
+  %2364 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2347, i64 16
+  store %"github.com/goplus/llgo/internal/abi.Method" %2290, ptr %2364, align 8
+  %2365 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2347, i64 17
+  store %"github.com/goplus/llgo/internal/abi.Method" %2301, ptr %2365, align 8
+  %2366 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2347, i64 18
+  store %"github.com/goplus/llgo/internal/abi.Method" %2312, ptr %2366, align 8
+  %2367 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2347, i64 19
+  store %"github.com/goplus/llgo/internal/abi.Method" %2323, ptr %2367, align 8
+  %2368 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2347, i64 20
+  store %"github.com/goplus/llgo/internal/abi.Method" %2335, ptr %2368, align 8
+  %2369 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2347, i64 21
+  store %"github.com/goplus/llgo/internal/abi.Method" %2346, ptr %2369, align 8
+  %2370 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %2371 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2370, i32 0, i32 0
+  store ptr %2347, ptr %2371, align 8
+  %2372 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2370, i32 0, i32 1
+  store i64 22, ptr %2372, align 4
+  %2373 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2370, i32 0, i32 2
+  store i64 22, ptr %2373, align 4
+  %2374 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2370, align 8
+  %2375 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2376 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2375, i32 0, i32 0
+  store ptr @3, ptr %2376, align 8
+  %2377 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2375, i32 0, i32 1
+  store i64 35, ptr %2377, align 4
+  %2378 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2375, align 8
+  %2379 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2380 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2379, i32 0, i32 0
+  store ptr @37, ptr %2380, align 8
+  %2381 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2379, i32 0, i32 1
+  store i64 13, ptr %2381, align 4
+  %2382 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2379, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %1170, %"github.com/goplus/llgo/internal/runtime.String" %2378, %"github.com/goplus/llgo/internal/runtime.String" %2382, ptr %1354, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %2374)
   br label %_llgo_90
 
 _llgo_111:                                        ; preds = %_llgo_109
-  %2381 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %2266)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %2381)
-  store ptr %2381, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  %2383 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %2268)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %2383)
+  store ptr %2383, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
   br label %_llgo_112
 
 _llgo_112:                                        ; preds = %_llgo_111, %_llgo_109
-  %2382 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
-  %2383 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
-  %2384 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
-  %2385 = icmp eq ptr %2384, null
-  br i1 %2385, label %_llgo_113, label %_llgo_114
+  %2384 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  %2385 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  %2386 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
+  %2387 = icmp eq ptr %2386, null
+  br i1 %2387, label %_llgo_113, label %_llgo_114
 
 _llgo_113:                                        ; preds = %_llgo_112
-  %2386 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %2387 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2388 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2387, i32 0, i32 0
-  store ptr %2386, ptr %2388, align 8
-  %2389 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2387, i32 0, i32 1
-  store i64 0, ptr %2389, align 4
-  %2390 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2387, i32 0, i32 2
-  store i64 0, ptr %2390, align 4
-  %2391 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2387, align 8
-  %2392 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %2393 = getelementptr ptr, ptr %2392, i64 0
-  store ptr %2383, ptr %2393, align 8
-  %2394 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2395 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2394, i32 0, i32 0
-  store ptr %2392, ptr %2395, align 8
-  %2396 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2394, i32 0, i32 1
-  store i64 1, ptr %2396, align 4
-  %2397 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2394, i32 0, i32 2
-  store i64 1, ptr %2397, align 4
-  %2398 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2394, align 8
-  %2399 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %2391, %"github.com/goplus/llgo/internal/runtime.Slice" %2398, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %2399)
-  store ptr %2399, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
+  %2388 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %2389 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %2390 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2389, i32 0, i32 0
+  store ptr %2388, ptr %2390, align 8
+  %2391 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2389, i32 0, i32 1
+  store i64 0, ptr %2391, align 4
+  %2392 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2389, i32 0, i32 2
+  store i64 0, ptr %2392, align 4
+  %2393 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2389, align 8
+  %2394 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %2395 = getelementptr ptr, ptr %2394, i64 0
+  store ptr %2385, ptr %2395, align 8
+  %2396 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %2397 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2396, i32 0, i32 0
+  store ptr %2394, ptr %2397, align 8
+  %2398 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2396, i32 0, i32 1
+  store i64 1, ptr %2398, align 4
+  %2399 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2396, i32 0, i32 2
+  store i64 1, ptr %2399, align 4
+  %2400 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2396, align 8
+  %2401 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %2393, %"github.com/goplus/llgo/internal/runtime.Slice" %2400, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %2401)
+  store ptr %2401, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
   br label %_llgo_114
 
 _llgo_114:                                        ; preds = %_llgo_113, %_llgo_112
-  %2400 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
-  %2401 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2402 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2401, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2261, ptr %2402, align 8
-  %2403 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2401, i32 0, i32 1
-  store ptr %2400, ptr %2403, align 8
-  %2404 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2401, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).MapType", ptr %2404, align 8
-  %2405 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2401, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).MapType", ptr %2405, align 8
-  %2406 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2401, align 8
-  %2407 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2408 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2407, i32 0, i32 0
-  store ptr @64, ptr %2408, align 8
-  %2409 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2407, i32 0, i32 1
-  store i64 13, ptr %2409, align 4
-  %2410 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2407, align 8
-  %2411 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2412 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2413 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2412, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2410, ptr %2413, align 8
-  %2414 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2412, i32 0, i32 1
-  store ptr %2411, ptr %2414, align 8
-  %2415 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2412, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).NeedKeyUpdate", ptr %2415, align 8
-  %2416 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2412, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).NeedKeyUpdate", ptr %2416, align 8
-  %2417 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2412, align 8
-  %2418 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2419 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2418, i32 0, i32 0
-  store ptr @65, ptr %2419, align 8
-  %2420 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2418, i32 0, i32 1
-  store i64 9, ptr %2420, align 4
-  %2421 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2418, align 8
-  %2422 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %2423 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2424 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2423, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2421, ptr %2424, align 8
-  %2425 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2423, i32 0, i32 1
-  store ptr %2422, ptr %2425, align 8
-  %2426 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2423, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).NumMethod", ptr %2426, align 8
-  %2427 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2423, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).NumMethod", ptr %2427, align 8
-  %2428 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2423, align 8
-  %2429 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2430 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2429, i32 0, i32 0
-  store ptr @66, ptr %2430, align 8
-  %2431 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2429, i32 0, i32 1
-  store i64 8, ptr %2431, align 4
-  %2432 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2429, align 8
-  %2433 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2434 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2435 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2434, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2432, ptr %2435, align 8
-  %2436 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2434, i32 0, i32 1
-  store ptr %2433, ptr %2436, align 8
-  %2437 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2434, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Pointers", ptr %2437, align 8
-  %2438 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2434, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Pointers", ptr %2438, align 8
-  %2439 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2434, align 8
-  %2440 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2441 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2440, i32 0, i32 0
-  store ptr @67, ptr %2441, align 8
-  %2442 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2440, i32 0, i32 1
-  store i64 12, ptr %2442, align 4
-  %2443 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2440, align 8
-  %2444 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2445 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2446 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2445, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2443, ptr %2446, align 8
-  %2447 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2445, i32 0, i32 1
-  store ptr %2444, ptr %2447, align 8
-  %2448 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2445, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ReflexiveKey", ptr %2448, align 8
-  %2449 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2445, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ReflexiveKey", ptr %2449, align 8
-  %2450 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2445, align 8
-  %2451 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2452 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2451, i32 0, i32 0
-  store ptr @68, ptr %2452, align 8
-  %2453 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2451, i32 0, i32 1
-  store i64 4, ptr %2453, align 4
-  %2454 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2451, align 8
-  %2455 = load ptr, ptr @_llgo_uintptr, align 8
-  %2456 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
-  %2457 = icmp eq ptr %2456, null
-  br i1 %2457, label %_llgo_115, label %_llgo_116
+  %2402 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
+  %2403 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2404 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2403, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2263, ptr %2404, align 8
+  %2405 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2403, i32 0, i32 1
+  store ptr %2402, ptr %2405, align 8
+  %2406 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2403, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).MapType", ptr %2406, align 8
+  %2407 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2403, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).MapType", ptr %2407, align 8
+  %2408 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2403, align 8
+  %2409 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2410 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2409, i32 0, i32 0
+  store ptr @64, ptr %2410, align 8
+  %2411 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2409, i32 0, i32 1
+  store i64 13, ptr %2411, align 4
+  %2412 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2409, align 8
+  %2413 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %2414 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2415 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2414, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2412, ptr %2415, align 8
+  %2416 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2414, i32 0, i32 1
+  store ptr %2413, ptr %2416, align 8
+  %2417 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2414, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).NeedKeyUpdate", ptr %2417, align 8
+  %2418 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2414, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).NeedKeyUpdate", ptr %2418, align 8
+  %2419 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2414, align 8
+  %2420 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2421 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2420, i32 0, i32 0
+  store ptr @65, ptr %2421, align 8
+  %2422 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2420, i32 0, i32 1
+  store i64 9, ptr %2422, align 4
+  %2423 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2420, align 8
+  %2424 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %2425 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2426 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2425, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2423, ptr %2426, align 8
+  %2427 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2425, i32 0, i32 1
+  store ptr %2424, ptr %2427, align 8
+  %2428 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2425, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).NumMethod", ptr %2428, align 8
+  %2429 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2425, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).NumMethod", ptr %2429, align 8
+  %2430 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2425, align 8
+  %2431 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2432 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2431, i32 0, i32 0
+  store ptr @66, ptr %2432, align 8
+  %2433 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2431, i32 0, i32 1
+  store i64 8, ptr %2433, align 4
+  %2434 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2431, align 8
+  %2435 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %2436 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2437 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2436, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2434, ptr %2437, align 8
+  %2438 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2436, i32 0, i32 1
+  store ptr %2435, ptr %2438, align 8
+  %2439 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2436, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Pointers", ptr %2439, align 8
+  %2440 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2436, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Pointers", ptr %2440, align 8
+  %2441 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2436, align 8
+  %2442 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2443 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2442, i32 0, i32 0
+  store ptr @67, ptr %2443, align 8
+  %2444 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2442, i32 0, i32 1
+  store i64 12, ptr %2444, align 4
+  %2445 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2442, align 8
+  %2446 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %2447 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2448 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2447, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2445, ptr %2448, align 8
+  %2449 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2447, i32 0, i32 1
+  store ptr %2446, ptr %2449, align 8
+  %2450 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2447, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ReflexiveKey", ptr %2450, align 8
+  %2451 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2447, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ReflexiveKey", ptr %2451, align 8
+  %2452 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2447, align 8
+  %2453 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2454 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2453, i32 0, i32 0
+  store ptr @68, ptr %2454, align 8
+  %2455 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2453, i32 0, i32 1
+  store i64 4, ptr %2455, align 4
+  %2456 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2453, align 8
+  %2457 = load ptr, ptr @_llgo_uintptr, align 8
+  %2458 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
+  %2459 = icmp eq ptr %2458, null
+  br i1 %2459, label %_llgo_115, label %_llgo_116
 
 _llgo_115:                                        ; preds = %_llgo_114
-  %2458 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %2459 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2460 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2459, i32 0, i32 0
-  store ptr %2458, ptr %2460, align 8
-  %2461 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2459, i32 0, i32 1
-  store i64 0, ptr %2461, align 4
-  %2462 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2459, i32 0, i32 2
-  store i64 0, ptr %2462, align 4
-  %2463 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2459, align 8
-  %2464 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %2465 = getelementptr ptr, ptr %2464, i64 0
-  store ptr %2455, ptr %2465, align 8
-  %2466 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2467 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2466, i32 0, i32 0
-  store ptr %2464, ptr %2467, align 8
-  %2468 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2466, i32 0, i32 1
-  store i64 1, ptr %2468, align 4
-  %2469 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2466, i32 0, i32 2
-  store i64 1, ptr %2469, align 4
-  %2470 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2466, align 8
-  %2471 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %2463, %"github.com/goplus/llgo/internal/runtime.Slice" %2470, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %2471)
-  store ptr %2471, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
+  %2460 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %2461 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %2462 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2461, i32 0, i32 0
+  store ptr %2460, ptr %2462, align 8
+  %2463 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2461, i32 0, i32 1
+  store i64 0, ptr %2463, align 4
+  %2464 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2461, i32 0, i32 2
+  store i64 0, ptr %2464, align 4
+  %2465 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2461, align 8
+  %2466 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %2467 = getelementptr ptr, ptr %2466, i64 0
+  store ptr %2457, ptr %2467, align 8
+  %2468 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %2469 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2468, i32 0, i32 0
+  store ptr %2466, ptr %2469, align 8
+  %2470 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2468, i32 0, i32 1
+  store i64 1, ptr %2470, align 4
+  %2471 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2468, i32 0, i32 2
+  store i64 1, ptr %2471, align 4
+  %2472 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2468, align 8
+  %2473 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %2465, %"github.com/goplus/llgo/internal/runtime.Slice" %2472, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %2473)
+  store ptr %2473, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
   br label %_llgo_116
 
 _llgo_116:                                        ; preds = %_llgo_115, %_llgo_114
-  %2472 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
-  %2473 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2474 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2473, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2454, ptr %2474, align 8
-  %2475 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2473, i32 0, i32 1
-  store ptr %2472, ptr %2475, align 8
-  %2476 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2473, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Size", ptr %2476, align 8
-  %2477 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2473, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Size", ptr %2477, align 8
-  %2478 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2473, align 8
-  %2479 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2480 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2479, i32 0, i32 0
-  store ptr @52, ptr %2480, align 8
-  %2481 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2479, i32 0, i32 1
-  store i64 6, ptr %2481, align 4
-  %2482 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2479, align 8
-  %2483 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %2484 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2485 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2484, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2482, ptr %2485, align 8
-  %2486 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2484, i32 0, i32 1
-  store ptr %2483, ptr %2486, align 8
-  %2487 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2484, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).String", ptr %2487, align 8
-  %2488 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2484, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).String", ptr %2488, align 8
-  %2489 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2484, align 8
-  %2490 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2491 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2490, i32 0, i32 0
-  store ptr @69, ptr %2491, align 8
-  %2492 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2490, i32 0, i32 1
-  store i64 10, ptr %2492, align 4
-  %2493 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2490, align 8
-  %2494 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2495 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2494, i32 0, i32 0
-  store ptr @70, ptr %2495, align 8
-  %2496 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2494, i32 0, i32 1
-  store i64 46, ptr %2496, align 4
-  %2497 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2494, align 8
-  %2498 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2497, i64 25, i64 120, i64 0, i64 22)
-  %2499 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
-  %2500 = icmp eq ptr %2499, null
-  br i1 %2500, label %_llgo_117, label %_llgo_118
+  %2474 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
+  %2475 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2476 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2475, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2456, ptr %2476, align 8
+  %2477 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2475, i32 0, i32 1
+  store ptr %2474, ptr %2477, align 8
+  %2478 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2475, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Size", ptr %2478, align 8
+  %2479 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2475, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Size", ptr %2479, align 8
+  %2480 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2475, align 8
+  %2481 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2482 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2481, i32 0, i32 0
+  store ptr @52, ptr %2482, align 8
+  %2483 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2481, i32 0, i32 1
+  store i64 6, ptr %2483, align 4
+  %2484 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2481, align 8
+  %2485 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %2486 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2487 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2486, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2484, ptr %2487, align 8
+  %2488 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2486, i32 0, i32 1
+  store ptr %2485, ptr %2488, align 8
+  %2489 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2486, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).String", ptr %2489, align 8
+  %2490 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2486, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).String", ptr %2490, align 8
+  %2491 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2486, align 8
+  %2492 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2493 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2492, i32 0, i32 0
+  store ptr @69, ptr %2493, align 8
+  %2494 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2492, i32 0, i32 1
+  store i64 10, ptr %2494, align 4
+  %2495 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2492, align 8
+  %2496 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2497 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2496, i32 0, i32 0
+  store ptr @70, ptr %2497, align 8
+  %2498 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2496, i32 0, i32 1
+  store i64 46, ptr %2498, align 4
+  %2499 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2496, align 8
+  %2500 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2499, i64 25, i64 120, i64 0, i64 22)
+  %2501 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  %2502 = icmp eq ptr %2501, null
+  br i1 %2502, label %_llgo_117, label %_llgo_118
 
 _llgo_117:                                        ; preds = %_llgo_116
-  store ptr %2498, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  store ptr %2500, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
   br label %_llgo_118
 
 _llgo_118:                                        ; preds = %_llgo_117, %_llgo_116
-  %2501 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2502 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2501, i32 0, i32 0
-  store ptr @71, ptr %2502, align 8
-  %2503 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2501, i32 0, i32 1
-  store i64 47, ptr %2503, align 4
-  %2504 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2501, align 8
-  %2505 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2504, i64 25, i64 56, i64 0, i64 2)
-  %2506 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
-  %2507 = icmp eq ptr %2506, null
-  br i1 %2507, label %_llgo_119, label %_llgo_120
+  %2503 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2504 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2503, i32 0, i32 0
+  store ptr @71, ptr %2504, align 8
+  %2505 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2503, i32 0, i32 1
+  store i64 47, ptr %2505, align 4
+  %2506 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2503, align 8
+  %2507 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2506, i64 25, i64 56, i64 0, i64 2)
+  %2508 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
+  %2509 = icmp eq ptr %2508, null
+  br i1 %2509, label %_llgo_119, label %_llgo_120
 
 _llgo_119:                                        ; preds = %_llgo_118
-  store ptr %2505, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
+  store ptr %2507, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
   br label %_llgo_120
 
 _llgo_120:                                        ; preds = %_llgo_119, %_llgo_118
-  %2508 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %2509 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2510 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2509, i32 0, i32 0
-  store ptr @1, ptr %2510, align 8
-  %2511 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2509, i32 0, i32 1
-  store i64 40, ptr %2511, align 4
-  %2512 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2509, align 8
-  %2513 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2512, i64 25, i64 80, i64 0, i64 22)
-  %2514 = load ptr, ptr @"_llgo_struct$GYlWrg0B_axMyyq9xClGPKuTjurG0iQMRoz8Me1fQig", align 8
-  %2515 = icmp eq ptr %2514, null
-  br i1 %2515, label %_llgo_121, label %_llgo_122
+  %2510 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %2511 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2512 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2511, i32 0, i32 0
+  store ptr @1, ptr %2512, align 8
+  %2513 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2511, i32 0, i32 1
+  store i64 40, ptr %2513, align 4
+  %2514 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2511, align 8
+  %2515 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2514, i64 25, i64 80, i64 0, i64 22)
+  %2516 = load ptr, ptr @"_llgo_struct$GYlWrg0B_axMyyq9xClGPKuTjurG0iQMRoz8Me1fQig", align 8
+  %2517 = icmp eq ptr %2516, null
+  br i1 %2517, label %_llgo_121, label %_llgo_122
 
 _llgo_121:                                        ; preds = %_llgo_120
-  %2516 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2517 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2516, i32 0, i32 0
-  store ptr @40, ptr %2517, align 8
-  %2518 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2516, i32 0, i32 1
-  store i64 5, ptr %2518, align 4
-  %2519 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2516, align 8
-  %2520 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2521 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2520, i32 0, i32 0
-  store ptr null, ptr %2521, align 8
-  %2522 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2520, i32 0, i32 1
-  store i64 0, ptr %2522, align 4
-  %2523 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2520, align 8
-  %2524 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %2525 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2519, ptr %2524, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %2523, i1 false)
-  %2526 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2527 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2526, i32 0, i32 0
-  store ptr @72, ptr %2527, align 8
-  %2528 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2526, i32 0, i32 1
-  store i64 3, ptr %2528, align 4
-  %2529 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2526, align 8
-  %2530 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2531 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2530, i32 0, i32 0
-  store ptr null, ptr %2531, align 8
-  %2532 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2530, i32 0, i32 1
-  store i64 0, ptr %2532, align 4
-  %2533 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2530, align 8
-  %2534 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %2513)
-  %2535 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2529, ptr %2534, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %2533, i1 false)
-  %2536 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2537 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2536, i32 0, i32 0
-  store ptr @73, ptr %2537, align 8
-  %2538 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2536, i32 0, i32 1
-  store i64 6, ptr %2538, align 4
-  %2539 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2536, align 8
-  %2540 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2541 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2540, i32 0, i32 0
-  store ptr null, ptr %2541, align 8
-  %2542 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2540, i32 0, i32 1
-  store i64 0, ptr %2542, align 4
-  %2543 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2540, align 8
-  %2544 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
-  %2545 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2539, ptr %2544, i64 24, %"github.com/goplus/llgo/internal/runtime.String" %2543, i1 false)
-  %2546 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2547 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2546, i32 0, i32 0
-  store ptr @74, ptr %2547, align 8
-  %2548 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2546, i32 0, i32 1
-  store i64 4, ptr %2548, align 4
-  %2549 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2546, align 8
-  %2550 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2551 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2550, i32 0, i32 0
-  store ptr null, ptr %2551, align 8
-  %2552 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2550, i32 0, i32 1
-  store i64 0, ptr %2552, align 4
-  %2553 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2550, align 8
-  %2554 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %2555 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2549, ptr %2554, i64 32, %"github.com/goplus/llgo/internal/runtime.String" %2553, i1 false)
-  %2556 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2557 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2556, i32 0, i32 0
-  store ptr @75, ptr %2557, align 8
-  %2558 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2556, i32 0, i32 1
-  store i64 9, ptr %2558, align 4
-  %2559 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2556, align 8
-  %2560 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2561 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2560, i32 0, i32 0
-  store ptr null, ptr %2561, align 8
-  %2562 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2560, i32 0, i32 1
-  store i64 0, ptr %2562, align 4
-  %2563 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2560, align 8
-  %2564 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 33)
-  %2565 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2559, ptr %2564, i64 48, %"github.com/goplus/llgo/internal/runtime.String" %2563, i1 false)
-  %2566 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2567 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2566, i32 0, i32 0
-  store ptr @7, ptr %2567, align 8
-  %2568 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2566, i32 0, i32 1
-  store i64 4, ptr %2568, align 4
-  %2569 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2566, align 8
-  %2570 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 280)
-  %2571 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2570, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2525, ptr %2571, align 8
-  %2572 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2570, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2535, ptr %2572, align 8
-  %2573 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2570, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2545, ptr %2573, align 8
-  %2574 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2570, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2555, ptr %2574, align 8
-  %2575 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2570, i64 4
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2565, ptr %2575, align 8
-  %2576 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2577 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2576, i32 0, i32 0
-  store ptr %2570, ptr %2577, align 8
-  %2578 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2576, i32 0, i32 1
-  store i64 5, ptr %2578, align 4
-  %2579 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2576, i32 0, i32 2
-  store i64 5, ptr %2579, align 4
-  %2580 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2576, align 8
-  %2581 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %2569, i64 56, %"github.com/goplus/llgo/internal/runtime.Slice" %2580)
-  store ptr %2581, ptr @"_llgo_struct$GYlWrg0B_axMyyq9xClGPKuTjurG0iQMRoz8Me1fQig", align 8
+  %2518 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2519 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2518, i32 0, i32 0
+  store ptr @40, ptr %2519, align 8
+  %2520 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2518, i32 0, i32 1
+  store i64 5, ptr %2520, align 4
+  %2521 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2518, align 8
+  %2522 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2523 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2522, i32 0, i32 0
+  store ptr null, ptr %2523, align 8
+  %2524 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2522, i32 0, i32 1
+  store i64 0, ptr %2524, align 4
+  %2525 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2522, align 8
+  %2526 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %2527 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2521, ptr %2526, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %2525, i1 false)
+  %2528 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2529 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2528, i32 0, i32 0
+  store ptr @72, ptr %2529, align 8
+  %2530 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2528, i32 0, i32 1
+  store i64 3, ptr %2530, align 4
+  %2531 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2528, align 8
+  %2532 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2533 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2532, i32 0, i32 0
+  store ptr null, ptr %2533, align 8
+  %2534 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2532, i32 0, i32 1
+  store i64 0, ptr %2534, align 4
+  %2535 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2532, align 8
+  %2536 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %2515)
+  %2537 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2531, ptr %2536, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %2535, i1 false)
+  %2538 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2539 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2538, i32 0, i32 0
+  store ptr @73, ptr %2539, align 8
+  %2540 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2538, i32 0, i32 1
+  store i64 6, ptr %2540, align 4
+  %2541 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2538, align 8
+  %2542 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2543 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2542, i32 0, i32 0
+  store ptr null, ptr %2543, align 8
+  %2544 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2542, i32 0, i32 1
+  store i64 0, ptr %2544, align 4
+  %2545 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2542, align 8
+  %2546 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
+  %2547 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2541, ptr %2546, i64 24, %"github.com/goplus/llgo/internal/runtime.String" %2545, i1 false)
+  %2548 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2549 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2548, i32 0, i32 0
+  store ptr @74, ptr %2549, align 8
+  %2550 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2548, i32 0, i32 1
+  store i64 4, ptr %2550, align 4
+  %2551 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2548, align 8
+  %2552 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2553 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2552, i32 0, i32 0
+  store ptr null, ptr %2553, align 8
+  %2554 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2552, i32 0, i32 1
+  store i64 0, ptr %2554, align 4
+  %2555 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2552, align 8
+  %2556 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %2557 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2551, ptr %2556, i64 32, %"github.com/goplus/llgo/internal/runtime.String" %2555, i1 false)
+  %2558 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2559 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2558, i32 0, i32 0
+  store ptr @75, ptr %2559, align 8
+  %2560 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2558, i32 0, i32 1
+  store i64 9, ptr %2560, align 4
+  %2561 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2558, align 8
+  %2562 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2563 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2562, i32 0, i32 0
+  store ptr null, ptr %2563, align 8
+  %2564 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2562, i32 0, i32 1
+  store i64 0, ptr %2564, align 4
+  %2565 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2562, align 8
+  %2566 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 33)
+  %2567 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2561, ptr %2566, i64 48, %"github.com/goplus/llgo/internal/runtime.String" %2565, i1 false)
+  %2568 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2569 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2568, i32 0, i32 0
+  store ptr @7, ptr %2569, align 8
+  %2570 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2568, i32 0, i32 1
+  store i64 4, ptr %2570, align 4
+  %2571 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2568, align 8
+  %2572 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 280)
+  %2573 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2572, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %2527, ptr %2573, align 8
+  %2574 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2572, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %2537, ptr %2574, align 8
+  %2575 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2572, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %2547, ptr %2575, align 8
+  %2576 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2572, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %2557, ptr %2576, align 8
+  %2577 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2572, i64 4
+  store %"github.com/goplus/llgo/internal/abi.StructField" %2567, ptr %2577, align 8
+  %2578 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %2579 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2578, i32 0, i32 0
+  store ptr %2572, ptr %2579, align 8
+  %2580 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2578, i32 0, i32 1
+  store i64 5, ptr %2580, align 4
+  %2581 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2578, i32 0, i32 2
+  store i64 5, ptr %2581, align 4
+  %2582 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2578, align 8
+  %2583 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %2571, i64 56, %"github.com/goplus/llgo/internal/runtime.Slice" %2582)
+  store ptr %2583, ptr @"_llgo_struct$GYlWrg0B_axMyyq9xClGPKuTjurG0iQMRoz8Me1fQig", align 8
   br label %_llgo_122
 
 _llgo_122:                                        ; preds = %_llgo_121, %_llgo_120
-  %2582 = load ptr, ptr @"_llgo_struct$GYlWrg0B_axMyyq9xClGPKuTjurG0iQMRoz8Me1fQig", align 8
-  br i1 %2507, label %_llgo_123, label %_llgo_124
+  %2584 = load ptr, ptr @"_llgo_struct$GYlWrg0B_axMyyq9xClGPKuTjurG0iQMRoz8Me1fQig", align 8
+  br i1 %2509, label %_llgo_123, label %_llgo_124
 
 _llgo_123:                                        ; preds = %_llgo_122
-  %2583 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2584 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2583, i32 0, i32 0
-  store ptr @76, ptr %2584, align 8
-  %2585 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2583, i32 0, i32 1
-  store i64 8, ptr %2585, align 4
-  %2586 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2583, align 8
-  %2587 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2588 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2589 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2588, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2586, ptr %2589, align 8
-  %2590 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2588, i32 0, i32 1
-  store ptr %2587, ptr %2590, align 8
-  %2591 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2588, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructField).Embedded", ptr %2591, align 8
-  %2592 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2588, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructField).Embedded", ptr %2592, align 8
-  %2593 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2588, align 8
-  %2594 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2595 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2594, i32 0, i32 0
-  store ptr @42, ptr %2595, align 8
-  %2596 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2594, i32 0, i32 1
-  store i64 8, ptr %2596, align 4
-  %2597 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2594, align 8
-  %2598 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2599 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2600 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2599, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2597, ptr %2600, align 8
-  %2601 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2599, i32 0, i32 1
-  store ptr %2598, ptr %2601, align 8
-  %2602 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2599, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructField).Exported", ptr %2602, align 8
-  %2603 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2599, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructField).Exported", ptr %2603, align 8
-  %2604 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2599, align 8
-  %2605 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
-  %2606 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2605, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %2593, ptr %2606, align 8
-  %2607 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2605, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %2604, ptr %2607, align 8
-  %2608 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2609 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2608, i32 0, i32 0
-  store ptr %2605, ptr %2609, align 8
-  %2610 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2608, i32 0, i32 1
-  store i64 2, ptr %2610, align 4
-  %2611 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2608, i32 0, i32 2
-  store i64 2, ptr %2611, align 4
-  %2612 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2608, align 8
-  %2613 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2614 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2613, i32 0, i32 0
-  store ptr @3, ptr %2614, align 8
-  %2615 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2613, i32 0, i32 1
-  store i64 35, ptr %2615, align 4
-  %2616 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2613, align 8
-  %2617 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2618 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2617, i32 0, i32 0
-  store ptr @77, ptr %2618, align 8
-  %2619 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2617, i32 0, i32 1
-  store i64 11, ptr %2619, align 4
-  %2620 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2617, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %2505, %"github.com/goplus/llgo/internal/runtime.String" %2616, %"github.com/goplus/llgo/internal/runtime.String" %2620, ptr %2582, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %2612)
+  %2585 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2586 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2585, i32 0, i32 0
+  store ptr @76, ptr %2586, align 8
+  %2587 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2585, i32 0, i32 1
+  store i64 8, ptr %2587, align 4
+  %2588 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2585, align 8
+  %2589 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %2590 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2591 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2590, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2588, ptr %2591, align 8
+  %2592 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2590, i32 0, i32 1
+  store ptr %2589, ptr %2592, align 8
+  %2593 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2590, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructField).Embedded", ptr %2593, align 8
+  %2594 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2590, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructField).Embedded", ptr %2594, align 8
+  %2595 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2590, align 8
+  %2596 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2597 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2596, i32 0, i32 0
+  store ptr @42, ptr %2597, align 8
+  %2598 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2596, i32 0, i32 1
+  store i64 8, ptr %2598, align 4
+  %2599 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2596, align 8
+  %2600 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %2601 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2602 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2601, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2599, ptr %2602, align 8
+  %2603 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2601, i32 0, i32 1
+  store ptr %2600, ptr %2603, align 8
+  %2604 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2601, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructField).Exported", ptr %2604, align 8
+  %2605 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2601, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructField).Exported", ptr %2605, align 8
+  %2606 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2601, align 8
+  %2607 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
+  %2608 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2607, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %2595, ptr %2608, align 8
+  %2609 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2607, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %2606, ptr %2609, align 8
+  %2610 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %2611 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2610, i32 0, i32 0
+  store ptr %2607, ptr %2611, align 8
+  %2612 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2610, i32 0, i32 1
+  store i64 2, ptr %2612, align 4
+  %2613 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2610, i32 0, i32 2
+  store i64 2, ptr %2613, align 4
+  %2614 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2610, align 8
+  %2615 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2616 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2615, i32 0, i32 0
+  store ptr @3, ptr %2616, align 8
+  %2617 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2615, i32 0, i32 1
+  store i64 35, ptr %2617, align 4
+  %2618 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2615, align 8
+  %2619 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2620 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2619, i32 0, i32 0
+  store ptr @77, ptr %2620, align 8
+  %2621 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2619, i32 0, i32 1
+  store i64 11, ptr %2621, align 4
+  %2622 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2619, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %2507, %"github.com/goplus/llgo/internal/runtime.String" %2618, %"github.com/goplus/llgo/internal/runtime.String" %2622, ptr %2584, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %2614)
   br label %_llgo_124
 
 _llgo_124:                                        ; preds = %_llgo_123, %_llgo_122
-  %2621 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
-  %2622 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2623 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2622, i32 0, i32 0
-  store ptr @71, ptr %2623, align 8
-  %2624 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2622, i32 0, i32 1
-  store i64 47, ptr %2624, align 4
-  %2625 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2622, align 8
-  %2626 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2625, i64 25, i64 56, i64 0, i64 2)
-  %2627 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
-  %2628 = icmp eq ptr %2627, null
-  br i1 %2628, label %_llgo_125, label %_llgo_126
+  %2623 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
+  %2624 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2625 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2624, i32 0, i32 0
+  store ptr @71, ptr %2625, align 8
+  %2626 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2624, i32 0, i32 1
+  store i64 47, ptr %2626, align 4
+  %2627 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2624, align 8
+  %2628 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2627, i64 25, i64 56, i64 0, i64 2)
+  %2629 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
+  %2630 = icmp eq ptr %2629, null
+  br i1 %2630, label %_llgo_125, label %_llgo_126
 
 _llgo_125:                                        ; preds = %_llgo_124
-  %2629 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %2626)
-  store ptr %2629, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
+  %2631 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %2628)
+  store ptr %2631, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
   br label %_llgo_126
 
 _llgo_126:                                        ; preds = %_llgo_125, %_llgo_124
-  %2630 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
-  %2631 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2632 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2631, i32 0, i32 0
-  store ptr @1, ptr %2632, align 8
-  %2633 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2631, i32 0, i32 1
-  store i64 40, ptr %2633, align 4
-  %2634 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2631, align 8
-  %2635 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2634, i64 25, i64 80, i64 0, i64 22)
-  %2636 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2637 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2636, i32 0, i32 0
-  store ptr @71, ptr %2637, align 8
-  %2638 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2636, i32 0, i32 1
-  store i64 47, ptr %2638, align 4
-  %2639 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2636, align 8
-  %2640 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2639, i64 25, i64 56, i64 0, i64 2)
-  %2641 = load ptr, ptr @"_llgo_struct$K_cvuhBwc2_5r7UW089ibWfcfsGoDb4pZ7K19IcMTk0", align 8
-  %2642 = icmp eq ptr %2641, null
-  br i1 %2642, label %_llgo_127, label %_llgo_128
+  %2632 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
+  %2633 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2634 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2633, i32 0, i32 0
+  store ptr @1, ptr %2634, align 8
+  %2635 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2633, i32 0, i32 1
+  store i64 40, ptr %2635, align 4
+  %2636 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2633, align 8
+  %2637 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2636, i64 25, i64 80, i64 0, i64 22)
+  %2638 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2639 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2638, i32 0, i32 0
+  store ptr @71, ptr %2639, align 8
+  %2640 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2638, i32 0, i32 1
+  store i64 47, ptr %2640, align 4
+  %2641 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2638, align 8
+  %2642 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2641, i64 25, i64 56, i64 0, i64 2)
+  %2643 = load ptr, ptr @"_llgo_struct$K_cvuhBwc2_5r7UW089ibWfcfsGoDb4pZ7K19IcMTk0", align 8
+  %2644 = icmp eq ptr %2643, null
+  br i1 %2644, label %_llgo_127, label %_llgo_128
 
 _llgo_127:                                        ; preds = %_llgo_126
-  %2643 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2644 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2643, i32 0, i32 0
-  store ptr @21, ptr %2644, align 8
-  %2645 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2643, i32 0, i32 1
-  store i64 4, ptr %2645, align 4
-  %2646 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2643, align 8
-  %2647 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2648 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2647, i32 0, i32 0
-  store ptr null, ptr %2648, align 8
-  %2649 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2647, i32 0, i32 1
-  store i64 0, ptr %2649, align 4
-  %2650 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2647, align 8
-  %2651 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2646, ptr %2635, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %2650, i1 true)
-  %2652 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2653 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2652, i32 0, i32 0
-  store ptr @46, ptr %2653, align 8
-  %2654 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2652, i32 0, i32 1
-  store i64 8, ptr %2654, align 4
-  %2655 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2652, align 8
-  %2656 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2657 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2656, i32 0, i32 0
-  store ptr null, ptr %2657, align 8
-  %2658 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2656, i32 0, i32 1
-  store i64 0, ptr %2658, align 4
-  %2659 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2656, align 8
-  %2660 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %2661 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2655, ptr %2660, i64 72, %"github.com/goplus/llgo/internal/runtime.String" %2659, i1 false)
-  %2662 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2663 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2662, i32 0, i32 0
-  store ptr @78, ptr %2663, align 8
-  %2664 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2662, i32 0, i32 1
-  store i64 6, ptr %2664, align 4
-  %2665 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2662, align 8
-  %2666 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2667 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2666, i32 0, i32 0
-  store ptr null, ptr %2667, align 8
-  %2668 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2666, i32 0, i32 1
-  store i64 0, ptr %2668, align 4
-  %2669 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2666, align 8
-  %2670 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %2640)
-  %2671 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2665, ptr %2670, i64 88, %"github.com/goplus/llgo/internal/runtime.String" %2669, i1 false)
-  %2672 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2673 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2672, i32 0, i32 0
-  store ptr @7, ptr %2673, align 8
-  %2674 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2672, i32 0, i32 1
-  store i64 4, ptr %2674, align 4
-  %2675 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2672, align 8
-  %2676 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 168)
-  %2677 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2676, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2651, ptr %2677, align 8
-  %2678 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2676, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2661, ptr %2678, align 8
-  %2679 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2676, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2671, ptr %2679, align 8
-  %2680 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2681 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2680, i32 0, i32 0
-  store ptr %2676, ptr %2681, align 8
-  %2682 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2680, i32 0, i32 1
-  store i64 3, ptr %2682, align 4
-  %2683 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2680, i32 0, i32 2
-  store i64 3, ptr %2683, align 4
-  %2684 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2680, align 8
-  %2685 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %2675, i64 112, %"github.com/goplus/llgo/internal/runtime.Slice" %2684)
-  store ptr %2685, ptr @"_llgo_struct$K_cvuhBwc2_5r7UW089ibWfcfsGoDb4pZ7K19IcMTk0", align 8
+  %2645 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2646 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2645, i32 0, i32 0
+  store ptr @21, ptr %2646, align 8
+  %2647 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2645, i32 0, i32 1
+  store i64 4, ptr %2647, align 4
+  %2648 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2645, align 8
+  %2649 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2650 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2649, i32 0, i32 0
+  store ptr null, ptr %2650, align 8
+  %2651 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2649, i32 0, i32 1
+  store i64 0, ptr %2651, align 4
+  %2652 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2649, align 8
+  %2653 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2648, ptr %2637, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %2652, i1 true)
+  %2654 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2655 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2654, i32 0, i32 0
+  store ptr @46, ptr %2655, align 8
+  %2656 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2654, i32 0, i32 1
+  store i64 8, ptr %2656, align 4
+  %2657 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2654, align 8
+  %2658 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2659 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2658, i32 0, i32 0
+  store ptr null, ptr %2659, align 8
+  %2660 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2658, i32 0, i32 1
+  store i64 0, ptr %2660, align 4
+  %2661 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2658, align 8
+  %2662 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %2663 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2657, ptr %2662, i64 72, %"github.com/goplus/llgo/internal/runtime.String" %2661, i1 false)
+  %2664 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2665 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2664, i32 0, i32 0
+  store ptr @78, ptr %2665, align 8
+  %2666 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2664, i32 0, i32 1
+  store i64 6, ptr %2666, align 4
+  %2667 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2664, align 8
+  %2668 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2669 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2668, i32 0, i32 0
+  store ptr null, ptr %2669, align 8
+  %2670 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2668, i32 0, i32 1
+  store i64 0, ptr %2670, align 4
+  %2671 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2668, align 8
+  %2672 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %2642)
+  %2673 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2667, ptr %2672, i64 88, %"github.com/goplus/llgo/internal/runtime.String" %2671, i1 false)
+  %2674 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2675 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2674, i32 0, i32 0
+  store ptr @7, ptr %2675, align 8
+  %2676 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2674, i32 0, i32 1
+  store i64 4, ptr %2676, align 4
+  %2677 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2674, align 8
+  %2678 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 168)
+  %2679 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2678, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %2653, ptr %2679, align 8
+  %2680 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2678, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %2663, ptr %2680, align 8
+  %2681 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2678, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %2673, ptr %2681, align 8
+  %2682 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %2683 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2682, i32 0, i32 0
+  store ptr %2678, ptr %2683, align 8
+  %2684 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2682, i32 0, i32 1
+  store i64 3, ptr %2684, align 4
+  %2685 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2682, i32 0, i32 2
+  store i64 3, ptr %2685, align 4
+  %2686 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2682, align 8
+  %2687 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %2677, i64 112, %"github.com/goplus/llgo/internal/runtime.Slice" %2686)
+  store ptr %2687, ptr @"_llgo_struct$K_cvuhBwc2_5r7UW089ibWfcfsGoDb4pZ7K19IcMTk0", align 8
   br label %_llgo_128
 
 _llgo_128:                                        ; preds = %_llgo_127, %_llgo_126
-  %2686 = load ptr, ptr @"_llgo_struct$K_cvuhBwc2_5r7UW089ibWfcfsGoDb4pZ7K19IcMTk0", align 8
-  br i1 %2500, label %_llgo_129, label %_llgo_130
+  %2688 = load ptr, ptr @"_llgo_struct$K_cvuhBwc2_5r7UW089ibWfcfsGoDb4pZ7K19IcMTk0", align 8
+  br i1 %2502, label %_llgo_129, label %_llgo_130
 
 _llgo_129:                                        ; preds = %_llgo_128
-  %2687 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2688 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2687, i32 0, i32 0
-  store ptr @18, ptr %2688, align 8
-  %2689 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2687, i32 0, i32 1
-  store i64 5, ptr %2689, align 4
-  %2690 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2687, align 8
-  %2691 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %2692 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2693 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2692, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2690, ptr %2693, align 8
-  %2694 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2692, i32 0, i32 1
-  store ptr %2691, ptr %2694, align 8
-  %2695 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2692, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Align", ptr %2695, align 8
-  %2696 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2692, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Align", ptr %2696, align 8
-  %2697 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2692, align 8
-  %2698 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2699 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2698, i32 0, i32 0
-  store ptr @19, ptr %2699, align 8
-  %2700 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2698, i32 0, i32 1
-  store i64 9, ptr %2700, align 4
-  %2701 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2698, align 8
-  %2702 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
-  %2703 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
-  %2704 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2705 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2704, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2701, ptr %2705, align 8
-  %2706 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2704, i32 0, i32 1
-  store ptr %2703, ptr %2706, align 8
-  %2707 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2704, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ArrayType", ptr %2707, align 8
-  %2708 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2704, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ArrayType", ptr %2708, align 8
-  %2709 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2704, align 8
-  %2710 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2711 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2710, i32 0, i32 0
-  store ptr @25, ptr %2711, align 8
-  %2712 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2710, i32 0, i32 1
-  store i64 7, ptr %2712, align 4
-  %2713 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2710, align 8
-  %2714 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
-  %2715 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2716 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2715, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2713, ptr %2716, align 8
-  %2717 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2715, i32 0, i32 1
-  store ptr %2714, ptr %2717, align 8
-  %2718 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2715, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ChanDir", ptr %2718, align 8
-  %2719 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2715, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ChanDir", ptr %2719, align 8
-  %2720 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2715, align 8
-  %2721 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2722 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2721, i32 0, i32 0
-  store ptr @27, ptr %2722, align 8
-  %2723 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2721, i32 0, i32 1
-  store i64 6, ptr %2723, align 4
-  %2724 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2721, align 8
-  %2725 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %2726 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %2727 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2728 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2727, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2724, ptr %2728, align 8
-  %2729 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2727, i32 0, i32 1
-  store ptr %2726, ptr %2729, align 8
-  %2730 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2727, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Common", ptr %2730, align 8
-  %2731 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2727, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Common", ptr %2731, align 8
-  %2732 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2727, align 8
-  %2733 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2734 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2733, i32 0, i32 0
-  store ptr @22, ptr %2734, align 8
-  %2735 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2733, i32 0, i32 1
-  store i64 4, ptr %2735, align 4
-  %2736 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2733, align 8
-  %2737 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %2738 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %2739 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2740 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2739, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2736, ptr %2740, align 8
-  %2741 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2739, i32 0, i32 1
-  store ptr %2738, ptr %2741, align 8
-  %2742 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2739, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Elem", ptr %2742, align 8
-  %2743 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2739, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Elem", ptr %2743, align 8
-  %2744 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2739, align 8
-  %2745 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2746 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2745, i32 0, i32 0
-  store ptr @28, ptr %2746, align 8
-  %2747 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2745, i32 0, i32 1
-  store i64 15, ptr %2747, align 4
-  %2748 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2745, align 8
-  %2749 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %2750 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
-  %2751 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2752 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2751, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2748, ptr %2752, align 8
-  %2753 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2751, i32 0, i32 1
-  store ptr %2750, ptr %2753, align 8
-  %2754 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2751, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ExportedMethods", ptr %2754, align 8
-  %2755 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2751, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ExportedMethods", ptr %2755, align 8
-  %2756 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2751, align 8
-  %2757 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2758 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2757, i32 0, i32 0
-  store ptr @33, ptr %2758, align 8
-  %2759 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2757, i32 0, i32 1
-  store i64 10, ptr %2759, align 4
-  %2760 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2757, align 8
-  %2761 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %2762 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2763 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2762, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2760, ptr %2763, align 8
-  %2764 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2762, i32 0, i32 1
-  store ptr %2761, ptr %2764, align 8
-  %2765 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2762, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).FieldAlign", ptr %2765, align 8
-  %2766 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2762, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).FieldAlign", ptr %2766, align 8
-  %2767 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2762, align 8
-  %2768 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2769 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2768, i32 0, i32 0
-  store ptr @34, ptr %2769, align 8
-  %2770 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2768, i32 0, i32 1
-  store i64 8, ptr %2770, align 4
-  %2771 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2768, align 8
-  %2772 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %2773 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
-  %2774 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2775 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2774, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2771, ptr %2775, align 8
-  %2776 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2774, i32 0, i32 1
-  store ptr %2773, ptr %2776, align 8
-  %2777 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2774, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).FuncType", ptr %2777, align 8
-  %2778 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2774, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).FuncType", ptr %2778, align 8
-  %2779 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2774, align 8
-  %2780 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2781 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2780, i32 0, i32 0
-  store ptr @35, ptr %2781, align 8
-  %2782 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2780, i32 0, i32 1
-  store i64 7, ptr %2782, align 4
-  %2783 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2780, align 8
-  %2784 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2785 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2786 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2785, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2783, ptr %2786, align 8
-  %2787 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2785, i32 0, i32 1
-  store ptr %2784, ptr %2787, align 8
-  %2788 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2785, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).HasName", ptr %2788, align 8
-  %2789 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2785, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).HasName", ptr %2789, align 8
-  %2790 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2785, align 8
-  %2791 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2792 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2791, i32 0, i32 0
-  store ptr @36, ptr %2792, align 8
-  %2793 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2791, i32 0, i32 1
-  store i64 10, ptr %2793, align 4
-  %2794 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2791, align 8
-  %2795 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2796 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2797 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2796, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2794, ptr %2797, align 8
-  %2798 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2796, i32 0, i32 1
-  store ptr %2795, ptr %2798, align 8
-  %2799 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2796, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).IfaceIndir", ptr %2799, align 8
-  %2800 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2796, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).IfaceIndir", ptr %2800, align 8
-  %2801 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2796, align 8
-  %2802 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2803 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2802, i32 0, i32 0
-  store ptr @37, ptr %2803, align 8
-  %2804 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2802, i32 0, i32 1
-  store i64 13, ptr %2804, align 4
-  %2805 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2802, align 8
-  %2806 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
-  %2807 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
-  %2808 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2809 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2808, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2805, ptr %2809, align 8
-  %2810 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2808, i32 0, i32 1
-  store ptr %2807, ptr %2810, align 8
-  %2811 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2808, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).InterfaceType", ptr %2811, align 8
-  %2812 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2808, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).InterfaceType", ptr %2812, align 8
-  %2813 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2808, align 8
-  %2814 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2815 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2814, i32 0, i32 0
-  store ptr @48, ptr %2815, align 8
-  %2816 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2814, i32 0, i32 1
-  store i64 13, ptr %2816, align 4
-  %2817 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2814, align 8
-  %2818 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2819 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2820 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2819, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2817, ptr %2820, align 8
-  %2821 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2819, i32 0, i32 1
-  store ptr %2818, ptr %2821, align 8
-  %2822 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2819, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).IsDirectIface", ptr %2822, align 8
-  %2823 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2819, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).IsDirectIface", ptr %2823, align 8
-  %2824 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2819, align 8
-  %2825 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2826 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2825, i32 0, i32 0
-  store ptr @49, ptr %2826, align 8
-  %2827 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2825, i32 0, i32 1
-  store i64 3, ptr %2827, align 4
-  %2828 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2825, align 8
-  %2829 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %2830 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %2831 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2832 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2831, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2828, ptr %2832, align 8
-  %2833 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2831, i32 0, i32 1
-  store ptr %2830, ptr %2833, align 8
-  %2834 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2831, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Key", ptr %2834, align 8
-  %2835 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2831, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Key", ptr %2835, align 8
-  %2836 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2831, align 8
-  %2837 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2838 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2837, i32 0, i32 0
-  store ptr @50, ptr %2838, align 8
-  %2839 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2837, i32 0, i32 1
-  store i64 4, ptr %2839, align 4
-  %2840 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2837, align 8
-  %2841 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
-  %2842 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2843 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2842, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2840, ptr %2843, align 8
-  %2844 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2842, i32 0, i32 1
-  store ptr %2841, ptr %2844, align 8
-  %2845 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2842, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Kind", ptr %2845, align 8
-  %2846 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2842, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Kind", ptr %2846, align 8
-  %2847 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2842, align 8
-  %2848 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2849 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2848, i32 0, i32 0
-  store ptr @24, ptr %2849, align 8
-  %2850 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2848, i32 0, i32 1
-  store i64 3, ptr %2850, align 4
-  %2851 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2848, align 8
-  %2852 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %2853 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2854 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2853, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2851, ptr %2854, align 8
-  %2855 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2853, i32 0, i32 1
-  store ptr %2852, ptr %2855, align 8
-  %2856 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2853, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Len", ptr %2856, align 8
-  %2857 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2853, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Len", ptr %2857, align 8
-  %2858 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2853, align 8
-  %2859 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2860 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2859, i32 0, i32 0
-  store ptr @53, ptr %2860, align 8
-  %2861 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2859, i32 0, i32 1
-  store i64 7, ptr %2861, align 4
-  %2862 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2859, align 8
-  %2863 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
-  %2864 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
-  %2865 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2866 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2865, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2862, ptr %2866, align 8
-  %2867 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2865, i32 0, i32 1
-  store ptr %2864, ptr %2867, align 8
-  %2868 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2865, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).MapType", ptr %2868, align 8
-  %2869 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2865, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).MapType", ptr %2869, align 8
-  %2870 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2865, align 8
-  %2871 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2872 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2871, i32 0, i32 0
-  store ptr @65, ptr %2872, align 8
-  %2873 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2871, i32 0, i32 1
-  store i64 9, ptr %2873, align 4
-  %2874 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2871, align 8
-  %2875 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %2876 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2877 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2876, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2874, ptr %2877, align 8
-  %2878 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2876, i32 0, i32 1
-  store ptr %2875, ptr %2878, align 8
-  %2879 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2876, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).NumMethod", ptr %2879, align 8
-  %2880 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2876, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).NumMethod", ptr %2880, align 8
-  %2881 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2876, align 8
-  %2882 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2883 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2882, i32 0, i32 0
-  store ptr @66, ptr %2883, align 8
-  %2884 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2882, i32 0, i32 1
-  store i64 8, ptr %2884, align 4
-  %2885 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2882, align 8
-  %2886 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2887 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2888 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2887, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2885, ptr %2888, align 8
-  %2889 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2887, i32 0, i32 1
-  store ptr %2886, ptr %2889, align 8
-  %2890 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2887, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Pointers", ptr %2890, align 8
-  %2891 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2887, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Pointers", ptr %2891, align 8
-  %2892 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2887, align 8
-  %2893 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2894 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2893, i32 0, i32 0
-  store ptr @68, ptr %2894, align 8
-  %2895 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2893, i32 0, i32 1
-  store i64 4, ptr %2895, align 4
-  %2896 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2893, align 8
-  %2897 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
-  %2898 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2899 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2898, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2896, ptr %2899, align 8
-  %2900 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2898, i32 0, i32 1
-  store ptr %2897, ptr %2900, align 8
-  %2901 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2898, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Size", ptr %2901, align 8
-  %2902 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2898, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Size", ptr %2902, align 8
-  %2903 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2898, align 8
-  %2904 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2905 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2904, i32 0, i32 0
-  store ptr @52, ptr %2905, align 8
-  %2906 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2904, i32 0, i32 1
-  store i64 6, ptr %2906, align 4
-  %2907 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2904, align 8
-  %2908 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %2909 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2910 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2909, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2907, ptr %2910, align 8
-  %2911 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2909, i32 0, i32 1
-  store ptr %2908, ptr %2911, align 8
-  %2912 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2909, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).String", ptr %2912, align 8
-  %2913 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2909, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).String", ptr %2913, align 8
-  %2914 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2909, align 8
-  %2915 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2916 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2915, i32 0, i32 0
-  store ptr @69, ptr %2916, align 8
-  %2917 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2915, i32 0, i32 1
-  store i64 10, ptr %2917, align 4
-  %2918 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2915, align 8
-  %2919 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2920 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2919, i32 0, i32 0
-  store ptr @70, ptr %2920, align 8
-  %2921 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2919, i32 0, i32 1
-  store i64 46, ptr %2921, align 4
-  %2922 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2919, align 8
-  %2923 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2922, i64 25, i64 120, i64 0, i64 22)
-  %2924 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
-  %2925 = icmp eq ptr %2924, null
-  br i1 %2925, label %_llgo_131, label %_llgo_132
+  %2689 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2690 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2689, i32 0, i32 0
+  store ptr @18, ptr %2690, align 8
+  %2691 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2689, i32 0, i32 1
+  store i64 5, ptr %2691, align 4
+  %2692 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2689, align 8
+  %2693 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %2694 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2695 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2694, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2692, ptr %2695, align 8
+  %2696 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2694, i32 0, i32 1
+  store ptr %2693, ptr %2696, align 8
+  %2697 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2694, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Align", ptr %2697, align 8
+  %2698 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2694, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Align", ptr %2698, align 8
+  %2699 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2694, align 8
+  %2700 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2701 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2700, i32 0, i32 0
+  store ptr @19, ptr %2701, align 8
+  %2702 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2700, i32 0, i32 1
+  store i64 9, ptr %2702, align 4
+  %2703 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2700, align 8
+  %2704 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  %2705 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
+  %2706 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2707 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2706, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2703, ptr %2707, align 8
+  %2708 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2706, i32 0, i32 1
+  store ptr %2705, ptr %2708, align 8
+  %2709 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2706, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ArrayType", ptr %2709, align 8
+  %2710 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2706, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ArrayType", ptr %2710, align 8
+  %2711 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2706, align 8
+  %2712 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2713 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2712, i32 0, i32 0
+  store ptr @25, ptr %2713, align 8
+  %2714 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2712, i32 0, i32 1
+  store i64 7, ptr %2714, align 4
+  %2715 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2712, align 8
+  %2716 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
+  %2717 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2718 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2717, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2715, ptr %2718, align 8
+  %2719 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2717, i32 0, i32 1
+  store ptr %2716, ptr %2719, align 8
+  %2720 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2717, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ChanDir", ptr %2720, align 8
+  %2721 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2717, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ChanDir", ptr %2721, align 8
+  %2722 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2717, align 8
+  %2723 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2724 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2723, i32 0, i32 0
+  store ptr @27, ptr %2724, align 8
+  %2725 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2723, i32 0, i32 1
+  store i64 6, ptr %2725, align 4
+  %2726 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2723, align 8
+  %2727 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %2728 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %2729 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2730 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2729, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2726, ptr %2730, align 8
+  %2731 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2729, i32 0, i32 1
+  store ptr %2728, ptr %2731, align 8
+  %2732 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2729, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Common", ptr %2732, align 8
+  %2733 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2729, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Common", ptr %2733, align 8
+  %2734 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2729, align 8
+  %2735 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2736 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2735, i32 0, i32 0
+  store ptr @22, ptr %2736, align 8
+  %2737 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2735, i32 0, i32 1
+  store i64 4, ptr %2737, align 4
+  %2738 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2735, align 8
+  %2739 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %2740 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %2741 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2742 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2741, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2738, ptr %2742, align 8
+  %2743 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2741, i32 0, i32 1
+  store ptr %2740, ptr %2743, align 8
+  %2744 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2741, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Elem", ptr %2744, align 8
+  %2745 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2741, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Elem", ptr %2745, align 8
+  %2746 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2741, align 8
+  %2747 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2748 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2747, i32 0, i32 0
+  store ptr @28, ptr %2748, align 8
+  %2749 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2747, i32 0, i32 1
+  store i64 15, ptr %2749, align 4
+  %2750 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2747, align 8
+  %2751 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %2752 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
+  %2753 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2754 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2753, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2750, ptr %2754, align 8
+  %2755 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2753, i32 0, i32 1
+  store ptr %2752, ptr %2755, align 8
+  %2756 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2753, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ExportedMethods", ptr %2756, align 8
+  %2757 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2753, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ExportedMethods", ptr %2757, align 8
+  %2758 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2753, align 8
+  %2759 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2760 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2759, i32 0, i32 0
+  store ptr @33, ptr %2760, align 8
+  %2761 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2759, i32 0, i32 1
+  store i64 10, ptr %2761, align 4
+  %2762 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2759, align 8
+  %2763 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %2764 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2765 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2764, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2762, ptr %2765, align 8
+  %2766 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2764, i32 0, i32 1
+  store ptr %2763, ptr %2766, align 8
+  %2767 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2764, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).FieldAlign", ptr %2767, align 8
+  %2768 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2764, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).FieldAlign", ptr %2768, align 8
+  %2769 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2764, align 8
+  %2770 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2771 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2770, i32 0, i32 0
+  store ptr @34, ptr %2771, align 8
+  %2772 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2770, i32 0, i32 1
+  store i64 8, ptr %2772, align 4
+  %2773 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2770, align 8
+  %2774 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %2775 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
+  %2776 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2777 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2776, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2773, ptr %2777, align 8
+  %2778 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2776, i32 0, i32 1
+  store ptr %2775, ptr %2778, align 8
+  %2779 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2776, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).FuncType", ptr %2779, align 8
+  %2780 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2776, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).FuncType", ptr %2780, align 8
+  %2781 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2776, align 8
+  %2782 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2783 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2782, i32 0, i32 0
+  store ptr @35, ptr %2783, align 8
+  %2784 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2782, i32 0, i32 1
+  store i64 7, ptr %2784, align 4
+  %2785 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2782, align 8
+  %2786 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %2787 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2788 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2787, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2785, ptr %2788, align 8
+  %2789 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2787, i32 0, i32 1
+  store ptr %2786, ptr %2789, align 8
+  %2790 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2787, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).HasName", ptr %2790, align 8
+  %2791 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2787, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).HasName", ptr %2791, align 8
+  %2792 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2787, align 8
+  %2793 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2794 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2793, i32 0, i32 0
+  store ptr @36, ptr %2794, align 8
+  %2795 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2793, i32 0, i32 1
+  store i64 10, ptr %2795, align 4
+  %2796 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2793, align 8
+  %2797 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %2798 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2799 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2798, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2796, ptr %2799, align 8
+  %2800 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2798, i32 0, i32 1
+  store ptr %2797, ptr %2800, align 8
+  %2801 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2798, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).IfaceIndir", ptr %2801, align 8
+  %2802 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2798, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).IfaceIndir", ptr %2802, align 8
+  %2803 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2798, align 8
+  %2804 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2805 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2804, i32 0, i32 0
+  store ptr @37, ptr %2805, align 8
+  %2806 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2804, i32 0, i32 1
+  store i64 13, ptr %2806, align 4
+  %2807 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2804, align 8
+  %2808 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  %2809 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
+  %2810 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2811 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2810, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2807, ptr %2811, align 8
+  %2812 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2810, i32 0, i32 1
+  store ptr %2809, ptr %2812, align 8
+  %2813 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2810, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).InterfaceType", ptr %2813, align 8
+  %2814 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2810, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).InterfaceType", ptr %2814, align 8
+  %2815 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2810, align 8
+  %2816 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2817 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2816, i32 0, i32 0
+  store ptr @48, ptr %2817, align 8
+  %2818 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2816, i32 0, i32 1
+  store i64 13, ptr %2818, align 4
+  %2819 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2816, align 8
+  %2820 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %2821 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2822 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2821, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2819, ptr %2822, align 8
+  %2823 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2821, i32 0, i32 1
+  store ptr %2820, ptr %2823, align 8
+  %2824 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2821, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).IsDirectIface", ptr %2824, align 8
+  %2825 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2821, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).IsDirectIface", ptr %2825, align 8
+  %2826 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2821, align 8
+  %2827 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2828 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2827, i32 0, i32 0
+  store ptr @49, ptr %2828, align 8
+  %2829 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2827, i32 0, i32 1
+  store i64 3, ptr %2829, align 4
+  %2830 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2827, align 8
+  %2831 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %2832 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %2833 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2834 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2833, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2830, ptr %2834, align 8
+  %2835 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2833, i32 0, i32 1
+  store ptr %2832, ptr %2835, align 8
+  %2836 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2833, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Key", ptr %2836, align 8
+  %2837 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2833, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Key", ptr %2837, align 8
+  %2838 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2833, align 8
+  %2839 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2840 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2839, i32 0, i32 0
+  store ptr @50, ptr %2840, align 8
+  %2841 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2839, i32 0, i32 1
+  store i64 4, ptr %2841, align 4
+  %2842 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2839, align 8
+  %2843 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
+  %2844 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2845 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2844, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2842, ptr %2845, align 8
+  %2846 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2844, i32 0, i32 1
+  store ptr %2843, ptr %2846, align 8
+  %2847 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2844, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Kind", ptr %2847, align 8
+  %2848 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2844, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Kind", ptr %2848, align 8
+  %2849 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2844, align 8
+  %2850 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2851 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2850, i32 0, i32 0
+  store ptr @24, ptr %2851, align 8
+  %2852 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2850, i32 0, i32 1
+  store i64 3, ptr %2852, align 4
+  %2853 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2850, align 8
+  %2854 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %2855 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2856 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2855, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2853, ptr %2856, align 8
+  %2857 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2855, i32 0, i32 1
+  store ptr %2854, ptr %2857, align 8
+  %2858 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2855, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Len", ptr %2858, align 8
+  %2859 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2855, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Len", ptr %2859, align 8
+  %2860 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2855, align 8
+  %2861 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2862 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2861, i32 0, i32 0
+  store ptr @53, ptr %2862, align 8
+  %2863 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2861, i32 0, i32 1
+  store i64 7, ptr %2863, align 4
+  %2864 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2861, align 8
+  %2865 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  %2866 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
+  %2867 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2868 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2867, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2864, ptr %2868, align 8
+  %2869 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2867, i32 0, i32 1
+  store ptr %2866, ptr %2869, align 8
+  %2870 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2867, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).MapType", ptr %2870, align 8
+  %2871 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2867, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).MapType", ptr %2871, align 8
+  %2872 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2867, align 8
+  %2873 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2874 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2873, i32 0, i32 0
+  store ptr @65, ptr %2874, align 8
+  %2875 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2873, i32 0, i32 1
+  store i64 9, ptr %2875, align 4
+  %2876 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2873, align 8
+  %2877 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %2878 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2879 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2878, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2876, ptr %2879, align 8
+  %2880 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2878, i32 0, i32 1
+  store ptr %2877, ptr %2880, align 8
+  %2881 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2878, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).NumMethod", ptr %2881, align 8
+  %2882 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2878, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).NumMethod", ptr %2882, align 8
+  %2883 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2878, align 8
+  %2884 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2885 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2884, i32 0, i32 0
+  store ptr @66, ptr %2885, align 8
+  %2886 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2884, i32 0, i32 1
+  store i64 8, ptr %2886, align 4
+  %2887 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2884, align 8
+  %2888 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %2889 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2890 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2889, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2887, ptr %2890, align 8
+  %2891 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2889, i32 0, i32 1
+  store ptr %2888, ptr %2891, align 8
+  %2892 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2889, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Pointers", ptr %2892, align 8
+  %2893 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2889, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Pointers", ptr %2893, align 8
+  %2894 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2889, align 8
+  %2895 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2896 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2895, i32 0, i32 0
+  store ptr @68, ptr %2896, align 8
+  %2897 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2895, i32 0, i32 1
+  store i64 4, ptr %2897, align 4
+  %2898 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2895, align 8
+  %2899 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
+  %2900 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2901 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2900, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2898, ptr %2901, align 8
+  %2902 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2900, i32 0, i32 1
+  store ptr %2899, ptr %2902, align 8
+  %2903 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2900, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Size", ptr %2903, align 8
+  %2904 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2900, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Size", ptr %2904, align 8
+  %2905 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2900, align 8
+  %2906 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2907 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2906, i32 0, i32 0
+  store ptr @52, ptr %2907, align 8
+  %2908 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2906, i32 0, i32 1
+  store i64 6, ptr %2908, align 4
+  %2909 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2906, align 8
+  %2910 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %2911 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2912 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2911, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2909, ptr %2912, align 8
+  %2913 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2911, i32 0, i32 1
+  store ptr %2910, ptr %2913, align 8
+  %2914 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2911, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).String", ptr %2914, align 8
+  %2915 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2911, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).String", ptr %2915, align 8
+  %2916 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2911, align 8
+  %2917 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2918 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2917, i32 0, i32 0
+  store ptr @69, ptr %2918, align 8
+  %2919 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2917, i32 0, i32 1
+  store i64 10, ptr %2919, align 4
+  %2920 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2917, align 8
+  %2921 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2922 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2921, i32 0, i32 0
+  store ptr @70, ptr %2922, align 8
+  %2923 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2921, i32 0, i32 1
+  store i64 46, ptr %2923, align 4
+  %2924 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2921, align 8
+  %2925 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2924, i64 25, i64 120, i64 0, i64 22)
+  %2926 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  %2927 = icmp eq ptr %2926, null
+  br i1 %2927, label %_llgo_131, label %_llgo_132
 
 _llgo_130:                                        ; preds = %_llgo_144, %_llgo_128
-  %2926 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
-  %2927 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
-  %2928 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
-  %2929 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2930 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2929, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2493, ptr %2930, align 8
-  %2931 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2929, i32 0, i32 1
-  store ptr %2928, ptr %2931, align 8
-  %2932 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2929, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).StructType", ptr %2932, align 8
-  %2933 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2929, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).StructType", ptr %2933, align 8
-  %2934 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2929, align 8
-  %2935 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2936 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2935, i32 0, i32 0
-  store ptr @79, ptr %2936, align 8
-  %2937 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2935, i32 0, i32 1
-  store i64 8, ptr %2937, align 4
-  %2938 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2935, align 8
-  %2939 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
-  %2940 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2941 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2940, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2938, ptr %2941, align 8
-  %2942 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2940, i32 0, i32 1
-  store ptr %2939, ptr %2942, align 8
-  %2943 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2940, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Uncommon", ptr %2943, align 8
-  %2944 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2940, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Uncommon", ptr %2944, align 8
-  %2945 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2940, align 8
-  %2946 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 1000)
-  %2947 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %2087, ptr %2947, align 8
-  %2948 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %2099, ptr %2948, align 8
-  %2949 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 2
-  store %"github.com/goplus/llgo/internal/abi.Method" %2110, ptr %2949, align 8
-  %2950 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 3
-  store %"github.com/goplus/llgo/internal/abi.Method" %2122, ptr %2950, align 8
-  %2951 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 4
-  store %"github.com/goplus/llgo/internal/abi.Method" %2134, ptr %2951, align 8
-  %2952 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 5
-  store %"github.com/goplus/llgo/internal/abi.Method" %2145, ptr %2952, align 8
-  %2953 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 6
-  store %"github.com/goplus/llgo/internal/abi.Method" %2157, ptr %2953, align 8
-  %2954 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 7
-  store %"github.com/goplus/llgo/internal/abi.Method" %2168, ptr %2954, align 8
-  %2955 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 8
-  store %"github.com/goplus/llgo/internal/abi.Method" %2179, ptr %2955, align 8
-  %2956 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 9
-  store %"github.com/goplus/llgo/internal/abi.Method" %2190, ptr %2956, align 8
-  %2957 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 10
-  store %"github.com/goplus/llgo/internal/abi.Method" %2201, ptr %2957, align 8
-  %2958 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 11
-  store %"github.com/goplus/llgo/internal/abi.Method" %2212, ptr %2958, align 8
-  %2959 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 12
-  store %"github.com/goplus/llgo/internal/abi.Method" %2224, ptr %2959, align 8
-  %2960 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 13
-  store %"github.com/goplus/llgo/internal/abi.Method" %2235, ptr %2960, align 8
-  %2961 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 14
-  store %"github.com/goplus/llgo/internal/abi.Method" %2246, ptr %2961, align 8
-  %2962 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 15
-  store %"github.com/goplus/llgo/internal/abi.Method" %2257, ptr %2962, align 8
-  %2963 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 16
-  store %"github.com/goplus/llgo/internal/abi.Method" %2406, ptr %2963, align 8
-  %2964 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 17
-  store %"github.com/goplus/llgo/internal/abi.Method" %2417, ptr %2964, align 8
-  %2965 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 18
-  store %"github.com/goplus/llgo/internal/abi.Method" %2428, ptr %2965, align 8
-  %2966 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 19
-  store %"github.com/goplus/llgo/internal/abi.Method" %2439, ptr %2966, align 8
-  %2967 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 20
-  store %"github.com/goplus/llgo/internal/abi.Method" %2450, ptr %2967, align 8
-  %2968 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 21
-  store %"github.com/goplus/llgo/internal/abi.Method" %2478, ptr %2968, align 8
-  %2969 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 22
-  store %"github.com/goplus/llgo/internal/abi.Method" %2489, ptr %2969, align 8
-  %2970 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 23
-  store %"github.com/goplus/llgo/internal/abi.Method" %2934, ptr %2970, align 8
-  %2971 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2946, i64 24
-  store %"github.com/goplus/llgo/internal/abi.Method" %2945, ptr %2971, align 8
-  %2972 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2973 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2972, i32 0, i32 0
-  store ptr %2946, ptr %2973, align 8
-  %2974 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2972, i32 0, i32 1
-  store i64 25, ptr %2974, align 4
-  %2975 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2972, i32 0, i32 2
-  store i64 25, ptr %2975, align 4
-  %2976 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2972, align 8
-  %2977 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2978 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2977, i32 0, i32 0
-  store ptr @3, ptr %2978, align 8
-  %2979 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2977, i32 0, i32 1
-  store i64 35, ptr %2979, align 4
-  %2980 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2977, align 8
-  %2981 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2982 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2981, i32 0, i32 0
-  store ptr @53, ptr %2982, align 8
-  %2983 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2981, i32 0, i32 1
-  store i64 7, ptr %2983, align 4
-  %2984 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2981, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %1807, %"github.com/goplus/llgo/internal/runtime.String" %2980, %"github.com/goplus/llgo/internal/runtime.String" %2984, ptr %2076, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %2976)
+  %2928 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  %2929 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  %2930 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
+  %2931 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2932 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2931, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2495, ptr %2932, align 8
+  %2933 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2931, i32 0, i32 1
+  store ptr %2930, ptr %2933, align 8
+  %2934 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2931, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).StructType", ptr %2934, align 8
+  %2935 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2931, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).StructType", ptr %2935, align 8
+  %2936 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2931, align 8
+  %2937 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2938 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2937, i32 0, i32 0
+  store ptr @79, ptr %2938, align 8
+  %2939 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2937, i32 0, i32 1
+  store i64 8, ptr %2939, align 4
+  %2940 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2937, align 8
+  %2941 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
+  %2942 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %2943 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2942, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2940, ptr %2943, align 8
+  %2944 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2942, i32 0, i32 1
+  store ptr %2941, ptr %2944, align 8
+  %2945 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2942, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Uncommon", ptr %2945, align 8
+  %2946 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2942, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Uncommon", ptr %2946, align 8
+  %2947 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2942, align 8
+  %2948 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 1000)
+  %2949 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %2089, ptr %2949, align 8
+  %2950 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %2101, ptr %2950, align 8
+  %2951 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 2
+  store %"github.com/goplus/llgo/internal/abi.Method" %2112, ptr %2951, align 8
+  %2952 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 3
+  store %"github.com/goplus/llgo/internal/abi.Method" %2124, ptr %2952, align 8
+  %2953 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 4
+  store %"github.com/goplus/llgo/internal/abi.Method" %2136, ptr %2953, align 8
+  %2954 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 5
+  store %"github.com/goplus/llgo/internal/abi.Method" %2147, ptr %2954, align 8
+  %2955 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 6
+  store %"github.com/goplus/llgo/internal/abi.Method" %2159, ptr %2955, align 8
+  %2956 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 7
+  store %"github.com/goplus/llgo/internal/abi.Method" %2170, ptr %2956, align 8
+  %2957 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 8
+  store %"github.com/goplus/llgo/internal/abi.Method" %2181, ptr %2957, align 8
+  %2958 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 9
+  store %"github.com/goplus/llgo/internal/abi.Method" %2192, ptr %2958, align 8
+  %2959 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 10
+  store %"github.com/goplus/llgo/internal/abi.Method" %2203, ptr %2959, align 8
+  %2960 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 11
+  store %"github.com/goplus/llgo/internal/abi.Method" %2214, ptr %2960, align 8
+  %2961 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 12
+  store %"github.com/goplus/llgo/internal/abi.Method" %2226, ptr %2961, align 8
+  %2962 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 13
+  store %"github.com/goplus/llgo/internal/abi.Method" %2237, ptr %2962, align 8
+  %2963 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 14
+  store %"github.com/goplus/llgo/internal/abi.Method" %2248, ptr %2963, align 8
+  %2964 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 15
+  store %"github.com/goplus/llgo/internal/abi.Method" %2259, ptr %2964, align 8
+  %2965 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 16
+  store %"github.com/goplus/llgo/internal/abi.Method" %2408, ptr %2965, align 8
+  %2966 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 17
+  store %"github.com/goplus/llgo/internal/abi.Method" %2419, ptr %2966, align 8
+  %2967 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 18
+  store %"github.com/goplus/llgo/internal/abi.Method" %2430, ptr %2967, align 8
+  %2968 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 19
+  store %"github.com/goplus/llgo/internal/abi.Method" %2441, ptr %2968, align 8
+  %2969 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 20
+  store %"github.com/goplus/llgo/internal/abi.Method" %2452, ptr %2969, align 8
+  %2970 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 21
+  store %"github.com/goplus/llgo/internal/abi.Method" %2480, ptr %2970, align 8
+  %2971 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 22
+  store %"github.com/goplus/llgo/internal/abi.Method" %2491, ptr %2971, align 8
+  %2972 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 23
+  store %"github.com/goplus/llgo/internal/abi.Method" %2936, ptr %2972, align 8
+  %2973 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2948, i64 24
+  store %"github.com/goplus/llgo/internal/abi.Method" %2947, ptr %2973, align 8
+  %2974 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %2975 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2974, i32 0, i32 0
+  store ptr %2948, ptr %2975, align 8
+  %2976 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2974, i32 0, i32 1
+  store i64 25, ptr %2976, align 4
+  %2977 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2974, i32 0, i32 2
+  store i64 25, ptr %2977, align 4
+  %2978 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2974, align 8
+  %2979 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2980 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2979, i32 0, i32 0
+  store ptr @3, ptr %2980, align 8
+  %2981 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2979, i32 0, i32 1
+  store i64 35, ptr %2981, align 4
+  %2982 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2979, align 8
+  %2983 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %2984 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2983, i32 0, i32 0
+  store ptr @53, ptr %2984, align 8
+  %2985 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2983, i32 0, i32 1
+  store i64 7, ptr %2985, align 4
+  %2986 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2983, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %1809, %"github.com/goplus/llgo/internal/runtime.String" %2982, %"github.com/goplus/llgo/internal/runtime.String" %2986, ptr %2078, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %2978)
   br label %_llgo_110
 
 _llgo_131:                                        ; preds = %_llgo_129
-  %2985 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %2923)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %2985)
-  store ptr %2985, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  %2987 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %2925)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %2987)
+  store ptr %2987, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
   br label %_llgo_132
 
 _llgo_132:                                        ; preds = %_llgo_131, %_llgo_129
-  %2986 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
-  %2987 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
-  %2988 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
-  %2989 = icmp eq ptr %2988, null
-  br i1 %2989, label %_llgo_133, label %_llgo_134
+  %2988 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  %2989 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  %2990 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
+  %2991 = icmp eq ptr %2990, null
+  br i1 %2991, label %_llgo_133, label %_llgo_134
 
 _llgo_133:                                        ; preds = %_llgo_132
-  %2990 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %2991 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2992 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2991, i32 0, i32 0
-  store ptr %2990, ptr %2992, align 8
-  %2993 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2991, i32 0, i32 1
-  store i64 0, ptr %2993, align 4
-  %2994 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2991, i32 0, i32 2
-  store i64 0, ptr %2994, align 4
-  %2995 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2991, align 8
-  %2996 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %2997 = getelementptr ptr, ptr %2996, i64 0
-  store ptr %2987, ptr %2997, align 8
-  %2998 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2999 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2998, i32 0, i32 0
-  store ptr %2996, ptr %2999, align 8
-  %3000 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2998, i32 0, i32 1
-  store i64 1, ptr %3000, align 4
-  %3001 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2998, i32 0, i32 2
-  store i64 1, ptr %3001, align 4
-  %3002 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2998, align 8
-  %3003 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %2995, %"github.com/goplus/llgo/internal/runtime.Slice" %3002, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %3003)
-  store ptr %3003, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
+  %2992 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %2993 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %2994 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2993, i32 0, i32 0
+  store ptr %2992, ptr %2994, align 8
+  %2995 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2993, i32 0, i32 1
+  store i64 0, ptr %2995, align 4
+  %2996 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2993, i32 0, i32 2
+  store i64 0, ptr %2996, align 4
+  %2997 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2993, align 8
+  %2998 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %2999 = getelementptr ptr, ptr %2998, i64 0
+  store ptr %2989, ptr %2999, align 8
+  %3000 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %3001 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3000, i32 0, i32 0
+  store ptr %2998, ptr %3001, align 8
+  %3002 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3000, i32 0, i32 1
+  store i64 1, ptr %3002, align 4
+  %3003 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3000, i32 0, i32 2
+  store i64 1, ptr %3003, align 4
+  %3004 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3000, align 8
+  %3005 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %2997, %"github.com/goplus/llgo/internal/runtime.Slice" %3004, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %3005)
+  store ptr %3005, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
   br label %_llgo_134
 
 _llgo_134:                                        ; preds = %_llgo_133, %_llgo_132
-  %3004 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
-  %3005 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3006 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3005, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2918, ptr %3006, align 8
-  %3007 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3005, i32 0, i32 1
-  store ptr %3004, ptr %3007, align 8
-  %3008 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3005, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).StructType", ptr %3008, align 8
-  %3009 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3005, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).StructType", ptr %3009, align 8
-  %3010 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3005, align 8
-  %3011 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3012 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3011, i32 0, i32 0
-  store ptr @79, ptr %3012, align 8
-  %3013 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3011, i32 0, i32 1
-  store i64 8, ptr %3013, align 4
-  %3014 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3011, align 8
-  %3015 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3016 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3015, i32 0, i32 0
-  store ptr @80, ptr %3016, align 8
-  %3017 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3015, i32 0, i32 1
-  store i64 48, ptr %3017, align 4
-  %3018 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3015, align 8
-  %3019 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3018, i64 25, i64 24, i64 0, i64 2)
-  %3020 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
-  %3021 = icmp eq ptr %3020, null
-  br i1 %3021, label %_llgo_135, label %_llgo_136
+  %3006 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
+  %3007 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %3008 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3007, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %2920, ptr %3008, align 8
+  %3009 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3007, i32 0, i32 1
+  store ptr %3006, ptr %3009, align 8
+  %3010 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3007, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).StructType", ptr %3010, align 8
+  %3011 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3007, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).StructType", ptr %3011, align 8
+  %3012 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3007, align 8
+  %3013 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3014 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3013, i32 0, i32 0
+  store ptr @79, ptr %3014, align 8
+  %3015 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3013, i32 0, i32 1
+  store i64 8, ptr %3015, align 4
+  %3016 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3013, align 8
+  %3017 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3018 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3017, i32 0, i32 0
+  store ptr @80, ptr %3018, align 8
+  %3019 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3017, i32 0, i32 1
+  store i64 48, ptr %3019, align 4
+  %3020 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3017, align 8
+  %3021 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3020, i64 25, i64 24, i64 0, i64 2)
+  %3022 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
+  %3023 = icmp eq ptr %3022, null
+  br i1 %3023, label %_llgo_135, label %_llgo_136
 
 _llgo_135:                                        ; preds = %_llgo_134
-  store ptr %3019, ptr @"_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
+  store ptr %3021, ptr @"_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
   br label %_llgo_136
 
 _llgo_136:                                        ; preds = %_llgo_135, %_llgo_134
-  %3022 = load ptr, ptr @"_llgo_struct$OKIlItfBJsawrEMnVSc2VQ7pxNxCHIgSoitcM9n4FVI", align 8
-  %3023 = icmp eq ptr %3022, null
-  br i1 %3023, label %_llgo_137, label %_llgo_138
+  %3024 = load ptr, ptr @"_llgo_struct$OKIlItfBJsawrEMnVSc2VQ7pxNxCHIgSoitcM9n4FVI", align 8
+  %3025 = icmp eq ptr %3024, null
+  br i1 %3025, label %_llgo_137, label %_llgo_138
 
 _llgo_137:                                        ; preds = %_llgo_136
-  %3024 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3025 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3024, i32 0, i32 0
-  store ptr @46, ptr %3025, align 8
-  %3026 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3024, i32 0, i32 1
-  store i64 8, ptr %3026, align 4
-  %3027 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3024, align 8
-  %3028 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3029 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3028, i32 0, i32 0
-  store ptr null, ptr %3029, align 8
-  %3030 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3028, i32 0, i32 1
-  store i64 0, ptr %3030, align 4
-  %3031 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3028, align 8
-  %3032 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %3033 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3027, ptr %3032, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %3031, i1 false)
-  %3034 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3035 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3034, i32 0, i32 0
-  store ptr @81, ptr %3035, align 8
-  %3036 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3034, i32 0, i32 1
-  store i64 6, ptr %3036, align 4
-  %3037 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3034, align 8
-  %3038 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3039 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3038, i32 0, i32 0
-  store ptr null, ptr %3039, align 8
-  %3040 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3038, i32 0, i32 1
-  store i64 0, ptr %3040, align 4
-  %3041 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3038, align 8
-  %3042 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 41)
-  %3043 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3037, ptr %3042, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %3041, i1 false)
-  %3044 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3045 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3044, i32 0, i32 0
-  store ptr @82, ptr %3045, align 8
-  %3046 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3044, i32 0, i32 1
-  store i64 6, ptr %3046, align 4
-  %3047 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3044, align 8
-  %3048 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3049 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3048, i32 0, i32 0
-  store ptr null, ptr %3049, align 8
-  %3050 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3048, i32 0, i32 1
-  store i64 0, ptr %3050, align 4
-  %3051 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3048, align 8
-  %3052 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 41)
-  %3053 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3047, ptr %3052, i64 18, %"github.com/goplus/llgo/internal/runtime.String" %3051, i1 false)
-  %3054 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3055 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3054, i32 0, i32 0
-  store ptr @83, ptr %3055, align 8
-  %3056 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3054, i32 0, i32 1
-  store i64 4, ptr %3056, align 4
-  %3057 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3054, align 8
-  %3058 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3059 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3058, i32 0, i32 0
-  store ptr null, ptr %3059, align 8
-  %3060 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3058, i32 0, i32 1
-  store i64 0, ptr %3060, align 4
-  %3061 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3058, align 8
-  %3062 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 42)
-  %3063 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3057, ptr %3062, i64 20, %"github.com/goplus/llgo/internal/runtime.String" %3061, i1 false)
-  %3064 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3065 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3064, i32 0, i32 0
-  store ptr @7, ptr %3065, align 8
-  %3066 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3064, i32 0, i32 1
-  store i64 4, ptr %3066, align 4
-  %3067 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3064, align 8
-  %3068 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
-  %3069 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3068, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3033, ptr %3069, align 8
-  %3070 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3068, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3043, ptr %3070, align 8
-  %3071 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3068, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3053, ptr %3071, align 8
-  %3072 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3068, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3063, ptr %3072, align 8
-  %3073 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %3074 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3073, i32 0, i32 0
-  store ptr %3068, ptr %3074, align 8
-  %3075 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3073, i32 0, i32 1
-  store i64 4, ptr %3075, align 4
-  %3076 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3073, i32 0, i32 2
-  store i64 4, ptr %3076, align 4
-  %3077 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3073, align 8
-  %3078 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %3067, i64 24, %"github.com/goplus/llgo/internal/runtime.Slice" %3077)
-  store ptr %3078, ptr @"_llgo_struct$OKIlItfBJsawrEMnVSc2VQ7pxNxCHIgSoitcM9n4FVI", align 8
+  %3026 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3027 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3026, i32 0, i32 0
+  store ptr @46, ptr %3027, align 8
+  %3028 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3026, i32 0, i32 1
+  store i64 8, ptr %3028, align 4
+  %3029 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3026, align 8
+  %3030 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3031 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3030, i32 0, i32 0
+  store ptr null, ptr %3031, align 8
+  %3032 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3030, i32 0, i32 1
+  store i64 0, ptr %3032, align 4
+  %3033 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3030, align 8
+  %3034 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %3035 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3029, ptr %3034, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %3033, i1 false)
+  %3036 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3037 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3036, i32 0, i32 0
+  store ptr @81, ptr %3037, align 8
+  %3038 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3036, i32 0, i32 1
+  store i64 6, ptr %3038, align 4
+  %3039 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3036, align 8
+  %3040 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3041 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3040, i32 0, i32 0
+  store ptr null, ptr %3041, align 8
+  %3042 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3040, i32 0, i32 1
+  store i64 0, ptr %3042, align 4
+  %3043 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3040, align 8
+  %3044 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 41)
+  %3045 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3039, ptr %3044, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %3043, i1 false)
+  %3046 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3047 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3046, i32 0, i32 0
+  store ptr @82, ptr %3047, align 8
+  %3048 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3046, i32 0, i32 1
+  store i64 6, ptr %3048, align 4
+  %3049 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3046, align 8
+  %3050 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3051 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3050, i32 0, i32 0
+  store ptr null, ptr %3051, align 8
+  %3052 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3050, i32 0, i32 1
+  store i64 0, ptr %3052, align 4
+  %3053 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3050, align 8
+  %3054 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 41)
+  %3055 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3049, ptr %3054, i64 18, %"github.com/goplus/llgo/internal/runtime.String" %3053, i1 false)
+  %3056 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3057 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3056, i32 0, i32 0
+  store ptr @83, ptr %3057, align 8
+  %3058 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3056, i32 0, i32 1
+  store i64 4, ptr %3058, align 4
+  %3059 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3056, align 8
+  %3060 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3061 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3060, i32 0, i32 0
+  store ptr null, ptr %3061, align 8
+  %3062 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3060, i32 0, i32 1
+  store i64 0, ptr %3062, align 4
+  %3063 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3060, align 8
+  %3064 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 42)
+  %3065 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3059, ptr %3064, i64 20, %"github.com/goplus/llgo/internal/runtime.String" %3063, i1 false)
+  %3066 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3067 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3066, i32 0, i32 0
+  store ptr @7, ptr %3067, align 8
+  %3068 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3066, i32 0, i32 1
+  store i64 4, ptr %3068, align 4
+  %3069 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3066, align 8
+  %3070 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
+  %3071 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3070, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %3035, ptr %3071, align 8
+  %3072 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3070, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %3045, ptr %3072, align 8
+  %3073 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3070, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %3055, ptr %3073, align 8
+  %3074 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3070, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %3065, ptr %3074, align 8
+  %3075 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %3076 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3075, i32 0, i32 0
+  store ptr %3070, ptr %3076, align 8
+  %3077 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3075, i32 0, i32 1
+  store i64 4, ptr %3077, align 4
+  %3078 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3075, i32 0, i32 2
+  store i64 4, ptr %3078, align 4
+  %3079 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3075, align 8
+  %3080 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %3069, i64 24, %"github.com/goplus/llgo/internal/runtime.Slice" %3079)
+  store ptr %3080, ptr @"_llgo_struct$OKIlItfBJsawrEMnVSc2VQ7pxNxCHIgSoitcM9n4FVI", align 8
   br label %_llgo_138
 
 _llgo_138:                                        ; preds = %_llgo_137, %_llgo_136
-  %3079 = load ptr, ptr @"_llgo_struct$OKIlItfBJsawrEMnVSc2VQ7pxNxCHIgSoitcM9n4FVI", align 8
-  br i1 %3021, label %_llgo_139, label %_llgo_140
+  %3081 = load ptr, ptr @"_llgo_struct$OKIlItfBJsawrEMnVSc2VQ7pxNxCHIgSoitcM9n4FVI", align 8
+  br i1 %3023, label %_llgo_139, label %_llgo_140
 
 _llgo_139:                                        ; preds = %_llgo_138
-  %3080 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3081 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3080, i32 0, i32 0
-  store ptr @28, ptr %3081, align 8
-  %3082 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3080, i32 0, i32 1
-  store i64 15, ptr %3082, align 4
-  %3083 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3080, align 8
-  %3084 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %3085 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
-  %3086 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3087 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3086, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3083, ptr %3087, align 8
-  %3088 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3086, i32 0, i32 1
-  store ptr %3085, ptr %3088, align 8
-  %3089 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3086, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*UncommonType).ExportedMethods", ptr %3089, align 8
-  %3090 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3086, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*UncommonType).ExportedMethods", ptr %3090, align 8
-  %3091 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3086, align 8
-  %3092 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3093 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3092, i32 0, i32 0
-  store ptr @47, ptr %3093, align 8
-  %3094 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3092, i32 0, i32 1
-  store i64 7, ptr %3094, align 4
-  %3095 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3092, align 8
-  %3096 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %3097 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
-  %3098 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3099 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3098, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3095, ptr %3099, align 8
-  %3100 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3098, i32 0, i32 1
-  store ptr %3097, ptr %3100, align 8
-  %3101 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3098, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*UncommonType).Methods", ptr %3101, align 8
-  %3102 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3098, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*UncommonType).Methods", ptr %3102, align 8
-  %3103 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3098, align 8
-  %3104 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
-  %3105 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3104, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %3091, ptr %3105, align 8
-  %3106 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3104, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %3103, ptr %3106, align 8
-  %3107 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %3108 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3107, i32 0, i32 0
-  store ptr %3104, ptr %3108, align 8
-  %3109 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3107, i32 0, i32 1
-  store i64 2, ptr %3109, align 4
-  %3110 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3107, i32 0, i32 2
-  store i64 2, ptr %3110, align 4
-  %3111 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3107, align 8
-  %3112 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3113 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3112, i32 0, i32 0
-  store ptr @3, ptr %3113, align 8
-  %3114 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3112, i32 0, i32 1
-  store i64 35, ptr %3114, align 4
-  %3115 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3112, align 8
-  %3116 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3117 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3116, i32 0, i32 0
-  store ptr @84, ptr %3117, align 8
-  %3118 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3116, i32 0, i32 1
-  store i64 12, ptr %3118, align 4
-  %3119 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3116, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %3019, %"github.com/goplus/llgo/internal/runtime.String" %3115, %"github.com/goplus/llgo/internal/runtime.String" %3119, ptr %3079, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %3111)
+  %3082 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3083 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3082, i32 0, i32 0
+  store ptr @28, ptr %3083, align 8
+  %3084 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3082, i32 0, i32 1
+  store i64 15, ptr %3084, align 4
+  %3085 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3082, align 8
+  %3086 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %3087 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
+  %3088 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %3089 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3088, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %3085, ptr %3089, align 8
+  %3090 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3088, i32 0, i32 1
+  store ptr %3087, ptr %3090, align 8
+  %3091 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3088, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*UncommonType).ExportedMethods", ptr %3091, align 8
+  %3092 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3088, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*UncommonType).ExportedMethods", ptr %3092, align 8
+  %3093 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3088, align 8
+  %3094 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3095 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3094, i32 0, i32 0
+  store ptr @47, ptr %3095, align 8
+  %3096 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3094, i32 0, i32 1
+  store i64 7, ptr %3096, align 4
+  %3097 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3094, align 8
+  %3098 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %3099 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
+  %3100 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %3101 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3100, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %3097, ptr %3101, align 8
+  %3102 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3100, i32 0, i32 1
+  store ptr %3099, ptr %3102, align 8
+  %3103 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3100, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*UncommonType).Methods", ptr %3103, align 8
+  %3104 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3100, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*UncommonType).Methods", ptr %3104, align 8
+  %3105 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3100, align 8
+  %3106 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
+  %3107 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3106, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %3093, ptr %3107, align 8
+  %3108 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3106, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %3105, ptr %3108, align 8
+  %3109 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %3110 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3109, i32 0, i32 0
+  store ptr %3106, ptr %3110, align 8
+  %3111 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3109, i32 0, i32 1
+  store i64 2, ptr %3111, align 4
+  %3112 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3109, i32 0, i32 2
+  store i64 2, ptr %3112, align 4
+  %3113 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3109, align 8
+  %3114 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3115 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3114, i32 0, i32 0
+  store ptr @3, ptr %3115, align 8
+  %3116 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3114, i32 0, i32 1
+  store i64 35, ptr %3116, align 4
+  %3117 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3114, align 8
+  %3118 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3119 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3118, i32 0, i32 0
+  store ptr @84, ptr %3119, align 8
+  %3120 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3118, i32 0, i32 1
+  store i64 12, ptr %3120, align 4
+  %3121 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3118, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %3021, %"github.com/goplus/llgo/internal/runtime.String" %3117, %"github.com/goplus/llgo/internal/runtime.String" %3121, ptr %3081, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %3113)
   br label %_llgo_140
 
 _llgo_140:                                        ; preds = %_llgo_139, %_llgo_138
-  %3120 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
-  %3121 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3122 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3121, i32 0, i32 0
-  store ptr @80, ptr %3122, align 8
-  %3123 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3121, i32 0, i32 1
-  store i64 48, ptr %3123, align 4
-  %3124 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3121, align 8
-  %3125 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3124, i64 25, i64 24, i64 0, i64 2)
-  %3126 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
-  %3127 = icmp eq ptr %3126, null
-  br i1 %3127, label %_llgo_141, label %_llgo_142
+  %3122 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
+  %3123 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3124 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3123, i32 0, i32 0
+  store ptr @80, ptr %3124, align 8
+  %3125 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3123, i32 0, i32 1
+  store i64 48, ptr %3125, align 4
+  %3126 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3123, align 8
+  %3127 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3126, i64 25, i64 24, i64 0, i64 2)
+  %3128 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
+  %3129 = icmp eq ptr %3128, null
+  br i1 %3129, label %_llgo_141, label %_llgo_142
 
 _llgo_141:                                        ; preds = %_llgo_140
-  %3128 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %3125)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %3128)
-  store ptr %3128, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
+  %3130 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %3127)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %3130)
+  store ptr %3130, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
   br label %_llgo_142
 
 _llgo_142:                                        ; preds = %_llgo_141, %_llgo_140
-  %3129 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
-  %3130 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
-  %3131 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
-  %3132 = icmp eq ptr %3131, null
-  br i1 %3132, label %_llgo_143, label %_llgo_144
+  %3131 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
+  %3132 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
+  %3133 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
+  %3134 = icmp eq ptr %3133, null
+  br i1 %3134, label %_llgo_143, label %_llgo_144
 
 _llgo_143:                                        ; preds = %_llgo_142
-  %3133 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %3134 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %3135 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3134, i32 0, i32 0
-  store ptr %3133, ptr %3135, align 8
-  %3136 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3134, i32 0, i32 1
-  store i64 0, ptr %3136, align 4
-  %3137 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3134, i32 0, i32 2
-  store i64 0, ptr %3137, align 4
-  %3138 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3134, align 8
-  %3139 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %3140 = getelementptr ptr, ptr %3139, i64 0
-  store ptr %3130, ptr %3140, align 8
-  %3141 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %3142 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3141, i32 0, i32 0
-  store ptr %3139, ptr %3142, align 8
-  %3143 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3141, i32 0, i32 1
-  store i64 1, ptr %3143, align 4
-  %3144 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3141, i32 0, i32 2
-  store i64 1, ptr %3144, align 4
-  %3145 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3141, align 8
-  %3146 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %3138, %"github.com/goplus/llgo/internal/runtime.Slice" %3145, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %3146)
-  store ptr %3146, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
+  %3135 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %3136 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %3137 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3136, i32 0, i32 0
+  store ptr %3135, ptr %3137, align 8
+  %3138 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3136, i32 0, i32 1
+  store i64 0, ptr %3138, align 4
+  %3139 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3136, i32 0, i32 2
+  store i64 0, ptr %3139, align 4
+  %3140 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3136, align 8
+  %3141 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %3142 = getelementptr ptr, ptr %3141, i64 0
+  store ptr %3132, ptr %3142, align 8
+  %3143 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %3144 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3143, i32 0, i32 0
+  store ptr %3141, ptr %3144, align 8
+  %3145 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3143, i32 0, i32 1
+  store i64 1, ptr %3145, align 4
+  %3146 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3143, i32 0, i32 2
+  store i64 1, ptr %3146, align 4
+  %3147 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3143, align 8
+  %3148 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %3140, %"github.com/goplus/llgo/internal/runtime.Slice" %3147, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %3148)
+  store ptr %3148, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
   br label %_llgo_144
 
 _llgo_144:                                        ; preds = %_llgo_143, %_llgo_142
-  %3147 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
-  %3148 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3149 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3148, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3014, ptr %3149, align 8
-  %3150 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3148, i32 0, i32 1
-  store ptr %3147, ptr %3150, align 8
-  %3151 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3148, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Uncommon", ptr %3151, align 8
-  %3152 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3148, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Uncommon", ptr %3152, align 8
-  %3153 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3148, align 8
-  %3154 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 880)
-  %3155 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3154, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %2697, ptr %3155, align 8
-  %3156 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3154, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %2709, ptr %3156, align 8
-  %3157 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3154, i64 2
-  store %"github.com/goplus/llgo/internal/abi.Method" %2720, ptr %3157, align 8
-  %3158 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3154, i64 3
-  store %"github.com/goplus/llgo/internal/abi.Method" %2732, ptr %3158, align 8
-  %3159 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3154, i64 4
-  store %"github.com/goplus/llgo/internal/abi.Method" %2744, ptr %3159, align 8
-  %3160 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3154, i64 5
-  store %"github.com/goplus/llgo/internal/abi.Method" %2756, ptr %3160, align 8
-  %3161 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3154, i64 6
-  store %"github.com/goplus/llgo/internal/abi.Method" %2767, ptr %3161, align 8
-  %3162 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3154, i64 7
-  store %"github.com/goplus/llgo/internal/abi.Method" %2779, ptr %3162, align 8
-  %3163 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3154, i64 8
-  store %"github.com/goplus/llgo/internal/abi.Method" %2790, ptr %3163, align 8
-  %3164 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3154, i64 9
-  store %"github.com/goplus/llgo/internal/abi.Method" %2801, ptr %3164, align 8
-  %3165 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3154, i64 10
-  store %"github.com/goplus/llgo/internal/abi.Method" %2813, ptr %3165, align 8
-  %3166 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3154, i64 11
-  store %"github.com/goplus/llgo/internal/abi.Method" %2824, ptr %3166, align 8
-  %3167 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3154, i64 12
-  store %"github.com/goplus/llgo/internal/abi.Method" %2836, ptr %3167, align 8
-  %3168 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3154, i64 13
-  store %"github.com/goplus/llgo/internal/abi.Method" %2847, ptr %3168, align 8
-  %3169 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3154, i64 14
-  store %"github.com/goplus/llgo/internal/abi.Method" %2858, ptr %3169, align 8
-  %3170 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3154, i64 15
-  store %"github.com/goplus/llgo/internal/abi.Method" %2870, ptr %3170, align 8
-  %3171 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3154, i64 16
-  store %"github.com/goplus/llgo/internal/abi.Method" %2881, ptr %3171, align 8
-  %3172 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3154, i64 17
-  store %"github.com/goplus/llgo/internal/abi.Method" %2892, ptr %3172, align 8
-  %3173 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3154, i64 18
-  store %"github.com/goplus/llgo/internal/abi.Method" %2903, ptr %3173, align 8
-  %3174 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3154, i64 19
-  store %"github.com/goplus/llgo/internal/abi.Method" %2914, ptr %3174, align 8
-  %3175 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3154, i64 20
-  store %"github.com/goplus/llgo/internal/abi.Method" %3010, ptr %3175, align 8
-  %3176 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3154, i64 21
-  store %"github.com/goplus/llgo/internal/abi.Method" %3153, ptr %3176, align 8
-  %3177 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %3178 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3177, i32 0, i32 0
-  store ptr %3154, ptr %3178, align 8
-  %3179 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3177, i32 0, i32 1
-  store i64 22, ptr %3179, align 4
-  %3180 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3177, i32 0, i32 2
-  store i64 22, ptr %3180, align 4
-  %3181 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3177, align 8
-  %3182 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3183 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3182, i32 0, i32 0
-  store ptr @3, ptr %3183, align 8
-  %3184 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3182, i32 0, i32 1
-  store i64 35, ptr %3184, align 4
-  %3185 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3182, align 8
-  %3186 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3187 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3186, i32 0, i32 0
-  store ptr @69, ptr %3187, align 8
-  %3188 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3186, i32 0, i32 1
-  store i64 10, ptr %3188, align 4
-  %3189 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3186, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %2498, %"github.com/goplus/llgo/internal/runtime.String" %3185, %"github.com/goplus/llgo/internal/runtime.String" %3189, ptr %2686, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %3181)
+  %3149 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
+  %3150 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %3151 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3150, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %3016, ptr %3151, align 8
+  %3152 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3150, i32 0, i32 1
+  store ptr %3149, ptr %3152, align 8
+  %3153 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3150, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Uncommon", ptr %3153, align 8
+  %3154 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3150, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Uncommon", ptr %3154, align 8
+  %3155 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3150, align 8
+  %3156 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 880)
+  %3157 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3156, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %2699, ptr %3157, align 8
+  %3158 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3156, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %2711, ptr %3158, align 8
+  %3159 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3156, i64 2
+  store %"github.com/goplus/llgo/internal/abi.Method" %2722, ptr %3159, align 8
+  %3160 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3156, i64 3
+  store %"github.com/goplus/llgo/internal/abi.Method" %2734, ptr %3160, align 8
+  %3161 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3156, i64 4
+  store %"github.com/goplus/llgo/internal/abi.Method" %2746, ptr %3161, align 8
+  %3162 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3156, i64 5
+  store %"github.com/goplus/llgo/internal/abi.Method" %2758, ptr %3162, align 8
+  %3163 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3156, i64 6
+  store %"github.com/goplus/llgo/internal/abi.Method" %2769, ptr %3163, align 8
+  %3164 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3156, i64 7
+  store %"github.com/goplus/llgo/internal/abi.Method" %2781, ptr %3164, align 8
+  %3165 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3156, i64 8
+  store %"github.com/goplus/llgo/internal/abi.Method" %2792, ptr %3165, align 8
+  %3166 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3156, i64 9
+  store %"github.com/goplus/llgo/internal/abi.Method" %2803, ptr %3166, align 8
+  %3167 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3156, i64 10
+  store %"github.com/goplus/llgo/internal/abi.Method" %2815, ptr %3167, align 8
+  %3168 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3156, i64 11
+  store %"github.com/goplus/llgo/internal/abi.Method" %2826, ptr %3168, align 8
+  %3169 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3156, i64 12
+  store %"github.com/goplus/llgo/internal/abi.Method" %2838, ptr %3169, align 8
+  %3170 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3156, i64 13
+  store %"github.com/goplus/llgo/internal/abi.Method" %2849, ptr %3170, align 8
+  %3171 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3156, i64 14
+  store %"github.com/goplus/llgo/internal/abi.Method" %2860, ptr %3171, align 8
+  %3172 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3156, i64 15
+  store %"github.com/goplus/llgo/internal/abi.Method" %2872, ptr %3172, align 8
+  %3173 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3156, i64 16
+  store %"github.com/goplus/llgo/internal/abi.Method" %2883, ptr %3173, align 8
+  %3174 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3156, i64 17
+  store %"github.com/goplus/llgo/internal/abi.Method" %2894, ptr %3174, align 8
+  %3175 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3156, i64 18
+  store %"github.com/goplus/llgo/internal/abi.Method" %2905, ptr %3175, align 8
+  %3176 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3156, i64 19
+  store %"github.com/goplus/llgo/internal/abi.Method" %2916, ptr %3176, align 8
+  %3177 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3156, i64 20
+  store %"github.com/goplus/llgo/internal/abi.Method" %3012, ptr %3177, align 8
+  %3178 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3156, i64 21
+  store %"github.com/goplus/llgo/internal/abi.Method" %3155, ptr %3178, align 8
+  %3179 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %3180 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3179, i32 0, i32 0
+  store ptr %3156, ptr %3180, align 8
+  %3181 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3179, i32 0, i32 1
+  store i64 22, ptr %3181, align 4
+  %3182 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3179, i32 0, i32 2
+  store i64 22, ptr %3182, align 4
+  %3183 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3179, align 8
+  %3184 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3185 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3184, i32 0, i32 0
+  store ptr @3, ptr %3185, align 8
+  %3186 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3184, i32 0, i32 1
+  store i64 35, ptr %3186, align 4
+  %3187 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3184, align 8
+  %3188 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3189 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3188, i32 0, i32 0
+  store ptr @69, ptr %3189, align 8
+  %3190 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3188, i32 0, i32 1
+  store i64 10, ptr %3190, align 4
+  %3191 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3188, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %2500, %"github.com/goplus/llgo/internal/runtime.String" %3187, %"github.com/goplus/llgo/internal/runtime.String" %3191, ptr %2688, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %3183)
   br label %_llgo_130
 
 _llgo_145:                                        ; preds = %_llgo_64
-  %3190 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3191 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3190, i32 0, i32 0
-  store ptr @40, ptr %3191, align 8
-  %3192 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3190, i32 0, i32 1
-  store i64 5, ptr %3192, align 4
-  %3193 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3190, align 8
-  %3194 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3195 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3194, i32 0, i32 0
-  store ptr null, ptr %3195, align 8
-  %3196 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3194, i32 0, i32 1
-  store i64 0, ptr %3196, align 4
-  %3197 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3194, align 8
-  %3198 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %3199 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3193, ptr %3198, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %3197, i1 false)
-  %3200 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3201 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3200, i32 0, i32 0
-  store ptr @86, ptr %3201, align 8
-  %3202 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3200, i32 0, i32 1
-  store i64 5, ptr %3202, align 4
-  %3203 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3200, align 8
-  %3204 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3205 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3204, i32 0, i32 0
-  store ptr null, ptr %3205, align 8
-  %3206 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3204, i32 0, i32 1
-  store i64 0, ptr %3206, align 4
-  %3207 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3204, align 8
-  %3208 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1044)
-  %3209 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3203, ptr %3208, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %3207, i1 false)
-  %3210 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3211 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3210, i32 0, i32 0
-  store ptr @87, ptr %3211, align 8
-  %3212 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3210, i32 0, i32 1
-  store i64 4, ptr %3212, align 4
-  %3213 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3210, align 8
-  %3214 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3215 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3214, i32 0, i32 0
-  store ptr null, ptr %3215, align 8
-  %3216 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3214, i32 0, i32 1
-  store i64 0, ptr %3216, align 4
-  %3217 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3214, align 8
-  %3218 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %3219 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3213, ptr %3218, i64 24, %"github.com/goplus/llgo/internal/runtime.String" %3217, i1 false)
-  %3220 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3221 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3220, i32 0, i32 0
-  store ptr @88, ptr %3221, align 8
-  %3222 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3220, i32 0, i32 1
-  store i64 4, ptr %3222, align 4
-  %3223 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3220, align 8
-  %3224 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3225 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3224, i32 0, i32 0
-  store ptr null, ptr %3225, align 8
-  %3226 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3224, i32 0, i32 1
-  store i64 0, ptr %3226, align 4
-  %3227 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3224, align 8
-  %3228 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %3229 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3223, ptr %3228, i64 32, %"github.com/goplus/llgo/internal/runtime.String" %3227, i1 false)
-  %3230 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3231 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3230, i32 0, i32 0
-  store ptr @7, ptr %3231, align 8
-  %3232 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3230, i32 0, i32 1
-  store i64 4, ptr %3232, align 4
-  %3233 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3230, align 8
-  %3234 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
-  %3235 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3234, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3199, ptr %3235, align 8
-  %3236 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3234, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3209, ptr %3236, align 8
-  %3237 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3234, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3219, ptr %3237, align 8
-  %3238 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3234, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3229, ptr %3238, align 8
-  %3239 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %3240 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3239, i32 0, i32 0
-  store ptr %3234, ptr %3240, align 8
-  %3241 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3239, i32 0, i32 1
-  store i64 4, ptr %3241, align 4
-  %3242 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3239, i32 0, i32 2
-  store i64 4, ptr %3242, align 4
-  %3243 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3239, align 8
-  %3244 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %3233, i64 40, %"github.com/goplus/llgo/internal/runtime.Slice" %3243)
-  store ptr %3244, ptr @"_llgo_struct$SDp3TNnYnxb26MhB1v8VMbmY71BX77YOaY7lgS1cFx0", align 8
+  %3192 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3193 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3192, i32 0, i32 0
+  store ptr @40, ptr %3193, align 8
+  %3194 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3192, i32 0, i32 1
+  store i64 5, ptr %3194, align 4
+  %3195 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3192, align 8
+  %3196 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3197 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3196, i32 0, i32 0
+  store ptr null, ptr %3197, align 8
+  %3198 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3196, i32 0, i32 1
+  store i64 0, ptr %3198, align 4
+  %3199 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3196, align 8
+  %3200 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %3201 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3195, ptr %3200, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %3199, i1 false)
+  %3202 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3203 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3202, i32 0, i32 0
+  store ptr @86, ptr %3203, align 8
+  %3204 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3202, i32 0, i32 1
+  store i64 5, ptr %3204, align 4
+  %3205 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3202, align 8
+  %3206 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3207 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3206, i32 0, i32 0
+  store ptr null, ptr %3207, align 8
+  %3208 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3206, i32 0, i32 1
+  store i64 0, ptr %3208, align 4
+  %3209 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3206, align 8
+  %3210 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1046)
+  %3211 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3205, ptr %3210, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %3209, i1 false)
+  %3212 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3213 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3212, i32 0, i32 0
+  store ptr @87, ptr %3213, align 8
+  %3214 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3212, i32 0, i32 1
+  store i64 4, ptr %3214, align 4
+  %3215 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3212, align 8
+  %3216 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3217 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3216, i32 0, i32 0
+  store ptr null, ptr %3217, align 8
+  %3218 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3216, i32 0, i32 1
+  store i64 0, ptr %3218, align 4
+  %3219 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3216, align 8
+  %3220 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %3221 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3215, ptr %3220, i64 24, %"github.com/goplus/llgo/internal/runtime.String" %3219, i1 false)
+  %3222 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3223 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3222, i32 0, i32 0
+  store ptr @88, ptr %3223, align 8
+  %3224 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3222, i32 0, i32 1
+  store i64 4, ptr %3224, align 4
+  %3225 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3222, align 8
+  %3226 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3227 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3226, i32 0, i32 0
+  store ptr null, ptr %3227, align 8
+  %3228 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3226, i32 0, i32 1
+  store i64 0, ptr %3228, align 4
+  %3229 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3226, align 8
+  %3230 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %3231 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3225, ptr %3230, i64 32, %"github.com/goplus/llgo/internal/runtime.String" %3229, i1 false)
+  %3232 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3233 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3232, i32 0, i32 0
+  store ptr @7, ptr %3233, align 8
+  %3234 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3232, i32 0, i32 1
+  store i64 4, ptr %3234, align 4
+  %3235 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3232, align 8
+  %3236 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
+  %3237 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3236, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %3201, ptr %3237, align 8
+  %3238 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3236, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %3211, ptr %3238, align 8
+  %3239 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3236, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %3221, ptr %3239, align 8
+  %3240 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3236, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %3231, ptr %3240, align 8
+  %3241 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %3242 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3241, i32 0, i32 0
+  store ptr %3236, ptr %3242, align 8
+  %3243 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3241, i32 0, i32 1
+  store i64 4, ptr %3243, align 4
+  %3244 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3241, i32 0, i32 2
+  store i64 4, ptr %3244, align 4
+  %3245 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3241, align 8
+  %3246 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %3235, i64 40, %"github.com/goplus/llgo/internal/runtime.Slice" %3245)
+  store ptr %3246, ptr @"_llgo_struct$SDp3TNnYnxb26MhB1v8VMbmY71BX77YOaY7lgS1cFx0", align 8
   br label %_llgo_146
 
 _llgo_146:                                        ; preds = %_llgo_145, %_llgo_64
-  %3245 = load ptr, ptr @"_llgo_struct$SDp3TNnYnxb26MhB1v8VMbmY71BX77YOaY7lgS1cFx0", align 8
-  br i1 %885, label %_llgo_147, label %_llgo_148
+  %3247 = load ptr, ptr @"_llgo_struct$SDp3TNnYnxb26MhB1v8VMbmY71BX77YOaY7lgS1cFx0", align 8
+  br i1 %887, label %_llgo_147, label %_llgo_148
 
 _llgo_147:                                        ; preds = %_llgo_146
-  %3246 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3247 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3246, i32 0, i32 0
-  store ptr @42, ptr %3247, align 8
-  %3248 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3246, i32 0, i32 1
-  store i64 8, ptr %3248, align 4
-  %3249 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3246, align 8
-  %3250 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %3251 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3252 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3251, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3249, ptr %3252, align 8
-  %3253 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3251, i32 0, i32 1
-  store ptr %3250, ptr %3253, align 8
-  %3254 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3251, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Method).Exported", ptr %3254, align 8
-  %3255 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3251, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Method).Exported", ptr %3255, align 8
-  %3256 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3251, align 8
-  %3257 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3258 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3257, i32 0, i32 0
-  store ptr @43, ptr %3258, align 8
-  %3259 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3257, i32 0, i32 1
-  store i64 4, ptr %3259, align 4
-  %3260 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3257, align 8
-  %3261 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %3262 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3263 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3262, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3260, ptr %3263, align 8
-  %3264 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3262, i32 0, i32 1
-  store ptr %3261, ptr %3264, align 8
-  %3265 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3262, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Method).Name", ptr %3265, align 8
-  %3266 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3262, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Method).Name", ptr %3266, align 8
-  %3267 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3262, align 8
-  %3268 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3269 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3268, i32 0, i32 0
-  store ptr @44, ptr %3269, align 8
-  %3270 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3268, i32 0, i32 1
-  store i64 7, ptr %3270, align 4
-  %3271 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3268, align 8
-  %3272 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %3273 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3274 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3273, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3271, ptr %3274, align 8
-  %3275 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3273, i32 0, i32 1
-  store ptr %3272, ptr %3275, align 8
-  %3276 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3273, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Method).PkgPath", ptr %3276, align 8
-  %3277 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3273, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Method).PkgPath", ptr %3277, align 8
-  %3278 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3273, align 8
-  %3279 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 120)
-  %3280 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3279, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %3256, ptr %3280, align 8
-  %3281 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3279, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %3267, ptr %3281, align 8
-  %3282 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3279, i64 2
-  store %"github.com/goplus/llgo/internal/abi.Method" %3278, ptr %3282, align 8
-  %3283 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %3284 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3283, i32 0, i32 0
-  store ptr %3279, ptr %3284, align 8
-  %3285 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3283, i32 0, i32 1
-  store i64 3, ptr %3285, align 4
-  %3286 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3283, i32 0, i32 2
-  store i64 3, ptr %3286, align 4
-  %3287 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3283, align 8
-  %3288 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3289 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3288, i32 0, i32 0
-  store ptr @3, ptr %3289, align 8
-  %3290 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3288, i32 0, i32 1
-  store i64 35, ptr %3290, align 4
-  %3291 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3288, align 8
-  %3292 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3293 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3292, i32 0, i32 0
-  store ptr @89, ptr %3293, align 8
-  %3294 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3292, i32 0, i32 1
-  store i64 6, ptr %3294, align 4
-  %3295 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3292, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %883, %"github.com/goplus/llgo/internal/runtime.String" %3291, %"github.com/goplus/llgo/internal/runtime.String" %3295, ptr %3245, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %3287)
+  %3248 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3249 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3248, i32 0, i32 0
+  store ptr @42, ptr %3249, align 8
+  %3250 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3248, i32 0, i32 1
+  store i64 8, ptr %3250, align 4
+  %3251 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3248, align 8
+  %3252 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %3253 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %3254 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3253, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %3251, ptr %3254, align 8
+  %3255 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3253, i32 0, i32 1
+  store ptr %3252, ptr %3255, align 8
+  %3256 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3253, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Method).Exported", ptr %3256, align 8
+  %3257 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3253, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Method).Exported", ptr %3257, align 8
+  %3258 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3253, align 8
+  %3259 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3260 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3259, i32 0, i32 0
+  store ptr @43, ptr %3260, align 8
+  %3261 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3259, i32 0, i32 1
+  store i64 4, ptr %3261, align 4
+  %3262 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3259, align 8
+  %3263 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %3264 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %3265 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3264, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %3262, ptr %3265, align 8
+  %3266 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3264, i32 0, i32 1
+  store ptr %3263, ptr %3266, align 8
+  %3267 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3264, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Method).Name", ptr %3267, align 8
+  %3268 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3264, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Method).Name", ptr %3268, align 8
+  %3269 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3264, align 8
+  %3270 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3271 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3270, i32 0, i32 0
+  store ptr @44, ptr %3271, align 8
+  %3272 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3270, i32 0, i32 1
+  store i64 7, ptr %3272, align 4
+  %3273 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3270, align 8
+  %3274 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %3275 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %3276 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3275, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %3273, ptr %3276, align 8
+  %3277 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3275, i32 0, i32 1
+  store ptr %3274, ptr %3277, align 8
+  %3278 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3275, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Method).PkgPath", ptr %3278, align 8
+  %3279 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3275, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*Method).PkgPath", ptr %3279, align 8
+  %3280 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3275, align 8
+  %3281 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 120)
+  %3282 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3281, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %3258, ptr %3282, align 8
+  %3283 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3281, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %3269, ptr %3283, align 8
+  %3284 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3281, i64 2
+  store %"github.com/goplus/llgo/internal/abi.Method" %3280, ptr %3284, align 8
+  %3285 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %3286 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3285, i32 0, i32 0
+  store ptr %3281, ptr %3286, align 8
+  %3287 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3285, i32 0, i32 1
+  store i64 3, ptr %3287, align 4
+  %3288 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3285, i32 0, i32 2
+  store i64 3, ptr %3288, align 4
+  %3289 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3285, align 8
+  %3290 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3291 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3290, i32 0, i32 0
+  store ptr @3, ptr %3291, align 8
+  %3292 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3290, i32 0, i32 1
+  store i64 35, ptr %3292, align 4
+  %3293 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3290, align 8
+  %3294 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3295 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3294, i32 0, i32 0
+  store ptr @89, ptr %3295, align 8
+  %3296 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3294, i32 0, i32 1
+  store i64 6, ptr %3296, align 4
+  %3297 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3294, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %885, %"github.com/goplus/llgo/internal/runtime.String" %3293, %"github.com/goplus/llgo/internal/runtime.String" %3297, ptr %3247, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %3289)
   br label %_llgo_148
 
 _llgo_148:                                        ; preds = %_llgo_147, %_llgo_146
-  %3296 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %3297 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %3298 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
-  %3299 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3300 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3299, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %878, ptr %3300, align 8
-  %3301 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3299, i32 0, i32 1
-  store ptr %3298, ptr %3301, align 8
-  %3302 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3299, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ExportedMethods", ptr %3302, align 8
-  %3303 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3299, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ExportedMethods", ptr %3303, align 8
-  %3304 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3299, align 8
-  %3305 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3306 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3305, i32 0, i32 0
-  store ptr @33, ptr %3306, align 8
-  %3307 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3305, i32 0, i32 1
-  store i64 10, ptr %3307, align 4
-  %3308 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3305, align 8
-  %3309 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %3310 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3311 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3310, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3308, ptr %3311, align 8
-  %3312 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3310, i32 0, i32 1
-  store ptr %3309, ptr %3312, align 8
-  %3313 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3310, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).FieldAlign", ptr %3313, align 8
-  %3314 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3310, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).FieldAlign", ptr %3314, align 8
-  %3315 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3310, align 8
-  %3316 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3317 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3316, i32 0, i32 0
-  store ptr @34, ptr %3317, align 8
-  %3318 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3316, i32 0, i32 1
-  store i64 8, ptr %3318, align 4
-  %3319 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3316, align 8
-  %3320 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %3321 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
-  %3322 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3323 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3322, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3319, ptr %3323, align 8
-  %3324 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3322, i32 0, i32 1
-  store ptr %3321, ptr %3324, align 8
-  %3325 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3322, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).FuncType", ptr %3325, align 8
-  %3326 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3322, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).FuncType", ptr %3326, align 8
-  %3327 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3322, align 8
-  %3328 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3329 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3328, i32 0, i32 0
-  store ptr @35, ptr %3329, align 8
-  %3330 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3328, i32 0, i32 1
-  store i64 7, ptr %3330, align 4
-  %3331 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3328, align 8
-  %3332 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %3333 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3334 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3333, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3331, ptr %3334, align 8
-  %3335 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3333, i32 0, i32 1
-  store ptr %3332, ptr %3335, align 8
-  %3336 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3333, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).HasName", ptr %3336, align 8
-  %3337 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3333, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).HasName", ptr %3337, align 8
-  %3338 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3333, align 8
-  %3339 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3340 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3339, i32 0, i32 0
-  store ptr @36, ptr %3340, align 8
-  %3341 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3339, i32 0, i32 1
-  store i64 10, ptr %3341, align 4
-  %3342 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3339, align 8
-  %3343 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %3344 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3345 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3344, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3342, ptr %3345, align 8
-  %3346 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3344, i32 0, i32 1
-  store ptr %3343, ptr %3346, align 8
-  %3347 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3344, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).IfaceIndir", ptr %3347, align 8
-  %3348 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3344, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).IfaceIndir", ptr %3348, align 8
-  %3349 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3344, align 8
-  %3350 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3351 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3350, i32 0, i32 0
-  store ptr @37, ptr %3351, align 8
-  %3352 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3350, i32 0, i32 1
-  store i64 13, ptr %3352, align 4
-  %3353 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3350, align 8
-  %3354 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
-  %3355 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
-  %3356 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3357 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3356, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3353, ptr %3357, align 8
-  %3358 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3356, i32 0, i32 1
-  store ptr %3355, ptr %3358, align 8
-  %3359 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3356, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).InterfaceType", ptr %3359, align 8
-  %3360 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3356, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).InterfaceType", ptr %3360, align 8
-  %3361 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3356, align 8
-  %3362 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3363 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3362, i32 0, i32 0
-  store ptr @48, ptr %3363, align 8
-  %3364 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3362, i32 0, i32 1
-  store i64 13, ptr %3364, align 4
-  %3365 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3362, align 8
-  %3366 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %3367 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3368 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3367, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3365, ptr %3368, align 8
-  %3369 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3367, i32 0, i32 1
-  store ptr %3366, ptr %3369, align 8
-  %3370 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3367, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).IsDirectIface", ptr %3370, align 8
-  %3371 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3367, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).IsDirectIface", ptr %3371, align 8
-  %3372 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3367, align 8
-  %3373 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3374 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3373, i32 0, i32 0
-  store ptr @49, ptr %3374, align 8
-  %3375 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3373, i32 0, i32 1
-  store i64 3, ptr %3375, align 4
-  %3376 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3373, align 8
-  %3377 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %3378 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %3379 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3380 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3379, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3376, ptr %3380, align 8
-  %3381 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3379, i32 0, i32 1
-  store ptr %3378, ptr %3381, align 8
-  %3382 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3379, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Key", ptr %3382, align 8
-  %3383 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3379, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Key", ptr %3383, align 8
-  %3384 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3379, align 8
-  %3385 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3386 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3385, i32 0, i32 0
-  store ptr @50, ptr %3386, align 8
-  %3387 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3385, i32 0, i32 1
-  store i64 4, ptr %3387, align 4
-  %3388 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3385, align 8
-  %3389 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
-  %3390 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3391 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3390, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3388, ptr %3391, align 8
-  %3392 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3390, i32 0, i32 1
-  store ptr %3389, ptr %3392, align 8
-  %3393 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3390, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Kind", ptr %3393, align 8
-  %3394 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3390, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Kind", ptr %3394, align 8
-  %3395 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3390, align 8
-  %3396 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3397 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3396, i32 0, i32 0
-  store ptr @53, ptr %3397, align 8
-  %3398 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3396, i32 0, i32 1
-  store i64 7, ptr %3398, align 4
-  %3399 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3396, align 8
-  %3400 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
-  %3401 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
-  %3402 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3403 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3402, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3399, ptr %3403, align 8
-  %3404 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3402, i32 0, i32 1
-  store ptr %3401, ptr %3404, align 8
-  %3405 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3402, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).MapType", ptr %3405, align 8
-  %3406 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3402, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).MapType", ptr %3406, align 8
-  %3407 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3402, align 8
-  %3408 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3409 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3408, i32 0, i32 0
-  store ptr @65, ptr %3409, align 8
-  %3410 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3408, i32 0, i32 1
-  store i64 9, ptr %3410, align 4
-  %3411 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3408, align 8
-  %3412 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %3413 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3414 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3413, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3411, ptr %3414, align 8
-  %3415 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3413, i32 0, i32 1
-  store ptr %3412, ptr %3415, align 8
-  %3416 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3413, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).NumMethod", ptr %3416, align 8
-  %3417 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3413, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).NumMethod", ptr %3417, align 8
-  %3418 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3413, align 8
-  %3419 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3420 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3419, i32 0, i32 0
-  store ptr @66, ptr %3420, align 8
-  %3421 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3419, i32 0, i32 1
-  store i64 8, ptr %3421, align 4
-  %3422 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3419, align 8
-  %3423 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %3424 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3425 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3424, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3422, ptr %3425, align 8
-  %3426 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3424, i32 0, i32 1
-  store ptr %3423, ptr %3426, align 8
-  %3427 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3424, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Pointers", ptr %3427, align 8
-  %3428 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3424, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Pointers", ptr %3428, align 8
-  %3429 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3424, align 8
-  %3430 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3431 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3430, i32 0, i32 0
-  store ptr @68, ptr %3431, align 8
-  %3432 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3430, i32 0, i32 1
-  store i64 4, ptr %3432, align 4
-  %3433 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3430, align 8
-  %3434 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
-  %3435 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3436 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3435, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3433, ptr %3436, align 8
-  %3437 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3435, i32 0, i32 1
-  store ptr %3434, ptr %3437, align 8
-  %3438 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3435, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Size", ptr %3438, align 8
-  %3439 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3435, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Size", ptr %3439, align 8
-  %3440 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3435, align 8
-  %3441 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3442 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3441, i32 0, i32 0
-  store ptr @52, ptr %3442, align 8
-  %3443 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3441, i32 0, i32 1
-  store i64 6, ptr %3443, align 4
-  %3444 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3441, align 8
-  %3445 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %3446 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3447 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3446, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3444, ptr %3447, align 8
-  %3448 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3446, i32 0, i32 1
-  store ptr %3445, ptr %3448, align 8
-  %3449 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3446, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).String", ptr %3449, align 8
-  %3450 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3446, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).String", ptr %3450, align 8
-  %3451 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3446, align 8
-  %3452 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3453 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3452, i32 0, i32 0
-  store ptr @69, ptr %3453, align 8
-  %3454 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3452, i32 0, i32 1
-  store i64 10, ptr %3454, align 4
-  %3455 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3452, align 8
-  %3456 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
-  %3457 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
-  %3458 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3459 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3458, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3455, ptr %3459, align 8
-  %3460 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3458, i32 0, i32 1
-  store ptr %3457, ptr %3460, align 8
-  %3461 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3458, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).StructType", ptr %3461, align 8
-  %3462 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3458, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).StructType", ptr %3462, align 8
-  %3463 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3458, align 8
-  %3464 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3465 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3464, i32 0, i32 0
-  store ptr @79, ptr %3465, align 8
-  %3466 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3464, i32 0, i32 1
-  store i64 8, ptr %3466, align 4
-  %3467 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3464, align 8
-  %3468 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
-  %3469 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3470 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3469, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3467, ptr %3470, align 8
-  %3471 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3469, i32 0, i32 1
-  store ptr %3468, ptr %3471, align 8
-  %3472 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3469, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Uncommon", ptr %3472, align 8
-  %3473 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3469, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Uncommon", ptr %3473, align 8
-  %3474 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3469, align 8
-  %3475 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 800)
-  %3476 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %490, ptr %3476, align 8
-  %3477 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %800, ptr %3477, align 8
-  %3478 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i64 2
-  store %"github.com/goplus/llgo/internal/abi.Method" %845, ptr %3478, align 8
-  %3479 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i64 3
-  store %"github.com/goplus/llgo/internal/abi.Method" %874, ptr %3479, align 8
-  %3480 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i64 4
-  store %"github.com/goplus/llgo/internal/abi.Method" %3304, ptr %3480, align 8
-  %3481 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i64 5
-  store %"github.com/goplus/llgo/internal/abi.Method" %3315, ptr %3481, align 8
-  %3482 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i64 6
-  store %"github.com/goplus/llgo/internal/abi.Method" %3327, ptr %3482, align 8
-  %3483 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i64 7
-  store %"github.com/goplus/llgo/internal/abi.Method" %3338, ptr %3483, align 8
-  %3484 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i64 8
-  store %"github.com/goplus/llgo/internal/abi.Method" %3349, ptr %3484, align 8
-  %3485 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i64 9
-  store %"github.com/goplus/llgo/internal/abi.Method" %3361, ptr %3485, align 8
-  %3486 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i64 10
-  store %"github.com/goplus/llgo/internal/abi.Method" %3372, ptr %3486, align 8
-  %3487 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i64 11
-  store %"github.com/goplus/llgo/internal/abi.Method" %3384, ptr %3487, align 8
-  %3488 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i64 12
-  store %"github.com/goplus/llgo/internal/abi.Method" %3395, ptr %3488, align 8
-  %3489 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i64 13
-  store %"github.com/goplus/llgo/internal/abi.Method" %3407, ptr %3489, align 8
-  %3490 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i64 14
-  store %"github.com/goplus/llgo/internal/abi.Method" %3418, ptr %3490, align 8
-  %3491 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i64 15
-  store %"github.com/goplus/llgo/internal/abi.Method" %3429, ptr %3491, align 8
-  %3492 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i64 16
-  store %"github.com/goplus/llgo/internal/abi.Method" %3440, ptr %3492, align 8
-  %3493 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i64 17
-  store %"github.com/goplus/llgo/internal/abi.Method" %3451, ptr %3493, align 8
-  %3494 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i64 18
-  store %"github.com/goplus/llgo/internal/abi.Method" %3463, ptr %3494, align 8
-  %3495 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i64 19
-  store %"github.com/goplus/llgo/internal/abi.Method" %3474, ptr %3495, align 8
-  %3496 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %3497 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3496, i32 0, i32 0
-  store ptr %3475, ptr %3497, align 8
-  %3498 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3496, i32 0, i32 1
-  store i64 20, ptr %3498, align 4
-  %3499 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3496, i32 0, i32 2
-  store i64 20, ptr %3499, align 4
-  %3500 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3496, align 8
-  %3501 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3502 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3501, i32 0, i32 0
-  store ptr @3, ptr %3502, align 8
-  %3503 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3501, i32 0, i32 1
-  store i64 35, ptr %3503, align 4
-  %3504 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3501, align 8
-  %3505 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3506 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3505, i32 0, i32 0
-  store ptr @19, ptr %3506, align 8
-  %3507 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3505, i32 0, i32 1
-  store i64 9, ptr %3507, align 4
-  %3508 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3505, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %403, %"github.com/goplus/llgo/internal/runtime.String" %3504, %"github.com/goplus/llgo/internal/runtime.String" %3508, ptr %479, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %3500)
+  %3298 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %3299 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %3300 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
+  %3301 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %3302 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3301, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %880, ptr %3302, align 8
+  %3303 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3301, i32 0, i32 1
+  store ptr %3300, ptr %3303, align 8
+  %3304 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3301, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ExportedMethods", ptr %3304, align 8
+  %3305 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3301, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ExportedMethods", ptr %3305, align 8
+  %3306 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3301, align 8
+  %3307 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3308 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3307, i32 0, i32 0
+  store ptr @33, ptr %3308, align 8
+  %3309 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3307, i32 0, i32 1
+  store i64 10, ptr %3309, align 4
+  %3310 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3307, align 8
+  %3311 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %3312 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %3313 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3312, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %3310, ptr %3313, align 8
+  %3314 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3312, i32 0, i32 1
+  store ptr %3311, ptr %3314, align 8
+  %3315 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3312, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).FieldAlign", ptr %3315, align 8
+  %3316 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3312, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).FieldAlign", ptr %3316, align 8
+  %3317 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3312, align 8
+  %3318 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3319 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3318, i32 0, i32 0
+  store ptr @34, ptr %3319, align 8
+  %3320 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3318, i32 0, i32 1
+  store i64 8, ptr %3320, align 4
+  %3321 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3318, align 8
+  %3322 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %3323 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
+  %3324 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %3325 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3324, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %3321, ptr %3325, align 8
+  %3326 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3324, i32 0, i32 1
+  store ptr %3323, ptr %3326, align 8
+  %3327 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3324, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).FuncType", ptr %3327, align 8
+  %3328 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3324, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).FuncType", ptr %3328, align 8
+  %3329 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3324, align 8
+  %3330 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3331 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3330, i32 0, i32 0
+  store ptr @35, ptr %3331, align 8
+  %3332 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3330, i32 0, i32 1
+  store i64 7, ptr %3332, align 4
+  %3333 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3330, align 8
+  %3334 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %3335 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %3336 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3335, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %3333, ptr %3336, align 8
+  %3337 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3335, i32 0, i32 1
+  store ptr %3334, ptr %3337, align 8
+  %3338 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3335, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).HasName", ptr %3338, align 8
+  %3339 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3335, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).HasName", ptr %3339, align 8
+  %3340 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3335, align 8
+  %3341 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3342 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3341, i32 0, i32 0
+  store ptr @36, ptr %3342, align 8
+  %3343 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3341, i32 0, i32 1
+  store i64 10, ptr %3343, align 4
+  %3344 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3341, align 8
+  %3345 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %3346 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %3347 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3346, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %3344, ptr %3347, align 8
+  %3348 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3346, i32 0, i32 1
+  store ptr %3345, ptr %3348, align 8
+  %3349 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3346, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).IfaceIndir", ptr %3349, align 8
+  %3350 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3346, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).IfaceIndir", ptr %3350, align 8
+  %3351 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3346, align 8
+  %3352 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3353 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3352, i32 0, i32 0
+  store ptr @37, ptr %3353, align 8
+  %3354 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3352, i32 0, i32 1
+  store i64 13, ptr %3354, align 4
+  %3355 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3352, align 8
+  %3356 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  %3357 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
+  %3358 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %3359 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3358, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %3355, ptr %3359, align 8
+  %3360 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3358, i32 0, i32 1
+  store ptr %3357, ptr %3360, align 8
+  %3361 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3358, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).InterfaceType", ptr %3361, align 8
+  %3362 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3358, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).InterfaceType", ptr %3362, align 8
+  %3363 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3358, align 8
+  %3364 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3365 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3364, i32 0, i32 0
+  store ptr @48, ptr %3365, align 8
+  %3366 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3364, i32 0, i32 1
+  store i64 13, ptr %3366, align 4
+  %3367 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3364, align 8
+  %3368 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %3369 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %3370 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3369, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %3367, ptr %3370, align 8
+  %3371 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3369, i32 0, i32 1
+  store ptr %3368, ptr %3371, align 8
+  %3372 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3369, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).IsDirectIface", ptr %3372, align 8
+  %3373 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3369, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).IsDirectIface", ptr %3373, align 8
+  %3374 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3369, align 8
+  %3375 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3376 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3375, i32 0, i32 0
+  store ptr @49, ptr %3376, align 8
+  %3377 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3375, i32 0, i32 1
+  store i64 3, ptr %3377, align 4
+  %3378 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3375, align 8
+  %3379 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %3380 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %3381 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %3382 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3381, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %3378, ptr %3382, align 8
+  %3383 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3381, i32 0, i32 1
+  store ptr %3380, ptr %3383, align 8
+  %3384 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3381, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Key", ptr %3384, align 8
+  %3385 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3381, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Key", ptr %3385, align 8
+  %3386 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3381, align 8
+  %3387 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3388 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3387, i32 0, i32 0
+  store ptr @50, ptr %3388, align 8
+  %3389 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3387, i32 0, i32 1
+  store i64 4, ptr %3389, align 4
+  %3390 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3387, align 8
+  %3391 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
+  %3392 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %3393 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3392, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %3390, ptr %3393, align 8
+  %3394 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3392, i32 0, i32 1
+  store ptr %3391, ptr %3394, align 8
+  %3395 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3392, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Kind", ptr %3395, align 8
+  %3396 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3392, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Kind", ptr %3396, align 8
+  %3397 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3392, align 8
+  %3398 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3399 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3398, i32 0, i32 0
+  store ptr @53, ptr %3399, align 8
+  %3400 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3398, i32 0, i32 1
+  store i64 7, ptr %3400, align 4
+  %3401 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3398, align 8
+  %3402 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  %3403 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
+  %3404 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %3405 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3404, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %3401, ptr %3405, align 8
+  %3406 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3404, i32 0, i32 1
+  store ptr %3403, ptr %3406, align 8
+  %3407 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3404, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).MapType", ptr %3407, align 8
+  %3408 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3404, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).MapType", ptr %3408, align 8
+  %3409 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3404, align 8
+  %3410 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3411 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3410, i32 0, i32 0
+  store ptr @65, ptr %3411, align 8
+  %3412 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3410, i32 0, i32 1
+  store i64 9, ptr %3412, align 4
+  %3413 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3410, align 8
+  %3414 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %3415 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %3416 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3415, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %3413, ptr %3416, align 8
+  %3417 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3415, i32 0, i32 1
+  store ptr %3414, ptr %3417, align 8
+  %3418 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3415, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).NumMethod", ptr %3418, align 8
+  %3419 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3415, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).NumMethod", ptr %3419, align 8
+  %3420 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3415, align 8
+  %3421 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3422 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3421, i32 0, i32 0
+  store ptr @66, ptr %3422, align 8
+  %3423 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3421, i32 0, i32 1
+  store i64 8, ptr %3423, align 4
+  %3424 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3421, align 8
+  %3425 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %3426 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %3427 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3426, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %3424, ptr %3427, align 8
+  %3428 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3426, i32 0, i32 1
+  store ptr %3425, ptr %3428, align 8
+  %3429 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3426, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Pointers", ptr %3429, align 8
+  %3430 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3426, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Pointers", ptr %3430, align 8
+  %3431 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3426, align 8
+  %3432 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3433 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3432, i32 0, i32 0
+  store ptr @68, ptr %3433, align 8
+  %3434 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3432, i32 0, i32 1
+  store i64 4, ptr %3434, align 4
+  %3435 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3432, align 8
+  %3436 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
+  %3437 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %3438 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3437, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %3435, ptr %3438, align 8
+  %3439 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3437, i32 0, i32 1
+  store ptr %3436, ptr %3439, align 8
+  %3440 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3437, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Size", ptr %3440, align 8
+  %3441 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3437, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Size", ptr %3441, align 8
+  %3442 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3437, align 8
+  %3443 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3444 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3443, i32 0, i32 0
+  store ptr @52, ptr %3444, align 8
+  %3445 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3443, i32 0, i32 1
+  store i64 6, ptr %3445, align 4
+  %3446 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3443, align 8
+  %3447 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %3448 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %3449 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3448, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %3446, ptr %3449, align 8
+  %3450 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3448, i32 0, i32 1
+  store ptr %3447, ptr %3450, align 8
+  %3451 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3448, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).String", ptr %3451, align 8
+  %3452 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3448, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).String", ptr %3452, align 8
+  %3453 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3448, align 8
+  %3454 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3455 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3454, i32 0, i32 0
+  store ptr @69, ptr %3455, align 8
+  %3456 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3454, i32 0, i32 1
+  store i64 10, ptr %3456, align 4
+  %3457 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3454, align 8
+  %3458 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  %3459 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
+  %3460 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %3461 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3460, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %3457, ptr %3461, align 8
+  %3462 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3460, i32 0, i32 1
+  store ptr %3459, ptr %3462, align 8
+  %3463 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3460, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).StructType", ptr %3463, align 8
+  %3464 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3460, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).StructType", ptr %3464, align 8
+  %3465 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3460, align 8
+  %3466 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3467 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3466, i32 0, i32 0
+  store ptr @79, ptr %3467, align 8
+  %3468 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3466, i32 0, i32 1
+  store i64 8, ptr %3468, align 4
+  %3469 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3466, align 8
+  %3470 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
+  %3471 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
+  %3472 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3471, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %3469, ptr %3472, align 8
+  %3473 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3471, i32 0, i32 1
+  store ptr %3470, ptr %3473, align 8
+  %3474 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3471, i32 0, i32 2
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Uncommon", ptr %3474, align 8
+  %3475 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3471, i32 0, i32 3
+  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Uncommon", ptr %3475, align 8
+  %3476 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3471, align 8
+  %3477 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 800)
+  %3478 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3477, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %492, ptr %3478, align 8
+  %3479 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3477, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %802, ptr %3479, align 8
+  %3480 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3477, i64 2
+  store %"github.com/goplus/llgo/internal/abi.Method" %847, ptr %3480, align 8
+  %3481 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3477, i64 3
+  store %"github.com/goplus/llgo/internal/abi.Method" %876, ptr %3481, align 8
+  %3482 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3477, i64 4
+  store %"github.com/goplus/llgo/internal/abi.Method" %3306, ptr %3482, align 8
+  %3483 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3477, i64 5
+  store %"github.com/goplus/llgo/internal/abi.Method" %3317, ptr %3483, align 8
+  %3484 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3477, i64 6
+  store %"github.com/goplus/llgo/internal/abi.Method" %3329, ptr %3484, align 8
+  %3485 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3477, i64 7
+  store %"github.com/goplus/llgo/internal/abi.Method" %3340, ptr %3485, align 8
+  %3486 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3477, i64 8
+  store %"github.com/goplus/llgo/internal/abi.Method" %3351, ptr %3486, align 8
+  %3487 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3477, i64 9
+  store %"github.com/goplus/llgo/internal/abi.Method" %3363, ptr %3487, align 8
+  %3488 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3477, i64 10
+  store %"github.com/goplus/llgo/internal/abi.Method" %3374, ptr %3488, align 8
+  %3489 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3477, i64 11
+  store %"github.com/goplus/llgo/internal/abi.Method" %3386, ptr %3489, align 8
+  %3490 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3477, i64 12
+  store %"github.com/goplus/llgo/internal/abi.Method" %3397, ptr %3490, align 8
+  %3491 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3477, i64 13
+  store %"github.com/goplus/llgo/internal/abi.Method" %3409, ptr %3491, align 8
+  %3492 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3477, i64 14
+  store %"github.com/goplus/llgo/internal/abi.Method" %3420, ptr %3492, align 8
+  %3493 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3477, i64 15
+  store %"github.com/goplus/llgo/internal/abi.Method" %3431, ptr %3493, align 8
+  %3494 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3477, i64 16
+  store %"github.com/goplus/llgo/internal/abi.Method" %3442, ptr %3494, align 8
+  %3495 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3477, i64 17
+  store %"github.com/goplus/llgo/internal/abi.Method" %3453, ptr %3495, align 8
+  %3496 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3477, i64 18
+  store %"github.com/goplus/llgo/internal/abi.Method" %3465, ptr %3496, align 8
+  %3497 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3477, i64 19
+  store %"github.com/goplus/llgo/internal/abi.Method" %3476, ptr %3497, align 8
+  %3498 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %3499 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3498, i32 0, i32 0
+  store ptr %3477, ptr %3499, align 8
+  %3500 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3498, i32 0, i32 1
+  store i64 20, ptr %3500, align 4
+  %3501 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3498, i32 0, i32 2
+  store i64 20, ptr %3501, align 4
+  %3502 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3498, align 8
+  %3503 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3504 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3503, i32 0, i32 0
+  store ptr @3, ptr %3504, align 8
+  %3505 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3503, i32 0, i32 1
+  store i64 35, ptr %3505, align 4
+  %3506 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3503, align 8
+  %3507 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3508 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3507, i32 0, i32 0
+  store ptr @19, ptr %3508, align 8
+  %3509 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3507, i32 0, i32 1
+  store i64 9, ptr %3509, align 4
+  %3510 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3507, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %405, %"github.com/goplus/llgo/internal/runtime.String" %3506, %"github.com/goplus/llgo/internal/runtime.String" %3510, ptr %481, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %3502)
   br label %_llgo_42
 
 _llgo_149:                                        ; preds = %_llgo_32
-  %3509 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %366)
-  store ptr %3509, ptr @"[]_llgo_main.T", align 8
+  %3511 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %368)
+  store ptr %3511, ptr @"[]_llgo_main.T", align 8
   br label %_llgo_150
 
 _llgo_150:                                        ; preds = %_llgo_149, %_llgo_32
-  %3510 = load ptr, ptr @"[]_llgo_main.T", align 8
-  %3511 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3512 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3511, i32 0, i32 0
-  store ptr @0, ptr %3512, align 8
-  %3513 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3511, i32 0, i32 1
-  store i64 6, ptr %3513, align 4
-  %3514 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3511, align 8
-  %3515 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3514, i64 25, i64 48, i64 0, i64 0)
-  %3516 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3517 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3516, i32 0, i32 0
-  store ptr @1, ptr %3517, align 8
-  %3518 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3516, i32 0, i32 1
-  store i64 40, ptr %3518, align 4
-  %3519 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3516, align 8
-  %3520 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3519, i64 25, i64 80, i64 0, i64 22)
-  %3521 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3522 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3521, i32 0, i32 0
-  store ptr @0, ptr %3522, align 8
-  %3523 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3521, i32 0, i32 1
-  store i64 6, ptr %3523, align 4
-  %3524 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3521, align 8
-  %3525 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3524, i64 25, i64 48, i64 0, i64 0)
-  %3526 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3527 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3526, i32 0, i32 0
-  store ptr @90, ptr %3527, align 8
-  %3528 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3526, i32 0, i32 1
-  store i64 1, ptr %3528, align 4
-  %3529 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3526, align 8
-  %3530 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3531 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3530, i32 0, i32 0
-  store ptr null, ptr %3531, align 8
-  %3532 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3530, i32 0, i32 1
-  store i64 0, ptr %3532, align 4
-  %3533 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3530, align 8
-  %3534 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %3515)
-  %3535 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3529, ptr %3534, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %3533, i1 false)
-  %3536 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3537 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3536, i32 0, i32 0
-  store ptr @91, ptr %3537, align 8
-  %3538 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3536, i32 0, i32 1
-  store i64 1, ptr %3538, align 4
-  %3539 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3536, align 8
-  %3540 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3541 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3540, i32 0, i32 0
-  store ptr null, ptr %3541, align 8
-  %3542 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3540, i32 0, i32 1
-  store i64 0, ptr %3542, align 4
-  %3543 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3540, align 8
-  %3544 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %3520)
-  %3545 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3539, ptr %3544, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %3543, i1 false)
-  %3546 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3547 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3546, i32 0, i32 0
-  store ptr @92, ptr %3547, align 8
-  %3548 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3546, i32 0, i32 1
-  store i64 1, ptr %3548, align 4
-  %3549 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3546, align 8
-  %3550 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3551 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3550, i32 0, i32 0
-  store ptr null, ptr %3551, align 8
-  %3552 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3550, i32 0, i32 1
-  store i64 0, ptr %3552, align 4
-  %3553 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3550, align 8
-  %3554 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
-  %3555 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3549, ptr %3554, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %3553, i1 false)
-  %3556 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3557 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3556, i32 0, i32 0
-  store ptr @93, ptr %3557, align 8
-  %3558 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3556, i32 0, i32 1
-  store i64 1, ptr %3558, align 4
-  %3559 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3556, align 8
-  %3560 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3561 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3560, i32 0, i32 0
-  store ptr null, ptr %3561, align 8
-  %3562 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3560, i32 0, i32 1
-  store i64 0, ptr %3562, align 4
-  %3563 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3560, align 8
-  %3564 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %3525)
-  %3565 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3559, ptr %3564, i64 24, %"github.com/goplus/llgo/internal/runtime.String" %3563, i1 false)
-  %3566 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3567 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3566, i32 0, i32 0
-  store ptr @7, ptr %3567, align 8
-  %3568 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3566, i32 0, i32 1
-  store i64 4, ptr %3568, align 4
-  %3569 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3566, align 8
-  %3570 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
-  %3571 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3570, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3535, ptr %3571, align 8
-  %3572 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3570, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3545, ptr %3572, align 8
-  %3573 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3570, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3555, ptr %3573, align 8
-  %3574 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3570, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3565, ptr %3574, align 8
-  %3575 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %3576 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3575, i32 0, i32 0
-  store ptr %3570, ptr %3576, align 8
-  %3577 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3575, i32 0, i32 1
-  store i64 4, ptr %3577, align 4
-  %3578 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3575, i32 0, i32 2
-  store i64 4, ptr %3578, align 4
-  %3579 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3575, align 8
-  %3580 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %3569, i64 48, %"github.com/goplus/llgo/internal/runtime.Slice" %3579)
-  store ptr %3580, ptr @"main.struct$FYfyNCnlvkYOztpQWjt-y8D_WY3tpxyt5Qo62CJffTE", align 8
-  %3581 = load ptr, ptr @"main.struct$FYfyNCnlvkYOztpQWjt-y8D_WY3tpxyt5Qo62CJffTE", align 8
+  %3512 = load ptr, ptr @"[]_llgo_main.T", align 8
+  %3513 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3514 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3513, i32 0, i32 0
+  store ptr @0, ptr %3514, align 8
+  %3515 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3513, i32 0, i32 1
+  store i64 6, ptr %3515, align 4
+  %3516 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3513, align 8
+  %3517 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3516, i64 25, i64 48, i64 0, i64 0)
+  %3518 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3519 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3518, i32 0, i32 0
+  store ptr @1, ptr %3519, align 8
+  %3520 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3518, i32 0, i32 1
+  store i64 40, ptr %3520, align 4
+  %3521 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3518, align 8
+  %3522 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3521, i64 25, i64 80, i64 0, i64 22)
+  %3523 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3524 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3523, i32 0, i32 0
+  store ptr @0, ptr %3524, align 8
+  %3525 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3523, i32 0, i32 1
+  store i64 6, ptr %3525, align 4
+  %3526 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3523, align 8
+  %3527 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3526, i64 25, i64 48, i64 0, i64 0)
+  %3528 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3529 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3528, i32 0, i32 0
+  store ptr @90, ptr %3529, align 8
+  %3530 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3528, i32 0, i32 1
+  store i64 1, ptr %3530, align 4
+  %3531 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3528, align 8
+  %3532 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3533 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3532, i32 0, i32 0
+  store ptr null, ptr %3533, align 8
+  %3534 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3532, i32 0, i32 1
+  store i64 0, ptr %3534, align 4
+  %3535 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3532, align 8
+  %3536 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %3517)
+  %3537 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3531, ptr %3536, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %3535, i1 false)
+  %3538 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3539 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3538, i32 0, i32 0
+  store ptr @91, ptr %3539, align 8
+  %3540 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3538, i32 0, i32 1
+  store i64 1, ptr %3540, align 4
+  %3541 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3538, align 8
+  %3542 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3543 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3542, i32 0, i32 0
+  store ptr null, ptr %3543, align 8
+  %3544 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3542, i32 0, i32 1
+  store i64 0, ptr %3544, align 4
+  %3545 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3542, align 8
+  %3546 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %3522)
+  %3547 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3541, ptr %3546, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %3545, i1 false)
+  %3548 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3549 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3548, i32 0, i32 0
+  store ptr @92, ptr %3549, align 8
+  %3550 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3548, i32 0, i32 1
+  store i64 1, ptr %3550, align 4
+  %3551 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3548, align 8
+  %3552 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3553 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3552, i32 0, i32 0
+  store ptr null, ptr %3553, align 8
+  %3554 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3552, i32 0, i32 1
+  store i64 0, ptr %3554, align 4
+  %3555 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3552, align 8
+  %3556 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
+  %3557 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3551, ptr %3556, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %3555, i1 false)
+  %3558 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3559 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3558, i32 0, i32 0
+  store ptr @93, ptr %3559, align 8
+  %3560 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3558, i32 0, i32 1
+  store i64 1, ptr %3560, align 4
+  %3561 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3558, align 8
+  %3562 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3563 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3562, i32 0, i32 0
+  store ptr null, ptr %3563, align 8
+  %3564 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3562, i32 0, i32 1
+  store i64 0, ptr %3564, align 4
+  %3565 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3562, align 8
+  %3566 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %3527)
+  %3567 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3561, ptr %3566, i64 24, %"github.com/goplus/llgo/internal/runtime.String" %3565, i1 false)
+  %3568 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3569 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3568, i32 0, i32 0
+  store ptr @7, ptr %3569, align 8
+  %3570 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3568, i32 0, i32 1
+  store i64 4, ptr %3570, align 4
+  %3571 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3568, align 8
+  %3572 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
+  %3573 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3572, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %3537, ptr %3573, align 8
+  %3574 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3572, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %3547, ptr %3574, align 8
+  %3575 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3572, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %3557, ptr %3575, align 8
+  %3576 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3572, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %3567, ptr %3576, align 8
+  %3577 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %3578 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3577, i32 0, i32 0
+  store ptr %3572, ptr %3578, align 8
+  %3579 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3577, i32 0, i32 1
+  store i64 4, ptr %3579, align 4
+  %3580 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3577, i32 0, i32 2
+  store i64 4, ptr %3580, align 4
+  %3581 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3577, align 8
+  %3582 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %3571, i64 48, %"github.com/goplus/llgo/internal/runtime.Slice" %3581)
+  store ptr %3582, ptr @"main.struct$FYfyNCnlvkYOztpQWjt-y8D_WY3tpxyt5Qo62CJffTE", align 8
+  %3583 = load ptr, ptr @"main.struct$FYfyNCnlvkYOztpQWjt-y8D_WY3tpxyt5Qo62CJffTE", align 8
   br i1 %6, label %_llgo_151, label %_llgo_152
 
 _llgo_151:                                        ; preds = %_llgo_150
-  %3582 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3583 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3582, i32 0, i32 0
-  store ptr @7, ptr %3583, align 8
-  %3584 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3582, i32 0, i32 1
-  store i64 4, ptr %3584, align 4
-  %3585 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3582, align 8
-  %3586 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3587 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3586, i32 0, i32 0
-  store ptr @94, ptr %3587, align 8
-  %3588 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3586, i32 0, i32 1
-  store i64 1, ptr %3588, align 4
-  %3589 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3586, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %4, %"github.com/goplus/llgo/internal/runtime.String" %3585, %"github.com/goplus/llgo/internal/runtime.String" %3589, ptr %3581, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  %3584 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3585 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3584, i32 0, i32 0
+  store ptr @7, ptr %3585, align 8
+  %3586 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3584, i32 0, i32 1
+  store i64 4, ptr %3586, align 4
+  %3587 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3584, align 8
+  %3588 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %3589 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3588, i32 0, i32 0
+  store ptr @94, ptr %3589, align 8
+  %3590 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3588, i32 0, i32 1
+  store i64 1, ptr %3590, align 4
+  %3591 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3588, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %4, %"github.com/goplus/llgo/internal/runtime.String" %3587, %"github.com/goplus/llgo/internal/runtime.String" %3591, ptr %3583, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
   br label %_llgo_152
 
 _llgo_152:                                        ; preds = %_llgo_151, %_llgo_150

--- a/cl/_testrt/tpmap/in.go
+++ b/cl/_testrt/tpmap/in.go
@@ -1,0 +1,26 @@
+package main
+
+type T1 int
+
+type T2 struct {
+	v int
+}
+
+type T3[T any] struct {
+	v T
+}
+
+type cacheKey struct {
+	t1 T1
+	t2 T2
+	t3 T3[any]
+	t4 *int
+	t5 uintptr
+}
+
+func main() {
+	m := map[cacheKey]string{}
+	m[cacheKey{0, T2{0}, T3[any]{0}, nil, 0}] = "world"
+	v, ok := m[cacheKey{0, T2{0}, T3[any]{0}, nil, 0}]
+	println(v, ok)
+}

--- a/cl/_testrt/tpmap/out.ll
+++ b/cl/_testrt/tpmap/out.ll
@@ -1,0 +1,706 @@
+; ModuleID = 'main'
+source_filename = "main"
+
+%main.cacheKey = type { i64, %main.T2, %"main.T3[any]", ptr, i64 }
+%main.T2 = type { i64 }
+%"main.T3[any]" = type { %"github.com/goplus/llgo/internal/runtime.eface" }
+%"github.com/goplus/llgo/internal/runtime.eface" = type { ptr, ptr }
+%"github.com/goplus/llgo/internal/runtime.String" = type { ptr, i64 }
+%"github.com/goplus/llgo/internal/abi.StructField" = type { %"github.com/goplus/llgo/internal/runtime.String", ptr, i64, %"github.com/goplus/llgo/internal/runtime.String", i1 }
+%"github.com/goplus/llgo/internal/runtime.Slice" = type { ptr, i64, i64 }
+
+@"main.init$guard" = global i1 false, align 1
+@__llgo_argc = global i32 0, align 4
+@__llgo_argv = global ptr null, align 8
+@_llgo_main.cacheKey = linkonce global ptr null, align 8
+@0 = private unnamed_addr constant [13 x i8] c"main.cacheKey", align 1
+@_llgo_main.T1 = linkonce global ptr null, align 8
+@1 = private unnamed_addr constant [7 x i8] c"main.T1", align 1
+@_llgo_int = linkonce global ptr null, align 8
+@2 = private unnamed_addr constant [4 x i8] c"main", align 1
+@3 = private unnamed_addr constant [2 x i8] c"T1", align 1
+@_llgo_main.T2 = linkonce global ptr null, align 8
+@4 = private unnamed_addr constant [7 x i8] c"main.T2", align 1
+@"main.struct$MYpsoM99ZwFY087IpUOkIw1zjBA_sgFXVodmn1m-G88" = linkonce global ptr null, align 8
+@5 = private unnamed_addr constant [1 x i8] c"v", align 1
+@6 = private unnamed_addr constant [2 x i8] c"T2", align 1
+@"_llgo_main.T3[any]" = linkonce global ptr null, align 8
+@7 = private unnamed_addr constant [12 x i8] c"main.T3[any]", align 1
+@_llgo_any = linkonce global ptr null, align 8
+@"main.struct$op7q0963ur0ih9ul6OteH-C75UVydPxwKOVpX1hUjzo" = linkonce global ptr null, align 8
+@8 = private unnamed_addr constant [7 x i8] c"T3[any]", align 1
+@"*_llgo_int" = linkonce global ptr null, align 8
+@_llgo_uintptr = linkonce global ptr null, align 8
+@"main.struct$ZLgMjv1XBA1L4yXCpdouRvQF2okeuHQ-YWVTE34gq4I" = linkonce global ptr null, align 8
+@9 = private unnamed_addr constant [2 x i8] c"t1", align 1
+@10 = private unnamed_addr constant [2 x i8] c"t2", align 1
+@11 = private unnamed_addr constant [2 x i8] c"t3", align 1
+@12 = private unnamed_addr constant [2 x i8] c"t4", align 1
+@13 = private unnamed_addr constant [2 x i8] c"t5", align 1
+@14 = private unnamed_addr constant [8 x i8] c"cacheKey", align 1
+@_llgo_string = linkonce global ptr null, align 8
+@"map[_llgo_main.cacheKey]_llgo_string" = linkonce global ptr null, align 8
+@15 = private unnamed_addr constant [7 x i8] c"topbits", align 1
+@16 = private unnamed_addr constant [4 x i8] c"keys", align 1
+@17 = private unnamed_addr constant [5 x i8] c"elems", align 1
+@18 = private unnamed_addr constant [8 x i8] c"overflow", align 1
+@19 = private unnamed_addr constant [5 x i8] c"world", align 1
+
+define void @main.init() {
+_llgo_0:
+  %0 = load i1, ptr @"main.init$guard", align 1
+  br i1 %0, label %_llgo_2, label %_llgo_1
+
+_llgo_1:                                          ; preds = %_llgo_0
+  store i1 true, ptr @"main.init$guard", align 1
+  call void @"main.init$after"()
+  br label %_llgo_2
+
+_llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+  ret void
+}
+
+define i32 @main(i32 %0, ptr %1) {
+_llgo_0:
+  store i32 %0, ptr @__llgo_argc, align 4
+  store ptr %1, ptr @__llgo_argv, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.init"()
+  call void @main.init()
+  %2 = load ptr, ptr @_llgo_main.cacheKey, align 8
+  %3 = load ptr, ptr @_llgo_string, align 8
+  %4 = load ptr, ptr @"map[_llgo_main.cacheKey]_llgo_string", align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.MakeMap"(ptr %4, i64 0)
+  %6 = alloca %main.cacheKey, align 8
+  call void @llvm.memset(ptr %6, i8 0, i64 48, i1 false)
+  %7 = getelementptr inbounds %main.cacheKey, ptr %6, i32 0, i32 0
+  %8 = getelementptr inbounds %main.cacheKey, ptr %6, i32 0, i32 1
+  %9 = getelementptr inbounds %main.T2, ptr %8, i32 0, i32 0
+  %10 = getelementptr inbounds %main.cacheKey, ptr %6, i32 0, i32 2
+  %11 = getelementptr inbounds %"main.T3[any]", ptr %10, i32 0, i32 0
+  %12 = getelementptr inbounds %main.cacheKey, ptr %6, i32 0, i32 3
+  %13 = getelementptr inbounds %main.cacheKey, ptr %6, i32 0, i32 4
+  store i64 0, ptr %7, align 4
+  store i64 0, ptr %9, align 4
+  %14 = load ptr, ptr @_llgo_int, align 8
+  %15 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %15, i32 0, i32 0
+  store ptr %14, ptr %16, align 8
+  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %15, i32 0, i32 1
+  store ptr null, ptr %17, align 8
+  %18 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %15, align 8
+  store %"github.com/goplus/llgo/internal/runtime.eface" %18, ptr %11, align 8
+  store ptr null, ptr %12, align 8
+  store i64 0, ptr %13, align 4
+  %19 = load %main.cacheKey, ptr %6, align 8
+  %20 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %20, i32 0, i32 0
+  store ptr @19, ptr %21, align 8
+  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %20, i32 0, i32 1
+  store i64 5, ptr %22, align 4
+  %23 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %20, align 8
+  %24 = load ptr, ptr @"map[_llgo_main.cacheKey]_llgo_string", align 8
+  %25 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  store %main.cacheKey %19, ptr %25, align 8
+  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %24, ptr %5, ptr %25)
+  store %"github.com/goplus/llgo/internal/runtime.String" %23, ptr %26, align 8
+  %27 = alloca %main.cacheKey, align 8
+  call void @llvm.memset(ptr %27, i8 0, i64 48, i1 false)
+  %28 = getelementptr inbounds %main.cacheKey, ptr %27, i32 0, i32 0
+  %29 = getelementptr inbounds %main.cacheKey, ptr %27, i32 0, i32 1
+  %30 = getelementptr inbounds %main.T2, ptr %29, i32 0, i32 0
+  %31 = getelementptr inbounds %main.cacheKey, ptr %27, i32 0, i32 2
+  %32 = getelementptr inbounds %"main.T3[any]", ptr %31, i32 0, i32 0
+  %33 = getelementptr inbounds %main.cacheKey, ptr %27, i32 0, i32 3
+  %34 = getelementptr inbounds %main.cacheKey, ptr %27, i32 0, i32 4
+  store i64 0, ptr %28, align 4
+  store i64 0, ptr %30, align 4
+  %35 = load ptr, ptr @_llgo_int, align 8
+  %36 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %36, i32 0, i32 0
+  store ptr %35, ptr %37, align 8
+  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %36, i32 0, i32 1
+  store ptr null, ptr %38, align 8
+  %39 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %36, align 8
+  store %"github.com/goplus/llgo/internal/runtime.eface" %39, ptr %32, align 8
+  store ptr null, ptr %33, align 8
+  store i64 0, ptr %34, align 4
+  %40 = load %main.cacheKey, ptr %27, align 8
+  %41 = load ptr, ptr @"map[_llgo_main.cacheKey]_llgo_string", align 8
+  %42 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  store %main.cacheKey %40, ptr %42, align 8
+  %43 = call { ptr, i1 } @"github.com/goplus/llgo/internal/runtime.MapAccess2"(ptr %41, ptr %5, ptr %42)
+  %44 = extractvalue { ptr, i1 } %43, 0
+  %45 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %44, align 8
+  %46 = extractvalue { ptr, i1 } %43, 1
+  %47 = alloca { %"github.com/goplus/llgo/internal/runtime.String", i1 }, align 8
+  %48 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.String", i1 }, ptr %47, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" %45, ptr %48, align 8
+  %49 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.String", i1 }, ptr %47, i32 0, i32 1
+  store i1 %46, ptr %49, align 1
+  %50 = load { %"github.com/goplus/llgo/internal/runtime.String", i1 }, ptr %47, align 8
+  %51 = extractvalue { %"github.com/goplus/llgo/internal/runtime.String", i1 } %50, 0
+  %52 = extractvalue { %"github.com/goplus/llgo/internal/runtime.String", i1 } %50, 1
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %51)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %52)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
+  ret i32 0
+}
+
+declare void @"github.com/goplus/llgo/internal/runtime.init"()
+
+define void @"main.init$after"() {
+_llgo_0:
+  %0 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 0
+  store ptr @0, ptr %1, align 8
+  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 1
+  store i64 13, ptr %2, align 4
+  %3 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %0, align 8
+  %4 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3, i64 25, i64 48, i64 0, i64 0)
+  store ptr %4, ptr @_llgo_main.cacheKey, align 8
+  %5 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %5, i32 0, i32 0
+  store ptr @1, ptr %6, align 8
+  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %5, i32 0, i32 1
+  store i64 7, ptr %7, align 4
+  %8 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %5, align 8
+  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %8, i64 2, i64 8, i64 0, i64 0)
+  %10 = load ptr, ptr @_llgo_main.T1, align 8
+  %11 = icmp eq ptr %10, null
+  br i1 %11, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  store ptr %9, ptr @_llgo_main.T1, align 8
+  br label %_llgo_2
+
+_llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+  %12 = load ptr, ptr @_llgo_int, align 8
+  %13 = icmp eq ptr %12, null
+  br i1 %13, label %_llgo_3, label %_llgo_4
+
+_llgo_3:                                          ; preds = %_llgo_2
+  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  store ptr %14, ptr @_llgo_int, align 8
+  br label %_llgo_4
+
+_llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
+  %15 = load ptr, ptr @_llgo_int, align 8
+  br i1 %11, label %_llgo_5, label %_llgo_6
+
+_llgo_5:                                          ; preds = %_llgo_4
+  %16 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %16, i32 0, i32 0
+  store ptr @2, ptr %17, align 8
+  %18 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %16, i32 0, i32 1
+  store i64 4, ptr %18, align 4
+  %19 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %16, align 8
+  %20 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %20, i32 0, i32 0
+  store ptr @3, ptr %21, align 8
+  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %20, i32 0, i32 1
+  store i64 2, ptr %22, align 4
+  %23 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %20, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %9, %"github.com/goplus/llgo/internal/runtime.String" %19, %"github.com/goplus/llgo/internal/runtime.String" %23, ptr %15, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  br label %_llgo_6
+
+_llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
+  %24 = load ptr, ptr @_llgo_main.T1, align 8
+  %25 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 0
+  store ptr @4, ptr %26, align 8
+  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 1
+  store i64 7, ptr %27, align 4
+  %28 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %25, align 8
+  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %28, i64 25, i64 8, i64 0, i64 0)
+  %30 = load ptr, ptr @_llgo_main.T2, align 8
+  %31 = icmp eq ptr %30, null
+  br i1 %31, label %_llgo_7, label %_llgo_8
+
+_llgo_7:                                          ; preds = %_llgo_6
+  store ptr %29, ptr @_llgo_main.T2, align 8
+  br label %_llgo_8
+
+_llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
+  %32 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %32, i32 0, i32 0
+  store ptr @5, ptr %33, align 8
+  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %32, i32 0, i32 1
+  store i64 1, ptr %34, align 4
+  %35 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %32, align 8
+  %36 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %36, i32 0, i32 0
+  store ptr null, ptr %37, align 8
+  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %36, i32 0, i32 1
+  store i64 0, ptr %38, align 4
+  %39 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %36, align 8
+  %40 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %41 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %35, ptr %40, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %39, i1 false)
+  %42 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %42, i32 0, i32 0
+  store ptr @2, ptr %43, align 8
+  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %42, i32 0, i32 1
+  store i64 4, ptr %44, align 4
+  %45 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %42, align 8
+  %46 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
+  %47 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %46, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %41, ptr %47, align 8
+  %48 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %49 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, i32 0, i32 0
+  store ptr %46, ptr %49, align 8
+  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, i32 0, i32 1
+  store i64 1, ptr %50, align 4
+  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, i32 0, i32 2
+  store i64 1, ptr %51, align 4
+  %52 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, align 8
+  %53 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %45, i64 8, %"github.com/goplus/llgo/internal/runtime.Slice" %52)
+  store ptr %53, ptr @"main.struct$MYpsoM99ZwFY087IpUOkIw1zjBA_sgFXVodmn1m-G88", align 8
+  %54 = load ptr, ptr @"main.struct$MYpsoM99ZwFY087IpUOkIw1zjBA_sgFXVodmn1m-G88", align 8
+  br i1 %31, label %_llgo_9, label %_llgo_10
+
+_llgo_9:                                          ; preds = %_llgo_8
+  %55 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 0
+  store ptr @2, ptr %56, align 8
+  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 1
+  store i64 4, ptr %57, align 4
+  %58 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %55, align 8
+  %59 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %59, i32 0, i32 0
+  store ptr @6, ptr %60, align 8
+  %61 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %59, i32 0, i32 1
+  store i64 2, ptr %61, align 4
+  %62 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %59, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %29, %"github.com/goplus/llgo/internal/runtime.String" %58, %"github.com/goplus/llgo/internal/runtime.String" %62, ptr %54, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  br label %_llgo_10
+
+_llgo_10:                                         ; preds = %_llgo_9, %_llgo_8
+  %63 = load ptr, ptr @_llgo_main.T2, align 8
+  %64 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %65 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %64, i32 0, i32 0
+  store ptr @7, ptr %65, align 8
+  %66 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %64, i32 0, i32 1
+  store i64 12, ptr %66, align 4
+  %67 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %64, align 8
+  %68 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %67, i64 25, i64 16, i64 0, i64 0)
+  %69 = load ptr, ptr @"_llgo_main.T3[any]", align 8
+  %70 = icmp eq ptr %69, null
+  br i1 %70, label %_llgo_11, label %_llgo_12
+
+_llgo_11:                                         ; preds = %_llgo_10
+  store ptr %68, ptr @"_llgo_main.T3[any]", align 8
+  br label %_llgo_12
+
+_llgo_12:                                         ; preds = %_llgo_11, %_llgo_10
+  %71 = load ptr, ptr @_llgo_any, align 8
+  %72 = icmp eq ptr %71, null
+  br i1 %72, label %_llgo_13, label %_llgo_14
+
+_llgo_13:                                         ; preds = %_llgo_12
+  %73 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %74 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %75 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %74, i32 0, i32 0
+  store ptr %73, ptr %75, align 8
+  %76 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %74, i32 0, i32 1
+  store i64 0, ptr %76, align 4
+  %77 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %74, i32 0, i32 2
+  store i64 0, ptr %77, align 4
+  %78 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %74, align 8
+  %79 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %80 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %79, i32 0, i32 0
+  store ptr @2, ptr %80, align 8
+  %81 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %79, i32 0, i32 1
+  store i64 4, ptr %81, align 4
+  %82 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %79, align 8
+  %83 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %84 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %83, i32 0, i32 0
+  store ptr null, ptr %84, align 8
+  %85 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %83, i32 0, i32 1
+  store i64 0, ptr %85, align 4
+  %86 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %83, align 8
+  %87 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %82, %"github.com/goplus/llgo/internal/runtime.String" %86, %"github.com/goplus/llgo/internal/runtime.Slice" %78)
+  store ptr %87, ptr @_llgo_any, align 8
+  br label %_llgo_14
+
+_llgo_14:                                         ; preds = %_llgo_13, %_llgo_12
+  %88 = load ptr, ptr @_llgo_any, align 8
+  %89 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %90 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %89, i32 0, i32 0
+  store ptr @5, ptr %90, align 8
+  %91 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %89, i32 0, i32 1
+  store i64 1, ptr %91, align 4
+  %92 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %89, align 8
+  %93 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %94 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %93, i32 0, i32 0
+  store ptr null, ptr %94, align 8
+  %95 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %93, i32 0, i32 1
+  store i64 0, ptr %95, align 4
+  %96 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %93, align 8
+  %97 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %98 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %99 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %98, i32 0, i32 0
+  store ptr %97, ptr %99, align 8
+  %100 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %98, i32 0, i32 1
+  store i64 0, ptr %100, align 4
+  %101 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %98, i32 0, i32 2
+  store i64 0, ptr %101, align 4
+  %102 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %98, align 8
+  %103 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %104 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %103, i32 0, i32 0
+  store ptr @2, ptr %104, align 8
+  %105 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %103, i32 0, i32 1
+  store i64 4, ptr %105, align 4
+  %106 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %103, align 8
+  %107 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %108 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %107, i32 0, i32 0
+  store ptr null, ptr %108, align 8
+  %109 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %107, i32 0, i32 1
+  store i64 0, ptr %109, align 4
+  %110 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %107, align 8
+  %111 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %106, %"github.com/goplus/llgo/internal/runtime.String" %110, %"github.com/goplus/llgo/internal/runtime.Slice" %102)
+  %112 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %92, ptr %111, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %96, i1 false)
+  %113 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %114 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %113, i32 0, i32 0
+  store ptr @2, ptr %114, align 8
+  %115 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %113, i32 0, i32 1
+  store i64 4, ptr %115, align 4
+  %116 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %113, align 8
+  %117 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
+  %118 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %117, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %112, ptr %118, align 8
+  %119 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %120 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %119, i32 0, i32 0
+  store ptr %117, ptr %120, align 8
+  %121 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %119, i32 0, i32 1
+  store i64 1, ptr %121, align 4
+  %122 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %119, i32 0, i32 2
+  store i64 1, ptr %122, align 4
+  %123 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %119, align 8
+  %124 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %116, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %123)
+  store ptr %124, ptr @"main.struct$op7q0963ur0ih9ul6OteH-C75UVydPxwKOVpX1hUjzo", align 8
+  %125 = load ptr, ptr @"main.struct$op7q0963ur0ih9ul6OteH-C75UVydPxwKOVpX1hUjzo", align 8
+  br i1 %70, label %_llgo_15, label %_llgo_16
+
+_llgo_15:                                         ; preds = %_llgo_14
+  %126 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %127 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %126, i32 0, i32 0
+  store ptr @2, ptr %127, align 8
+  %128 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %126, i32 0, i32 1
+  store i64 4, ptr %128, align 4
+  %129 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %126, align 8
+  %130 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %131 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %130, i32 0, i32 0
+  store ptr @8, ptr %131, align 8
+  %132 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %130, i32 0, i32 1
+  store i64 7, ptr %132, align 4
+  %133 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %130, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %68, %"github.com/goplus/llgo/internal/runtime.String" %129, %"github.com/goplus/llgo/internal/runtime.String" %133, ptr %125, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  br label %_llgo_16
+
+_llgo_16:                                         ; preds = %_llgo_15, %_llgo_14
+  %134 = load ptr, ptr @"_llgo_main.T3[any]", align 8
+  %135 = load ptr, ptr @"*_llgo_int", align 8
+  %136 = icmp eq ptr %135, null
+  br i1 %136, label %_llgo_17, label %_llgo_18
+
+_llgo_17:                                         ; preds = %_llgo_16
+  %137 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %138 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %137)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %138)
+  store ptr %138, ptr @"*_llgo_int", align 8
+  br label %_llgo_18
+
+_llgo_18:                                         ; preds = %_llgo_17, %_llgo_16
+  %139 = load ptr, ptr @"*_llgo_int", align 8
+  %140 = load ptr, ptr @_llgo_uintptr, align 8
+  %141 = icmp eq ptr %140, null
+  br i1 %141, label %_llgo_19, label %_llgo_20
+
+_llgo_19:                                         ; preds = %_llgo_18
+  %142 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
+  store ptr %142, ptr @_llgo_uintptr, align 8
+  br label %_llgo_20
+
+_llgo_20:                                         ; preds = %_llgo_19, %_llgo_18
+  %143 = load ptr, ptr @_llgo_uintptr, align 8
+  %144 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %145 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %144, i32 0, i32 0
+  store ptr @1, ptr %145, align 8
+  %146 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %144, i32 0, i32 1
+  store i64 7, ptr %146, align 4
+  %147 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %144, align 8
+  %148 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %147, i64 2, i64 8, i64 0, i64 0)
+  %149 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %150 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %149, i32 0, i32 0
+  store ptr @4, ptr %150, align 8
+  %151 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %149, i32 0, i32 1
+  store i64 7, ptr %151, align 4
+  %152 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %149, align 8
+  %153 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %152, i64 25, i64 8, i64 0, i64 0)
+  %154 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %155 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %154, i32 0, i32 0
+  store ptr @7, ptr %155, align 8
+  %156 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %154, i32 0, i32 1
+  store i64 12, ptr %156, align 4
+  %157 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %154, align 8
+  %158 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %157, i64 25, i64 16, i64 0, i64 0)
+  %159 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %160 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %159, i32 0, i32 0
+  store ptr @9, ptr %160, align 8
+  %161 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %159, i32 0, i32 1
+  store i64 2, ptr %161, align 4
+  %162 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %159, align 8
+  %163 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %164 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %163, i32 0, i32 0
+  store ptr null, ptr %164, align 8
+  %165 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %163, i32 0, i32 1
+  store i64 0, ptr %165, align 4
+  %166 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %163, align 8
+  %167 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %162, ptr %148, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %166, i1 false)
+  %168 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %169 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %168, i32 0, i32 0
+  store ptr @10, ptr %169, align 8
+  %170 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %168, i32 0, i32 1
+  store i64 2, ptr %170, align 4
+  %171 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %168, align 8
+  %172 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %173 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %172, i32 0, i32 0
+  store ptr null, ptr %173, align 8
+  %174 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %172, i32 0, i32 1
+  store i64 0, ptr %174, align 4
+  %175 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %172, align 8
+  %176 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %171, ptr %153, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %175, i1 false)
+  %177 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %178 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %177, i32 0, i32 0
+  store ptr @11, ptr %178, align 8
+  %179 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %177, i32 0, i32 1
+  store i64 2, ptr %179, align 4
+  %180 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %177, align 8
+  %181 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %182 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %181, i32 0, i32 0
+  store ptr null, ptr %182, align 8
+  %183 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %181, i32 0, i32 1
+  store i64 0, ptr %183, align 4
+  %184 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %181, align 8
+  %185 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %180, ptr %158, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %184, i1 false)
+  %186 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %187 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %186, i32 0, i32 0
+  store ptr @12, ptr %187, align 8
+  %188 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %186, i32 0, i32 1
+  store i64 2, ptr %188, align 4
+  %189 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %186, align 8
+  %190 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %191 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %190, i32 0, i32 0
+  store ptr null, ptr %191, align 8
+  %192 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %190, i32 0, i32 1
+  store i64 0, ptr %192, align 4
+  %193 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %190, align 8
+  %194 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %195 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %194)
+  %196 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %189, ptr %195, i64 32, %"github.com/goplus/llgo/internal/runtime.String" %193, i1 false)
+  %197 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %198 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %197, i32 0, i32 0
+  store ptr @13, ptr %198, align 8
+  %199 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %197, i32 0, i32 1
+  store i64 2, ptr %199, align 4
+  %200 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %197, align 8
+  %201 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %202 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %201, i32 0, i32 0
+  store ptr null, ptr %202, align 8
+  %203 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %201, i32 0, i32 1
+  store i64 0, ptr %203, align 4
+  %204 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %201, align 8
+  %205 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
+  %206 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %200, ptr %205, i64 40, %"github.com/goplus/llgo/internal/runtime.String" %204, i1 false)
+  %207 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %208 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %207, i32 0, i32 0
+  store ptr @2, ptr %208, align 8
+  %209 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %207, i32 0, i32 1
+  store i64 4, ptr %209, align 4
+  %210 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %207, align 8
+  %211 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 280)
+  %212 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %211, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %167, ptr %212, align 8
+  %213 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %211, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %176, ptr %213, align 8
+  %214 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %211, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %185, ptr %214, align 8
+  %215 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %211, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %196, ptr %215, align 8
+  %216 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %211, i64 4
+  store %"github.com/goplus/llgo/internal/abi.StructField" %206, ptr %216, align 8
+  %217 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %218 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %217, i32 0, i32 0
+  store ptr %211, ptr %218, align 8
+  %219 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %217, i32 0, i32 1
+  store i64 5, ptr %219, align 4
+  %220 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %217, i32 0, i32 2
+  store i64 5, ptr %220, align 4
+  %221 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %217, align 8
+  %222 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %210, i64 48, %"github.com/goplus/llgo/internal/runtime.Slice" %221)
+  store ptr %222, ptr @"main.struct$ZLgMjv1XBA1L4yXCpdouRvQF2okeuHQ-YWVTE34gq4I", align 8
+  %223 = load ptr, ptr @"main.struct$ZLgMjv1XBA1L4yXCpdouRvQF2okeuHQ-YWVTE34gq4I", align 8
+  %224 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %225 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %224, i32 0, i32 0
+  store ptr @2, ptr %225, align 8
+  %226 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %224, i32 0, i32 1
+  store i64 4, ptr %226, align 4
+  %227 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %224, align 8
+  %228 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %229 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %228, i32 0, i32 0
+  store ptr @14, ptr %229, align 8
+  %230 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %228, i32 0, i32 1
+  store i64 8, ptr %230, align 4
+  %231 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %228, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %4, %"github.com/goplus/llgo/internal/runtime.String" %227, %"github.com/goplus/llgo/internal/runtime.String" %231, ptr %223, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  %232 = load ptr, ptr @_llgo_string, align 8
+  %233 = icmp eq ptr %232, null
+  br i1 %233, label %_llgo_21, label %_llgo_22
+
+_llgo_21:                                         ; preds = %_llgo_20
+  %234 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  store ptr %234, ptr @_llgo_string, align 8
+  br label %_llgo_22
+
+_llgo_22:                                         ; preds = %_llgo_21, %_llgo_20
+  %235 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %236 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %235, i32 0, i32 0
+  store ptr @0, ptr %236, align 8
+  %237 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %235, i32 0, i32 1
+  store i64 13, ptr %237, align 4
+  %238 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %235, align 8
+  %239 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %238, i64 25, i64 48, i64 0, i64 0)
+  %240 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %241 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %240, i32 0, i32 0
+  store ptr @0, ptr %241, align 8
+  %242 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %240, i32 0, i32 1
+  store i64 13, ptr %242, align 4
+  %243 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %240, align 8
+  %244 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %243, i64 25, i64 48, i64 0, i64 0)
+  %245 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %246 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %247 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %246, i32 0, i32 0
+  store ptr @15, ptr %247, align 8
+  %248 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %246, i32 0, i32 1
+  store i64 7, ptr %248, align 4
+  %249 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %246, align 8
+  %250 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %251 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %250, i32 0, i32 0
+  store ptr null, ptr %251, align 8
+  %252 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %250, i32 0, i32 1
+  store i64 0, ptr %252, align 4
+  %253 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %250, align 8
+  %254 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %255 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %254)
+  %256 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %249, ptr %255, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %253, i1 false)
+  %257 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %258 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %257, i32 0, i32 0
+  store ptr @16, ptr %258, align 8
+  %259 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %257, i32 0, i32 1
+  store i64 4, ptr %259, align 4
+  %260 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %257, align 8
+  %261 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %262 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %261, i32 0, i32 0
+  store ptr null, ptr %262, align 8
+  %263 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %261, i32 0, i32 1
+  store i64 0, ptr %263, align 4
+  %264 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %261, align 8
+  %265 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %244)
+  %266 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %260, ptr %265, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %264, i1 false)
+  %267 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %268 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %267, i32 0, i32 0
+  store ptr @17, ptr %268, align 8
+  %269 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %267, i32 0, i32 1
+  store i64 5, ptr %269, align 4
+  %270 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %267, align 8
+  %271 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %272 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %271, i32 0, i32 0
+  store ptr null, ptr %272, align 8
+  %273 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %271, i32 0, i32 1
+  store i64 0, ptr %273, align 4
+  %274 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %271, align 8
+  %275 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %276 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %275)
+  %277 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %270, ptr %276, i64 392, %"github.com/goplus/llgo/internal/runtime.String" %274, i1 false)
+  %278 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %279 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %278, i32 0, i32 0
+  store ptr @18, ptr %279, align 8
+  %280 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %278, i32 0, i32 1
+  store i64 8, ptr %280, align 4
+  %281 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %278, align 8
+  %282 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %283 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %282, i32 0, i32 0
+  store ptr null, ptr %283, align 8
+  %284 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %282, i32 0, i32 1
+  store i64 0, ptr %284, align 4
+  %285 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %282, align 8
+  %286 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %287 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %281, ptr %286, i64 520, %"github.com/goplus/llgo/internal/runtime.String" %285, i1 false)
+  %288 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %289 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %288, i32 0, i32 0
+  store ptr @2, ptr %289, align 8
+  %290 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %288, i32 0, i32 1
+  store i64 4, ptr %290, align 4
+  %291 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %288, align 8
+  %292 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
+  %293 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %292, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %256, ptr %293, align 8
+  %294 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %292, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %266, ptr %294, align 8
+  %295 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %292, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %277, ptr %295, align 8
+  %296 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %292, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %287, ptr %296, align 8
+  %297 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %298 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %297, i32 0, i32 0
+  store ptr %292, ptr %298, align 8
+  %299 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %297, i32 0, i32 1
+  store i64 4, ptr %299, align 4
+  %300 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %297, i32 0, i32 2
+  store i64 4, ptr %300, align 4
+  %301 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %297, align 8
+  %302 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %291, i64 528, %"github.com/goplus/llgo/internal/runtime.Slice" %301)
+  %303 = call ptr @"github.com/goplus/llgo/internal/runtime.MapOf"(ptr %239, ptr %245, ptr %302, i64 24)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %303)
+  store ptr %303, ptr @"map[_llgo_main.cacheKey]_llgo_string", align 8
+  ret void
+}
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String", i64, i64, i64, i64)
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64)
+
+declare void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr, %"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.String", ptr, %"github.com/goplus/llgo/internal/runtime.Slice", %"github.com/goplus/llgo/internal/runtime.Slice")
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String", i64, %"github.com/goplus/llgo/internal/runtime.Slice")
+
+declare %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String", ptr, i64, %"github.com/goplus/llgo/internal/runtime.String", i1)
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64)
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.Slice")
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr)
+
+declare void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr)
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.MapOf"(ptr, ptr, ptr, i64)
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64, ptr)
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.MakeMap"(ptr, i64)
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr, ptr, ptr)
+
+declare { ptr, i1 } @"github.com/goplus/llgo/internal/runtime.MapAccess2"(ptr, ptr, ptr)
+
+declare void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String")
+
+declare void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8)
+
+declare void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1)
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/builtin_test.go
+++ b/cl/builtin_test.go
@@ -345,3 +345,20 @@ func TestContextResolveLinkname(t *testing.T) {
 		})
 	}
 }
+
+func TestInstantiate(t *testing.T) {
+	obj := types.NewTypeName(0, nil, "T", nil)
+	named := types.NewNamed(obj, types.Typ[types.Int], nil)
+	if typ := obj.Type(); typ != instantiate(typ, named) {
+		t.Fatal("error")
+	}
+	tparam := types.NewTypeParam(types.NewTypeName(0, nil, "P", nil), types.NewInterface(nil, nil))
+	named.SetTypeParams([]*types.TypeParam{tparam})
+	inamed, err := types.Instantiate(nil, named, []types.Type{types.Typ[types.Int]}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if typ := instantiate(obj.Type(), inamed.(*types.Named)); typ == obj.Type() || typ.(*types.Named).TypeArgs() == nil {
+		t.Fatal("error")
+	}
+}

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1036,7 +1036,19 @@ func (p *context) patchType(typ types.Type) types.Type {
 		if pkg := o.Pkg(); typepatch.IsPatched(pkg) {
 			if patch, ok := p.patches[pkg.Path()]; ok {
 				if obj := patch.Types.Scope().Lookup(o.Name()); obj != nil {
-					return p.prog.Type(obj.Type(), llssa.InGo).RawType()
+					otyp := obj.Type()
+					if tp := t.TypeArgs(); tp != nil {
+						targs := make([]types.Type, tp.Len())
+						for i := 0; i < tp.Len(); i++ {
+							targs[i] = tp.At(i)
+						}
+						var err error
+						otyp, err = types.Instantiate(nil, obj.Type(), targs, true)
+						if err != nil {
+							panic(fmt.Errorf("patchType error: %v", err))
+						}
+					}
+					return p.prog.Type(otyp, llssa.InGo).RawType()
 				}
 			}
 		}

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1036,24 +1036,17 @@ func (p *context) patchType(typ types.Type) types.Type {
 		if pkg := o.Pkg(); typepatch.IsPatched(pkg) {
 			if patch, ok := p.patches[pkg.Path()]; ok {
 				if obj := patch.Types.Scope().Lookup(o.Name()); obj != nil {
-					otyp := obj.Type()
-					if tp := t.TypeArgs(); tp != nil {
-						targs := make([]types.Type, tp.Len())
-						for i := 0; i < tp.Len(); i++ {
-							targs[i] = tp.At(i)
-						}
-						var err error
-						otyp, err = types.Instantiate(nil, obj.Type(), targs, true)
-						if err != nil {
-							panic(fmt.Errorf("patchType error: %v", err))
-						}
-					}
-					return p.prog.Type(otyp, llssa.InGo).RawType()
+					return p.prog.Type(instantiate(obj.Type(), t), llssa.InGo).RawType()
 				}
 			}
 		}
 	}
 	return typ
+}
+
+func instantiate(orig types.Type, t *types.Named) (typ types.Type) {
+	typ, _ = llssa.Instantiate(orig, t)
+	return
 }
 
 func (p *context) resolveLinkname(name string) string {

--- a/internal/lib/sync/map.go
+++ b/internal/lib/sync/map.go
@@ -1,0 +1,515 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package sync
+
+import (
+	"sync/atomic"
+)
+
+// Map is like a Go map[interface{}]interface{} but is safe for concurrent use
+// by multiple goroutines without additional locking or coordination.
+// Loads, stores, and deletes run in amortized constant time.
+//
+// The Map type is specialized. Most code should use a plain Go map instead,
+// with separate locking or coordination, for better type safety and to make it
+// easier to maintain other invariants along with the map content.
+//
+// The Map type is optimized for two common use cases: (1) when the entry for a given
+// key is only ever written once but read many times, as in caches that only grow,
+// or (2) when multiple goroutines read, write, and overwrite entries for disjoint
+// sets of keys. In these two cases, use of a Map may significantly reduce lock
+// contention compared to a Go map paired with a separate Mutex or RWMutex.
+//
+// The zero Map is empty and ready for use. A Map must not be copied after first use.
+//
+// In the terminology of the Go memory model, Map arranges that a write operation
+// “synchronizes before” any read operation that observes the effect of the write, where
+// read and write operations are defined as follows.
+// Load, LoadAndDelete, LoadOrStore, Swap, CompareAndSwap, and CompareAndDelete
+// are read operations; Delete, LoadAndDelete, Store, and Swap are write operations;
+// LoadOrStore is a write operation when it returns loaded set to false;
+// CompareAndSwap is a write operation when it returns swapped set to true;
+// and CompareAndDelete is a write operation when it returns deleted set to true.
+type Map struct {
+	mu Mutex
+
+	// read contains the portion of the map's contents that are safe for
+	// concurrent access (with or without mu held).
+	//
+	// The read field itself is always safe to load, but must only be stored with
+	// mu held.
+	//
+	// Entries stored in read may be updated concurrently without mu, but updating
+	// a previously-expunged entry requires that the entry be copied to the dirty
+	// map and unexpunged with mu held.
+	read atomic.Pointer[readOnly]
+
+	// dirty contains the portion of the map's contents that require mu to be
+	// held. To ensure that the dirty map can be promoted to the read map quickly,
+	// it also includes all of the non-expunged entries in the read map.
+	//
+	// Expunged entries are not stored in the dirty map. An expunged entry in the
+	// clean map must be unexpunged and added to the dirty map before a new value
+	// can be stored to it.
+	//
+	// If the dirty map is nil, the next write to the map will initialize it by
+	// making a shallow copy of the clean map, omitting stale entries.
+	dirty map[any]*entry
+
+	// misses counts the number of loads since the read map was last updated that
+	// needed to lock mu to determine whether the key was present.
+	//
+	// Once enough misses have occurred to cover the cost of copying the dirty
+	// map, the dirty map will be promoted to the read map (in the unamended
+	// state) and the next store to the map will make a new dirty copy.
+	misses int
+}
+
+// readOnly is an immutable struct stored atomically in the Map.read field.
+type readOnly struct {
+	m       map[any]*entry
+	amended bool // true if the dirty map contains some key not in m.
+}
+
+// expunged is an arbitrary pointer that marks entries which have been deleted
+// from the dirty map.
+var expunged = new(any)
+
+// An entry is a slot in the map corresponding to a particular key.
+type entry struct {
+	// p points to the interface{} value stored for the entry.
+	//
+	// If p == nil, the entry has been deleted, and either m.dirty == nil or
+	// m.dirty[key] is e.
+	//
+	// If p == expunged, the entry has been deleted, m.dirty != nil, and the entry
+	// is missing from m.dirty.
+	//
+	// Otherwise, the entry is valid and recorded in m.read.m[key] and, if m.dirty
+	// != nil, in m.dirty[key].
+	//
+	// An entry can be deleted by atomic replacement with nil: when m.dirty is
+	// next created, it will atomically replace nil with expunged and leave
+	// m.dirty[key] unset.
+	//
+	// An entry's associated value can be updated by atomic replacement, provided
+	// p != expunged. If p == expunged, an entry's associated value can be updated
+	// only after first setting m.dirty[key] = e so that lookups using the dirty
+	// map find the entry.
+	p atomic.Pointer[any]
+}
+
+func newEntry(i any) *entry {
+	e := &entry{}
+	e.p.Store(&i)
+	return e
+}
+
+func (m *Map) loadReadOnly() readOnly {
+	if p := m.read.Load(); p != nil {
+		return *p
+	}
+	return readOnly{}
+}
+
+// Load returns the value stored in the map for a key, or nil if no
+// value is present.
+// The ok result indicates whether value was found in the map.
+func (m *Map) Load(key any) (value any, ok bool) {
+	read := m.loadReadOnly()
+	e, ok := read.m[key]
+	if !ok && read.amended {
+		m.mu.Lock()
+		// Avoid reporting a spurious miss if m.dirty got promoted while we were
+		// blocked on m.mu. (If further loads of the same key will not miss, it's
+		// not worth copying the dirty map for this key.)
+		read = m.loadReadOnly()
+		e, ok = read.m[key]
+		if !ok && read.amended {
+			e, ok = m.dirty[key]
+			// Regardless of whether the entry was present, record a miss: this key
+			// will take the slow path until the dirty map is promoted to the read
+			// map.
+			m.missLocked()
+		}
+		m.mu.Unlock()
+	}
+	if !ok {
+		return nil, false
+	}
+	return e.load()
+}
+
+func (e *entry) load() (value any, ok bool) {
+	p := e.p.Load()
+	if p == nil || p == expunged {
+		return nil, false
+	}
+	return *p, true
+}
+
+// Store sets the value for a key.
+func (m *Map) Store(key, value any) {
+	_, _ = m.Swap(key, value)
+}
+
+// tryCompareAndSwap compare the entry with the given old value and swaps
+// it with a new value if the entry is equal to the old value, and the entry
+// has not been expunged.
+//
+// If the entry is expunged, tryCompareAndSwap returns false and leaves
+// the entry unchanged.
+func (e *entry) tryCompareAndSwap(old, new any) bool {
+	p := e.p.Load()
+	if p == nil || p == expunged || *p != old {
+		return false
+	}
+
+	// Copy the interface after the first load to make this method more amenable
+	// to escape analysis: if the comparison fails from the start, we shouldn't
+	// bother heap-allocating an interface value to store.
+	nc := new
+	for {
+		if e.p.CompareAndSwap(p, &nc) {
+			return true
+		}
+		p = e.p.Load()
+		if p == nil || p == expunged || *p != old {
+			return false
+		}
+	}
+}
+
+// unexpungeLocked ensures that the entry is not marked as expunged.
+//
+// If the entry was previously expunged, it must be added to the dirty map
+// before m.mu is unlocked.
+func (e *entry) unexpungeLocked() (wasExpunged bool) {
+	return e.p.CompareAndSwap(expunged, nil)
+}
+
+// swapLocked unconditionally swaps a value into the entry.
+//
+// The entry must be known not to be expunged.
+func (e *entry) swapLocked(i *any) *any {
+	return e.p.Swap(i)
+}
+
+// LoadOrStore returns the existing value for the key if present.
+// Otherwise, it stores and returns the given value.
+// The loaded result is true if the value was loaded, false if stored.
+func (m *Map) LoadOrStore(key, value any) (actual any, loaded bool) {
+	// Avoid locking if it's a clean hit.
+	read := m.loadReadOnly()
+	if e, ok := read.m[key]; ok {
+		actual, loaded, ok := e.tryLoadOrStore(value)
+		if ok {
+			return actual, loaded
+		}
+	}
+
+	m.mu.Lock()
+	read = m.loadReadOnly()
+	if e, ok := read.m[key]; ok {
+		if e.unexpungeLocked() {
+			m.dirty[key] = e
+		}
+		actual, loaded, _ = e.tryLoadOrStore(value)
+	} else if e, ok := m.dirty[key]; ok {
+		actual, loaded, _ = e.tryLoadOrStore(value)
+		m.missLocked()
+	} else {
+		if !read.amended {
+			// We're adding the first new key to the dirty map.
+			// Make sure it is allocated and mark the read-only map as incomplete.
+			m.dirtyLocked()
+			m.read.Store(&readOnly{m: read.m, amended: true})
+		}
+		m.dirty[key] = newEntry(value)
+		actual, loaded = value, false
+	}
+	m.mu.Unlock()
+
+	return actual, loaded
+}
+
+// tryLoadOrStore atomically loads or stores a value if the entry is not
+// expunged.
+//
+// If the entry is expunged, tryLoadOrStore leaves the entry unchanged and
+// returns with ok==false.
+func (e *entry) tryLoadOrStore(i any) (actual any, loaded, ok bool) {
+	p := e.p.Load()
+	if p == expunged {
+		return nil, false, false
+	}
+	if p != nil {
+		return *p, true, true
+	}
+
+	// Copy the interface after the first load to make this method more amenable
+	// to escape analysis: if we hit the "load" path or the entry is expunged, we
+	// shouldn't bother heap-allocating.
+	ic := i
+	for {
+		if e.p.CompareAndSwap(nil, &ic) {
+			return i, false, true
+		}
+		p = e.p.Load()
+		if p == expunged {
+			return nil, false, false
+		}
+		if p != nil {
+			return *p, true, true
+		}
+	}
+}
+
+// LoadAndDelete deletes the value for a key, returning the previous value if any.
+// The loaded result reports whether the key was present.
+func (m *Map) LoadAndDelete(key any) (value any, loaded bool) {
+	read := m.loadReadOnly()
+	e, ok := read.m[key]
+	if !ok && read.amended {
+		m.mu.Lock()
+		read = m.loadReadOnly()
+		e, ok = read.m[key]
+		if !ok && read.amended {
+			e, ok = m.dirty[key]
+			delete(m.dirty, key)
+			// Regardless of whether the entry was present, record a miss: this key
+			// will take the slow path until the dirty map is promoted to the read
+			// map.
+			m.missLocked()
+		}
+		m.mu.Unlock()
+	}
+	if ok {
+		return e.delete()
+	}
+	return nil, false
+}
+
+// Delete deletes the value for a key.
+func (m *Map) Delete(key any) {
+	m.LoadAndDelete(key)
+}
+
+func (e *entry) delete() (value any, ok bool) {
+	for {
+		p := e.p.Load()
+		if p == nil || p == expunged {
+			return nil, false
+		}
+		if e.p.CompareAndSwap(p, nil) {
+			return *p, true
+		}
+	}
+}
+
+// trySwap swaps a value if the entry has not been expunged.
+//
+// If the entry is expunged, trySwap returns false and leaves the entry
+// unchanged.
+func (e *entry) trySwap(i *any) (*any, bool) {
+	for {
+		p := e.p.Load()
+		if p == expunged {
+			return nil, false
+		}
+		if e.p.CompareAndSwap(p, i) {
+			return p, true
+		}
+	}
+}
+
+// Swap swaps the value for a key and returns the previous value if any.
+// The loaded result reports whether the key was present.
+func (m *Map) Swap(key, value any) (previous any, loaded bool) {
+	read := m.loadReadOnly()
+	if e, ok := read.m[key]; ok {
+		if v, ok := e.trySwap(&value); ok {
+			if v == nil {
+				return nil, false
+			}
+			return *v, true
+		}
+	}
+
+	m.mu.Lock()
+	read = m.loadReadOnly()
+	if e, ok := read.m[key]; ok {
+		if e.unexpungeLocked() {
+			// The entry was previously expunged, which implies that there is a
+			// non-nil dirty map and this entry is not in it.
+			m.dirty[key] = e
+		}
+		if v := e.swapLocked(&value); v != nil {
+			loaded = true
+			previous = *v
+		}
+	} else if e, ok := m.dirty[key]; ok {
+		if v := e.swapLocked(&value); v != nil {
+			loaded = true
+			previous = *v
+		}
+	} else {
+		if !read.amended {
+			// We're adding the first new key to the dirty map.
+			// Make sure it is allocated and mark the read-only map as incomplete.
+			m.dirtyLocked()
+			m.read.Store(&readOnly{m: read.m, amended: true})
+		}
+		m.dirty[key] = newEntry(value)
+	}
+	m.mu.Unlock()
+	return previous, loaded
+}
+
+// CompareAndSwap swaps the old and new values for key
+// if the value stored in the map is equal to old.
+// The old value must be of a comparable type.
+func (m *Map) CompareAndSwap(key, old, new any) bool {
+	read := m.loadReadOnly()
+	if e, ok := read.m[key]; ok {
+		return e.tryCompareAndSwap(old, new)
+	} else if !read.amended {
+		return false // No existing value for key.
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	read = m.loadReadOnly()
+	swapped := false
+	if e, ok := read.m[key]; ok {
+		swapped = e.tryCompareAndSwap(old, new)
+	} else if e, ok := m.dirty[key]; ok {
+		swapped = e.tryCompareAndSwap(old, new)
+		// We needed to lock mu in order to load the entry for key,
+		// and the operation didn't change the set of keys in the map
+		// (so it would be made more efficient by promoting the dirty
+		// map to read-only).
+		// Count it as a miss so that we will eventually switch to the
+		// more efficient steady state.
+		m.missLocked()
+	}
+	return swapped
+}
+
+// CompareAndDelete deletes the entry for key if its value is equal to old.
+// The old value must be of a comparable type.
+//
+// If there is no current value for key in the map, CompareAndDelete
+// returns false (even if the old value is the nil interface value).
+func (m *Map) CompareAndDelete(key, old any) (deleted bool) {
+	read := m.loadReadOnly()
+	e, ok := read.m[key]
+	if !ok && read.amended {
+		m.mu.Lock()
+		read = m.loadReadOnly()
+		e, ok = read.m[key]
+		if !ok && read.amended {
+			e, ok = m.dirty[key]
+			// Don't delete key from m.dirty: we still need to do the “compare” part
+			// of the operation. The entry will eventually be expunged when the
+			// dirty map is promoted to the read map.
+			//
+			// Regardless of whether the entry was present, record a miss: this key
+			// will take the slow path until the dirty map is promoted to the read
+			// map.
+			m.missLocked()
+		}
+		m.mu.Unlock()
+	}
+	for ok {
+		p := e.p.Load()
+		if p == nil || p == expunged || *p != old {
+			return false
+		}
+		if e.p.CompareAndSwap(p, nil) {
+			return true
+		}
+	}
+	return false
+}
+
+// Range calls f sequentially for each key and value present in the map.
+// If f returns false, range stops the iteration.
+//
+// Range does not necessarily correspond to any consistent snapshot of the Map's
+// contents: no key will be visited more than once, but if the value for any key
+// is stored or deleted concurrently (including by f), Range may reflect any
+// mapping for that key from any point during the Range call. Range does not
+// block other methods on the receiver; even f itself may call any method on m.
+//
+// Range may be O(N) with the number of elements in the map even if f returns
+// false after a constant number of calls.
+func (m *Map) Range(f func(key, value any) bool) {
+	// We need to be able to iterate over all of the keys that were already
+	// present at the start of the call to Range.
+	// If read.amended is false, then read.m satisfies that property without
+	// requiring us to hold m.mu for a long time.
+	read := m.loadReadOnly()
+	if read.amended {
+		// m.dirty contains keys not in read.m. Fortunately, Range is already O(N)
+		// (assuming the caller does not break out early), so a call to Range
+		// amortizes an entire copy of the map: we can promote the dirty copy
+		// immediately!
+		m.mu.Lock()
+		read = m.loadReadOnly()
+		if read.amended {
+			read = readOnly{m: m.dirty}
+			m.read.Store(&read)
+			m.dirty = nil
+			m.misses = 0
+		}
+		m.mu.Unlock()
+	}
+
+	for k, e := range read.m {
+		v, ok := e.load()
+		if !ok {
+			continue
+		}
+		if !f(k, v) {
+			break
+		}
+	}
+}
+
+func (m *Map) missLocked() {
+	m.misses++
+	if m.misses < len(m.dirty) {
+		return
+	}
+	m.read.Store(&readOnly{m: m.dirty})
+	m.dirty = nil
+	m.misses = 0
+}
+
+func (m *Map) dirtyLocked() {
+	if m.dirty != nil {
+		return
+	}
+
+	read := m.loadReadOnly()
+	m.dirty = make(map[any]*entry, len(read.m))
+	for k, e := range read.m {
+		if !e.tryExpungeLocked() {
+			m.dirty[k] = e
+		}
+	}
+}
+
+func (e *entry) tryExpungeLocked() (isExpunged bool) {
+	p := e.p.Load()
+	for p == nil {
+		if e.p.CompareAndSwap(nil, expunged) {
+			return true
+		}
+		p = e.p.Load()
+	}
+	return p == expunged
+}

--- a/internal/lib/sync/sync.go
+++ b/internal/lib/sync/sync.go
@@ -25,10 +25,6 @@ import (
 	"github.com/goplus/llgo/c/pthread/sync"
 )
 
-const (
-	LLGoPackage = "link"
-)
-
 // -----------------------------------------------------------------------------
 
 type Mutex sync.Mutex

--- a/ssa/type_cvt.go
+++ b/ssa/type_cvt.go
@@ -145,7 +145,7 @@ func (p goTypes) cvtNamed(t *types.Named) (raw *types.Named, cvt bool) {
 		}
 		named.SetTypeParams(list)
 	}
-	p.typs[unsafe.Pointer(t)] = unsafe.Pointer(named)
+	p.typs[unsafe.Pointer(t)] = unsafe.Pointer(t)
 	if tund, cvt := p.cvtType(t.Underlying()); cvt {
 		named.SetUnderlying(tund)
 		if tp := t.TypeArgs(); tp != nil {
@@ -158,11 +158,10 @@ func (p goTypes) cvtNamed(t *types.Named) (raw *types.Named, cvt bool) {
 				panic(fmt.Errorf("cvtNamed error: %v", err))
 			}
 			named = typ.(*types.Named)
-			p.typs[unsafe.Pointer(t)] = unsafe.Pointer(named)
 		}
+		p.typs[unsafe.Pointer(t)] = unsafe.Pointer(named)
 		return named, true
 	}
-	p.typs[unsafe.Pointer(t)] = unsafe.Pointer(t)
 	return t, false
 }
 


### PR DESCRIPTION
- ssa: fix goTypes.cvtNamed recurs for typeargs
- ssa: fix map key has typeargs ( in struct )
- internal/lib/sync: support sync.Map