### PR TITLE
Use LLVM memset intrinsic for compatibility and performance

### DIFF
--- a/cl/_testgo/equal/out.ll
+++ b/cl/_testgo/equal/out.ll
@@ -130,201 +130,201 @@ define void @"main.init#2"() {
 _llgo_0:
   call void @main.assert(i1 true)
   %0 = alloca [3 x i64], align 8
-  %1 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %0, i64 24)
-  %2 = getelementptr inbounds i64, ptr %1, i64 0
-  %3 = getelementptr inbounds i64, ptr %1, i64 1
-  %4 = getelementptr inbounds i64, ptr %1, i64 2
-  store i64 1, ptr %2, align 4
-  store i64 2, ptr %3, align 4
-  store i64 3, ptr %4, align 4
-  %5 = alloca [3 x i64], align 8
-  %6 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %5, i64 24)
-  %7 = getelementptr inbounds i64, ptr %6, i64 0
-  %8 = getelementptr inbounds i64, ptr %6, i64 1
-  %9 = getelementptr inbounds i64, ptr %6, i64 2
-  store i64 1, ptr %7, align 4
-  store i64 2, ptr %8, align 4
-  store i64 3, ptr %9, align 4
-  %10 = load [3 x i64], ptr %1, align 4
-  %11 = load [3 x i64], ptr %6, align 4
-  %12 = extractvalue [3 x i64] %10, 0
-  %13 = extractvalue [3 x i64] %11, 0
-  %14 = icmp eq i64 %12, %13
-  %15 = and i1 true, %14
-  %16 = extractvalue [3 x i64] %10, 1
-  %17 = extractvalue [3 x i64] %11, 1
-  %18 = icmp eq i64 %16, %17
-  %19 = and i1 %15, %18
-  %20 = extractvalue [3 x i64] %10, 2
-  %21 = extractvalue [3 x i64] %11, 2
-  %22 = icmp eq i64 %20, %21
-  %23 = and i1 %19, %22
-  call void @main.assert(i1 %23)
-  %24 = getelementptr inbounds i64, ptr %6, i64 1
-  store i64 1, ptr %24, align 4
-  %25 = load [3 x i64], ptr %1, align 4
-  %26 = load [3 x i64], ptr %6, align 4
-  %27 = extractvalue [3 x i64] %25, 0
-  %28 = extractvalue [3 x i64] %26, 0
-  %29 = icmp eq i64 %27, %28
-  %30 = and i1 true, %29
-  %31 = extractvalue [3 x i64] %25, 1
-  %32 = extractvalue [3 x i64] %26, 1
-  %33 = icmp eq i64 %31, %32
-  %34 = and i1 %30, %33
-  %35 = extractvalue [3 x i64] %25, 2
-  %36 = extractvalue [3 x i64] %26, 2
-  %37 = icmp eq i64 %35, %36
-  %38 = and i1 %34, %37
-  %39 = xor i1 %38, true
-  call void @main.assert(i1 %39)
+  call void @llvm.memset(ptr %0, i8 0, i64 24, i1 false)
+  %1 = getelementptr inbounds i64, ptr %0, i64 0
+  %2 = getelementptr inbounds i64, ptr %0, i64 1
+  %3 = getelementptr inbounds i64, ptr %0, i64 2
+  store i64 1, ptr %1, align 4
+  store i64 2, ptr %2, align 4
+  store i64 3, ptr %3, align 4
+  %4 = alloca [3 x i64], align 8
+  call void @llvm.memset(ptr %4, i8 0, i64 24, i1 false)
+  %5 = getelementptr inbounds i64, ptr %4, i64 0
+  %6 = getelementptr inbounds i64, ptr %4, i64 1
+  %7 = getelementptr inbounds i64, ptr %4, i64 2
+  store i64 1, ptr %5, align 4
+  store i64 2, ptr %6, align 4
+  store i64 3, ptr %7, align 4
+  %8 = load [3 x i64], ptr %0, align 4
+  %9 = load [3 x i64], ptr %4, align 4
+  %10 = extractvalue [3 x i64] %8, 0
+  %11 = extractvalue [3 x i64] %9, 0
+  %12 = icmp eq i64 %10, %11
+  %13 = and i1 true, %12
+  %14 = extractvalue [3 x i64] %8, 1
+  %15 = extractvalue [3 x i64] %9, 1
+  %16 = icmp eq i64 %14, %15
+  %17 = and i1 %13, %16
+  %18 = extractvalue [3 x i64] %8, 2
+  %19 = extractvalue [3 x i64] %9, 2
+  %20 = icmp eq i64 %18, %19
+  %21 = and i1 %17, %20
+  call void @main.assert(i1 %21)
+  %22 = getelementptr inbounds i64, ptr %4, i64 1
+  store i64 1, ptr %22, align 4
+  %23 = load [3 x i64], ptr %0, align 4
+  %24 = load [3 x i64], ptr %4, align 4
+  %25 = extractvalue [3 x i64] %23, 0
+  %26 = extractvalue [3 x i64] %24, 0
+  %27 = icmp eq i64 %25, %26
+  %28 = and i1 true, %27
+  %29 = extractvalue [3 x i64] %23, 1
+  %30 = extractvalue [3 x i64] %24, 1
+  %31 = icmp eq i64 %29, %30
+  %32 = and i1 %28, %31
+  %33 = extractvalue [3 x i64] %23, 2
+  %34 = extractvalue [3 x i64] %24, 2
+  %35 = icmp eq i64 %33, %34
+  %36 = and i1 %32, %35
+  %37 = xor i1 %36, true
+  call void @main.assert(i1 %37)
   ret void
 }
 
 define void @"main.init#3"() {
 _llgo_0:
   %0 = alloca %main.T, align 8
-  %1 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %0, i64 48)
-  %2 = getelementptr inbounds %main.T, ptr %1, i32 0, i32 0
-  %3 = getelementptr inbounds %main.T, ptr %1, i32 0, i32 1
-  %4 = getelementptr inbounds %main.T, ptr %1, i32 0, i32 2
-  %5 = getelementptr inbounds %main.T, ptr %1, i32 0, i32 3
-  store i64 10, ptr %2, align 4
-  store i64 20, ptr %3, align 4
-  %6 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %6, i32 0, i32 0
-  store ptr @1, ptr %7, align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %6, i32 0, i32 1
-  store i64 5, ptr %8, align 4
-  %9 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %6, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %9, ptr %4, align 8
-  %10 = load ptr, ptr @_llgo_int, align 8
-  %11 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %11, i32 0, i32 0
-  store ptr %10, ptr %12, align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %11, i32 0, i32 1
-  store ptr inttoptr (i64 1 to ptr), ptr %13, align 8
-  %14 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %11, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %14, ptr %5, align 8
-  %15 = alloca %main.T, align 8
-  %16 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %15, i64 48)
-  %17 = getelementptr inbounds %main.T, ptr %16, i32 0, i32 0
-  %18 = getelementptr inbounds %main.T, ptr %16, i32 0, i32 1
-  %19 = getelementptr inbounds %main.T, ptr %16, i32 0, i32 2
-  %20 = getelementptr inbounds %main.T, ptr %16, i32 0, i32 3
-  store i64 10, ptr %17, align 4
-  store i64 20, ptr %18, align 4
-  %21 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %21, i32 0, i32 0
-  store ptr @1, ptr %22, align 8
-  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %21, i32 0, i32 1
-  store i64 5, ptr %23, align 4
-  %24 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %21, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %24, ptr %19, align 8
-  %25 = load ptr, ptr @_llgo_int, align 8
-  %26 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %26, i32 0, i32 0
-  store ptr %25, ptr %27, align 8
-  %28 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %26, i32 0, i32 1
-  store ptr inttoptr (i64 1 to ptr), ptr %28, align 8
-  %29 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %26, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %29, ptr %20, align 8
-  %30 = alloca %main.T, align 8
-  %31 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %30, i64 48)
-  %32 = getelementptr inbounds %main.T, ptr %31, i32 0, i32 0
-  %33 = getelementptr inbounds %main.T, ptr %31, i32 0, i32 1
-  %34 = getelementptr inbounds %main.T, ptr %31, i32 0, i32 2
-  %35 = getelementptr inbounds %main.T, ptr %31, i32 0, i32 3
-  store i64 10, ptr %32, align 4
-  store i64 20, ptr %33, align 4
-  %36 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %36, i32 0, i32 0
-  store ptr @1, ptr %37, align 8
-  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %36, i32 0, i32 1
-  store i64 5, ptr %38, align 4
-  %39 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %36, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %39, ptr %34, align 8
-  %40 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %41 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %40, i32 0, i32 0
-  store ptr @2, ptr %41, align 8
-  %42 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %40, i32 0, i32 1
-  store i64 2, ptr %42, align 4
-  %43 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %40, align 8
-  %44 = load ptr, ptr @_llgo_string, align 8
-  %45 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %43, ptr %45, align 8
-  %46 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %47 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %46, i32 0, i32 0
-  store ptr %44, ptr %47, align 8
-  %48 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %46, i32 0, i32 1
-  store ptr %45, ptr %48, align 8
-  %49 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %46, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %49, ptr %35, align 8
+  call void @llvm.memset(ptr %0, i8 0, i64 48, i1 false)
+  %1 = getelementptr inbounds %main.T, ptr %0, i32 0, i32 0
+  %2 = getelementptr inbounds %main.T, ptr %0, i32 0, i32 1
+  %3 = getelementptr inbounds %main.T, ptr %0, i32 0, i32 2
+  %4 = getelementptr inbounds %main.T, ptr %0, i32 0, i32 3
+  store i64 10, ptr %1, align 4
+  store i64 20, ptr %2, align 4
+  %5 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %5, i32 0, i32 0
+  store ptr @1, ptr %6, align 8
+  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %5, i32 0, i32 1
+  store i64 5, ptr %7, align 4
+  %8 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %5, align 8
+  store %"github.com/goplus/llgo/internal/runtime.String" %8, ptr %3, align 8
+  %9 = load ptr, ptr @_llgo_int, align 8
+  %10 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 0
+  store ptr %9, ptr %11, align 8
+  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 1
+  store ptr inttoptr (i64 1 to ptr), ptr %12, align 8
+  %13 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, align 8
+  store %"github.com/goplus/llgo/internal/runtime.eface" %13, ptr %4, align 8
+  %14 = alloca %main.T, align 8
+  call void @llvm.memset(ptr %14, i8 0, i64 48, i1 false)
+  %15 = getelementptr inbounds %main.T, ptr %14, i32 0, i32 0
+  %16 = getelementptr inbounds %main.T, ptr %14, i32 0, i32 1
+  %17 = getelementptr inbounds %main.T, ptr %14, i32 0, i32 2
+  %18 = getelementptr inbounds %main.T, ptr %14, i32 0, i32 3
+  store i64 10, ptr %15, align 4
+  store i64 20, ptr %16, align 4
+  %19 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %19, i32 0, i32 0
+  store ptr @1, ptr %20, align 8
+  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %19, i32 0, i32 1
+  store i64 5, ptr %21, align 4
+  %22 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %19, align 8
+  store %"github.com/goplus/llgo/internal/runtime.String" %22, ptr %17, align 8
+  %23 = load ptr, ptr @_llgo_int, align 8
+  %24 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %24, i32 0, i32 0
+  store ptr %23, ptr %25, align 8
+  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %24, i32 0, i32 1
+  store ptr inttoptr (i64 1 to ptr), ptr %26, align 8
+  %27 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %24, align 8
+  store %"github.com/goplus/llgo/internal/runtime.eface" %27, ptr %18, align 8
+  %28 = alloca %main.T, align 8
+  call void @llvm.memset(ptr %28, i8 0, i64 48, i1 false)
+  %29 = getelementptr inbounds %main.T, ptr %28, i32 0, i32 0
+  %30 = getelementptr inbounds %main.T, ptr %28, i32 0, i32 1
+  %31 = getelementptr inbounds %main.T, ptr %28, i32 0, i32 2
+  %32 = getelementptr inbounds %main.T, ptr %28, i32 0, i32 3
+  store i64 10, ptr %29, align 4
+  store i64 20, ptr %30, align 4
+  %33 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %33, i32 0, i32 0
+  store ptr @1, ptr %34, align 8
+  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %33, i32 0, i32 1
+  store i64 5, ptr %35, align 4
+  %36 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %33, align 8
+  store %"github.com/goplus/llgo/internal/runtime.String" %36, ptr %31, align 8
+  %37 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %37, i32 0, i32 0
+  store ptr @2, ptr %38, align 8
+  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %37, i32 0, i32 1
+  store i64 2, ptr %39, align 4
+  %40 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %37, align 8
+  %41 = load ptr, ptr @_llgo_string, align 8
+  %42 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %40, ptr %42, align 8
+  %43 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %43, i32 0, i32 0
+  store ptr %41, ptr %44, align 8
+  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %43, i32 0, i32 1
+  store ptr %42, ptr %45, align 8
+  %46 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %43, align 8
+  store %"github.com/goplus/llgo/internal/runtime.eface" %46, ptr %32, align 8
   call void @main.assert(i1 true)
-  %50 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer)
-  %51 = and i1 true, %50
-  %52 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.eface" zeroinitializer)
-  %53 = and i1 %51, %52
-  call void @main.assert(i1 %53)
-  %54 = load %main.T, ptr %1, align 8
-  %55 = load %main.T, ptr %16, align 8
-  %56 = extractvalue %main.T %54, 0
-  %57 = extractvalue %main.T %55, 0
-  %58 = icmp eq i64 %56, %57
-  %59 = and i1 true, %58
-  %60 = extractvalue %main.T %54, 1
-  %61 = extractvalue %main.T %55, 1
-  %62 = icmp eq i64 %60, %61
-  %63 = and i1 %59, %62
-  %64 = extractvalue %main.T %54, 2
-  %65 = extractvalue %main.T %55, 2
-  %66 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %64, %"github.com/goplus/llgo/internal/runtime.String" %65)
-  %67 = and i1 %63, %66
-  %68 = extractvalue %main.T %54, 3
-  %69 = extractvalue %main.T %55, 3
-  %70 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %68, %"github.com/goplus/llgo/internal/runtime.eface" %69)
-  %71 = and i1 %67, %70
-  call void @main.assert(i1 %71)
-  %72 = load %main.T, ptr %1, align 8
-  %73 = load %main.T, ptr %31, align 8
-  %74 = extractvalue %main.T %72, 0
-  %75 = extractvalue %main.T %73, 0
-  %76 = icmp eq i64 %74, %75
-  %77 = and i1 true, %76
-  %78 = extractvalue %main.T %72, 1
-  %79 = extractvalue %main.T %73, 1
-  %80 = icmp eq i64 %78, %79
-  %81 = and i1 %77, %80
-  %82 = extractvalue %main.T %72, 2
-  %83 = extractvalue %main.T %73, 2
-  %84 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %82, %"github.com/goplus/llgo/internal/runtime.String" %83)
-  %85 = and i1 %81, %84
-  %86 = extractvalue %main.T %72, 3
-  %87 = extractvalue %main.T %73, 3
-  %88 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %86, %"github.com/goplus/llgo/internal/runtime.eface" %87)
-  %89 = and i1 %85, %88
-  %90 = xor i1 %89, true
-  call void @main.assert(i1 %90)
-  %91 = load %main.T, ptr %16, align 8
-  %92 = load %main.T, ptr %31, align 8
-  %93 = extractvalue %main.T %91, 0
-  %94 = extractvalue %main.T %92, 0
-  %95 = icmp eq i64 %93, %94
-  %96 = and i1 true, %95
-  %97 = extractvalue %main.T %91, 1
-  %98 = extractvalue %main.T %92, 1
-  %99 = icmp eq i64 %97, %98
-  %100 = and i1 %96, %99
-  %101 = extractvalue %main.T %91, 2
-  %102 = extractvalue %main.T %92, 2
-  %103 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %101, %"github.com/goplus/llgo/internal/runtime.String" %102)
-  %104 = and i1 %100, %103
-  %105 = extractvalue %main.T %91, 3
-  %106 = extractvalue %main.T %92, 3
-  %107 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %105, %"github.com/goplus/llgo/internal/runtime.eface" %106)
-  %108 = and i1 %104, %107
-  %109 = xor i1 %108, true
-  call void @main.assert(i1 %109)
+  %47 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer)
+  %48 = and i1 true, %47
+  %49 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.eface" zeroinitializer)
+  %50 = and i1 %48, %49
+  call void @main.assert(i1 %50)
+  %51 = load %main.T, ptr %0, align 8
+  %52 = load %main.T, ptr %14, align 8
+  %53 = extractvalue %main.T %51, 0
+  %54 = extractvalue %main.T %52, 0
+  %55 = icmp eq i64 %53, %54
+  %56 = and i1 true, %55
+  %57 = extractvalue %main.T %51, 1
+  %58 = extractvalue %main.T %52, 1
+  %59 = icmp eq i64 %57, %58
+  %60 = and i1 %56, %59
+  %61 = extractvalue %main.T %51, 2
+  %62 = extractvalue %main.T %52, 2
+  %63 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %61, %"github.com/goplus/llgo/internal/runtime.String" %62)
+  %64 = and i1 %60, %63
+  %65 = extractvalue %main.T %51, 3
+  %66 = extractvalue %main.T %52, 3
+  %67 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %65, %"github.com/goplus/llgo/internal/runtime.eface" %66)
+  %68 = and i1 %64, %67
+  call void @main.assert(i1 %68)
+  %69 = load %main.T, ptr %0, align 8
+  %70 = load %main.T, ptr %28, align 8
+  %71 = extractvalue %main.T %69, 0
+  %72 = extractvalue %main.T %70, 0
+  %73 = icmp eq i64 %71, %72
+  %74 = and i1 true, %73
+  %75 = extractvalue %main.T %69, 1
+  %76 = extractvalue %main.T %70, 1
+  %77 = icmp eq i64 %75, %76
+  %78 = and i1 %74, %77
+  %79 = extractvalue %main.T %69, 2
+  %80 = extractvalue %main.T %70, 2
+  %81 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %79, %"github.com/goplus/llgo/internal/runtime.String" %80)
+  %82 = and i1 %78, %81
+  %83 = extractvalue %main.T %69, 3
+  %84 = extractvalue %main.T %70, 3
+  %85 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %83, %"github.com/goplus/llgo/internal/runtime.eface" %84)
+  %86 = and i1 %82, %85
+  %87 = xor i1 %86, true
+  call void @main.assert(i1 %87)
+  %88 = load %main.T, ptr %14, align 8
+  %89 = load %main.T, ptr %28, align 8
+  %90 = extractvalue %main.T %88, 0
+  %91 = extractvalue %main.T %89, 0
+  %92 = icmp eq i64 %90, %91
+  %93 = and i1 true, %92
+  %94 = extractvalue %main.T %88, 1
+  %95 = extractvalue %main.T %89, 1
+  %96 = icmp eq i64 %94, %95
+  %97 = and i1 %93, %96
+  %98 = extractvalue %main.T %88, 2
+  %99 = extractvalue %main.T %89, 2
+  %100 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %98, %"github.com/goplus/llgo/internal/runtime.String" %99)
+  %101 = and i1 %97, %100
+  %102 = extractvalue %main.T %88, 3
+  %103 = extractvalue %main.T %89, 3
+  %104 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %102, %"github.com/goplus/llgo/internal/runtime.eface" %103)
+  %105 = and i1 %101, %104
+  %106 = xor i1 %105, true
+  call void @main.assert(i1 %106)
   ret void
 }
 
@@ -382,149 +382,149 @@ _llgo_0:
   store ptr %6, ptr %9, align 8
   %10 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, align 8
   %11 = alloca %main.T, align 8
-  %12 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %11, i64 48)
-  %13 = getelementptr inbounds %main.T, ptr %12, i32 0, i32 0
-  %14 = getelementptr inbounds %main.T, ptr %12, i32 0, i32 1
-  %15 = getelementptr inbounds %main.T, ptr %12, i32 0, i32 2
-  %16 = getelementptr inbounds %main.T, ptr %12, i32 0, i32 3
-  store i64 10, ptr %13, align 4
-  store i64 20, ptr %14, align 4
-  %17 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %18 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %17, i32 0, i32 0
-  store ptr @1, ptr %18, align 8
-  %19 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %17, i32 0, i32 1
-  store i64 5, ptr %19, align 4
-  %20 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %17, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %20, ptr %15, align 8
-  %21 = load ptr, ptr @_llgo_int, align 8
-  %22 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %22, i32 0, i32 0
-  store ptr %21, ptr %23, align 8
-  %24 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %22, i32 0, i32 1
-  store ptr inttoptr (i64 1 to ptr), ptr %24, align 8
-  %25 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %22, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %25, ptr %16, align 8
-  %26 = load %main.T, ptr %12, align 8
-  %27 = load ptr, ptr @_llgo_main.T, align 8
-  %28 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  store %main.T %26, ptr %28, align 8
-  %29 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %29, i32 0, i32 0
+  call void @llvm.memset(ptr %11, i8 0, i64 48, i1 false)
+  %12 = getelementptr inbounds %main.T, ptr %11, i32 0, i32 0
+  %13 = getelementptr inbounds %main.T, ptr %11, i32 0, i32 1
+  %14 = getelementptr inbounds %main.T, ptr %11, i32 0, i32 2
+  %15 = getelementptr inbounds %main.T, ptr %11, i32 0, i32 3
+  store i64 10, ptr %12, align 4
+  store i64 20, ptr %13, align 4
+  %16 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %16, i32 0, i32 0
+  store ptr @1, ptr %17, align 8
+  %18 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %16, i32 0, i32 1
+  store i64 5, ptr %18, align 4
+  %19 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %16, align 8
+  store %"github.com/goplus/llgo/internal/runtime.String" %19, ptr %14, align 8
+  %20 = load ptr, ptr @_llgo_int, align 8
+  %21 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %21, i32 0, i32 0
+  store ptr %20, ptr %22, align 8
+  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %21, i32 0, i32 1
+  store ptr inttoptr (i64 1 to ptr), ptr %23, align 8
+  %24 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %21, align 8
+  store %"github.com/goplus/llgo/internal/runtime.eface" %24, ptr %15, align 8
+  %25 = load %main.T, ptr %11, align 8
+  %26 = load ptr, ptr @_llgo_main.T, align 8
+  %27 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  store %main.T %25, ptr %27, align 8
+  %28 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %29 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %28, i32 0, i32 0
+  store ptr %26, ptr %29, align 8
+  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %28, i32 0, i32 1
   store ptr %27, ptr %30, align 8
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %29, i32 0, i32 1
-  store ptr %28, ptr %31, align 8
-  %32 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %29, align 8
-  %33 = alloca %main.T, align 8
-  %34 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %33, i64 48)
-  %35 = getelementptr inbounds %main.T, ptr %34, i32 0, i32 0
-  %36 = getelementptr inbounds %main.T, ptr %34, i32 0, i32 1
-  %37 = getelementptr inbounds %main.T, ptr %34, i32 0, i32 2
-  %38 = getelementptr inbounds %main.T, ptr %34, i32 0, i32 3
-  store i64 10, ptr %35, align 4
-  store i64 20, ptr %36, align 4
-  %39 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %40 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %39, i32 0, i32 0
-  store ptr @1, ptr %40, align 8
-  %41 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %39, i32 0, i32 1
-  store i64 5, ptr %41, align 4
-  %42 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %39, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %42, ptr %37, align 8
-  %43 = load ptr, ptr @_llgo_int, align 8
-  %44 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %44, i32 0, i32 0
-  store ptr %43, ptr %45, align 8
-  %46 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %44, i32 0, i32 1
-  store ptr inttoptr (i64 1 to ptr), ptr %46, align 8
-  %47 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %44, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %47, ptr %38, align 8
-  %48 = alloca %main.T, align 8
-  %49 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %48, i64 48)
-  %50 = getelementptr inbounds %main.T, ptr %49, i32 0, i32 0
-  %51 = getelementptr inbounds %main.T, ptr %49, i32 0, i32 1
-  %52 = getelementptr inbounds %main.T, ptr %49, i32 0, i32 2
-  %53 = getelementptr inbounds %main.T, ptr %49, i32 0, i32 3
-  store i64 10, ptr %50, align 4
-  store i64 20, ptr %51, align 4
-  %54 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %54, i32 0, i32 0
-  store ptr @1, ptr %55, align 8
-  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %54, i32 0, i32 1
-  store i64 5, ptr %56, align 4
-  %57 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %54, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %57, ptr %52, align 8
-  %58 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %59 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %58, i32 0, i32 0
-  store ptr @2, ptr %59, align 8
-  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %58, i32 0, i32 1
-  store i64 2, ptr %60, align 4
-  %61 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %58, align 8
-  %62 = load ptr, ptr @_llgo_string, align 8
-  %63 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %61, ptr %63, align 8
-  %64 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %65 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %64, i32 0, i32 0
-  store ptr %62, ptr %65, align 8
-  %66 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %64, i32 0, i32 1
-  store ptr %63, ptr %66, align 8
-  %67 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %64, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %67, ptr %53, align 8
-  %68 = load ptr, ptr @_llgo_int, align 8
-  %69 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %70 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %69, i32 0, i32 0
-  store ptr %68, ptr %70, align 8
-  %71 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %69, i32 0, i32 1
-  store ptr inttoptr (i64 100 to ptr), ptr %71, align 8
-  %72 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %69, align 8
-  %73 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %4, %"github.com/goplus/llgo/internal/runtime.eface" %72)
-  call void @main.assert(i1 %73)
-  %74 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
-  %75 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  store {} zeroinitializer, ptr %75, align 1
-  %76 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %77 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %76, i32 0, i32 0
-  store ptr %74, ptr %77, align 8
-  %78 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %76, i32 0, i32 1
-  store ptr %75, ptr %78, align 8
-  %79 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %76, align 8
-  %80 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %10, %"github.com/goplus/llgo/internal/runtime.eface" %79)
-  call void @main.assert(i1 %80)
-  %81 = load ptr, ptr @_llgo_main.N, align 8
-  %82 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  store %main.N zeroinitializer, ptr %82, align 1
-  %83 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %84 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %83, i32 0, i32 0
-  store ptr %81, ptr %84, align 8
-  %85 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %83, i32 0, i32 1
-  store ptr %82, ptr %85, align 8
-  %86 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %83, align 8
-  %87 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %10, %"github.com/goplus/llgo/internal/runtime.eface" %86)
-  %88 = xor i1 %87, true
-  call void @main.assert(i1 %88)
-  %89 = load %main.T, ptr %34, align 8
-  %90 = load ptr, ptr @_llgo_main.T, align 8
-  %91 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  store %main.T %89, ptr %91, align 8
-  %92 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %93 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %92, i32 0, i32 0
-  store ptr %90, ptr %93, align 8
-  %94 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %92, i32 0, i32 1
-  store ptr %91, ptr %94, align 8
-  %95 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %92, align 8
-  %96 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %32, %"github.com/goplus/llgo/internal/runtime.eface" %95)
-  call void @main.assert(i1 %96)
-  %97 = load %main.T, ptr %49, align 8
-  %98 = load ptr, ptr @_llgo_main.T, align 8
-  %99 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  store %main.T %97, ptr %99, align 8
-  %100 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %101 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %100, i32 0, i32 0
-  store ptr %98, ptr %101, align 8
-  %102 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %100, i32 0, i32 1
-  store ptr %99, ptr %102, align 8
-  %103 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %100, align 8
-  %104 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %32, %"github.com/goplus/llgo/internal/runtime.eface" %103)
-  %105 = xor i1 %104, true
-  call void @main.assert(i1 %105)
+  %31 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %28, align 8
+  %32 = alloca %main.T, align 8
+  call void @llvm.memset(ptr %32, i8 0, i64 48, i1 false)
+  %33 = getelementptr inbounds %main.T, ptr %32, i32 0, i32 0
+  %34 = getelementptr inbounds %main.T, ptr %32, i32 0, i32 1
+  %35 = getelementptr inbounds %main.T, ptr %32, i32 0, i32 2
+  %36 = getelementptr inbounds %main.T, ptr %32, i32 0, i32 3
+  store i64 10, ptr %33, align 4
+  store i64 20, ptr %34, align 4
+  %37 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %37, i32 0, i32 0
+  store ptr @1, ptr %38, align 8
+  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %37, i32 0, i32 1
+  store i64 5, ptr %39, align 4
+  %40 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %37, align 8
+  store %"github.com/goplus/llgo/internal/runtime.String" %40, ptr %35, align 8
+  %41 = load ptr, ptr @_llgo_int, align 8
+  %42 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %42, i32 0, i32 0
+  store ptr %41, ptr %43, align 8
+  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %42, i32 0, i32 1
+  store ptr inttoptr (i64 1 to ptr), ptr %44, align 8
+  %45 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %42, align 8
+  store %"github.com/goplus/llgo/internal/runtime.eface" %45, ptr %36, align 8
+  %46 = alloca %main.T, align 8
+  call void @llvm.memset(ptr %46, i8 0, i64 48, i1 false)
+  %47 = getelementptr inbounds %main.T, ptr %46, i32 0, i32 0
+  %48 = getelementptr inbounds %main.T, ptr %46, i32 0, i32 1
+  %49 = getelementptr inbounds %main.T, ptr %46, i32 0, i32 2
+  %50 = getelementptr inbounds %main.T, ptr %46, i32 0, i32 3
+  store i64 10, ptr %47, align 4
+  store i64 20, ptr %48, align 4
+  %51 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %52 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %51, i32 0, i32 0
+  store ptr @1, ptr %52, align 8
+  %53 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %51, i32 0, i32 1
+  store i64 5, ptr %53, align 4
+  %54 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %51, align 8
+  store %"github.com/goplus/llgo/internal/runtime.String" %54, ptr %49, align 8
+  %55 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 0
+  store ptr @2, ptr %56, align 8
+  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 1
+  store i64 2, ptr %57, align 4
+  %58 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %55, align 8
+  %59 = load ptr, ptr @_llgo_string, align 8
+  %60 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %58, ptr %60, align 8
+  %61 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %62 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %61, i32 0, i32 0
+  store ptr %59, ptr %62, align 8
+  %63 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %61, i32 0, i32 1
+  store ptr %60, ptr %63, align 8
+  %64 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %61, align 8
+  store %"github.com/goplus/llgo/internal/runtime.eface" %64, ptr %50, align 8
+  %65 = load ptr, ptr @_llgo_int, align 8
+  %66 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %67 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %66, i32 0, i32 0
+  store ptr %65, ptr %67, align 8
+  %68 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %66, i32 0, i32 1
+  store ptr inttoptr (i64 100 to ptr), ptr %68, align 8
+  %69 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %66, align 8
+  %70 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %4, %"github.com/goplus/llgo/internal/runtime.eface" %69)
+  call void @main.assert(i1 %70)
+  %71 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
+  %72 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  store {} zeroinitializer, ptr %72, align 1
+  %73 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %74 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %73, i32 0, i32 0
+  store ptr %71, ptr %74, align 8
+  %75 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %73, i32 0, i32 1
+  store ptr %72, ptr %75, align 8
+  %76 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %73, align 8
+  %77 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %10, %"github.com/goplus/llgo/internal/runtime.eface" %76)
+  call void @main.assert(i1 %77)
+  %78 = load ptr, ptr @_llgo_main.N, align 8
+  %79 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  store %main.N zeroinitializer, ptr %79, align 1
+  %80 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %81 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %80, i32 0, i32 0
+  store ptr %78, ptr %81, align 8
+  %82 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %80, i32 0, i32 1
+  store ptr %79, ptr %82, align 8
+  %83 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %80, align 8
+  %84 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %10, %"github.com/goplus/llgo/internal/runtime.eface" %83)
+  %85 = xor i1 %84, true
+  call void @main.assert(i1 %85)
+  %86 = load %main.T, ptr %32, align 8
+  %87 = load ptr, ptr @_llgo_main.T, align 8
+  %88 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  store %main.T %86, ptr %88, align 8
+  %89 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %90 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %89, i32 0, i32 0
+  store ptr %87, ptr %90, align 8
+  %91 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %89, i32 0, i32 1
+  store ptr %88, ptr %91, align 8
+  %92 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %89, align 8
+  %93 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %31, %"github.com/goplus/llgo/internal/runtime.eface" %92)
+  call void @main.assert(i1 %93)
+  %94 = load %main.T, ptr %46, align 8
+  %95 = load ptr, ptr @_llgo_main.T, align 8
+  %96 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  store %main.T %94, ptr %96, align 8
+  %97 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %98 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %97, i32 0, i32 0
+  store ptr %95, ptr %98, align 8
+  %99 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %97, i32 0, i32 1
+  store ptr %96, ptr %99, align 8
+  %100 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %97, align 8
+  %101 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %31, %"github.com/goplus/llgo/internal/runtime.eface" %100)
+  %102 = xor i1 %101, true
+  call void @main.assert(i1 %102)
   ret void
 }
 
@@ -895,7 +895,8 @@ declare void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64)
 
 declare void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8)
 
-declare ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr, i64)
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
 
 declare i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.String")
 
@@ -924,3 +925,5 @@ declare void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr)
 declare ptr @"github.com/goplus/llgo/internal/runtime.MakeMap"(ptr, i64)
 
 declare void @"github.com/goplus/llgo/internal/runtime.init"()
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/ifaceprom/out.ll
+++ b/cl/_testgo/ifaceprom/out.ll
@@ -35,47 +35,47 @@ source_filename = "main"
 define i64 @main.S.one(%main.S %0) {
 _llgo_0:
   %1 = alloca %main.S, align 8
-  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %1, i64 16)
-  store %main.S %0, ptr %2, align 8
-  %3 = getelementptr inbounds %main.S, ptr %2, i32 0, i32 0
-  %4 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %3, align 8
-  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %4)
-  %6 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %4, 0
-  %7 = getelementptr ptr, ptr %6, i64 3
-  %8 = load ptr, ptr %7, align 8
-  %9 = alloca { ptr, ptr }, align 8
-  %10 = getelementptr inbounds { ptr, ptr }, ptr %9, i32 0, i32 0
-  store ptr %8, ptr %10, align 8
-  %11 = getelementptr inbounds { ptr, ptr }, ptr %9, i32 0, i32 1
-  store ptr %5, ptr %11, align 8
-  %12 = load { ptr, ptr }, ptr %9, align 8
-  %13 = extractvalue { ptr, ptr } %12, 1
-  %14 = extractvalue { ptr, ptr } %12, 0
-  %15 = call i64 %14(ptr %13)
-  ret i64 %15
+  call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+  store %main.S %0, ptr %1, align 8
+  %2 = getelementptr inbounds %main.S, ptr %1, i32 0, i32 0
+  %3 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %2, align 8
+  %4 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %3)
+  %5 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %3, 0
+  %6 = getelementptr ptr, ptr %5, i64 3
+  %7 = load ptr, ptr %6, align 8
+  %8 = alloca { ptr, ptr }, align 8
+  %9 = getelementptr inbounds { ptr, ptr }, ptr %8, i32 0, i32 0
+  store ptr %7, ptr %9, align 8
+  %10 = getelementptr inbounds { ptr, ptr }, ptr %8, i32 0, i32 1
+  store ptr %4, ptr %10, align 8
+  %11 = load { ptr, ptr }, ptr %8, align 8
+  %12 = extractvalue { ptr, ptr } %11, 1
+  %13 = extractvalue { ptr, ptr } %11, 0
+  %14 = call i64 %13(ptr %12)
+  ret i64 %14
 }
 
 define %"github.com/goplus/llgo/internal/runtime.String" @main.S.two(%main.S %0) {
 _llgo_0:
   %1 = alloca %main.S, align 8
-  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %1, i64 16)
-  store %main.S %0, ptr %2, align 8
-  %3 = getelementptr inbounds %main.S, ptr %2, i32 0, i32 0
-  %4 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %3, align 8
-  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %4)
-  %6 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %4, 0
-  %7 = getelementptr ptr, ptr %6, i64 4
-  %8 = load ptr, ptr %7, align 8
-  %9 = alloca { ptr, ptr }, align 8
-  %10 = getelementptr inbounds { ptr, ptr }, ptr %9, i32 0, i32 0
-  store ptr %8, ptr %10, align 8
-  %11 = getelementptr inbounds { ptr, ptr }, ptr %9, i32 0, i32 1
-  store ptr %5, ptr %11, align 8
-  %12 = load { ptr, ptr }, ptr %9, align 8
-  %13 = extractvalue { ptr, ptr } %12, 1
-  %14 = extractvalue { ptr, ptr } %12, 0
-  %15 = call %"github.com/goplus/llgo/internal/runtime.String" %14(ptr %13)
-  ret %"github.com/goplus/llgo/internal/runtime.String" %15
+  call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+  store %main.S %0, ptr %1, align 8
+  %2 = getelementptr inbounds %main.S, ptr %1, i32 0, i32 0
+  %3 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %2, align 8
+  %4 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %3)
+  %5 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %3, 0
+  %6 = getelementptr ptr, ptr %5, i64 4
+  %7 = load ptr, ptr %6, align 8
+  %8 = alloca { ptr, ptr }, align 8
+  %9 = getelementptr inbounds { ptr, ptr }, ptr %8, i32 0, i32 0
+  store ptr %7, ptr %9, align 8
+  %10 = getelementptr inbounds { ptr, ptr }, ptr %8, i32 0, i32 1
+  store ptr %4, ptr %10, align 8
+  %11 = load { ptr, ptr }, ptr %8, align 8
+  %12 = extractvalue { ptr, ptr } %11, 1
+  %13 = extractvalue { ptr, ptr } %11, 0
+  %14 = call %"github.com/goplus/llgo/internal/runtime.String" %13(ptr %12)
+  ret %"github.com/goplus/llgo/internal/runtime.String" %14
 }
 
 define i64 @"main.(*S).one"(ptr %0) {
@@ -169,444 +169,445 @@ _llgo_0:
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
   %2 = alloca %main.S, align 8
-  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %2, i64 16)
-  %4 = getelementptr inbounds %main.S, ptr %3, i32 0, i32 0
-  %5 = load ptr, ptr @_llgo_main.impl, align 8
-  %6 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  store %main.impl zeroinitializer, ptr %6, align 1
-  %7 = load ptr, ptr @"main.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", align 8
-  %8 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %7, ptr %5)
-  %9 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %9, i32 0, i32 0
-  store ptr %8, ptr %10, align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %9, i32 0, i32 1
-  store ptr %6, ptr %11, align 8
-  %12 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %9, align 8
-  store %"github.com/goplus/llgo/internal/runtime.iface" %12, ptr %4, align 8
-  %13 = getelementptr inbounds %main.S, ptr %3, i32 0, i32 0
-  %14 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %13, align 8
-  %15 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %14)
-  %16 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %14, 0
-  %17 = getelementptr ptr, ptr %16, i64 3
-  %18 = load ptr, ptr %17, align 8
-  %19 = alloca { ptr, ptr }, align 8
-  %20 = getelementptr inbounds { ptr, ptr }, ptr %19, i32 0, i32 0
-  store ptr %18, ptr %20, align 8
-  %21 = getelementptr inbounds { ptr, ptr }, ptr %19, i32 0, i32 1
-  store ptr %15, ptr %21, align 8
-  %22 = load { ptr, ptr }, ptr %19, align 8
-  %23 = extractvalue { ptr, ptr } %22, 1
-  %24 = extractvalue { ptr, ptr } %22, 0
-  %25 = call i64 %24(ptr %23)
-  %26 = icmp ne i64 %25, 1
-  br i1 %26, label %_llgo_1, label %_llgo_2
+  call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+  %3 = getelementptr inbounds %main.S, ptr %2, i32 0, i32 0
+  %4 = load ptr, ptr @_llgo_main.impl, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  store %main.impl zeroinitializer, ptr %5, align 1
+  %6 = load ptr, ptr @"main.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", align 8
+  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %6, ptr %4)
+  %8 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
+  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %8, i32 0, i32 0
+  store ptr %7, ptr %9, align 8
+  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %8, i32 0, i32 1
+  store ptr %5, ptr %10, align 8
+  %11 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %8, align 8
+  store %"github.com/goplus/llgo/internal/runtime.iface" %11, ptr %3, align 8
+  %12 = getelementptr inbounds %main.S, ptr %2, i32 0, i32 0
+  %13 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %12, align 8
+  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %13)
+  %15 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %13, 0
+  %16 = getelementptr ptr, ptr %15, i64 3
+  %17 = load ptr, ptr %16, align 8
+  %18 = alloca { ptr, ptr }, align 8
+  %19 = getelementptr inbounds { ptr, ptr }, ptr %18, i32 0, i32 0
+  store ptr %17, ptr %19, align 8
+  %20 = getelementptr inbounds { ptr, ptr }, ptr %18, i32 0, i32 1
+  store ptr %14, ptr %20, align 8
+  %21 = load { ptr, ptr }, ptr %18, align 8
+  %22 = extractvalue { ptr, ptr } %21, 1
+  %23 = extractvalue { ptr, ptr } %21, 0
+  %24 = call i64 %23(ptr %22)
+  %25 = icmp ne i64 %24, 1
+  br i1 %25, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %27 = load ptr, ptr @_llgo_int, align 8
-  %28 = inttoptr i64 %25 to ptr
-  %29 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %29, i32 0, i32 0
+  %26 = load ptr, ptr @_llgo_int, align 8
+  %27 = inttoptr i64 %24 to ptr
+  %28 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %29 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %28, i32 0, i32 0
+  store ptr %26, ptr %29, align 8
+  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %28, i32 0, i32 1
   store ptr %27, ptr %30, align 8
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %29, i32 0, i32 1
-  store ptr %28, ptr %31, align 8
-  %32 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %29, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %32)
+  %31 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %28, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %31)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %33 = load %main.S, ptr %3, align 8
-  %34 = extractvalue %main.S %33, 0
-  %35 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %34)
-  %36 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %34, 0
-  %37 = getelementptr ptr, ptr %36, i64 3
-  %38 = load ptr, ptr %37, align 8
-  %39 = alloca { ptr, ptr }, align 8
-  %40 = getelementptr inbounds { ptr, ptr }, ptr %39, i32 0, i32 0
-  store ptr %38, ptr %40, align 8
-  %41 = getelementptr inbounds { ptr, ptr }, ptr %39, i32 0, i32 1
-  store ptr %35, ptr %41, align 8
-  %42 = load { ptr, ptr }, ptr %39, align 8
-  %43 = extractvalue { ptr, ptr } %42, 1
-  %44 = extractvalue { ptr, ptr } %42, 0
-  %45 = call i64 %44(ptr %43)
-  %46 = icmp ne i64 %45, 1
-  br i1 %46, label %_llgo_3, label %_llgo_4
+  %32 = load %main.S, ptr %2, align 8
+  %33 = extractvalue %main.S %32, 0
+  %34 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %33)
+  %35 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %33, 0
+  %36 = getelementptr ptr, ptr %35, i64 3
+  %37 = load ptr, ptr %36, align 8
+  %38 = alloca { ptr, ptr }, align 8
+  %39 = getelementptr inbounds { ptr, ptr }, ptr %38, i32 0, i32 0
+  store ptr %37, ptr %39, align 8
+  %40 = getelementptr inbounds { ptr, ptr }, ptr %38, i32 0, i32 1
+  store ptr %34, ptr %40, align 8
+  %41 = load { ptr, ptr }, ptr %38, align 8
+  %42 = extractvalue { ptr, ptr } %41, 1
+  %43 = extractvalue { ptr, ptr } %41, 0
+  %44 = call i64 %43(ptr %42)
+  %45 = icmp ne i64 %44, 1
+  br i1 %45, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %47 = load ptr, ptr @_llgo_int, align 8
-  %48 = inttoptr i64 %45 to ptr
-  %49 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %49, i32 0, i32 0
+  %46 = load ptr, ptr @_llgo_int, align 8
+  %47 = inttoptr i64 %44 to ptr
+  %48 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %49 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %48, i32 0, i32 0
+  store ptr %46, ptr %49, align 8
+  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %48, i32 0, i32 1
   store ptr %47, ptr %50, align 8
-  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %49, i32 0, i32 1
-  store ptr %48, ptr %51, align 8
-  %52 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %49, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %52)
+  %51 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %48, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %51)
   unreachable
 
 _llgo_4:                                          ; preds = %_llgo_2
-  %53 = getelementptr inbounds %main.S, ptr %3, i32 0, i32 0
-  %54 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %53, align 8
-  %55 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %54)
-  %56 = load ptr, ptr @_llgo_main.I, align 8
-  %57 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %56, ptr %55)
-  br i1 %57, label %_llgo_17, label %_llgo_18
+  %52 = getelementptr inbounds %main.S, ptr %2, i32 0, i32 0
+  %53 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %52, align 8
+  %54 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %53)
+  %55 = load ptr, ptr @_llgo_main.I, align 8
+  %56 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %55, ptr %54)
+  br i1 %56, label %_llgo_17, label %_llgo_18
 
 _llgo_5:                                          ; preds = %_llgo_17
-  %58 = load ptr, ptr @_llgo_int, align 8
-  %59 = inttoptr i64 %166 to ptr
-  %60 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %61 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %60, i32 0, i32 0
+  %57 = load ptr, ptr @_llgo_int, align 8
+  %58 = inttoptr i64 %165 to ptr
+  %59 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %59, i32 0, i32 0
+  store ptr %57, ptr %60, align 8
+  %61 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %59, i32 0, i32 1
   store ptr %58, ptr %61, align 8
-  %62 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %60, i32 0, i32 1
-  store ptr %59, ptr %62, align 8
-  %63 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %60, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %63)
+  %62 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %59, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %62)
   unreachable
 
 _llgo_6:                                          ; preds = %_llgo_17
-  %64 = load %main.S, ptr %3, align 8
-  %65 = extractvalue %main.S %64, 0
-  %66 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %65)
-  %67 = load ptr, ptr @_llgo_main.I, align 8
-  %68 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %67, ptr %66)
-  br i1 %68, label %_llgo_19, label %_llgo_20
+  %63 = load %main.S, ptr %2, align 8
+  %64 = extractvalue %main.S %63, 0
+  %65 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %64)
+  %66 = load ptr, ptr @_llgo_main.I, align 8
+  %67 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %66, ptr %65)
+  br i1 %67, label %_llgo_19, label %_llgo_20
 
 _llgo_7:                                          ; preds = %_llgo_19
-  %69 = load ptr, ptr @_llgo_int, align 8
-  %70 = inttoptr i64 %193 to ptr
-  %71 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %72 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %71, i32 0, i32 0
+  %68 = load ptr, ptr @_llgo_int, align 8
+  %69 = inttoptr i64 %192 to ptr
+  %70 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %71 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %70, i32 0, i32 0
+  store ptr %68, ptr %71, align 8
+  %72 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %70, i32 0, i32 1
   store ptr %69, ptr %72, align 8
-  %73 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %71, i32 0, i32 1
-  store ptr %70, ptr %73, align 8
-  %74 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %71, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %74)
+  %73 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %70, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %73)
   unreachable
 
 _llgo_8:                                          ; preds = %_llgo_19
-  %75 = getelementptr inbounds %main.S, ptr %3, i32 0, i32 0
-  %76 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %75, align 8
-  %77 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %76)
-  %78 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %76, 0
-  %79 = getelementptr ptr, ptr %78, i64 4
-  %80 = load ptr, ptr %79, align 8
-  %81 = alloca { ptr, ptr }, align 8
-  %82 = getelementptr inbounds { ptr, ptr }, ptr %81, i32 0, i32 0
-  store ptr %80, ptr %82, align 8
-  %83 = getelementptr inbounds { ptr, ptr }, ptr %81, i32 0, i32 1
-  store ptr %77, ptr %83, align 8
-  %84 = load { ptr, ptr }, ptr %81, align 8
-  %85 = extractvalue { ptr, ptr } %84, 1
-  %86 = extractvalue { ptr, ptr } %84, 0
-  %87 = call %"github.com/goplus/llgo/internal/runtime.String" %86(ptr %85)
-  %88 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %89 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %88, i32 0, i32 0
-  store ptr @0, ptr %89, align 8
-  %90 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %88, i32 0, i32 1
-  store i64 3, ptr %90, align 4
-  %91 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %88, align 8
-  %92 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %87, %"github.com/goplus/llgo/internal/runtime.String" %91)
-  %93 = xor i1 %92, true
-  br i1 %93, label %_llgo_9, label %_llgo_10
+  %74 = getelementptr inbounds %main.S, ptr %2, i32 0, i32 0
+  %75 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %74, align 8
+  %76 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %75)
+  %77 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %75, 0
+  %78 = getelementptr ptr, ptr %77, i64 4
+  %79 = load ptr, ptr %78, align 8
+  %80 = alloca { ptr, ptr }, align 8
+  %81 = getelementptr inbounds { ptr, ptr }, ptr %80, i32 0, i32 0
+  store ptr %79, ptr %81, align 8
+  %82 = getelementptr inbounds { ptr, ptr }, ptr %80, i32 0, i32 1
+  store ptr %76, ptr %82, align 8
+  %83 = load { ptr, ptr }, ptr %80, align 8
+  %84 = extractvalue { ptr, ptr } %83, 1
+  %85 = extractvalue { ptr, ptr } %83, 0
+  %86 = call %"github.com/goplus/llgo/internal/runtime.String" %85(ptr %84)
+  %87 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %88 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %87, i32 0, i32 0
+  store ptr @0, ptr %88, align 8
+  %89 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %87, i32 0, i32 1
+  store i64 3, ptr %89, align 4
+  %90 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %87, align 8
+  %91 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %86, %"github.com/goplus/llgo/internal/runtime.String" %90)
+  %92 = xor i1 %91, true
+  br i1 %92, label %_llgo_9, label %_llgo_10
 
 _llgo_9:                                          ; preds = %_llgo_8
-  %94 = load ptr, ptr @_llgo_string, align 8
-  %95 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %87, ptr %95, align 8
-  %96 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %97 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %96, i32 0, i32 0
+  %93 = load ptr, ptr @_llgo_string, align 8
+  %94 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %86, ptr %94, align 8
+  %95 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %96 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %95, i32 0, i32 0
+  store ptr %93, ptr %96, align 8
+  %97 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %95, i32 0, i32 1
   store ptr %94, ptr %97, align 8
-  %98 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %96, i32 0, i32 1
-  store ptr %95, ptr %98, align 8
-  %99 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %96, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %99)
+  %98 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %95, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %98)
   unreachable
 
 _llgo_10:                                         ; preds = %_llgo_8
-  %100 = load %main.S, ptr %3, align 8
-  %101 = extractvalue %main.S %100, 0
-  %102 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %101)
-  %103 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %101, 0
-  %104 = getelementptr ptr, ptr %103, i64 4
-  %105 = load ptr, ptr %104, align 8
-  %106 = alloca { ptr, ptr }, align 8
-  %107 = getelementptr inbounds { ptr, ptr }, ptr %106, i32 0, i32 0
-  store ptr %105, ptr %107, align 8
-  %108 = getelementptr inbounds { ptr, ptr }, ptr %106, i32 0, i32 1
-  store ptr %102, ptr %108, align 8
-  %109 = load { ptr, ptr }, ptr %106, align 8
-  %110 = extractvalue { ptr, ptr } %109, 1
-  %111 = extractvalue { ptr, ptr } %109, 0
-  %112 = call %"github.com/goplus/llgo/internal/runtime.String" %111(ptr %110)
-  %113 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %114 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %113, i32 0, i32 0
-  store ptr @0, ptr %114, align 8
-  %115 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %113, i32 0, i32 1
-  store i64 3, ptr %115, align 4
-  %116 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %113, align 8
-  %117 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %112, %"github.com/goplus/llgo/internal/runtime.String" %116)
-  %118 = xor i1 %117, true
-  br i1 %118, label %_llgo_11, label %_llgo_12
+  %99 = load %main.S, ptr %2, align 8
+  %100 = extractvalue %main.S %99, 0
+  %101 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %100)
+  %102 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %100, 0
+  %103 = getelementptr ptr, ptr %102, i64 4
+  %104 = load ptr, ptr %103, align 8
+  %105 = alloca { ptr, ptr }, align 8
+  %106 = getelementptr inbounds { ptr, ptr }, ptr %105, i32 0, i32 0
+  store ptr %104, ptr %106, align 8
+  %107 = getelementptr inbounds { ptr, ptr }, ptr %105, i32 0, i32 1
+  store ptr %101, ptr %107, align 8
+  %108 = load { ptr, ptr }, ptr %105, align 8
+  %109 = extractvalue { ptr, ptr } %108, 1
+  %110 = extractvalue { ptr, ptr } %108, 0
+  %111 = call %"github.com/goplus/llgo/internal/runtime.String" %110(ptr %109)
+  %112 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %113 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %112, i32 0, i32 0
+  store ptr @0, ptr %113, align 8
+  %114 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %112, i32 0, i32 1
+  store i64 3, ptr %114, align 4
+  %115 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %112, align 8
+  %116 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %111, %"github.com/goplus/llgo/internal/runtime.String" %115)
+  %117 = xor i1 %116, true
+  br i1 %117, label %_llgo_11, label %_llgo_12
 
 _llgo_11:                                         ; preds = %_llgo_10
-  %119 = load ptr, ptr @_llgo_string, align 8
-  %120 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %112, ptr %120, align 8
-  %121 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %122 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %121, i32 0, i32 0
+  %118 = load ptr, ptr @_llgo_string, align 8
+  %119 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %111, ptr %119, align 8
+  %120 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %121 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %120, i32 0, i32 0
+  store ptr %118, ptr %121, align 8
+  %122 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %120, i32 0, i32 1
   store ptr %119, ptr %122, align 8
-  %123 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %121, i32 0, i32 1
-  store ptr %120, ptr %123, align 8
-  %124 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %121, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %124)
+  %123 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %120, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %123)
   unreachable
 
 _llgo_12:                                         ; preds = %_llgo_10
-  %125 = getelementptr inbounds %main.S, ptr %3, i32 0, i32 0
-  %126 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %125, align 8
-  %127 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %126)
-  %128 = load ptr, ptr @_llgo_main.I, align 8
-  %129 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %128, ptr %127)
-  br i1 %129, label %_llgo_21, label %_llgo_22
+  %124 = getelementptr inbounds %main.S, ptr %2, i32 0, i32 0
+  %125 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %124, align 8
+  %126 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %125)
+  %127 = load ptr, ptr @_llgo_main.I, align 8
+  %128 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %127, ptr %126)
+  br i1 %128, label %_llgo_21, label %_llgo_22
 
 _llgo_13:                                         ; preds = %_llgo_21
-  %130 = load ptr, ptr @_llgo_string, align 8
-  %131 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %220, ptr %131, align 8
-  %132 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %133 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %132, i32 0, i32 0
+  %129 = load ptr, ptr @_llgo_string, align 8
+  %130 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %219, ptr %130, align 8
+  %131 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %132 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %131, i32 0, i32 0
+  store ptr %129, ptr %132, align 8
+  %133 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %131, i32 0, i32 1
   store ptr %130, ptr %133, align 8
-  %134 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %132, i32 0, i32 1
-  store ptr %131, ptr %134, align 8
-  %135 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %132, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %135)
+  %134 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %131, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %134)
   unreachable
 
 _llgo_14:                                         ; preds = %_llgo_21
-  %136 = load %main.S, ptr %3, align 8
-  %137 = extractvalue %main.S %136, 0
-  %138 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %137)
-  %139 = load ptr, ptr @_llgo_main.I, align 8
-  %140 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %139, ptr %138)
-  br i1 %140, label %_llgo_23, label %_llgo_24
+  %135 = load %main.S, ptr %2, align 8
+  %136 = extractvalue %main.S %135, 0
+  %137 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %136)
+  %138 = load ptr, ptr @_llgo_main.I, align 8
+  %139 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %138, ptr %137)
+  br i1 %139, label %_llgo_23, label %_llgo_24
 
 _llgo_15:                                         ; preds = %_llgo_23
-  %141 = load ptr, ptr @_llgo_string, align 8
-  %142 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %252, ptr %142, align 8
-  %143 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %144 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %143, i32 0, i32 0
+  %140 = load ptr, ptr @_llgo_string, align 8
+  %141 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %251, ptr %141, align 8
+  %142 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %143 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %142, i32 0, i32 0
+  store ptr %140, ptr %143, align 8
+  %144 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %142, i32 0, i32 1
   store ptr %141, ptr %144, align 8
-  %145 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %143, i32 0, i32 1
-  store ptr %142, ptr %145, align 8
-  %146 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %143, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %146)
+  %145 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %142, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %145)
   unreachable
 
 _llgo_16:                                         ; preds = %_llgo_23
-  %147 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %148 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %147, i32 0, i32 0
-  store ptr @8, ptr %148, align 8
-  %149 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %147, i32 0, i32 1
-  store i64 4, ptr %149, align 4
-  %150 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %147, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %150)
+  %146 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %147 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %146, i32 0, i32 0
+  store ptr @8, ptr %147, align 8
+  %148 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %146, i32 0, i32 1
+  store i64 4, ptr %148, align 4
+  %149 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %146, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %149)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 
 _llgo_17:                                         ; preds = %_llgo_4
-  %151 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %54, 1
-  %152 = load ptr, ptr @"main.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", align 8
-  %153 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %152, ptr %55)
-  %154 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %155 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %154, i32 0, i32 0
-  store ptr %153, ptr %155, align 8
-  %156 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %154, i32 0, i32 1
-  store ptr %151, ptr %156, align 8
-  %157 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %154, align 8
-  %158 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %159 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %158, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.iface" %54, ptr %159, align 8
-  %160 = alloca { ptr, ptr }, align 8
-  %161 = getelementptr inbounds { ptr, ptr }, ptr %160, i32 0, i32 0
-  store ptr @"main.one$bound", ptr %161, align 8
-  %162 = getelementptr inbounds { ptr, ptr }, ptr %160, i32 0, i32 1
-  store ptr %158, ptr %162, align 8
-  %163 = load { ptr, ptr }, ptr %160, align 8
-  %164 = extractvalue { ptr, ptr } %163, 1
-  %165 = extractvalue { ptr, ptr } %163, 0
-  %166 = call i64 %165(ptr %164)
-  %167 = icmp ne i64 %166, 1
-  br i1 %167, label %_llgo_5, label %_llgo_6
+  %150 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %53, 1
+  %151 = load ptr, ptr @"main.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", align 8
+  %152 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %151, ptr %54)
+  %153 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
+  %154 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %153, i32 0, i32 0
+  store ptr %152, ptr %154, align 8
+  %155 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %153, i32 0, i32 1
+  store ptr %150, ptr %155, align 8
+  %156 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %153, align 8
+  %157 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %158 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %157, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.iface" %53, ptr %158, align 8
+  %159 = alloca { ptr, ptr }, align 8
+  %160 = getelementptr inbounds { ptr, ptr }, ptr %159, i32 0, i32 0
+  store ptr @"main.one$bound", ptr %160, align 8
+  %161 = getelementptr inbounds { ptr, ptr }, ptr %159, i32 0, i32 1
+  store ptr %157, ptr %161, align 8
+  %162 = load { ptr, ptr }, ptr %159, align 8
+  %163 = extractvalue { ptr, ptr } %162, 1
+  %164 = extractvalue { ptr, ptr } %162, 0
+  %165 = call i64 %164(ptr %163)
+  %166 = icmp ne i64 %165, 1
+  br i1 %166, label %_llgo_5, label %_llgo_6
 
 _llgo_18:                                         ; preds = %_llgo_4
-  %168 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %169 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %168, i32 0, i32 0
-  store ptr @7, ptr %169, align 8
-  %170 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %168, i32 0, i32 1
-  store i64 21, ptr %170, align 4
-  %171 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %168, align 8
-  %172 = load ptr, ptr @_llgo_string, align 8
-  %173 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %171, ptr %173, align 8
-  %174 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %175 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %174, i32 0, i32 0
+  %167 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %168 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %167, i32 0, i32 0
+  store ptr @7, ptr %168, align 8
+  %169 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %167, i32 0, i32 1
+  store i64 21, ptr %169, align 4
+  %170 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %167, align 8
+  %171 = load ptr, ptr @_llgo_string, align 8
+  %172 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %170, ptr %172, align 8
+  %173 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %174 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %173, i32 0, i32 0
+  store ptr %171, ptr %174, align 8
+  %175 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %173, i32 0, i32 1
   store ptr %172, ptr %175, align 8
-  %176 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %174, i32 0, i32 1
-  store ptr %173, ptr %176, align 8
-  %177 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %174, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %177)
+  %176 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %173, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %176)
   unreachable
 
 _llgo_19:                                         ; preds = %_llgo_6
-  %178 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %65, 1
-  %179 = load ptr, ptr @"main.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", align 8
-  %180 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %179, ptr %66)
-  %181 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %182 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %181, i32 0, i32 0
-  store ptr %180, ptr %182, align 8
-  %183 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %181, i32 0, i32 1
-  store ptr %178, ptr %183, align 8
-  %184 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %181, align 8
-  %185 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %186 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %185, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.iface" %65, ptr %186, align 8
-  %187 = alloca { ptr, ptr }, align 8
-  %188 = getelementptr inbounds { ptr, ptr }, ptr %187, i32 0, i32 0
-  store ptr @"main.one$bound", ptr %188, align 8
-  %189 = getelementptr inbounds { ptr, ptr }, ptr %187, i32 0, i32 1
-  store ptr %185, ptr %189, align 8
-  %190 = load { ptr, ptr }, ptr %187, align 8
-  %191 = extractvalue { ptr, ptr } %190, 1
-  %192 = extractvalue { ptr, ptr } %190, 0
-  %193 = call i64 %192(ptr %191)
-  %194 = icmp ne i64 %193, 1
-  br i1 %194, label %_llgo_7, label %_llgo_8
+  %177 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %64, 1
+  %178 = load ptr, ptr @"main.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", align 8
+  %179 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %178, ptr %65)
+  %180 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
+  %181 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %180, i32 0, i32 0
+  store ptr %179, ptr %181, align 8
+  %182 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %180, i32 0, i32 1
+  store ptr %177, ptr %182, align 8
+  %183 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %180, align 8
+  %184 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %185 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %184, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.iface" %64, ptr %185, align 8
+  %186 = alloca { ptr, ptr }, align 8
+  %187 = getelementptr inbounds { ptr, ptr }, ptr %186, i32 0, i32 0
+  store ptr @"main.one$bound", ptr %187, align 8
+  %188 = getelementptr inbounds { ptr, ptr }, ptr %186, i32 0, i32 1
+  store ptr %184, ptr %188, align 8
+  %189 = load { ptr, ptr }, ptr %186, align 8
+  %190 = extractvalue { ptr, ptr } %189, 1
+  %191 = extractvalue { ptr, ptr } %189, 0
+  %192 = call i64 %191(ptr %190)
+  %193 = icmp ne i64 %192, 1
+  br i1 %193, label %_llgo_7, label %_llgo_8
 
 _llgo_20:                                         ; preds = %_llgo_6
-  %195 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %196 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %195, i32 0, i32 0
-  store ptr @7, ptr %196, align 8
-  %197 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %195, i32 0, i32 1
-  store i64 21, ptr %197, align 4
-  %198 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %195, align 8
-  %199 = load ptr, ptr @_llgo_string, align 8
-  %200 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %198, ptr %200, align 8
-  %201 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %202 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %201, i32 0, i32 0
+  %194 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %195 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %194, i32 0, i32 0
+  store ptr @7, ptr %195, align 8
+  %196 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %194, i32 0, i32 1
+  store i64 21, ptr %196, align 4
+  %197 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %194, align 8
+  %198 = load ptr, ptr @_llgo_string, align 8
+  %199 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %197, ptr %199, align 8
+  %200 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %201 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %200, i32 0, i32 0
+  store ptr %198, ptr %201, align 8
+  %202 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %200, i32 0, i32 1
   store ptr %199, ptr %202, align 8
-  %203 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %201, i32 0, i32 1
-  store ptr %200, ptr %203, align 8
-  %204 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %201, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %204)
+  %203 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %200, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %203)
   unreachable
 
 _llgo_21:                                         ; preds = %_llgo_12
-  %205 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %126, 1
-  %206 = load ptr, ptr @"main.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", align 8
-  %207 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %206, ptr %127)
-  %208 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %209 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %208, i32 0, i32 0
-  store ptr %207, ptr %209, align 8
-  %210 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %208, i32 0, i32 1
-  store ptr %205, ptr %210, align 8
-  %211 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %208, align 8
-  %212 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %213 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %212, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.iface" %126, ptr %213, align 8
-  %214 = alloca { ptr, ptr }, align 8
-  %215 = getelementptr inbounds { ptr, ptr }, ptr %214, i32 0, i32 0
-  store ptr @"main.two$bound", ptr %215, align 8
-  %216 = getelementptr inbounds { ptr, ptr }, ptr %214, i32 0, i32 1
-  store ptr %212, ptr %216, align 8
-  %217 = load { ptr, ptr }, ptr %214, align 8
-  %218 = extractvalue { ptr, ptr } %217, 1
-  %219 = extractvalue { ptr, ptr } %217, 0
-  %220 = call %"github.com/goplus/llgo/internal/runtime.String" %219(ptr %218)
-  %221 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %222 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %221, i32 0, i32 0
-  store ptr @0, ptr %222, align 8
-  %223 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %221, i32 0, i32 1
-  store i64 3, ptr %223, align 4
-  %224 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %221, align 8
-  %225 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %220, %"github.com/goplus/llgo/internal/runtime.String" %224)
-  %226 = xor i1 %225, true
-  br i1 %226, label %_llgo_13, label %_llgo_14
+  %204 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %125, 1
+  %205 = load ptr, ptr @"main.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", align 8
+  %206 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %205, ptr %126)
+  %207 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
+  %208 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %207, i32 0, i32 0
+  store ptr %206, ptr %208, align 8
+  %209 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %207, i32 0, i32 1
+  store ptr %204, ptr %209, align 8
+  %210 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %207, align 8
+  %211 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %212 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %211, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.iface" %125, ptr %212, align 8
+  %213 = alloca { ptr, ptr }, align 8
+  %214 = getelementptr inbounds { ptr, ptr }, ptr %213, i32 0, i32 0
+  store ptr @"main.two$bound", ptr %214, align 8
+  %215 = getelementptr inbounds { ptr, ptr }, ptr %213, i32 0, i32 1
+  store ptr %211, ptr %215, align 8
+  %216 = load { ptr, ptr }, ptr %213, align 8
+  %217 = extractvalue { ptr, ptr } %216, 1
+  %218 = extractvalue { ptr, ptr } %216, 0
+  %219 = call %"github.com/goplus/llgo/internal/runtime.String" %218(ptr %217)
+  %220 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %221 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %220, i32 0, i32 0
+  store ptr @0, ptr %221, align 8
+  %222 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %220, i32 0, i32 1
+  store i64 3, ptr %222, align 4
+  %223 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %220, align 8
+  %224 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %219, %"github.com/goplus/llgo/internal/runtime.String" %223)
+  %225 = xor i1 %224, true
+  br i1 %225, label %_llgo_13, label %_llgo_14
 
 _llgo_22:                                         ; preds = %_llgo_12
-  %227 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %228 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %227, i32 0, i32 0
-  store ptr @7, ptr %228, align 8
-  %229 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %227, i32 0, i32 1
-  store i64 21, ptr %229, align 4
-  %230 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %227, align 8
-  %231 = load ptr, ptr @_llgo_string, align 8
-  %232 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %230, ptr %232, align 8
-  %233 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %234 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %233, i32 0, i32 0
+  %226 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %227 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %226, i32 0, i32 0
+  store ptr @7, ptr %227, align 8
+  %228 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %226, i32 0, i32 1
+  store i64 21, ptr %228, align 4
+  %229 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %226, align 8
+  %230 = load ptr, ptr @_llgo_string, align 8
+  %231 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %229, ptr %231, align 8
+  %232 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %233 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %232, i32 0, i32 0
+  store ptr %230, ptr %233, align 8
+  %234 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %232, i32 0, i32 1
   store ptr %231, ptr %234, align 8
-  %235 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %233, i32 0, i32 1
-  store ptr %232, ptr %235, align 8
-  %236 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %233, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %236)
+  %235 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %232, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %235)
   unreachable
 
 _llgo_23:                                         ; preds = %_llgo_14
-  %237 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %137, 1
-  %238 = load ptr, ptr @"main.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", align 8
-  %239 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %238, ptr %138)
-  %240 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %241 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %240, i32 0, i32 0
-  store ptr %239, ptr %241, align 8
-  %242 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %240, i32 0, i32 1
-  store ptr %237, ptr %242, align 8
-  %243 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %240, align 8
-  %244 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %245 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %244, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.iface" %137, ptr %245, align 8
-  %246 = alloca { ptr, ptr }, align 8
-  %247 = getelementptr inbounds { ptr, ptr }, ptr %246, i32 0, i32 0
-  store ptr @"main.two$bound", ptr %247, align 8
-  %248 = getelementptr inbounds { ptr, ptr }, ptr %246, i32 0, i32 1
-  store ptr %244, ptr %248, align 8
-  %249 = load { ptr, ptr }, ptr %246, align 8
-  %250 = extractvalue { ptr, ptr } %249, 1
-  %251 = extractvalue { ptr, ptr } %249, 0
-  %252 = call %"github.com/goplus/llgo/internal/runtime.String" %251(ptr %250)
-  %253 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %254 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %253, i32 0, i32 0
-  store ptr @0, ptr %254, align 8
-  %255 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %253, i32 0, i32 1
-  store i64 3, ptr %255, align 4
-  %256 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %253, align 8
-  %257 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %252, %"github.com/goplus/llgo/internal/runtime.String" %256)
-  %258 = xor i1 %257, true
-  br i1 %258, label %_llgo_15, label %_llgo_16
+  %236 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %136, 1
+  %237 = load ptr, ptr @"main.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", align 8
+  %238 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %237, ptr %137)
+  %239 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
+  %240 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %239, i32 0, i32 0
+  store ptr %238, ptr %240, align 8
+  %241 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %239, i32 0, i32 1
+  store ptr %236, ptr %241, align 8
+  %242 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %239, align 8
+  %243 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %244 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %243, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.iface" %136, ptr %244, align 8
+  %245 = alloca { ptr, ptr }, align 8
+  %246 = getelementptr inbounds { ptr, ptr }, ptr %245, i32 0, i32 0
+  store ptr @"main.two$bound", ptr %246, align 8
+  %247 = getelementptr inbounds { ptr, ptr }, ptr %245, i32 0, i32 1
+  store ptr %243, ptr %247, align 8
+  %248 = load { ptr, ptr }, ptr %245, align 8
+  %249 = extractvalue { ptr, ptr } %248, 1
+  %250 = extractvalue { ptr, ptr } %248, 0
+  %251 = call %"github.com/goplus/llgo/internal/runtime.String" %250(ptr %249)
+  %252 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %253 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %252, i32 0, i32 0
+  store ptr @0, ptr %253, align 8
+  %254 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %252, i32 0, i32 1
+  store i64 3, ptr %254, align 4
+  %255 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %252, align 8
+  %256 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %251, %"github.com/goplus/llgo/internal/runtime.String" %255)
+  %257 = xor i1 %256, true
+  br i1 %257, label %_llgo_15, label %_llgo_16
 
 _llgo_24:                                         ; preds = %_llgo_14
-  %259 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %260 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %259, i32 0, i32 0
-  store ptr @7, ptr %260, align 8
-  %261 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %259, i32 0, i32 1
-  store i64 21, ptr %261, align 4
-  %262 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %259, align 8
-  %263 = load ptr, ptr @_llgo_string, align 8
-  %264 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %262, ptr %264, align 8
-  %265 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %266 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %265, i32 0, i32 0
+  %258 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %259 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %258, i32 0, i32 0
+  store ptr @7, ptr %259, align 8
+  %260 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %258, i32 0, i32 1
+  store i64 21, ptr %260, align 4
+  %261 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %258, align 8
+  %262 = load ptr, ptr @_llgo_string, align 8
+  %263 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %261, ptr %263, align 8
+  %264 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %265 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %264, i32 0, i32 0
+  store ptr %262, ptr %265, align 8
+  %266 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %264, i32 0, i32 1
   store ptr %263, ptr %266, align 8
-  %267 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %265, i32 0, i32 1
-  store ptr %264, ptr %267, align 8
-  %268 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %265, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %268)
+  %267 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %264, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %267)
   unreachable
 }
 
-declare ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr, i64)
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface")
 
@@ -1019,3 +1020,5 @@ _llgo_0:
 declare void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String")
 
 declare void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8)
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/interface/out.ll
+++ b/cl/_testgo/interface/out.ll
@@ -38,22 +38,22 @@ source_filename = "main"
 define void @main.Game1.Load(%main.Game1 %0) {
 _llgo_0:
   %1 = alloca %main.Game1, align 8
-  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %1, i64 8)
-  store %main.Game1 %0, ptr %2, align 8
-  %3 = getelementptr inbounds %main.Game1, ptr %2, i32 0, i32 0
-  %4 = load ptr, ptr %3, align 8
-  call void @"github.com/goplus/llgo/cl/internal/foo.(*Game).Load"(ptr %4)
+  call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
+  store %main.Game1 %0, ptr %1, align 8
+  %2 = getelementptr inbounds %main.Game1, ptr %1, i32 0, i32 0
+  %3 = load ptr, ptr %2, align 8
+  call void @"github.com/goplus/llgo/cl/internal/foo.(*Game).Load"(ptr %3)
   ret void
 }
 
 define void @main.Game1.initGame(%main.Game1 %0) {
 _llgo_0:
   %1 = alloca %main.Game1, align 8
-  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %1, i64 8)
-  store %main.Game1 %0, ptr %2, align 8
-  %3 = getelementptr inbounds %main.Game1, ptr %2, i32 0, i32 0
-  %4 = load ptr, ptr %3, align 8
-  call void @"github.com/goplus/llgo/cl/internal/foo.(*Game).initGame"(ptr %4)
+  call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
+  store %main.Game1 %0, ptr %1, align 8
+  %2 = getelementptr inbounds %main.Game1, ptr %1, i32 0, i32 0
+  %3 = load ptr, ptr %2, align 8
+  call void @"github.com/goplus/llgo/cl/internal/foo.(*Game).initGame"(ptr %3)
   ret void
 }
 
@@ -236,7 +236,8 @@ _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
   ret i32 0
 }
 
-declare ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr, i64)
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
 
 declare void @"github.com/goplus/llgo/cl/internal/foo.(*Game).Load"(ptr)
 
@@ -686,3 +687,5 @@ declare void @"github.com/goplus/llgo/internal/runtime.PrintIface"(%"github.com/
 declare void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1)
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface")
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/invoke/out.ll
+++ b/cl/_testgo/invoke/out.ll
@@ -73,19 +73,19 @@ source_filename = "main"
 define i64 @main.T.Invoke(%main.T %0) {
 _llgo_0:
   %1 = alloca %main.T, align 8
-  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %1, i64 16)
-  store %main.T %0, ptr %2, align 8
-  %3 = getelementptr inbounds %main.T, ptr %2, i32 0, i32 0
-  %4 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3, align 8
-  %5 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %5, i32 0, i32 0
-  store ptr @0, ptr %6, align 8
-  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %5, i32 0, i32 1
-  store i64 6, ptr %7, align 4
-  %8 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %5, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %8)
+  call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+  store %main.T %0, ptr %1, align 8
+  %2 = getelementptr inbounds %main.T, ptr %1, i32 0, i32 0
+  %3 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
+  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
+  store ptr @0, ptr %5, align 8
+  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
+  store i64 6, ptr %6, align 4
+  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %7)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %4)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %3)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i64 0
 }
@@ -166,19 +166,19 @@ _llgo_0:
 define i64 @main.T4.Invoke([1 x i64] %0) {
 _llgo_0:
   %1 = alloca [1 x i64], align 8
-  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %1, i64 8)
-  store [1 x i64] %0, ptr %2, align 4
-  %3 = getelementptr inbounds i64, ptr %2, i64 0
-  %4 = load i64, ptr %3, align 4
-  %5 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %5, i32 0, i32 0
-  store ptr @4, ptr %6, align 8
-  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %5, i32 0, i32 1
-  store i64 7, ptr %7, align 4
-  %8 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %5, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %8)
+  call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
+  store [1 x i64] %0, ptr %1, align 4
+  %2 = getelementptr inbounds i64, ptr %1, i64 0
+  %3 = load i64, ptr %2, align 4
+  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
+  store ptr @4, ptr %5, align 8
+  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
+  store i64 7, ptr %6, align 4
+  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %7)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %4)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %3)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i64 4
 }
@@ -193,19 +193,19 @@ _llgo_0:
 define i64 @main.T5.Invoke(%main.T5 %0) {
 _llgo_0:
   %1 = alloca %main.T5, align 8
-  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %1, i64 8)
-  store %main.T5 %0, ptr %2, align 4
-  %3 = getelementptr inbounds %main.T5, ptr %2, i32 0, i32 0
-  %4 = load i64, ptr %3, align 4
-  %5 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %5, i32 0, i32 0
-  store ptr @5, ptr %6, align 8
-  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %5, i32 0, i32 1
-  store i64 7, ptr %7, align 4
-  %8 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %5, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %8)
+  call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
+  store %main.T5 %0, ptr %1, align 4
+  %2 = getelementptr inbounds %main.T5, ptr %1, i32 0, i32 0
+  %3 = load i64, ptr %2, align 4
+  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
+  store ptr @5, ptr %5, align 8
+  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
+  store i64 7, ptr %6, align 4
+  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %7)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %4)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %3)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i64 5
 }
@@ -492,127 +492,127 @@ _llgo_0:
   %147 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %144, align 8
   call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %147)
   %148 = alloca %main.T, align 8
-  %149 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %148, i64 16)
-  %150 = getelementptr inbounds %main.T, ptr %149, i32 0, i32 0
-  %151 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %152 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %151, i32 0, i32 0
-  store ptr @22, ptr %152, align 8
-  %153 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %151, i32 0, i32 1
-  store i64 5, ptr %153, align 4
-  %154 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %151, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %154, ptr %150, align 8
-  %155 = load %main.T, ptr %149, align 8
-  %156 = load ptr, ptr @_llgo_main.T, align 8
-  %157 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %main.T %155, ptr %157, align 8
-  %158 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %159 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %158, i32 0, i32 0
+  call void @llvm.memset(ptr %148, i8 0, i64 16, i1 false)
+  %149 = getelementptr inbounds %main.T, ptr %148, i32 0, i32 0
+  %150 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %151 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %150, i32 0, i32 0
+  store ptr @22, ptr %151, align 8
+  %152 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %150, i32 0, i32 1
+  store i64 5, ptr %152, align 4
+  %153 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %150, align 8
+  store %"github.com/goplus/llgo/internal/runtime.String" %153, ptr %149, align 8
+  %154 = load %main.T, ptr %148, align 8
+  %155 = load ptr, ptr @_llgo_main.T, align 8
+  %156 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %main.T %154, ptr %156, align 8
+  %157 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %158 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %157, i32 0, i32 0
+  store ptr %155, ptr %158, align 8
+  %159 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %157, i32 0, i32 1
   store ptr %156, ptr %159, align 8
-  %160 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %158, i32 0, i32 1
-  store ptr %157, ptr %160, align 8
-  %161 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %158, align 8
-  %162 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %161, 0
-  %163 = load ptr, ptr @_llgo_main.I, align 8
-  %164 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %163, ptr %162)
-  br i1 %164, label %_llgo_1, label %_llgo_2
+  %160 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %157, align 8
+  %161 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %160, 0
+  %162 = load ptr, ptr @_llgo_main.I, align 8
+  %163 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %162, ptr %161)
+  br i1 %163, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %165 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %161, 1
-  %166 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
-  %167 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %166, ptr %162)
-  %168 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %169 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %168, i32 0, i32 0
-  store ptr %167, ptr %169, align 8
-  %170 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %168, i32 0, i32 1
-  store ptr %165, ptr %170, align 8
-  %171 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %168, align 8
-  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %171)
-  %172 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %161, 0
-  %173 = load ptr, ptr @_llgo_any, align 8
-  %174 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %173, ptr %172)
-  br i1 %174, label %_llgo_3, label %_llgo_4
+  %164 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %160, 1
+  %165 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
+  %166 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %165, ptr %161)
+  %167 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
+  %168 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %167, i32 0, i32 0
+  store ptr %166, ptr %168, align 8
+  %169 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %167, i32 0, i32 1
+  store ptr %164, ptr %169, align 8
+  %170 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %167, align 8
+  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %170)
+  %171 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %160, 0
+  %172 = load ptr, ptr @_llgo_any, align 8
+  %173 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %172, ptr %171)
+  br i1 %173, label %_llgo_3, label %_llgo_4
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %175 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %176 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %175, i32 0, i32 0
-  store ptr @24, ptr %176, align 8
-  %177 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %175, i32 0, i32 1
-  store i64 21, ptr %177, align 4
-  %178 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %175, align 8
-  %179 = load ptr, ptr @_llgo_string, align 8
-  %180 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %178, ptr %180, align 8
-  %181 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %182 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %181, i32 0, i32 0
+  %174 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %175 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %174, i32 0, i32 0
+  store ptr @24, ptr %175, align 8
+  %176 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %174, i32 0, i32 1
+  store i64 21, ptr %176, align 4
+  %177 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %174, align 8
+  %178 = load ptr, ptr @_llgo_string, align 8
+  %179 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %177, ptr %179, align 8
+  %180 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %181 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %180, i32 0, i32 0
+  store ptr %178, ptr %181, align 8
+  %182 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %180, i32 0, i32 1
   store ptr %179, ptr %182, align 8
-  %183 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %181, i32 0, i32 1
-  store ptr %180, ptr %183, align 8
-  %184 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %181, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %184)
+  %183 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %180, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %183)
   unreachable
 
 _llgo_3:                                          ; preds = %_llgo_1
-  %185 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %161, 1
-  %186 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %187 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %186, i32 0, i32 0
-  store ptr %172, ptr %187, align 8
-  %188 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %186, i32 0, i32 1
-  store ptr %185, ptr %188, align 8
-  %189 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %186, align 8
-  %190 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %189, 0
-  %191 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
-  %192 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %191, ptr %190)
-  br i1 %192, label %_llgo_5, label %_llgo_6
+  %184 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %160, 1
+  %185 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %186 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %185, i32 0, i32 0
+  store ptr %171, ptr %186, align 8
+  %187 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %185, i32 0, i32 1
+  store ptr %184, ptr %187, align 8
+  %188 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %185, align 8
+  %189 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %188, 0
+  %190 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
+  %191 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %190, ptr %189)
+  br i1 %191, label %_llgo_5, label %_llgo_6
 
 _llgo_4:                                          ; preds = %_llgo_1
-  %193 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %194 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %193, i32 0, i32 0
-  store ptr @24, ptr %194, align 8
-  %195 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %193, i32 0, i32 1
-  store i64 21, ptr %195, align 4
-  %196 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %193, align 8
-  %197 = load ptr, ptr @_llgo_string, align 8
-  %198 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %196, ptr %198, align 8
-  %199 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %200 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %199, i32 0, i32 0
+  %192 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %193 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %192, i32 0, i32 0
+  store ptr @24, ptr %193, align 8
+  %194 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %192, i32 0, i32 1
+  store i64 21, ptr %194, align 4
+  %195 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %192, align 8
+  %196 = load ptr, ptr @_llgo_string, align 8
+  %197 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %195, ptr %197, align 8
+  %198 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %199 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %198, i32 0, i32 0
+  store ptr %196, ptr %199, align 8
+  %200 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %198, i32 0, i32 1
   store ptr %197, ptr %200, align 8
-  %201 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %199, i32 0, i32 1
-  store ptr %198, ptr %201, align 8
-  %202 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %199, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %202)
+  %201 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %198, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %201)
   unreachable
 
 _llgo_5:                                          ; preds = %_llgo_3
-  %203 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %189, 1
-  %204 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
-  %205 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %204, ptr %190)
-  %206 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %207 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %206, i32 0, i32 0
-  store ptr %205, ptr %207, align 8
-  %208 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %206, i32 0, i32 1
-  store ptr %203, ptr %208, align 8
-  %209 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %206, align 8
-  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %209)
+  %202 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %188, 1
+  %203 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
+  %204 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %203, ptr %189)
+  %205 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
+  %206 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %205, i32 0, i32 0
+  store ptr %204, ptr %206, align 8
+  %207 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %205, i32 0, i32 1
+  store ptr %202, ptr %207, align 8
+  %208 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %205, align 8
+  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %208)
   ret i32 0
 
 _llgo_6:                                          ; preds = %_llgo_3
-  %210 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %211 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %210, i32 0, i32 0
-  store ptr @24, ptr %211, align 8
-  %212 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %210, i32 0, i32 1
-  store i64 21, ptr %212, align 4
-  %213 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %210, align 8
-  %214 = load ptr, ptr @_llgo_string, align 8
-  %215 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %213, ptr %215, align 8
-  %216 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %217 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %216, i32 0, i32 0
+  %209 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %210 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %209, i32 0, i32 0
+  store ptr @24, ptr %210, align 8
+  %211 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %209, i32 0, i32 1
+  store i64 21, ptr %211, align 4
+  %212 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %209, align 8
+  %213 = load ptr, ptr @_llgo_string, align 8
+  %214 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %212, ptr %214, align 8
+  %215 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %216 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %215, i32 0, i32 0
+  store ptr %213, ptr %216, align 8
+  %217 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %215, i32 0, i32 1
   store ptr %214, ptr %217, align 8
-  %218 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %216, i32 0, i32 1
-  store ptr %215, ptr %218, align 8
-  %219 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %216, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %219)
+  %218 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %215, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %218)
   unreachable
 }
 
@@ -621,7 +621,8 @@ _llgo_0:
   ret i64 400
 }
 
-declare ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr, i64)
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
 
 declare void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String")
 
@@ -1754,3 +1755,5 @@ declare void @"github.com/goplus/llgo/internal/runtime.PrintIface"(%"github.com/
 declare i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr, ptr)
 
 declare void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface")
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/reader/out.ll
+++ b/cl/_testgo/reader/out.ll
@@ -102,74 +102,74 @@ _llgo_0:
 
 _llgo_1:                                          ; preds = %_llgo_5
   %4 = alloca %main.nopCloserWriterTo, align 8
-  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %4, i64 16)
-  %6 = getelementptr inbounds %main.nopCloserWriterTo, ptr %5, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.iface" %0, ptr %6, align 8
-  %7 = load %main.nopCloserWriterTo, ptr %5, align 8
-  %8 = load ptr, ptr @_llgo_main.nopCloserWriterTo, align 8
-  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %main.nopCloserWriterTo %7, ptr %9, align 8
-  %10 = load ptr, ptr @"_llgo_iface$L2Ik-AJcd0jsoBw5fQ07pQpfUM-kh78Wn2bOeak6M3I", align 8
-  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %10, ptr %8)
-  %12 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %12, i32 0, i32 0
-  store ptr %11, ptr %13, align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %12, i32 0, i32 1
-  store ptr %9, ptr %14, align 8
-  %15 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %12, align 8
-  ret %"github.com/goplus/llgo/internal/runtime.iface" %15
+  call void @llvm.memset(ptr %4, i8 0, i64 16, i1 false)
+  %5 = getelementptr inbounds %main.nopCloserWriterTo, ptr %4, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.iface" %0, ptr %5, align 8
+  %6 = load %main.nopCloserWriterTo, ptr %4, align 8
+  %7 = load ptr, ptr @_llgo_main.nopCloserWriterTo, align 8
+  %8 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %main.nopCloserWriterTo %6, ptr %8, align 8
+  %9 = load ptr, ptr @"_llgo_iface$L2Ik-AJcd0jsoBw5fQ07pQpfUM-kh78Wn2bOeak6M3I", align 8
+  %10 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %9, ptr %7)
+  %11 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
+  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %11, i32 0, i32 0
+  store ptr %10, ptr %12, align 8
+  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %11, i32 0, i32 1
+  store ptr %8, ptr %13, align 8
+  %14 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %11, align 8
+  ret %"github.com/goplus/llgo/internal/runtime.iface" %14
 
 _llgo_2:                                          ; preds = %_llgo_5
-  %16 = alloca %main.nopCloser, align 8
-  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %16, i64 16)
-  %18 = getelementptr inbounds %main.nopCloser, ptr %17, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.iface" %0, ptr %18, align 8
-  %19 = load %main.nopCloser, ptr %17, align 8
-  %20 = load ptr, ptr @_llgo_main.nopCloser, align 8
-  %21 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %main.nopCloser %19, ptr %21, align 8
-  %22 = load ptr, ptr @"_llgo_iface$L2Ik-AJcd0jsoBw5fQ07pQpfUM-kh78Wn2bOeak6M3I", align 8
-  %23 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %22, ptr %20)
-  %24 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %24, i32 0, i32 0
-  store ptr %23, ptr %25, align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %24, i32 0, i32 1
-  store ptr %21, ptr %26, align 8
-  %27 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %24, align 8
-  ret %"github.com/goplus/llgo/internal/runtime.iface" %27
+  %15 = alloca %main.nopCloser, align 8
+  call void @llvm.memset(ptr %15, i8 0, i64 16, i1 false)
+  %16 = getelementptr inbounds %main.nopCloser, ptr %15, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.iface" %0, ptr %16, align 8
+  %17 = load %main.nopCloser, ptr %15, align 8
+  %18 = load ptr, ptr @_llgo_main.nopCloser, align 8
+  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %main.nopCloser %17, ptr %19, align 8
+  %20 = load ptr, ptr @"_llgo_iface$L2Ik-AJcd0jsoBw5fQ07pQpfUM-kh78Wn2bOeak6M3I", align 8
+  %21 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %20, ptr %18)
+  %22 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
+  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %22, i32 0, i32 0
+  store ptr %21, ptr %23, align 8
+  %24 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %22, i32 0, i32 1
+  store ptr %19, ptr %24, align 8
+  %25 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %22, align 8
+  ret %"github.com/goplus/llgo/internal/runtime.iface" %25
 
 _llgo_3:                                          ; preds = %_llgo_0
-  %28 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %0, 1
-  %29 = load ptr, ptr @"_llgo_iface$eN81k1zqixGTyagHw_4nqH4mGfwwehTOCTXUlbT9kzk", align 8
-  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %29, ptr %1)
-  %31 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %31, i32 0, i32 0
-  store ptr %30, ptr %32, align 8
-  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %31, i32 0, i32 1
-  store ptr %28, ptr %33, align 8
-  %34 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %31, align 8
-  %35 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
-  %36 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %35, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.iface" %34, ptr %36, align 8
-  %37 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %35, i32 0, i32 1
-  store i1 true, ptr %37, align 1
-  %38 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %35, align 8
+  %26 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %0, 1
+  %27 = load ptr, ptr @"_llgo_iface$eN81k1zqixGTyagHw_4nqH4mGfwwehTOCTXUlbT9kzk", align 8
+  %28 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %27, ptr %1)
+  %29 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
+  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %29, i32 0, i32 0
+  store ptr %28, ptr %30, align 8
+  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %29, i32 0, i32 1
+  store ptr %26, ptr %31, align 8
+  %32 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %29, align 8
+  %33 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
+  %34 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %33, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.iface" %32, ptr %34, align 8
+  %35 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %33, i32 0, i32 1
+  store i1 true, ptr %35, align 1
+  %36 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %33, align 8
   br label %_llgo_5
 
 _llgo_4:                                          ; preds = %_llgo_0
-  %39 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
-  %40 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %39, i32 0, i32 0
-  store { ptr, ptr } zeroinitializer, ptr %40, align 8
-  %41 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %39, i32 0, i32 1
-  store i1 false, ptr %41, align 1
-  %42 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %39, align 8
+  %37 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
+  %38 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %37, i32 0, i32 0
+  store { ptr, ptr } zeroinitializer, ptr %38, align 8
+  %39 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %37, i32 0, i32 1
+  store i1 false, ptr %39, align 1
+  %40 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %37, align 8
   br label %_llgo_5
 
 _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
-  %43 = phi { %"github.com/goplus/llgo/internal/runtime.iface", i1 } [ %38, %_llgo_3 ], [ %42, %_llgo_4 ]
-  %44 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %43, 0
-  %45 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %43, 1
-  br i1 %45, label %_llgo_1, label %_llgo_2
+  %41 = phi { %"github.com/goplus/llgo/internal/runtime.iface", i1 } [ %36, %_llgo_3 ], [ %40, %_llgo_4 ]
+  %42 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %41, 0
+  %43 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %41, 1
+  br i1 %43, label %_llgo_1, label %_llgo_2
 }
 
 define { %"github.com/goplus/llgo/internal/runtime.Slice", %"github.com/goplus/llgo/internal/runtime.iface" } @main.ReadAll(%"github.com/goplus/llgo/internal/runtime.iface" %0) {
@@ -474,32 +474,32 @@ _llgo_0:
 define { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @main.nopCloser.Read(%main.nopCloser %0, %"github.com/goplus/llgo/internal/runtime.Slice" %1) {
 _llgo_0:
   %2 = alloca %main.nopCloser, align 8
-  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %2, i64 16)
-  store %main.nopCloser %0, ptr %3, align 8
-  %4 = getelementptr inbounds %main.nopCloser, ptr %3, i32 0, i32 0
-  %5 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %4, align 8
-  %6 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %5)
-  %7 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %5, 0
-  %8 = getelementptr ptr, ptr %7, i64 3
-  %9 = load ptr, ptr %8, align 8
-  %10 = alloca { ptr, ptr }, align 8
-  %11 = getelementptr inbounds { ptr, ptr }, ptr %10, i32 0, i32 0
-  store ptr %9, ptr %11, align 8
-  %12 = getelementptr inbounds { ptr, ptr }, ptr %10, i32 0, i32 1
-  store ptr %6, ptr %12, align 8
-  %13 = load { ptr, ptr }, ptr %10, align 8
-  %14 = extractvalue { ptr, ptr } %13, 1
-  %15 = extractvalue { ptr, ptr } %13, 0
-  %16 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %15(ptr %14, %"github.com/goplus/llgo/internal/runtime.Slice" %1)
-  %17 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %16, 0
-  %18 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %16, 1
-  %19 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %20 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %19, i32 0, i32 0
-  store i64 %17, ptr %20, align 4
-  %21 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %19, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" %18, ptr %21, align 8
-  %22 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %19, align 8
-  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %22
+  call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+  store %main.nopCloser %0, ptr %2, align 8
+  %3 = getelementptr inbounds %main.nopCloser, ptr %2, i32 0, i32 0
+  %4 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %3, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %4)
+  %6 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %4, 0
+  %7 = getelementptr ptr, ptr %6, i64 3
+  %8 = load ptr, ptr %7, align 8
+  %9 = alloca { ptr, ptr }, align 8
+  %10 = getelementptr inbounds { ptr, ptr }, ptr %9, i32 0, i32 0
+  store ptr %8, ptr %10, align 8
+  %11 = getelementptr inbounds { ptr, ptr }, ptr %9, i32 0, i32 1
+  store ptr %5, ptr %11, align 8
+  %12 = load { ptr, ptr }, ptr %9, align 8
+  %13 = extractvalue { ptr, ptr } %12, 1
+  %14 = extractvalue { ptr, ptr } %12, 0
+  %15 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %14(ptr %13, %"github.com/goplus/llgo/internal/runtime.Slice" %1)
+  %16 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %15, 0
+  %17 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %15, 1
+  %18 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
+  %19 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %18, i32 0, i32 0
+  store i64 %16, ptr %19, align 4
+  %20 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %18, i32 0, i32 1
+  store %"github.com/goplus/llgo/internal/runtime.iface" %17, ptr %20, align 8
+  %21 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %18, align 8
+  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %21
 }
 
 define %"github.com/goplus/llgo/internal/runtime.iface" @"main.(*nopCloser).Close"(ptr %0) {
@@ -545,96 +545,96 @@ _llgo_0:
 define { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @main.nopCloserWriterTo.Read(%main.nopCloserWriterTo %0, %"github.com/goplus/llgo/internal/runtime.Slice" %1) {
 _llgo_0:
   %2 = alloca %main.nopCloserWriterTo, align 8
-  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %2, i64 16)
-  store %main.nopCloserWriterTo %0, ptr %3, align 8
-  %4 = getelementptr inbounds %main.nopCloserWriterTo, ptr %3, i32 0, i32 0
-  %5 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %4, align 8
-  %6 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %5)
-  %7 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %5, 0
-  %8 = getelementptr ptr, ptr %7, i64 3
-  %9 = load ptr, ptr %8, align 8
-  %10 = alloca { ptr, ptr }, align 8
-  %11 = getelementptr inbounds { ptr, ptr }, ptr %10, i32 0, i32 0
-  store ptr %9, ptr %11, align 8
-  %12 = getelementptr inbounds { ptr, ptr }, ptr %10, i32 0, i32 1
-  store ptr %6, ptr %12, align 8
-  %13 = load { ptr, ptr }, ptr %10, align 8
-  %14 = extractvalue { ptr, ptr } %13, 1
-  %15 = extractvalue { ptr, ptr } %13, 0
-  %16 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %15(ptr %14, %"github.com/goplus/llgo/internal/runtime.Slice" %1)
-  %17 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %16, 0
-  %18 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %16, 1
-  %19 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %20 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %19, i32 0, i32 0
-  store i64 %17, ptr %20, align 4
-  %21 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %19, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" %18, ptr %21, align 8
-  %22 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %19, align 8
-  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %22
+  call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+  store %main.nopCloserWriterTo %0, ptr %2, align 8
+  %3 = getelementptr inbounds %main.nopCloserWriterTo, ptr %2, i32 0, i32 0
+  %4 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %3, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %4)
+  %6 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %4, 0
+  %7 = getelementptr ptr, ptr %6, i64 3
+  %8 = load ptr, ptr %7, align 8
+  %9 = alloca { ptr, ptr }, align 8
+  %10 = getelementptr inbounds { ptr, ptr }, ptr %9, i32 0, i32 0
+  store ptr %8, ptr %10, align 8
+  %11 = getelementptr inbounds { ptr, ptr }, ptr %9, i32 0, i32 1
+  store ptr %5, ptr %11, align 8
+  %12 = load { ptr, ptr }, ptr %9, align 8
+  %13 = extractvalue { ptr, ptr } %12, 1
+  %14 = extractvalue { ptr, ptr } %12, 0
+  %15 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %14(ptr %13, %"github.com/goplus/llgo/internal/runtime.Slice" %1)
+  %16 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %15, 0
+  %17 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %15, 1
+  %18 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
+  %19 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %18, i32 0, i32 0
+  store i64 %16, ptr %19, align 4
+  %20 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %18, i32 0, i32 1
+  store %"github.com/goplus/llgo/internal/runtime.iface" %17, ptr %20, align 8
+  %21 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %18, align 8
+  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %21
 }
 
 define { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @main.nopCloserWriterTo.WriteTo(%main.nopCloserWriterTo %0, %"github.com/goplus/llgo/internal/runtime.iface" %1) {
 _llgo_0:
   %2 = alloca %main.nopCloserWriterTo, align 8
-  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %2, i64 16)
-  store %main.nopCloserWriterTo %0, ptr %3, align 8
-  %4 = getelementptr inbounds %main.nopCloserWriterTo, ptr %3, i32 0, i32 0
-  %5 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %4, align 8
-  %6 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %5)
-  %7 = load ptr, ptr @_llgo_main.WriterTo, align 8
-  %8 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %7, ptr %6)
-  br i1 %8, label %_llgo_1, label %_llgo_2
+  call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+  store %main.nopCloserWriterTo %0, ptr %2, align 8
+  %3 = getelementptr inbounds %main.nopCloserWriterTo, ptr %2, i32 0, i32 0
+  %4 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %3, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %4)
+  %6 = load ptr, ptr @_llgo_main.WriterTo, align 8
+  %7 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %6, ptr %5)
+  br i1 %7, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %9 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %5, 1
-  %10 = load ptr, ptr @"_llgo_iface$eN81k1zqixGTyagHw_4nqH4mGfwwehTOCTXUlbT9kzk", align 8
-  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %10, ptr %6)
-  %12 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %12, i32 0, i32 0
-  store ptr %11, ptr %13, align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %12, i32 0, i32 1
-  store ptr %9, ptr %14, align 8
-  %15 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %12, align 8
-  %16 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %15)
-  %17 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %15, 0
-  %18 = getelementptr ptr, ptr %17, i64 3
-  %19 = load ptr, ptr %18, align 8
-  %20 = alloca { ptr, ptr }, align 8
-  %21 = getelementptr inbounds { ptr, ptr }, ptr %20, i32 0, i32 0
-  store ptr %19, ptr %21, align 8
-  %22 = getelementptr inbounds { ptr, ptr }, ptr %20, i32 0, i32 1
-  store ptr %16, ptr %22, align 8
-  %23 = load { ptr, ptr }, ptr %20, align 8
-  %24 = extractvalue { ptr, ptr } %23, 1
-  %25 = extractvalue { ptr, ptr } %23, 0
-  %26 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %25(ptr %24, %"github.com/goplus/llgo/internal/runtime.iface" %1)
-  %27 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %26, 0
-  %28 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %26, 1
-  %29 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %30 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %29, i32 0, i32 0
-  store i64 %27, ptr %30, align 4
-  %31 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %29, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" %28, ptr %31, align 8
-  %32 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %29, align 8
-  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %32
+  %8 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %4, 1
+  %9 = load ptr, ptr @"_llgo_iface$eN81k1zqixGTyagHw_4nqH4mGfwwehTOCTXUlbT9kzk", align 8
+  %10 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %9, ptr %5)
+  %11 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
+  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %11, i32 0, i32 0
+  store ptr %10, ptr %12, align 8
+  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %11, i32 0, i32 1
+  store ptr %8, ptr %13, align 8
+  %14 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %11, align 8
+  %15 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %14)
+  %16 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %14, 0
+  %17 = getelementptr ptr, ptr %16, i64 3
+  %18 = load ptr, ptr %17, align 8
+  %19 = alloca { ptr, ptr }, align 8
+  %20 = getelementptr inbounds { ptr, ptr }, ptr %19, i32 0, i32 0
+  store ptr %18, ptr %20, align 8
+  %21 = getelementptr inbounds { ptr, ptr }, ptr %19, i32 0, i32 1
+  store ptr %15, ptr %21, align 8
+  %22 = load { ptr, ptr }, ptr %19, align 8
+  %23 = extractvalue { ptr, ptr } %22, 1
+  %24 = extractvalue { ptr, ptr } %22, 0
+  %25 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %24(ptr %23, %"github.com/goplus/llgo/internal/runtime.iface" %1)
+  %26 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %25, 0
+  %27 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %25, 1
+  %28 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
+  %29 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %28, i32 0, i32 0
+  store i64 %26, ptr %29, align 4
+  %30 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %28, i32 0, i32 1
+  store %"github.com/goplus/llgo/internal/runtime.iface" %27, ptr %30, align 8
+  %31 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %28, align 8
+  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %31
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %33 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %33, i32 0, i32 0
-  store ptr @31, ptr %34, align 8
-  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %33, i32 0, i32 1
-  store i64 21, ptr %35, align 4
-  %36 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %33, align 8
-  %37 = load ptr, ptr @_llgo_string, align 8
-  %38 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %36, ptr %38, align 8
-  %39 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %40 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %39, i32 0, i32 0
+  %32 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %32, i32 0, i32 0
+  store ptr @31, ptr %33, align 8
+  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %32, i32 0, i32 1
+  store i64 21, ptr %34, align 4
+  %35 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %32, align 8
+  %36 = load ptr, ptr @_llgo_string, align 8
+  %37 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %35, ptr %37, align 8
+  %38 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i32 0, i32 0
+  store ptr %36, ptr %39, align 8
+  %40 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i32 0, i32 1
   store ptr %37, ptr %40, align 8
-  %41 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %39, i32 0, i32 1
-  store ptr %38, ptr %41, align 8
-  %42 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %39, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %42)
+  %41 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %41)
   unreachable
 }
 
@@ -2788,7 +2788,8 @@ declare i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr, ptr)
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr, ptr)
 
-declare ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr, i64)
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(i64, i64, i64, i64)
 
@@ -2833,3 +2834,5 @@ declare i64 @"github.com/goplus/llgo/internal/runtime.SliceCopy"(%"github.com/go
 declare void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1)
 
 declare { i32, i64 } @"unicode/utf8.DecodeRuneInString"(%"github.com/goplus/llgo/internal/runtime.String")
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/selects/out.ll
+++ b/cl/_testgo/selects/out.ll
@@ -75,122 +75,122 @@ _llgo_0:
   %24 = call i32 @"github.com/goplus/llgo/internal/runtime.CreateThread"(ptr %19, ptr null, %"github.com/goplus/llgo/c/pthread.RoutineFunc" %23, ptr %17)
   %25 = load ptr, ptr %2, align 8
   %26 = alloca {}, align 8
-  %27 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %26, i64 0)
-  store {} zeroinitializer, ptr %27, align 1
-  %28 = call i1 @"github.com/goplus/llgo/internal/runtime.ChanSend"(ptr %25, ptr %27, i64 0)
-  %29 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %29, i32 0, i32 0
-  store ptr @0, ptr %30, align 8
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %29, i32 0, i32 1
-  store i64 4, ptr %31, align 4
-  %32 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %29, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %32)
+  call void @llvm.memset(ptr %26, i8 0, i64 0, i1 false)
+  store {} zeroinitializer, ptr %26, align 1
+  %27 = call i1 @"github.com/goplus/llgo/internal/runtime.ChanSend"(ptr %25, ptr %26, i64 0)
+  %28 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %29 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %28, i32 0, i32 0
+  store ptr @0, ptr %29, align 8
+  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %28, i32 0, i32 1
+  store i64 4, ptr %30, align 4
+  %31 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %28, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %31)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %33 = load ptr, ptr %4, align 8
-  %34 = alloca {}, align 8
-  %35 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %34, i64 0)
-  %36 = alloca %"github.com/goplus/llgo/internal/runtime.ChanOp", align 8
-  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %36, i32 0, i32 0
-  store ptr %33, ptr %37, align 8
-  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %36, i32 0, i32 1
-  store ptr %35, ptr %38, align 8
-  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %36, i32 0, i32 2
-  store i64 0, ptr %39, align 4
-  %40 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %36, i32 0, i32 3
-  store i1 false, ptr %40, align 1
-  %41 = load %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %36, align 8
-  %42 = alloca {}, align 8
-  %43 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %42, i64 0)
-  %44 = alloca %"github.com/goplus/llgo/internal/runtime.ChanOp", align 8
-  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %44, i32 0, i32 0
-  store ptr %8, ptr %45, align 8
-  %46 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %44, i32 0, i32 1
-  store ptr %43, ptr %46, align 8
-  %47 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %44, i32 0, i32 2
-  store i64 0, ptr %47, align 4
-  %48 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %44, i32 0, i32 3
-  store i1 false, ptr %48, align 1
-  %49 = load %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %44, align 8
-  %50 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  %51 = getelementptr %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %50, i64 0
-  store %"github.com/goplus/llgo/internal/runtime.ChanOp" %41, ptr %51, align 8
-  %52 = getelementptr %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %50, i64 1
-  store %"github.com/goplus/llgo/internal/runtime.ChanOp" %49, ptr %52, align 8
-  %53 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %54 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %53, i32 0, i32 0
-  store ptr %50, ptr %54, align 8
-  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %53, i32 0, i32 1
-  store i64 2, ptr %55, align 4
-  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %53, i32 0, i32 2
-  store i64 2, ptr %56, align 4
-  %57 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %53, align 8
-  %58 = call { i64, i1 } @"github.com/goplus/llgo/internal/runtime.Select"(%"github.com/goplus/llgo/internal/runtime.Slice" %57)
-  %59 = extractvalue { i64, i1 } %58, 0
-  %60 = extractvalue { i64, i1 } %58, 1
-  %61 = extractvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %41, 1
-  %62 = load {}, ptr %61, align 1
-  %63 = extractvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %49, 1
-  %64 = load {}, ptr %63, align 1
-  %65 = alloca { i64, i1, {}, {} }, align 8
-  %66 = getelementptr inbounds { i64, i1, {}, {} }, ptr %65, i32 0, i32 0
-  store i64 %59, ptr %66, align 4
-  %67 = getelementptr inbounds { i64, i1, {}, {} }, ptr %65, i32 0, i32 1
-  store i1 %60, ptr %67, align 1
-  %68 = getelementptr inbounds { i64, i1, {}, {} }, ptr %65, i32 0, i32 2
-  store {} %62, ptr %68, align 1
-  %69 = getelementptr inbounds { i64, i1, {}, {} }, ptr %65, i32 0, i32 3
-  store {} %64, ptr %69, align 1
-  %70 = load { i64, i1, {}, {} }, ptr %65, align 4
-  %71 = extractvalue { i64, i1, {}, {} } %70, 0
-  %72 = icmp eq i64 %71, 0
-  br i1 %72, label %_llgo_2, label %_llgo_3
+  %32 = load ptr, ptr %4, align 8
+  %33 = alloca {}, align 8
+  call void @llvm.memset(ptr %33, i8 0, i64 0, i1 false)
+  %34 = alloca %"github.com/goplus/llgo/internal/runtime.ChanOp", align 8
+  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %34, i32 0, i32 0
+  store ptr %32, ptr %35, align 8
+  %36 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %34, i32 0, i32 1
+  store ptr %33, ptr %36, align 8
+  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %34, i32 0, i32 2
+  store i64 0, ptr %37, align 4
+  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %34, i32 0, i32 3
+  store i1 false, ptr %38, align 1
+  %39 = load %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %34, align 8
+  %40 = alloca {}, align 8
+  call void @llvm.memset(ptr %40, i8 0, i64 0, i1 false)
+  %41 = alloca %"github.com/goplus/llgo/internal/runtime.ChanOp", align 8
+  %42 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %41, i32 0, i32 0
+  store ptr %8, ptr %42, align 8
+  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %41, i32 0, i32 1
+  store ptr %40, ptr %43, align 8
+  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %41, i32 0, i32 2
+  store i64 0, ptr %44, align 4
+  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %41, i32 0, i32 3
+  store i1 false, ptr %45, align 1
+  %46 = load %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %41, align 8
+  %47 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  %48 = getelementptr %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %47, i64 0
+  store %"github.com/goplus/llgo/internal/runtime.ChanOp" %39, ptr %48, align 8
+  %49 = getelementptr %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %47, i64 1
+  store %"github.com/goplus/llgo/internal/runtime.ChanOp" %46, ptr %49, align 8
+  %50 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %50, i32 0, i32 0
+  store ptr %47, ptr %51, align 8
+  %52 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %50, i32 0, i32 1
+  store i64 2, ptr %52, align 4
+  %53 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %50, i32 0, i32 2
+  store i64 2, ptr %53, align 4
+  %54 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %50, align 8
+  %55 = call { i64, i1 } @"github.com/goplus/llgo/internal/runtime.Select"(%"github.com/goplus/llgo/internal/runtime.Slice" %54)
+  %56 = extractvalue { i64, i1 } %55, 0
+  %57 = extractvalue { i64, i1 } %55, 1
+  %58 = extractvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %39, 1
+  %59 = load {}, ptr %58, align 1
+  %60 = extractvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %46, 1
+  %61 = load {}, ptr %60, align 1
+  %62 = alloca { i64, i1, {}, {} }, align 8
+  %63 = getelementptr inbounds { i64, i1, {}, {} }, ptr %62, i32 0, i32 0
+  store i64 %56, ptr %63, align 4
+  %64 = getelementptr inbounds { i64, i1, {}, {} }, ptr %62, i32 0, i32 1
+  store i1 %57, ptr %64, align 1
+  %65 = getelementptr inbounds { i64, i1, {}, {} }, ptr %62, i32 0, i32 2
+  store {} %59, ptr %65, align 1
+  %66 = getelementptr inbounds { i64, i1, {}, {} }, ptr %62, i32 0, i32 3
+  store {} %61, ptr %66, align 1
+  %67 = load { i64, i1, {}, {} }, ptr %62, align 4
+  %68 = extractvalue { i64, i1, {}, {} } %67, 0
+  %69 = icmp eq i64 %68, 0
+  br i1 %69, label %_llgo_2, label %_llgo_3
 
 _llgo_1:                                          ; preds = %_llgo_4, %_llgo_2
   ret i32 0
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %73 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %74 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %73, i32 0, i32 0
-  store ptr @1, ptr %74, align 8
-  %75 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %73, i32 0, i32 1
-  store i64 4, ptr %75, align 4
-  %76 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %73, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %76)
+  %70 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %71 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %70, i32 0, i32 0
+  store ptr @1, ptr %71, align 8
+  %72 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %70, i32 0, i32 1
+  store i64 4, ptr %72, align 4
+  %73 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %70, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %73)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_1
 
 _llgo_3:                                          ; preds = %_llgo_0
-  %77 = icmp eq i64 %71, 1
-  br i1 %77, label %_llgo_4, label %_llgo_5
+  %74 = icmp eq i64 %68, 1
+  br i1 %74, label %_llgo_4, label %_llgo_5
 
 _llgo_4:                                          ; preds = %_llgo_3
-  %78 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %79 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %78, i32 0, i32 0
-  store ptr @2, ptr %79, align 8
-  %80 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %78, i32 0, i32 1
-  store i64 4, ptr %80, align 4
-  %81 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %78, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %81)
+  %75 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %76 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %75, i32 0, i32 0
+  store ptr @2, ptr %76, align 8
+  %77 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %75, i32 0, i32 1
+  store i64 4, ptr %77, align 4
+  %78 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %75, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %78)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_1
 
 _llgo_5:                                          ; preds = %_llgo_3
-  %82 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %83 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %82, i32 0, i32 0
-  store ptr @3, ptr %83, align 8
-  %84 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %82, i32 0, i32 1
-  store i64 31, ptr %84, align 4
-  %85 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %82, align 8
-  %86 = load ptr, ptr @_llgo_string, align 8
-  %87 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %85, ptr %87, align 8
-  %88 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %89 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %88, i32 0, i32 0
-  store ptr %86, ptr %89, align 8
-  %90 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %88, i32 0, i32 1
-  store ptr %87, ptr %90, align 8
-  %91 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %88, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %91)
+  %79 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %80 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %79, i32 0, i32 0
+  store ptr @3, ptr %80, align 8
+  %81 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %79, i32 0, i32 1
+  store i64 31, ptr %81, align 4
+  %82 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %79, align 8
+  %83 = load ptr, ptr @_llgo_string, align 8
+  %84 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %82, ptr %84, align 8
+  %85 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %86 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %85, i32 0, i32 0
+  store ptr %83, ptr %86, align 8
+  %87 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %85, i32 0, i32 1
+  store ptr %84, ptr %87, align 8
+  %88 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %85, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %88)
   unreachable
 }
 
@@ -200,122 +200,122 @@ _llgo_0:
   %2 = extractvalue { ptr, ptr, ptr } %1, 0
   %3 = load ptr, ptr %2, align 8
   %4 = alloca {}, align 8
-  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %4, i64 0)
-  %6 = call i1 @"github.com/goplus/llgo/internal/runtime.ChanRecv"(ptr %3, ptr %5, i64 0)
-  %7 = load {}, ptr %5, align 1
-  %8 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %8, i32 0, i32 0
-  store ptr @4, ptr %9, align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %8, i32 0, i32 1
-  store i64 4, ptr %10, align 4
-  %11 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %8, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %11)
+  call void @llvm.memset(ptr %4, i8 0, i64 0, i1 false)
+  %5 = call i1 @"github.com/goplus/llgo/internal/runtime.ChanRecv"(ptr %3, ptr %4, i64 0)
+  %6 = load {}, ptr %4, align 1
+  %7 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %7, i32 0, i32 0
+  store ptr @4, ptr %8, align 8
+  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %7, i32 0, i32 1
+  store i64 4, ptr %9, align 4
+  %10 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %7, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %10)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %12 = extractvalue { ptr, ptr, ptr } %1, 1
-  %13 = load ptr, ptr %12, align 8
-  %14 = extractvalue { ptr, ptr, ptr } %1, 2
-  %15 = load ptr, ptr %14, align 8
-  %16 = alloca {}, align 8
-  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %16, i64 0)
-  store {} zeroinitializer, ptr %17, align 1
-  %18 = alloca %"github.com/goplus/llgo/internal/runtime.ChanOp", align 8
-  %19 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %18, i32 0, i32 0
-  store ptr %13, ptr %19, align 8
-  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %18, i32 0, i32 1
-  store ptr %17, ptr %20, align 8
-  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %18, i32 0, i32 2
-  store i32 0, ptr %21, align 4
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %18, i32 0, i32 3
-  store i1 true, ptr %22, align 1
-  %23 = load %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %18, align 8
-  %24 = alloca {}, align 8
-  %25 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %24, i64 0)
-  %26 = alloca %"github.com/goplus/llgo/internal/runtime.ChanOp", align 8
-  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %26, i32 0, i32 0
-  store ptr %15, ptr %27, align 8
-  %28 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %26, i32 0, i32 1
-  store ptr %25, ptr %28, align 8
-  %29 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %26, i32 0, i32 2
-  store i64 0, ptr %29, align 4
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %26, i32 0, i32 3
-  store i1 false, ptr %30, align 1
-  %31 = load %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %26, align 8
-  %32 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  %33 = getelementptr %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %32, i64 0
-  store %"github.com/goplus/llgo/internal/runtime.ChanOp" %23, ptr %33, align 8
-  %34 = getelementptr %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %32, i64 1
-  store %"github.com/goplus/llgo/internal/runtime.ChanOp" %31, ptr %34, align 8
-  %35 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %36 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %35, i32 0, i32 0
-  store ptr %32, ptr %36, align 8
-  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %35, i32 0, i32 1
-  store i64 2, ptr %37, align 4
-  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %35, i32 0, i32 2
-  store i64 2, ptr %38, align 4
-  %39 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %35, align 8
-  %40 = call { i64, i1 } @"github.com/goplus/llgo/internal/runtime.Select"(%"github.com/goplus/llgo/internal/runtime.Slice" %39)
-  %41 = extractvalue { i64, i1 } %40, 0
-  %42 = extractvalue { i64, i1 } %40, 1
-  %43 = extractvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %31, 1
-  %44 = load {}, ptr %43, align 1
-  %45 = alloca { i64, i1, {} }, align 8
-  %46 = getelementptr inbounds { i64, i1, {} }, ptr %45, i32 0, i32 0
-  store i64 %41, ptr %46, align 4
-  %47 = getelementptr inbounds { i64, i1, {} }, ptr %45, i32 0, i32 1
-  store i1 %42, ptr %47, align 1
-  %48 = getelementptr inbounds { i64, i1, {} }, ptr %45, i32 0, i32 2
-  store {} %44, ptr %48, align 1
-  %49 = load { i64, i1, {} }, ptr %45, align 4
-  %50 = extractvalue { i64, i1, {} } %49, 0
-  %51 = icmp eq i64 %50, 0
-  br i1 %51, label %_llgo_2, label %_llgo_3
+  %11 = extractvalue { ptr, ptr, ptr } %1, 1
+  %12 = load ptr, ptr %11, align 8
+  %13 = extractvalue { ptr, ptr, ptr } %1, 2
+  %14 = load ptr, ptr %13, align 8
+  %15 = alloca {}, align 8
+  call void @llvm.memset(ptr %15, i8 0, i64 0, i1 false)
+  store {} zeroinitializer, ptr %15, align 1
+  %16 = alloca %"github.com/goplus/llgo/internal/runtime.ChanOp", align 8
+  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %16, i32 0, i32 0
+  store ptr %12, ptr %17, align 8
+  %18 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %16, i32 0, i32 1
+  store ptr %15, ptr %18, align 8
+  %19 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %16, i32 0, i32 2
+  store i32 0, ptr %19, align 4
+  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %16, i32 0, i32 3
+  store i1 true, ptr %20, align 1
+  %21 = load %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %16, align 8
+  %22 = alloca {}, align 8
+  call void @llvm.memset(ptr %22, i8 0, i64 0, i1 false)
+  %23 = alloca %"github.com/goplus/llgo/internal/runtime.ChanOp", align 8
+  %24 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %23, i32 0, i32 0
+  store ptr %14, ptr %24, align 8
+  %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %23, i32 0, i32 1
+  store ptr %22, ptr %25, align 8
+  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %23, i32 0, i32 2
+  store i64 0, ptr %26, align 4
+  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %23, i32 0, i32 3
+  store i1 false, ptr %27, align 1
+  %28 = load %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %23, align 8
+  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  %30 = getelementptr %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %29, i64 0
+  store %"github.com/goplus/llgo/internal/runtime.ChanOp" %21, ptr %30, align 8
+  %31 = getelementptr %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %29, i64 1
+  store %"github.com/goplus/llgo/internal/runtime.ChanOp" %28, ptr %31, align 8
+  %32 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %32, i32 0, i32 0
+  store ptr %29, ptr %33, align 8
+  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %32, i32 0, i32 1
+  store i64 2, ptr %34, align 4
+  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %32, i32 0, i32 2
+  store i64 2, ptr %35, align 4
+  %36 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %32, align 8
+  %37 = call { i64, i1 } @"github.com/goplus/llgo/internal/runtime.Select"(%"github.com/goplus/llgo/internal/runtime.Slice" %36)
+  %38 = extractvalue { i64, i1 } %37, 0
+  %39 = extractvalue { i64, i1 } %37, 1
+  %40 = extractvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %28, 1
+  %41 = load {}, ptr %40, align 1
+  %42 = alloca { i64, i1, {} }, align 8
+  %43 = getelementptr inbounds { i64, i1, {} }, ptr %42, i32 0, i32 0
+  store i64 %38, ptr %43, align 4
+  %44 = getelementptr inbounds { i64, i1, {} }, ptr %42, i32 0, i32 1
+  store i1 %39, ptr %44, align 1
+  %45 = getelementptr inbounds { i64, i1, {} }, ptr %42, i32 0, i32 2
+  store {} %41, ptr %45, align 1
+  %46 = load { i64, i1, {} }, ptr %42, align 4
+  %47 = extractvalue { i64, i1, {} } %46, 0
+  %48 = icmp eq i64 %47, 0
+  br i1 %48, label %_llgo_2, label %_llgo_3
 
 _llgo_1:                                          ; preds = %_llgo_4, %_llgo_2
   ret void
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %52 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %53 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %52, i32 0, i32 0
-  store ptr @5, ptr %53, align 8
-  %54 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %52, i32 0, i32 1
-  store i64 4, ptr %54, align 4
-  %55 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %52, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %55)
+  %49 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %49, i32 0, i32 0
+  store ptr @5, ptr %50, align 8
+  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %49, i32 0, i32 1
+  store i64 4, ptr %51, align 4
+  %52 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %49, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %52)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_1
 
 _llgo_3:                                          ; preds = %_llgo_0
-  %56 = icmp eq i64 %50, 1
-  br i1 %56, label %_llgo_4, label %_llgo_5
+  %53 = icmp eq i64 %47, 1
+  br i1 %53, label %_llgo_4, label %_llgo_5
 
 _llgo_4:                                          ; preds = %_llgo_3
-  %57 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %58 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %57, i32 0, i32 0
-  store ptr @6, ptr %58, align 8
-  %59 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %57, i32 0, i32 1
-  store i64 4, ptr %59, align 4
-  %60 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %57, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %60)
+  %54 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %54, i32 0, i32 0
+  store ptr @6, ptr %55, align 8
+  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %54, i32 0, i32 1
+  store i64 4, ptr %56, align 4
+  %57 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %54, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %57)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_1
 
 _llgo_5:                                          ; preds = %_llgo_3
-  %61 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %62 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %61, i32 0, i32 0
-  store ptr @3, ptr %62, align 8
-  %63 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %61, i32 0, i32 1
-  store i64 31, ptr %63, align 4
-  %64 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %61, align 8
-  %65 = load ptr, ptr @_llgo_string, align 8
-  %66 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %64, ptr %66, align 8
-  %67 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %68 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %67, i32 0, i32 0
-  store ptr %65, ptr %68, align 8
-  %69 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %67, i32 0, i32 1
-  store ptr %66, ptr %69, align 8
-  %70 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %67, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %70)
+  %58 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %59 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %58, i32 0, i32 0
+  store ptr @3, ptr %59, align 8
+  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %58, i32 0, i32 1
+  store i64 31, ptr %60, align 4
+  %61 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %58, align 8
+  %62 = load ptr, ptr @_llgo_string, align 8
+  %63 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %61, ptr %63, align 8
+  %64 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %65 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %64, i32 0, i32 0
+  store ptr %62, ptr %65, align 8
+  %66 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %64, i32 0, i32 1
+  store ptr %63, ptr %66, align 8
+  %67 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %64, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %67)
   unreachable
 }
 
@@ -352,7 +352,8 @@ _llgo_0:
 
 declare i1 @"github.com/goplus/llgo/internal/runtime.ChanSend"(ptr, ptr, i64)
 
-declare ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr, i64)
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
 
 declare void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String")
 
@@ -380,3 +381,5 @@ declare ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64)
 declare void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface")
 
 declare i1 @"github.com/goplus/llgo/internal/runtime.ChanRecv"(ptr, ptr, i64)
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/strucintf/out.ll
+++ b/cl/_testgo/strucintf/out.ll
@@ -21,20 +21,20 @@ source_filename = "main"
 define %"github.com/goplus/llgo/internal/runtime.eface" @main.Foo() {
 _llgo_0:
   %0 = alloca { i64 }, align 8
-  %1 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %0, i64 8)
-  %2 = getelementptr inbounds { i64 }, ptr %1, i32 0, i32 0
-  store i64 1, ptr %2, align 4
-  %3 = load { i64 }, ptr %1, align 4
-  %4 = load ptr, ptr @"main.struct$MYpsoM99ZwFY087IpUOkIw1zjBA_sgFXVodmn1m-G88", align 8
-  %5 = extractvalue { i64 } %3, 0
-  %6 = inttoptr i64 %5 to ptr
-  %7 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, i32 0, i32 0
-  store ptr %4, ptr %8, align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, i32 0, i32 1
-  store ptr %6, ptr %9, align 8
-  %10 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, align 8
-  ret %"github.com/goplus/llgo/internal/runtime.eface" %10
+  call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
+  %1 = getelementptr inbounds { i64 }, ptr %0, i32 0, i32 0
+  store i64 1, ptr %1, align 4
+  %2 = load { i64 }, ptr %0, align 4
+  %3 = load ptr, ptr @"main.struct$MYpsoM99ZwFY087IpUOkIw1zjBA_sgFXVodmn1m-G88", align 8
+  %4 = extractvalue { i64 } %2, 0
+  %5 = inttoptr i64 %4 to ptr
+  %6 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %6, i32 0, i32 0
+  store ptr %3, ptr %7, align 8
+  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %6, i32 0, i32 1
+  store ptr %5, ptr %8, align 8
+  %9 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %6, align 8
+  ret %"github.com/goplus/llgo/internal/runtime.eface" %9
 }
 
 define void @main.init() {
@@ -60,70 +60,70 @@ _llgo_0:
   call void @main.init()
   %2 = call %"github.com/goplus/llgo/internal/runtime.eface" @main.Foo()
   %3 = alloca { i64 }, align 8
-  %4 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %3, i64 8)
-  %5 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %2, 0
-  %6 = load ptr, ptr @"main.struct$MYpsoM99ZwFY087IpUOkIw1zjBA_sgFXVodmn1m-G88", align 8
-  %7 = icmp eq ptr %5, %6
-  br i1 %7, label %_llgo_10, label %_llgo_11
+  call void @llvm.memset(ptr %3, i8 0, i64 8, i1 false)
+  %4 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %2, 0
+  %5 = load ptr, ptr @"main.struct$MYpsoM99ZwFY087IpUOkIw1zjBA_sgFXVodmn1m-G88", align 8
+  %6 = icmp eq ptr %4, %5
+  br i1 %6, label %_llgo_10, label %_llgo_11
 
 _llgo_1:                                          ; preds = %_llgo_12
-  %8 = getelementptr inbounds { i64 }, ptr %4, i32 0, i32 0
-  %9 = load i64, ptr %8, align 4
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %9)
+  %7 = getelementptr inbounds { i64 }, ptr %3, i32 0, i32 0
+  %8 = load i64, ptr %7, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %8)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_3, %_llgo_1
-  %10 = call %"github.com/goplus/llgo/internal/runtime.eface" @"github.com/goplus/llgo/cl/internal/foo.Bar"()
-  %11 = alloca { i64 }, align 8
-  %12 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %11, i64 8)
-  %13 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %10, 0
-  %14 = load ptr, ptr @"_llgo_struct$K-dZ9QotZfVPz2a0YdRa9vmZUuDXPTqZOlMShKEDJtk", align 8
-  %15 = icmp eq ptr %13, %14
-  br i1 %15, label %_llgo_13, label %_llgo_14
+  %9 = call %"github.com/goplus/llgo/internal/runtime.eface" @"github.com/goplus/llgo/cl/internal/foo.Bar"()
+  %10 = alloca { i64 }, align 8
+  call void @llvm.memset(ptr %10, i8 0, i64 8, i1 false)
+  %11 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %9, 0
+  %12 = load ptr, ptr @"_llgo_struct$K-dZ9QotZfVPz2a0YdRa9vmZUuDXPTqZOlMShKEDJtk", align 8
+  %13 = icmp eq ptr %11, %12
+  br i1 %13, label %_llgo_13, label %_llgo_14
 
 _llgo_3:                                          ; preds = %_llgo_12
-  %16 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %16, i32 0, i32 0
-  store ptr @2, ptr %17, align 8
-  %18 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %16, i32 0, i32 1
-  store i64 11, ptr %18, align 4
-  %19 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %16, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %19)
+  %14 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %14, i32 0, i32 0
+  store ptr @2, ptr %15, align 8
+  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %14, i32 0, i32 1
+  store i64 11, ptr %16, align 4
+  %17 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %14, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %17)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_2
 
 _llgo_4:                                          ; preds = %_llgo_15
-  %20 = getelementptr inbounds { i64 }, ptr %12, i32 0, i32 0
-  %21 = load i64, ptr %20, align 4
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %21)
+  %18 = getelementptr inbounds { i64 }, ptr %10, i32 0, i32 0
+  %19 = load i64, ptr %18, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %19)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_5
 
 _llgo_5:                                          ; preds = %_llgo_6, %_llgo_4
-  %22 = alloca { i64 }, align 8
-  %23 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %22, i64 8)
-  %24 = call %"github.com/goplus/llgo/internal/runtime.eface" @"github.com/goplus/llgo/cl/internal/foo.F"()
-  %25 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %24, 0
-  %26 = load ptr, ptr @"main.struct$MYpsoM99ZwFY087IpUOkIw1zjBA_sgFXVodmn1m-G88", align 8
-  %27 = icmp eq ptr %25, %26
-  br i1 %27, label %_llgo_16, label %_llgo_17
+  %20 = alloca { i64 }, align 8
+  call void @llvm.memset(ptr %20, i8 0, i64 8, i1 false)
+  %21 = call %"github.com/goplus/llgo/internal/runtime.eface" @"github.com/goplus/llgo/cl/internal/foo.F"()
+  %22 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %21, 0
+  %23 = load ptr, ptr @"main.struct$MYpsoM99ZwFY087IpUOkIw1zjBA_sgFXVodmn1m-G88", align 8
+  %24 = icmp eq ptr %22, %23
+  br i1 %24, label %_llgo_16, label %_llgo_17
 
 _llgo_6:                                          ; preds = %_llgo_15
-  %28 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %29 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %28, i32 0, i32 0
-  store ptr @4, ptr %29, align 8
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %28, i32 0, i32 1
-  store i64 11, ptr %30, align 4
-  %31 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %28, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %31)
+  %25 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 0
+  store ptr @4, ptr %26, align 8
+  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 1
+  store i64 11, ptr %27, align 4
+  %28 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %25, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %28)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_5
 
 _llgo_7:                                          ; preds = %_llgo_18
-  %32 = getelementptr inbounds { i64 }, ptr %23, i32 0, i32 0
-  %33 = load i64, ptr %32, align 4
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %33)
+  %29 = getelementptr inbounds { i64 }, ptr %20, i32 0, i32 0
+  %30 = load i64, ptr %29, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %30)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_8
 
@@ -131,111 +131,112 @@ _llgo_8:                                          ; preds = %_llgo_9, %_llgo_7
   ret i32 0
 
 _llgo_9:                                          ; preds = %_llgo_18
-  %34 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %34, i32 0, i32 0
-  store ptr @5, ptr %35, align 8
-  %36 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %34, i32 0, i32 1
-  store i64 9, ptr %36, align 4
-  %37 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %34, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %37)
+  %31 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %31, i32 0, i32 0
+  store ptr @5, ptr %32, align 8
+  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %31, i32 0, i32 1
+  store i64 9, ptr %33, align 4
+  %34 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %31, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %34)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_8
 
 _llgo_10:                                         ; preds = %_llgo_0
-  %38 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %2, 1
-  %39 = ptrtoint ptr %38 to i64
-  %40 = alloca { i64 }, align 8
-  %41 = getelementptr inbounds { i64 }, ptr %40, i32 0, i32 0
-  store i64 %39, ptr %41, align 4
-  %42 = load { i64 }, ptr %40, align 4
-  %43 = alloca { { i64 }, i1 }, align 8
-  %44 = getelementptr inbounds { { i64 }, i1 }, ptr %43, i32 0, i32 0
-  store { i64 } %42, ptr %44, align 4
-  %45 = getelementptr inbounds { { i64 }, i1 }, ptr %43, i32 0, i32 1
-  store i1 true, ptr %45, align 1
-  %46 = load { { i64 }, i1 }, ptr %43, align 4
+  %35 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %2, 1
+  %36 = ptrtoint ptr %35 to i64
+  %37 = alloca { i64 }, align 8
+  %38 = getelementptr inbounds { i64 }, ptr %37, i32 0, i32 0
+  store i64 %36, ptr %38, align 4
+  %39 = load { i64 }, ptr %37, align 4
+  %40 = alloca { { i64 }, i1 }, align 8
+  %41 = getelementptr inbounds { { i64 }, i1 }, ptr %40, i32 0, i32 0
+  store { i64 } %39, ptr %41, align 4
+  %42 = getelementptr inbounds { { i64 }, i1 }, ptr %40, i32 0, i32 1
+  store i1 true, ptr %42, align 1
+  %43 = load { { i64 }, i1 }, ptr %40, align 4
   br label %_llgo_12
 
 _llgo_11:                                         ; preds = %_llgo_0
-  %47 = alloca { { i64 }, i1 }, align 8
-  %48 = getelementptr inbounds { { i64 }, i1 }, ptr %47, i32 0, i32 0
-  store { i64 } zeroinitializer, ptr %48, align 4
-  %49 = getelementptr inbounds { { i64 }, i1 }, ptr %47, i32 0, i32 1
-  store i1 false, ptr %49, align 1
-  %50 = load { { i64 }, i1 }, ptr %47, align 4
+  %44 = alloca { { i64 }, i1 }, align 8
+  %45 = getelementptr inbounds { { i64 }, i1 }, ptr %44, i32 0, i32 0
+  store { i64 } zeroinitializer, ptr %45, align 4
+  %46 = getelementptr inbounds { { i64 }, i1 }, ptr %44, i32 0, i32 1
+  store i1 false, ptr %46, align 1
+  %47 = load { { i64 }, i1 }, ptr %44, align 4
   br label %_llgo_12
 
 _llgo_12:                                         ; preds = %_llgo_11, %_llgo_10
-  %51 = phi { { i64 }, i1 } [ %46, %_llgo_10 ], [ %50, %_llgo_11 ]
-  %52 = extractvalue { { i64 }, i1 } %51, 0
-  store { i64 } %52, ptr %4, align 4
-  %53 = extractvalue { { i64 }, i1 } %51, 1
-  br i1 %53, label %_llgo_1, label %_llgo_3
+  %48 = phi { { i64 }, i1 } [ %43, %_llgo_10 ], [ %47, %_llgo_11 ]
+  %49 = extractvalue { { i64 }, i1 } %48, 0
+  store { i64 } %49, ptr %3, align 4
+  %50 = extractvalue { { i64 }, i1 } %48, 1
+  br i1 %50, label %_llgo_1, label %_llgo_3
 
 _llgo_13:                                         ; preds = %_llgo_2
-  %54 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %10, 1
-  %55 = ptrtoint ptr %54 to i64
-  %56 = alloca { i64 }, align 8
-  %57 = getelementptr inbounds { i64 }, ptr %56, i32 0, i32 0
-  store i64 %55, ptr %57, align 4
-  %58 = load { i64 }, ptr %56, align 4
-  %59 = alloca { { i64 }, i1 }, align 8
-  %60 = getelementptr inbounds { { i64 }, i1 }, ptr %59, i32 0, i32 0
-  store { i64 } %58, ptr %60, align 4
-  %61 = getelementptr inbounds { { i64 }, i1 }, ptr %59, i32 0, i32 1
-  store i1 true, ptr %61, align 1
-  %62 = load { { i64 }, i1 }, ptr %59, align 4
+  %51 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %9, 1
+  %52 = ptrtoint ptr %51 to i64
+  %53 = alloca { i64 }, align 8
+  %54 = getelementptr inbounds { i64 }, ptr %53, i32 0, i32 0
+  store i64 %52, ptr %54, align 4
+  %55 = load { i64 }, ptr %53, align 4
+  %56 = alloca { { i64 }, i1 }, align 8
+  %57 = getelementptr inbounds { { i64 }, i1 }, ptr %56, i32 0, i32 0
+  store { i64 } %55, ptr %57, align 4
+  %58 = getelementptr inbounds { { i64 }, i1 }, ptr %56, i32 0, i32 1
+  store i1 true, ptr %58, align 1
+  %59 = load { { i64 }, i1 }, ptr %56, align 4
   br label %_llgo_15
 
 _llgo_14:                                         ; preds = %_llgo_2
-  %63 = alloca { { i64 }, i1 }, align 8
-  %64 = getelementptr inbounds { { i64 }, i1 }, ptr %63, i32 0, i32 0
-  store { i64 } zeroinitializer, ptr %64, align 4
-  %65 = getelementptr inbounds { { i64 }, i1 }, ptr %63, i32 0, i32 1
-  store i1 false, ptr %65, align 1
-  %66 = load { { i64 }, i1 }, ptr %63, align 4
+  %60 = alloca { { i64 }, i1 }, align 8
+  %61 = getelementptr inbounds { { i64 }, i1 }, ptr %60, i32 0, i32 0
+  store { i64 } zeroinitializer, ptr %61, align 4
+  %62 = getelementptr inbounds { { i64 }, i1 }, ptr %60, i32 0, i32 1
+  store i1 false, ptr %62, align 1
+  %63 = load { { i64 }, i1 }, ptr %60, align 4
   br label %_llgo_15
 
 _llgo_15:                                         ; preds = %_llgo_14, %_llgo_13
-  %67 = phi { { i64 }, i1 } [ %62, %_llgo_13 ], [ %66, %_llgo_14 ]
-  %68 = extractvalue { { i64 }, i1 } %67, 0
-  store { i64 } %68, ptr %12, align 4
-  %69 = extractvalue { { i64 }, i1 } %67, 1
-  br i1 %69, label %_llgo_4, label %_llgo_6
+  %64 = phi { { i64 }, i1 } [ %59, %_llgo_13 ], [ %63, %_llgo_14 ]
+  %65 = extractvalue { { i64 }, i1 } %64, 0
+  store { i64 } %65, ptr %10, align 4
+  %66 = extractvalue { { i64 }, i1 } %64, 1
+  br i1 %66, label %_llgo_4, label %_llgo_6
 
 _llgo_16:                                         ; preds = %_llgo_5
-  %70 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %24, 1
-  %71 = ptrtoint ptr %70 to i64
-  %72 = alloca { i64 }, align 8
-  %73 = getelementptr inbounds { i64 }, ptr %72, i32 0, i32 0
-  store i64 %71, ptr %73, align 4
-  %74 = load { i64 }, ptr %72, align 4
-  %75 = alloca { { i64 }, i1 }, align 8
-  %76 = getelementptr inbounds { { i64 }, i1 }, ptr %75, i32 0, i32 0
-  store { i64 } %74, ptr %76, align 4
-  %77 = getelementptr inbounds { { i64 }, i1 }, ptr %75, i32 0, i32 1
-  store i1 true, ptr %77, align 1
-  %78 = load { { i64 }, i1 }, ptr %75, align 4
+  %67 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %21, 1
+  %68 = ptrtoint ptr %67 to i64
+  %69 = alloca { i64 }, align 8
+  %70 = getelementptr inbounds { i64 }, ptr %69, i32 0, i32 0
+  store i64 %68, ptr %70, align 4
+  %71 = load { i64 }, ptr %69, align 4
+  %72 = alloca { { i64 }, i1 }, align 8
+  %73 = getelementptr inbounds { { i64 }, i1 }, ptr %72, i32 0, i32 0
+  store { i64 } %71, ptr %73, align 4
+  %74 = getelementptr inbounds { { i64 }, i1 }, ptr %72, i32 0, i32 1
+  store i1 true, ptr %74, align 1
+  %75 = load { { i64 }, i1 }, ptr %72, align 4
   br label %_llgo_18
 
 _llgo_17:                                         ; preds = %_llgo_5
-  %79 = alloca { { i64 }, i1 }, align 8
-  %80 = getelementptr inbounds { { i64 }, i1 }, ptr %79, i32 0, i32 0
-  store { i64 } zeroinitializer, ptr %80, align 4
-  %81 = getelementptr inbounds { { i64 }, i1 }, ptr %79, i32 0, i32 1
-  store i1 false, ptr %81, align 1
-  %82 = load { { i64 }, i1 }, ptr %79, align 4
+  %76 = alloca { { i64 }, i1 }, align 8
+  %77 = getelementptr inbounds { { i64 }, i1 }, ptr %76, i32 0, i32 0
+  store { i64 } zeroinitializer, ptr %77, align 4
+  %78 = getelementptr inbounds { { i64 }, i1 }, ptr %76, i32 0, i32 1
+  store i1 false, ptr %78, align 1
+  %79 = load { { i64 }, i1 }, ptr %76, align 4
   br label %_llgo_18
 
 _llgo_18:                                         ; preds = %_llgo_17, %_llgo_16
-  %83 = phi { { i64 }, i1 } [ %78, %_llgo_16 ], [ %82, %_llgo_17 ]
-  %84 = extractvalue { { i64 }, i1 } %83, 0
-  store { i64 } %84, ptr %23, align 4
-  %85 = extractvalue { { i64 }, i1 } %83, 1
-  br i1 %85, label %_llgo_7, label %_llgo_9
+  %80 = phi { { i64 }, i1 } [ %75, %_llgo_16 ], [ %79, %_llgo_17 ]
+  %81 = extractvalue { { i64 }, i1 } %80, 0
+  store { i64 } %81, ptr %20, align 4
+  %82 = extractvalue { { i64 }, i1 } %80, 1
+  br i1 %82, label %_llgo_7, label %_llgo_9
 }
 
-declare ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr, i64)
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
 
 define void @"main.init$after"() {
 _llgo_0:
@@ -337,3 +338,5 @@ declare void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com
 declare %"github.com/goplus/llgo/internal/runtime.eface" @"github.com/goplus/llgo/cl/internal/foo.Bar"()
 
 declare %"github.com/goplus/llgo/internal/runtime.eface" @"github.com/goplus/llgo/cl/internal/foo.F"()
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/struczero/out.ll
+++ b/cl/_testgo/struczero/out.ll
@@ -131,56 +131,56 @@ _llgo_0:
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
   %2 = alloca %main.bar, align 8
-  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %2, i64 16)
-  %4 = call { %main.bar, i1 } @main.Foo(%"github.com/goplus/llgo/internal/runtime.eface" zeroinitializer)
-  %5 = extractvalue { %main.bar, i1 } %4, 0
-  store %main.bar %5, ptr %3, align 8
-  %6 = extractvalue { %main.bar, i1 } %4, 1
-  %7 = getelementptr inbounds %main.bar, ptr %3, i32 0, i32 0
-  %8 = load ptr, ptr %7, align 8
-  %9 = getelementptr inbounds %main.bar, ptr %3, i32 0, i32 1
-  %10 = load float, ptr %9, align 4
-  %11 = xor i1 %6, true
-  %12 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %12, i32 0, i32 0
-  store ptr @8, ptr %13, align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %12, i32 0, i32 1
-  store i64 6, ptr %14, align 4
-  %15 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %12, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %8)
+  call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+  %3 = call { %main.bar, i1 } @main.Foo(%"github.com/goplus/llgo/internal/runtime.eface" zeroinitializer)
+  %4 = extractvalue { %main.bar, i1 } %3, 0
+  store %main.bar %4, ptr %2, align 8
+  %5 = extractvalue { %main.bar, i1 } %3, 1
+  %6 = getelementptr inbounds %main.bar, ptr %2, i32 0, i32 0
+  %7 = load ptr, ptr %6, align 8
+  %8 = getelementptr inbounds %main.bar, ptr %2, i32 0, i32 1
+  %9 = load float, ptr %8, align 4
+  %10 = xor i1 %5, true
+  %11 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %11, i32 0, i32 0
+  store ptr @8, ptr %12, align 8
+  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %11, i32 0, i32 1
+  store i64 6, ptr %13, align 4
+  %14 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %11, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %7)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  %16 = fpext float %10 to double
-  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %16)
+  %15 = fpext float %9 to double
+  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %15)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %15)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %14)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %11)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %10)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %17 = alloca %"github.com/goplus/llgo/cl/internal/foo.Foo", align 8
-  %18 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %17, i64 16)
-  %19 = load ptr, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Foo", align 8
-  %20 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/cl/internal/foo.Foo" zeroinitializer, ptr %20, align 8
-  %21 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %21, i32 0, i32 0
-  store ptr %19, ptr %22, align 8
-  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %21, i32 0, i32 1
-  store ptr %20, ptr %23, align 8
-  %24 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %21, align 8
-  %25 = call { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } @main.Bar(%"github.com/goplus/llgo/internal/runtime.eface" %24)
-  %26 = extractvalue { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } %25, 0
-  store %"github.com/goplus/llgo/cl/internal/foo.Foo" %26, ptr %18, align 8
-  %27 = extractvalue { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } %25, 1
-  %28 = load %"github.com/goplus/llgo/cl/internal/foo.Foo", ptr %18, align 8
-  %29 = call ptr @"github.com/goplus/llgo/cl/internal/foo.Foo.Pb"(%"github.com/goplus/llgo/cl/internal/foo.Foo" %28)
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/cl/internal/foo.Foo", ptr %18, i32 0, i32 1
-  %31 = load float, ptr %30, align 4
-  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %29)
+  %16 = alloca %"github.com/goplus/llgo/cl/internal/foo.Foo", align 8
+  call void @llvm.memset(ptr %16, i8 0, i64 16, i1 false)
+  %17 = load ptr, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Foo", align 8
+  %18 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/cl/internal/foo.Foo" zeroinitializer, ptr %18, align 8
+  %19 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %19, i32 0, i32 0
+  store ptr %17, ptr %20, align 8
+  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %19, i32 0, i32 1
+  store ptr %18, ptr %21, align 8
+  %22 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %19, align 8
+  %23 = call { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } @main.Bar(%"github.com/goplus/llgo/internal/runtime.eface" %22)
+  %24 = extractvalue { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } %23, 0
+  store %"github.com/goplus/llgo/cl/internal/foo.Foo" %24, ptr %16, align 8
+  %25 = extractvalue { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } %23, 1
+  %26 = load %"github.com/goplus/llgo/cl/internal/foo.Foo", ptr %16, align 8
+  %27 = call ptr @"github.com/goplus/llgo/cl/internal/foo.Foo.Pb"(%"github.com/goplus/llgo/cl/internal/foo.Foo" %26)
+  %28 = getelementptr inbounds %"github.com/goplus/llgo/cl/internal/foo.Foo", ptr %16, i32 0, i32 1
+  %29 = load float, ptr %28, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %27)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  %32 = fpext float %31 to double
-  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %32)
+  %30 = fpext float %29 to double
+  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %30)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %27)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %25)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 }
@@ -465,7 +465,8 @@ declare void @"github.com/goplus/llgo/cl/internal/foo.init"()
 
 declare void @"github.com/goplus/llgo/internal/runtime.init"()
 
-declare ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr, i64)
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
 
 declare void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr)
 
@@ -476,3 +477,5 @@ declare void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double)
 declare void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String")
 
 declare void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1)
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/tptypes/out.ll
+++ b/cl/_testgo/tptypes/out.ll
@@ -33,168 +33,169 @@ _llgo_0:
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
   %2 = alloca %"main.Data[int]", align 8
-  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %2, i64 8)
-  %4 = getelementptr inbounds %"main.Data[int]", ptr %3, i32 0, i32 0
-  store i64 1, ptr %4, align 4
-  %5 = load %"main.Data[int]", ptr %3, align 4
-  %6 = extractvalue %"main.Data[int]" %5, 0
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %6)
+  call void @llvm.memset(ptr %2, i8 0, i64 8, i1 false)
+  %3 = getelementptr inbounds %"main.Data[int]", ptr %2, i32 0, i32 0
+  store i64 1, ptr %3, align 4
+  %4 = load %"main.Data[int]", ptr %2, align 4
+  %5 = extractvalue %"main.Data[int]" %4, 0
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %5)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %7 = alloca %"main.Data[string]", align 8
-  %8 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %7, i64 16)
-  %9 = getelementptr inbounds %"main.Data[string]", ptr %8, i32 0, i32 0
-  %10 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %10, i32 0, i32 0
-  store ptr @0, ptr %11, align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %10, i32 0, i32 1
-  store i64 5, ptr %12, align 4
-  %13 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %10, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %13, ptr %9, align 8
-  %14 = load %"main.Data[string]", ptr %8, align 8
-  %15 = extractvalue %"main.Data[string]" %14, 0
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %15)
+  %6 = alloca %"main.Data[string]", align 8
+  call void @llvm.memset(ptr %6, i8 0, i64 16, i1 false)
+  %7 = getelementptr inbounds %"main.Data[string]", ptr %6, i32 0, i32 0
+  %8 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %8, i32 0, i32 0
+  store ptr @0, ptr %9, align 8
+  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %8, i32 0, i32 1
+  store i64 5, ptr %10, align 4
+  %11 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %8, align 8
+  store %"github.com/goplus/llgo/internal/runtime.String" %11, ptr %7, align 8
+  %12 = load %"main.Data[string]", ptr %6, align 8
+  %13 = extractvalue %"main.Data[string]" %12, 0
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %13)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %16 = alloca %"main.Data[int]", align 8
-  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %16, i64 8)
-  %18 = getelementptr inbounds %"main.Data[int]", ptr %17, i32 0, i32 0
-  store i64 100, ptr %18, align 4
-  %19 = load %"main.Data[int]", ptr %17, align 4
-  %20 = extractvalue %"main.Data[int]" %19, 0
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %20)
+  %14 = alloca %"main.Data[int]", align 8
+  call void @llvm.memset(ptr %14, i8 0, i64 8, i1 false)
+  %15 = getelementptr inbounds %"main.Data[int]", ptr %14, i32 0, i32 0
+  store i64 100, ptr %15, align 4
+  %16 = load %"main.Data[int]", ptr %14, align 4
+  %17 = extractvalue %"main.Data[int]" %16, 0
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %17)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %21 = alloca %"main.Data[string]", align 8
-  %22 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %21, i64 16)
-  %23 = getelementptr inbounds %"main.Data[string]", ptr %22, i32 0, i32 0
-  %24 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %24, i32 0, i32 0
-  store ptr @0, ptr %25, align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %24, i32 0, i32 1
-  store i64 5, ptr %26, align 4
-  %27 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %24, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %27, ptr %23, align 8
-  %28 = load %"main.Data[string]", ptr %22, align 8
-  %29 = extractvalue %"main.Data[string]" %28, 0
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %29)
+  %18 = alloca %"main.Data[string]", align 8
+  call void @llvm.memset(ptr %18, i8 0, i64 16, i1 false)
+  %19 = getelementptr inbounds %"main.Data[string]", ptr %18, i32 0, i32 0
+  %20 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %20, i32 0, i32 0
+  store ptr @0, ptr %21, align 8
+  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %20, i32 0, i32 1
+  store i64 5, ptr %22, align 4
+  %23 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %20, align 8
+  store %"github.com/goplus/llgo/internal/runtime.String" %23, ptr %19, align 8
+  %24 = load %"main.Data[string]", ptr %18, align 8
+  %25 = extractvalue %"main.Data[string]" %24, 0
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %25)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 0)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
-  %31 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 8)
-  %32 = getelementptr inbounds i64, ptr %31, i64 0
-  store i64 100, ptr %32, align 4
-  %33 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %33, i32 0, i32 0
-  store ptr %31, ptr %34, align 8
-  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %33, i32 0, i32 1
-  store i64 1, ptr %35, align 4
-  %36 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %33, i32 0, i32 2
-  store i64 1, ptr %36, align 4
-  %37 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %33, align 8
-  %38 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"main.(*Slice[[]int,int]).Append"(ptr %30, %"github.com/goplus/llgo/internal/runtime.Slice" %37)
-  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
-  %40 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 16)
-  %41 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %40, i64 0
-  %42 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %42, i32 0, i32 0
-  store ptr @0, ptr %43, align 8
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %42, i32 0, i32 1
-  store i64 5, ptr %44, align 4
-  %45 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %42, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %45, ptr %41, align 8
-  %46 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %47 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %46, i32 0, i32 0
-  store ptr %40, ptr %47, align 8
-  %48 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %46, i32 0, i32 1
-  store i64 1, ptr %48, align 4
-  %49 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %46, i32 0, i32 2
-  store i64 1, ptr %49, align 4
-  %50 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %46, align 8
-  %51 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"main.(*Slice[[]string,string]).Append"(ptr %39, %"github.com/goplus/llgo/internal/runtime.Slice" %50)
-  %52 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
-  %53 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
-  %54 = getelementptr inbounds i64, ptr %53, i64 0
-  store i64 1, ptr %54, align 4
-  %55 = getelementptr inbounds i64, ptr %53, i64 1
-  store i64 2, ptr %55, align 4
-  %56 = getelementptr inbounds i64, ptr %53, i64 2
-  store i64 3, ptr %56, align 4
-  %57 = getelementptr inbounds i64, ptr %53, i64 3
+  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
+  %27 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 8)
+  %28 = getelementptr inbounds i64, ptr %27, i64 0
+  store i64 100, ptr %28, align 4
+  %29 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %29, i32 0, i32 0
+  store ptr %27, ptr %30, align 8
+  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %29, i32 0, i32 1
+  store i64 1, ptr %31, align 4
+  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %29, i32 0, i32 2
+  store i64 1, ptr %32, align 4
+  %33 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %29, align 8
+  %34 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"main.(*Slice[[]int,int]).Append"(ptr %26, %"github.com/goplus/llgo/internal/runtime.Slice" %33)
+  %35 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
+  %36 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 16)
+  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %36, i64 0
+  %38 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %38, i32 0, i32 0
+  store ptr @0, ptr %39, align 8
+  %40 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %38, i32 0, i32 1
+  store i64 5, ptr %40, align 4
+  %41 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %38, align 8
+  store %"github.com/goplus/llgo/internal/runtime.String" %41, ptr %37, align 8
+  %42 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, i32 0, i32 0
+  store ptr %36, ptr %43, align 8
+  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, i32 0, i32 1
+  store i64 1, ptr %44, align 4
+  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, i32 0, i32 2
+  store i64 1, ptr %45, align 4
+  %46 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, align 8
+  %47 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"main.(*Slice[[]string,string]).Append"(ptr %35, %"github.com/goplus/llgo/internal/runtime.Slice" %46)
+  %48 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
+  %49 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
+  %50 = getelementptr inbounds i64, ptr %49, i64 0
+  store i64 1, ptr %50, align 4
+  %51 = getelementptr inbounds i64, ptr %49, i64 1
+  store i64 2, ptr %51, align 4
+  %52 = getelementptr inbounds i64, ptr %49, i64 2
+  store i64 3, ptr %52, align 4
+  %53 = getelementptr inbounds i64, ptr %49, i64 3
+  store i64 4, ptr %53, align 4
+  %54 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %54, i32 0, i32 0
+  store ptr %49, ptr %55, align 8
+  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %54, i32 0, i32 1
+  store i64 4, ptr %56, align 4
+  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %54, i32 0, i32 2
   store i64 4, ptr %57, align 4
-  %58 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %59 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %58, i32 0, i32 0
-  store ptr %53, ptr %59, align 8
-  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %58, i32 0, i32 1
-  store i64 4, ptr %60, align 4
-  %61 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %58, i32 0, i32 2
-  store i64 4, ptr %61, align 4
-  %62 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %58, align 8
-  %63 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"main.(*Slice[[]int,int]).Append"(ptr %52, %"github.com/goplus/llgo/internal/runtime.Slice" %62)
-  %64 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
-  %65 = getelementptr inbounds i64, ptr %64, i64 0
-  store i64 1, ptr %65, align 4
-  %66 = getelementptr inbounds i64, ptr %64, i64 1
-  store i64 2, ptr %66, align 4
-  %67 = getelementptr inbounds i64, ptr %64, i64 2
-  store i64 3, ptr %67, align 4
-  %68 = getelementptr inbounds i64, ptr %64, i64 3
+  %58 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %54, align 8
+  %59 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"main.(*Slice[[]int,int]).Append"(ptr %48, %"github.com/goplus/llgo/internal/runtime.Slice" %58)
+  %60 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
+  %61 = getelementptr inbounds i64, ptr %60, i64 0
+  store i64 1, ptr %61, align 4
+  %62 = getelementptr inbounds i64, ptr %60, i64 1
+  store i64 2, ptr %62, align 4
+  %63 = getelementptr inbounds i64, ptr %60, i64 2
+  store i64 3, ptr %63, align 4
+  %64 = getelementptr inbounds i64, ptr %60, i64 3
+  store i64 4, ptr %64, align 4
+  %65 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %66 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %65, i32 0, i32 0
+  store ptr %60, ptr %66, align 8
+  %67 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %65, i32 0, i32 1
+  store i64 4, ptr %67, align 4
+  %68 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %65, i32 0, i32 2
   store i64 4, ptr %68, align 4
-  %69 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %70 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %69, i32 0, i32 0
-  store ptr %64, ptr %70, align 8
-  %71 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %69, i32 0, i32 1
-  store i64 4, ptr %71, align 4
-  %72 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %69, i32 0, i32 2
-  store i64 4, ptr %72, align 4
-  %73 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %69, align 8
-  %74 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"main.(*Slice[[]int,int]).Append2"(ptr %52, %"github.com/goplus/llgo/internal/runtime.Slice" %73)
-  %75 = getelementptr inbounds %"main.Slice[[]int,int]", ptr %30, i32 0, i32 0
-  %76 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %75, align 8
-  %77 = getelementptr inbounds %"main.Slice[[]int,int]", ptr %30, i32 0, i32 0
-  %78 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %77, align 8
-  %79 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %78, 0
-  %80 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %78, 1
-  %81 = icmp sge i64 0, %80
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %81)
-  %82 = getelementptr inbounds i64, ptr %79, i64 0
-  %83 = load i64, ptr %82, align 4
-  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %76)
+  %69 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %65, align 8
+  %70 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"main.(*Slice[[]int,int]).Append2"(ptr %48, %"github.com/goplus/llgo/internal/runtime.Slice" %69)
+  %71 = getelementptr inbounds %"main.Slice[[]int,int]", ptr %26, i32 0, i32 0
+  %72 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %71, align 8
+  %73 = getelementptr inbounds %"main.Slice[[]int,int]", ptr %26, i32 0, i32 0
+  %74 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %73, align 8
+  %75 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %74, 0
+  %76 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %74, 1
+  %77 = icmp sge i64 0, %76
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %77)
+  %78 = getelementptr inbounds i64, ptr %75, i64 0
+  %79 = load i64, ptr %78, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %72)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %83)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %79)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %84 = getelementptr inbounds %"main.Slice[[]string,string]", ptr %39, i32 0, i32 0
-  %85 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %84, align 8
-  %86 = getelementptr inbounds %"main.Slice[[]string,string]", ptr %39, i32 0, i32 0
-  %87 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %86, align 8
-  %88 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %87, 0
-  %89 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %87, 1
-  %90 = icmp sge i64 0, %89
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %90)
-  %91 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %88, i64 0
-  %92 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %91, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %85)
+  %80 = getelementptr inbounds %"main.Slice[[]string,string]", ptr %35, i32 0, i32 0
+  %81 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %80, align 8
+  %82 = getelementptr inbounds %"main.Slice[[]string,string]", ptr %35, i32 0, i32 0
+  %83 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %82, align 8
+  %84 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %83, 0
+  %85 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %83, 1
+  %86 = icmp sge i64 0, %85
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %86)
+  %87 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %84, i64 0
+  %88 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %87, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %81)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %92)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %88)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %93 = getelementptr inbounds %"main.Slice[[]int,int]", ptr %52, i32 0, i32 0
-  %94 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %93, align 8
-  %95 = getelementptr inbounds %"main.Slice[[]int,int]", ptr %52, i32 0, i32 0
-  %96 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %95, align 8
-  %97 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %96, 0
-  %98 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %96, 1
-  %99 = icmp sge i64 0, %98
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %99)
-  %100 = getelementptr inbounds i64, ptr %97, i64 0
-  %101 = load i64, ptr %100, align 4
-  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %94)
+  %89 = getelementptr inbounds %"main.Slice[[]int,int]", ptr %48, i32 0, i32 0
+  %90 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %89, align 8
+  %91 = getelementptr inbounds %"main.Slice[[]int,int]", ptr %48, i32 0, i32 0
+  %92 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %91, align 8
+  %93 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %92, 0
+  %94 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %92, 1
+  %95 = icmp sge i64 0, %94
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %95)
+  %96 = getelementptr inbounds i64, ptr %93, i64 0
+  %97 = load i64, ptr %96, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %90)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %101)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %97)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 }
 
 declare void @"github.com/goplus/llgo/internal/runtime.init"()
 
-declare ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr, i64)
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
 
 declare void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64)
 
@@ -251,3 +252,5 @@ declare void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1)
 declare void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice")
 
 declare %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.SliceAppend"(%"github.com/goplus/llgo/internal/runtime.Slice", ptr, i64, i64)
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testrt/abinamed/out.ll
+++ b/cl/_testrt/abinamed/out.ll
@@ -190,237 +190,237 @@ _llgo_0:
   call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %27)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   %28 = alloca %"github.com/goplus/llgo/internal/abi.StructField", align 8
-  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %28, i64 56)
-  %30 = getelementptr inbounds %main.eface, ptr %8, i32 0, i32 0
-  %31 = load ptr, ptr %30, align 8
-  %32 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType"(ptr %31)
-  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructType", ptr %32, i32 0, i32 2
-  %34 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %33, align 8
-  %35 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %34, 0
-  %36 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %34, 1
-  %37 = icmp sge i64 0, %36
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %37)
-  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %35, i64 0
-  %39 = load %"github.com/goplus/llgo/internal/abi.StructField", ptr %38, align 8
-  store %"github.com/goplus/llgo/internal/abi.StructField" %39, ptr %29, align 8
-  %40 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %29, i32 0, i32 1
-  %41 = load ptr, ptr %40, align 8
-  %42 = getelementptr inbounds %main.eface, ptr %8, i32 0, i32 0
-  %43 = load ptr, ptr %42, align 8
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Type", ptr %43, i32 0, i32 10
-  %45 = load ptr, ptr %44, align 8
-  %46 = icmp ne ptr %41, %45
-  br i1 %46, label %_llgo_1, label %_llgo_2
+  call void @llvm.memset(ptr %28, i8 0, i64 56, i1 false)
+  %29 = getelementptr inbounds %main.eface, ptr %8, i32 0, i32 0
+  %30 = load ptr, ptr %29, align 8
+  %31 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType"(ptr %30)
+  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructType", ptr %31, i32 0, i32 2
+  %33 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %32, align 8
+  %34 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %33, 0
+  %35 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %33, 1
+  %36 = icmp sge i64 0, %35
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %36)
+  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %34, i64 0
+  %38 = load %"github.com/goplus/llgo/internal/abi.StructField", ptr %37, align 8
+  store %"github.com/goplus/llgo/internal/abi.StructField" %38, ptr %28, align 8
+  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %28, i32 0, i32 1
+  %40 = load ptr, ptr %39, align 8
+  %41 = getelementptr inbounds %main.eface, ptr %8, i32 0, i32 0
+  %42 = load ptr, ptr %41, align 8
+  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Type", ptr %42, i32 0, i32 10
+  %44 = load ptr, ptr %43, align 8
+  %45 = icmp ne ptr %40, %44
+  br i1 %45, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %47 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %48 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %47, i32 0, i32 0
-  store ptr @63, ptr %48, align 8
-  %49 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %47, i32 0, i32 1
-  store i64 13, ptr %49, align 4
-  %50 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %47, align 8
-  %51 = load ptr, ptr @_llgo_string, align 8
-  %52 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %50, ptr %52, align 8
-  %53 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %54 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %53, i32 0, i32 0
+  %46 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %47 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %46, i32 0, i32 0
+  store ptr @63, ptr %47, align 8
+  %48 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %46, i32 0, i32 1
+  store i64 13, ptr %48, align 4
+  %49 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %46, align 8
+  %50 = load ptr, ptr @_llgo_string, align 8
+  %51 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %49, ptr %51, align 8
+  %52 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %53 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %52, i32 0, i32 0
+  store ptr %50, ptr %53, align 8
+  %54 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %52, i32 0, i32 1
   store ptr %51, ptr %54, align 8
-  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %53, i32 0, i32 1
-  store ptr %52, ptr %55, align 8
-  %56 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %53, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %56)
+  %55 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %52, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %55)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %29, i32 0, i32 1
-  %58 = load ptr, ptr %57, align 8
-  %59 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).Elem"(ptr %58)
-  %60 = getelementptr inbounds %main.eface, ptr %8, i32 0, i32 0
-  %61 = load ptr, ptr %60, align 8
-  %62 = icmp ne ptr %59, %61
-  br i1 %62, label %_llgo_3, label %_llgo_4
+  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %28, i32 0, i32 1
+  %57 = load ptr, ptr %56, align 8
+  %58 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).Elem"(ptr %57)
+  %59 = getelementptr inbounds %main.eface, ptr %8, i32 0, i32 0
+  %60 = load ptr, ptr %59, align 8
+  %61 = icmp ne ptr %58, %60
+  br i1 %61, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %63 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %64 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %63, i32 0, i32 0
-  store ptr @64, ptr %64, align 8
-  %65 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %63, i32 0, i32 1
-  store i64 18, ptr %65, align 4
-  %66 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %63, align 8
-  %67 = load ptr, ptr @_llgo_string, align 8
-  %68 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %66, ptr %68, align 8
-  %69 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %70 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %69, i32 0, i32 0
+  %62 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %63 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %62, i32 0, i32 0
+  store ptr @64, ptr %63, align 8
+  %64 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %62, i32 0, i32 1
+  store i64 18, ptr %64, align 4
+  %65 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %62, align 8
+  %66 = load ptr, ptr @_llgo_string, align 8
+  %67 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %65, ptr %67, align 8
+  %68 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %69 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i32 0, i32 0
+  store ptr %66, ptr %69, align 8
+  %70 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i32 0, i32 1
   store ptr %67, ptr %70, align 8
-  %71 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %69, i32 0, i32 1
-  store ptr %68, ptr %71, align 8
-  %72 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %69, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %72)
+  %71 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %71)
   unreachable
 
 _llgo_4:                                          ; preds = %_llgo_2
-  %73 = alloca %"github.com/goplus/llgo/internal/abi.StructField", align 8
-  %74 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %73, i64 56)
-  %75 = getelementptr inbounds %main.eface, ptr %8, i32 0, i32 0
-  %76 = load ptr, ptr %75, align 8
-  %77 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType"(ptr %76)
-  %78 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructType", ptr %77, i32 0, i32 2
-  %79 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %78, align 8
-  %80 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %79, 0
-  %81 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %79, 1
-  %82 = icmp sge i64 1, %81
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %82)
-  %83 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %80, i64 1
-  %84 = load %"github.com/goplus/llgo/internal/abi.StructField", ptr %83, align 8
-  store %"github.com/goplus/llgo/internal/abi.StructField" %84, ptr %74, align 8
-  %85 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %74, i32 0, i32 1
+  %72 = alloca %"github.com/goplus/llgo/internal/abi.StructField", align 8
+  call void @llvm.memset(ptr %72, i8 0, i64 56, i1 false)
+  %73 = getelementptr inbounds %main.eface, ptr %8, i32 0, i32 0
+  %74 = load ptr, ptr %73, align 8
+  %75 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType"(ptr %74)
+  %76 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructType", ptr %75, i32 0, i32 2
+  %77 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %76, align 8
+  %78 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %77, 0
+  %79 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %77, 1
+  %80 = icmp sge i64 1, %79
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %80)
+  %81 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %78, i64 1
+  %82 = load %"github.com/goplus/llgo/internal/abi.StructField", ptr %81, align 8
+  store %"github.com/goplus/llgo/internal/abi.StructField" %82, ptr %72, align 8
+  %83 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %72, i32 0, i32 1
+  %84 = load ptr, ptr %83, align 8
+  %85 = getelementptr inbounds %main.eface, ptr %15, i32 0, i32 0
   %86 = load ptr, ptr %85, align 8
-  %87 = getelementptr inbounds %main.eface, ptr %15, i32 0, i32 0
+  %87 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Type", ptr %86, i32 0, i32 10
   %88 = load ptr, ptr %87, align 8
-  %89 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Type", ptr %88, i32 0, i32 10
-  %90 = load ptr, ptr %89, align 8
-  %91 = icmp ne ptr %86, %90
-  br i1 %91, label %_llgo_5, label %_llgo_6
+  %89 = icmp ne ptr %84, %88
+  br i1 %89, label %_llgo_5, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_4
-  %92 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %93 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %92, i32 0, i32 0
-  store ptr @65, ptr %93, align 8
-  %94 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %92, i32 0, i32 1
-  store i64 13, ptr %94, align 4
-  %95 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %92, align 8
-  %96 = load ptr, ptr @_llgo_string, align 8
-  %97 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %95, ptr %97, align 8
-  %98 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %99 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %98, i32 0, i32 0
-  store ptr %96, ptr %99, align 8
-  %100 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %98, i32 0, i32 1
-  store ptr %97, ptr %100, align 8
-  %101 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %98, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %101)
+  %90 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %91 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %90, i32 0, i32 0
+  store ptr @65, ptr %91, align 8
+  %92 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %90, i32 0, i32 1
+  store i64 13, ptr %92, align 4
+  %93 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %90, align 8
+  %94 = load ptr, ptr @_llgo_string, align 8
+  %95 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %93, ptr %95, align 8
+  %96 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %97 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %96, i32 0, i32 0
+  store ptr %94, ptr %97, align 8
+  %98 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %96, i32 0, i32 1
+  store ptr %95, ptr %98, align 8
+  %99 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %96, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %99)
   unreachable
 
 _llgo_6:                                          ; preds = %_llgo_4
-  %102 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %74, i32 0, i32 1
-  %103 = load ptr, ptr %102, align 8
-  %104 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).Elem"(ptr %103)
-  %105 = getelementptr inbounds %main.eface, ptr %15, i32 0, i32 0
-  %106 = load ptr, ptr %105, align 8
-  %107 = icmp ne ptr %104, %106
-  br i1 %107, label %_llgo_7, label %_llgo_8
+  %100 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %72, i32 0, i32 1
+  %101 = load ptr, ptr %100, align 8
+  %102 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).Elem"(ptr %101)
+  %103 = getelementptr inbounds %main.eface, ptr %15, i32 0, i32 0
+  %104 = load ptr, ptr %103, align 8
+  %105 = icmp ne ptr %102, %104
+  br i1 %105, label %_llgo_7, label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_6
-  %108 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %109 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %108, i32 0, i32 0
-  store ptr @66, ptr %109, align 8
-  %110 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %108, i32 0, i32 1
-  store i64 18, ptr %110, align 4
-  %111 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %108, align 8
-  %112 = load ptr, ptr @_llgo_string, align 8
-  %113 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %111, ptr %113, align 8
-  %114 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %115 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %114, i32 0, i32 0
-  store ptr %112, ptr %115, align 8
-  %116 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %114, i32 0, i32 1
-  store ptr %113, ptr %116, align 8
-  %117 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %114, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %117)
+  %106 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %107 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %106, i32 0, i32 0
+  store ptr @66, ptr %107, align 8
+  %108 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %106, i32 0, i32 1
+  store i64 18, ptr %108, align 4
+  %109 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %106, align 8
+  %110 = load ptr, ptr @_llgo_string, align 8
+  %111 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %109, ptr %111, align 8
+  %112 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %113 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %112, i32 0, i32 0
+  store ptr %110, ptr %113, align 8
+  %114 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %112, i32 0, i32 1
+  store ptr %111, ptr %114, align 8
+  %115 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %112, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %115)
   unreachable
 
 _llgo_8:                                          ; preds = %_llgo_6
-  %118 = alloca %"github.com/goplus/llgo/internal/abi.StructField", align 8
-  %119 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %118, i64 56)
-  %120 = getelementptr inbounds %main.eface, ptr %8, i32 0, i32 0
-  %121 = load ptr, ptr %120, align 8
-  %122 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType"(ptr %121)
-  %123 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructType", ptr %122, i32 0, i32 2
-  %124 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %123, align 8
-  %125 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %124, 0
-  %126 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %124, 1
-  %127 = icmp sge i64 2, %126
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %127)
-  %128 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %125, i64 2
-  %129 = load %"github.com/goplus/llgo/internal/abi.StructField", ptr %128, align 8
-  store %"github.com/goplus/llgo/internal/abi.StructField" %129, ptr %119, align 8
-  %130 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %119, i32 0, i32 1
-  %131 = load ptr, ptr %130, align 8
-  %132 = getelementptr inbounds %main.eface, ptr %15, i32 0, i32 0
-  %133 = load ptr, ptr %132, align 8
-  %134 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType"(ptr %133)
-  %135 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructType", ptr %134, i32 0, i32 2
-  %136 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %135, align 8
-  %137 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %136, 0
-  %138 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %136, 1
-  %139 = icmp sge i64 0, %138
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %139)
-  %140 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %137, i64 0
-  %141 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %140, i32 0, i32 1
-  %142 = load ptr, ptr %141, align 8
-  %143 = icmp ne ptr %131, %142
-  br i1 %143, label %_llgo_9, label %_llgo_10
+  %116 = alloca %"github.com/goplus/llgo/internal/abi.StructField", align 8
+  call void @llvm.memset(ptr %116, i8 0, i64 56, i1 false)
+  %117 = getelementptr inbounds %main.eface, ptr %8, i32 0, i32 0
+  %118 = load ptr, ptr %117, align 8
+  %119 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType"(ptr %118)
+  %120 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructType", ptr %119, i32 0, i32 2
+  %121 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %120, align 8
+  %122 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %121, 0
+  %123 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %121, 1
+  %124 = icmp sge i64 2, %123
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %124)
+  %125 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %122, i64 2
+  %126 = load %"github.com/goplus/llgo/internal/abi.StructField", ptr %125, align 8
+  store %"github.com/goplus/llgo/internal/abi.StructField" %126, ptr %116, align 8
+  %127 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %116, i32 0, i32 1
+  %128 = load ptr, ptr %127, align 8
+  %129 = getelementptr inbounds %main.eface, ptr %15, i32 0, i32 0
+  %130 = load ptr, ptr %129, align 8
+  %131 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType"(ptr %130)
+  %132 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructType", ptr %131, i32 0, i32 2
+  %133 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %132, align 8
+  %134 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %133, 0
+  %135 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %133, 1
+  %136 = icmp sge i64 0, %135
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %136)
+  %137 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %134, i64 0
+  %138 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %137, i32 0, i32 1
+  %139 = load ptr, ptr %138, align 8
+  %140 = icmp ne ptr %128, %139
+  br i1 %140, label %_llgo_9, label %_llgo_10
 
 _llgo_9:                                          ; preds = %_llgo_8
-  %144 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %145 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %144, i32 0, i32 0
-  store ptr @67, ptr %145, align 8
-  %146 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %144, i32 0, i32 1
-  store i64 13, ptr %146, align 4
-  %147 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %144, align 8
-  %148 = load ptr, ptr @_llgo_string, align 8
-  %149 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %147, ptr %149, align 8
-  %150 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %151 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %150, i32 0, i32 0
-  store ptr %148, ptr %151, align 8
-  %152 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %150, i32 0, i32 1
-  store ptr %149, ptr %152, align 8
-  %153 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %150, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %153)
+  %141 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %142 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %141, i32 0, i32 0
+  store ptr @67, ptr %142, align 8
+  %143 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %141, i32 0, i32 1
+  store i64 13, ptr %143, align 4
+  %144 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %141, align 8
+  %145 = load ptr, ptr @_llgo_string, align 8
+  %146 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %144, ptr %146, align 8
+  %147 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %148 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %147, i32 0, i32 0
+  store ptr %145, ptr %148, align 8
+  %149 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %147, i32 0, i32 1
+  store ptr %146, ptr %149, align 8
+  %150 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %147, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %150)
   unreachable
 
 _llgo_10:                                         ; preds = %_llgo_8
-  %154 = alloca %"github.com/goplus/llgo/internal/abi.StructField", align 8
-  %155 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %154, i64 56)
-  %156 = getelementptr inbounds %main.eface, ptr %8, i32 0, i32 0
-  %157 = load ptr, ptr %156, align 8
-  %158 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType"(ptr %157)
-  %159 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructType", ptr %158, i32 0, i32 2
-  %160 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %159, align 8
-  %161 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %160, 0
-  %162 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %160, 1
-  %163 = icmp sge i64 3, %162
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %163)
-  %164 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %161, i64 3
-  %165 = load %"github.com/goplus/llgo/internal/abi.StructField", ptr %164, align 8
-  store %"github.com/goplus/llgo/internal/abi.StructField" %165, ptr %155, align 8
-  %166 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %155, i32 0, i32 1
-  %167 = load ptr, ptr %166, align 8
-  %168 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).Elem"(ptr %167)
-  %169 = getelementptr inbounds %main.eface, ptr %8, i32 0, i32 0
-  %170 = load ptr, ptr %169, align 8
-  %171 = icmp ne ptr %168, %170
-  br i1 %171, label %_llgo_11, label %_llgo_12
+  %151 = alloca %"github.com/goplus/llgo/internal/abi.StructField", align 8
+  call void @llvm.memset(ptr %151, i8 0, i64 56, i1 false)
+  %152 = getelementptr inbounds %main.eface, ptr %8, i32 0, i32 0
+  %153 = load ptr, ptr %152, align 8
+  %154 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType"(ptr %153)
+  %155 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructType", ptr %154, i32 0, i32 2
+  %156 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %155, align 8
+  %157 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %156, 0
+  %158 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %156, 1
+  %159 = icmp sge i64 3, %158
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %159)
+  %160 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %157, i64 3
+  %161 = load %"github.com/goplus/llgo/internal/abi.StructField", ptr %160, align 8
+  store %"github.com/goplus/llgo/internal/abi.StructField" %161, ptr %151, align 8
+  %162 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %151, i32 0, i32 1
+  %163 = load ptr, ptr %162, align 8
+  %164 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).Elem"(ptr %163)
+  %165 = getelementptr inbounds %main.eface, ptr %8, i32 0, i32 0
+  %166 = load ptr, ptr %165, align 8
+  %167 = icmp ne ptr %164, %166
+  br i1 %167, label %_llgo_11, label %_llgo_12
 
 _llgo_11:                                         ; preds = %_llgo_10
-  %172 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %173 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %172, i32 0, i32 0
-  store ptr @68, ptr %173, align 8
-  %174 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %172, i32 0, i32 1
-  store i64 13, ptr %174, align 4
-  %175 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %172, align 8
-  %176 = load ptr, ptr @_llgo_string, align 8
-  %177 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %175, ptr %177, align 8
-  %178 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %179 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %178, i32 0, i32 0
-  store ptr %176, ptr %179, align 8
-  %180 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %178, i32 0, i32 1
-  store ptr %177, ptr %180, align 8
-  %181 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %178, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %181)
+  %168 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %169 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %168, i32 0, i32 0
+  store ptr @68, ptr %169, align 8
+  %170 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %168, i32 0, i32 1
+  store i64 13, ptr %170, align 4
+  %171 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %168, align 8
+  %172 = load ptr, ptr @_llgo_string, align 8
+  %173 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %171, ptr %173, align 8
+  %174 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %175 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %174, i32 0, i32 0
+  store ptr %172, ptr %175, align 8
+  %176 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %174, i32 0, i32 1
+  store ptr %173, ptr %176, align 8
+  %177 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %174, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %177)
   unreachable
 
 _llgo_12:                                         ; preds = %_llgo_10
@@ -4793,10 +4793,13 @@ declare void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr)
 
 declare void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8)
 
-declare ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr, i64)
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
 
 declare void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1)
 
 declare void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface")
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64)
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testrt/index/out.ll
+++ b/cl/_testrt/index/out.ll
@@ -30,144 +30,144 @@ _llgo_0:
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
   %2 = alloca %main.point, align 8
-  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %2, i64 16)
-  %4 = alloca [3 x %main.point], align 8
-  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %4, i64 48)
-  %6 = getelementptr inbounds %main.point, ptr %5, i64 0
-  %7 = getelementptr inbounds %main.point, ptr %6, i32 0, i32 0
-  %8 = getelementptr inbounds %main.point, ptr %6, i32 0, i32 1
-  %9 = getelementptr inbounds %main.point, ptr %5, i64 1
-  %10 = getelementptr inbounds %main.point, ptr %9, i32 0, i32 0
-  %11 = getelementptr inbounds %main.point, ptr %9, i32 0, i32 1
-  %12 = getelementptr inbounds %main.point, ptr %5, i64 2
-  %13 = getelementptr inbounds %main.point, ptr %12, i32 0, i32 0
-  %14 = getelementptr inbounds %main.point, ptr %12, i32 0, i32 1
-  store i64 1, ptr %7, align 4
-  store i64 2, ptr %8, align 4
-  store i64 3, ptr %10, align 4
-  store i64 4, ptr %11, align 4
-  store i64 5, ptr %13, align 4
-  store i64 6, ptr %14, align 4
-  %15 = load [3 x %main.point], ptr %5, align 4
-  %16 = getelementptr inbounds %main.point, ptr %5, i64 2
-  %17 = load %main.point, ptr %16, align 4
-  store %main.point %17, ptr %3, align 4
-  %18 = getelementptr inbounds %main.point, ptr %3, i32 0, i32 0
+  call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+  %3 = alloca [3 x %main.point], align 8
+  call void @llvm.memset(ptr %3, i8 0, i64 48, i1 false)
+  %4 = getelementptr inbounds %main.point, ptr %3, i64 0
+  %5 = getelementptr inbounds %main.point, ptr %4, i32 0, i32 0
+  %6 = getelementptr inbounds %main.point, ptr %4, i32 0, i32 1
+  %7 = getelementptr inbounds %main.point, ptr %3, i64 1
+  %8 = getelementptr inbounds %main.point, ptr %7, i32 0, i32 0
+  %9 = getelementptr inbounds %main.point, ptr %7, i32 0, i32 1
+  %10 = getelementptr inbounds %main.point, ptr %3, i64 2
+  %11 = getelementptr inbounds %main.point, ptr %10, i32 0, i32 0
+  %12 = getelementptr inbounds %main.point, ptr %10, i32 0, i32 1
+  store i64 1, ptr %5, align 4
+  store i64 2, ptr %6, align 4
+  store i64 3, ptr %8, align 4
+  store i64 4, ptr %9, align 4
+  store i64 5, ptr %11, align 4
+  store i64 6, ptr %12, align 4
+  %13 = load [3 x %main.point], ptr %3, align 4
+  %14 = getelementptr inbounds %main.point, ptr %3, i64 2
+  %15 = load %main.point, ptr %14, align 4
+  store %main.point %15, ptr %2, align 4
+  %16 = getelementptr inbounds %main.point, ptr %2, i32 0, i32 0
+  %17 = load i64, ptr %16, align 4
+  %18 = getelementptr inbounds %main.point, ptr %2, i32 0, i32 1
   %19 = load i64, ptr %18, align 4
-  %20 = getelementptr inbounds %main.point, ptr %3, i32 0, i32 1
-  %21 = load i64, ptr %20, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %17)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %19)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
+  %20 = alloca [2 x i64], align 8
+  call void @llvm.memset(ptr %20, i8 0, i64 16, i1 false)
+  %21 = alloca [2 x [2 x i64]], align 8
+  call void @llvm.memset(ptr %21, i8 0, i64 32, i1 false)
+  %22 = getelementptr inbounds [2 x i64], ptr %21, i64 0
+  %23 = getelementptr inbounds i64, ptr %22, i64 0
+  %24 = getelementptr inbounds i64, ptr %22, i64 1
+  %25 = getelementptr inbounds [2 x i64], ptr %21, i64 1
+  %26 = getelementptr inbounds i64, ptr %25, i64 0
+  %27 = getelementptr inbounds i64, ptr %25, i64 1
+  store i64 1, ptr %23, align 4
+  store i64 2, ptr %24, align 4
+  store i64 3, ptr %26, align 4
+  store i64 4, ptr %27, align 4
+  %28 = load [2 x [2 x i64]], ptr %21, align 4
+  %29 = getelementptr inbounds [2 x i64], ptr %21, i64 1
+  %30 = load [2 x i64], ptr %29, align 4
+  store [2 x i64] %30, ptr %20, align 4
+  %31 = getelementptr inbounds i64, ptr %20, i64 0
+  %32 = load i64, ptr %31, align 4
+  %33 = getelementptr inbounds i64, ptr %20, i64 1
+  %34 = load i64, ptr %33, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %21)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %34)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %22 = alloca [2 x i64], align 8
-  %23 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %22, i64 16)
-  %24 = alloca [2 x [2 x i64]], align 8
-  %25 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %24, i64 32)
-  %26 = getelementptr inbounds [2 x i64], ptr %25, i64 0
-  %27 = getelementptr inbounds i64, ptr %26, i64 0
-  %28 = getelementptr inbounds i64, ptr %26, i64 1
-  %29 = getelementptr inbounds [2 x i64], ptr %25, i64 1
-  %30 = getelementptr inbounds i64, ptr %29, i64 0
-  %31 = getelementptr inbounds i64, ptr %29, i64 1
-  store i64 1, ptr %27, align 4
-  store i64 2, ptr %28, align 4
-  store i64 3, ptr %30, align 4
-  store i64 4, ptr %31, align 4
-  %32 = load [2 x [2 x i64]], ptr %25, align 4
-  %33 = getelementptr inbounds [2 x i64], ptr %25, i64 1
-  %34 = load [2 x i64], ptr %33, align 4
-  store [2 x i64] %34, ptr %23, align 4
-  %35 = getelementptr inbounds i64, ptr %23, i64 0
-  %36 = load i64, ptr %35, align 4
-  %37 = getelementptr inbounds i64, ptr %23, i64 1
-  %38 = load i64, ptr %37, align 4
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %36)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %38)
+  %35 = alloca [5 x i64], align 8
+  call void @llvm.memset(ptr %35, i8 0, i64 40, i1 false)
+  %36 = getelementptr inbounds i64, ptr %35, i64 0
+  %37 = getelementptr inbounds i64, ptr %35, i64 1
+  %38 = getelementptr inbounds i64, ptr %35, i64 2
+  %39 = getelementptr inbounds i64, ptr %35, i64 3
+  %40 = getelementptr inbounds i64, ptr %35, i64 4
+  store i64 1, ptr %36, align 4
+  store i64 2, ptr %37, align 4
+  store i64 3, ptr %38, align 4
+  store i64 4, ptr %39, align 4
+  store i64 5, ptr %40, align 4
+  %41 = load [5 x i64], ptr %35, align 4
+  %42 = getelementptr inbounds i64, ptr %35, i64 2
+  %43 = load i64, ptr %42, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %43)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %39 = alloca [5 x i64], align 8
-  %40 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %39, i64 40)
-  %41 = getelementptr inbounds i64, ptr %40, i64 0
-  %42 = getelementptr inbounds i64, ptr %40, i64 1
-  %43 = getelementptr inbounds i64, ptr %40, i64 2
-  %44 = getelementptr inbounds i64, ptr %40, i64 3
-  %45 = getelementptr inbounds i64, ptr %40, i64 4
-  store i64 1, ptr %41, align 4
-  store i64 2, ptr %42, align 4
-  store i64 3, ptr %43, align 4
-  store i64 4, ptr %44, align 4
-  store i64 5, ptr %45, align 4
-  %46 = load [5 x i64], ptr %40, align 4
-  %47 = getelementptr inbounds i64, ptr %40, i64 2
-  %48 = load i64, ptr %47, align 4
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %48)
+  %44 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %44, i32 0, i32 0
+  store ptr @0, ptr %45, align 8
+  %46 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %44, i32 0, i32 1
+  store i64 6, ptr %46, align 4
+  %47 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %44, align 8
+  %48 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %47, 0
+  %49 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %47, 1
+  %50 = icmp sge i64 2, %49
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %50)
+  %51 = getelementptr inbounds i8, ptr %48, i64 2
+  %52 = load i8, ptr %51, align 1
+  %53 = sext i8 %52 to i32
+  %54 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringFromRune"(i32 %53)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %54)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %49 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %49, i32 0, i32 0
-  store ptr @0, ptr %50, align 8
-  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %49, i32 0, i32 1
-  store i64 6, ptr %51, align 4
-  %52 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %49, align 8
-  %53 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %52, 0
-  %54 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %52, 1
-  %55 = icmp sge i64 2, %54
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %55)
-  %56 = getelementptr inbounds i8, ptr %53, i64 2
-  %57 = load i8, ptr %56, align 1
-  %58 = sext i8 %57 to i32
-  %59 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringFromRune"(i32 %58)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %59)
+  %55 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 0
+  store ptr @0, ptr %56, align 8
+  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 1
+  store i64 6, ptr %57, align 4
+  %58 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %55, align 8
+  %59 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %58, 0
+  %60 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %58, 1
+  %61 = icmp sge i64 1, %60
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %61)
+  %62 = getelementptr inbounds i8, ptr %59, i64 1
+  %63 = load i8, ptr %62, align 1
+  %64 = sext i8 %63 to i32
+  %65 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringFromRune"(i32 %64)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %65)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %60 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %61 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %60, i32 0, i32 0
-  store ptr @0, ptr %61, align 8
-  %62 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %60, i32 0, i32 1
-  store i64 6, ptr %62, align 4
-  %63 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %60, align 8
-  %64 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %63, 0
-  %65 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %63, 1
-  %66 = icmp sge i64 1, %65
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %66)
-  %67 = getelementptr inbounds i8, ptr %64, i64 1
-  %68 = load i8, ptr %67, align 1
-  %69 = sext i8 %68 to i32
-  %70 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringFromRune"(i32 %69)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %70)
+  %66 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 16)
+  %67 = getelementptr inbounds i64, ptr %66, i64 0
+  %68 = getelementptr inbounds i64, ptr %66, i64 1
+  store i64 1, ptr %67, align 4
+  store i64 2, ptr %68, align 4
+  %69 = getelementptr inbounds i64, ptr %66, i64 1
+  %70 = load i64, ptr %69, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %70)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %71 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 16)
+  %71 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
   %72 = getelementptr inbounds i64, ptr %71, i64 0
-  %73 = getelementptr inbounds i64, ptr %71, i64 1
   store i64 1, ptr %72, align 4
+  %73 = getelementptr inbounds i64, ptr %71, i64 1
   store i64 2, ptr %73, align 4
-  %74 = getelementptr inbounds i64, ptr %71, i64 1
-  %75 = load i64, ptr %74, align 4
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %75)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %76 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
-  %77 = getelementptr inbounds i64, ptr %76, i64 0
-  store i64 1, ptr %77, align 4
-  %78 = getelementptr inbounds i64, ptr %76, i64 1
-  store i64 2, ptr %78, align 4
-  %79 = getelementptr inbounds i64, ptr %76, i64 2
-  store i64 3, ptr %79, align 4
-  %80 = getelementptr inbounds i64, ptr %76, i64 3
-  store i64 4, ptr %80, align 4
-  %81 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %82 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %81, i32 0, i32 0
-  store ptr %76, ptr %82, align 8
-  %83 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %81, i32 0, i32 1
-  store i64 4, ptr %83, align 4
-  %84 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %81, i32 0, i32 2
-  store i64 4, ptr %84, align 4
-  %85 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %81, align 8
-  %86 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %85, 0
-  %87 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %85, 1
-  %88 = icmp sge i64 1, %87
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %88)
-  %89 = getelementptr inbounds i64, ptr %86, i64 1
-  %90 = load i64, ptr %89, align 4
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %90)
+  %74 = getelementptr inbounds i64, ptr %71, i64 2
+  store i64 3, ptr %74, align 4
+  %75 = getelementptr inbounds i64, ptr %71, i64 3
+  store i64 4, ptr %75, align 4
+  %76 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %77 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %76, i32 0, i32 0
+  store ptr %71, ptr %77, align 8
+  %78 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %76, i32 0, i32 1
+  store i64 4, ptr %78, align 4
+  %79 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %76, i32 0, i32 2
+  store i64 4, ptr %79, align 4
+  %80 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %76, align 8
+  %81 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %80, 0
+  %82 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %80, 1
+  %83 = icmp sge i64 1, %82
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %83)
+  %84 = getelementptr inbounds i64, ptr %81, i64 1
+  %85 = load i64, ptr %84, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %85)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 0)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
@@ -176,7 +176,8 @@ _llgo_0:
 
 declare void @"github.com/goplus/llgo/internal/runtime.init"()
 
-declare ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr, i64)
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
 
 declare void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64)
 
@@ -189,3 +190,5 @@ declare %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/ll
 declare void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String")
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64)
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testrt/makemap/out.ll
+++ b/cl/_testrt/makemap/out.ll
@@ -453,37 +453,228 @@ _llgo_0:
   %9 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
   %10 = call ptr @"github.com/goplus/llgo/internal/runtime.MakeMap"(ptr %9, i64 0)
   %11 = alloca [1 x i64], align 8
-  %12 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %11, i64 8)
-  %13 = getelementptr inbounds i64, ptr %12, i64 0
-  store i64 1, ptr %13, align 4
-  %14 = load [1 x i64], ptr %12, align 4
-  %15 = load ptr, ptr @_llgo_main.N1, align 8
-  %16 = extractvalue [1 x i64] %14, 0
-  %17 = inttoptr i64 %16 to ptr
+  call void @llvm.memset(ptr %11, i8 0, i64 8, i1 false)
+  %12 = getelementptr inbounds i64, ptr %11, i64 0
+  store i64 1, ptr %12, align 4
+  %13 = load [1 x i64], ptr %11, align 4
+  %14 = load ptr, ptr @_llgo_main.N1, align 8
+  %15 = extractvalue [1 x i64] %13, 0
+  %16 = inttoptr i64 %15 to ptr
+  %17 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %18 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %17, i32 0, i32 0
+  store ptr %14, ptr %18, align 8
+  %19 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %17, i32 0, i32 1
+  store ptr %16, ptr %19, align 8
+  %20 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %17, align 8
+  %21 = load ptr, ptr @_llgo_any, align 8
+  %22 = load ptr, ptr @_llgo_int, align 8
+  %23 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
+  %24 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.eface" %20, ptr %24, align 8
+  %25 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %23, ptr %10, ptr %24)
+  store i64 100, ptr %25, align 4
+  %26 = alloca [1 x i64], align 8
+  call void @llvm.memset(ptr %26, i8 0, i64 8, i1 false)
+  %27 = getelementptr inbounds i64, ptr %26, i64 0
+  store i64 2, ptr %27, align 4
+  %28 = load [1 x i64], ptr %26, align 4
+  %29 = load ptr, ptr @_llgo_main.N1, align 8
+  %30 = extractvalue [1 x i64] %28, 0
+  %31 = inttoptr i64 %30 to ptr
+  %32 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %32, i32 0, i32 0
+  store ptr %29, ptr %33, align 8
+  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %32, i32 0, i32 1
+  store ptr %31, ptr %34, align 8
+  %35 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %32, align 8
+  %36 = load ptr, ptr @_llgo_any, align 8
+  %37 = load ptr, ptr @_llgo_int, align 8
+  %38 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
+  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.eface" %35, ptr %39, align 8
+  %40 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %38, ptr %10, ptr %39)
+  store i64 200, ptr %40, align 4
+  %41 = alloca [1 x i64], align 8
+  call void @llvm.memset(ptr %41, i8 0, i64 8, i1 false)
+  %42 = getelementptr inbounds i64, ptr %41, i64 0
+  store i64 3, ptr %42, align 4
+  %43 = load [1 x i64], ptr %41, align 4
+  %44 = load ptr, ptr @_llgo_main.N1, align 8
+  %45 = extractvalue [1 x i64] %43, 0
+  %46 = inttoptr i64 %45 to ptr
+  %47 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %48 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %47, i32 0, i32 0
+  store ptr %44, ptr %48, align 8
+  %49 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %47, i32 0, i32 1
+  store ptr %46, ptr %49, align 8
+  %50 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %47, align 8
+  %51 = load ptr, ptr @_llgo_any, align 8
+  %52 = load ptr, ptr @_llgo_int, align 8
+  %53 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
+  %54 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.eface" %50, ptr %54, align 8
+  %55 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %53, ptr %10, ptr %54)
+  store i64 300, ptr %55, align 4
+  %56 = alloca [1 x i64], align 8
+  call void @llvm.memset(ptr %56, i8 0, i64 8, i1 false)
+  %57 = getelementptr inbounds i64, ptr %56, i64 0
+  store i64 2, ptr %57, align 4
+  %58 = load [1 x i64], ptr %56, align 4
+  %59 = load ptr, ptr @_llgo_main.N1, align 8
+  %60 = extractvalue [1 x i64] %58, 0
+  %61 = inttoptr i64 %60 to ptr
+  %62 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %63 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %62, i32 0, i32 0
+  store ptr %59, ptr %63, align 8
+  %64 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %62, i32 0, i32 1
+  store ptr %61, ptr %64, align 8
+  %65 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %62, align 8
+  %66 = load ptr, ptr @_llgo_any, align 8
+  %67 = load ptr, ptr @_llgo_int, align 8
+  %68 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
+  %69 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.eface" %65, ptr %69, align 8
+  %70 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %68, ptr %10, ptr %69)
+  store i64 -200, ptr %70, align 4
+  %71 = load ptr, ptr @_llgo_any, align 8
+  %72 = load ptr, ptr @_llgo_int, align 8
+  %73 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
+  %74 = call ptr @"github.com/goplus/llgo/internal/runtime.NewMapIter"(ptr %73, ptr %10)
+  br label %_llgo_1
+
+_llgo_1:                                          ; preds = %_llgo_7, %_llgo_0
+  %75 = call { i1, ptr, ptr } @"github.com/goplus/llgo/internal/runtime.MapIterNext"(ptr %74)
+  %76 = extractvalue { i1, ptr, ptr } %75, 0
+  br i1 %76, label %_llgo_4, label %_llgo_5
+
+_llgo_2:                                          ; preds = %_llgo_6
+  %77 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %96, 1
+  %78 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %96, 2
+  %79 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %77, 0
+  %80 = load ptr, ptr @_llgo_main.N1, align 8
+  %81 = icmp eq ptr %79, %80
+  br i1 %81, label %_llgo_7, label %_llgo_8
+
+_llgo_3:                                          ; preds = %_llgo_6
+  ret void
+
+_llgo_4:                                          ; preds = %_llgo_1
+  %82 = extractvalue { i1, ptr, ptr } %75, 1
+  %83 = extractvalue { i1, ptr, ptr } %75, 2
+  %84 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %82, align 8
+  %85 = load i64, ptr %83, align 4
+  %86 = alloca { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, align 8
+  %87 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %86, i32 0, i32 0
+  store i1 true, ptr %87, align 1
+  %88 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %86, i32 0, i32 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %84, ptr %88, align 8
+  %89 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %86, i32 0, i32 2
+  store i64 %85, ptr %89, align 4
+  %90 = load { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %86, align 8
+  br label %_llgo_6
+
+_llgo_5:                                          ; preds = %_llgo_1
+  %91 = alloca { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, align 8
+  %92 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %91, i32 0, i32 0
+  store i1 false, ptr %92, align 1
+  %93 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %91, i32 0, i32 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" zeroinitializer, ptr %93, align 8
+  %94 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %91, i32 0, i32 2
+  store i64 0, ptr %94, align 4
+  %95 = load { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %91, align 8
+  br label %_llgo_6
+
+_llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
+  %96 = phi { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } [ %90, %_llgo_4 ], [ %95, %_llgo_5 ]
+  %97 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %96, 0
+  br i1 %97, label %_llgo_2, label %_llgo_3
+
+_llgo_7:                                          ; preds = %_llgo_2
+  %98 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %77, 1
+  %99 = ptrtoint ptr %98 to i64
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %99)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %78)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
+  br label %_llgo_1
+
+_llgo_8:                                          ; preds = %_llgo_2
+  %100 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %101 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %100, i32 0, i32 0
+  store ptr @13, ptr %101, align 8
+  %102 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %100, i32 0, i32 1
+  store i64 21, ptr %102, align 4
+  %103 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %100, align 8
+  %104 = load ptr, ptr @_llgo_string, align 8
+  %105 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %103, ptr %105, align 8
+  %106 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %107 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %106, i32 0, i32 0
+  store ptr %104, ptr %107, align 8
+  %108 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %106, i32 0, i32 1
+  store ptr %105, ptr %108, align 8
+  %109 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %106, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %109)
+  unreachable
+}
+
+define void @main.make3() {
+_llgo_0:
+  %0 = alloca [1 x %main.N], align 8
+  call void @llvm.memset(ptr %0, i8 0, i64 2, i1 false)
+  %1 = getelementptr inbounds %main.N, ptr %0, i64 0
+  %2 = getelementptr inbounds %main.N, ptr %1, i32 0, i32 0
+  %3 = getelementptr inbounds %main.N, ptr %1, i32 0, i32 1
+  store i8 1, ptr %2, align 1
+  store i8 2, ptr %3, align 1
+  %4 = load [1 x %main.N], ptr %0, align 1
+  %5 = load ptr, ptr @_llgo_main.K, align 8
+  %6 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 2)
+  store [1 x %main.N] %4, ptr %6, align 1
+  %7 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, i32 0, i32 0
+  store ptr %5, ptr %8, align 8
+  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, i32 0, i32 1
+  store ptr %6, ptr %9, align 8
+  %10 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, align 8
+  %11 = alloca [1 x %main.N], align 8
+  call void @llvm.memset(ptr %11, i8 0, i64 2, i1 false)
+  %12 = getelementptr inbounds %main.N, ptr %11, i64 0
+  %13 = getelementptr inbounds %main.N, ptr %12, i32 0, i32 0
+  %14 = getelementptr inbounds %main.N, ptr %12, i32 0, i32 1
+  store i8 1, ptr %13, align 1
+  store i8 2, ptr %14, align 1
+  %15 = load [1 x %main.N], ptr %11, align 1
+  %16 = load ptr, ptr @_llgo_main.K, align 8
+  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 2)
+  store [1 x %main.N] %15, ptr %17, align 1
   %18 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
   %19 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %18, i32 0, i32 0
-  store ptr %15, ptr %19, align 8
+  store ptr %16, ptr %19, align 8
   %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %18, i32 0, i32 1
   store ptr %17, ptr %20, align 8
   %21 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %18, align 8
-  %22 = load ptr, ptr @_llgo_any, align 8
-  %23 = load ptr, ptr @_llgo_int, align 8
-  %24 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
-  %25 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.eface" %21, ptr %25, align 8
-  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %24, ptr %10, ptr %25)
-  store i64 100, ptr %26, align 4
-  %27 = alloca [1 x i64], align 8
-  %28 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %27, i64 8)
-  %29 = getelementptr inbounds i64, ptr %28, i64 0
-  store i64 2, ptr %29, align 4
-  %30 = load [1 x i64], ptr %28, align 4
-  %31 = load ptr, ptr @_llgo_main.N1, align 8
-  %32 = extractvalue [1 x i64] %30, 0
-  %33 = inttoptr i64 %32 to ptr
+  %22 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %10, %"github.com/goplus/llgo/internal/runtime.eface" %21)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %22)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
+  %23 = load ptr, ptr @_llgo_any, align 8
+  %24 = load ptr, ptr @_llgo_int, align 8
+  %25 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
+  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.MakeMap"(ptr %25, i64 0)
+  %27 = alloca [1 x %main.N], align 8
+  call void @llvm.memset(ptr %27, i8 0, i64 2, i1 false)
+  %28 = getelementptr inbounds %main.N, ptr %27, i64 0
+  %29 = getelementptr inbounds %main.N, ptr %28, i32 0, i32 0
+  %30 = getelementptr inbounds %main.N, ptr %28, i32 0, i32 1
+  store i8 1, ptr %29, align 1
+  store i8 2, ptr %30, align 1
+  %31 = load [1 x %main.N], ptr %27, align 1
+  %32 = load ptr, ptr @_llgo_main.K, align 8
+  %33 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 2)
+  store [1 x %main.N] %31, ptr %33, align 1
   %34 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
   %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %34, i32 0, i32 0
-  store ptr %31, ptr %35, align 8
+  store ptr %32, ptr %35, align 8
   %36 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %34, i32 0, i32 1
   store ptr %33, ptr %36, align 8
   %37 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %34, align 8
@@ -492,19 +683,22 @@ _llgo_0:
   %40 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
   %41 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
   store %"github.com/goplus/llgo/internal/runtime.eface" %37, ptr %41, align 8
-  %42 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %40, ptr %10, ptr %41)
-  store i64 200, ptr %42, align 4
-  %43 = alloca [1 x i64], align 8
-  %44 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %43, i64 8)
-  %45 = getelementptr inbounds i64, ptr %44, i64 0
-  store i64 3, ptr %45, align 4
-  %46 = load [1 x i64], ptr %44, align 4
-  %47 = load ptr, ptr @_llgo_main.N1, align 8
-  %48 = extractvalue [1 x i64] %46, 0
-  %49 = inttoptr i64 %48 to ptr
+  %42 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %40, ptr %26, ptr %41)
+  store i64 100, ptr %42, align 4
+  %43 = alloca [1 x %main.N], align 8
+  call void @llvm.memset(ptr %43, i8 0, i64 2, i1 false)
+  %44 = getelementptr inbounds %main.N, ptr %43, i64 0
+  %45 = getelementptr inbounds %main.N, ptr %44, i32 0, i32 0
+  %46 = getelementptr inbounds %main.N, ptr %44, i32 0, i32 1
+  store i8 3, ptr %45, align 1
+  store i8 4, ptr %46, align 1
+  %47 = load [1 x %main.N], ptr %43, align 1
+  %48 = load ptr, ptr @_llgo_main.K, align 8
+  %49 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 2)
+  store [1 x %main.N] %47, ptr %49, align 1
   %50 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
   %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %50, i32 0, i32 0
-  store ptr %47, ptr %51, align 8
+  store ptr %48, ptr %51, align 8
   %52 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %50, i32 0, i32 1
   store ptr %49, ptr %52, align 8
   %53 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %50, align 8
@@ -513,141 +707,129 @@ _llgo_0:
   %56 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
   %57 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
   store %"github.com/goplus/llgo/internal/runtime.eface" %53, ptr %57, align 8
-  %58 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %56, ptr %10, ptr %57)
-  store i64 300, ptr %58, align 4
-  %59 = alloca [1 x i64], align 8
-  %60 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %59, i64 8)
-  %61 = getelementptr inbounds i64, ptr %60, i64 0
-  store i64 2, ptr %61, align 4
-  %62 = load [1 x i64], ptr %60, align 4
-  %63 = load ptr, ptr @_llgo_main.N1, align 8
-  %64 = extractvalue [1 x i64] %62, 0
-  %65 = inttoptr i64 %64 to ptr
-  %66 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %67 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %66, i32 0, i32 0
-  store ptr %63, ptr %67, align 8
-  %68 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %66, i32 0, i32 1
-  store ptr %65, ptr %68, align 8
-  %69 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %66, align 8
-  %70 = load ptr, ptr @_llgo_any, align 8
-  %71 = load ptr, ptr @_llgo_int, align 8
-  %72 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
-  %73 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.eface" %69, ptr %73, align 8
-  %74 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %72, ptr %10, ptr %73)
-  store i64 -200, ptr %74, align 4
-  %75 = load ptr, ptr @_llgo_any, align 8
-  %76 = load ptr, ptr @_llgo_int, align 8
-  %77 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
-  %78 = call ptr @"github.com/goplus/llgo/internal/runtime.NewMapIter"(ptr %77, ptr %10)
+  %58 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %56, ptr %26, ptr %57)
+  store i64 200, ptr %58, align 4
+  %59 = load ptr, ptr @_llgo_any, align 8
+  %60 = load ptr, ptr @_llgo_int, align 8
+  %61 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
+  %62 = call ptr @"github.com/goplus/llgo/internal/runtime.NewMapIter"(ptr %61, ptr %26)
   br label %_llgo_1
 
 _llgo_1:                                          ; preds = %_llgo_7, %_llgo_0
-  %79 = call { i1, ptr, ptr } @"github.com/goplus/llgo/internal/runtime.MapIterNext"(ptr %78)
-  %80 = extractvalue { i1, ptr, ptr } %79, 0
-  br i1 %80, label %_llgo_4, label %_llgo_5
+  %63 = call { i1, ptr, ptr } @"github.com/goplus/llgo/internal/runtime.MapIterNext"(ptr %62)
+  %64 = extractvalue { i1, ptr, ptr } %63, 0
+  br i1 %64, label %_llgo_4, label %_llgo_5
 
 _llgo_2:                                          ; preds = %_llgo_6
-  %81 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %100, 1
-  %82 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %100, 2
-  %83 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %81, 0
-  %84 = load ptr, ptr @_llgo_main.N1, align 8
-  %85 = icmp eq ptr %83, %84
-  br i1 %85, label %_llgo_7, label %_llgo_8
+  %65 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %84, 1
+  %66 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %84, 2
+  %67 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %65, 0
+  %68 = load ptr, ptr @_llgo_main.K, align 8
+  %69 = icmp eq ptr %67, %68
+  br i1 %69, label %_llgo_7, label %_llgo_8
 
 _llgo_3:                                          ; preds = %_llgo_6
   ret void
 
 _llgo_4:                                          ; preds = %_llgo_1
-  %86 = extractvalue { i1, ptr, ptr } %79, 1
-  %87 = extractvalue { i1, ptr, ptr } %79, 2
-  %88 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %86, align 8
-  %89 = load i64, ptr %87, align 4
-  %90 = alloca { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, align 8
-  %91 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %90, i32 0, i32 0
-  store i1 true, ptr %91, align 1
-  %92 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %90, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.eface" %88, ptr %92, align 8
-  %93 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %90, i32 0, i32 2
-  store i64 %89, ptr %93, align 4
-  %94 = load { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %90, align 8
+  %70 = extractvalue { i1, ptr, ptr } %63, 1
+  %71 = extractvalue { i1, ptr, ptr } %63, 2
+  %72 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %70, align 8
+  %73 = load i64, ptr %71, align 4
+  %74 = alloca { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, align 8
+  %75 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %74, i32 0, i32 0
+  store i1 true, ptr %75, align 1
+  %76 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %74, i32 0, i32 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %72, ptr %76, align 8
+  %77 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %74, i32 0, i32 2
+  store i64 %73, ptr %77, align 4
+  %78 = load { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %74, align 8
   br label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_1
-  %95 = alloca { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, align 8
-  %96 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %95, i32 0, i32 0
-  store i1 false, ptr %96, align 1
-  %97 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %95, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.eface" zeroinitializer, ptr %97, align 8
-  %98 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %95, i32 0, i32 2
-  store i64 0, ptr %98, align 4
-  %99 = load { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %95, align 8
+  %79 = alloca { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, align 8
+  %80 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %79, i32 0, i32 0
+  store i1 false, ptr %80, align 1
+  %81 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %79, i32 0, i32 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" zeroinitializer, ptr %81, align 8
+  %82 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %79, i32 0, i32 2
+  store i64 0, ptr %82, align 4
+  %83 = load { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %79, align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %100 = phi { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } [ %94, %_llgo_4 ], [ %99, %_llgo_5 ]
-  %101 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %100, 0
-  br i1 %101, label %_llgo_2, label %_llgo_3
+  %84 = phi { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } [ %78, %_llgo_4 ], [ %83, %_llgo_5 ]
+  %85 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %84, 0
+  br i1 %85, label %_llgo_2, label %_llgo_3
 
 _llgo_7:                                          ; preds = %_llgo_2
-  %102 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %81, 1
-  %103 = ptrtoint ptr %102 to i64
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %103)
+  %86 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %65, 1
+  %87 = load [1 x %main.N], ptr %86, align 1
+  %88 = alloca [1 x %main.N], align 8
+  call void @llvm.memset(ptr %88, i8 0, i64 2, i1 false)
+  store [1 x %main.N] %87, ptr %88, align 1
+  %89 = getelementptr inbounds %main.N, ptr %88, i64 0
+  %90 = load %main.N, ptr %89, align 1
+  %91 = extractvalue %main.N %90, 0
+  %92 = sext i8 %91 to i64
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %92)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %82)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %66)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_1
 
 _llgo_8:                                          ; preds = %_llgo_2
-  %104 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %105 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %104, i32 0, i32 0
-  store ptr @13, ptr %105, align 8
-  %106 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %104, i32 0, i32 1
-  store i64 21, ptr %106, align 4
-  %107 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %104, align 8
-  %108 = load ptr, ptr @_llgo_string, align 8
-  %109 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %107, ptr %109, align 8
-  %110 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %111 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %110, i32 0, i32 0
-  store ptr %108, ptr %111, align 8
-  %112 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %110, i32 0, i32 1
-  store ptr %109, ptr %112, align 8
-  %113 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %110, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %113)
+  %93 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %94 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %93, i32 0, i32 0
+  store ptr @13, ptr %94, align 8
+  %95 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %93, i32 0, i32 1
+  store i64 21, ptr %95, align 4
+  %96 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %93, align 8
+  %97 = load ptr, ptr @_llgo_string, align 8
+  %98 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %96, ptr %98, align 8
+  %99 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %100 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %99, i32 0, i32 0
+  store ptr %97, ptr %100, align 8
+  %101 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %99, i32 0, i32 1
+  store ptr %98, ptr %101, align 8
+  %102 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %99, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %102)
   unreachable
 }
 
-define void @main.make3() {
+define void @main.make4() {
 _llgo_0:
-  %0 = alloca [1 x %main.N], align 8
-  %1 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %0, i64 2)
-  %2 = getelementptr inbounds %main.N, ptr %1, i64 0
+  %0 = alloca [1 x ptr], align 8
+  call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
+  %1 = getelementptr inbounds ptr, ptr %0, i64 0
+  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 2)
   %3 = getelementptr inbounds %main.N, ptr %2, i32 0, i32 0
   %4 = getelementptr inbounds %main.N, ptr %2, i32 0, i32 1
   store i8 1, ptr %3, align 1
   store i8 2, ptr %4, align 1
-  %5 = load [1 x %main.N], ptr %1, align 1
-  %6 = load ptr, ptr @_llgo_main.K, align 8
-  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 2)
-  store [1 x %main.N] %5, ptr %7, align 1
+  store ptr %2, ptr %1, align 8
+  %5 = load [1 x ptr], ptr %0, align 8
+  %6 = load ptr, ptr @_llgo_main.K2, align 8
+  %7 = extractvalue [1 x ptr] %5, 0
   %8 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
   %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, i32 0, i32 0
   store ptr %6, ptr %9, align 8
   %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, i32 0, i32 1
   store ptr %7, ptr %10, align 8
   %11 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, align 8
-  %12 = alloca [1 x %main.N], align 8
-  %13 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %12, i64 2)
-  %14 = getelementptr inbounds %main.N, ptr %13, i64 0
+  %12 = alloca [1 x ptr], align 8
+  call void @llvm.memset(ptr %12, i8 0, i64 8, i1 false)
+  %13 = getelementptr inbounds ptr, ptr %12, i64 0
+  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 2)
   %15 = getelementptr inbounds %main.N, ptr %14, i32 0, i32 0
   %16 = getelementptr inbounds %main.N, ptr %14, i32 0, i32 1
   store i8 1, ptr %15, align 1
   store i8 2, ptr %16, align 1
-  %17 = load [1 x %main.N], ptr %13, align 1
-  %18 = load ptr, ptr @_llgo_main.K, align 8
-  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 2)
-  store [1 x %main.N] %17, ptr %19, align 1
+  store ptr %14, ptr %13, align 8
+  %17 = load [1 x ptr], ptr %12, align 8
+  %18 = load ptr, ptr @_llgo_main.K2, align 8
+  %19 = extractvalue [1 x ptr] %17, 0
   %20 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
   %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %20, i32 0, i32 0
   store ptr %18, ptr %21, align 8
@@ -661,17 +843,18 @@ _llgo_0:
   %26 = load ptr, ptr @_llgo_int, align 8
   %27 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
   %28 = call ptr @"github.com/goplus/llgo/internal/runtime.MakeMap"(ptr %27, i64 0)
-  %29 = alloca [1 x %main.N], align 8
-  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %29, i64 2)
-  %31 = getelementptr inbounds %main.N, ptr %30, i64 0
+  %29 = alloca [1 x ptr], align 8
+  call void @llvm.memset(ptr %29, i8 0, i64 8, i1 false)
+  %30 = getelementptr inbounds ptr, ptr %29, i64 0
+  %31 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 2)
   %32 = getelementptr inbounds %main.N, ptr %31, i32 0, i32 0
   %33 = getelementptr inbounds %main.N, ptr %31, i32 0, i32 1
   store i8 1, ptr %32, align 1
   store i8 2, ptr %33, align 1
-  %34 = load [1 x %main.N], ptr %30, align 1
-  %35 = load ptr, ptr @_llgo_main.K, align 8
-  %36 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 2)
-  store [1 x %main.N] %34, ptr %36, align 1
+  store ptr %31, ptr %30, align 8
+  %34 = load [1 x ptr], ptr %29, align 8
+  %35 = load ptr, ptr @_llgo_main.K2, align 8
+  %36 = extractvalue [1 x ptr] %34, 0
   %37 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
   %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %37, i32 0, i32 0
   store ptr %35, ptr %38, align 8
@@ -685,17 +868,18 @@ _llgo_0:
   store %"github.com/goplus/llgo/internal/runtime.eface" %40, ptr %44, align 8
   %45 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %43, ptr %28, ptr %44)
   store i64 100, ptr %45, align 4
-  %46 = alloca [1 x %main.N], align 8
-  %47 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %46, i64 2)
-  %48 = getelementptr inbounds %main.N, ptr %47, i64 0
+  %46 = alloca [1 x ptr], align 8
+  call void @llvm.memset(ptr %46, i8 0, i64 8, i1 false)
+  %47 = getelementptr inbounds ptr, ptr %46, i64 0
+  %48 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 2)
   %49 = getelementptr inbounds %main.N, ptr %48, i32 0, i32 0
   %50 = getelementptr inbounds %main.N, ptr %48, i32 0, i32 1
   store i8 3, ptr %49, align 1
   store i8 4, ptr %50, align 1
-  %51 = load [1 x %main.N], ptr %47, align 1
-  %52 = load ptr, ptr @_llgo_main.K, align 8
-  %53 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 2)
-  store [1 x %main.N] %51, ptr %53, align 1
+  store ptr %48, ptr %47, align 8
+  %51 = load [1 x ptr], ptr %46, align 8
+  %52 = load ptr, ptr @_llgo_main.K2, align 8
+  %53 = extractvalue [1 x ptr] %51, 0
   %54 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
   %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %54, i32 0, i32 0
   store ptr %52, ptr %55, align 8
@@ -724,7 +908,7 @@ _llgo_2:                                          ; preds = %_llgo_6
   %69 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %88, 1
   %70 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %88, 2
   %71 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %69, 0
-  %72 = load ptr, ptr @_llgo_main.K, align 8
+  %72 = load ptr, ptr @_llgo_main.K2, align 8
   %73 = icmp eq ptr %71, %72
   br i1 %73, label %_llgo_7, label %_llgo_8
 
@@ -764,216 +948,32 @@ _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
 
 _llgo_7:                                          ; preds = %_llgo_2
   %90 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %69, 1
-  %91 = load [1 x %main.N], ptr %90, align 1
-  %92 = alloca [1 x %main.N], align 8
-  %93 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %92, i64 2)
-  store [1 x %main.N] %91, ptr %93, align 1
-  %94 = getelementptr inbounds %main.N, ptr %93, i64 0
-  %95 = load %main.N, ptr %94, align 1
-  %96 = extractvalue %main.N %95, 0
-  %97 = sext i8 %96 to i64
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %97)
+  %91 = getelementptr inbounds %main.N, ptr %90, i32 0, i32 0
+  %92 = load i8, ptr %91, align 1
+  %93 = sext i8 %92 to i64
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %93)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %70)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_1
 
 _llgo_8:                                          ; preds = %_llgo_2
-  %98 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %99 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %98, i32 0, i32 0
-  store ptr @13, ptr %99, align 8
-  %100 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %98, i32 0, i32 1
-  store i64 21, ptr %100, align 4
-  %101 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %98, align 8
-  %102 = load ptr, ptr @_llgo_string, align 8
-  %103 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %101, ptr %103, align 8
-  %104 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %105 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %104, i32 0, i32 0
-  store ptr %102, ptr %105, align 8
-  %106 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %104, i32 0, i32 1
-  store ptr %103, ptr %106, align 8
-  %107 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %104, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %107)
-  unreachable
-}
-
-define void @main.make4() {
-_llgo_0:
-  %0 = alloca [1 x ptr], align 8
-  %1 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %0, i64 8)
-  %2 = getelementptr inbounds ptr, ptr %1, i64 0
-  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 2)
-  %4 = getelementptr inbounds %main.N, ptr %3, i32 0, i32 0
-  %5 = getelementptr inbounds %main.N, ptr %3, i32 0, i32 1
-  store i8 1, ptr %4, align 1
-  store i8 2, ptr %5, align 1
-  store ptr %3, ptr %2, align 8
-  %6 = load [1 x ptr], ptr %1, align 8
-  %7 = load ptr, ptr @_llgo_main.K2, align 8
-  %8 = extractvalue [1 x ptr] %6, 0
-  %9 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %9, i32 0, i32 0
-  store ptr %7, ptr %10, align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %9, i32 0, i32 1
-  store ptr %8, ptr %11, align 8
-  %12 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %9, align 8
-  %13 = alloca [1 x ptr], align 8
-  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %13, i64 8)
-  %15 = getelementptr inbounds ptr, ptr %14, i64 0
-  %16 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 2)
-  %17 = getelementptr inbounds %main.N, ptr %16, i32 0, i32 0
-  %18 = getelementptr inbounds %main.N, ptr %16, i32 0, i32 1
-  store i8 1, ptr %17, align 1
-  store i8 2, ptr %18, align 1
-  store ptr %16, ptr %15, align 8
-  %19 = load [1 x ptr], ptr %14, align 8
-  %20 = load ptr, ptr @_llgo_main.K2, align 8
-  %21 = extractvalue [1 x ptr] %19, 0
-  %22 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %22, i32 0, i32 0
-  store ptr %20, ptr %23, align 8
-  %24 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %22, i32 0, i32 1
-  store ptr %21, ptr %24, align 8
-  %25 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %22, align 8
-  %26 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %12, %"github.com/goplus/llgo/internal/runtime.eface" %25)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %26)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %27 = load ptr, ptr @_llgo_any, align 8
-  %28 = load ptr, ptr @_llgo_int, align 8
-  %29 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
-  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.MakeMap"(ptr %29, i64 0)
-  %31 = alloca [1 x ptr], align 8
-  %32 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %31, i64 8)
-  %33 = getelementptr inbounds ptr, ptr %32, i64 0
-  %34 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 2)
-  %35 = getelementptr inbounds %main.N, ptr %34, i32 0, i32 0
-  %36 = getelementptr inbounds %main.N, ptr %34, i32 0, i32 1
-  store i8 1, ptr %35, align 1
-  store i8 2, ptr %36, align 1
-  store ptr %34, ptr %33, align 8
-  %37 = load [1 x ptr], ptr %32, align 8
-  %38 = load ptr, ptr @_llgo_main.K2, align 8
-  %39 = extractvalue [1 x ptr] %37, 0
-  %40 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %41 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %40, i32 0, i32 0
-  store ptr %38, ptr %41, align 8
-  %42 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %40, i32 0, i32 1
-  store ptr %39, ptr %42, align 8
-  %43 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %40, align 8
-  %44 = load ptr, ptr @_llgo_any, align 8
-  %45 = load ptr, ptr @_llgo_int, align 8
-  %46 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
-  %47 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.eface" %43, ptr %47, align 8
-  %48 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %46, ptr %30, ptr %47)
-  store i64 100, ptr %48, align 4
-  %49 = alloca [1 x ptr], align 8
-  %50 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %49, i64 8)
-  %51 = getelementptr inbounds ptr, ptr %50, i64 0
-  %52 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 2)
-  %53 = getelementptr inbounds %main.N, ptr %52, i32 0, i32 0
-  %54 = getelementptr inbounds %main.N, ptr %52, i32 0, i32 1
-  store i8 3, ptr %53, align 1
-  store i8 4, ptr %54, align 1
-  store ptr %52, ptr %51, align 8
-  %55 = load [1 x ptr], ptr %50, align 8
-  %56 = load ptr, ptr @_llgo_main.K2, align 8
-  %57 = extractvalue [1 x ptr] %55, 0
-  %58 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %59 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %58, i32 0, i32 0
-  store ptr %56, ptr %59, align 8
-  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %58, i32 0, i32 1
-  store ptr %57, ptr %60, align 8
-  %61 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %58, align 8
-  %62 = load ptr, ptr @_llgo_any, align 8
-  %63 = load ptr, ptr @_llgo_int, align 8
-  %64 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
-  %65 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.eface" %61, ptr %65, align 8
-  %66 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %64, ptr %30, ptr %65)
-  store i64 200, ptr %66, align 4
-  %67 = load ptr, ptr @_llgo_any, align 8
-  %68 = load ptr, ptr @_llgo_int, align 8
-  %69 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
-  %70 = call ptr @"github.com/goplus/llgo/internal/runtime.NewMapIter"(ptr %69, ptr %30)
-  br label %_llgo_1
-
-_llgo_1:                                          ; preds = %_llgo_7, %_llgo_0
-  %71 = call { i1, ptr, ptr } @"github.com/goplus/llgo/internal/runtime.MapIterNext"(ptr %70)
-  %72 = extractvalue { i1, ptr, ptr } %71, 0
-  br i1 %72, label %_llgo_4, label %_llgo_5
-
-_llgo_2:                                          ; preds = %_llgo_6
-  %73 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %92, 1
-  %74 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %92, 2
-  %75 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %73, 0
-  %76 = load ptr, ptr @_llgo_main.K2, align 8
-  %77 = icmp eq ptr %75, %76
-  br i1 %77, label %_llgo_7, label %_llgo_8
-
-_llgo_3:                                          ; preds = %_llgo_6
-  ret void
-
-_llgo_4:                                          ; preds = %_llgo_1
-  %78 = extractvalue { i1, ptr, ptr } %71, 1
-  %79 = extractvalue { i1, ptr, ptr } %71, 2
-  %80 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %78, align 8
-  %81 = load i64, ptr %79, align 4
-  %82 = alloca { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, align 8
-  %83 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %82, i32 0, i32 0
-  store i1 true, ptr %83, align 1
-  %84 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %82, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.eface" %80, ptr %84, align 8
-  %85 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %82, i32 0, i32 2
-  store i64 %81, ptr %85, align 4
-  %86 = load { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %82, align 8
-  br label %_llgo_6
-
-_llgo_5:                                          ; preds = %_llgo_1
-  %87 = alloca { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, align 8
-  %88 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %87, i32 0, i32 0
-  store i1 false, ptr %88, align 1
-  %89 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %87, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.eface" zeroinitializer, ptr %89, align 8
-  %90 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %87, i32 0, i32 2
-  store i64 0, ptr %90, align 4
-  %91 = load { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %87, align 8
-  br label %_llgo_6
-
-_llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %92 = phi { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } [ %86, %_llgo_4 ], [ %91, %_llgo_5 ]
-  %93 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %92, 0
-  br i1 %93, label %_llgo_2, label %_llgo_3
-
-_llgo_7:                                          ; preds = %_llgo_2
-  %94 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %73, 1
-  %95 = getelementptr inbounds %main.N, ptr %94, i32 0, i32 0
-  %96 = load i8, ptr %95, align 1
-  %97 = sext i8 %96 to i64
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %97)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %74)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  br label %_llgo_1
-
-_llgo_8:                                          ; preds = %_llgo_2
-  %98 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %99 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %98, i32 0, i32 0
-  store ptr @13, ptr %99, align 8
-  %100 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %98, i32 0, i32 1
-  store i64 21, ptr %100, align 4
-  %101 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %98, align 8
-  %102 = load ptr, ptr @_llgo_string, align 8
-  %103 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %101, ptr %103, align 8
-  %104 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %105 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %104, i32 0, i32 0
-  store ptr %102, ptr %105, align 8
-  %106 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %104, i32 0, i32 1
-  store ptr %103, ptr %106, align 8
-  %107 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %104, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %107)
+  %94 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %95 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %94, i32 0, i32 0
+  store ptr @13, ptr %95, align 8
+  %96 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %94, i32 0, i32 1
+  store i64 21, ptr %96, align 4
+  %97 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %94, align 8
+  %98 = load ptr, ptr @_llgo_string, align 8
+  %99 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %97, ptr %99, align 8
+  %100 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %101 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %100, i32 0, i32 0
+  store ptr %98, ptr %101, align 8
+  %102 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %100, i32 0, i32 1
+  store ptr %99, ptr %102, align 8
+  %103 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %100, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %103)
   unreachable
 }
 
@@ -2139,7 +2139,8 @@ declare void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplu
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.Slice")
 
-declare ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr, i64)
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(i64, i64, i64, i64)
 
@@ -2154,3 +2155,5 @@ declare ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr)
 declare ptr @"github.com/goplus/llgo/internal/runtime.NewChan"(i64, i64)
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.ChanOf"(i64, %"github.com/goplus/llgo/internal/runtime.String", ptr)
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testrt/slice2array/out.ll
+++ b/cl/_testrt/slice2array/out.ll
@@ -95,21 +95,21 @@ _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
   %42 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %38, 0
   %43 = load [2 x i8], ptr %42, align 1
   %44 = alloca [2 x i8], align 1
-  %45 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %44, i64 2)
-  %46 = getelementptr inbounds i8, ptr %45, i64 0
-  %47 = getelementptr inbounds i8, ptr %45, i64 1
-  store i8 1, ptr %46, align 1
-  store i8 2, ptr %47, align 1
-  %48 = load [2 x i8], ptr %45, align 1
-  %49 = extractvalue [2 x i8] %43, 0
-  %50 = extractvalue [2 x i8] %48, 0
-  %51 = icmp eq i8 %49, %50
-  %52 = and i1 true, %51
-  %53 = extractvalue [2 x i8] %43, 1
-  %54 = extractvalue [2 x i8] %48, 1
-  %55 = icmp eq i8 %53, %54
-  %56 = and i1 %52, %55
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %56)
+  call void @llvm.memset(ptr %44, i8 0, i64 2, i1 false)
+  %45 = getelementptr inbounds i8, ptr %44, i64 0
+  %46 = getelementptr inbounds i8, ptr %44, i64 1
+  store i8 1, ptr %45, align 1
+  store i8 2, ptr %46, align 1
+  %47 = load [2 x i8], ptr %44, align 1
+  %48 = extractvalue [2 x i8] %43, 0
+  %49 = extractvalue [2 x i8] %47, 0
+  %50 = icmp eq i8 %48, %49
+  %51 = and i1 true, %50
+  %52 = extractvalue [2 x i8] %43, 1
+  %53 = extractvalue [2 x i8] %47, 1
+  %54 = icmp eq i8 %52, %53
+  %55 = and i1 %51, %54
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %55)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 }
@@ -124,4 +124,7 @@ declare void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1)
 
 declare void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8)
 
-declare ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr, i64)
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testrt/struct/out.ll
+++ b/cl/_testrt/struct/out.ll
@@ -11,16 +11,16 @@ source_filename = "main"
 define void @main.Foo.Print(%main.Foo %0) {
 _llgo_0:
   %1 = alloca %main.Foo, align 8
-  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %1, i64 8)
-  store %main.Foo %0, ptr %2, align 4
-  %3 = getelementptr inbounds %main.Foo, ptr %2, i32 0, i32 1
-  %4 = load i1, ptr %3, align 1
-  br i1 %4, label %_llgo_1, label %_llgo_2
+  call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
+  store %main.Foo %0, ptr %1, align 4
+  %2 = getelementptr inbounds %main.Foo, ptr %1, i32 0, i32 1
+  %3 = load i1, ptr %2, align 1
+  br i1 %3, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %5 = getelementptr inbounds %main.Foo, ptr %2, i32 0, i32 0
-  %6 = load i32, ptr %5, align 4
-  call void (ptr, ...) @printf(ptr @main.format, i32 %6)
+  %4 = getelementptr inbounds %main.Foo, ptr %1, i32 0, i32 0
+  %5 = load i32, ptr %4, align 4
+  call void (ptr, ...) @printf(ptr @main.format, i32 %5)
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
@@ -65,20 +65,23 @@ _llgo_0:
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
   %2 = alloca %main.Foo, align 8
-  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %2, i64 8)
-  %4 = getelementptr inbounds %main.Foo, ptr %3, i32 0, i32 0
-  %5 = getelementptr inbounds %main.Foo, ptr %3, i32 0, i32 1
-  store i32 100, ptr %4, align 4
-  store i1 true, ptr %5, align 1
-  %6 = load %main.Foo, ptr %3, align 4
-  call void @main.Foo.Print(%main.Foo %6)
+  call void @llvm.memset(ptr %2, i8 0, i64 8, i1 false)
+  %3 = getelementptr inbounds %main.Foo, ptr %2, i32 0, i32 0
+  %4 = getelementptr inbounds %main.Foo, ptr %2, i32 0, i32 1
+  store i32 100, ptr %3, align 4
+  store i1 true, ptr %4, align 1
+  %5 = load %main.Foo, ptr %2, align 4
+  call void @main.Foo.Print(%main.Foo %5)
   ret i32 0
 }
 
-declare ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr, i64)
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
 
 declare void @printf(ptr, ...)
 
 declare void @syscall.init()
 
 declare void @"github.com/goplus/llgo/internal/runtime.init"()
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testrt/tpabi/out.ll
+++ b/cl/_testrt/tpabi/out.ll
@@ -50,120 +50,120 @@ _llgo_0:
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
   %2 = alloca %"main.T[string,int]", align 8
-  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %2, i64 24)
-  %4 = getelementptr inbounds %"main.T[string,int]", ptr %3, i32 0, i32 0
-  %5 = getelementptr inbounds %"main.T[string,int]", ptr %3, i32 0, i32 1
-  %6 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %6, i32 0, i32 0
-  store ptr @0, ptr %7, align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %6, i32 0, i32 1
-  store i64 1, ptr %8, align 4
-  %9 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %6, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %9, ptr %4, align 8
-  store i64 1, ptr %5, align 4
-  %10 = load %"main.T[string,int]", ptr %3, align 8
-  %11 = load ptr, ptr @"_llgo_main.T[string,int]", align 8
-  %12 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  store %"main.T[string,int]" %10, ptr %12, align 8
-  %13 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %13, i32 0, i32 0
+  call void @llvm.memset(ptr %2, i8 0, i64 24, i1 false)
+  %3 = getelementptr inbounds %"main.T[string,int]", ptr %2, i32 0, i32 0
+  %4 = getelementptr inbounds %"main.T[string,int]", ptr %2, i32 0, i32 1
+  %5 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %5, i32 0, i32 0
+  store ptr @0, ptr %6, align 8
+  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %5, i32 0, i32 1
+  store i64 1, ptr %7, align 4
+  %8 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %5, align 8
+  store %"github.com/goplus/llgo/internal/runtime.String" %8, ptr %3, align 8
+  store i64 1, ptr %4, align 4
+  %9 = load %"main.T[string,int]", ptr %2, align 8
+  %10 = load ptr, ptr @"_llgo_main.T[string,int]", align 8
+  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  store %"main.T[string,int]" %9, ptr %11, align 8
+  %12 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %12, i32 0, i32 0
+  store ptr %10, ptr %13, align 8
+  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %12, i32 0, i32 1
   store ptr %11, ptr %14, align 8
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %13, i32 0, i32 1
-  store ptr %12, ptr %15, align 8
-  %16 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %13, align 8
-  %17 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %16, 0
-  %18 = load ptr, ptr @"_llgo_main.T[string,int]", align 8
-  %19 = icmp eq ptr %17, %18
-  br i1 %19, label %_llgo_1, label %_llgo_2
+  %15 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %12, align 8
+  %16 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %15, 0
+  %17 = load ptr, ptr @"_llgo_main.T[string,int]", align 8
+  %18 = icmp eq ptr %16, %17
+  br i1 %18, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %20 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %16, 1
-  %21 = load %"main.T[string,int]", ptr %20, align 8
-  %22 = extractvalue %"main.T[string,int]" %21, 0
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %22)
+  %19 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %15, 1
+  %20 = load %"main.T[string,int]", ptr %19, align 8
+  %21 = extractvalue %"main.T[string,int]" %20, 0
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %21)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %23 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
-  %24 = getelementptr inbounds %"main.T[string,int]", ptr %23, i32 0, i32 0
-  %25 = getelementptr inbounds %"main.T[string,int]", ptr %23, i32 0, i32 1
-  %26 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %26, i32 0, i32 0
-  store ptr @8, ptr %27, align 8
-  %28 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %26, i32 0, i32 1
-  store i64 5, ptr %28, align 4
-  %29 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %26, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %29, ptr %24, align 8
-  store i64 100, ptr %25, align 4
-  %30 = load ptr, ptr @"*_llgo_main.T[string,int]", align 8
-  %31 = load ptr, ptr @"_llgo_iface$BP0p_lUsEd-IbbtJVukGmgrdQkqzcoYzSiwgUvgFvUs", align 8
-  %32 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %31, ptr %30)
-  %33 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %33, i32 0, i32 0
-  store ptr %32, ptr %34, align 8
-  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %33, i32 0, i32 1
-  store ptr %23, ptr %35, align 8
-  %36 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %33, align 8
-  %37 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %36)
-  %38 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %36, 0
-  %39 = getelementptr ptr, ptr %38, i64 3
-  %40 = load ptr, ptr %39, align 8
-  %41 = alloca { ptr, ptr }, align 8
-  %42 = getelementptr inbounds { ptr, ptr }, ptr %41, i32 0, i32 0
-  store ptr %40, ptr %42, align 8
-  %43 = getelementptr inbounds { ptr, ptr }, ptr %41, i32 0, i32 1
-  store ptr %37, ptr %43, align 8
-  %44 = load { ptr, ptr }, ptr %41, align 8
-  %45 = extractvalue { ptr, ptr } %44, 1
-  %46 = extractvalue { ptr, ptr } %44, 0
-  call void %46(ptr %45)
-  %47 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
-  %48 = getelementptr inbounds i64, ptr %47, i64 0
-  %49 = getelementptr inbounds i64, ptr %47, i64 1
-  %50 = getelementptr inbounds i64, ptr %47, i64 2
-  %51 = getelementptr inbounds i64, ptr %47, i64 3
-  store i64 1, ptr %48, align 4
-  store i64 2, ptr %49, align 4
-  store i64 3, ptr %50, align 4
-  store i64 4, ptr %51, align 4
-  %52 = getelementptr [4 x i64], ptr %47, i64 1
+  %22 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
+  %23 = getelementptr inbounds %"main.T[string,int]", ptr %22, i32 0, i32 0
+  %24 = getelementptr inbounds %"main.T[string,int]", ptr %22, i32 0, i32 1
+  %25 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 0
+  store ptr @8, ptr %26, align 8
+  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 1
+  store i64 5, ptr %27, align 4
+  %28 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %25, align 8
+  store %"github.com/goplus/llgo/internal/runtime.String" %28, ptr %23, align 8
+  store i64 100, ptr %24, align 4
+  %29 = load ptr, ptr @"*_llgo_main.T[string,int]", align 8
+  %30 = load ptr, ptr @"_llgo_iface$BP0p_lUsEd-IbbtJVukGmgrdQkqzcoYzSiwgUvgFvUs", align 8
+  %31 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %30, ptr %29)
+  %32 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
+  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %32, i32 0, i32 0
+  store ptr %31, ptr %33, align 8
+  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %32, i32 0, i32 1
+  store ptr %22, ptr %34, align 8
+  %35 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %32, align 8
+  %36 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %35)
+  %37 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %35, 0
+  %38 = getelementptr ptr, ptr %37, i64 3
+  %39 = load ptr, ptr %38, align 8
+  %40 = alloca { ptr, ptr }, align 8
+  %41 = getelementptr inbounds { ptr, ptr }, ptr %40, i32 0, i32 0
+  store ptr %39, ptr %41, align 8
+  %42 = getelementptr inbounds { ptr, ptr }, ptr %40, i32 0, i32 1
+  store ptr %36, ptr %42, align 8
+  %43 = load { ptr, ptr }, ptr %40, align 8
+  %44 = extractvalue { ptr, ptr } %43, 1
+  %45 = extractvalue { ptr, ptr } %43, 0
+  call void %45(ptr %44)
+  %46 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
+  %47 = getelementptr inbounds i64, ptr %46, i64 0
+  %48 = getelementptr inbounds i64, ptr %46, i64 1
+  %49 = getelementptr inbounds i64, ptr %46, i64 2
+  %50 = getelementptr inbounds i64, ptr %46, i64 3
+  store i64 1, ptr %47, align 4
+  store i64 2, ptr %48, align 4
+  store i64 3, ptr %49, align 4
+  store i64 4, ptr %50, align 4
+  %51 = getelementptr [4 x i64], ptr %46, i64 1
+  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %51)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
+  %52 = getelementptr [4 x i64], ptr %46, i64 1
   call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %52)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %53 = getelementptr [4 x i64], ptr %47, i64 1
-  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %53)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %54 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %54, i32 0, i32 0
-  store ptr @7, ptr %55, align 8
-  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %54, i32 0, i32 1
-  store i64 21, ptr %56, align 4
-  %57 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %54, align 8
-  %58 = load ptr, ptr @_llgo_string, align 8
-  %59 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %57, ptr %59, align 8
-  %60 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %61 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %60, i32 0, i32 0
+  %53 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %54 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %53, i32 0, i32 0
+  store ptr @7, ptr %54, align 8
+  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %53, i32 0, i32 1
+  store i64 21, ptr %55, align 4
+  %56 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %53, align 8
+  %57 = load ptr, ptr @_llgo_string, align 8
+  %58 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %56, ptr %58, align 8
+  %59 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %59, i32 0, i32 0
+  store ptr %57, ptr %60, align 8
+  %61 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %59, i32 0, i32 1
   store ptr %58, ptr %61, align 8
-  %62 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %60, i32 0, i32 1
-  store ptr %59, ptr %62, align 8
-  %63 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %60, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %63)
+  %62 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %59, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %62)
   unreachable
 }
 
 define linkonce void @"main.T[string,int].Info"(%"main.T[string,int]" %0) {
 _llgo_0:
   %1 = alloca %"main.T[string,int]", align 8
-  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %1, i64 24)
-  store %"main.T[string,int]" %0, ptr %2, align 8
-  %3 = getelementptr inbounds %"main.T[string,int]", ptr %2, i32 0, i32 0
-  %4 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3, align 8
-  %5 = getelementptr inbounds %"main.T[string,int]", ptr %2, i32 0, i32 1
-  %6 = load i64, ptr %5, align 4
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %4)
+  call void @llvm.memset(ptr %1, i8 0, i64 24, i1 false)
+  store %"main.T[string,int]" %0, ptr %1, align 8
+  %2 = getelementptr inbounds %"main.T[string,int]", ptr %1, i32 0, i32 0
+  %3 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
+  %4 = getelementptr inbounds %"main.T[string,int]", ptr %1, i32 0, i32 1
+  %5 = load i64, ptr %4, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %3)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %6)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %5)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret void
 }
@@ -190,7 +190,8 @@ _llgo_0:
 
 declare void @"github.com/goplus/llgo/internal/runtime.init"()
 
-declare ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr, i64)
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
 
 define void @"main.init$after"() {
 _llgo_0:
@@ -475,3 +476,5 @@ declare ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com
 declare void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr)
 
 declare void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64)
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testrt/tpmethod/out.ll
+++ b/cl/_testrt/tpmethod/out.ll
@@ -54,13 +54,13 @@ _llgo_0:
 define void @"main.ReadFile$1"({ ptr, ptr } %0) {
 _llgo_0:
   %1 = alloca %"main.Tuple[error]", align 8
-  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %1, i64 16)
-  %3 = getelementptr inbounds %"main.Tuple[error]", ptr %2, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer, ptr %3, align 8
-  %4 = load %"main.Tuple[error]", ptr %2, align 8
-  %5 = extractvalue { ptr, ptr } %0, 1
-  %6 = extractvalue { ptr, ptr } %0, 0
-  call void %6(ptr %5, %"main.Tuple[error]" %4)
+  call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+  %2 = getelementptr inbounds %"main.Tuple[error]", ptr %1, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer, ptr %2, align 8
+  %3 = load %"main.Tuple[error]", ptr %1, align 8
+  %4 = extractvalue { ptr, ptr } %0, 1
+  %5 = extractvalue { ptr, ptr } %0, 0
+  call void %5(ptr %4, %"main.Tuple[error]" %3)
   ret void
 }
 
@@ -124,11 +124,11 @@ _llgo_0:
 define linkonce %"github.com/goplus/llgo/internal/runtime.iface" @"main.Tuple[error].Get"(%"main.Tuple[error]" %0) {
 _llgo_0:
   %1 = alloca %"main.Tuple[error]", align 8
-  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %1, i64 16)
-  store %"main.Tuple[error]" %0, ptr %2, align 8
-  %3 = getelementptr inbounds %"main.Tuple[error]", ptr %2, i32 0, i32 0
-  %4 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %3, align 8
-  ret %"github.com/goplus/llgo/internal/runtime.iface" %4
+  call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+  store %"main.Tuple[error]" %0, ptr %1, align 8
+  %2 = getelementptr inbounds %"main.Tuple[error]", ptr %1, i32 0, i32 0
+  %3 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %2, align 8
+  ret %"github.com/goplus/llgo/internal/runtime.iface" %3
 }
 
 define %"github.com/goplus/llgo/internal/runtime.iface" @"main.(*Tuple[error]).Get"(ptr %0) {
@@ -171,7 +171,8 @@ _llgo_0:
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr, i64)
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
 
 declare void @"github.com/goplus/llgo/internal/runtime.init"()
 
@@ -796,3 +797,5 @@ declare void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr, %"github.
 declare ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr)
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr, ptr)
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testrt/typed/out.ll
+++ b/cl/_testrt/typed/out.ll
@@ -117,62 +117,62 @@ _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
   call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %42)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   %43 = alloca [2 x i64], align 8
-  %44 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %43, i64 16)
-  %45 = getelementptr inbounds i64, ptr %44, i64 0
-  %46 = getelementptr inbounds i64, ptr %44, i64 1
-  store i64 1, ptr %45, align 4
-  store i64 2, ptr %46, align 4
-  %47 = load [2 x i64], ptr %44, align 4
-  %48 = load ptr, ptr @_llgo_main.A, align 8
-  %49 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store [2 x i64] %47, ptr %49, align 4
-  %50 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %50, i32 0, i32 0
+  call void @llvm.memset(ptr %43, i8 0, i64 16, i1 false)
+  %44 = getelementptr inbounds i64, ptr %43, i64 0
+  %45 = getelementptr inbounds i64, ptr %43, i64 1
+  store i64 1, ptr %44, align 4
+  store i64 2, ptr %45, align 4
+  %46 = load [2 x i64], ptr %43, align 4
+  %47 = load ptr, ptr @_llgo_main.A, align 8
+  %48 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store [2 x i64] %46, ptr %48, align 4
+  %49 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %49, i32 0, i32 0
+  store ptr %47, ptr %50, align 8
+  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %49, i32 0, i32 1
   store ptr %48, ptr %51, align 8
-  %52 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %50, i32 0, i32 1
-  store ptr %49, ptr %52, align 8
-  %53 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %50, align 8
-  %54 = alloca [2 x i64], align 8
-  %55 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %54, i64 16)
-  %56 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %53, 0
-  %57 = load ptr, ptr @_llgo_main.A, align 8
-  %58 = icmp eq ptr %56, %57
-  br i1 %58, label %_llgo_6, label %_llgo_7
+  %52 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %49, align 8
+  %53 = alloca [2 x i64], align 8
+  call void @llvm.memset(ptr %53, i8 0, i64 16, i1 false)
+  %54 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %52, 0
+  %55 = load ptr, ptr @_llgo_main.A, align 8
+  %56 = icmp eq ptr %54, %55
+  br i1 %56, label %_llgo_6, label %_llgo_7
 
 _llgo_6:                                          ; preds = %_llgo_5
-  %59 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %53, 1
-  %60 = load [2 x i64], ptr %59, align 4
-  %61 = alloca { [2 x i64], i1 }, align 8
-  %62 = getelementptr inbounds { [2 x i64], i1 }, ptr %61, i32 0, i32 0
-  store [2 x i64] %60, ptr %62, align 4
-  %63 = getelementptr inbounds { [2 x i64], i1 }, ptr %61, i32 0, i32 1
-  store i1 true, ptr %63, align 1
-  %64 = load { [2 x i64], i1 }, ptr %61, align 4
+  %57 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %52, 1
+  %58 = load [2 x i64], ptr %57, align 4
+  %59 = alloca { [2 x i64], i1 }, align 8
+  %60 = getelementptr inbounds { [2 x i64], i1 }, ptr %59, i32 0, i32 0
+  store [2 x i64] %58, ptr %60, align 4
+  %61 = getelementptr inbounds { [2 x i64], i1 }, ptr %59, i32 0, i32 1
+  store i1 true, ptr %61, align 1
+  %62 = load { [2 x i64], i1 }, ptr %59, align 4
   br label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_5
-  %65 = alloca { [2 x i64], i1 }, align 8
-  %66 = getelementptr inbounds { [2 x i64], i1 }, ptr %65, i32 0, i32 0
-  store [2 x i64] zeroinitializer, ptr %66, align 4
-  %67 = getelementptr inbounds { [2 x i64], i1 }, ptr %65, i32 0, i32 1
-  store i1 false, ptr %67, align 1
-  %68 = load { [2 x i64], i1 }, ptr %65, align 4
+  %63 = alloca { [2 x i64], i1 }, align 8
+  %64 = getelementptr inbounds { [2 x i64], i1 }, ptr %63, i32 0, i32 0
+  store [2 x i64] zeroinitializer, ptr %64, align 4
+  %65 = getelementptr inbounds { [2 x i64], i1 }, ptr %63, i32 0, i32 1
+  store i1 false, ptr %65, align 1
+  %66 = load { [2 x i64], i1 }, ptr %63, align 4
   br label %_llgo_8
 
 _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
-  %69 = phi { [2 x i64], i1 } [ %64, %_llgo_6 ], [ %68, %_llgo_7 ]
-  %70 = extractvalue { [2 x i64], i1 } %69, 0
-  store [2 x i64] %70, ptr %55, align 4
-  %71 = extractvalue { [2 x i64], i1 } %69, 1
-  %72 = getelementptr inbounds i64, ptr %55, i64 0
+  %67 = phi { [2 x i64], i1 } [ %62, %_llgo_6 ], [ %66, %_llgo_7 ]
+  %68 = extractvalue { [2 x i64], i1 } %67, 0
+  store [2 x i64] %68, ptr %53, align 4
+  %69 = extractvalue { [2 x i64], i1 } %67, 1
+  %70 = getelementptr inbounds i64, ptr %53, i64 0
+  %71 = load i64, ptr %70, align 4
+  %72 = getelementptr inbounds i64, ptr %53, i64 1
   %73 = load i64, ptr %72, align 4
-  %74 = getelementptr inbounds i64, ptr %55, i64 1
-  %75 = load i64, ptr %74, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %71)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %73)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %75)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %71)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %69)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 }
@@ -292,8 +292,11 @@ declare void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8)
 
 declare void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1)
 
-declare ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr, i64)
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64, ptr)
 
 declare void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64)
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/internal/runtime/z_rt.go
+++ b/internal/runtime/z_rt.go
@@ -95,11 +95,6 @@ func stringTracef(fp c.FilePtr, format *c.Char, s String) {
 
 // -----------------------------------------------------------------------------
 
-// Zeroinit initializes memory to zero.
-func Zeroinit(p unsafe.Pointer, size uintptr) unsafe.Pointer {
-	return c.Memset(p, 0, size)
-}
-
 // New allocates memory and initializes it to zero.
 func New(t *Type) unsafe.Pointer {
 	return AllocZ(t.Size_)

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -179,8 +179,9 @@ type aProgram struct {
 	getAttrStr   *types.Signature
 	pyUniStr     *types.Signature
 
-	mallocTy *types.Signature
-	freeTy   *types.Signature
+	mallocTy       *types.Signature
+	freeTy         *types.Signature
+	memsetInlineTy *types.Signature
 
 	createKeyTy *types.Signature
 	getSpecTy   *types.Signature


### PR DESCRIPTION
The `runtime.Zeroinit` function isn't compatible with `ssa.NaiveForm` mode (fully disable SSA optimizations for debugging), because the compiler will generate recursive code.

Another reason is that in the disassembly code, `runtime.Zeroinit` isn't inlined; it calls the C function `_memset`. These should be replaced with the `LLVM memset intrinsic` and be compiled to inlined code. See https://llvm.org/docs/LangRef.html#llvm-memset-intrinsics

`c.Memset` maybe also need to be replaced with an `llgo:link` instruction to rewrite it to the `memset intrinsic`.

Test code:
```go

type E struct {
}
type F struct {
	e *E
	i int
	f float64
}

func Bar() {
	f := F{e: &E{}}
	println(f.e)
}
```

Before:
```llvm
define void @main.Bar() {
_llgo_0:
  %0 = alloca %main.F, align 8
  %1 = call ptr @"github.com/goplus/llgo/internal/runtime.Zeroinit"(ptr %0, i64 24)
  %2 = getelementptr inbounds %main.F, ptr %1, i32 0, i32 0
  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 0)
  store ptr %3, ptr %2, align 8
  %4 = getelementptr inbounds %main.F, ptr %1, i32 0, i32 0
  %5 = load ptr, ptr %4, align 8
  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %5)
  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
  ret void
}
```

```asm
_main.Bar:
00000001000007d0	sub	sp, sp, #0x30
00000001000007d4	stp	x29, x30, [sp, #0x20]
00000001000007d8	add	x0, sp, #0x8
00000001000007dc	mov	w8, #0x18
00000001000007e0	mov	x1, x8
00000001000007e4	bl	"_github.com/goplus/llgo/internal/runtime.Zeroinit"
00000001000007e8	str	x0, [sp]
00000001000007ec	mov	x0, #0x0
00000001000007f0	bl	"_github.com/goplus/llgo/internal/runtime.AllocZ"
00000001000007f4	mov	x8, x0
00000001000007f8	ldr	x0, [sp]
00000001000007fc	str	x8, [x0]
0000000100000800	ldr	x0, [x0]
0000000100000804	bl	"_github.com/goplus/llgo/internal/runtime.PrintPointer"
0000000100000808	mov	w0, #0xa
000000010000080c	bl	"_github.com/goplus/llgo/internal/runtime.PrintByte"
0000000100000810	ldp	x29, x30, [sp, #0x20]
0000000100000814	add	sp, sp, #0x30
0000000100000818	ret

_github.com/goplus/llgo/internal/runtime.Zeroinit:
0000000100003a48	stp	x29, x30, [sp, #-0x10]!
0000000100003a4c	mov	x2, x1
0000000100003a50	mov	w1, #0x0
0000000100003a54	bl	0x10000ad98 ; symbol stub for: _memset
0000000100003a58	ldp	x29, x30, [sp], #0x10
0000000100003a5c	ret
```

After:

```llvm
define void @main.Bar() {
_llgo_0:
  %0 = alloca %main.F, align 8
  call void @llvm.memset(ptr %0, i8 0, i64 24, i1 false)
  %1 = getelementptr inbounds %main.F, ptr %0, i32 0, i32 0
  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 0)
  store ptr %2, ptr %1, align 8
  %3 = getelementptr inbounds %main.F, ptr %0, i32 0, i32 0
  %4 = load ptr, ptr %3, align 8
  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %4)
  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
  ret void
}
```

```asm
_main.Bar:
00000001000007d0	sub	sp, sp, #0x30
00000001000007d4	stp	x29, x30, [sp, #0x20]
00000001000007d8	str	xzr, [sp, #0x8]
00000001000007dc	str	xzr, [sp, #0x10]
00000001000007e0	str	xzr, [sp, #0x18]
00000001000007e4	mov	x0, #0x0
00000001000007e8	bl	"_github.com/goplus/llgo/internal/runtime.AllocZ"
00000001000007ec	str	x0, [sp, #0x8]
00000001000007f0	ldr	x0, [sp, #0x8]
00000001000007f4	bl	"_github.com/goplus/llgo/internal/runtime.PrintPointer"
00000001000007f8	mov	w0, #0xa
00000001000007fc	bl	"_github.com/goplus/llgo/internal/runtime.PrintByte"
0000000100000800	ldp	x29, x30, [sp, #0x20]
0000000100000804	add	sp, sp, #0x30
0000000100000808	ret
```

The instruction `call void @llvm.memset(ptr %0, i8 0, i64 24, i1 false)` will be compiled to 3 `str` instructions.

Calls `memset` on a large more memory range will be compiled like below:

```llvm
call void @llvm.memset(ptr %0, i8 0, i64 1304, i1 false)
```

```asm
00000001000007d8	sub	sp, sp, #0x520
00000001000007dc	add	x0, sp, #0x8
00000001000007e0	mov	w8, #0x518
00000001000007e4	mov	x1, x8
00000001000007e8	bl	0x10000a964 ; symbol stub for: _bzero
```