### PR TITLE
Debug: fix struct vars debug, params modication, supports expressions, lexical scope/lifecycle

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -99,6 +99,7 @@ jobs:
           bash .github/workflows/test_llgo.sh
       
       - name: LLDB tests
+        if: ${{startsWith(matrix.os, 'macos')}}
         run: |
           echo "Test lldb with llgo plugin on ${{matrix.os}} with LLVM ${{matrix.llvm}}"
           bash _lldb/runtest.sh -v

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -101,7 +101,7 @@ jobs:
       - name: LLDB tests
         run: |
           echo "Test lldb with llgo plugin on ${{matrix.os}} with LLVM ${{matrix.llvm}}"
-          bash _lldb/runtest.sh
+          bash _lldb/runtest.sh -v
 
       - name: Test demos
         continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ build.dir/
 # Test binary, built with `go test -c`
 *.test
 
+# Debug symbols
+*.dSYM
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 *.swp

--- a/_lldb/common.sh
+++ b/_lldb/common.sh
@@ -34,5 +34,5 @@ export DEFAULT_PACKAGE_PATH="./cl/_testdata/debug"
 # Function to build the project
 build_project() {
     local package_path="$1"
-    LLGO_DEBUG=1 go run ./cmd/llgo build -o "${package_path}/out" "${package_path}"
+    LLGO_DEBUG=1 go run ./cmd/llgo build -o "${package_path}/debug.out" "${package_path}"
 }

--- a/_lldb/common.sh
+++ b/_lldb/common.sh
@@ -26,6 +26,8 @@ find_lldb() {
 
 # Find LLDB 18+
 LLDB_PATH=$(find_lldb)
+echo "LLDB_PATH: $LLDB_PATH"
+$LLDB_PATH --version
 export LLDB_PATH
 
 # Default package path

--- a/_lldb/llgo_plugin.py
+++ b/_lldb/llgo_plugin.py
@@ -147,7 +147,10 @@ def format_value(var: lldb.SBValue, debugger: lldb.SBDebugger, include_type: boo
 
 
 def format_slice(var: lldb.SBValue, debugger: lldb.SBDebugger, indent: int) -> str:
-    length = int(var.GetChildMemberWithName('len').GetValue())
+    length = var.GetChildMemberWithName('len').GetValue()
+    if length is None:
+        return "<variable not available>"
+    length = int(length)
     data_ptr = var.GetChildMemberWithName('data')
     elements: List[str] = []
 
@@ -204,11 +207,12 @@ def format_string(var: lldb.SBValue) -> str:
         return summary  # Keep the quotes
     else:
         data = var.GetChildMemberWithName('data').GetValue()
-        length = int(var.GetChildMemberWithName('len').GetValue())
+        length = var.GetChildMemberWithName('len').GetValue()
         if data and length:
+            length = int(length)
             error = lldb.SBError()
             return '"%s"' % var.process.ReadCStringFromMemory(int(data, 16), length + 1, error)
-    return '""'
+    return "<variable not available>"
 
 
 def format_struct(var: lldb.SBValue, debugger: lldb.SBDebugger, include_type: bool = True, indent: int = 0, type_name: str = "") -> str:

--- a/_lldb/llgo_plugin.py
+++ b/_lldb/llgo_plugin.py
@@ -117,8 +117,15 @@ def format_value(var: lldb.SBValue, debugger: lldb.SBDebugger, include_type: boo
     type_class = var_type.GetTypeClass()
     type_name = map_type_name(var_type.GetName())
 
+    # Handle typedef types
+    original_type_name = type_name
+    while var_type.IsTypedefType():
+        var_type = var_type.GetTypedefedType()
+        type_name = map_type_name(var_type.GetName())
+        type_class = var_type.GetTypeClass()
+
     if var_type.IsPointerType():
-        return format_pointer(var, debugger, indent, type_name)
+        return format_pointer(var, debugger, indent, original_type_name)
 
     if type_name.startswith('[]'):  # Slice
         return format_slice(var, debugger, indent)
@@ -127,7 +134,7 @@ def format_value(var: lldb.SBValue, debugger: lldb.SBDebugger, include_type: boo
     elif type_name == 'string':  # String
         return format_string(var)
     elif type_class in [lldb.eTypeClassStruct, lldb.eTypeClassClass]:
-        return format_struct(var, debugger, include_type, indent, type_name)
+        return format_struct(var, debugger, include_type, indent, original_type_name)
     else:
         value = var.GetValue()
         summary = var.GetSummary()

--- a/_lldb/llgo_plugin.py
+++ b/_lldb/llgo_plugin.py
@@ -93,7 +93,7 @@ def print_all_variables(debugger: lldb.SBDebugger, _command: str, result: lldb.S
 
     frame = debugger.GetSelectedTarget().GetProcess(
     ).GetSelectedThread().GetSelectedFrame()
-    variables = frame.GetVariables(True, True, True, False)
+    variables = frame.GetVariables(True, True, True, True)
 
     output: List[str] = []
     for var in variables:

--- a/_lldb/runlldb.sh
+++ b/_lldb/runlldb.sh
@@ -8,5 +8,8 @@ source "$(dirname "$0")/common.sh"
 
 executable="$1"
 
-# Run LLDB
-"$LLDB_PATH" "$executable"
+# Get the directory of the current script
+script_dir="$(dirname "$0")"
+
+# Run LLDB with the LLGO plugin
+"$LLDB_PATH" -O "command script import ${script_dir}/llgo_plugin.py" "$executable"

--- a/_lldb/runtest.sh
+++ b/_lldb/runtest.sh
@@ -40,8 +40,23 @@ build_project "$package_path" || exit 1
 # Set up the result file path
 result_file="/tmp/lldb_exit_code"
 
+# Prepare LLDB commands
+lldb_commands=(
+    "command script import _lldb/llgo_plugin.py"
+    "command script import _lldb/test.py"
+    "script test.run_tests_with_result('${package_path}/debug.out', ['${package_path}/in.go'], $verbose, $interactive, $plugin_path, '$result_file')"
+    "quit"
+)
+
+# Run LLDB with prepared commands 
+lldb_command_string=""
+for cmd in "${lldb_commands[@]}"; do
+    lldb_command_string+=" -o \"$cmd\""
+done
+
+
 # Run LLDB with the test script
-"$LLDB_PATH" -o "command script import _lldb/test.py" -o "script test.run_tests_with_result('${package_path}/debug.out', ['${package_path}/in.go'], $verbose, $interactive, $plugin_path, '$result_file')" -o "quit"
+eval "$LLDB_PATH $lldb_command_string"
 
 # Read the exit code from the result file
 if [ -f "$result_file" ]; then

--- a/_lldb/runtest.sh
+++ b/_lldb/runtest.sh
@@ -40,7 +40,7 @@ build_project "$package_path" || exit 1
 # Prepare LLDB commands
 lldb_commands=(
     "command script import _lldb/test.py"
-    "script test.run_tests(\\\"${package_path}/out\\\", [\\\"${package_path}/in.go\\\"], ${verbose}, ${interactive}, ${plugin_path})"
+    "script test.run_tests(\\\"${package_path}/debug.out\\\", [\\\"${package_path}/in.go\\\"], ${verbose}, ${interactive}, ${plugin_path})"
 )
 
 # Add quit command if not in interactive mode

--- a/_lldb/runtest.sh
+++ b/_lldb/runtest.sh
@@ -4,7 +4,8 @@ set -e
 
 # Source common functions and variables
 # shellcheck source=./_lldb/common.sh
-source "$(dirname "$0")/common.sh"
+# shellcheck disable=SC1091
+source "$(dirname "$0")/common.sh" || exit 1
 
 # Parse command-line arguments
 package_path="$DEFAULT_PACKAGE_PATH"
@@ -34,7 +35,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Build the project
-build_project "$package_path"
+build_project "$package_path" || exit 1
 
 # Prepare LLDB commands
 lldb_commands=(
@@ -53,4 +54,4 @@ for cmd in "${lldb_commands[@]}"; do
     lldb_command_string+=" -O \"$cmd\""
 done
 
-eval "$LLDB_PATH $lldb_command_string"
+eval "$LLDB_PATH $lldb_command_string" || exit 1

--- a/_lldb/test.py
+++ b/_lldb/test.py
@@ -252,7 +252,7 @@ def run_tests(executable_path: str, source_files: List[str], verbose: bool, inte
     print_test_results(results)
 
     if results.total != results.passed:
-        os._exit(1)
+        sys.exit(1)
 
 
 def execute_test_case(debugger: LLDBDebugger, test_case: TestCase, all_variable_names: Set[str]) -> CaseResult:

--- a/_lldb/test.py
+++ b/_lldb/test.py
@@ -107,7 +107,7 @@ class LLDBDebugger:
 
     def get_all_variable_names(self) -> Set[str]:
         frame = self.process.GetSelectedThread().GetFrameAtIndex(0)
-        return set(var.GetName() for var in frame.GetVariables(True, True, True, False))
+        return set(var.GetName() for var in frame.GetVariables(True, True, True, True))
 
     def get_current_function_name(self) -> str:
         frame = self.process.GetSelectedThread().GetFrameAtIndex(0)

--- a/chore/llgen/llgen.go
+++ b/chore/llgen/llgen.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/goplus/llgo/internal/build"
 	"github.com/goplus/llgo/internal/llgen"
 )
 
@@ -29,7 +28,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "Usage: llgen [flags] <pkg> [pkgPath]")
 		return
 	}
-	llgen.Init(build.IsDebugEnabled())
+	llgen.Init()
 	args := os.Args[1:]
 	llgen.SmartDoFile(args[0], args[1:]...)
 }

--- a/cl/_testdata/debug/in.go
+++ b/cl/_testdata/debug/in.go
@@ -408,6 +408,43 @@ func ScopeFor() {
 	println("a:", a)
 }
 
+func ScopeSwitch(i int) {
+	a := 0
+	switch i {
+	case 1:
+		b := 1
+		println("i is 1")
+		// Expected:
+		//   all variables: i a b
+		//   i: 1
+		//   a: 0
+		//   b: 1
+		println("i:", i, "a:", a, "b:", b)
+	case 2:
+		c := 2
+		println("i is 2")
+		// Expected:
+		//   all variables: i a c
+		//   i: 2
+		//   a: 0
+		//   c: 2
+		println("i:", i, "a:", a, "c:", c)
+	default:
+		d := 3
+		println("i is", i)
+		// Expected:
+		//   all variables: i a d
+		//   i: 3
+		//   a: 0
+		//   d: 3
+		println("i:", i, "a:", a, "d:", d)
+	}
+	// Expected:
+	//   all variables: a i
+	//   a: 0
+	println("a:", a)
+}
+
 func main() {
 	FuncStructParams(TinyStruct{I: 1}, SmallStruct{I: 2, J: 3}, MidStruct{I: 4, J: 5, K: 6}, BigStruct{I: 7, J: 8, K: 9, L: 10, M: 11, N: 12, O: 13, P: 14, Q: 15, R: 16})
 	FuncStructPtrParams(&TinyStruct{I: 1}, &SmallStruct{I: 2, J: 3}, &MidStruct{I: 4, J: 5, K: 6}, &BigStruct{I: 7, J: 8, K: 9, L: 10, M: 11, N: 12, O: 13, P: 14, Q: 15, R: 16})
@@ -498,6 +535,9 @@ func main() {
 	ScopeIf(1)
 	ScopeIf(0)
 	ScopeFor()
+	ScopeSwitch(1)
+	ScopeSwitch(2)
+	ScopeSwitch(3)
 	println(globalStructPtr)
 	println(&globalStruct)
 	s.i8 = 0x12

--- a/cl/_testdata/debug/in.go
+++ b/cl/_testdata/debug/in.go
@@ -193,7 +193,7 @@ func FuncWithAllTypeParams(
 	s = "world"
 	e = E{i: 40}
 
-	// Expected:
+	// Expected(skip):
 	//   i8: '\x09'
 	//   i16: 10
 	//   i32: 11

--- a/cl/_testdata/debug/in.go
+++ b/cl/_testdata/debug/in.go
@@ -130,14 +130,6 @@ func FuncWithAllTypeParams(
 	//   arr: [3]int{24, 25, 26}
 	//   arr2: [3]github.com/goplus/llgo/cl/_testdata/debug.E{{i = 27}, {i = 28}, {i = 29}}
 	//   e: github.com/goplus/llgo/cl/_testdata/debug.E{i = 30}
-	//   i8: '\b'
-	//   i16: 2
-	//   u8: '\x06'
-	//   u16: 7
-	//   b: true
-	//   c64: complex64{real = 13, imag = 14}
-	//   c128: complex128{real = 15, imag = 16}
-	//   s: "hello"
 
 	// Expected(skip):
 	//   i8: '\b'

--- a/cl/_testdata/debug/in.go
+++ b/cl/_testdata/debug/in.go
@@ -129,6 +129,15 @@ func FuncWithAllTypeParams(
 	//   slice: []int{21, 22, 23}
 	//   arr: [3]int{24, 25, 26}
 	//   arr2: [3]github.com/goplus/llgo/cl/_testdata/debug.E{{i = 27}, {i = 28}, {i = 29}}
+	//   slice[0]: 21
+	//   slice[1]: 22
+	//   slice[2]: 23
+	//   arr[0]: 24
+	//   arr[1]: 25
+	//   arr[2]: 26
+	//   arr2[0].i: 27
+	//   arr2[1].i: 28
+	//   arr2[2].i: 29
 	//   e: github.com/goplus/llgo/cl/_testdata/debug.E{i = 30}
 
 	// Expected(skip):
@@ -375,7 +384,7 @@ func ScopeIf(branch int) {
 		//   c: 3
 		//   d: 4
 		//   branch: 0
-		println(c, d)
+		println(a, c, d)
 	}
 	// Expected:
 	//   all variables: a branch

--- a/cl/_testdata/debug/in.go
+++ b/cl/_testdata/debug/in.go
@@ -81,6 +81,7 @@ func FuncWithAllTypeStructParam(s StructWithAllTypeFields) {
 	s.i8 = 8
 	// Expected(skio):
 	//   s.i8: '\x08'
+	//   s.i16: 2
 	println(len(s.s), s.i8)
 }
 
@@ -115,6 +116,28 @@ func FuncWithAllTypeParams(
 	err error,
 	fn func(string) (int, error),
 ) (int, error) {
+	// Expected:
+	//   all variables: i8 i16 i32 i64 i u8 u16 u32 u64 u f32 f64 b c64 c128 slice arr arr2 s e f pf pi intr m c err fn
+	//   i8: '\x01'
+	//   i16: 2
+	//   i32: 3
+	//   i64: 4
+	//   i: 5
+	//   u8: '\x06'
+	//   u16: 7
+	//   u32: 8
+	//   u64: 9
+	//   u: 10
+	//   f32: 11
+	//   f64: 12
+	//   b: true
+	//   c64: complex64{real = 13, imag = 14}
+	//   c128: complex128{real = 15, imag = 16}
+	//   slice: []int{21, 22, 23}
+	//   arr: [3]int{24, 25, 26}
+	//   arr2: [3]github.com/goplus/llgo/cl/_testdata/debug.E{{i = 27}, {i = 28}, {i = 29}}
+	//   s: "hello"
+	//   e: github.com/goplus/llgo/cl/_testdata/debug.E{i = 30}
 	println(
 		i8, i16, i32, i64, i, u8, u16, u32, u64, u,
 		f32, f64, b,
@@ -150,9 +173,58 @@ func FuncWithAllTypeParams(
 	//   s: "hello"
 	//   e: github.com/goplus/llgo/cl/_testdata/debug.E{i = 30}
 	i8 = 9
-	// Expected(skip):
+	i16 = 10
+	i32 = 11
+	i64 = 12
+	i = 13
+	u8 = 14
+	u16 = 15
+	u32 = 16
+	u64 = 17
+	u = 18
+	f32 = 19
+	f64 = 20
+	b = false
+	c64 = 21 + 22i
+	c128 = 23 + 24i
+	slice = []int{31, 32, 33}
+	arr = [3]int{34, 35, 36}
+	arr2 = [3]E{{i: 37}, {i: 38}, {i: 39}}
+	s = "world"
+	e = E{i: 40}
+
+	// Expected:
 	//   i8: '\x09'
-	println(i8)
+	//   i16: 10
+	//   i32: 11
+	//   i64: 12
+	//   i: 13
+	//   u8: 14
+	//   u16: 15
+	//   u32: 16
+	//   u64: 17
+	//   u: 18
+	//   f32: 19
+	//   f64: 20
+	//   b: false
+	//   c64: complex64{real = 21, imag = 22}
+	//   c128: complex128{real = 23, imag = 24}
+	//   slice: []int{31, 32, 33}
+	//   arr: [3]int{34, 35, 36}
+	//   arr2: [3]github.com/goplus/llgo/cl/_testdata/debug.E{{i = 37}, {i = 38}, {i = 39}}
+	//   s: "world"
+	//   e: github.com/goplus/llgo/cl/_testdata/debug.E{i = 40}
+	println(i8, i16, i32, i64, i, u8, u16, u32, u64, u,
+		f32, f64, b,
+		c64, c128,
+		slice, arr[0:], &arr2,
+		s,
+		&e,
+		&f, pf, pi, intr, m,
+		c,
+		err,
+		fn,
+	)
 	return 1, errors.New("some error")
 }
 
@@ -185,7 +257,7 @@ type BigStruct struct {
 }
 
 func FuncStructParams(t TinyStruct, s SmallStruct, m MidStruct, b BigStruct) {
-	println(&t, &s, &m, &b)
+	// println(&t, &s, &m, &b)
 	// Expected:
 	//   all variables: t s m b
 	//   t.I: 1
@@ -205,9 +277,39 @@ func FuncStructParams(t TinyStruct, s SmallStruct, m MidStruct, b BigStruct) {
 	//   b.Q: 15
 	//   b.R: 16
 	t.I = 10
-	// Expected(skip):
+	s.I = 20
+	s.J = 21
+	m.I = 40
+	m.J = 41
+	m.K = 42
+	b.I = 70
+	b.J = 71
+	b.K = 72
+	b.L = 73
+	b.M = 74
+	b.N = 75
+	b.O = 76
+	b.P = 77
+	b.Q = 78
+	b.R = 79
+	// Expected:
 	//   all variables: t s m b
 	//   t.I: 10
+	//   s.I: 20
+	//   s.J: 21
+	//   m.I: 40
+	//   m.J: 41
+	//   m.K: 42
+	//   b.I: 70
+	//   b.J: 71
+	//   b.K: 72
+	//   b.L: 73
+	//   b.M: 74
+	//   b.N: 75
+	//   b.O: 76
+	//   b.P: 77
+	//   b.Q: 78
+	//   b.R: 79
 	println("done")
 }
 
@@ -232,9 +334,40 @@ func FuncStructPtrParams(t *TinyStruct, s *SmallStruct, m *MidStruct, b *BigStru
 	//   b.Q: 15
 	//   b.R: 16
 	t.I = 10
+	s.I = 20
+	s.J = 21
+	m.I = 40
+	m.J = 41
+	m.K = 42
+	b.I = 70
+	b.J = 71
+	b.K = 72
+	b.L = 73
+	b.M = 74
+	b.N = 75
+	b.O = 76
+	b.P = 77
+	b.Q = 78
+	b.R = 79
 	// Expected:
 	//   all variables: t s m b
 	//   t.I: 10
+	//   s.I: 20
+	//   s.J: 21
+	//   m.I: 40
+	//   m.J: 41
+	//   m.K: 42
+	//   b.I: 70
+	//   b.J: 71
+	//   b.K: 72
+	//   b.L: 73
+	//   b.M: 74
+	//   b.N: 75
+	//   b.O: 76
+	//   b.P: 77
+	//   b.Q: 78
+	//   b.R: 79
+	println(t.I, s.I, s.J, m.I, m.J, m.K, b.I, b.J, b.K, b.L, b.M, b.N, b.O, b.P, b.Q, b.R)
 	println("done")
 }
 
@@ -263,7 +396,7 @@ func main() {
 		arr2:  [3]E{{i: 27}, {i: 28}, {i: 29}},
 		s:     "hello",
 		e:     E{i: 30},
-		pf:    &StructWithAllTypeFields{},
+		pf:    &StructWithAllTypeFields{i16: 100},
 		pi:    &i,
 		intr:  &Struct{},
 		m:     map[string]uint64{"a": 31, "b": 32},
@@ -277,6 +410,31 @@ func main() {
 		pad1: 100,
 		pad2: 200,
 	}
+	// Expected:
+	//   all variables: globalInt globalStruct globalStructPtr s i err
+	//   s.i8: '\x01'
+	//   s.i16: 2
+	//   s.i32: 3
+	//   s.i64: 4
+	//   s.i: 5
+	//   s.u8: '\x06'
+	//   s.u16: 7
+	//   s.u32: 8
+	//   s.u64: 9
+	//   s.u: 10
+	//   s.f32: 11
+	//   s.f64: 12
+	//   s.b: true
+	//   s.c64: complex64{real = 13, imag = 14}
+	//   s.c128: complex128{real = 15, imag = 16}
+	//   s.slice: []int{21, 22, 23}
+	//   s.arr: [3]int{24, 25, 26}
+	//   s.arr2: [3]github.com/goplus/llgo/cl/_testdata/debug.E{{i = 27}, {i = 28}, {i = 29}}
+	//   s.s: "hello"
+	//   s.e: github.com/goplus/llgo/cl/_testdata/debug.E{i = 30}
+	//   s.pf.i16: 100
+	//   *(s.pf).i16: 100
+	//   *(s.pi): 100
 	globalStructPtr = &s
 	globalStruct = s
 	println("globalInt:", globalInt)
@@ -301,13 +459,9 @@ func main() {
 	println("called function with types")
 	println(globalStructPtr)
 	println(&globalStruct)
-	// Expected(skip):
-	//   all variables: globalInt globalStruct globalStructPtr s i err
-	//   s.i8: '\x01'
-	//   s.i16: 2
 	s.i8 = 0x12
 	println(s.i8)
-	// Expected(skip):
+	// Expected:
 	//   all variables: globalInt globalStruct globalStructPtr s i err
 	//   s.i8: '\x12'
 	//   globalStruct.i8: '\x01'

--- a/cl/_testdata/debug/in.go
+++ b/cl/_testdata/debug/in.go
@@ -78,9 +78,9 @@ func FuncWithAllTypeStructParam(s StructWithAllTypeFields) {
 	//   s.e: github.com/goplus/llgo/cl/_testdata/debug.E{i = 30}
 	//   s.pad1: 100
 	//   s.pad2: 200
-	s.i8 = 8
-	// Expected(skio):
-	//   s.i8: '\x08'
+	s.i8 = '\b'
+	// Expected:
+	//   s.i8: '\b'
 	//   s.i16: 2
 	println(len(s.s), s.i8)
 }
@@ -150,28 +150,6 @@ func FuncWithAllTypeParams(
 		err,
 		fn,
 	)
-	// Expected:
-	//   all variables: i8 i16 i32 i64 i u8 u16 u32 u64 u f32 f64 b c64 c128 slice arr arr2 s e f pf pi intr m c err fn
-	//   i8: '\x01'
-	//   i16: 2
-	//   i32: 3
-	//   i64: 4
-	//   i: 5
-	//   u8: '\x06'
-	//   u16: 7
-	//   u32: 8
-	//   u64: 9
-	//   u: 10
-	//   f32: 11
-	//   f64: 12
-	//   b: true
-	//   c64: complex64{real = 13, imag = 14}
-	//   c128: complex128{real = 15, imag = 16}
-	//   slice: []int{21, 22, 23}
-	//   arr: [3]int{24, 25, 26}
-	//   arr2: [3]github.com/goplus/llgo/cl/_testdata/debug.E{{i = 27}, {i = 28}, {i = 29}}
-	//   s: "hello"
-	//   e: github.com/goplus/llgo/cl/_testdata/debug.E{i = 30}
 	i8 = 9
 	i16 = 10
 	i32 = 11
@@ -193,27 +171,6 @@ func FuncWithAllTypeParams(
 	s = "world"
 	e = E{i: 40}
 
-	// Expected(skip):
-	//   i8: '\x09'
-	//   i16: 10
-	//   i32: 11
-	//   i64: 12
-	//   i: 13
-	//   u8: 14
-	//   u16: 15
-	//   u32: 16
-	//   u64: 17
-	//   u: 18
-	//   f32: 19
-	//   f64: 20
-	//   b: false
-	//   c64: complex64{real = 21, imag = 22}
-	//   c128: complex128{real = 23, imag = 24}
-	//   slice: []int{31, 32, 33}
-	//   arr: [3]int{34, 35, 36}
-	//   arr2: [3]github.com/goplus/llgo/cl/_testdata/debug.E{{i = 37}, {i = 38}, {i = 39}}
-	//   s: "world"
-	//   e: github.com/goplus/llgo/cl/_testdata/debug.E{i = 40}
 	println(i8, i16, i32, i64, i, u8, u16, u32, u64, u,
 		f32, f64, b,
 		c64, c128,
@@ -225,6 +182,29 @@ func FuncWithAllTypeParams(
 		err,
 		fn,
 	)
+	// Expected:
+	//   i8: '\t'
+	//   i16: 10
+	//   i32: 11
+	//   i64: 12
+	//   i: 13
+	//   u8: '\x0e'
+	//   u16: 15
+	//   u32: 16
+	//   u64: 17
+	//   u: 18
+	//   f32: 19
+	//   f64: 20
+	//   b: false
+	//   c64: complex64{real = 21, imag = 22}
+	//   c128: complex128{real = 23, imag = 24}
+	//   slice: []int{31, 32, 33}
+	//   arr2: [3]github.com/goplus/llgo/cl/_testdata/debug.E{{i = 37}, {i = 38}, {i = 39}}
+	//   s: "world"
+	//   e: github.com/goplus/llgo/cl/_testdata/debug.E{i = 40}
+
+	// Expected(skip):
+	//   arr: [3]int{34, 35, 36}
 	return 1, errors.New("some error")
 }
 
@@ -276,6 +256,7 @@ func FuncStructParams(t TinyStruct, s SmallStruct, m MidStruct, b BigStruct) {
 	//   b.P: 14
 	//   b.Q: 15
 	//   b.R: 16
+	println(t.I, s.I, s.J, m.I, m.J, m.K, b.I, b.J, b.K, b.L, b.M, b.N, b.O, b.P, b.Q, b.R)
 	t.I = 10
 	s.I = 20
 	s.J = 21
@@ -314,7 +295,6 @@ func FuncStructParams(t TinyStruct, s SmallStruct, m MidStruct, b BigStruct) {
 }
 
 func FuncStructPtrParams(t *TinyStruct, s *SmallStruct, m *MidStruct, b *BigStruct) {
-	println(t, s, m, b)
 	// Expected:
 	//   all variables: t s m b
 	//   t.I: 1
@@ -333,6 +313,7 @@ func FuncStructPtrParams(t *TinyStruct, s *SmallStruct, m *MidStruct, b *BigStru
 	//   b.P: 14
 	//   b.Q: 15
 	//   b.R: 16
+	println(t, s, m, b)
 	t.I = 10
 	s.I = 20
 	s.J = 21

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -334,16 +334,6 @@ func (p *context) debugRef(b llssa.Builder, v *ssa.DebugRef) {
 	}
 }
 
-func isBasicTypeOrPtr(ty types.Type) bool {
-	if _, ok := ty.(*types.Basic); ok {
-		return true
-	}
-	if _, ok := ty.(*types.Pointer); ok {
-		return true
-	}
-	return false
-}
-
 func (p *context) debugParams(b llssa.Builder, f *ssa.Function) {
 	for i, param := range f.Params {
 		variable := param.Object().(*types.Var)
@@ -352,11 +342,7 @@ func (p *context) debugParams(b llssa.Builder, f *ssa.Function) {
 		ty := param.Type()
 		argNo := i + 1
 		div := b.DIVarParam(p.fn, pos, param.Name(), p.prog.Type(ty, llssa.InGo), argNo)
-		if isBasicTypeOrPtr(ty) {
-			b.DIDeclare(variable, v, div, p.fn, pos, p.fn.Block(0))
-		} else {
-			b.DIValue(variable, v, div, p.fn, pos, p.fn.Block(0))
-		}
+		b.DIParam(variable, v, div, p.fn, pos, p.fn.Block(0))
 	}
 }
 

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -298,7 +298,11 @@ func (p *context) debugParams(b llssa.Builder, f *ssa.Function) {
 		ty := param.Type()
 		argNo := i + 1
 		div := b.DIVarParam(p.fn, pos, param.Name(), p.prog.Type(ty, llssa.InGo), argNo)
-		b.DIDeclare(v, div, p.fn, pos, p.fn.Block(0))
+		if _, ok := param.Type().(*types.Pointer); ok {
+			b.DIDeclare(v, div, p.fn, pos, p.fn.Block(0))
+		} else {
+			b.DIDeclare(v, div, p.fn, pos, p.fn.Block(0))
+		}
 	}
 }
 

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -267,6 +267,9 @@ func (p *context) funcOf(fn *ssa.Function) (aFn llssa.Function, pyFn llssa.PyObj
 			}
 			sig := fn.Signature
 			aFn = pkg.NewFuncEx(name, sig, llssa.Background(ftype), false, fn.Origin() != nil)
+			if debugSymbols {
+				aFn.Inline(llssa.NoInline)
+			}
 		}
 	}
 	return

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -187,7 +187,14 @@ func Do(args []string, conf *Config) {
 		return dedup.Check(llssa.PkgPython).Types
 	})
 
-	progSSA := ssa.NewProgram(initial[0].Fset, ssaBuildMode)
+	buildMode := ssaBuildMode
+	if cl.DebugSymbols() {
+		buildMode |= ssa.GlobalDebug
+	}
+	if !IsOptimizeEnabled() {
+		buildMode |= ssa.NaiveForm
+	}
+	progSSA := ssa.NewProgram(initial[0].Fset, buildMode)
 	patches := make(cl.Patches, len(altPkgPaths))
 	altSSAPkgs(progSSA, patches, altPkgs[1:], verbose)
 
@@ -237,7 +244,7 @@ func isNeedRuntimeOrPyInit(pkg *packages.Package) (needRuntime, needPyInit bool)
 }
 
 const (
-	ssaBuildMode = ssa.SanityCheckFunctions | ssa.InstantiateGenerics | ssa.GlobalDebug
+	ssaBuildMode = ssa.SanityCheckFunctions | ssa.InstantiateGenerics
 )
 
 type context struct {
@@ -609,10 +616,22 @@ var (
 )
 
 const llgoDebug = "LLGO_DEBUG"
+const llgoOptimize = "LLGO_OPTIMIZE"
+
+func isEnvOn(env string, defVal bool) bool {
+	envVal := strings.ToLower(os.Getenv(env))
+	if envVal == "" {
+		return defVal
+	}
+	return envVal == "1" || envVal == "true" || envVal == "on"
+}
 
 func IsDebugEnabled() bool {
-	llgoDbgVal := strings.ToLower(os.Getenv(llgoDebug))
-	return llgoDbgVal == "1" || llgoDbgVal == "true" || llgoDbgVal == "on"
+	return isEnvOn(llgoDebug, false)
+}
+
+func IsOptimizeEnabled() bool {
+	return isEnvOn(llgoOptimize, true)
 }
 
 func ParseArgs(args []string, swflags map[string]bool) (flags, patterns []string, verbose bool) {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -445,7 +445,7 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, llFiles 
 	}
 	args = append(args, exargs...)
 	if cl.DebugSymbols() {
-		args = append(args, "-gdwarf-5")
+		args = append(args, "-gdwarf-4")
 	}
 
 	// TODO(xsw): show work

--- a/internal/llgen/llgen.go
+++ b/internal/llgen/llgen.go
@@ -20,16 +20,17 @@ import (
 	"os"
 
 	"github.com/goplus/llgo/cl"
+	"github.com/goplus/llgo/internal/build"
 	"github.com/goplus/llgo/internal/mod"
 
 	llssa "github.com/goplus/llgo/ssa"
 )
 
-func Init(enableDbg bool) {
+func Init() {
 	llssa.Initialize(llssa.InitAll)
 	llssa.SetDebug(llssa.DbgFlagAll)
 	cl.SetDebug(cl.DbgFlagAll)
-	cl.EnableDebugSymbols(enableDbg)
+	cl.EnableDebugSymbols(build.IsDebugEnabled())
 }
 
 func PkgPath(dir string) string {

--- a/internal/llgen/llgenf.go
+++ b/internal/llgen/llgenf.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/goplus/llgo/cl"
+	"github.com/goplus/llgo/internal/build"
 	"github.com/goplus/llgo/internal/packages"
 	"golang.org/x/tools/go/ssa"
 	"golang.org/x/tools/go/ssa/ssautil"
@@ -90,7 +91,14 @@ func genFrom(fileOrPkg string, pkgPath string) string {
 	initial, err := packages.LoadEx(dedup, prog.TypeSizes, cfg, fileOrPkg)
 	check(err)
 
-	_, pkgs := ssautil.AllPackages(initial, ssa.SanityCheckFunctions|ssa.InstantiateGenerics|ssa.GlobalDebug)
+	buildMode := ssa.SanityCheckFunctions | ssa.InstantiateGenerics
+	if build.IsDebugEnabled() {
+		buildMode |= ssa.GlobalDebug
+	}
+	if !build.IsOptimizeEnabled() {
+		buildMode |= ssa.NaiveForm
+	}
+	_, pkgs := ssautil.AllPackages(initial, buildMode)
 
 	pkg := initial[0]
 	ssaPkg := pkgs[0]

--- a/ssa/decl.go
+++ b/ssa/decl.go
@@ -329,9 +329,12 @@ func (p Function) SetRecover(blk BasicBlock) {
 
 func (p Function) scopeMeta(b diBuilder, pos token.Position) DIScopeMeta {
 	if p.diFunc == nil {
-		paramTypes := make([]llvm.Metadata, len(p.params))
+		sig := p.Type.raw.Type.(*types.Signature)
+		rt := p.Prog.Type(sig.Results(), InGo)
+		paramTypes := make([]llvm.Metadata, len(p.params)+1)
+		paramTypes[0] = b.diType(rt, pos).ll
 		for i, t := range p.params {
-			paramTypes[i] = b.diType(t, pos).ll
+			paramTypes[i+1] = b.diType(t, pos).ll
 		}
 		diFuncType := b.di.CreateSubroutineType(llvm.DISubroutineType{
 			File:       b.file(pos.Filename).ll,

--- a/ssa/decl.go
+++ b/ssa/decl.go
@@ -17,7 +17,6 @@
 package ssa
 
 import (
-	"go/token"
 	"go/types"
 	"log"
 	"strconv"
@@ -325,38 +324,6 @@ func (p Function) Block(idx int) BasicBlock {
 // SetRecover sets the recover block for the function.
 func (p Function) SetRecover(blk BasicBlock) {
 	p.recov = blk
-}
-
-func (p Function) scopeMeta(b diBuilder, pos token.Position) DIScopeMeta {
-	if p.diFunc == nil {
-		sig := p.Type.raw.Type.(*types.Signature)
-		rt := p.Prog.Type(sig.Results(), InGo)
-		paramTypes := make([]llvm.Metadata, len(p.params)+1)
-		paramTypes[0] = b.diType(rt, pos).ll
-		for i, t := range p.params {
-			paramTypes[i+1] = b.diType(t, pos).ll
-		}
-		diFuncType := b.di.CreateSubroutineType(llvm.DISubroutineType{
-			File:       b.file(pos.Filename).ll,
-			Parameters: paramTypes,
-		})
-		p.diFunc = &aDIFunction{
-			b.di.CreateFunction(
-				b.file(pos.Filename).ll,
-				llvm.DIFunction{
-					Type:         diFuncType,
-					Name:         p.Name(),
-					LinkageName:  p.Name(),
-					File:         b.file(pos.Filename).ll,
-					Line:         pos.Line,
-					IsDefinition: true,
-					Optimized:    false,
-				},
-			),
-		}
-		p.impl.SetSubprogram(p.diFunc.ll)
-	}
-	return &aDIScopeMeta{p.diFunc.ll}
 }
 
 // -----------------------------------------------------------------------------

--- a/ssa/di.go
+++ b/ssa/di.go
@@ -38,7 +38,7 @@ func newDIBuilder(prog Program, pkg Package, positioner Positioner) diBuilder {
 	}
 
 	b.addNamedMetadataOperand("llvm.module.flags", 2, "Debug Info Version", 3)
-	b.addNamedMetadataOperand("llvm.module.flags", 7, "Dwarf Version", 5)
+	b.addNamedMetadataOperand("llvm.module.flags", 7, "Dwarf Version", 4)
 	b.addNamedMetadataOperand("llvm.module.flags", 1, "wchar_size", 4)
 	b.addNamedMetadataOperand("llvm.module.flags", 8, "PIC Level", 2)
 	b.addNamedMetadataOperand("llvm.module.flags", 7, "uwtable", 1)

--- a/ssa/eh.go
+++ b/ssa/eh.go
@@ -141,6 +141,10 @@ const (
 )
 
 func (b Builder) getDefer(kind DoAction) *aDefer {
+	if b.Func.recov == nil {
+		// b.Func.recov maybe nil in ssa.NaiveForm
+		return nil
+	}
 	self := b.Func
 	if self.defer_ == nil {
 		// TODO(xsw): check if in pkg.init
@@ -241,6 +245,9 @@ func (b Builder) Defer(kind DoAction, fn Expr, args ...Expr) {
 // RunDefers emits instructions to run deferred instructions.
 func (b Builder) RunDefers() {
 	self := b.getDefer(DeferInCond)
+	if self == nil {
+		return
+	}
 	blk := b.Func.MakeBlock()
 	self.rundsNext = append(self.rundsNext, blk)
 

--- a/ssa/stmt_builder.go
+++ b/ssa/stmt_builder.go
@@ -58,9 +58,8 @@ func (p BasicBlock) Addr() Expr {
 // -----------------------------------------------------------------------------
 
 type dbgExpr struct {
-	ptr   Expr
-	val   Expr
-	deref bool
+	ptr Expr
+	val Expr
 }
 
 type aBuilder struct {
@@ -70,7 +69,8 @@ type aBuilder struct {
 	Pkg  Package
 	Prog Program
 
-	dbgVars map[Expr]dbgExpr
+	dbgVars      map[Expr]dbgExpr         // save copied address and values for debug info
+	diScopeCache map[*types.Scope]DIScope // avoid duplicated DILexicalBlock(s)
 }
 
 // Builder represents a builder for creating instructions in a function.

--- a/ssa/type_cvt.go
+++ b/ssa/type_cvt.go
@@ -109,6 +109,8 @@ func (p goTypes) cvtType(typ types.Type) (raw types.Type, cvt bool) {
 		if elem, cvt := p.cvtType(t.Elem()); cvt {
 			return types.NewChan(t.Dir(), elem), true
 		}
+	case *types.Tuple:
+		return p.cvtTuple(t)
 	default:
 		panic(fmt.Sprintf("cvtType: unexpected type - %T", typ))
 	}


### PR DESCRIPTION
- [x] Supports full types
  - [x] Struct params/vars modification
  - [x] Basic type params modification
    - discuz:
      - https://stackoverflow.com/questions/79023513/whats-wrong-in-my-generated-debug-info-in-llvm-ir
      - https://chat.stackoverflow.com/rooms/258538/discussion-between-jmmartinez-and-jacky-lee
      - just use simple rules, and ignore discarded debug info of clang
  - [x] Return types (including tuples)
  - [x] Fix pointer type size
  - [x] types.Named -> Typedef
- [x] Scope
  - [x] Lexical scope (if, for, closure)
  - [x] Variable lifecycle
- [x] Go expressions
  - [x] p *(s.pf).a
  - [x] p s.pf.a