### PR TITLE
py: remove static methods

### DIFF
--- a/py/call.go
+++ b/py/call.go
@@ -107,12 +107,6 @@ func (o *Object) CallMethod(name *c.Char, format *c.Char, __llgo_va_list ...any)
 // llgo:link (*Object).CallMethodObjArgs C.PyObject_CallMethodObjArgs
 func (o *Object) CallMethodObjArgs(name *Object, __llgo_va_list ...any) *Object { return nil }
 
-// llgo:link (*Object).CallMethodNoArgs C.PyObject_CallMethodNoArgs
-func (o *Object) CallMethodNoArgs(name *Object) *Object { return nil }
-
-// llgo:link (*Object).CallMethodOneArg C.PyObject_CallMethodOneArg
-func (o *Object) CallMethodOneArg(name, arg *Object) *Object { return nil }
-
 // llgo:link (*Object).Vectorcall C.PyObject_Vectorcall
 func (o *Object) Vectorcall(args **Object, nargs uintptr, kwnames *Object) *Object {
 	return nil


### PR DESCRIPTION
Test:

```go
package main

import (
	"fmt"

	"github.com/goplus/llgo/c"
	"github.com/goplus/llgo/py"
)

func main() {
	py.Initialize()
	py.SetProgramName(*c.Argv)
	code := py.CompileString(c.Str(`print('Hello, World!')`), c.Str(`hello.py`), py.EvalInput)
	fmt.Printf("code: %p\n", code)
}
```

Compile:

```shell
ld64.lld: error: undefined symbol: PyObject_CallMethodOneArg
>>> referenced by /var/folders/f2/88rgt2bx533_m89qy6pqqp8w0000gn/T/47fbbe34e8445e113519eece8f659d08212a2f24496f75d8225b90b3cc8c6a0b-d-abff41.o:(symbol main.init$after+0x17ac)
>>> referenced by /var/folders/f2/88rgt2bx533_m89qy6pqqp8w0000gn/T/47fbbe34e8445e113519eece8f659d08212a2f24496f75d8225b90b3cc8c6a0b-d-abff41.o:(symbol main.init$after+0x17a8)

ld64.lld: error: undefined symbol: PyObject_CallMethodNoArgs
>>> referenced by /var/folders/f2/88rgt2bx533_m89qy6pqqp8w0000gn/T/47fbbe34e8445e113519eece8f659d08212a2f24496f75d8225b90b3cc8c6a0b-d-abff41.o:(symbol main.init$after+0x1498)
>>> referenced by /var/folders/f2/88rgt2bx533_m89qy6pqqp8w0000gn/T/47fbbe34e8445e113519eece8f659d08212a2f24496f75d8225b90b3cc8c6a0b-d-abff41.o:(symbol main.init$after+0x1494)
clang: error: linker command failed with exit code 1 (use -v to see invocation)
exit status 1
```

See

https://github.com/python/cpython/blob/3.12/Include/cpython/abstract.h#L90-L104

those methods are static inline methods.