### PR TITLE
[wip] os:correct error of noexist file & os.Error 's nil pointer dereference in linux

### DIFF
--- a/internal/lib/syscall/syscall.go
+++ b/internal/lib/syscall/syscall.go
@@ -148,7 +148,7 @@ func Lstat(path string, stat *Stat_t) (err error) {
 	if ret == 0 {
 		return nil
 	}
-	return Errno(ret)
+	return Errno(os.Errno)
 }
 
 func Stat(path string, stat *Stat_t) (err error) {
@@ -156,7 +156,7 @@ func Stat(path string, stat *Stat_t) (err error) {
 	if ret == 0 {
 		return nil
 	}
-	return Errno(ret)
+	return Errno(os.Errno)
 }
 
 func Pipe(p []int) (err error) {


### PR DESCRIPTION
#825 
#### Unexcepted file error
current  patch in llgo only returns 0 and -1. The value -1 is not the appropriate return value for file errors

### nil pointer dereference(linux)
The panic was in the use `os.Errno`.
in the generate ir in llgo like this demo.
```llvm
; ModuleID = 'errno'
source_filename = "errno"

@errno = external global i32, align 4

declare i32 @putchar(i32)

define i32 @main() {
entry:
  %0 = load i32, ptr @errno, align 4
  %1 = add i32 %0, 48  ; Convert to ASCII digit (assuming errno is 0-9)
  call i32 @putchar(i32 %1)
  call i32 @putchar(i32 10)  ; Print newline
  ret i32 0
}
```
will cause follow error
```bash
/usr/bin/ld: errno: TLS definition in /lib/aarch64-linux-gnu/libc.so.6 section .tbss mismatches non-TLS reference in demo.o
/usr/bin/ld: /lib/aarch64-linux-gnu/libc.so.6: error adding symbols: bad value
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
we can see the marcos define the errno is actually call the__errno_location. in linux
```c
extern int *__errno_location (void) __THROW __attribute_const__;
# define errno (*__errno_location ())
```
in macos is call __error
```c
extern int * __error(void);
#define errno (*__error())
```
so we need another way to get the errno
```llvm
; ModuleID = 'errno'
source_filename = "errno"

declare i32* @__errno_location()
declare i32 @putchar(i32)

define i32 @main() {
entry:
  %errno_ptr = call i32* @__errno_location()
  %errno_val = load i32, i32* %errno_ptr, align 4
  %ascii_val = add i32 %errno_val, 48  
  call i32 @putchar(i32 %ascii_val)
  call i32 @putchar(i32 10)  
  ret i32 0
}
```
```bash
root@be00d9b1c2c9:~/llgo/chore/_xtool/llcppsymg/oserrno/llvm# llvm-as demo.ll -o demo.bc
root@be00d9b1c2c9:~/llgo/chore/_xtool/llcppsymg/oserrno/llvm# llc -filetype=obj demo.bc -o demo.o
root@be00d9b1c2c9:~/llgo/chore/_xtool/llcppsymg/oserrno/llvm# clang demo.o -o demo
root@be00d9b1c2c9:~/llgo/chore/_xtool/llcppsymg/oserrno/llvm# ./demo
0
```