### PR TITLE
os:fix os.Errno 's nil pointer derefer in linux

### DIFF
--- a/_demo/checkfile/demo.go
+++ b/_demo/checkfile/demo.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func main() {
+	tempDir := os.TempDir()
+	noexist := filepath.Join(tempDir, "noexist.txt")
+
+	if _, err := os.Stat(noexist); err != nil {
+		if os.IsNotExist(err) {
+			fmt.Println("noexist:", err.Error())
+		} else {
+			fmt.Println("exist,other err:", err.Error())
+		}
+	}
+
+	if _, err := os.Open(noexist); err != nil {
+		if os.IsNotExist(err) {
+			fmt.Println("noexist:", err.Error())
+		} else {
+			fmt.Println("exist,other err:", err.Error())
+		}
+	}
+}

--- a/c/os/_os/os.c
+++ b/c/os/_os/os.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <errno.h>
 
 int llgoClearenv() {
 	extern char **environ;
@@ -7,3 +8,5 @@ int llgoClearenv() {
 	}
 	return 0;
 }
+
+int llgoErrno() { return errno; }

--- a/c/os/os.go
+++ b/c/os/os.go
@@ -70,8 +70,8 @@ type (
 	StatT = syscall.Stat_t
 )
 
-//go:linkname Errno errno
-var Errno c.Int
+//go:linkname Errno C.llgoErrno
+func Errno() c.Int
 
 //go:linkname Umask C.umask
 func Umask(cmask ModeT) ModeT

--- a/c/os/os_linux.go
+++ b/c/os/os_linux.go
@@ -21,7 +21,8 @@ package os
 import "C"
 
 const (
-	LLGoPackage = "decl"
+	LLGoFiles   = "_os/os.c"
+	LLGoPackage = "link"
 )
 
 //go:linkname Clearenv C.clearenv

--- a/internal/build/_overlay/net/textproto/textproto.go
+++ b/internal/build/_overlay/net/textproto/textproto.go
@@ -108,7 +108,7 @@ func (conn *cConn) Read(p []byte) (n int, err error) {
 	for n < len(p) {
 		result := os.Read(conn.socketFd, unsafe.Pointer(&p[n:][0]), uintptr(len(p)-n))
 		if result < 0 {
-			if os.Errno == c.Int(syscall.EINTR) {
+			if os.Errno() == c.Int(syscall.EINTR) {
 				continue
 			}
 			return n, errors.New("read error")
@@ -128,7 +128,7 @@ func (conn *cConn) Write(p []byte) (n int, err error) {
 	for n < len(p) {
 		result := os.Write(conn.socketFd, unsafe.Pointer(&p[n:][0]), uintptr(len(p)-n))
 		if result < 0 {
-			if os.Errno == c.Int(syscall.EINTR) {
+			if os.Errno() == c.Int(syscall.EINTR) {
 				continue
 			}
 			return n, errors.New("write error")
@@ -151,7 +151,7 @@ func (conn *cConn) Close() error {
 	conn.closed = true
 	result := os.Close(conn.socketFd)
 	if result < 0 {
-		return errors.New(c.GoString(c.Strerror(os.Errno)))
+		return errors.New(c.GoString(c.Strerror(os.Errno())))
 	}
 	return nil
 }

--- a/internal/lib/os/os.go
+++ b/internal/lib/os/os.go
@@ -183,7 +183,7 @@ func Getwd() (dir string, err error) {
 	if wd != nil {
 		return c.GoString(wd), nil
 	}
-	return "", syscall.Errno(os.Errno)
+	return "", syscall.Errno(os.Errno())
 }
 
 // TODO(xsw):

--- a/internal/lib/os/types.go
+++ b/internal/lib/os/types.go
@@ -33,7 +33,7 @@ func (f *File) write(b []byte) (int, error) {
 	if ret >= 0 {
 		return int(ret), nil
 	}
-	return 0, syscall.Errno(os.Errno)
+	return 0, syscall.Errno(os.Errno())
 }
 
 /* TODO(xsw):
@@ -56,7 +56,7 @@ func (f *File) read(b []byte) (int, error) {
 	if ret == 0 {
 		return 0, io.EOF
 	}
-	return 0, syscall.Errno(os.Errno)
+	return 0, syscall.Errno(os.Errno())
 }
 
 /* TODO(xsw):

--- a/internal/lib/syscall/exec_libc2.go
+++ b/internal/lib/syscall/exec_libc2.go
@@ -264,14 +264,14 @@ func forkAndExecInChild(argv0 *c.Char, argv, envv **c.Char, chroot, dir *c.Char,
 			// dup2(i, i) won't clear close-on-exec flag on Linux,
 			// probably not elsewhere either.
 			if ret := os.Fcntl(c.Int(fd[i]), syscall.F_SETFD, 0); ret < 0 {
-				err1 = Errno(os.Errno)
+				err1 = Errno(os.Errno())
 				goto childerror
 			}
 			continue
 		}
 		// The new fd is created NOT close-on-exec,
 		if ret := os.Dup2(c.Int(fd[i]), c.Int(i)); ret < 0 {
-			err1 = Errno(os.Errno)
+			err1 = Errno(os.Errno())
 			goto childerror
 		}
 	}

--- a/internal/lib/syscall/syscall.go
+++ b/internal/lib/syscall/syscall.go
@@ -62,7 +62,7 @@ func Getcwd(buf []byte) (n int, err error) {
 	if ret != nil {
 		return int(c.Strlen(ret)), nil
 	}
-	return 0, Errno(os.Errno)
+	return 0, Errno(os.Errno())
 }
 
 func Getwd() (string, error) {
@@ -70,7 +70,7 @@ func Getwd() (string, error) {
 	if wd != nil {
 		return c.GoString(wd), nil
 	}
-	return "", Errno(os.Errno)
+	return "", Errno(os.Errno())
 }
 
 func Getpid() (pid int) {
@@ -90,7 +90,7 @@ func fork() (uintptr, Errno) {
 	if ret >= 0 {
 		return uintptr(ret), Errno(0)
 	}
-	return 0, Errno(os.Errno)
+	return 0, Errno(os.Errno())
 }
 
 func wait4(pid int, wstatus *c.Int, options int, rusage *syscall.Rusage) (wpid int, err error) {
@@ -98,7 +98,7 @@ func wait4(pid int, wstatus *c.Int, options int, rusage *syscall.Rusage) (wpid i
 	if ret >= 0 {
 		return int(ret), nil
 	}
-	return 0, Errno(os.Errno)
+	return 0, Errno(os.Errno())
 }
 
 func Open(path string, mode int, perm uint32) (fd int, err error) {
@@ -106,7 +106,7 @@ func Open(path string, mode int, perm uint32) (fd int, err error) {
 	if ret >= 0 {
 		return int(ret), nil
 	}
-	return 0, Errno(os.Errno)
+	return 0, Errno(os.Errno())
 }
 
 func Seek(fd int, offset int64, whence int) (newoffset int64, err error) {
@@ -114,7 +114,7 @@ func Seek(fd int, offset int64, whence int) (newoffset int64, err error) {
 	if ret >= 0 {
 		return int64(ret), nil
 	}
-	return -1, Errno(os.Errno)
+	return -1, Errno(os.Errno())
 }
 
 func Read(fd int, p []byte) (n int, err error) {
@@ -122,7 +122,7 @@ func Read(fd int, p []byte) (n int, err error) {
 	if ret >= 0 {
 		return ret, nil // TODO(xsw): confirm err == nil (not io.EOF) when ret == 0
 	}
-	return 0, Errno(os.Errno)
+	return 0, Errno(os.Errno())
 }
 
 func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
@@ -130,7 +130,7 @@ func readlen(fd int, buf *byte, nbuf int) (n int, err error) {
 	if ret >= 0 {
 		return ret, nil // TODO(xsw): confirm err == nil (not io.EOF) when ret == 0
 	}
-	return 0, Errno(os.Errno)
+	return 0, Errno(os.Errno())
 }
 
 func Close(fd int) (err error) {
@@ -148,7 +148,7 @@ func Lstat(path string, stat *Stat_t) (err error) {
 	if ret == 0 {
 		return nil
 	}
-	return Errno(os.Errno)
+	return Errno(os.Errno())
 }
 
 func Stat(path string, stat *Stat_t) (err error) {
@@ -156,7 +156,7 @@ func Stat(path string, stat *Stat_t) (err error) {
 	if ret == 0 {
 		return nil
 	}
-	return Errno(os.Errno)
+	return Errno(os.Errno())
 }
 
 func Pipe(p []int) (err error) {

--- a/internal/lib/syscall/syscall_bsd.go
+++ b/internal/lib/syscall/syscall_bsd.go
@@ -466,7 +466,7 @@ func SysctlUint32(name string) (value uint32, err error) {
 	n := uintptr(4)
 	ret := os.Sysctlbyname(c.AllocaCStr(name), unsafe.Pointer(&value), &n, nil, 0)
 	if ret != 0 {
-		err = Errno(os.Errno)
+		err = Errno(os.Errno())
 	}
 	return
 }


### PR DESCRIPTION
fix #825 

The panic was in the use `os.Errno`.
in the generate ir in llgo like this demo.
```llvm
; ModuleID = 'errno'
source_filename = "errno"

@errno = external global i32, align 4

declare i32 @putchar(i32)

define i32 @main() {
entry:
  %0 = load i32, ptr @errno, align 4
  %1 = add i32 %0, 48  ; Convert to ASCII digit (assuming errno is 0-9)
  call i32 @putchar(i32 %1)
  call i32 @putchar(i32 10)  ; Print newline
  ret i32 0
}
```
will cause follow error
```bash
/usr/bin/ld: errno: TLS definition in /lib/aarch64-linux-gnu/libc.so.6 section .tbss mismatches non-TLS reference in demo.o
/usr/bin/ld: /lib/aarch64-linux-gnu/libc.so.6: error adding symbols: bad value
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
we can see the marcos define the errno is actually call the__errno_location. in linux
```c
extern int *__errno_location (void) __THROW __attribute_const__;
# define errno (*__errno_location ())
```
in macos is call __error
```c
extern int * __error(void);
#define errno (*__error())
```
so we need another way to get the errno
```llvm
; ModuleID = 'errno'
source_filename = "errno"

declare i32* @__errno_location()
declare i32 @putchar(i32)

define i32 @main() {
entry:
  %errno_ptr = call i32* @__errno_location()
  %errno_val = load i32, i32* %errno_ptr, align 4
  %ascii_val = add i32 %errno_val, 48  
  call i32 @putchar(i32 %ascii_val)
  call i32 @putchar(i32 10)  
  ret i32 0
}
```
```bash
root@be00d9b1c2c9:~/llgo/chore/_xtool/llcppsymg/oserrno/llvm# llvm-as demo.ll -o demo.bc
root@be00d9b1c2c9:~/llgo/chore/_xtool/llcppsymg/oserrno/llvm# llc -filetype=obj demo.bc -o demo.o
root@be00d9b1c2c9:~/llgo/chore/_xtool/llcppsymg/oserrno/llvm# clang demo.o -o demo
root@be00d9b1c2c9:~/llgo/chore/_xtool/llcppsymg/oserrno/llvm# ./demo
0
```
so,by wrapping the errno macro in a C function, we can obtain the actual errno value through a function call across different platforms.
```c
 #include <errno.h>
 int llgoErrno() { return errno; }
```
```go
//go:linkname Errno C.llgoErrno
func Errno() c.Int
```
#### result
we can get expected result of os.Errno's  use

In this demo, when attempting to open a non-existent file, the program uses os.Error to retrieve the actual reason for the operation failure. This tests whether os.Error() is correctly referenced and functioning. The output showing "No such file or directory" confirms that the errno handling is working as expected across different platforms.

`macos`
```bash
❯ llgo run .
noexist: stat /var/folders/5j/sgtxqmbn1hbdqtgx5kkp6y700000gn/T/noexist.txt: No such file or directory
noexist: open /var/folders/5j/sgtxqmbn1hbdqtgx5kkp6y700000gn/T/noexist.txt: No such file or directory
```
`linux`
```bash
noexist: stat /tmp/noexist.txt: No such file or directory
noexist: open /tmp/noexist.txt: No such file or directory
```