### PR TITLE
xtool/nm:flags option & symbol version

### DIFF
--- a/chore/nmdump/nmdump.go
+++ b/chore/nmdump/nmdump.go
@@ -25,13 +25,21 @@ import (
 )
 
 func main() {
-	if len(os.Args) != 2 {
-		fmt.Fprintln(os.Stderr, "Usage: nmdump libfile")
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "Usage: nmdump [flags] libfile")
 		return
 	}
 
 	nm := llvm.New("").Nm()
-	items, err := nm.List(os.Args[1])
+
+	var flags []string
+	libfile := os.Args[len(os.Args)-1]
+	if len(os.Args) > 2 {
+		flags = os.Args[1 : len(os.Args)-1]
+	}
+
+	items, err := nm.List(libfile, flags...)
+
 	for _, item := range items {
 		if item.File != "" {
 			fmt.Printf("\n%s:\n", item.File)

--- a/chore/nmdump/nmdump.go
+++ b/chore/nmdump/nmdump.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"github.com/goplus/llgo/xtool/env/llvm"
+	nmtool "github.com/goplus/llgo/xtool/nm"
 )
 
 func main() {
@@ -45,10 +46,17 @@ func main() {
 			fmt.Printf("\n%s:\n", item.File)
 		}
 		for _, sym := range item.Symbols {
+			var versionInfo string
+			switch sym.VersionType {
+			case nmtool.VersionSpecific:
+				versionInfo = fmt.Sprintf("@%s", sym.Version)
+			case nmtool.VersionDefault:
+				versionInfo = fmt.Sprintf("@@%s", sym.Version)
+			}
 			if sym.FAddr {
-				fmt.Printf("%016x %c %s\n", sym.Addr, sym.Type, sym.Name)
+				fmt.Printf("%016x %c %s%s\n", sym.Addr, sym.Type, sym.Name, versionInfo)
 			} else {
-				fmt.Printf("%16s %c %s\n", "", sym.Type, sym.Name)
+				fmt.Printf("%16s %c %s%s\n", "", sym.Type, sym.Name, versionInfo)
 			}
 		}
 	}

--- a/xtool/nm/nm.go
+++ b/xtool/nm/nm.go
@@ -76,11 +76,20 @@ type ObjectFile struct {
 	Symbols []*Symbol // symbols
 }
 
-// List lists symbols in an archive file.
-func (p *Cmd) List(arfile string) (items []*ObjectFile, err error) {
+// List lists symbols in an archive file
+// accepts optional nm command flags.
+// Note: The available flags may vary depending on the operating system.
+// On Linux, the -D flag is used to display dynamic symbols from the dynamic symbol table.
+// On macOS, there's no -D flag. The nm command displays all symbols (including dynamic ones) by default.
+// This difference is due to the distinct ways Linux (using ELF format) and macOS (using Mach-O format)
+// When working with dynamic libraries:
+// On Linux: Use 'nm -D /path/to/library.so'
+// On macOS: Simply use 'nm /path/to/library.dylib'
+func (p *Cmd) List(arfile string, options ...string) (items []*ObjectFile, err error) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	cmd := exec.Command(p.app, arfile)
+	args := append(options, arfile)
+	cmd := exec.Command(p.app, args...)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	e := cmd.Run()


### PR DESCRIPTION
#830 

* support pass flag
* parse symbol version for linux 


For llcppsymg  get dynamic symbol in linux by passing option to `nm`.

before havent symbol output
```bash
root@be00d9b1c2c9:/lib/aarch64-linux-gnu# nmdump liblua5.4.so
root@be00d9b1c2c9:/lib/aarch64-linux-gnu# 
```
after,pass -D flag can outout dynamic symbol normally
```
root@be00d9b1c2c9:/lib/aarch64-linux-gnu# nmdump -D liblua5.4.so
0000000000000000 A LUA_5.4@@LUA_5.4
                 w _ITM_deregisterTMCloneTable
                 w _ITM_registerTMCloneTable
                 U __ctype_b_loc@GLIBC_2.17
                 U __ctype_tolower_loc@GLIBC_2.17
                 U __ctype_toupper_loc@GLIBC_2.17
                 w __cxa_finalize@GLIBC_2.17
                 U __errno_location@GLIBC_2.17
                 U __fprintf_chk@GLIBC_2.17
                 w __gmon_start__
```