### PR TITLE
modify llcppg command to run go mod init and go get

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ _tinygo/
 _output/
 build.dir/
 .vscode/
+.devcontainer/
+*.cfg
+*.json
 
 # Test binary, built with `go test -c`
 *.test

--- a/chore/llcppg/llcppg.go
+++ b/chore/llcppg/llcppg.go
@@ -53,6 +53,13 @@ func gogensig(in io.Reader) error {
 	return cmd.Run()
 }
 
+func runCommand(cmdName string, args ...string) error {
+	cmd := exec.Command(cmdName, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
 func main() {
 	cfgFile := "llcppg.cfg"
 	if len(os.Args) > 1 {
@@ -71,6 +78,10 @@ func main() {
 	json.NewDecoder(f).Decode(&conf)
 	conf.CFlags = env.ExpandEnv(conf.CFlags)
 	conf.Libs = env.ExpandEnv(conf.Libs)
+
+	runCommand("go", "mod", "init", conf.Name)
+
+	runCommand("go", "get", "github.com/goplus/llgo")
 
 	b, err := json.MarshalIndent(&conf, "", "  ")
 	check(err)


### PR DESCRIPTION
If you do not add it, you cannot run the gogensig command successfully.