### PR TITLE
ssa: fix int constant type conversion

### DIFF
--- a/cl/_testgo/constconv/in.go
+++ b/cl/_testgo/constconv/in.go
@@ -1,0 +1,9 @@
+package main
+
+func main() {
+	var i64 int64 = 1
+	var u64 uint64 = 1
+	var c int64 = i64 + (1.0 / (1.0 / 10))
+	var d uint64 = u64 + (1.0 / (1.0 / 10))
+	println(u64, i64, c, d)
+}

--- a/cl/_testgo/constconv/out.ll
+++ b/cl/_testgo/constconv/out.ll
@@ -1,0 +1,44 @@
+; ModuleID = 'main'
+source_filename = "main"
+
+@"main.init$guard" = global i1 false, align 1
+@__llgo_argc = global i32 0, align 4
+@__llgo_argv = global ptr null, align 8
+
+define void @main.init() {
+_llgo_0:
+  %0 = load i1, ptr @"main.init$guard", align 1
+  br i1 %0, label %_llgo_2, label %_llgo_1
+
+_llgo_1:                                          ; preds = %_llgo_0
+  store i1 true, ptr @"main.init$guard", align 1
+  br label %_llgo_2
+
+_llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+  ret void
+}
+
+define i32 @main(i32 %0, ptr %1) {
+_llgo_0:
+  store i32 %0, ptr @__llgo_argc, align 4
+  store ptr %1, ptr @__llgo_argv, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.init"()
+  call void @main.init()
+  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 1)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 1)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 11)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 11)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
+  ret i32 0
+}
+
+declare void @"github.com/goplus/llgo/internal/runtime.init"()
+
+declare void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64)
+
+declare void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8)
+
+declare void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64)

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -223,15 +223,15 @@ func (b Builder) Const(v constant.Value, typ Type) Expr {
 		case kind == types.Bool:
 			return Expr{prog.BoolVal(constant.BoolVal(v)).impl, typ}
 		case kind >= types.Int && kind <= types.Int64:
-			if v, exact := constant.Int64Val(v); exact {
+			if v, exact := constant.Int64Val(constant.ToInt(v)); exact {
 				return prog.IntVal(uint64(v), typ)
 			}
 		case kind >= types.Uint && kind <= types.Uintptr:
-			if v, exact := constant.Uint64Val(v); exact {
+			if v, exact := constant.Uint64Val(constant.ToInt(v)); exact {
 				return prog.IntVal(v, typ)
 			}
 		case kind == types.Float64 || kind == types.Float32:
-			v, _ := constant.Float64Val(v)
+			v, _ := constant.Float64Val(constant.ToFloat(v))
 			return prog.FloatVal(v, typ)
 		case kind == types.String:
 			return Expr{b.Str(constant.StringVal(v)).impl, typ}


### PR DESCRIPTION
```go
func main() {
	var i64 int64 = 1
	var u64 uint64 = 1
	var c int64 = i64 + (1.0 / (1.0 / 10))
	var d uint64 = u64 + (1.0 / (1.0 / 10))
	println(u64, i64, c, d)
}
```
Compiles error:

```
panic: 10 not an Int
```