### PR TITLE
ssa: fix closure type

### DIFF
--- a/cl/_testgo/selects/out.ll
+++ b/cl/_testgo/selects/out.ll
@@ -149,50 +149,48 @@ _llgo_1:                                          ; preds = %_llgo_4, %_llgo_2
   ret i32 0
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %70 = extractvalue { i64, i1, {}, {} } %67, 2
-  %71 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %72 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %71, i32 0, i32 0
-  store ptr @1, ptr %72, align 8
-  %73 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %71, i32 0, i32 1
-  store i64 4, ptr %73, align 4
-  %74 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %71, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %74)
+  %70 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %71 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %70, i32 0, i32 0
+  store ptr @1, ptr %71, align 8
+  %72 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %70, i32 0, i32 1
+  store i64 4, ptr %72, align 4
+  %73 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %70, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %73)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_1
 
 _llgo_3:                                          ; preds = %_llgo_0
-  %75 = icmp eq i64 %68, 1
-  br i1 %75, label %_llgo_4, label %_llgo_5
+  %74 = icmp eq i64 %68, 1
+  br i1 %74, label %_llgo_4, label %_llgo_5
 
 _llgo_4:                                          ; preds = %_llgo_3
-  %76 = extractvalue { i64, i1, {}, {} } %67, 3
-  %77 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %78 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %77, i32 0, i32 0
-  store ptr @2, ptr %78, align 8
-  %79 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %77, i32 0, i32 1
-  store i64 4, ptr %79, align 4
-  %80 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %77, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %80)
+  %75 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %76 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %75, i32 0, i32 0
+  store ptr @2, ptr %76, align 8
+  %77 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %75, i32 0, i32 1
+  store i64 4, ptr %77, align 4
+  %78 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %75, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %78)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_1
 
 _llgo_5:                                          ; preds = %_llgo_3
-  %81 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %82 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %81, i32 0, i32 0
-  store ptr @3, ptr %82, align 8
-  %83 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %81, i32 0, i32 1
-  store i64 31, ptr %83, align 4
-  %84 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %81, align 8
-  %85 = load ptr, ptr @_llgo_string, align 8
-  %86 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %84, ptr %86, align 8
-  %87 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %88 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %87, i32 0, i32 0
-  store ptr %85, ptr %88, align 8
-  %89 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %87, i32 0, i32 1
-  store ptr %86, ptr %89, align 8
-  %90 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %87, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %90)
+  %79 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %80 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %79, i32 0, i32 0
+  store ptr @3, ptr %80, align 8
+  %81 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %79, i32 0, i32 1
+  store i64 31, ptr %81, align 4
+  %82 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %79, align 8
+  %83 = load ptr, ptr @_llgo_string, align 8
+  %84 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %82, ptr %84, align 8
+  %85 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %86 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %85, i32 0, i32 0
+  store ptr %83, ptr %86, align 8
+  %87 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %85, i32 0, i32 1
+  store ptr %84, ptr %87, align 8
+  %88 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %85, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %88)
   unreachable
 }
 
@@ -291,34 +289,33 @@ _llgo_3:                                          ; preds = %_llgo_0
   br i1 %53, label %_llgo_4, label %_llgo_5
 
 _llgo_4:                                          ; preds = %_llgo_3
-  %54 = extractvalue { i64, i1, {} } %46, 2
-  %55 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 0
-  store ptr @6, ptr %56, align 8
-  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 1
-  store i64 4, ptr %57, align 4
-  %58 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %55, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %58)
+  %54 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %54, i32 0, i32 0
+  store ptr @6, ptr %55, align 8
+  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %54, i32 0, i32 1
+  store i64 4, ptr %56, align 4
+  %57 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %54, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %57)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_1
 
 _llgo_5:                                          ; preds = %_llgo_3
-  %59 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %59, i32 0, i32 0
-  store ptr @3, ptr %60, align 8
-  %61 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %59, i32 0, i32 1
-  store i64 31, ptr %61, align 4
-  %62 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %59, align 8
-  %63 = load ptr, ptr @_llgo_string, align 8
-  %64 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %62, ptr %64, align 8
-  %65 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %66 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %65, i32 0, i32 0
+  %58 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %59 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %58, i32 0, i32 0
+  store ptr @3, ptr %59, align 8
+  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %58, i32 0, i32 1
+  store i64 31, ptr %60, align 4
+  %61 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %58, align 8
+  %62 = load ptr, ptr @_llgo_string, align 8
+  %63 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %61, ptr %63, align 8
+  %64 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %65 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %64, i32 0, i32 0
+  store ptr %62, ptr %65, align 8
+  %66 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %64, i32 0, i32 1
   store ptr %63, ptr %66, align 8
-  %67 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %65, i32 0, i32 1
-  store ptr %64, ptr %67, align 8
-  %68 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %65, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %68)
+  %67 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %64, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %67)
   unreachable
 }
 

--- a/cl/_testrt/closureiface/in.go
+++ b/cl/_testrt/closureiface/in.go
@@ -1,0 +1,14 @@
+package main
+
+func main() {
+	var m int = 200
+	fn := func(n int) int {
+		return m + n
+	}
+	var i any = fn
+	f, ok := i.(func(int) int)
+	if !ok {
+		panic("error")
+	}
+	println(f(100))
+}

--- a/cl/_testrt/closureiface/out.ll
+++ b/cl/_testrt/closureiface/out.ll
@@ -1,0 +1,303 @@
+; ModuleID = 'main'
+source_filename = "main"
+
+%"github.com/goplus/llgo/internal/runtime.eface" = type { ptr, ptr }
+%"github.com/goplus/llgo/internal/runtime.String" = type { ptr, i64 }
+%"github.com/goplus/llgo/internal/runtime.Slice" = type { ptr, i64, i64 }
+%"github.com/goplus/llgo/internal/abi.StructField" = type { %"github.com/goplus/llgo/internal/runtime.String", ptr, i64, %"github.com/goplus/llgo/internal/runtime.String", i1 }
+
+@"main.init$guard" = global i1 false, align 1
+@__llgo_argc = global i32 0, align 4
+@__llgo_argv = global ptr null, align 8
+@_llgo_Pointer = linkonce global ptr null, align 8
+@_llgo_int = linkonce global ptr null, align 8
+@"_llgo_func$LW7NaHY4krmx4VSCwrrjp23xg526aJ8NlR7kN98tIyE" = linkonce global ptr null, align 8
+@"main.struct$J4GOle3xvLePlAXZSFNKiHRJ-WQyyOMhvl8OQfxW2Q8" = linkonce global ptr null, align 8
+@0 = private unnamed_addr constant [1 x i8] c"f", align 1
+@1 = private unnamed_addr constant [4 x i8] c"data", align 1
+@2 = private unnamed_addr constant [4 x i8] c"main", align 1
+@3 = private unnamed_addr constant [5 x i8] c"error", align 1
+@_llgo_string = linkonce global ptr null, align 8
+
+define void @main.init() {
+_llgo_0:
+  %0 = load i1, ptr @"main.init$guard", align 1
+  br i1 %0, label %_llgo_2, label %_llgo_1
+
+_llgo_1:                                          ; preds = %_llgo_0
+  store i1 true, ptr @"main.init$guard", align 1
+  call void @"main.init$after"()
+  br label %_llgo_2
+
+_llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+  ret void
+}
+
+define i32 @main(i32 %0, ptr %1) {
+_llgo_0:
+  store i32 %0, ptr @__llgo_argc, align 4
+  store ptr %1, ptr @__llgo_argv, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.init"()
+  call void @main.init()
+  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 8)
+  store i64 200, ptr %2, align 4
+  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %4 = getelementptr inbounds { ptr }, ptr %3, i32 0, i32 0
+  store ptr %2, ptr %4, align 8
+  %5 = alloca { ptr, ptr }, align 8
+  %6 = getelementptr inbounds { ptr, ptr }, ptr %5, i32 0, i32 0
+  store ptr @"main.main$1", ptr %6, align 8
+  %7 = getelementptr inbounds { ptr, ptr }, ptr %5, i32 0, i32 1
+  store ptr %3, ptr %7, align 8
+  %8 = load { ptr, ptr }, ptr %5, align 8
+  %9 = load ptr, ptr @_llgo_Pointer, align 8
+  %10 = load ptr, ptr @_llgo_int, align 8
+  %11 = load ptr, ptr @"_llgo_func$LW7NaHY4krmx4VSCwrrjp23xg526aJ8NlR7kN98tIyE", align 8
+  %12 = load ptr, ptr @"main.struct$J4GOle3xvLePlAXZSFNKiHRJ-WQyyOMhvl8OQfxW2Q8", align 8
+  %13 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store { ptr, ptr } %8, ptr %13, align 8
+  %14 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %14, i32 0, i32 0
+  store ptr %12, ptr %15, align 8
+  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %14, i32 0, i32 1
+  store ptr %13, ptr %16, align 8
+  %17 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %14, align 8
+  %18 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %17, 0
+  %19 = load ptr, ptr @"main.struct$J4GOle3xvLePlAXZSFNKiHRJ-WQyyOMhvl8OQfxW2Q8", align 8
+  %20 = icmp eq ptr %18, %19
+  br i1 %20, label %_llgo_3, label %_llgo_4
+
+_llgo_1:                                          ; preds = %_llgo_5
+  %21 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %21, i32 0, i32 0
+  store ptr @3, ptr %22, align 8
+  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %21, i32 0, i32 1
+  store i64 5, ptr %23, align 4
+  %24 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %21, align 8
+  %25 = load ptr, ptr @_llgo_string, align 8
+  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %24, ptr %26, align 8
+  %27 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
+  %28 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %27, i32 0, i32 0
+  store ptr %25, ptr %28, align 8
+  %29 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %27, i32 0, i32 1
+  store ptr %26, ptr %29, align 8
+  %30 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %27, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %30)
+  unreachable
+
+_llgo_2:                                          ; preds = %_llgo_5
+  %31 = extractvalue { ptr, ptr } %45, 1
+  %32 = extractvalue { ptr, ptr } %45, 0
+  %33 = call i64 %32(ptr %31, i64 100)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %33)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
+  ret i32 0
+
+_llgo_3:                                          ; preds = %_llgo_0
+  %34 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %17, 1
+  %35 = load { ptr, ptr }, ptr %34, align 8
+  %36 = alloca { { ptr, ptr }, i1 }, align 8
+  %37 = getelementptr inbounds { { ptr, ptr }, i1 }, ptr %36, i32 0, i32 0
+  store { ptr, ptr } %35, ptr %37, align 8
+  %38 = getelementptr inbounds { { ptr, ptr }, i1 }, ptr %36, i32 0, i32 1
+  store i1 true, ptr %38, align 1
+  %39 = load { { ptr, ptr }, i1 }, ptr %36, align 8
+  br label %_llgo_5
+
+_llgo_4:                                          ; preds = %_llgo_0
+  %40 = alloca { { ptr, ptr }, i1 }, align 8
+  %41 = getelementptr inbounds { { ptr, ptr }, i1 }, ptr %40, i32 0, i32 0
+  store { ptr, ptr } zeroinitializer, ptr %41, align 8
+  %42 = getelementptr inbounds { { ptr, ptr }, i1 }, ptr %40, i32 0, i32 1
+  store i1 false, ptr %42, align 1
+  %43 = load { { ptr, ptr }, i1 }, ptr %40, align 8
+  br label %_llgo_5
+
+_llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
+  %44 = phi { { ptr, ptr }, i1 } [ %39, %_llgo_3 ], [ %43, %_llgo_4 ]
+  %45 = extractvalue { { ptr, ptr }, i1 } %44, 0
+  %46 = extractvalue { { ptr, ptr }, i1 } %44, 1
+  br i1 %46, label %_llgo_2, label %_llgo_1
+}
+
+define i64 @"main.main$1"(ptr %0, i64 %1) {
+_llgo_0:
+  %2 = load { ptr }, ptr %0, align 8
+  %3 = extractvalue { ptr } %2, 0
+  %4 = load i64, ptr %3, align 4
+  %5 = add i64 %4, %1
+  ret i64 %5
+}
+
+declare void @"github.com/goplus/llgo/internal/runtime.init"()
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64)
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64)
+
+define void @"main.init$after"() {
+_llgo_0:
+  %0 = load ptr, ptr @_llgo_Pointer, align 8
+  %1 = icmp eq ptr %0, null
+  br i1 %1, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %2)
+  store ptr %2, ptr @_llgo_Pointer, align 8
+  br label %_llgo_2
+
+_llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+  %3 = load ptr, ptr @_llgo_int, align 8
+  %4 = icmp eq ptr %3, null
+  br i1 %4, label %_llgo_3, label %_llgo_4
+
+_llgo_3:                                          ; preds = %_llgo_2
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  store ptr %5, ptr @_llgo_int, align 8
+  br label %_llgo_4
+
+_llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
+  %6 = load ptr, ptr @_llgo_Pointer, align 8
+  %7 = load ptr, ptr @_llgo_int, align 8
+  %8 = load ptr, ptr @_llgo_int, align 8
+  %9 = load ptr, ptr @"_llgo_func$LW7NaHY4krmx4VSCwrrjp23xg526aJ8NlR7kN98tIyE", align 8
+  %10 = icmp eq ptr %9, null
+  br i1 %10, label %_llgo_5, label %_llgo_6
+
+_llgo_5:                                          ; preds = %_llgo_4
+  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %12 = getelementptr ptr, ptr %11, i64 0
+  store ptr %6, ptr %12, align 8
+  %13 = getelementptr ptr, ptr %11, i64 1
+  store ptr %7, ptr %13, align 8
+  %14 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %14, i32 0, i32 0
+  store ptr %11, ptr %15, align 8
+  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %14, i32 0, i32 1
+  store i64 2, ptr %16, align 4
+  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %14, i32 0, i32 2
+  store i64 2, ptr %17, align 4
+  %18 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %14, align 8
+  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %20 = getelementptr ptr, ptr %19, i64 0
+  store ptr %8, ptr %20, align 8
+  %21 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, i32 0, i32 0
+  store ptr %19, ptr %22, align 8
+  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, i32 0, i32 1
+  store i64 1, ptr %23, align 4
+  %24 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, i32 0, i32 2
+  store i64 1, ptr %24, align 4
+  %25 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, align 8
+  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %18, %"github.com/goplus/llgo/internal/runtime.Slice" %25, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %26)
+  store ptr %26, ptr @"_llgo_func$LW7NaHY4krmx4VSCwrrjp23xg526aJ8NlR7kN98tIyE", align 8
+  br label %_llgo_6
+
+_llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
+  %27 = load ptr, ptr @_llgo_Pointer, align 8
+  %28 = load ptr, ptr @_llgo_int, align 8
+  %29 = load ptr, ptr @_llgo_int, align 8
+  %30 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %30, i32 0, i32 0
+  store ptr @0, ptr %31, align 8
+  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %30, i32 0, i32 1
+  store i64 1, ptr %32, align 4
+  %33 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %30, align 8
+  %34 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %34, i32 0, i32 0
+  store ptr null, ptr %35, align 8
+  %36 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %34, i32 0, i32 1
+  store i64 0, ptr %36, align 4
+  %37 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %34, align 8
+  %38 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %39 = getelementptr ptr, ptr %38, i64 0
+  store ptr %27, ptr %39, align 8
+  %40 = getelementptr ptr, ptr %38, i64 1
+  store ptr %28, ptr %40, align 8
+  %41 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %42 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %41, i32 0, i32 0
+  store ptr %38, ptr %42, align 8
+  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %41, i32 0, i32 1
+  store i64 2, ptr %43, align 4
+  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %41, i32 0, i32 2
+  store i64 2, ptr %44, align 4
+  %45 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %41, align 8
+  %46 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %47 = getelementptr ptr, ptr %46, i64 0
+  store ptr %29, ptr %47, align 8
+  %48 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %49 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, i32 0, i32 0
+  store ptr %46, ptr %49, align 8
+  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, i32 0, i32 1
+  store i64 1, ptr %50, align 4
+  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, i32 0, i32 2
+  store i64 1, ptr %51, align 4
+  %52 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, align 8
+  %53 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %45, %"github.com/goplus/llgo/internal/runtime.Slice" %52, i1 false)
+  %54 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %33, ptr %53, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %37, i1 false)
+  %55 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 0
+  store ptr @1, ptr %56, align 8
+  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 1
+  store i64 4, ptr %57, align 4
+  %58 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %55, align 8
+  %59 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %59, i32 0, i32 0
+  store ptr null, ptr %60, align 8
+  %61 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %59, i32 0, i32 1
+  store i64 0, ptr %61, align 4
+  %62 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %59, align 8
+  %63 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %64 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %58, ptr %63, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %62, i1 false)
+  %65 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %66 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %65, i32 0, i32 0
+  store ptr @2, ptr %66, align 8
+  %67 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %65, i32 0, i32 1
+  store i64 4, ptr %67, align 4
+  %68 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %65, align 8
+  %69 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %70 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %69, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %54, ptr %70, align 8
+  %71 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %69, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %64, ptr %71, align 8
+  %72 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
+  %73 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %72, i32 0, i32 0
+  store ptr %69, ptr %73, align 8
+  %74 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %72, i32 0, i32 1
+  store i64 2, ptr %74, align 4
+  %75 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %72, i32 0, i32 2
+  store i64 2, ptr %75, align 4
+  %76 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %72, align 8
+  %77 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %68, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %76)
+  store ptr %77, ptr @"main.struct$J4GOle3xvLePlAXZSFNKiHRJ-WQyyOMhvl8OQfxW2Q8", align 8
+  %78 = load ptr, ptr @_llgo_string, align 8
+  %79 = icmp eq ptr %78, null
+  br i1 %79, label %_llgo_7, label %_llgo_8
+
+_llgo_7:                                          ; preds = %_llgo_6
+  %80 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  store ptr %80, ptr @_llgo_string, align 8
+  br label %_llgo_8
+
+_llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
+  ret void
+}
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64)
+
+declare void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr)
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice", %"github.com/goplus/llgo/internal/runtime.Slice", i1)
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String", i64, %"github.com/goplus/llgo/internal/runtime.Slice")
+
+declare %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String", ptr, i64, %"github.com/goplus/llgo/internal/runtime.String", i1)
+
+declare void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64)
+
+declare void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8)
+
+declare void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface")

--- a/cl/cltest/cltest.go
+++ b/cl/cltest/cltest.go
@@ -144,11 +144,11 @@ func testFrom(t *testing.T, pkgDir, sel string, byLLGen bool) {
 			t.Fatalf("\n==> got:\n%s\n==> expected:\n%s\n", v, expected)
 		}
 	} else {
-		TestCompileEx(t, nil, in, expected)
+		TestCompileEx(t, nil, in, expected, dbg)
 	}
 }
 
-func TestCompileEx(t *testing.T, src any, fname, expected string) {
+func TestCompileEx(t *testing.T, src any, fname, expected string, dbg bool) {
 	t.Helper()
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, fname, src, parser.ParseComments)
@@ -159,8 +159,12 @@ func TestCompileEx(t *testing.T, src any, fname, expected string) {
 	name := f.Name.Name
 	pkg := types.NewPackage(name, name)
 	imp := packages.NewImporter(fset)
+	mode := ssa.SanityCheckFunctions | ssa.InstantiateGenerics
+	if dbg {
+		mode |= ssa.GlobalDebug
+	}
 	foo, _, err := ssautil.BuildPackage(
-		&types.Config{Importer: imp}, fset, pkg, files, ssa.SanityCheckFunctions|ssa.InstantiateGenerics|ssa.GlobalDebug)
+		&types.Config{Importer: imp}, fset, pkg, files, mode)
 	if err != nil {
 		t.Fatal("BuildPackage failed:", err)
 	}

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -26,7 +26,7 @@ import (
 
 func testCompile(t *testing.T, src, expected string) {
 	t.Helper()
-	cltest.TestCompileEx(t, src, "foo.go", expected)
+	cltest.TestCompileEx(t, src, "foo.go", expected, false)
 }
 
 func TestFromTestgo(t *testing.T) {

--- a/ssa/di.go
+++ b/ssa/di.go
@@ -179,7 +179,7 @@ func (b diBuilder) createType(name string, ty Type, pos token.Position) DIType {
 	case *types.Struct:
 		return b.createStructType(name, ty, pos)
 	case *types.Signature:
-		tyFn := b.prog.Closure(ty)
+		tyFn := b.prog.Closure(t)
 		return b.createFuncPtrType(name, tyFn, pos)
 	case *types.Array:
 		return b.createArrayType(ty, t.Len())
@@ -600,7 +600,7 @@ func (b Builder) doConstructDebugAddr(v Expr, t types.Type) (dbgPtr Expr, dbgVal
 	case *types.Slice:
 		ty = b.Prog.Type(b.Prog.rtType("Slice").RawType().Underlying(), InGo)
 	case *types.Signature:
-		ty = b.Prog.Closure(b.Prog.rawType(t))
+		ty = b.Prog.Closure(t)
 	case *types.Named:
 		ty = b.Prog.Type(t.Underlying(), InGo)
 	case *types.Map:

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -924,7 +924,19 @@ func (b Builder) MakeClosure(fn Expr, bindings []Expr) Expr {
 	tctx := sig.Params().At(0).Type().Underlying().(*types.Pointer).Elem().(*types.Struct)
 	flds := llvmFields(bindings, tctx, b)
 	data := b.aggregateAllocU(prog.rawType(tctx), flds...)
-	return b.aggregateValue(prog.Closure(tfn), fn.impl, data)
+	return b.aggregateValue(closureType(prog, sig), fn.impl, data)
+}
+
+func closureType(p Program, sig *types.Signature) Type {
+	params := sig.Params()
+	n := params.Len()
+	args := make([]*types.Var, n-1)
+	for i := 0; i < n-1; i++ {
+		args[i] = params.At(i + 1)
+	}
+	sig = types.NewSignature(sig.Recv(), types.NewTuple(args...), sig.Results(), sig.Variadic())
+	closure := p.gocvt.cvtClosure(sig)
+	return p.rawType(closure)
 }
 
 // -----------------------------------------------------------------------------

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -924,19 +924,17 @@ func (b Builder) MakeClosure(fn Expr, bindings []Expr) Expr {
 	tctx := sig.Params().At(0).Type().Underlying().(*types.Pointer).Elem().(*types.Struct)
 	flds := llvmFields(bindings, tctx, b)
 	data := b.aggregateAllocU(prog.rawType(tctx), flds...)
-	return b.aggregateValue(closureType(prog, sig), fn.impl, data)
+	return b.aggregateValue(prog.Closure(removeCtx(sig)), fn.impl, data)
 }
 
-func closureType(p Program, sig *types.Signature) Type {
+func removeCtx(sig *types.Signature) *types.Signature {
 	params := sig.Params()
 	n := params.Len()
 	args := make([]*types.Var, n-1)
 	for i := 0; i < n-1; i++ {
 		args[i] = params.At(i + 1)
 	}
-	sig = types.NewSignature(sig.Recv(), types.NewTuple(args...), sig.Results(), sig.Variadic())
-	closure := p.gocvt.cvtClosure(sig)
-	return p.rawType(closure)
+	return types.NewSignature(sig.Recv(), types.NewTuple(args...), sig.Results(), sig.Variadic())
 }
 
 // -----------------------------------------------------------------------------

--- a/ssa/type_cvt.go
+++ b/ssa/type_cvt.go
@@ -67,8 +67,7 @@ func (p Program) FuncDecl(sig *types.Signature, bg Background) Type {
 }
 
 // Closure creates a closture type for a function.
-func (p Program) Closure(fn Type) Type {
-	sig := fn.raw.Type.(*types.Signature)
+func (p Program) Closure(sig *types.Signature) Type {
 	closure := p.gocvt.cvtClosure(sig)
 	return p.rawType(closure)
 }


### PR DESCRIPTION
- fix closure type

```
var m int = 200
fn := func(n int) int {
	return m + n
}
```
```
Do 0 make closure main$1 [t0] [100:int]
Call 10 struct{f func(__llgo_ctx unsafe.Pointer, __llgo_ctx *struct{m *int}, n int) int; data unsafe.Pointer} closure: i64 100
```
   fixed type to
```
Do 0 make closure main$1 [t0] [100:int]
Call 10 struct{f func(__llgo_ctx unsafe.Pointer, n int) int; data unsafe.Pointer} closure: i64 100
```
- fix closure conv
```
func main() {
	var m int = 200
	fn := func(n int) int {
		return m + n
	}
	var i any = fn
	f, ok := i.(func(int) int)
	if !ok {
		panic("error")
	}
	println(f(100))
}
```
