### PR TITLE
c/clang:include

### DIFF
--- a/c/clang/_demo/inclusion/inclusion.go
+++ b/c/clang/_demo/inclusion/inclusion.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"unsafe"
+
+	"github.com/goplus/llgo/c"
+	"github.com/goplus/llgo/c/clang"
+	"github.com/goplus/llgo/chore/_xtool/llcppsymg/clangutils"
+)
+
+func main() {
+	_, unit, err := clangutils.CreateTranslationUnit(&clangutils.Config{
+		File:  "#include <stddef.h>",
+		Temp:  true,
+		IsCpp: false,
+	})
+	if err != nil {
+		println(err.Error())
+		return
+	}
+
+	clang.GetInclusions(unit, func(included_file clang.File, inclusion_stack *clang.SourceLocation, include_len c.Uint, client_data c.Pointer) {
+		filename := included_file.FileName()
+		c.Printf(c.Str("Included file: %s Include length: %d\n"), filename.CStr(), include_len)
+		inclusions := unsafe.Slice(inclusion_stack, include_len)
+		if include_len > 0 {
+			for i := range inclusions {
+				loc := inclusions[i]
+				var file clang.File
+				var line, column c.Uint
+				loc.SpellingLocation(&file, &line, &column, nil)
+				filename = file.FileName()
+				c.Printf(c.Str("  included from: %s:%d:%d\n"), filename.CStr(), line, column)
+			}
+		}
+	}, nil)
+}

--- a/c/clang/clang.go
+++ b/c/clang/clang.go
@@ -2643,6 +2643,29 @@ func VisitChildren(
 type Visitor func(cursor, parent Cursor, clientData ClientData) ChildVisitResult
 
 /**
+ * Visitor invoked for each file in a translation unit
+ *        (used with clang_getInclusions()).
+ *
+ * This visitor function will be invoked by clang_getInclusions() for each
+ * file included (either at the top-level or by \#include directives) within
+ * a translation unit.  The first argument is the file being included, and
+ * the second and third arguments provide the inclusion stack.  The
+ * array is sorted in order of immediate inclusion.  For example,
+ * the first element refers to the location that included 'included_file'.
+ */
+//llgo:type C
+type InclusionVisitor func(included_file File, inclusion_stack *SourceLocation, include_len c.Uint, client_data ClientData)
+
+/**
+ * Visit the set of preprocessor inclusions in a translation unit.
+ *   The visitor function is called with the provided data for every included
+ *   file.  This does not include headers included by the PCH file (unless one
+ *   is inspecting the inclusions in the PCH file itself).
+ */
+//go:linkname GetInclusions C.clang_getInclusions
+func GetInclusions(tu *TranslationUnit, visitor InclusionVisitor, client_data ClientData)
+
+/**
  * Tokenize the source code described by the given range into raw
  * lexical tokens.
  *


### PR DESCRIPTION

below problem resolved in PR #850

#### problem
During the development process, a bug (#848) was discovered that causes incorrect iteration over a slice formed from a non-existent include stack when traversing the include stack. 
```bash
clang/_demo/inclusion on  c/clang/visitinclude [$!?] via 🐹 v1.20.4 
❯ llgo run .
Included file: temp.h Include length: 0
panic: runtime error: invalid memory address or nil pointer dereference
```

