### PR TITLE
llcppsigfetch:abs include path & system header & config mode 's include flags

### DIFF
--- a/chore/_xtool/llcppsigfetch/llcppsigfetch.go
+++ b/chore/_xtool/llcppsigfetch/llcppsigfetch.go
@@ -162,7 +162,10 @@ func runFromConfig(cfgFile string, useStdin bool, outputToFile bool, verbose boo
 		}
 	}
 
-	context := parse.NewContext(conf.Cplusplus)
+	context := parse.NewContext(&parse.ContextConfig{
+		IsCpp:   conf.Cplusplus,
+		Include: conf.Include,
+	})
 	err = context.ProcessFiles(files)
 	check(err)
 

--- a/chore/_xtool/llcppsigfetch/parse/cvt.go
+++ b/chore/_xtool/llcppsigfetch/parse/cvt.go
@@ -153,7 +153,9 @@ func (ct *Converter) GetCurFile(cursor clang.Cursor) *ast.File {
 
 func (ct *Converter) CreateDeclBase(cursor clang.Cursor) ast.DeclBase {
 	base := ast.DeclBase{
-		Loc:    &ct.curLoc,
+		Loc: &ast.Location{
+			File: ct.curLoc.File,
+		},
 		Parent: ct.BuildScopingExpr(cursor.SemanticParent()),
 	}
 	commentGroup, isDoc := ct.ParseCommentGroup(cursor)

--- a/chore/_xtool/llcppsigfetch/parse/cvt_test/cvt.go
+++ b/chore/_xtool/llcppsigfetch/parse/cvt_test/cvt.go
@@ -79,7 +79,7 @@ func GetType(option *GetTypeOptions) (clang.Type, *clang.Index, *clang.Translati
 	}
 	cursor := unit.Cursor()
 	var typ clang.Type
-	parse.VisitChildren(cursor, func(child, parent clang.Cursor) clang.ChildVisitResult {
+	clangutils.VisitChildren(cursor, func(child, parent clang.Cursor) clang.ChildVisitResult {
 		if child.Kind == clang.CursorVarDecl && (option.ExpectTypeKind == clang.TypeInvalid || option.ExpectTypeKind == child.Type().Kind) {
 			typ = child.Type()
 			return clang.ChildVisit_Break

--- a/chore/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/llgo.expect
+++ b/chore/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/llgo.expect
@@ -1,4 +1,6 @@
 #stdout
+=== TestSystemHeader ===
+include files are all system headers
 TestDefine Case 1:
 {
 	"temp.h":	{

--- a/chore/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/llgo.expect
+++ b/chore/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/llgo.expect
@@ -2,6 +2,8 @@
 === TestSystemHeader ===
 stdio.h is absolute path
 include files are all system headers
+=== TestInclusionMap ===
+sys/types.h include path found
 TestDefine Case 1:
 {
 	"temp.h":	{
@@ -169,7 +171,7 @@ TestMacroExpansionOtherFile:
 			}],
 		"includes":	[{
 				"_Type":	"Include",
-				"Path":	"def.h"
+				"Path":	"./testdata/macroexpan/def.h"
 			}],
 		"macros":	[]
 	},

--- a/chore/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/llgo.expect
+++ b/chore/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/llgo.expect
@@ -1,5 +1,6 @@
 #stdout
 === TestSystemHeader ===
+stdio.h is absolute path
 include files are all system headers
 TestDefine Case 1:
 {
@@ -112,10 +113,7 @@ TestInclude Case 1:
 	"temp.h":	{
 		"_Type":	"File",
 		"decls":	[],
-		"includes":	[{
-				"_Type":	"Include",
-				"Path":	"foo.h"
-			}],
+		"includes":	[],
 		"macros":	[]
 	}
 }

--- a/chore/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/preprocess.go
+++ b/chore/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/preprocess.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/goplus/llgo/c"
+	"github.com/goplus/llgo/chore/_xtool/llcppsigfetch/parse"
 	test "github.com/goplus/llgo/chore/_xtool/llcppsigfetch/parse/cvt_test"
 	"github.com/goplus/llgo/chore/_xtool/llcppsymg/clangutils"
 )
@@ -9,6 +12,7 @@ import (
 func main() {
 	TestDefine()
 	TestInclude()
+	TestSystemHeader()
 	TestMacroExpansionOtherFile()
 }
 
@@ -27,6 +31,31 @@ func TestInclude() {
 		// `#include <limits.h>`, //  Standard libraries are mostly platform-dependent
 	}
 	test.RunTest("TestInclude", testCases)
+}
+
+func TestSystemHeader() {
+	fmt.Println("=== TestSystemHeader ===")
+	converter, err := parse.NewConverter(&clangutils.Config{
+		File:  "#include <stdio.h>",
+		Temp:  true,
+		IsCpp: false,
+	})
+	if err != nil {
+		panic(err)
+	}
+	converter.Convert()
+	if len(converter.Files) < 2 {
+		panic("expect 2 files")
+	}
+	if converter.Files[0].IsSys {
+		panic("entry file is not system header")
+	}
+	for i := 1; i < len(converter.Files); i++ {
+		if !converter.Files[i].IsSys {
+			panic(fmt.Errorf("include file is not system header: %s", converter.Files[i].Path))
+		}
+	}
+	fmt.Println("include files are all system headers")
 }
 
 func TestMacroExpansionOtherFile() {

--- a/chore/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/preprocess.go
+++ b/chore/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/preprocess.go
@@ -16,6 +16,7 @@ func main() {
 	TestDefine()
 	TestInclude()
 	TestSystemHeader()
+	TestInclusionMap()
 	TestMacroExpansionOtherFile()
 }
 
@@ -34,6 +35,29 @@ func TestInclude() {
 		// `#include <limits.h>`, //  Standard libraries are mostly platform-dependent
 	}
 	test.RunTest("TestInclude", testCases)
+}
+
+func TestInclusionMap() {
+	fmt.Println("=== TestInclusionMap ===")
+	converter, err := parse.NewConverter(&clangutils.Config{
+		File:  "#include <sys/types.h>",
+		Temp:  true,
+		IsCpp: false,
+	})
+	if err != nil {
+		panic(err)
+	}
+	found := false
+	for _, f := range converter.Files {
+		if f.IncPath == "sys/types.h" {
+			found = true
+		}
+	}
+	if !found {
+		panic("sys/types.h not found")
+	} else {
+		fmt.Println("sys/types.h include path found")
+	}
 }
 
 func TestSystemHeader() {

--- a/chore/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/preprocess.go
+++ b/chore/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/preprocess.go
@@ -9,6 +9,7 @@ import (
 	"github.com/goplus/llgo/chore/_xtool/llcppsigfetch/parse"
 	test "github.com/goplus/llgo/chore/_xtool/llcppsigfetch/parse/cvt_test"
 	"github.com/goplus/llgo/chore/_xtool/llcppsymg/clangutils"
+	"github.com/goplus/llgo/chore/llcppg/ast"
 )
 
 func main() {
@@ -61,6 +62,17 @@ func TestSystemHeader() {
 	for i := 1; i < len(converter.Files); i++ {
 		if !converter.Files[i].IsSys {
 			panic(fmt.Errorf("include file is not system header: %s", converter.Files[i].Path))
+		}
+		for _, decl := range converter.Files[i].Doc.Decls {
+			switch decl := decl.(type) {
+			case *ast.TypeDecl:
+			case *ast.EnumTypeDecl:
+			case *ast.FuncDecl:
+			case *ast.TypedefDecl:
+				if decl.DeclBase.Loc.File != converter.Files[i].Path {
+					fmt.Println("Decl is not in the file", decl.DeclBase.Loc.File, "expect", converter.Files[i].Path)
+				}
+			}
 		}
 	}
 	fmt.Println("include files are all system headers")

--- a/chore/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/preprocess.go
+++ b/chore/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/preprocess.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	"github.com/goplus/llgo/c"
 	"github.com/goplus/llgo/chore/_xtool/llcppsigfetch/parse"
@@ -50,6 +52,12 @@ func TestSystemHeader() {
 	if converter.Files[0].IsSys {
 		panic("entry file is not system header")
 	}
+
+	includePath := converter.Files[0].Doc.Includes[0].Path
+	if strings.HasSuffix(includePath, "stdio.h") && filepath.IsAbs(includePath) {
+		fmt.Println("stdio.h is absolute path")
+	}
+
 	for i := 1; i < len(converter.Files); i++ {
 		if !converter.Files[i].IsSys {
 			panic(fmt.Errorf("include file is not system header: %s", converter.Files[i].Path))

--- a/chore/_xtool/llcppsigfetch/parse/dump.go
+++ b/chore/_xtool/llcppsigfetch/parse/dump.go
@@ -13,6 +13,7 @@ func MarshalOutputASTFiles(files []*FileEntry) *cjson.JSON {
 		path := cjson.String(c.AllocaCStr(entry.Path))
 		f.SetItem(c.Str("path"), path)
 		f.SetItem(c.Str("doc"), MarshalASTFile(entry.Doc))
+		f.SetItem(c.Str("IsSys"), boolField(entry.IsSys))
 		root.AddItem(f)
 	}
 	return root

--- a/chore/_xtool/llcppsigfetch/parse/dump.go
+++ b/chore/_xtool/llcppsigfetch/parse/dump.go
@@ -13,7 +13,7 @@ func MarshalOutputASTFiles(files []*FileEntry) *cjson.JSON {
 		path := cjson.String(c.AllocaCStr(entry.Path))
 		f.SetItem(c.Str("path"), path)
 		f.SetItem(c.Str("doc"), MarshalASTFile(entry.Doc))
-		f.SetItem(c.Str("IsSys"), boolField(entry.IsSys))
+		f.SetItem(c.Str("isSys"), boolField(entry.IsSys))
 		root.AddItem(f)
 	}
 	return root

--- a/chore/_xtool/llcppsigfetch/parse/dump.go
+++ b/chore/_xtool/llcppsigfetch/parse/dump.go
@@ -11,6 +11,8 @@ func MarshalOutputASTFiles(files []*FileEntry) *cjson.JSON {
 	for _, entry := range files {
 		f := cjson.Object()
 		path := cjson.String(c.AllocaCStr(entry.Path))
+		incPath := cjson.String(c.AllocaCStr(entry.IncPath))
+		f.SetItem(c.Str("incPath"), incPath)
 		f.SetItem(c.Str("path"), path)
 		f.SetItem(c.Str("doc"), MarshalASTFile(entry.Doc))
 		f.SetItem(c.Str("isSys"), boolField(entry.IsSys))

--- a/chore/_xtool/llcppsymg/clangutils/clangutils.go
+++ b/chore/_xtool/llcppsymg/clangutils/clangutils.go
@@ -18,6 +18,8 @@ type Config struct {
 
 type Visitor func(cursor, parent clang.Cursor) clang.ChildVisitResult
 
+type InclusionVisitor func(included_file clang.File, inclusions []clang.SourceLocation)
+
 const TEMP_FILE = "temp.h"
 
 func CreateTranslationUnit(config *Config) (*clang.Index, *clang.TranslationUnit, error) {
@@ -98,4 +100,12 @@ func VisitChildren(cursor clang.Cursor, fn Visitor) c.Uint {
 		cfn := *(*Visitor)(clientData)
 		return cfn(cursor, parent)
 	}, unsafe.Pointer(&fn))
+}
+
+func GetInclusions(unit *clang.TranslationUnit, visitor InclusionVisitor) {
+	clang.GetInclusions(unit, func(inced clang.File, incin *clang.SourceLocation, incilen c.Uint, data c.Pointer) {
+		ics := unsafe.Slice(incin, incilen)
+		cfn := *(*InclusionVisitor)(data)
+		cfn(inced, ics)
+	}, unsafe.Pointer(&visitor))
 }


### PR DESCRIPTION
* Change includes to output absolute paths for corresponding header files
* Identify system header files
* std include path
* config mode 's include flags
```json
    {
    "incPath": "stddef.h",
    "isSys": true,
    "path": "/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/stddef.h",
    "doc": {
      "_Type": "File",
      "includes": [
        {
          "_Type": "Include",
          "Path": "/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/_types.h"
        },
        {
          "_Type": "Include",
          "Path": "/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/sys/_types/_size_t.h"
        },
      ],
    },
  {
    "incPath": "sys/_types/_size_t.h",
    "path": "/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/sys/_types/_size_t.h",
    "doc": {
      "_Type": "File",
      "includes": [
        {
          "_Type": "Include",
          "Path": "/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/machine/_types.h"
        }
      ],
    },
    "isSys": true
  },
  },
```