### PR TITLE
workflow:libffi

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,8 +26,9 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: |
           brew update
-          brew install llvm@${{matrix.llvm}} pkg-config bdw-gc openssl
+          brew install llvm@${{matrix.llvm}} pkg-config bdw-gc openssl libffi
           echo "$(brew --prefix llvm@${{matrix.llvm}})/bin" >> $GITHUB_PATH
+          echo "PKG_CONFIG_PATH=/opt/homebrew/opt/libffi/lib/pkgconfig" >> $GITHUB_ENV
 
           # Install optional deps for demos.
           #
@@ -45,7 +46,7 @@ jobs:
           echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${{matrix.llvm}} main" | sudo tee /etc/apt/sources.list.d/llvm.list
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo apt-get update
-          sudo apt-get install -y llvm-${{matrix.llvm}}-dev clang-${{matrix.llvm}} lld-${{matrix.llvm}} pkg-config libgc-dev libssl-dev zlib1g-dev
+          sudo apt-get install -y llvm-${{matrix.llvm}}-dev clang-${{matrix.llvm}} lld-${{matrix.llvm}} pkg-config libgc-dev libssl-dev zlib1g-dev libffi-dev
           echo "/usr/lib/llvm-${{matrix.llvm}}/bin" >> $GITHUB_PATH
 
           # Install optional deps for demos.


### PR DESCRIPTION
If libffi's PKG_CONFIG_PATH is not set for Homebrew-installed libffi, the llgo-compiled llcppsigfetch program fails to execute due to missing libffi.dylib dependency.

https://github.com/luoliwoshang/llgo/actions/runs/11679357457/job/32520313633

```bash
=== RUN   TestSigfetch/cpp_sigfetch
    symb_test.go:72: error running llcppsigfetch: signal: abort trap
        Stderr: dyld[7125]: Library not loaded: @rpath/libffi.dylib
          Referenced from: <4C4C443F-5555-3144-A1F4-363ACED773AF> /Users/runner/go/bin/llcppsigfetch
          Reason: tried: '/Users/runner/go/bin/libffi.dylib' (no such file), '/Users/runner/go/bin/../lib/libffi.dylib' (no such file), '/opt/homebrew/Cellar/cjson/1.7.18/lib/libffi.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/cjson/1.7.18/lib/libffi.dylib' (no such file), '/opt/homebrew/Cellar/llvm@18/18.1.8/lib/libffi.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/llvm@18/18.1.8/lib/libffi.dylib' (no such file), '/opt/homebrew/Cellar/bdw-gc/8.2.8/lib/libffi.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/bdw-gc/8.2.8/lib/libffi.dylib' (no such file), '/opt/homebrew/Cellar/bdw-gc/8.2.8/lib/libffi.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/bdw-gc/8.2.8/lib/libffi.dylib' (no such file), '/Users/runner/go/bin/libffi.dylib' (no such file), '/Users/runner/go/bin/../lib/libffi.dylib' (no such file), '/opt/homebrew/Cellar/cjson/1.7.18/lib/libffi.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/cjson/1.7.18/lib/libffi.dylib' (no such file), '/opt/homebrew/Cellar/llvm@18/18.1.8/lib/libffi.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/llvm@18/18.1.8/lib/libffi.dylib' (no such file), '/opt/homebrew/Cellar/bdw-gc/8.2.8/lib/libffi.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/bdw-gc/8.2.8/lib/libffi.dylib' (no such file), '/opt/homebrew/Cellar/bdw-gc/8.2.8/lib/libffi.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/bdw-gc/8.2.8/lib/libffi.dylib' (no such file)
```