### PR TITLE
llcppsigfetch:typedef refer same struct & remove tokenize check for underlying

### DIFF
--- a/chore/_xtool/llcppsigfetch/parse/cvt_test/cvt.go
+++ b/chore/_xtool/llcppsigfetch/parse/cvt_test/cvt.go
@@ -12,28 +12,33 @@ import (
 
 func RunTest(testName string, testCases []string) {
 	for i, content := range testCases {
-		converter, err := parse.NewConverter(&clangutils.Config{
+		c.Printf(c.Str("%s Case %d:\n"), c.AllocaCStr(testName), c.Int(i+1))
+		RunTestWithConfig(&clangutils.Config{
 			File:  content,
 			Temp:  true,
 			IsCpp: true,
 		})
-		if err != nil {
-			panic(err)
-		}
-
-		_, err = converter.Convert()
-		if err != nil {
-			panic(err)
-		}
-
-		result := converter.MarshalASTFiles()
-		str := result.Print()
-		c.Printf(c.Str("%s Case %d:\n%s\n\n"), c.AllocaCStr(testName), c.Int(i+1), str)
-
-		cjson.FreeCStr(str)
-		result.Delete()
-		converter.Dispose()
 	}
+}
+
+func RunTestWithConfig(config *clangutils.Config) {
+	converter, err := parse.NewConverter(config)
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = converter.Convert()
+	if err != nil {
+		panic(err)
+	}
+
+	result := converter.MarshalASTFiles()
+	str := result.Print()
+	c.Printf(c.Str("%s\n\n"), str)
+
+	cjson.FreeCStr(str)
+	result.Delete()
+	converter.Dispose()
 }
 
 type GetTypeOptions struct {

--- a/chore/_xtool/llcppsigfetch/parse/cvt_test/decl_test/typedef_test/llgo.expect
+++ b/chore/_xtool/llcppsigfetch/parse/cvt_test/decl_test/typedef_test/llgo.expect
@@ -484,39 +484,6 @@ TestTypeDefDecl Case 7:
 				},
 				"Doc":	null,
 				"Parent":	null,
-				"Name":	null,
-				"Type":	{
-					"_Type":	"RecordType",
-					"Tag":	0,
-					"Fields":	{
-						"_Type":	"FieldList",
-						"List":	[{
-								"_Type":	"Field",
-								"Type":	{
-									"_Type":	"BuiltinType",
-									"Kind":	6,
-									"Flags":	0
-								},
-								"Doc":	null,
-								"Comment":	null,
-								"IsStatic":	false,
-								"Access":	1,
-								"Names":	[{
-										"_Type":	"Ident",
-										"Name":	"x"
-									}]
-							}]
-					},
-					"Methods":	[]
-				}
-			}, {
-				"_Type":	"TypedefDecl",
-				"Loc":	{
-					"_Type":	"Location",
-					"File":	"temp.h"
-				},
-				"Doc":	null,
-				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
 					"Name":	"MyStruct"
@@ -563,39 +530,6 @@ TestTypeDefDecl Case 8:
 				},
 				"Doc":	null,
 				"Parent":	null,
-				"Name":	null,
-				"Type":	{
-					"_Type":	"RecordType",
-					"Tag":	1,
-					"Fields":	{
-						"_Type":	"FieldList",
-						"List":	[{
-								"_Type":	"Field",
-								"Type":	{
-									"_Type":	"BuiltinType",
-									"Kind":	6,
-									"Flags":	0
-								},
-								"Doc":	null,
-								"Comment":	null,
-								"IsStatic":	false,
-								"Access":	1,
-								"Names":	[{
-										"_Type":	"Ident",
-										"Name":	"x"
-									}]
-							}]
-					},
-					"Methods":	[]
-				}
-			}, {
-				"_Type":	"TypedefDecl",
-				"Loc":	{
-					"_Type":	"Location",
-					"File":	"temp.h"
-				},
-				"Doc":	null,
-				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
 					"Name":	"MyUnion"
@@ -636,52 +570,6 @@ TestTypeDefDecl Case 9:
 		"_Type":	"File",
 		"decls":	[{
 				"_Type":	"EnumTypeDecl",
-				"Loc":	{
-					"_Type":	"Location",
-					"File":	"temp.h"
-				},
-				"Doc":	null,
-				"Parent":	null,
-				"Name":	null,
-				"Type":	{
-					"_Type":	"EnumType",
-					"Items":	[{
-							"_Type":	"EnumItem",
-							"Name":	{
-								"_Type":	"Ident",
-								"Name":	"RED"
-							},
-							"Value":	{
-								"_Type":	"BasicLit",
-								"Kind":	0,
-								"Value":	"0"
-							}
-						}, {
-							"_Type":	"EnumItem",
-							"Name":	{
-								"_Type":	"Ident",
-								"Name":	"GREEN"
-							},
-							"Value":	{
-								"_Type":	"BasicLit",
-								"Kind":	0,
-								"Value":	"1"
-							}
-						}, {
-							"_Type":	"EnumItem",
-							"Name":	{
-								"_Type":	"Ident",
-								"Name":	"BLUE"
-							},
-							"Value":	{
-								"_Type":	"BasicLit",
-								"Kind":	0,
-								"Value":	"2"
-							}
-						}]
-				}
-			}, {
-				"_Type":	"TypedefDecl",
 				"Loc":	{
 					"_Type":	"Location",
 					"File":	"temp.h"
@@ -747,39 +635,6 @@ TestTypeDefDecl Case 10:
 				},
 				"Doc":	null,
 				"Parent":	null,
-				"Name":	null,
-				"Type":	{
-					"_Type":	"RecordType",
-					"Tag":	0,
-					"Fields":	{
-						"_Type":	"FieldList",
-						"List":	[{
-								"_Type":	"Field",
-								"Type":	{
-									"_Type":	"BuiltinType",
-									"Kind":	6,
-									"Flags":	0
-								},
-								"Doc":	null,
-								"Comment":	null,
-								"IsStatic":	false,
-								"Access":	1,
-								"Names":	[{
-										"_Type":	"Ident",
-										"Name":	"x"
-									}]
-							}]
-					},
-					"Methods":	[]
-				}
-			}, {
-				"_Type":	"TypedefDecl",
-				"Loc":	{
-					"_Type":	"Location",
-					"File":	"temp.h"
-				},
-				"Doc":	null,
-				"Parent":	null,
 				"Name":	{
 					"_Type":	"Ident",
 					"Name":	"MyStruct"
@@ -821,28 +676,12 @@ TestTypeDefDecl Case 10:
 					"Name":	"MyStruct2"
 				},
 				"Type":	{
-					"_Type":	"RecordType",
-					"Tag":	0,
-					"Fields":	{
-						"_Type":	"FieldList",
-						"List":	[{
-								"_Type":	"Field",
-								"Type":	{
-									"_Type":	"BuiltinType",
-									"Kind":	6,
-									"Flags":	0
-								},
-								"Doc":	null,
-								"Comment":	null,
-								"IsStatic":	false,
-								"Access":	1,
-								"Names":	[{
-										"_Type":	"Ident",
-										"Name":	"x"
-									}]
-							}]
+					"_Type":	"TagExpr",
+					"Name":	{
+						"_Type":	"Ident",
+						"Name":	"MyStruct"
 					},
-					"Methods":	[]
+					"Tag":	0
 				}
 			}, {
 				"_Type":	"TypedefDecl",
@@ -859,28 +698,12 @@ TestTypeDefDecl Case 10:
 				"Type":	{
 					"_Type":	"PointerType",
 					"X":	{
-						"_Type":	"RecordType",
-						"Tag":	0,
-						"Fields":	{
-							"_Type":	"FieldList",
-							"List":	[{
-									"_Type":	"Field",
-									"Type":	{
-										"_Type":	"BuiltinType",
-										"Kind":	6,
-										"Flags":	0
-									},
-									"Doc":	null,
-									"Comment":	null,
-									"IsStatic":	false,
-									"Access":	1,
-									"Names":	[{
-											"_Type":	"Ident",
-											"Name":	"x"
-										}]
-								}]
+						"_Type":	"TagExpr",
+						"Name":	{
+							"_Type":	"Ident",
+							"Name":	"MyStruct"
 						},
-						"Methods":	[]
+						"Tag":	0
 					}
 				}
 			}, {
@@ -898,28 +721,12 @@ TestTypeDefDecl Case 10:
 				"Type":	{
 					"_Type":	"ArrayType",
 					"Elt":	{
-						"_Type":	"RecordType",
-						"Tag":	0,
-						"Fields":	{
-							"_Type":	"FieldList",
-							"List":	[{
-									"_Type":	"Field",
-									"Type":	{
-										"_Type":	"BuiltinType",
-										"Kind":	6,
-										"Flags":	0
-									},
-									"Doc":	null,
-									"Comment":	null,
-									"IsStatic":	false,
-									"Access":	1,
-									"Names":	[{
-											"_Type":	"Ident",
-											"Name":	"x"
-										}]
-								}]
+						"_Type":	"TagExpr",
+						"Name":	{
+							"_Type":	"Ident",
+							"Name":	"MyStruct"
 						},
-						"Methods":	[]
+						"Tag":	0
 					},
 					"Len":	null
 				}
@@ -951,49 +758,6 @@ TestTypeDefDecl Case 11:
 						"Name":	"A"
 					}
 				},
-				"Name":	null,
-				"Type":	{
-					"_Type":	"RecordType",
-					"Tag":	0,
-					"Fields":	{
-						"_Type":	"FieldList",
-						"List":	[{
-								"_Type":	"Field",
-								"Type":	{
-									"_Type":	"BuiltinType",
-									"Kind":	6,
-									"Flags":	0
-								},
-								"Doc":	null,
-								"Comment":	null,
-								"IsStatic":	false,
-								"Access":	1,
-								"Names":	[{
-										"_Type":	"Ident",
-										"Name":	"x"
-									}]
-							}]
-					},
-					"Methods":	[]
-				}
-			}, {
-				"_Type":	"TypedefDecl",
-				"Loc":	{
-					"_Type":	"Location",
-					"File":	"temp.h"
-				},
-				"Doc":	null,
-				"Parent":	{
-					"_Type":	"ScopingExpr",
-					"X":	{
-						"_Type":	"Ident",
-						"Name":	"B"
-					},
-					"Parent":	{
-						"_Type":	"Ident",
-						"Name":	"A"
-					}
-				},
 				"Name":	{
 					"_Type":	"Ident",
 					"Name":	"MyStruct"
@@ -1045,28 +809,26 @@ TestTypeDefDecl Case 11:
 					"Name":	"MyStruct2"
 				},
 				"Type":	{
-					"_Type":	"RecordType",
-					"Tag":	0,
-					"Fields":	{
-						"_Type":	"FieldList",
-						"List":	[{
-								"_Type":	"Field",
-								"Type":	{
-									"_Type":	"BuiltinType",
-									"Kind":	6,
-									"Flags":	0
-								},
-								"Doc":	null,
-								"Comment":	null,
-								"IsStatic":	false,
-								"Access":	1,
-								"Names":	[{
-										"_Type":	"Ident",
-										"Name":	"x"
-									}]
-							}]
+					"_Type":	"TagExpr",
+					"Name":	{
+						"_Type":	"ScopingExpr",
+						"X":	{
+							"_Type":	"Ident",
+							"Name":	"MyStruct"
+						},
+						"Parent":	{
+							"_Type":	"ScopingExpr",
+							"X":	{
+								"_Type":	"Ident",
+								"Name":	"B"
+							},
+							"Parent":	{
+								"_Type":	"Ident",
+								"Name":	"A"
+							}
+						}
 					},
-					"Methods":	[]
+					"Tag":	0
 				}
 			}, {
 				"_Type":	"TypedefDecl",
@@ -1093,28 +855,26 @@ TestTypeDefDecl Case 11:
 				"Type":	{
 					"_Type":	"PointerType",
 					"X":	{
-						"_Type":	"RecordType",
-						"Tag":	0,
-						"Fields":	{
-							"_Type":	"FieldList",
-							"List":	[{
-									"_Type":	"Field",
-									"Type":	{
-										"_Type":	"BuiltinType",
-										"Kind":	6,
-										"Flags":	0
-									},
-									"Doc":	null,
-									"Comment":	null,
-									"IsStatic":	false,
-									"Access":	1,
-									"Names":	[{
-											"_Type":	"Ident",
-											"Name":	"x"
-										}]
-								}]
+						"_Type":	"TagExpr",
+						"Name":	{
+							"_Type":	"ScopingExpr",
+							"X":	{
+								"_Type":	"Ident",
+								"Name":	"MyStruct"
+							},
+							"Parent":	{
+								"_Type":	"ScopingExpr",
+								"X":	{
+									"_Type":	"Ident",
+									"Name":	"B"
+								},
+								"Parent":	{
+									"_Type":	"Ident",
+									"Name":	"A"
+								}
+							}
 						},
-						"Methods":	[]
+						"Tag":	0
 					}
 				}
 			}, {
@@ -1142,28 +902,26 @@ TestTypeDefDecl Case 11:
 				"Type":	{
 					"_Type":	"ArrayType",
 					"Elt":	{
-						"_Type":	"RecordType",
-						"Tag":	0,
-						"Fields":	{
-							"_Type":	"FieldList",
-							"List":	[{
-									"_Type":	"Field",
-									"Type":	{
-										"_Type":	"BuiltinType",
-										"Kind":	6,
-										"Flags":	0
-									},
-									"Doc":	null,
-									"Comment":	null,
-									"IsStatic":	false,
-									"Access":	1,
-									"Names":	[{
-											"_Type":	"Ident",
-											"Name":	"x"
-										}]
-								}]
+						"_Type":	"TagExpr",
+						"Name":	{
+							"_Type":	"ScopingExpr",
+							"X":	{
+								"_Type":	"Ident",
+								"Name":	"MyStruct"
+							},
+							"Parent":	{
+								"_Type":	"ScopingExpr",
+								"X":	{
+									"_Type":	"Ident",
+									"Name":	"B"
+								},
+								"Parent":	{
+									"_Type":	"Ident",
+									"Name":	"A"
+								}
+							}
 						},
-						"Methods":	[]
+						"Tag":	0
 					},
 					"Len":	null
 				}

--- a/chore/_xtool/llcppsigfetch/parse/cvt_test/decl_test/typedef_test/llgo.expect
+++ b/chore/_xtool/llcppsigfetch/parse/cvt_test/decl_test/typedef_test/llgo.expect
@@ -741,6 +741,132 @@ TestTypeDefDecl Case 11:
 	"temp.h":	{
 		"_Type":	"File",
 		"decls":	[{
+				"_Type":	"EnumTypeDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"temp.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"MyEnum"
+				},
+				"Type":	{
+					"_Type":	"EnumType",
+					"Items":	[{
+							"_Type":	"EnumItem",
+							"Name":	{
+								"_Type":	"Ident",
+								"Name":	"RED"
+							},
+							"Value":	{
+								"_Type":	"BasicLit",
+								"Kind":	0,
+								"Value":	"0"
+							}
+						}, {
+							"_Type":	"EnumItem",
+							"Name":	{
+								"_Type":	"Ident",
+								"Name":	"GREEN"
+							},
+							"Value":	{
+								"_Type":	"BasicLit",
+								"Kind":	0,
+								"Value":	"1"
+							}
+						}, {
+							"_Type":	"EnumItem",
+							"Name":	{
+								"_Type":	"Ident",
+								"Name":	"BLUE"
+							},
+							"Value":	{
+								"_Type":	"BasicLit",
+								"Kind":	0,
+								"Value":	"2"
+							}
+						}]
+				}
+			}, {
+				"_Type":	"TypedefDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"temp.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"MyEnum2"
+				},
+				"Type":	{
+					"_Type":	"TagExpr",
+					"Name":	{
+						"_Type":	"Ident",
+						"Name":	"MyEnum"
+					},
+					"Tag":	2
+				}
+			}, {
+				"_Type":	"TypedefDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"temp.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"EnumPtr"
+				},
+				"Type":	{
+					"_Type":	"PointerType",
+					"X":	{
+						"_Type":	"TagExpr",
+						"Name":	{
+							"_Type":	"Ident",
+							"Name":	"MyEnum"
+						},
+						"Tag":	2
+					}
+				}
+			}, {
+				"_Type":	"TypedefDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"temp.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"EnumArr"
+				},
+				"Type":	{
+					"_Type":	"ArrayType",
+					"Elt":	{
+						"_Type":	"TagExpr",
+						"Name":	{
+							"_Type":	"Ident",
+							"Name":	"MyEnum"
+						},
+						"Tag":	2
+					},
+					"Len":	null
+				}
+			}],
+		"includes":	[],
+		"macros":	[]
+	}
+}
+
+TestTypeDefDecl Case 12:
+{
+	"temp.h":	{
+		"_Type":	"File",
+		"decls":	[{
 				"_Type":	"TypeDecl",
 				"Loc":	{
 					"_Type":	"Location",

--- a/chore/_xtool/llcppsigfetch/parse/cvt_test/decl_test/typedef_test/typedef.go
+++ b/chore/_xtool/llcppsigfetch/parse/cvt_test/decl_test/typedef_test/typedef.go
@@ -41,6 +41,12 @@ func TestTypeDefDecl() {
 			int x;
 		} MyStruct,MyStruct2,*StructPtr, StructArr[];`,
 
+		`typedef enum {
+			RED,
+			GREEN,
+			BLUE
+		} MyEnum,MyEnum2,*EnumPtr,EnumArr[];`,
+
 		`namespace A{
 			namespace B{
 				typedef struct {

--- a/chore/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/llgo.expect
+++ b/chore/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/llgo.expect
@@ -118,6 +118,113 @@ TestInclude Case 1:
 	}
 }
 
+TestMacroExpansionOtherFile:
+{
+	"./testdata/macroexpan/ref.h":	{
+		"_Type":	"File",
+		"decls":	[{
+				"_Type":	"TypeDecl",
+				"Loc":	{
+					"_Type":	"Location",
+					"File":	"./testdata/macroexpan/ref.h"
+				},
+				"Doc":	null,
+				"Parent":	null,
+				"Name":	{
+					"_Type":	"Ident",
+					"Name":	"NewType"
+				},
+				"Type":	{
+					"_Type":	"RecordType",
+					"Tag":	0,
+					"Fields":	{
+						"_Type":	"FieldList",
+						"List":	[{
+								"_Type":	"Field",
+								"Type":	{
+									"_Type":	"ArrayType",
+									"Elt":	{
+										"_Type":	"BuiltinType",
+										"Kind":	6,
+										"Flags":	0
+									},
+									"Len":	{
+										"_Type":	"BasicLit",
+										"Kind":	0,
+										"Value":	"2"
+									}
+								},
+								"Doc":	null,
+								"Comment":	null,
+								"IsStatic":	false,
+								"Access":	1,
+								"Names":	[{
+										"_Type":	"Ident",
+										"Name":	"__val"
+									}]
+							}]
+					},
+					"Methods":	[]
+				}
+			}],
+		"includes":	[{
+				"_Type":	"Include",
+				"Path":	"def.h"
+			}],
+		"macros":	[]
+	},
+	"./testdata/macroexpan/def.h":	{
+		"_Type":	"File",
+		"decls":	[],
+		"includes":	[],
+		"macros":	[{
+				"_Type":	"Macro",
+				"Name":	"__FSID_T_TYPE",
+				"Tokens":	[{
+						"_Type":	"Token",
+						"Token":	3,
+						"Lit":	"__FSID_T_TYPE"
+					}, {
+						"_Type":	"Token",
+						"Token":	2,
+						"Lit":	"struct"
+					}, {
+						"_Type":	"Token",
+						"Token":	1,
+						"Lit":	"{"
+					}, {
+						"_Type":	"Token",
+						"Token":	2,
+						"Lit":	"int"
+					}, {
+						"_Type":	"Token",
+						"Token":	3,
+						"Lit":	"__val"
+					}, {
+						"_Type":	"Token",
+						"Token":	1,
+						"Lit":	"["
+					}, {
+						"_Type":	"Token",
+						"Token":	4,
+						"Lit":	"2"
+					}, {
+						"_Type":	"Token",
+						"Token":	1,
+						"Lit":	"]"
+					}, {
+						"_Type":	"Token",
+						"Token":	1,
+						"Lit":	";"
+					}, {
+						"_Type":	"Token",
+						"Token":	1,
+						"Lit":	"}"
+					}]
+			}]
+	}
+}
+
 
 #stderr
 

--- a/chore/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/preprocess.go
+++ b/chore/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/preprocess.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"github.com/goplus/llgo/c"
 	test "github.com/goplus/llgo/chore/_xtool/llcppsigfetch/parse/cvt_test"
+	"github.com/goplus/llgo/chore/_xtool/llcppsymg/clangutils"
 )
 
 func main() {
 	TestDefine()
 	TestInclude()
+	TestMacroExpansionOtherFile()
 }
 
 func TestDefine() {
@@ -24,4 +27,13 @@ func TestInclude() {
 		// `#include <limits.h>`, //  Standard libraries are mostly platform-dependent
 	}
 	test.RunTest("TestInclude", testCases)
+}
+
+func TestMacroExpansionOtherFile() {
+	c.Printf(c.Str("TestMacroExpansionOtherFile:\n"))
+	test.RunTestWithConfig(&clangutils.Config{
+		File:  "./testdata/macroexpan/ref.h",
+		Temp:  false,
+		IsCpp: false,
+	})
 }

--- a/chore/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/testdata/macroexpan/def.h
+++ b/chore/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/testdata/macroexpan/def.h
@@ -1,0 +1,4 @@
+#define __FSID_T_TYPE                                                                                                  \
+    struct {                                                                                                           \
+        int __val[2];                                                                                                  \
+    }

--- a/chore/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/testdata/macroexpan/ref.h
+++ b/chore/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/testdata/macroexpan/ref.h
@@ -1,0 +1,2 @@
+#include "def.h"
+typedef __FSID_T_TYPE NewType;


### PR DESCRIPTION
Fix  https://github.com/luoliwoshang/llgo/issues/78
解决在Linux下引入stdlib.h后出现的  index out of range panic。


## Desc
一个宏定义在另外一个头文件中，当头文件其中一个类型引用后，可以获得其Underlying类型，但是为了判断其实际的匿名性质，访问其定义节点，对其Token序列化，返回Token序列为空，导致无法通过Token序列获取其实际的匿名性质。

最小复现https://github.com/goplus/llgo/blob/069760541c2c7092cc39df5c66b62381740654aa/chore/_xtool/llcppsigfetch/parse/cvt_test/preprocess_test/preprocess.go#L45
`fsid.h`
```c
#define __FSID_T_TYPE struct {  int __val[2]; }
```
`typedef.h`
```c
#include "fsid.h"
typedef __FSID_T_TYPE NewType;
```
对于这个类型声明节点，其range 仍然为原始宏名称的开始和结束的位置.
https://github.com/luoliwoshang/CTest/commit/d564aa5b4d1e94ef96c8e5d62241ecf58f9f3a8c
```bash
underlying type: struct NewType
type declaration: NewType
type declaration kind: StructDecl
range start: 2:9, range end: 2:22
```
### Resolve(3)
Libclang 并不能直接获得类型定义是一个宏展开节点的Token序列，那么回到这个问题本身，主要是为了解决 typedef一个匿名结构体时出现的额外的具名匿名结构体
```c
typedef struct {
    int x;
} MyStruct
```
在这个Pr之前，会解析为如下结构
```
{
   Node:TypeDecl,
   Name:nil(remove name),
   Type:RecordType { int x;}
},
{
    Node:TypedefDecl,
    Name:MyStruct,
    Type:RecordType { int x;}
}
```
而在这个结构中，更应该保留的是TypeDecl，而不是Typedef，否则对于一个复杂类型的声明，即会存在两个表达姿势，即TypedefDecl和本身的TypeDecl，并且对于Enum来说，也会存在EnumDecl和TypedefDecl的表达姿势，这部分的复杂度是没有必要的，并就需求来说，检查Typedef的Underlying是否是一个实际的匿名类型，期望的是不出现重复的声明，那么对于后续的冗余的Typedef声明，做跳过的处理，即能达到预期。

并对于一个Typedef 多个Name指向相同的一个匿名RecordType，从之前的多个Typedecl都存在相同的内嵌类型，导致类型唯一性不能保证，修改处理为了后续的类型声明具名引用自第一个类型定义。目前表达为如下。
```
{
         typedef struct {
	        int x;
        } MyStruct,MyStruct2,*StructPtr, StructArr[];
}
```
to
```
{
    "temp.h": {
        "decls": [
            {
                "_Type": "TypeDecl",
                "Name": {
                    "Name": "MyStruct"
                },
                "Type": {
                    "_Type": "RecordType",
                    "Tag": 0,
                    "Fields": {
                        "List": [ {
                                "Type": { "Kind": 6,"Flags": 0},
                                "Names": [ {"Name": "x"} ]
                            } ]
                    },
                }
            },
            {
                "_Type": "TypedefDecl",
                "Name": {"Name": "MyStruct2"},
                "Type": {
                    "_Type": "TagExpr",
                    "Name": { "Name": "MyStruct"},
                    "Tag": 0
                }
            },
            {
                "_Type": "TypedefDecl",
                "Name": { "Name": "StructPtr"},
                "Type": {
                    "_Type": "PointerType",
                    "X": {
                        "_Type": "TagExpr",
                        "Name": {"Name": "MyStruct"},
                        "Tag": 0
                    }
                }
            },
            {
                "_Type": "TypedefDecl",
                "Name": {"Name": "StructArr"},
                "Type": {
                    "_Type": "ArrayType",
                    "Elt": {
                        "_Type": "TagExpr",
                        "Name": {"Name": "MyStruct" },
                        "Tag": 0
                    },
                    "Len": null
                }
            }
        ],
    }
}
```
在PR前，会抛出对应的Token序列化越界的错误。
```
root@be00d9b1c2c9:~/llgo# llcppsigfetch --extract "#include <stdint.h>" -temp=true -out=true               
panic: runtime error: index out of range
```
After In linux
```bash
root@be00d9b1c2c9:~/llgo/chore/_xtool/llcppsigfetch# llcppsigfetch --extract "#include <stdint.h>" -temp=true -out=true            
Results saved to llcppg.sigfetch.json
```
```json
{
    "_Type": "TypeDecl",
    "Loc": {
        "_Type": "Location",
        "File": "/usr/include/stdint.h"
    },
    "Doc": null,
    "Parent": null,
    "Name": {
        "_Type": "Ident",
        "Name": "__fsid_t"
    },
    "Type": {
        "_Type": "RecordType",
        "Tag": 0,
        "Fields": {
            "_Type": "FieldList",
            "List": [
                {
                    "_Type": "Field",
                    "Type": {
                        "_Type": "ArrayType",
                        "Elt": {
                            "_Type": "BuiltinType",
                            "Kind": 6,
                            "Flags": 0
                        },
                        "Len": {
                            "_Type": "BasicLit",
                            "Kind": 0,
                            "Value": "2"
                        }
                    },
                    "Names": [
                        {
                            "_Type": "Ident",
                            "Name": "__val"
                        }
                    ]
                }
            ]
        },
    }
}
```


## Before Resolution
### Resolve(1) **Fail**
https://discourse.llvm.org/t/querying-information-about-preprocessing-directives-in-libclang/19007/3
这里提到可以通过 clang_getCursorReferenced 来 将从宏实例化游标映射宏定义。
```c

/** For a cursor that is a reference, retrieve a cursor representing the
 * entity that it references.
 *
 * Reference cursors refer to other entities in the AST. For example, an
 * Objective-C superclass reference cursor refers to an Objective-C class.
 * This function produces the cursor for the Objective-C class from the
 * cursor for the superclass reference. If the input cursor is a declaration or
 * definition, it returns that declaration or definition unchanged.
 * Otherwise, returns the NULL cursor.
 */
CINDEX_LINKAGE CXCursor clang_getCursorReferenced(CXCursor);
```
对于这个实际的`StructDecl Cursor`定义，实际上就是从宏定义来的，那么尝试去获得宏对应的`StructDecl`的`clang_getCursorReferenced` 是否为一个宏定义，发现获取的仅仅是一个同样的`StructDecl`。所以该方案失败。
同样的 `clang_getCursorDefinition`的并不奏效
### Resolve(2) **(Not Perfect)**
对于整个AST树节点遍历发现，在定义前，会存在CXCursor_MacroExpansion 宏展开节点，对于一个宏展开节点，他的源文件范围与Typedef中引用的宏对应的结构体声明的范围一致。
https://github.com/luoliwoshang/CTest/commit/5dd9fb9e7721cdcf4dc9810398d4e876b575a7f6
```
macro expansion: __FSID_T_TYPE
macro expansion range start: 2:9, range end: 2:22
underlying type: struct NewType
type declaration: NewType
type declaration kind: StructDecl
Cursor at range start:
  Kind: StructDecl
  Spelling: NewType
range start: 2:9, range end: 2:22
```
获取宏展开的节点信息并进行缓存，对于序列化为空的一个类型引用，则可以认为是一个宏展开，那么就可以通过比对当前Token为空的声明节点的偏移量和宏展开节点的偏移量，如果一致，那么就可以认为是同一个节点，则可以通过宏的序列获得实际的声明Token序列。

即流程为收集宏展开节点与宏定义映射->Token序列为空的类型声明->检查是否为一个宏展开->通过映射关系找到实际的宏->获得其Token序列继续检查其实际的匿名性质

当前这个方案能解决目前这个情况
```c
#define __FSID_T_TYPE struct {  int __val[2]; }
```
`typedef.h`
```c
#include "fsid.h"
typedef __FSID_T_TYPE NewType;
```
但是如果存在一个用例，这个宏再嵌套一层，就也不能正确识别了。
