### PR TITLE
Reduce alloca

### DIFF
--- a/cl/_testdata/print/out.ll
+++ b/cl/_testdata/print/out.ll
@@ -122,13 +122,7 @@ _llgo_0:
   store ptr %1, ptr @__llgo_argv, align 8
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
-  %2 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 0
-  store ptr @1, ptr %3, align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 1
-  store i64 4, ptr %4, align 4
-  %5 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
-  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" %5)
+  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 })
   call void @main.printnl()
   call void @main.printuint(i64 1024)
   call void @main.printnl()
@@ -142,294 +136,160 @@ _llgo_0:
   call void @main.printnl()
   call void @main.prinfsub(double 1.001000e+02)
   call void @main.printnl()
-  %6 = load ptr, ptr @_llgo_float32, align 8
-  %7 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, i32 0, i32 0
-  store ptr %6, ptr %8, align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, i32 0, i32 1
-  store ptr inttoptr (i32 1315859240 to ptr), ptr %9, align 8
-  %10 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, align 8
-  call void @main.printany(%"github.com/goplus/llgo/internal/runtime.eface" %10)
+  %2 = load ptr, ptr @_llgo_float32, align 8
+  %3 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %2, 0
+  %4 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %3, ptr inttoptr (i32 1315859240 to ptr), 1
+  call void @main.printany(%"github.com/goplus/llgo/internal/runtime.eface" %4)
   call void @main.printnl()
-  %11 = load ptr, ptr @_llgo_float64, align 8
-  %12 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %12, i32 0, i32 0
-  store ptr %11, ptr %13, align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %12, i32 0, i32 1
-  store ptr inttoptr (i64 4746175415993761792 to ptr), ptr %14, align 8
-  %15 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %12, align 8
-  call void @main.printany(%"github.com/goplus/llgo/internal/runtime.eface" %15)
+  %5 = load ptr, ptr @_llgo_float64, align 8
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %5, 0
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %6, ptr inttoptr (i64 4746175415993761792 to ptr), 1
+  call void @main.printany(%"github.com/goplus/llgo/internal/runtime.eface" %7)
   call void @main.printnl()
   br i1 true, label %_llgo_3, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_3
-  %16 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
-  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %16, i64 0
-  %18 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %19 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %18, i32 0, i32 0
-  store ptr @2, ptr %19, align 8
-  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %18, i32 0, i32 1
-  store i64 10, ptr %20, align 4
-  %21 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %18, align 8
-  %22 = load ptr, ptr @_llgo_string, align 8
-  %23 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %21, ptr %23, align 8
-  %24 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %24, i32 0, i32 0
-  store ptr %22, ptr %25, align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %24, i32 0, i32 1
-  store ptr %23, ptr %26, align 8
-  %27 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %24, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %27, ptr %17, align 8
-  %28 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %16, i64 1
-  %29 = load ptr, ptr @_llgo_bool, align 8
-  %30 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %30, i32 0, i32 0
-  store ptr %29, ptr %31, align 8
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %30, i32 0, i32 1
-  store ptr inttoptr (i64 -1 to ptr), ptr %32, align 8
-  %33 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %30, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %33, ptr %28, align 8
-  %34 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %34, i32 0, i32 0
-  store ptr %16, ptr %35, align 8
-  %36 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %34, i32 0, i32 1
-  store i64 2, ptr %36, align 4
-  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %34, i32 0, i32 2
-  store i64 2, ptr %37, align 4
-  %38 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %34, align 8
-  call void @main.println(%"github.com/goplus/llgo/internal/runtime.Slice" %38)
+  %8 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
+  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, i64 0
+  %10 = load ptr, ptr @_llgo_string, align 8
+  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 10 }, ptr %11, align 8
+  %12 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %10, 0
+  %13 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %12, ptr %11, 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %13, ptr %9, align 8
+  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, i64 1
+  %15 = load ptr, ptr @_llgo_bool, align 8
+  %16 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %15, 0
+  %17 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %16, ptr inttoptr (i64 -1 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %17, ptr %14, align 8
+  %18 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %8, 0
+  %19 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %18, i64 2, 1
+  %20 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %19, i64 2, 2
+  call void @main.println(%"github.com/goplus/llgo/internal/runtime.Slice" %20)
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_3, %_llgo_0
-  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 48)
-  %40 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %39, i64 0
-  %41 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %42 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %41, i32 0, i32 0
-  store ptr @3, ptr %42, align 8
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %41, i32 0, i32 1
-  store i64 8, ptr %43, align 4
-  %44 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %41, align 8
-  %45 = load ptr, ptr @_llgo_string, align 8
-  %46 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %44, ptr %46, align 8
-  %47 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %48 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %47, i32 0, i32 0
-  store ptr %45, ptr %48, align 8
-  %49 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %47, i32 0, i32 1
-  store ptr %46, ptr %49, align 8
-  %50 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %47, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %50, ptr %40, align 8
-  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %39, i64 1
-  %52 = load ptr, ptr @_llgo_bool, align 8
-  %53 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %54 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %53, i32 0, i32 0
-  store ptr %52, ptr %54, align 8
-  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %53, i32 0, i32 1
-  store ptr inttoptr (i64 -1 to ptr), ptr %55, align 8
-  %56 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %53, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %56, ptr %51, align 8
-  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %39, i64 2
-  %58 = load ptr, ptr @_llgo_bool, align 8
-  %59 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %59, i32 0, i32 0
-  store ptr %58, ptr %60, align 8
-  %61 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %59, i32 0, i32 1
-  store ptr inttoptr (i64 -1 to ptr), ptr %61, align 8
-  %62 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %59, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %62, ptr %57, align 8
-  %63 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %64 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %63, i32 0, i32 0
-  store ptr %39, ptr %64, align 8
-  %65 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %63, i32 0, i32 1
-  store i64 3, ptr %65, align 4
-  %66 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %63, i32 0, i32 2
-  store i64 3, ptr %66, align 4
-  %67 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %63, align 8
-  call void @main.println(%"github.com/goplus/llgo/internal/runtime.Slice" %67)
-  %68 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 256)
-  %69 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i64 0
-  %70 = load ptr, ptr @_llgo_bool, align 8
-  %71 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %72 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %71, i32 0, i32 0
-  store ptr %70, ptr %72, align 8
-  %73 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %71, i32 0, i32 1
-  store ptr inttoptr (i64 -1 to ptr), ptr %73, align 8
-  %74 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %71, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %74, ptr %69, align 8
-  %75 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i64 1
-  %76 = load ptr, ptr @_llgo_bool, align 8
-  %77 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %78 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %77, i32 0, i32 0
-  store ptr %76, ptr %78, align 8
-  %79 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %77, i32 0, i32 1
-  store ptr null, ptr %79, align 8
-  %80 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %77, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %80, ptr %75, align 8
-  %81 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i64 2
-  %82 = load ptr, ptr @_llgo_int32, align 8
-  %83 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %84 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %83, i32 0, i32 0
-  store ptr %82, ptr %84, align 8
-  %85 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %83, i32 0, i32 1
-  store ptr inttoptr (i64 97 to ptr), ptr %85, align 8
-  %86 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %83, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %86, ptr %81, align 8
-  %87 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i64 3
-  %88 = load ptr, ptr @_llgo_int32, align 8
-  %89 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %90 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %89, i32 0, i32 0
-  store ptr %88, ptr %90, align 8
-  %91 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %89, i32 0, i32 1
-  store ptr inttoptr (i64 65 to ptr), ptr %91, align 8
-  %92 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %89, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %92, ptr %87, align 8
-  %93 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i64 4
-  %94 = load ptr, ptr @_llgo_int32, align 8
-  %95 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %96 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %95, i32 0, i32 0
-  store ptr %94, ptr %96, align 8
-  %97 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %95, i32 0, i32 1
-  store ptr inttoptr (i64 20013 to ptr), ptr %97, align 8
-  %98 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %95, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %98, ptr %93, align 8
-  %99 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i64 5
-  %100 = load ptr, ptr @_llgo_int8, align 8
-  %101 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %102 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %101, i32 0, i32 0
-  store ptr %100, ptr %102, align 8
-  %103 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %101, i32 0, i32 1
-  store ptr inttoptr (i64 1 to ptr), ptr %103, align 8
-  %104 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %101, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %104, ptr %99, align 8
-  %105 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i64 6
-  %106 = load ptr, ptr @_llgo_int16, align 8
-  %107 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %108 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %107, i32 0, i32 0
-  store ptr %106, ptr %108, align 8
-  %109 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %107, i32 0, i32 1
-  store ptr inttoptr (i64 2 to ptr), ptr %109, align 8
-  %110 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %107, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %110, ptr %105, align 8
-  %111 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i64 7
-  %112 = load ptr, ptr @_llgo_int32, align 8
-  %113 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %114 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %113, i32 0, i32 0
-  store ptr %112, ptr %114, align 8
-  %115 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %113, i32 0, i32 1
-  store ptr inttoptr (i64 3 to ptr), ptr %115, align 8
-  %116 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %113, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %116, ptr %111, align 8
-  %117 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i64 8
-  %118 = load ptr, ptr @_llgo_int64, align 8
-  %119 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %120 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %119, i32 0, i32 0
-  store ptr %118, ptr %120, align 8
-  %121 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %119, i32 0, i32 1
-  store ptr inttoptr (i64 4 to ptr), ptr %121, align 8
-  %122 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %119, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %122, ptr %117, align 8
-  %123 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i64 9
-  %124 = load ptr, ptr @_llgo_int, align 8
-  %125 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %126 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %125, i32 0, i32 0
-  store ptr %124, ptr %126, align 8
-  %127 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %125, i32 0, i32 1
-  store ptr inttoptr (i64 5 to ptr), ptr %127, align 8
-  %128 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %125, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %128, ptr %123, align 8
-  %129 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i64 10
-  %130 = load ptr, ptr @_llgo_uint8, align 8
-  %131 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %132 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %131, i32 0, i32 0
-  store ptr %130, ptr %132, align 8
-  %133 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %131, i32 0, i32 1
-  store ptr inttoptr (i64 1 to ptr), ptr %133, align 8
-  %134 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %131, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %134, ptr %129, align 8
-  %135 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i64 11
-  %136 = load ptr, ptr @_llgo_uint16, align 8
-  %137 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %138 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %137, i32 0, i32 0
-  store ptr %136, ptr %138, align 8
-  %139 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %137, i32 0, i32 1
-  store ptr inttoptr (i64 2 to ptr), ptr %139, align 8
-  %140 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %137, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %140, ptr %135, align 8
-  %141 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i64 12
-  %142 = load ptr, ptr @_llgo_uint32, align 8
-  %143 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %144 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %143, i32 0, i32 0
-  store ptr %142, ptr %144, align 8
-  %145 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %143, i32 0, i32 1
-  store ptr inttoptr (i64 3 to ptr), ptr %145, align 8
-  %146 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %143, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %146, ptr %141, align 8
-  %147 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i64 13
-  %148 = load ptr, ptr @_llgo_uint64, align 8
-  %149 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %150 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %149, i32 0, i32 0
-  store ptr %148, ptr %150, align 8
-  %151 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %149, i32 0, i32 1
-  store ptr inttoptr (i64 4 to ptr), ptr %151, align 8
-  %152 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %149, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %152, ptr %147, align 8
-  %153 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i64 14
-  %154 = load ptr, ptr @_llgo_uintptr, align 8
-  %155 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %156 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %155, i32 0, i32 0
-  store ptr %154, ptr %156, align 8
-  %157 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %155, i32 0, i32 1
-  store ptr inttoptr (i64 5 to ptr), ptr %157, align 8
-  %158 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %155, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %158, ptr %153, align 8
-  %159 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i64 15
-  %160 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %161 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %160, i32 0, i32 0
-  store ptr @1, ptr %161, align 8
-  %162 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %160, i32 0, i32 1
-  store i64 4, ptr %162, align 4
-  %163 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %160, align 8
-  %164 = load ptr, ptr @_llgo_string, align 8
-  %165 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %163, ptr %165, align 8
-  %166 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %167 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %166, i32 0, i32 0
-  store ptr %164, ptr %167, align 8
-  %168 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %166, i32 0, i32 1
-  store ptr %165, ptr %168, align 8
-  %169 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %166, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %169, ptr %159, align 8
-  %170 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %171 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %170, i32 0, i32 0
-  store ptr %68, ptr %171, align 8
-  %172 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %170, i32 0, i32 1
-  store i64 16, ptr %172, align 4
-  %173 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %170, i32 0, i32 2
-  store i64 16, ptr %173, align 4
-  %174 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %170, align 8
-  call void @main.println(%"github.com/goplus/llgo/internal/runtime.Slice" %174)
-  %175 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 16)
-  %176 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %175, i64 0
-  %177 = load ptr, ptr @_llgo_complex128, align 8
-  %178 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store { double, double } { double 1.000000e+00, double 2.000000e+00 }, ptr %178, align 8
-  %179 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %180 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %179, i32 0, i32 0
-  store ptr %177, ptr %180, align 8
-  %181 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %179, i32 0, i32 1
-  store ptr %178, ptr %181, align 8
-  %182 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %179, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %182, ptr %176, align 8
-  %183 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %184 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %183, i32 0, i32 0
-  store ptr %175, ptr %184, align 8
-  %185 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %183, i32 0, i32 1
-  store i64 1, ptr %185, align 4
-  %186 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %183, i32 0, i32 2
-  store i64 1, ptr %186, align 4
-  %187 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %183, align 8
-  call void @main.println(%"github.com/goplus/llgo/internal/runtime.Slice" %187)
+  %21 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 48)
+  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %21, i64 0
+  %23 = load ptr, ptr @_llgo_string, align 8
+  %24 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 8 }, ptr %24, align 8
+  %25 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %23, 0
+  %26 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %25, ptr %24, 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %26, ptr %22, align 8
+  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %21, i64 1
+  %28 = load ptr, ptr @_llgo_bool, align 8
+  %29 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %28, 0
+  %30 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %29, ptr inttoptr (i64 -1 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %30, ptr %27, align 8
+  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %21, i64 2
+  %32 = load ptr, ptr @_llgo_bool, align 8
+  %33 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %32, 0
+  %34 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %33, ptr inttoptr (i64 -1 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %34, ptr %31, align 8
+  %35 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %21, 0
+  %36 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %35, i64 3, 1
+  %37 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %36, i64 3, 2
+  call void @main.println(%"github.com/goplus/llgo/internal/runtime.Slice" %37)
+  %38 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 256)
+  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i64 0
+  %40 = load ptr, ptr @_llgo_bool, align 8
+  %41 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %40, 0
+  %42 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %41, ptr inttoptr (i64 -1 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %42, ptr %39, align 8
+  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i64 1
+  %44 = load ptr, ptr @_llgo_bool, align 8
+  %45 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %44, 0
+  %46 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %45, ptr null, 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %46, ptr %43, align 8
+  %47 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i64 2
+  %48 = load ptr, ptr @_llgo_int32, align 8
+  %49 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %48, 0
+  %50 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %49, ptr inttoptr (i64 97 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %50, ptr %47, align 8
+  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i64 3
+  %52 = load ptr, ptr @_llgo_int32, align 8
+  %53 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %52, 0
+  %54 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %53, ptr inttoptr (i64 65 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %54, ptr %51, align 8
+  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i64 4
+  %56 = load ptr, ptr @_llgo_int32, align 8
+  %57 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %56, 0
+  %58 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %57, ptr inttoptr (i64 20013 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %58, ptr %55, align 8
+  %59 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i64 5
+  %60 = load ptr, ptr @_llgo_int8, align 8
+  %61 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %60, 0
+  %62 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %61, ptr inttoptr (i64 1 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %62, ptr %59, align 8
+  %63 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i64 6
+  %64 = load ptr, ptr @_llgo_int16, align 8
+  %65 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %64, 0
+  %66 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %65, ptr inttoptr (i64 2 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %66, ptr %63, align 8
+  %67 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i64 7
+  %68 = load ptr, ptr @_llgo_int32, align 8
+  %69 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %68, 0
+  %70 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %69, ptr inttoptr (i64 3 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %70, ptr %67, align 8
+  %71 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i64 8
+  %72 = load ptr, ptr @_llgo_int64, align 8
+  %73 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %72, 0
+  %74 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %73, ptr inttoptr (i64 4 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %74, ptr %71, align 8
+  %75 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i64 9
+  %76 = load ptr, ptr @_llgo_int, align 8
+  %77 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %76, 0
+  %78 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %77, ptr inttoptr (i64 5 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %78, ptr %75, align 8
+  %79 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i64 10
+  %80 = load ptr, ptr @_llgo_uint8, align 8
+  %81 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %80, 0
+  %82 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %81, ptr inttoptr (i64 1 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %82, ptr %79, align 8
+  %83 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i64 11
+  %84 = load ptr, ptr @_llgo_uint16, align 8
+  %85 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %84, 0
+  %86 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %85, ptr inttoptr (i64 2 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %86, ptr %83, align 8
+  %87 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i64 12
+  %88 = load ptr, ptr @_llgo_uint32, align 8
+  %89 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %88, 0
+  %90 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %89, ptr inttoptr (i64 3 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %90, ptr %87, align 8
+  %91 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i64 13
+  %92 = load ptr, ptr @_llgo_uint64, align 8
+  %93 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %92, 0
+  %94 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %93, ptr inttoptr (i64 4 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %94, ptr %91, align 8
+  %95 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i64 14
+  %96 = load ptr, ptr @_llgo_uintptr, align 8
+  %97 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %96, 0
+  %98 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %97, ptr inttoptr (i64 5 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %98, ptr %95, align 8
+  %99 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i64 15
+  %100 = load ptr, ptr @_llgo_string, align 8
+  %101 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, ptr %101, align 8
+  %102 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %100, 0
+  %103 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %102, ptr %101, 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %103, ptr %99, align 8
+  %104 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %38, 0
+  %105 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %104, i64 16, 1
+  %106 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %105, i64 16, 2
+  call void @main.println(%"github.com/goplus/llgo/internal/runtime.Slice" %106)
+  %107 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 16)
+  %108 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %107, i64 0
+  %109 = load ptr, ptr @_llgo_complex128, align 8
+  %110 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store { double, double } { double 1.000000e+00, double 2.000000e+00 }, ptr %110, align 8
+  %111 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %109, 0
+  %112 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %111, ptr %110, 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %112, ptr %108, align 8
+  %113 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %107, 0
+  %114 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %113, i64 1, 1
+  %115 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %114, i64 1, 2
+  call void @main.println(%"github.com/goplus/llgo/internal/runtime.Slice" %115)
   ret i32 0
 
 _llgo_3:                                          ; preds = %_llgo_0
@@ -461,7 +321,7 @@ _llgo_1:                                          ; preds = %_llgo_34, %_llgo_85
   ret void
 
 _llgo_2:                                          ; preds = %_llgo_37
-  call void @main.printbool(i1 %93)
+  call void @main.printbool(i1 %71)
   br label %_llgo_1
 
 _llgo_3:                                          ; preds = %_llgo_37
@@ -471,7 +331,7 @@ _llgo_3:                                          ; preds = %_llgo_37
   br i1 %6, label %_llgo_38, label %_llgo_39
 
 _llgo_4:                                          ; preds = %_llgo_40
-  call void @main.printint(i64 %106)
+  call void @main.printint(i64 %78)
   br label %_llgo_1
 
 _llgo_5:                                          ; preds = %_llgo_40
@@ -481,7 +341,7 @@ _llgo_5:                                          ; preds = %_llgo_40
   br i1 %9, label %_llgo_41, label %_llgo_42
 
 _llgo_6:                                          ; preds = %_llgo_43
-  %10 = sext i8 %120 to i64
+  %10 = sext i8 %86 to i64
   call void @main.printint(i64 %10)
   br label %_llgo_1
 
@@ -492,7 +352,7 @@ _llgo_7:                                          ; preds = %_llgo_43
   br i1 %13, label %_llgo_44, label %_llgo_45
 
 _llgo_8:                                          ; preds = %_llgo_46
-  %14 = sext i16 %134 to i64
+  %14 = sext i16 %94 to i64
   call void @main.printint(i64 %14)
   br label %_llgo_1
 
@@ -503,7 +363,7 @@ _llgo_9:                                          ; preds = %_llgo_46
   br i1 %17, label %_llgo_47, label %_llgo_48
 
 _llgo_10:                                         ; preds = %_llgo_49
-  %18 = sext i32 %148 to i64
+  %18 = sext i32 %102 to i64
   call void @main.printint(i64 %18)
   br label %_llgo_1
 
@@ -514,7 +374,7 @@ _llgo_11:                                         ; preds = %_llgo_49
   br i1 %21, label %_llgo_50, label %_llgo_51
 
 _llgo_12:                                         ; preds = %_llgo_52
-  call void @main.printint(i64 %161)
+  call void @main.printint(i64 %109)
   br label %_llgo_1
 
 _llgo_13:                                         ; preds = %_llgo_52
@@ -524,7 +384,7 @@ _llgo_13:                                         ; preds = %_llgo_52
   br i1 %24, label %_llgo_53, label %_llgo_54
 
 _llgo_14:                                         ; preds = %_llgo_55
-  call void @main.printuint(i64 %174)
+  call void @main.printuint(i64 %116)
   br label %_llgo_1
 
 _llgo_15:                                         ; preds = %_llgo_55
@@ -534,7 +394,7 @@ _llgo_15:                                         ; preds = %_llgo_55
   br i1 %27, label %_llgo_56, label %_llgo_57
 
 _llgo_16:                                         ; preds = %_llgo_58
-  %28 = zext i8 %188 to i64
+  %28 = zext i8 %124 to i64
   call void @main.printuint(i64 %28)
   br label %_llgo_1
 
@@ -545,7 +405,7 @@ _llgo_17:                                         ; preds = %_llgo_58
   br i1 %31, label %_llgo_59, label %_llgo_60
 
 _llgo_18:                                         ; preds = %_llgo_61
-  %32 = zext i16 %202 to i64
+  %32 = zext i16 %132 to i64
   call void @main.printuint(i64 %32)
   br label %_llgo_1
 
@@ -556,7 +416,7 @@ _llgo_19:                                         ; preds = %_llgo_61
   br i1 %35, label %_llgo_62, label %_llgo_63
 
 _llgo_20:                                         ; preds = %_llgo_64
-  %36 = zext i32 %216 to i64
+  %36 = zext i32 %140 to i64
   call void @main.printuint(i64 %36)
   br label %_llgo_1
 
@@ -567,7 +427,7 @@ _llgo_21:                                         ; preds = %_llgo_64
   br i1 %39, label %_llgo_65, label %_llgo_66
 
 _llgo_22:                                         ; preds = %_llgo_67
-  call void @main.printuint(i64 %229)
+  call void @main.printuint(i64 %147)
   br label %_llgo_1
 
 _llgo_23:                                         ; preds = %_llgo_67
@@ -577,7 +437,7 @@ _llgo_23:                                         ; preds = %_llgo_67
   br i1 %42, label %_llgo_68, label %_llgo_69
 
 _llgo_24:                                         ; preds = %_llgo_70
-  call void @main.printuint(i64 %242)
+  call void @main.printuint(i64 %154)
   br label %_llgo_1
 
 _llgo_25:                                         ; preds = %_llgo_70
@@ -587,7 +447,7 @@ _llgo_25:                                         ; preds = %_llgo_70
   br i1 %45, label %_llgo_71, label %_llgo_72
 
 _llgo_26:                                         ; preds = %_llgo_73
-  %46 = fpext float %257 to double
+  %46 = fpext float %163 to double
   call void @main.printfloat(double %46)
   br label %_llgo_1
 
@@ -598,7 +458,7 @@ _llgo_27:                                         ; preds = %_llgo_73
   br i1 %49, label %_llgo_74, label %_llgo_75
 
 _llgo_28:                                         ; preds = %_llgo_76
-  call void @main.printfloat(double %271)
+  call void @main.printfloat(double %171)
   br label %_llgo_1
 
 _llgo_29:                                         ; preds = %_llgo_76
@@ -608,516 +468,322 @@ _llgo_29:                                         ; preds = %_llgo_76
   br i1 %52, label %_llgo_77, label %_llgo_78
 
 _llgo_30:                                         ; preds = %_llgo_79
-  %53 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %54 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %53, i32 0, i32 0
-  store ptr @4, ptr %54, align 8
-  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %53, i32 0, i32 1
-  store i64 1, ptr %55, align 4
-  %56 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %53, align 8
-  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" %56)
-  %57 = extractvalue { float, float } %284, 0
-  %58 = fpext float %57 to double
-  call void @main.printfloat(double %58)
-  %59 = extractvalue { float, float } %284, 1
-  %60 = fpext float %59 to double
-  call void @main.printfloat(double %60)
-  %61 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %62 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %61, i32 0, i32 0
-  store ptr @5, ptr %62, align 8
-  %63 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %61, i32 0, i32 1
-  store i64 2, ptr %63, align 4
-  %64 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %61, align 8
-  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" %64)
+  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 1 })
+  %53 = extractvalue { float, float } %178, 0
+  %54 = fpext float %53 to double
+  call void @main.printfloat(double %54)
+  %55 = extractvalue { float, float } %178, 1
+  %56 = fpext float %55 to double
+  call void @main.printfloat(double %56)
+  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 2 })
   br label %_llgo_1
 
 _llgo_31:                                         ; preds = %_llgo_79
-  %65 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 0
-  %66 = load ptr, ptr @_llgo_complex128, align 8
-  %67 = icmp eq ptr %65, %66
-  br i1 %67, label %_llgo_80, label %_llgo_81
+  %57 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 0
+  %58 = load ptr, ptr @_llgo_complex128, align 8
+  %59 = icmp eq ptr %57, %58
+  br i1 %59, label %_llgo_80, label %_llgo_81
 
 _llgo_32:                                         ; preds = %_llgo_82
-  %68 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %69 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %68, i32 0, i32 0
-  store ptr @4, ptr %69, align 8
-  %70 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %68, i32 0, i32 1
-  store i64 1, ptr %70, align 4
-  %71 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %68, align 8
-  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" %71)
-  %72 = extractvalue { double, double } %297, 0
-  call void @main.printfloat(double %72)
-  %73 = extractvalue { double, double } %297, 1
-  call void @main.printfloat(double %73)
-  %74 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %75 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %74, i32 0, i32 0
-  store ptr @5, ptr %75, align 8
-  %76 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %74, i32 0, i32 1
-  store i64 2, ptr %76, align 4
-  %77 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %74, align 8
-  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" %77)
+  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 1 })
+  %60 = extractvalue { double, double } %185, 0
+  call void @main.printfloat(double %60)
+  %61 = extractvalue { double, double } %185, 1
+  call void @main.printfloat(double %61)
+  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 2 })
   br label %_llgo_1
 
 _llgo_33:                                         ; preds = %_llgo_82
-  %78 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 0
-  %79 = load ptr, ptr @_llgo_string, align 8
-  %80 = icmp eq ptr %78, %79
-  br i1 %80, label %_llgo_83, label %_llgo_84
+  %62 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 0
+  %63 = load ptr, ptr @_llgo_string, align 8
+  %64 = icmp eq ptr %62, %63
+  br i1 %64, label %_llgo_83, label %_llgo_84
 
 _llgo_34:                                         ; preds = %_llgo_85
-  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" %310)
+  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" %192)
   br label %_llgo_1
 
 _llgo_35:                                         ; preds = %_llgo_0
-  %81 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
-  %82 = ptrtoint ptr %81 to i64
-  %83 = trunc i64 %82 to i1
-  %84 = alloca { i1, i1 }, align 8
-  %85 = getelementptr inbounds { i1, i1 }, ptr %84, i32 0, i32 0
-  store i1 %83, ptr %85, align 1
-  %86 = getelementptr inbounds { i1, i1 }, ptr %84, i32 0, i32 1
-  store i1 true, ptr %86, align 1
-  %87 = load { i1, i1 }, ptr %84, align 1
+  %65 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
+  %66 = ptrtoint ptr %65 to i64
+  %67 = trunc i64 %66 to i1
+  %68 = insertvalue { i1, i1 } undef, i1 %67, 0
+  %69 = insertvalue { i1, i1 } %68, i1 true, 1
   br label %_llgo_37
 
 _llgo_36:                                         ; preds = %_llgo_0
-  %88 = alloca { i1, i1 }, align 8
-  %89 = getelementptr inbounds { i1, i1 }, ptr %88, i32 0, i32 0
-  store i1 false, ptr %89, align 1
-  %90 = getelementptr inbounds { i1, i1 }, ptr %88, i32 0, i32 1
-  store i1 false, ptr %90, align 1
-  %91 = load { i1, i1 }, ptr %88, align 1
   br label %_llgo_37
 
 _llgo_37:                                         ; preds = %_llgo_36, %_llgo_35
-  %92 = phi { i1, i1 } [ %87, %_llgo_35 ], [ %91, %_llgo_36 ]
-  %93 = extractvalue { i1, i1 } %92, 0
-  %94 = extractvalue { i1, i1 } %92, 1
-  br i1 %94, label %_llgo_2, label %_llgo_3
+  %70 = phi { i1, i1 } [ %69, %_llgo_35 ], [ zeroinitializer, %_llgo_36 ]
+  %71 = extractvalue { i1, i1 } %70, 0
+  %72 = extractvalue { i1, i1 } %70, 1
+  br i1 %72, label %_llgo_2, label %_llgo_3
 
 _llgo_38:                                         ; preds = %_llgo_3
-  %95 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
-  %96 = ptrtoint ptr %95 to i64
-  %97 = alloca { i64, i1 }, align 8
-  %98 = getelementptr inbounds { i64, i1 }, ptr %97, i32 0, i32 0
-  store i64 %96, ptr %98, align 4
-  %99 = getelementptr inbounds { i64, i1 }, ptr %97, i32 0, i32 1
-  store i1 true, ptr %99, align 1
-  %100 = load { i64, i1 }, ptr %97, align 4
+  %73 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
+  %74 = ptrtoint ptr %73 to i64
+  %75 = insertvalue { i64, i1 } undef, i64 %74, 0
+  %76 = insertvalue { i64, i1 } %75, i1 true, 1
   br label %_llgo_40
 
 _llgo_39:                                         ; preds = %_llgo_3
-  %101 = alloca { i64, i1 }, align 8
-  %102 = getelementptr inbounds { i64, i1 }, ptr %101, i32 0, i32 0
-  store i64 0, ptr %102, align 4
-  %103 = getelementptr inbounds { i64, i1 }, ptr %101, i32 0, i32 1
-  store i1 false, ptr %103, align 1
-  %104 = load { i64, i1 }, ptr %101, align 4
   br label %_llgo_40
 
 _llgo_40:                                         ; preds = %_llgo_39, %_llgo_38
-  %105 = phi { i64, i1 } [ %100, %_llgo_38 ], [ %104, %_llgo_39 ]
-  %106 = extractvalue { i64, i1 } %105, 0
-  %107 = extractvalue { i64, i1 } %105, 1
-  br i1 %107, label %_llgo_4, label %_llgo_5
+  %77 = phi { i64, i1 } [ %76, %_llgo_38 ], [ zeroinitializer, %_llgo_39 ]
+  %78 = extractvalue { i64, i1 } %77, 0
+  %79 = extractvalue { i64, i1 } %77, 1
+  br i1 %79, label %_llgo_4, label %_llgo_5
 
 _llgo_41:                                         ; preds = %_llgo_5
-  %108 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
-  %109 = ptrtoint ptr %108 to i64
-  %110 = trunc i64 %109 to i8
-  %111 = alloca { i8, i1 }, align 8
-  %112 = getelementptr inbounds { i8, i1 }, ptr %111, i32 0, i32 0
-  store i8 %110, ptr %112, align 1
-  %113 = getelementptr inbounds { i8, i1 }, ptr %111, i32 0, i32 1
-  store i1 true, ptr %113, align 1
-  %114 = load { i8, i1 }, ptr %111, align 1
+  %80 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
+  %81 = ptrtoint ptr %80 to i64
+  %82 = trunc i64 %81 to i8
+  %83 = insertvalue { i8, i1 } undef, i8 %82, 0
+  %84 = insertvalue { i8, i1 } %83, i1 true, 1
   br label %_llgo_43
 
 _llgo_42:                                         ; preds = %_llgo_5
-  %115 = alloca { i8, i1 }, align 8
-  %116 = getelementptr inbounds { i8, i1 }, ptr %115, i32 0, i32 0
-  store i8 0, ptr %116, align 1
-  %117 = getelementptr inbounds { i8, i1 }, ptr %115, i32 0, i32 1
-  store i1 false, ptr %117, align 1
-  %118 = load { i8, i1 }, ptr %115, align 1
   br label %_llgo_43
 
 _llgo_43:                                         ; preds = %_llgo_42, %_llgo_41
-  %119 = phi { i8, i1 } [ %114, %_llgo_41 ], [ %118, %_llgo_42 ]
-  %120 = extractvalue { i8, i1 } %119, 0
-  %121 = extractvalue { i8, i1 } %119, 1
-  br i1 %121, label %_llgo_6, label %_llgo_7
+  %85 = phi { i8, i1 } [ %84, %_llgo_41 ], [ zeroinitializer, %_llgo_42 ]
+  %86 = extractvalue { i8, i1 } %85, 0
+  %87 = extractvalue { i8, i1 } %85, 1
+  br i1 %87, label %_llgo_6, label %_llgo_7
 
 _llgo_44:                                         ; preds = %_llgo_7
-  %122 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
-  %123 = ptrtoint ptr %122 to i64
-  %124 = trunc i64 %123 to i16
-  %125 = alloca { i16, i1 }, align 8
-  %126 = getelementptr inbounds { i16, i1 }, ptr %125, i32 0, i32 0
-  store i16 %124, ptr %126, align 2
-  %127 = getelementptr inbounds { i16, i1 }, ptr %125, i32 0, i32 1
-  store i1 true, ptr %127, align 1
-  %128 = load { i16, i1 }, ptr %125, align 2
+  %88 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
+  %89 = ptrtoint ptr %88 to i64
+  %90 = trunc i64 %89 to i16
+  %91 = insertvalue { i16, i1 } undef, i16 %90, 0
+  %92 = insertvalue { i16, i1 } %91, i1 true, 1
   br label %_llgo_46
 
 _llgo_45:                                         ; preds = %_llgo_7
-  %129 = alloca { i16, i1 }, align 8
-  %130 = getelementptr inbounds { i16, i1 }, ptr %129, i32 0, i32 0
-  store i16 0, ptr %130, align 2
-  %131 = getelementptr inbounds { i16, i1 }, ptr %129, i32 0, i32 1
-  store i1 false, ptr %131, align 1
-  %132 = load { i16, i1 }, ptr %129, align 2
   br label %_llgo_46
 
 _llgo_46:                                         ; preds = %_llgo_45, %_llgo_44
-  %133 = phi { i16, i1 } [ %128, %_llgo_44 ], [ %132, %_llgo_45 ]
-  %134 = extractvalue { i16, i1 } %133, 0
-  %135 = extractvalue { i16, i1 } %133, 1
-  br i1 %135, label %_llgo_8, label %_llgo_9
+  %93 = phi { i16, i1 } [ %92, %_llgo_44 ], [ zeroinitializer, %_llgo_45 ]
+  %94 = extractvalue { i16, i1 } %93, 0
+  %95 = extractvalue { i16, i1 } %93, 1
+  br i1 %95, label %_llgo_8, label %_llgo_9
 
 _llgo_47:                                         ; preds = %_llgo_9
-  %136 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
-  %137 = ptrtoint ptr %136 to i64
-  %138 = trunc i64 %137 to i32
-  %139 = alloca { i32, i1 }, align 8
-  %140 = getelementptr inbounds { i32, i1 }, ptr %139, i32 0, i32 0
-  store i32 %138, ptr %140, align 4
-  %141 = getelementptr inbounds { i32, i1 }, ptr %139, i32 0, i32 1
-  store i1 true, ptr %141, align 1
-  %142 = load { i32, i1 }, ptr %139, align 4
+  %96 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
+  %97 = ptrtoint ptr %96 to i64
+  %98 = trunc i64 %97 to i32
+  %99 = insertvalue { i32, i1 } undef, i32 %98, 0
+  %100 = insertvalue { i32, i1 } %99, i1 true, 1
   br label %_llgo_49
 
 _llgo_48:                                         ; preds = %_llgo_9
-  %143 = alloca { i32, i1 }, align 8
-  %144 = getelementptr inbounds { i32, i1 }, ptr %143, i32 0, i32 0
-  store i32 0, ptr %144, align 4
-  %145 = getelementptr inbounds { i32, i1 }, ptr %143, i32 0, i32 1
-  store i1 false, ptr %145, align 1
-  %146 = load { i32, i1 }, ptr %143, align 4
   br label %_llgo_49
 
 _llgo_49:                                         ; preds = %_llgo_48, %_llgo_47
-  %147 = phi { i32, i1 } [ %142, %_llgo_47 ], [ %146, %_llgo_48 ]
-  %148 = extractvalue { i32, i1 } %147, 0
-  %149 = extractvalue { i32, i1 } %147, 1
-  br i1 %149, label %_llgo_10, label %_llgo_11
+  %101 = phi { i32, i1 } [ %100, %_llgo_47 ], [ zeroinitializer, %_llgo_48 ]
+  %102 = extractvalue { i32, i1 } %101, 0
+  %103 = extractvalue { i32, i1 } %101, 1
+  br i1 %103, label %_llgo_10, label %_llgo_11
 
 _llgo_50:                                         ; preds = %_llgo_11
-  %150 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
-  %151 = ptrtoint ptr %150 to i64
-  %152 = alloca { i64, i1 }, align 8
-  %153 = getelementptr inbounds { i64, i1 }, ptr %152, i32 0, i32 0
-  store i64 %151, ptr %153, align 4
-  %154 = getelementptr inbounds { i64, i1 }, ptr %152, i32 0, i32 1
-  store i1 true, ptr %154, align 1
-  %155 = load { i64, i1 }, ptr %152, align 4
+  %104 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
+  %105 = ptrtoint ptr %104 to i64
+  %106 = insertvalue { i64, i1 } undef, i64 %105, 0
+  %107 = insertvalue { i64, i1 } %106, i1 true, 1
   br label %_llgo_52
 
 _llgo_51:                                         ; preds = %_llgo_11
-  %156 = alloca { i64, i1 }, align 8
-  %157 = getelementptr inbounds { i64, i1 }, ptr %156, i32 0, i32 0
-  store i64 0, ptr %157, align 4
-  %158 = getelementptr inbounds { i64, i1 }, ptr %156, i32 0, i32 1
-  store i1 false, ptr %158, align 1
-  %159 = load { i64, i1 }, ptr %156, align 4
   br label %_llgo_52
 
 _llgo_52:                                         ; preds = %_llgo_51, %_llgo_50
-  %160 = phi { i64, i1 } [ %155, %_llgo_50 ], [ %159, %_llgo_51 ]
-  %161 = extractvalue { i64, i1 } %160, 0
-  %162 = extractvalue { i64, i1 } %160, 1
-  br i1 %162, label %_llgo_12, label %_llgo_13
+  %108 = phi { i64, i1 } [ %107, %_llgo_50 ], [ zeroinitializer, %_llgo_51 ]
+  %109 = extractvalue { i64, i1 } %108, 0
+  %110 = extractvalue { i64, i1 } %108, 1
+  br i1 %110, label %_llgo_12, label %_llgo_13
 
 _llgo_53:                                         ; preds = %_llgo_13
-  %163 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
-  %164 = ptrtoint ptr %163 to i64
-  %165 = alloca { i64, i1 }, align 8
-  %166 = getelementptr inbounds { i64, i1 }, ptr %165, i32 0, i32 0
-  store i64 %164, ptr %166, align 4
-  %167 = getelementptr inbounds { i64, i1 }, ptr %165, i32 0, i32 1
-  store i1 true, ptr %167, align 1
-  %168 = load { i64, i1 }, ptr %165, align 4
+  %111 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
+  %112 = ptrtoint ptr %111 to i64
+  %113 = insertvalue { i64, i1 } undef, i64 %112, 0
+  %114 = insertvalue { i64, i1 } %113, i1 true, 1
   br label %_llgo_55
 
 _llgo_54:                                         ; preds = %_llgo_13
-  %169 = alloca { i64, i1 }, align 8
-  %170 = getelementptr inbounds { i64, i1 }, ptr %169, i32 0, i32 0
-  store i64 0, ptr %170, align 4
-  %171 = getelementptr inbounds { i64, i1 }, ptr %169, i32 0, i32 1
-  store i1 false, ptr %171, align 1
-  %172 = load { i64, i1 }, ptr %169, align 4
   br label %_llgo_55
 
 _llgo_55:                                         ; preds = %_llgo_54, %_llgo_53
-  %173 = phi { i64, i1 } [ %168, %_llgo_53 ], [ %172, %_llgo_54 ]
-  %174 = extractvalue { i64, i1 } %173, 0
-  %175 = extractvalue { i64, i1 } %173, 1
-  br i1 %175, label %_llgo_14, label %_llgo_15
+  %115 = phi { i64, i1 } [ %114, %_llgo_53 ], [ zeroinitializer, %_llgo_54 ]
+  %116 = extractvalue { i64, i1 } %115, 0
+  %117 = extractvalue { i64, i1 } %115, 1
+  br i1 %117, label %_llgo_14, label %_llgo_15
 
 _llgo_56:                                         ; preds = %_llgo_15
-  %176 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
-  %177 = ptrtoint ptr %176 to i64
-  %178 = trunc i64 %177 to i8
-  %179 = alloca { i8, i1 }, align 8
-  %180 = getelementptr inbounds { i8, i1 }, ptr %179, i32 0, i32 0
-  store i8 %178, ptr %180, align 1
-  %181 = getelementptr inbounds { i8, i1 }, ptr %179, i32 0, i32 1
-  store i1 true, ptr %181, align 1
-  %182 = load { i8, i1 }, ptr %179, align 1
+  %118 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
+  %119 = ptrtoint ptr %118 to i64
+  %120 = trunc i64 %119 to i8
+  %121 = insertvalue { i8, i1 } undef, i8 %120, 0
+  %122 = insertvalue { i8, i1 } %121, i1 true, 1
   br label %_llgo_58
 
 _llgo_57:                                         ; preds = %_llgo_15
-  %183 = alloca { i8, i1 }, align 8
-  %184 = getelementptr inbounds { i8, i1 }, ptr %183, i32 0, i32 0
-  store i8 0, ptr %184, align 1
-  %185 = getelementptr inbounds { i8, i1 }, ptr %183, i32 0, i32 1
-  store i1 false, ptr %185, align 1
-  %186 = load { i8, i1 }, ptr %183, align 1
   br label %_llgo_58
 
 _llgo_58:                                         ; preds = %_llgo_57, %_llgo_56
-  %187 = phi { i8, i1 } [ %182, %_llgo_56 ], [ %186, %_llgo_57 ]
-  %188 = extractvalue { i8, i1 } %187, 0
-  %189 = extractvalue { i8, i1 } %187, 1
-  br i1 %189, label %_llgo_16, label %_llgo_17
+  %123 = phi { i8, i1 } [ %122, %_llgo_56 ], [ zeroinitializer, %_llgo_57 ]
+  %124 = extractvalue { i8, i1 } %123, 0
+  %125 = extractvalue { i8, i1 } %123, 1
+  br i1 %125, label %_llgo_16, label %_llgo_17
 
 _llgo_59:                                         ; preds = %_llgo_17
-  %190 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
-  %191 = ptrtoint ptr %190 to i64
-  %192 = trunc i64 %191 to i16
-  %193 = alloca { i16, i1 }, align 8
-  %194 = getelementptr inbounds { i16, i1 }, ptr %193, i32 0, i32 0
-  store i16 %192, ptr %194, align 2
-  %195 = getelementptr inbounds { i16, i1 }, ptr %193, i32 0, i32 1
-  store i1 true, ptr %195, align 1
-  %196 = load { i16, i1 }, ptr %193, align 2
+  %126 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
+  %127 = ptrtoint ptr %126 to i64
+  %128 = trunc i64 %127 to i16
+  %129 = insertvalue { i16, i1 } undef, i16 %128, 0
+  %130 = insertvalue { i16, i1 } %129, i1 true, 1
   br label %_llgo_61
 
 _llgo_60:                                         ; preds = %_llgo_17
-  %197 = alloca { i16, i1 }, align 8
-  %198 = getelementptr inbounds { i16, i1 }, ptr %197, i32 0, i32 0
-  store i16 0, ptr %198, align 2
-  %199 = getelementptr inbounds { i16, i1 }, ptr %197, i32 0, i32 1
-  store i1 false, ptr %199, align 1
-  %200 = load { i16, i1 }, ptr %197, align 2
   br label %_llgo_61
 
 _llgo_61:                                         ; preds = %_llgo_60, %_llgo_59
-  %201 = phi { i16, i1 } [ %196, %_llgo_59 ], [ %200, %_llgo_60 ]
-  %202 = extractvalue { i16, i1 } %201, 0
-  %203 = extractvalue { i16, i1 } %201, 1
-  br i1 %203, label %_llgo_18, label %_llgo_19
+  %131 = phi { i16, i1 } [ %130, %_llgo_59 ], [ zeroinitializer, %_llgo_60 ]
+  %132 = extractvalue { i16, i1 } %131, 0
+  %133 = extractvalue { i16, i1 } %131, 1
+  br i1 %133, label %_llgo_18, label %_llgo_19
 
 _llgo_62:                                         ; preds = %_llgo_19
-  %204 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
-  %205 = ptrtoint ptr %204 to i64
-  %206 = trunc i64 %205 to i32
-  %207 = alloca { i32, i1 }, align 8
-  %208 = getelementptr inbounds { i32, i1 }, ptr %207, i32 0, i32 0
-  store i32 %206, ptr %208, align 4
-  %209 = getelementptr inbounds { i32, i1 }, ptr %207, i32 0, i32 1
-  store i1 true, ptr %209, align 1
-  %210 = load { i32, i1 }, ptr %207, align 4
+  %134 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
+  %135 = ptrtoint ptr %134 to i64
+  %136 = trunc i64 %135 to i32
+  %137 = insertvalue { i32, i1 } undef, i32 %136, 0
+  %138 = insertvalue { i32, i1 } %137, i1 true, 1
   br label %_llgo_64
 
 _llgo_63:                                         ; preds = %_llgo_19
-  %211 = alloca { i32, i1 }, align 8
-  %212 = getelementptr inbounds { i32, i1 }, ptr %211, i32 0, i32 0
-  store i32 0, ptr %212, align 4
-  %213 = getelementptr inbounds { i32, i1 }, ptr %211, i32 0, i32 1
-  store i1 false, ptr %213, align 1
-  %214 = load { i32, i1 }, ptr %211, align 4
   br label %_llgo_64
 
 _llgo_64:                                         ; preds = %_llgo_63, %_llgo_62
-  %215 = phi { i32, i1 } [ %210, %_llgo_62 ], [ %214, %_llgo_63 ]
-  %216 = extractvalue { i32, i1 } %215, 0
-  %217 = extractvalue { i32, i1 } %215, 1
-  br i1 %217, label %_llgo_20, label %_llgo_21
+  %139 = phi { i32, i1 } [ %138, %_llgo_62 ], [ zeroinitializer, %_llgo_63 ]
+  %140 = extractvalue { i32, i1 } %139, 0
+  %141 = extractvalue { i32, i1 } %139, 1
+  br i1 %141, label %_llgo_20, label %_llgo_21
 
 _llgo_65:                                         ; preds = %_llgo_21
-  %218 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
-  %219 = ptrtoint ptr %218 to i64
-  %220 = alloca { i64, i1 }, align 8
-  %221 = getelementptr inbounds { i64, i1 }, ptr %220, i32 0, i32 0
-  store i64 %219, ptr %221, align 4
-  %222 = getelementptr inbounds { i64, i1 }, ptr %220, i32 0, i32 1
-  store i1 true, ptr %222, align 1
-  %223 = load { i64, i1 }, ptr %220, align 4
+  %142 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
+  %143 = ptrtoint ptr %142 to i64
+  %144 = insertvalue { i64, i1 } undef, i64 %143, 0
+  %145 = insertvalue { i64, i1 } %144, i1 true, 1
   br label %_llgo_67
 
 _llgo_66:                                         ; preds = %_llgo_21
-  %224 = alloca { i64, i1 }, align 8
-  %225 = getelementptr inbounds { i64, i1 }, ptr %224, i32 0, i32 0
-  store i64 0, ptr %225, align 4
-  %226 = getelementptr inbounds { i64, i1 }, ptr %224, i32 0, i32 1
-  store i1 false, ptr %226, align 1
-  %227 = load { i64, i1 }, ptr %224, align 4
   br label %_llgo_67
 
 _llgo_67:                                         ; preds = %_llgo_66, %_llgo_65
-  %228 = phi { i64, i1 } [ %223, %_llgo_65 ], [ %227, %_llgo_66 ]
-  %229 = extractvalue { i64, i1 } %228, 0
-  %230 = extractvalue { i64, i1 } %228, 1
-  br i1 %230, label %_llgo_22, label %_llgo_23
+  %146 = phi { i64, i1 } [ %145, %_llgo_65 ], [ zeroinitializer, %_llgo_66 ]
+  %147 = extractvalue { i64, i1 } %146, 0
+  %148 = extractvalue { i64, i1 } %146, 1
+  br i1 %148, label %_llgo_22, label %_llgo_23
 
 _llgo_68:                                         ; preds = %_llgo_23
-  %231 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
-  %232 = ptrtoint ptr %231 to i64
-  %233 = alloca { i64, i1 }, align 8
-  %234 = getelementptr inbounds { i64, i1 }, ptr %233, i32 0, i32 0
-  store i64 %232, ptr %234, align 4
-  %235 = getelementptr inbounds { i64, i1 }, ptr %233, i32 0, i32 1
-  store i1 true, ptr %235, align 1
-  %236 = load { i64, i1 }, ptr %233, align 4
+  %149 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
+  %150 = ptrtoint ptr %149 to i64
+  %151 = insertvalue { i64, i1 } undef, i64 %150, 0
+  %152 = insertvalue { i64, i1 } %151, i1 true, 1
   br label %_llgo_70
 
 _llgo_69:                                         ; preds = %_llgo_23
-  %237 = alloca { i64, i1 }, align 8
-  %238 = getelementptr inbounds { i64, i1 }, ptr %237, i32 0, i32 0
-  store i64 0, ptr %238, align 4
-  %239 = getelementptr inbounds { i64, i1 }, ptr %237, i32 0, i32 1
-  store i1 false, ptr %239, align 1
-  %240 = load { i64, i1 }, ptr %237, align 4
   br label %_llgo_70
 
 _llgo_70:                                         ; preds = %_llgo_69, %_llgo_68
-  %241 = phi { i64, i1 } [ %236, %_llgo_68 ], [ %240, %_llgo_69 ]
-  %242 = extractvalue { i64, i1 } %241, 0
-  %243 = extractvalue { i64, i1 } %241, 1
-  br i1 %243, label %_llgo_24, label %_llgo_25
+  %153 = phi { i64, i1 } [ %152, %_llgo_68 ], [ zeroinitializer, %_llgo_69 ]
+  %154 = extractvalue { i64, i1 } %153, 0
+  %155 = extractvalue { i64, i1 } %153, 1
+  br i1 %155, label %_llgo_24, label %_llgo_25
 
 _llgo_71:                                         ; preds = %_llgo_25
-  %244 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
-  %245 = ptrtoint ptr %244 to i64
-  %246 = trunc i64 %245 to i32
-  %247 = bitcast i32 %246 to float
-  %248 = alloca { float, i1 }, align 8
-  %249 = getelementptr inbounds { float, i1 }, ptr %248, i32 0, i32 0
-  store float %247, ptr %249, align 4
-  %250 = getelementptr inbounds { float, i1 }, ptr %248, i32 0, i32 1
-  store i1 true, ptr %250, align 1
-  %251 = load { float, i1 }, ptr %248, align 4
+  %156 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
+  %157 = ptrtoint ptr %156 to i64
+  %158 = trunc i64 %157 to i32
+  %159 = bitcast i32 %158 to float
+  %160 = insertvalue { float, i1 } undef, float %159, 0
+  %161 = insertvalue { float, i1 } %160, i1 true, 1
   br label %_llgo_73
 
 _llgo_72:                                         ; preds = %_llgo_25
-  %252 = alloca { float, i1 }, align 8
-  %253 = getelementptr inbounds { float, i1 }, ptr %252, i32 0, i32 0
-  store double 0.000000e+00, ptr %253, align 8
-  %254 = getelementptr inbounds { float, i1 }, ptr %252, i32 0, i32 1
-  store i1 false, ptr %254, align 1
-  %255 = load { float, i1 }, ptr %252, align 4
   br label %_llgo_73
 
 _llgo_73:                                         ; preds = %_llgo_72, %_llgo_71
-  %256 = phi { float, i1 } [ %251, %_llgo_71 ], [ %255, %_llgo_72 ]
-  %257 = extractvalue { float, i1 } %256, 0
-  %258 = extractvalue { float, i1 } %256, 1
-  br i1 %258, label %_llgo_26, label %_llgo_27
+  %162 = phi { float, i1 } [ %161, %_llgo_71 ], [ zeroinitializer, %_llgo_72 ]
+  %163 = extractvalue { float, i1 } %162, 0
+  %164 = extractvalue { float, i1 } %162, 1
+  br i1 %164, label %_llgo_26, label %_llgo_27
 
 _llgo_74:                                         ; preds = %_llgo_27
-  %259 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
-  %260 = ptrtoint ptr %259 to i64
-  %261 = bitcast i64 %260 to double
-  %262 = alloca { double, i1 }, align 8
-  %263 = getelementptr inbounds { double, i1 }, ptr %262, i32 0, i32 0
-  store double %261, ptr %263, align 8
-  %264 = getelementptr inbounds { double, i1 }, ptr %262, i32 0, i32 1
-  store i1 true, ptr %264, align 1
-  %265 = load { double, i1 }, ptr %262, align 8
+  %165 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
+  %166 = ptrtoint ptr %165 to i64
+  %167 = bitcast i64 %166 to double
+  %168 = insertvalue { double, i1 } undef, double %167, 0
+  %169 = insertvalue { double, i1 } %168, i1 true, 1
   br label %_llgo_76
 
 _llgo_75:                                         ; preds = %_llgo_27
-  %266 = alloca { double, i1 }, align 8
-  %267 = getelementptr inbounds { double, i1 }, ptr %266, i32 0, i32 0
-  store double 0.000000e+00, ptr %267, align 8
-  %268 = getelementptr inbounds { double, i1 }, ptr %266, i32 0, i32 1
-  store i1 false, ptr %268, align 1
-  %269 = load { double, i1 }, ptr %266, align 8
   br label %_llgo_76
 
 _llgo_76:                                         ; preds = %_llgo_75, %_llgo_74
-  %270 = phi { double, i1 } [ %265, %_llgo_74 ], [ %269, %_llgo_75 ]
-  %271 = extractvalue { double, i1 } %270, 0
-  %272 = extractvalue { double, i1 } %270, 1
-  br i1 %272, label %_llgo_28, label %_llgo_29
+  %170 = phi { double, i1 } [ %169, %_llgo_74 ], [ zeroinitializer, %_llgo_75 ]
+  %171 = extractvalue { double, i1 } %170, 0
+  %172 = extractvalue { double, i1 } %170, 1
+  br i1 %172, label %_llgo_28, label %_llgo_29
 
 _llgo_77:                                         ; preds = %_llgo_29
-  %273 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
-  %274 = load { float, float }, ptr %273, align 4
-  %275 = alloca { { float, float }, i1 }, align 8
-  %276 = getelementptr inbounds { { float, float }, i1 }, ptr %275, i32 0, i32 0
-  store { float, float } %274, ptr %276, align 4
-  %277 = getelementptr inbounds { { float, float }, i1 }, ptr %275, i32 0, i32 1
-  store i1 true, ptr %277, align 1
-  %278 = load { { float, float }, i1 }, ptr %275, align 4
+  %173 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
+  %174 = load { float, float }, ptr %173, align 4
+  %175 = insertvalue { { float, float }, i1 } undef, { float, float } %174, 0
+  %176 = insertvalue { { float, float }, i1 } %175, i1 true, 1
   br label %_llgo_79
 
 _llgo_78:                                         ; preds = %_llgo_29
-  %279 = alloca { { float, float }, i1 }, align 8
-  %280 = getelementptr inbounds { { float, float }, i1 }, ptr %279, i32 0, i32 0
-  store { float, float } zeroinitializer, ptr %280, align 4
-  %281 = getelementptr inbounds { { float, float }, i1 }, ptr %279, i32 0, i32 1
-  store i1 false, ptr %281, align 1
-  %282 = load { { float, float }, i1 }, ptr %279, align 4
   br label %_llgo_79
 
 _llgo_79:                                         ; preds = %_llgo_78, %_llgo_77
-  %283 = phi { { float, float }, i1 } [ %278, %_llgo_77 ], [ %282, %_llgo_78 ]
-  %284 = extractvalue { { float, float }, i1 } %283, 0
-  %285 = extractvalue { { float, float }, i1 } %283, 1
-  br i1 %285, label %_llgo_30, label %_llgo_31
+  %177 = phi { { float, float }, i1 } [ %176, %_llgo_77 ], [ zeroinitializer, %_llgo_78 ]
+  %178 = extractvalue { { float, float }, i1 } %177, 0
+  %179 = extractvalue { { float, float }, i1 } %177, 1
+  br i1 %179, label %_llgo_30, label %_llgo_31
 
 _llgo_80:                                         ; preds = %_llgo_31
-  %286 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
-  %287 = load { double, double }, ptr %286, align 8
-  %288 = alloca { { double, double }, i1 }, align 8
-  %289 = getelementptr inbounds { { double, double }, i1 }, ptr %288, i32 0, i32 0
-  store { double, double } %287, ptr %289, align 8
-  %290 = getelementptr inbounds { { double, double }, i1 }, ptr %288, i32 0, i32 1
-  store i1 true, ptr %290, align 1
-  %291 = load { { double, double }, i1 }, ptr %288, align 8
+  %180 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
+  %181 = load { double, double }, ptr %180, align 8
+  %182 = insertvalue { { double, double }, i1 } undef, { double, double } %181, 0
+  %183 = insertvalue { { double, double }, i1 } %182, i1 true, 1
   br label %_llgo_82
 
 _llgo_81:                                         ; preds = %_llgo_31
-  %292 = alloca { { double, double }, i1 }, align 8
-  %293 = getelementptr inbounds { { double, double }, i1 }, ptr %292, i32 0, i32 0
-  store { double, double } zeroinitializer, ptr %293, align 8
-  %294 = getelementptr inbounds { { double, double }, i1 }, ptr %292, i32 0, i32 1
-  store i1 false, ptr %294, align 1
-  %295 = load { { double, double }, i1 }, ptr %292, align 8
   br label %_llgo_82
 
 _llgo_82:                                         ; preds = %_llgo_81, %_llgo_80
-  %296 = phi { { double, double }, i1 } [ %291, %_llgo_80 ], [ %295, %_llgo_81 ]
-  %297 = extractvalue { { double, double }, i1 } %296, 0
-  %298 = extractvalue { { double, double }, i1 } %296, 1
-  br i1 %298, label %_llgo_32, label %_llgo_33
+  %184 = phi { { double, double }, i1 } [ %183, %_llgo_80 ], [ zeroinitializer, %_llgo_81 ]
+  %185 = extractvalue { { double, double }, i1 } %184, 0
+  %186 = extractvalue { { double, double }, i1 } %184, 1
+  br i1 %186, label %_llgo_32, label %_llgo_33
 
 _llgo_83:                                         ; preds = %_llgo_33
-  %299 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
-  %300 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %299, align 8
-  %301 = alloca { %"github.com/goplus/llgo/internal/runtime.String", i1 }, align 8
-  %302 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.String", i1 }, ptr %301, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %300, ptr %302, align 8
-  %303 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.String", i1 }, ptr %301, i32 0, i32 1
-  store i1 true, ptr %303, align 1
-  %304 = load { %"github.com/goplus/llgo/internal/runtime.String", i1 }, ptr %301, align 8
+  %187 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
+  %188 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %187, align 8
+  %189 = insertvalue { %"github.com/goplus/llgo/internal/runtime.String", i1 } undef, %"github.com/goplus/llgo/internal/runtime.String" %188, 0
+  %190 = insertvalue { %"github.com/goplus/llgo/internal/runtime.String", i1 } %189, i1 true, 1
   br label %_llgo_85
 
 _llgo_84:                                         ; preds = %_llgo_33
-  %305 = alloca { %"github.com/goplus/llgo/internal/runtime.String", i1 }, align 8
-  %306 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.String", i1 }, ptr %305, i32 0, i32 0
-  store { ptr, i64 } zeroinitializer, ptr %306, align 8
-  %307 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.String", i1 }, ptr %305, i32 0, i32 1
-  store i1 false, ptr %307, align 1
-  %308 = load { %"github.com/goplus/llgo/internal/runtime.String", i1 }, ptr %305, align 8
   br label %_llgo_85
 
 _llgo_85:                                         ; preds = %_llgo_84, %_llgo_83
-  %309 = phi { %"github.com/goplus/llgo/internal/runtime.String", i1 } [ %304, %_llgo_83 ], [ %308, %_llgo_84 ]
-  %310 = extractvalue { %"github.com/goplus/llgo/internal/runtime.String", i1 } %309, 0
-  %311 = extractvalue { %"github.com/goplus/llgo/internal/runtime.String", i1 } %309, 1
-  br i1 %311, label %_llgo_34, label %_llgo_1
+  %191 = phi { %"github.com/goplus/llgo/internal/runtime.String", i1 } [ %190, %_llgo_83 ], [ zeroinitializer, %_llgo_84 ]
+  %192 = extractvalue { %"github.com/goplus/llgo/internal/runtime.String", i1 } %191, 0
+  %193 = extractvalue { %"github.com/goplus/llgo/internal/runtime.String", i1 } %191, 1
+  br i1 %193, label %_llgo_34, label %_llgo_1
 }
 
 define void @main.printbool(i1 %0) {
@@ -1125,26 +791,14 @@ _llgo_0:
   br i1 %0, label %_llgo_1, label %_llgo_3
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %1 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1, i32 0, i32 0
-  store ptr @6, ptr %2, align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1, i32 0, i32 1
-  store i64 4, ptr %3, align 4
-  %4 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1, align 8
-  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" %4)
+  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 4 })
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_3, %_llgo_1
   ret void
 
 _llgo_3:                                          ; preds = %_llgo_0
-  %5 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %5, i32 0, i32 0
-  store ptr @7, ptr %6, align 8
-  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %5, i32 0, i32 1
-  store i64 5, ptr %7, align 4
-  %8 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %5, align 8
-  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" %8)
+  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 5 })
   br label %_llgo_2
 }
 
@@ -1154,209 +808,186 @@ _llgo_0:
   br i1 %1, label %_llgo_1, label %_llgo_3
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %2 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 0
-  store ptr @8, ptr %3, align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 1
-  store i64 3, ptr %4, align 4
-  %5 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
-  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" %5)
+  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 3 })
   ret void
 
 _llgo_2:                                          ; preds = %_llgo_7
-  %6 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %6, i32 0, i32 0
-  store ptr @9, ptr %7, align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %6, i32 0, i32 1
-  store i64 4, ptr %8, align 4
-  %9 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %6, align 8
-  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" %9)
+  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 4 })
   ret void
 
 _llgo_3:                                          ; preds = %_llgo_0
-  %10 = fadd double %0, %0
-  %11 = fcmp oeq double %10, %0
-  br i1 %11, label %_llgo_6, label %_llgo_7
+  %2 = fadd double %0, %0
+  %3 = fcmp oeq double %2, %0
+  br i1 %3, label %_llgo_6, label %_llgo_7
 
 _llgo_4:                                          ; preds = %_llgo_10
-  %12 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %12, i32 0, i32 0
-  store ptr @10, ptr %13, align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %12, i32 0, i32 1
-  store i64 4, ptr %14, align 4
-  %15 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %12, align 8
-  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" %15)
+  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 })
   ret void
 
 _llgo_5:                                          ; preds = %_llgo_7
-  %16 = fadd double %0, %0
-  %17 = fcmp oeq double %16, %0
-  br i1 %17, label %_llgo_9, label %_llgo_10
+  %4 = fadd double %0, %0
+  %5 = fcmp oeq double %4, %0
+  br i1 %5, label %_llgo_9, label %_llgo_10
 
 _llgo_6:                                          ; preds = %_llgo_3
-  %18 = fcmp ogt double %0, 0.000000e+00
+  %6 = fcmp ogt double %0, 0.000000e+00
   br label %_llgo_7
 
 _llgo_7:                                          ; preds = %_llgo_6, %_llgo_3
-  %19 = phi i1 [ false, %_llgo_3 ], [ %18, %_llgo_6 ]
-  br i1 %19, label %_llgo_2, label %_llgo_5
+  %7 = phi i1 [ false, %_llgo_3 ], [ %6, %_llgo_6 ]
+  br i1 %7, label %_llgo_2, label %_llgo_5
 
 _llgo_8:                                          ; preds = %_llgo_10
-  %20 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 14)
-  %21 = getelementptr inbounds i8, ptr %20, i64 0
-  store i8 43, ptr %21, align 1
-  %22 = fcmp oeq double %0, 0.000000e+00
-  br i1 %22, label %_llgo_11, label %_llgo_13
+  %8 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 14)
+  %9 = getelementptr inbounds i8, ptr %8, i64 0
+  store i8 43, ptr %9, align 1
+  %10 = fcmp oeq double %0, 0.000000e+00
+  br i1 %10, label %_llgo_11, label %_llgo_13
 
 _llgo_9:                                          ; preds = %_llgo_5
-  %23 = fcmp olt double %0, 0.000000e+00
+  %11 = fcmp olt double %0, 0.000000e+00
   br label %_llgo_10
 
 _llgo_10:                                         ; preds = %_llgo_9, %_llgo_5
-  %24 = phi i1 [ false, %_llgo_5 ], [ %23, %_llgo_9 ]
-  br i1 %24, label %_llgo_4, label %_llgo_8
+  %12 = phi i1 [ false, %_llgo_5 ], [ %11, %_llgo_9 ]
+  br i1 %12, label %_llgo_4, label %_llgo_8
 
 _llgo_11:                                         ; preds = %_llgo_8
-  %25 = fdiv double 1.000000e+00, %0
-  %26 = fcmp olt double %25, 0.000000e+00
-  br i1 %26, label %_llgo_14, label %_llgo_12
+  %13 = fdiv double 1.000000e+00, %0
+  %14 = fcmp olt double %13, 0.000000e+00
+  br i1 %14, label %_llgo_14, label %_llgo_12
 
 _llgo_12:                                         ; preds = %_llgo_24, %_llgo_22, %_llgo_14, %_llgo_11
-  %27 = phi double [ %0, %_llgo_11 ], [ %45, %_llgo_22 ], [ %0, %_llgo_14 ], [ %51, %_llgo_24 ]
-  %28 = phi i64 [ 0, %_llgo_11 ], [ %41, %_llgo_22 ], [ 0, %_llgo_14 ], [ %50, %_llgo_24 ]
+  %15 = phi double [ %0, %_llgo_11 ], [ %33, %_llgo_22 ], [ %0, %_llgo_14 ], [ %39, %_llgo_24 ]
+  %16 = phi i64 [ 0, %_llgo_11 ], [ %29, %_llgo_22 ], [ 0, %_llgo_14 ], [ %38, %_llgo_24 ]
   br label %_llgo_27
 
 _llgo_13:                                         ; preds = %_llgo_8
-  %29 = fcmp olt double %0, 0.000000e+00
-  br i1 %29, label %_llgo_15, label %_llgo_17
+  %17 = fcmp olt double %0, 0.000000e+00
+  br i1 %17, label %_llgo_15, label %_llgo_17
 
 _llgo_14:                                         ; preds = %_llgo_11
-  %30 = getelementptr inbounds i8, ptr %20, i64 0
-  store i8 45, ptr %30, align 1
+  %18 = getelementptr inbounds i8, ptr %8, i64 0
+  store i8 45, ptr %18, align 1
   br label %_llgo_12
 
 _llgo_15:                                         ; preds = %_llgo_13
-  %31 = fneg double %0
-  %32 = getelementptr inbounds i8, ptr %20, i64 0
-  store i8 45, ptr %32, align 1
+  %19 = fneg double %0
+  %20 = getelementptr inbounds i8, ptr %8, i64 0
+  store i8 45, ptr %20, align 1
   br label %_llgo_17
 
 _llgo_16:                                         ; preds = %_llgo_17
-  %33 = add i64 %36, 1
-  %34 = fdiv double %35, 1.000000e+01
+  %21 = add i64 %24, 1
+  %22 = fdiv double %23, 1.000000e+01
   br label %_llgo_17
 
 _llgo_17:                                         ; preds = %_llgo_16, %_llgo_15, %_llgo_13
-  %35 = phi double [ %0, %_llgo_13 ], [ %34, %_llgo_16 ], [ %31, %_llgo_15 ]
-  %36 = phi i64 [ 0, %_llgo_13 ], [ %33, %_llgo_16 ], [ 0, %_llgo_15 ]
-  %37 = fcmp oge double %35, 1.000000e+01
-  br i1 %37, label %_llgo_16, label %_llgo_20
+  %23 = phi double [ %0, %_llgo_13 ], [ %22, %_llgo_16 ], [ %19, %_llgo_15 ]
+  %24 = phi i64 [ 0, %_llgo_13 ], [ %21, %_llgo_16 ], [ 0, %_llgo_15 ]
+  %25 = fcmp oge double %23, 1.000000e+01
+  br i1 %25, label %_llgo_16, label %_llgo_20
 
 _llgo_18:                                         ; preds = %_llgo_20
-  %38 = sub i64 %41, 1
-  %39 = fmul double %40, 1.000000e+01
+  %26 = sub i64 %29, 1
+  %27 = fmul double %28, 1.000000e+01
   br label %_llgo_20
 
 _llgo_19:                                         ; preds = %_llgo_20
   br label %_llgo_23
 
 _llgo_20:                                         ; preds = %_llgo_18, %_llgo_17
-  %40 = phi double [ %35, %_llgo_17 ], [ %39, %_llgo_18 ]
-  %41 = phi i64 [ %36, %_llgo_17 ], [ %38, %_llgo_18 ]
-  %42 = fcmp olt double %40, 1.000000e+00
-  br i1 %42, label %_llgo_18, label %_llgo_19
+  %28 = phi double [ %23, %_llgo_17 ], [ %27, %_llgo_18 ]
+  %29 = phi i64 [ %24, %_llgo_17 ], [ %26, %_llgo_18 ]
+  %30 = fcmp olt double %28, 1.000000e+00
+  br i1 %30, label %_llgo_18, label %_llgo_19
 
 _llgo_21:                                         ; preds = %_llgo_23
-  %43 = fdiv double %47, 1.000000e+01
-  %44 = add i64 %48, 1
+  %31 = fdiv double %35, 1.000000e+01
+  %32 = add i64 %36, 1
   br label %_llgo_23
 
 _llgo_22:                                         ; preds = %_llgo_23
-  %45 = fadd double %40, %47
-  %46 = fcmp oge double %45, 1.000000e+01
-  br i1 %46, label %_llgo_24, label %_llgo_12
+  %33 = fadd double %28, %35
+  %34 = fcmp oge double %33, 1.000000e+01
+  br i1 %34, label %_llgo_24, label %_llgo_12
 
 _llgo_23:                                         ; preds = %_llgo_21, %_llgo_19
-  %47 = phi double [ 5.000000e+00, %_llgo_19 ], [ %43, %_llgo_21 ]
-  %48 = phi i64 [ 0, %_llgo_19 ], [ %44, %_llgo_21 ]
-  %49 = icmp slt i64 %48, 7
-  br i1 %49, label %_llgo_21, label %_llgo_22
+  %35 = phi double [ 5.000000e+00, %_llgo_19 ], [ %31, %_llgo_21 ]
+  %36 = phi i64 [ 0, %_llgo_19 ], [ %32, %_llgo_21 ]
+  %37 = icmp slt i64 %36, 7
+  br i1 %37, label %_llgo_21, label %_llgo_22
 
 _llgo_24:                                         ; preds = %_llgo_22
-  %50 = add i64 %41, 1
-  %51 = fdiv double %45, 1.000000e+01
+  %38 = add i64 %29, 1
+  %39 = fdiv double %33, 1.000000e+01
   br label %_llgo_12
 
 _llgo_25:                                         ; preds = %_llgo_27
-  %52 = fptosi double %71 to i64
-  %53 = add i64 %72, 2
-  %54 = add i64 %52, 48
-  %55 = trunc i64 %54 to i8
-  %56 = icmp slt i64 %53, 0
-  %57 = icmp sge i64 %53, 14
-  %58 = or i1 %57, %56
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %58)
-  %59 = getelementptr inbounds i8, ptr %20, i64 %53
-  store i8 %55, ptr %59, align 1
-  %60 = sitofp i64 %52 to double
-  %61 = fsub double %71, %60
-  %62 = fmul double %61, 1.000000e+01
-  %63 = add i64 %72, 1
+  %40 = fptosi double %59 to i64
+  %41 = add i64 %60, 2
+  %42 = add i64 %40, 48
+  %43 = trunc i64 %42 to i8
+  %44 = icmp slt i64 %41, 0
+  %45 = icmp sge i64 %41, 14
+  %46 = or i1 %45, %44
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %46)
+  %47 = getelementptr inbounds i8, ptr %8, i64 %41
+  store i8 %43, ptr %47, align 1
+  %48 = sitofp i64 %40 to double
+  %49 = fsub double %59, %48
+  %50 = fmul double %49, 1.000000e+01
+  %51 = add i64 %60, 1
   br label %_llgo_27
 
 _llgo_26:                                         ; preds = %_llgo_27
-  %64 = getelementptr inbounds i8, ptr %20, i64 2
-  %65 = load i8, ptr %64, align 1
-  %66 = getelementptr inbounds i8, ptr %20, i64 1
-  store i8 %65, ptr %66, align 1
-  %67 = getelementptr inbounds i8, ptr %20, i64 2
-  store i8 46, ptr %67, align 1
-  %68 = getelementptr inbounds i8, ptr %20, i64 9
-  store i8 101, ptr %68, align 1
-  %69 = getelementptr inbounds i8, ptr %20, i64 10
-  store i8 43, ptr %69, align 1
-  %70 = icmp slt i64 %28, 0
-  br i1 %70, label %_llgo_28, label %_llgo_29
+  %52 = getelementptr inbounds i8, ptr %8, i64 2
+  %53 = load i8, ptr %52, align 1
+  %54 = getelementptr inbounds i8, ptr %8, i64 1
+  store i8 %53, ptr %54, align 1
+  %55 = getelementptr inbounds i8, ptr %8, i64 2
+  store i8 46, ptr %55, align 1
+  %56 = getelementptr inbounds i8, ptr %8, i64 9
+  store i8 101, ptr %56, align 1
+  %57 = getelementptr inbounds i8, ptr %8, i64 10
+  store i8 43, ptr %57, align 1
+  %58 = icmp slt i64 %16, 0
+  br i1 %58, label %_llgo_28, label %_llgo_29
 
 _llgo_27:                                         ; preds = %_llgo_25, %_llgo_12
-  %71 = phi double [ %27, %_llgo_12 ], [ %62, %_llgo_25 ]
-  %72 = phi i64 [ 0, %_llgo_12 ], [ %63, %_llgo_25 ]
-  %73 = icmp slt i64 %72, 7
-  br i1 %73, label %_llgo_25, label %_llgo_26
+  %59 = phi double [ %15, %_llgo_12 ], [ %50, %_llgo_25 ]
+  %60 = phi i64 [ 0, %_llgo_12 ], [ %51, %_llgo_25 ]
+  %61 = icmp slt i64 %60, 7
+  br i1 %61, label %_llgo_25, label %_llgo_26
 
 _llgo_28:                                         ; preds = %_llgo_26
-  %74 = sub i64 0, %28
-  %75 = getelementptr inbounds i8, ptr %20, i64 10
-  store i8 45, ptr %75, align 1
+  %62 = sub i64 0, %16
+  %63 = getelementptr inbounds i8, ptr %8, i64 10
+  store i8 45, ptr %63, align 1
   br label %_llgo_29
 
 _llgo_29:                                         ; preds = %_llgo_28, %_llgo_26
-  %76 = phi i64 [ %28, %_llgo_26 ], [ %74, %_llgo_28 ]
-  %77 = sdiv i64 %76, 100
-  %78 = trunc i64 %77 to i8
-  %79 = add i8 %78, 48
-  %80 = getelementptr inbounds i8, ptr %20, i64 11
-  store i8 %79, ptr %80, align 1
-  %81 = sdiv i64 %76, 10
-  %82 = trunc i64 %81 to i8
-  %83 = urem i8 %82, 10
-  %84 = add i8 %83, 48
-  %85 = getelementptr inbounds i8, ptr %20, i64 12
-  store i8 %84, ptr %85, align 1
-  %86 = srem i64 %76, 10
-  %87 = trunc i64 %86 to i8
-  %88 = add i8 %87, 48
-  %89 = getelementptr inbounds i8, ptr %20, i64 13
-  store i8 %88, ptr %89, align 1
-  %90 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %91 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %90, i32 0, i32 0
-  store ptr %20, ptr %91, align 8
-  %92 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %90, i32 0, i32 1
-  store i64 14, ptr %92, align 4
-  %93 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %90, i32 0, i32 2
-  store i64 14, ptr %93, align 4
-  %94 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %90, align 8
-  call void @main.gwrite(%"github.com/goplus/llgo/internal/runtime.Slice" %94)
+  %64 = phi i64 [ %16, %_llgo_26 ], [ %62, %_llgo_28 ]
+  %65 = sdiv i64 %64, 100
+  %66 = trunc i64 %65 to i8
+  %67 = add i8 %66, 48
+  %68 = getelementptr inbounds i8, ptr %8, i64 11
+  store i8 %67, ptr %68, align 1
+  %69 = sdiv i64 %64, 10
+  %70 = trunc i64 %69 to i8
+  %71 = urem i8 %70, 10
+  %72 = add i8 %71, 48
+  %73 = getelementptr inbounds i8, ptr %8, i64 12
+  store i8 %72, ptr %73, align 1
+  %74 = srem i64 %64, 10
+  %75 = trunc i64 %74 to i8
+  %76 = add i8 %75, 48
+  %77 = getelementptr inbounds i8, ptr %8, i64 13
+  store i8 %76, ptr %77, align 1
+  %78 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %8, 0
+  %79 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %78, i64 14, 1
+  %80 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %79, i64 14, 2
+  call void @main.gwrite(%"github.com/goplus/llgo/internal/runtime.Slice" %80)
   ret void
 }
 
@@ -1366,63 +997,55 @@ _llgo_0:
   br label %_llgo_3
 
 _llgo_1:                                          ; preds = %_llgo_3
-  %2 = urem i64 %28, 16
-  %3 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3, i32 0, i32 0
-  store ptr @11, ptr %4, align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3, i32 0, i32 1
-  store i64 16, ptr %5, align 4
-  %6 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3, align 8
-  %7 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %6, 0
-  %8 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %6, 1
-  %9 = icmp sge i64 %2, %8
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %9)
-  %10 = getelementptr inbounds i8, ptr %7, i64 %2
-  %11 = load i8, ptr %10, align 1
-  %12 = icmp slt i64 %29, 0
-  %13 = icmp sge i64 %29, 100
-  %14 = or i1 %13, %12
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %14)
-  %15 = getelementptr inbounds i8, ptr %1, i64 %29
-  store i8 %11, ptr %15, align 1
-  %16 = icmp ult i64 %28, 16
-  br i1 %16, label %_llgo_5, label %_llgo_4
+  %2 = urem i64 %22, 16
+  %3 = icmp sge i64 %2, 16
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %3)
+  %4 = getelementptr inbounds i8, ptr @11, i64 %2
+  %5 = load i8, ptr %4, align 1
+  %6 = icmp slt i64 %23, 0
+  %7 = icmp sge i64 %23, 100
+  %8 = or i1 %7, %6
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %8)
+  %9 = getelementptr inbounds i8, ptr %1, i64 %23
+  store i8 %5, ptr %9, align 1
+  %10 = icmp ult i64 %22, 16
+  br i1 %10, label %_llgo_5, label %_llgo_4
 
 _llgo_2:                                          ; preds = %_llgo_5, %_llgo_3
-  %17 = sub i64 %29, 1
-  %18 = icmp slt i64 %17, 0
-  %19 = icmp sge i64 %17, 100
-  %20 = or i1 %19, %18
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %20)
-  %21 = getelementptr inbounds i8, ptr %1, i64 %17
-  store i8 120, ptr %21, align 1
-  %22 = sub i64 %17, 1
-  %23 = icmp slt i64 %22, 0
-  %24 = icmp sge i64 %22, 100
-  %25 = or i1 %24, %23
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %25)
-  %26 = getelementptr inbounds i8, ptr %1, i64 %22
-  store i8 48, ptr %26, align 1
-  %27 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %1, i64 1, i64 100, i64 %22, i64 100, i64 100)
-  call void @main.gwrite(%"github.com/goplus/llgo/internal/runtime.Slice" %27)
+  %11 = sub i64 %23, 1
+  %12 = icmp slt i64 %11, 0
+  %13 = icmp sge i64 %11, 100
+  %14 = or i1 %13, %12
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %14)
+  %15 = getelementptr inbounds i8, ptr %1, i64 %11
+  store i8 120, ptr %15, align 1
+  %16 = sub i64 %11, 1
+  %17 = icmp slt i64 %16, 0
+  %18 = icmp sge i64 %16, 100
+  %19 = or i1 %18, %17
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %19)
+  %20 = getelementptr inbounds i8, ptr %1, i64 %16
+  store i8 48, ptr %20, align 1
+  %21 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %1, i64 1, i64 100, i64 %16, i64 100, i64 100)
+  call void @main.gwrite(%"github.com/goplus/llgo/internal/runtime.Slice" %21)
   ret void
 
 _llgo_3:                                          ; preds = %_llgo_4, %_llgo_0
-  %28 = phi i64 [ %0, %_llgo_0 ], [ %31, %_llgo_4 ]
-  %29 = phi i64 [ 99, %_llgo_0 ], [ %32, %_llgo_4 ]
-  %30 = icmp sgt i64 %29, 0
-  br i1 %30, label %_llgo_1, label %_llgo_2
+  %22 = phi i64 [ %0, %_llgo_0 ], [ %25, %_llgo_4 ]
+  %23 = phi i64 [ 99, %_llgo_0 ], [ %26, %_llgo_4 ]
+  %24 = icmp sgt i64 %23, 0
+  br i1 %24, label %_llgo_1, label %_llgo_2
 
 _llgo_4:                                          ; preds = %_llgo_5, %_llgo_1
-  %31 = udiv i64 %28, 16
-  %32 = sub i64 %29, 1
+  %25 = udiv i64 %22, 16
+  %26 = sub i64 %23, 1
   br label %_llgo_3
 
 _llgo_5:                                          ; preds = %_llgo_1
-  %33 = sub i64 100, %29
-  %34 = load i64, ptr @main.minhexdigits, align 4
-  %35 = icmp sge i64 %33, %34
-  br i1 %35, label %_llgo_2, label %_llgo_4
+  %27 = sub i64 100, %23
+  %28 = load i64, ptr @main.minhexdigits, align 4
+  %29 = icmp sge i64 %27, %28
+  br i1 %29, label %_llgo_2, label %_llgo_4
 }
 
 define void @main.printint(i64 %0) {
@@ -1431,19 +1054,13 @@ _llgo_0:
   br i1 %1, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %2 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 0
-  store ptr @12, ptr %3, align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 1
-  store i64 1, ptr %4, align 4
-  %5 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
-  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" %5)
-  %6 = sub i64 0, %0
+  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" { ptr @12, i64 1 })
+  %2 = sub i64 0, %0
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-  %7 = phi i64 [ %0, %_llgo_0 ], [ %6, %_llgo_1 ]
-  call void @main.printuint(i64 %7)
+  %3 = phi i64 [ %0, %_llgo_0 ], [ %2, %_llgo_1 ]
+  call void @main.printuint(i64 %3)
   ret void
 }
 
@@ -1475,13 +1092,7 @@ _llgo_3:                                          ; preds = %_llgo_1
   ret void
 
 _llgo_4:                                          ; preds = %_llgo_2
-  %13 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %13, i32 0, i32 0
-  store ptr @13, ptr %14, align 8
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %13, i32 0, i32 1
-  store i64 1, ptr %15, align 4
-  %16 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %13, align 8
-  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" %16)
+  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" { ptr @13, i64 1 })
   br label %_llgo_5
 
 _llgo_5:                                          ; preds = %_llgo_4, %_llgo_2
@@ -1491,25 +1102,13 @@ _llgo_5:                                          ; preds = %_llgo_4, %_llgo_2
 
 define void @main.printnl() {
 _llgo_0:
-  %0 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 0
-  store ptr @14, ptr %1, align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 1
-  store i64 1, ptr %2, align 4
-  %3 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %0, align 8
-  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" %3)
+  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" { ptr @14, i64 1 })
   ret void
 }
 
 define void @main.printsp() {
 _llgo_0:
-  %0 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 0
-  store ptr @13, ptr %1, align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 1
-  store i64 1, ptr %2, align 4
-  %3 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %0, align 8
-  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" %3)
+  call void @main.printstring(%"github.com/goplus/llgo/internal/runtime.String" { ptr @13, i64 1 })
   ret void
 }
 

--- a/cl/_testdata/utf8/out.ll
+++ b/cl/_testdata/utf8/out.ll
@@ -52,41 +52,27 @@ _llgo_0:
   br label %_llgo_3
 
 _llgo_1:                                          ; preds = %_llgo_3
-  %2 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 0
-  store ptr @0, ptr %3, align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 1
-  store i64 7, ptr %4, align 4
-  %5 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
-  %6 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %5, 1
-  %7 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringSlice"(%"github.com/goplus/llgo/internal/runtime.String" %5, i64 %15, i64 %6)
-  %8 = call { i32, i64 } @"unicode/utf8.DecodeRuneInString"(%"github.com/goplus/llgo/internal/runtime.String" %7)
-  %9 = extractvalue { i32, i64 } %8, 0
-  %10 = extractvalue { i32, i64 } %8, 1
-  %11 = add i64 %15, %10
-  %12 = sext i32 %9 to i64
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %12)
+  %2 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringSlice"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 7 }, i64 %10, i64 7)
+  %3 = call { i32, i64 } @"unicode/utf8.DecodeRuneInString"(%"github.com/goplus/llgo/internal/runtime.String" %2)
+  %4 = extractvalue { i32, i64 } %3, 0
+  %5 = extractvalue { i32, i64 } %3, 1
+  %6 = add i64 %10, %5
+  %7 = sext i32 %4 to i64
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %7)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_3
 
 _llgo_2:                                          ; preds = %_llgo_3
-  %13 = call i8 @main.index(i8 2)
-  %14 = icmp eq i8 %13, 3
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %14)
+  %8 = call i8 @main.index(i8 2)
+  %9 = icmp eq i8 %8, 3
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %9)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 
 _llgo_3:                                          ; preds = %_llgo_1, %_llgo_0
-  %15 = phi i64 [ 0, %_llgo_0 ], [ %11, %_llgo_1 ]
-  %16 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %16, i32 0, i32 0
-  store ptr @0, ptr %17, align 8
-  %18 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %16, i32 0, i32 1
-  store i64 7, ptr %18, align 4
-  %19 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %16, align 8
-  %20 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %19, 1
-  %21 = icmp slt i64 %15, %20
-  br i1 %21, label %_llgo_1, label %_llgo_2
+  %10 = phi i64 [ 0, %_llgo_0 ], [ %6, %_llgo_1 ]
+  %11 = icmp slt i64 %10, 7
+  br i1 %11, label %_llgo_1, label %_llgo_2
 }
 
 declare void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1)

--- a/cl/_testdata/vargs/out.ll
+++ b/cl/_testdata/vargs/out.ll
@@ -36,40 +36,23 @@ _llgo_0:
   %2 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 48)
   %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %2, i64 0
   %4 = load ptr, ptr @_llgo_int, align 8
-  %5 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %5, i32 0, i32 0
-  store ptr %4, ptr %6, align 8
-  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %5, i32 0, i32 1
-  store ptr inttoptr (i64 1 to ptr), ptr %7, align 8
-  %8 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %5, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %8, ptr %3, align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %2, i64 1
-  %10 = load ptr, ptr @_llgo_int, align 8
-  %11 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %11, i32 0, i32 0
-  store ptr %10, ptr %12, align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %11, i32 0, i32 1
-  store ptr inttoptr (i64 2 to ptr), ptr %13, align 8
-  %14 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %11, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %14, ptr %9, align 8
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %2, i64 2
-  %16 = load ptr, ptr @_llgo_int, align 8
-  %17 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %18 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %17, i32 0, i32 0
-  store ptr %16, ptr %18, align 8
-  %19 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %17, i32 0, i32 1
-  store ptr inttoptr (i64 3 to ptr), ptr %19, align 8
-  %20 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %17, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %20, ptr %15, align 8
-  %21 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, i32 0, i32 0
-  store ptr %2, ptr %22, align 8
-  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, i32 0, i32 1
-  store i64 3, ptr %23, align 4
-  %24 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, i32 0, i32 2
-  store i64 3, ptr %24, align 4
-  %25 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, align 8
-  call void @main.test(%"github.com/goplus/llgo/internal/runtime.Slice" %25)
+  %5 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %4, 0
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %5, ptr inttoptr (i64 1 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %6, ptr %3, align 8
+  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %2, i64 1
+  %8 = load ptr, ptr @_llgo_int, align 8
+  %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %8, 0
+  %10 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %9, ptr inttoptr (i64 2 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %10, ptr %7, align 8
+  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %2, i64 2
+  %12 = load ptr, ptr @_llgo_int, align 8
+  %13 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %12, 0
+  %14 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %13, ptr inttoptr (i64 3 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %14, ptr %11, align 8
+  %15 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %2, 0
+  %16 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %15, i64 3, 1
+  %17 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %16, i64 3, 2
+  call void @main.test(%"github.com/goplus/llgo/internal/runtime.Slice" %17)
   ret i32 0
 }
 
@@ -108,22 +91,12 @@ _llgo_4:                                          ; preds = %_llgo_2
   br label %_llgo_1
 
 _llgo_5:                                          ; preds = %_llgo_2
-  %18 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %19 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %18, i32 0, i32 0
-  store ptr @1, ptr %19, align 8
-  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %18, i32 0, i32 1
-  store i64 21, ptr %20, align 4
-  %21 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %18, align 8
-  %22 = load ptr, ptr @_llgo_string, align 8
-  %23 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %21, ptr %23, align 8
-  %24 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %24, i32 0, i32 0
-  store ptr %22, ptr %25, align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %24, i32 0, i32 1
-  store ptr %23, ptr %26, align 8
-  %27 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %24, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %27)
+  %18 = load ptr, ptr @_llgo_string, align 8
+  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 21 }, ptr %19, align 8
+  %20 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %18, 0
+  %21 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %20, ptr %19, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %21)
   unreachable
 }
 

--- a/cl/_testgo/allocinloop/in.go
+++ b/cl/_testgo/allocinloop/in.go
@@ -1,0 +1,17 @@
+package main
+
+func Foo(s string) int {
+	return len(s)
+}
+
+func Test() {
+	j := 0
+	for i := 0; i < 10000000; i++ {
+		j += Foo("hello")
+	}
+	println(j)
+}
+
+func main() {
+	Test()
+}

--- a/cl/_testgo/allocinloop/out.ll
+++ b/cl/_testgo/allocinloop/out.ll
@@ -1,0 +1,66 @@
+; ModuleID = 'main'
+source_filename = "main"
+
+%"github.com/goplus/llgo/internal/runtime.String" = type { ptr, i64 }
+
+@"main.init$guard" = global i1 false, align 1
+@0 = private unnamed_addr constant [5 x i8] c"hello", align 1
+@__llgo_argc = global i32 0, align 4
+@__llgo_argv = global ptr null, align 8
+
+define i64 @main.Foo(%"github.com/goplus/llgo/internal/runtime.String" %0) {
+_llgo_0:
+  %1 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %0, 1
+  ret i64 %1
+}
+
+define void @main.Test() {
+_llgo_0:
+  br label %_llgo_3
+
+_llgo_1:                                          ; preds = %_llgo_3
+  %0 = call i64 @main.Foo(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 })
+  %1 = add i64 %3, %0
+  %2 = add i64 %4, 1
+  br label %_llgo_3
+
+_llgo_2:                                          ; preds = %_llgo_3
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %3)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
+  ret void
+
+_llgo_3:                                          ; preds = %_llgo_1, %_llgo_0
+  %3 = phi i64 [ 0, %_llgo_0 ], [ %1, %_llgo_1 ]
+  %4 = phi i64 [ 0, %_llgo_0 ], [ %2, %_llgo_1 ]
+  %5 = icmp slt i64 %4, 10000000
+  br i1 %5, label %_llgo_1, label %_llgo_2
+}
+
+define void @main.init() {
+_llgo_0:
+  %0 = load i1, ptr @"main.init$guard", align 1
+  br i1 %0, label %_llgo_2, label %_llgo_1
+
+_llgo_1:                                          ; preds = %_llgo_0
+  store i1 true, ptr @"main.init$guard", align 1
+  br label %_llgo_2
+
+_llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+  ret void
+}
+
+define i32 @main(i32 %0, ptr %1) {
+_llgo_0:
+  store i32 %0, ptr @__llgo_argc, align 4
+  store ptr %1, ptr @__llgo_argv, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.init"()
+  call void @main.init()
+  call void @main.Test()
+  ret i32 0
+}
+
+declare void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64)
+
+declare void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8)
+
+declare void @"github.com/goplus/llgo/internal/runtime.init"()

--- a/cl/_testgo/closure/out.ll
+++ b/cl/_testgo/closure/out.ll
@@ -31,49 +31,24 @@ _llgo_0:
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
   %2 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 16)
-  %3 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3, i32 0, i32 0
-  store ptr @0, ptr %4, align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3, i32 0, i32 1
-  store i64 3, ptr %5, align 4
-  %6 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %6, ptr %2, align 8
-  %7 = alloca %main.T, align 8
-  %8 = getelementptr inbounds %main.T, ptr %7, i32 0, i32 0
-  store ptr @"__llgo_stub.main.main$1", ptr %8, align 8
-  %9 = getelementptr inbounds %main.T, ptr %7, i32 0, i32 1
-  store ptr null, ptr %9, align 8
-  %10 = load %main.T, ptr %7, align 8
-  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %12 = getelementptr inbounds { ptr }, ptr %11, i32 0, i32 0
-  store ptr %2, ptr %12, align 8
-  %13 = alloca { ptr, ptr }, align 8
-  %14 = getelementptr inbounds { ptr, ptr }, ptr %13, i32 0, i32 0
-  store ptr @"main.main$2", ptr %14, align 8
-  %15 = getelementptr inbounds { ptr, ptr }, ptr %13, i32 0, i32 1
-  store ptr %11, ptr %15, align 8
-  %16 = load { ptr, ptr }, ptr %13, align 8
-  %17 = alloca %main.T, align 8
-  store { ptr, ptr } %16, ptr %17, align 8
-  %18 = load %main.T, ptr %17, align 8
-  %19 = extractvalue %main.T %10, 1
-  %20 = extractvalue %main.T %10, 0
-  call void %20(ptr %19, i64 100)
-  %21 = extractvalue %main.T %18, 1
-  %22 = extractvalue %main.T %18, 0
-  call void %22(ptr %21, i64 200)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 3 }, ptr %2, align 8
+  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %4 = getelementptr inbounds { ptr }, ptr %3, i32 0, i32 0
+  store ptr %2, ptr %4, align 8
+  %5 = insertvalue { ptr, ptr } { ptr @"main.main$2", ptr undef }, ptr %3, 1
+  %6 = alloca %main.T, align 8
+  store { ptr, ptr } %5, ptr %6, align 8
+  %7 = load %main.T, ptr %6, align 8
+  call void @"__llgo_stub.main.main$1"(ptr null, i64 100)
+  %8 = extractvalue %main.T %7, 1
+  %9 = extractvalue %main.T %7, 0
+  call void %9(ptr %8, i64 200)
   ret i32 0
 }
 
 define void @"main.main$1"(i64 %0) {
 _llgo_0:
-  %1 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1, i32 0, i32 0
-  store ptr @1, ptr %2, align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1, i32 0, i32 1
-  store i64 4, ptr %3, align 4
-  %4 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %4)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %0)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
@@ -85,13 +60,7 @@ _llgo_0:
   %2 = load { ptr }, ptr %0, align 8
   %3 = extractvalue { ptr } %2, 0
   %4 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3, align 8
-  %5 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %5, i32 0, i32 0
-  store ptr @2, ptr %6, align 8
-  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %5, i32 0, i32 1
-  store i64 7, ptr %7, align 4
-  %8 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %5, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %8)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 7 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %1)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)

--- a/cl/_testgo/equal/out.ll
+++ b/cl/_testgo/equal/out.ll
@@ -41,22 +41,12 @@ _llgo_0:
   br i1 %0, label %_llgo_2, label %_llgo_1
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %1 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1, i32 0, i32 0
-  store ptr @0, ptr %2, align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1, i32 0, i32 1
-  store i64 6, ptr %3, align 4
-  %4 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1, align 8
-  %5 = load ptr, ptr @_llgo_string, align 8
-  %6 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %4, ptr %6, align 8
-  %7 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, i32 0, i32 0
-  store ptr %5, ptr %8, align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, i32 0, i32 1
-  store ptr %6, ptr %9, align 8
-  %10 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %10)
+  %1 = load ptr, ptr @_llgo_string, align 8
+  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 6 }, ptr %2, align 8
+  %3 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %1, 0
+  %4 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %3, ptr %2, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %4)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_0
@@ -90,24 +80,19 @@ _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
   %2 = getelementptr inbounds { ptr }, ptr %1, i32 0, i32 0
   store ptr %0, ptr %2, align 8
-  %3 = alloca { ptr, ptr }, align 8
-  %4 = getelementptr inbounds { ptr, ptr }, ptr %3, i32 0, i32 0
-  store ptr @"main.init#1$2", ptr %4, align 8
-  %5 = getelementptr inbounds { ptr, ptr }, ptr %3, i32 0, i32 1
-  store ptr %1, ptr %5, align 8
-  %6 = load { ptr, ptr }, ptr %3, align 8
+  %3 = insertvalue { ptr, ptr } { ptr @"main.init#1$2", ptr undef }, ptr %1, 1
   call void @main.assert(i1 true)
   call void @main.assert(i1 true)
   call void @main.assert(i1 true)
   call void @main.assert(i1 true)
   call void @main.assert(i1 true)
   call void @main.assert(i1 true)
-  %7 = extractvalue { ptr, ptr } %6, 0
-  %8 = icmp ne ptr %7, null
-  call void @main.assert(i1 %8)
-  %9 = extractvalue { ptr, ptr } %6, 0
-  %10 = icmp ne ptr null, %9
-  call void @main.assert(i1 %10)
+  %4 = extractvalue { ptr, ptr } %3, 0
+  %5 = icmp ne ptr %4, null
+  call void @main.assert(i1 %5)
+  %6 = extractvalue { ptr, ptr } %3, 0
+  %7 = icmp ne ptr null, %6
+  call void @main.assert(i1 %7)
   call void @main.assert(i1 true)
   call void @main.assert(i1 true)
   ret void
@@ -194,140 +179,104 @@ _llgo_0:
   %4 = getelementptr inbounds %main.T, ptr %0, i32 0, i32 3
   store i64 10, ptr %1, align 4
   store i64 20, ptr %2, align 4
-  %5 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %5, i32 0, i32 0
-  store ptr @1, ptr %6, align 8
-  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %5, i32 0, i32 1
-  store i64 5, ptr %7, align 4
-  %8 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %5, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %8, ptr %3, align 8
-  %9 = load ptr, ptr @_llgo_int, align 8
-  %10 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 0
-  store ptr %9, ptr %11, align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 1
-  store ptr inttoptr (i64 1 to ptr), ptr %12, align 8
-  %13 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %13, ptr %4, align 8
-  %14 = alloca %main.T, align 8
-  call void @llvm.memset(ptr %14, i8 0, i64 48, i1 false)
-  %15 = getelementptr inbounds %main.T, ptr %14, i32 0, i32 0
-  %16 = getelementptr inbounds %main.T, ptr %14, i32 0, i32 1
-  %17 = getelementptr inbounds %main.T, ptr %14, i32 0, i32 2
-  %18 = getelementptr inbounds %main.T, ptr %14, i32 0, i32 3
-  store i64 10, ptr %15, align 4
-  store i64 20, ptr %16, align 4
-  %19 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %19, i32 0, i32 0
-  store ptr @1, ptr %20, align 8
-  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %19, i32 0, i32 1
-  store i64 5, ptr %21, align 4
-  %22 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %19, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %22, ptr %17, align 8
-  %23 = load ptr, ptr @_llgo_int, align 8
-  %24 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %24, i32 0, i32 0
-  store ptr %23, ptr %25, align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %24, i32 0, i32 1
-  store ptr inttoptr (i64 1 to ptr), ptr %26, align 8
-  %27 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %24, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %27, ptr %18, align 8
-  %28 = alloca %main.T, align 8
-  call void @llvm.memset(ptr %28, i8 0, i64 48, i1 false)
-  %29 = getelementptr inbounds %main.T, ptr %28, i32 0, i32 0
-  %30 = getelementptr inbounds %main.T, ptr %28, i32 0, i32 1
-  %31 = getelementptr inbounds %main.T, ptr %28, i32 0, i32 2
-  %32 = getelementptr inbounds %main.T, ptr %28, i32 0, i32 3
-  store i64 10, ptr %29, align 4
-  store i64 20, ptr %30, align 4
-  %33 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %33, i32 0, i32 0
-  store ptr @1, ptr %34, align 8
-  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %33, i32 0, i32 1
-  store i64 5, ptr %35, align 4
-  %36 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %33, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %36, ptr %31, align 8
-  %37 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %37, i32 0, i32 0
-  store ptr @2, ptr %38, align 8
-  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %37, i32 0, i32 1
-  store i64 2, ptr %39, align 4
-  %40 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %37, align 8
-  %41 = load ptr, ptr @_llgo_string, align 8
-  %42 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %40, ptr %42, align 8
-  %43 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %43, i32 0, i32 0
-  store ptr %41, ptr %44, align 8
-  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %43, i32 0, i32 1
-  store ptr %42, ptr %45, align 8
-  %46 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %43, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %46, ptr %32, align 8
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 5 }, ptr %3, align 8
+  %5 = load ptr, ptr @_llgo_int, align 8
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %5, 0
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %6, ptr inttoptr (i64 1 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %7, ptr %4, align 8
+  %8 = alloca %main.T, align 8
+  call void @llvm.memset(ptr %8, i8 0, i64 48, i1 false)
+  %9 = getelementptr inbounds %main.T, ptr %8, i32 0, i32 0
+  %10 = getelementptr inbounds %main.T, ptr %8, i32 0, i32 1
+  %11 = getelementptr inbounds %main.T, ptr %8, i32 0, i32 2
+  %12 = getelementptr inbounds %main.T, ptr %8, i32 0, i32 3
+  store i64 10, ptr %9, align 4
+  store i64 20, ptr %10, align 4
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 5 }, ptr %11, align 8
+  %13 = load ptr, ptr @_llgo_int, align 8
+  %14 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %13, 0
+  %15 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %14, ptr inttoptr (i64 1 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %15, ptr %12, align 8
+  %16 = alloca %main.T, align 8
+  call void @llvm.memset(ptr %16, i8 0, i64 48, i1 false)
+  %17 = getelementptr inbounds %main.T, ptr %16, i32 0, i32 0
+  %18 = getelementptr inbounds %main.T, ptr %16, i32 0, i32 1
+  %19 = getelementptr inbounds %main.T, ptr %16, i32 0, i32 2
+  %20 = getelementptr inbounds %main.T, ptr %16, i32 0, i32 3
+  store i64 10, ptr %17, align 4
+  store i64 20, ptr %18, align 4
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 5 }, ptr %19, align 8
+  %21 = load ptr, ptr @_llgo_string, align 8
+  %22 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 2 }, ptr %22, align 8
+  %23 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %21, 0
+  %24 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %23, ptr %22, 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %24, ptr %20, align 8
   call void @main.assert(i1 true)
-  %47 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer)
-  %48 = and i1 true, %47
-  %49 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.eface" zeroinitializer)
-  %50 = and i1 %48, %49
-  call void @main.assert(i1 %50)
-  %51 = load %main.T, ptr %0, align 8
-  %52 = load %main.T, ptr %14, align 8
-  %53 = extractvalue %main.T %51, 0
-  %54 = extractvalue %main.T %52, 0
+  %25 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer)
+  %26 = and i1 true, %25
+  %27 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.eface" zeroinitializer)
+  %28 = and i1 %26, %27
+  call void @main.assert(i1 %28)
+  %29 = load %main.T, ptr %0, align 8
+  %30 = load %main.T, ptr %8, align 8
+  %31 = extractvalue %main.T %29, 0
+  %32 = extractvalue %main.T %30, 0
+  %33 = icmp eq i64 %31, %32
+  %34 = and i1 true, %33
+  %35 = extractvalue %main.T %29, 1
+  %36 = extractvalue %main.T %30, 1
+  %37 = icmp eq i64 %35, %36
+  %38 = and i1 %34, %37
+  %39 = extractvalue %main.T %29, 2
+  %40 = extractvalue %main.T %30, 2
+  %41 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %39, %"github.com/goplus/llgo/internal/runtime.String" %40)
+  %42 = and i1 %38, %41
+  %43 = extractvalue %main.T %29, 3
+  %44 = extractvalue %main.T %30, 3
+  %45 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %43, %"github.com/goplus/llgo/internal/runtime.eface" %44)
+  %46 = and i1 %42, %45
+  call void @main.assert(i1 %46)
+  %47 = load %main.T, ptr %0, align 8
+  %48 = load %main.T, ptr %16, align 8
+  %49 = extractvalue %main.T %47, 0
+  %50 = extractvalue %main.T %48, 0
+  %51 = icmp eq i64 %49, %50
+  %52 = and i1 true, %51
+  %53 = extractvalue %main.T %47, 1
+  %54 = extractvalue %main.T %48, 1
   %55 = icmp eq i64 %53, %54
-  %56 = and i1 true, %55
-  %57 = extractvalue %main.T %51, 1
-  %58 = extractvalue %main.T %52, 1
-  %59 = icmp eq i64 %57, %58
+  %56 = and i1 %52, %55
+  %57 = extractvalue %main.T %47, 2
+  %58 = extractvalue %main.T %48, 2
+  %59 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %57, %"github.com/goplus/llgo/internal/runtime.String" %58)
   %60 = and i1 %56, %59
-  %61 = extractvalue %main.T %51, 2
-  %62 = extractvalue %main.T %52, 2
-  %63 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %61, %"github.com/goplus/llgo/internal/runtime.String" %62)
+  %61 = extractvalue %main.T %47, 3
+  %62 = extractvalue %main.T %48, 3
+  %63 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %61, %"github.com/goplus/llgo/internal/runtime.eface" %62)
   %64 = and i1 %60, %63
-  %65 = extractvalue %main.T %51, 3
-  %66 = extractvalue %main.T %52, 3
-  %67 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %65, %"github.com/goplus/llgo/internal/runtime.eface" %66)
-  %68 = and i1 %64, %67
-  call void @main.assert(i1 %68)
-  %69 = load %main.T, ptr %0, align 8
-  %70 = load %main.T, ptr %28, align 8
-  %71 = extractvalue %main.T %69, 0
-  %72 = extractvalue %main.T %70, 0
-  %73 = icmp eq i64 %71, %72
-  %74 = and i1 true, %73
-  %75 = extractvalue %main.T %69, 1
-  %76 = extractvalue %main.T %70, 1
-  %77 = icmp eq i64 %75, %76
-  %78 = and i1 %74, %77
-  %79 = extractvalue %main.T %69, 2
-  %80 = extractvalue %main.T %70, 2
-  %81 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %79, %"github.com/goplus/llgo/internal/runtime.String" %80)
-  %82 = and i1 %78, %81
-  %83 = extractvalue %main.T %69, 3
-  %84 = extractvalue %main.T %70, 3
-  %85 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %83, %"github.com/goplus/llgo/internal/runtime.eface" %84)
-  %86 = and i1 %82, %85
-  %87 = xor i1 %86, true
-  call void @main.assert(i1 %87)
-  %88 = load %main.T, ptr %14, align 8
-  %89 = load %main.T, ptr %28, align 8
-  %90 = extractvalue %main.T %88, 0
-  %91 = extractvalue %main.T %89, 0
-  %92 = icmp eq i64 %90, %91
-  %93 = and i1 true, %92
-  %94 = extractvalue %main.T %88, 1
-  %95 = extractvalue %main.T %89, 1
-  %96 = icmp eq i64 %94, %95
-  %97 = and i1 %93, %96
-  %98 = extractvalue %main.T %88, 2
-  %99 = extractvalue %main.T %89, 2
-  %100 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %98, %"github.com/goplus/llgo/internal/runtime.String" %99)
-  %101 = and i1 %97, %100
-  %102 = extractvalue %main.T %88, 3
-  %103 = extractvalue %main.T %89, 3
-  %104 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %102, %"github.com/goplus/llgo/internal/runtime.eface" %103)
-  %105 = and i1 %101, %104
-  %106 = xor i1 %105, true
-  call void @main.assert(i1 %106)
+  %65 = xor i1 %64, true
+  call void @main.assert(i1 %65)
+  %66 = load %main.T, ptr %8, align 8
+  %67 = load %main.T, ptr %16, align 8
+  %68 = extractvalue %main.T %66, 0
+  %69 = extractvalue %main.T %67, 0
+  %70 = icmp eq i64 %68, %69
+  %71 = and i1 true, %70
+  %72 = extractvalue %main.T %66, 1
+  %73 = extractvalue %main.T %67, 1
+  %74 = icmp eq i64 %72, %73
+  %75 = and i1 %71, %74
+  %76 = extractvalue %main.T %66, 2
+  %77 = extractvalue %main.T %67, 2
+  %78 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %76, %"github.com/goplus/llgo/internal/runtime.String" %77)
+  %79 = and i1 %75, %78
+  %80 = extractvalue %main.T %66, 3
+  %81 = extractvalue %main.T %67, 3
+  %82 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %80, %"github.com/goplus/llgo/internal/runtime.eface" %81)
+  %83 = and i1 %79, %82
+  %84 = xor i1 %83, true
+  call void @main.assert(i1 %84)
   ret void
 }
 
@@ -340,28 +289,23 @@ _llgo_0:
   store i64 2, ptr %2, align 4
   %3 = getelementptr inbounds i64, ptr %0, i64 2
   store i64 3, ptr %3, align 4
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %4, i32 0, i32 0
-  store ptr %0, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %4, i32 0, i32 1
-  store i64 3, ptr %6, align 4
-  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %4, i32 0, i32 2
-  store i64 3, ptr %7, align 4
-  %8 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %4, align 8
+  %4 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %0, 0
+  %5 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %4, i64 3, 1
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %5, i64 3, 2
+  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 16)
+  %8 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %7, i64 8, i64 2, i64 0, i64 2, i64 2)
   %9 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 16)
-  %10 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %9, i64 8, i64 2, i64 0, i64 2, i64 2)
-  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 16)
-  %12 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %11, i64 8, i64 2, i64 0, i64 0, i64 2)
+  %10 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %9, i64 8, i64 2, i64 0, i64 0, i64 2)
   call void @main.assert(i1 true)
+  %11 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %6, 0
+  %12 = icmp ne ptr %11, null
+  call void @main.assert(i1 %12)
   %13 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %8, 0
   %14 = icmp ne ptr %13, null
   call void @main.assert(i1 %14)
   %15 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %10, 0
   %16 = icmp ne ptr %15, null
   call void @main.assert(i1 %16)
-  %17 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %12, 0
-  %18 = icmp ne ptr %17, null
-  call void @main.assert(i1 %18)
   call void @main.assert(i1 true)
   ret void
 }
@@ -369,165 +313,97 @@ _llgo_0:
 define void @"main.init#5"() {
 _llgo_0:
   %0 = load ptr, ptr @_llgo_int, align 8
-  %1 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %1, i32 0, i32 0
-  store ptr %0, ptr %2, align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %1, i32 0, i32 1
-  store ptr inttoptr (i64 100 to ptr), ptr %3, align 8
-  %4 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %1, align 8
-  %5 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
-  %6 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  store {} zeroinitializer, ptr %6, align 1
-  %7 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, i32 0, i32 0
-  store ptr %5, ptr %8, align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, i32 0, i32 1
-  store ptr %6, ptr %9, align 8
-  %10 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, align 8
-  %11 = alloca %main.T, align 8
-  call void @llvm.memset(ptr %11, i8 0, i64 48, i1 false)
-  %12 = getelementptr inbounds %main.T, ptr %11, i32 0, i32 0
-  %13 = getelementptr inbounds %main.T, ptr %11, i32 0, i32 1
-  %14 = getelementptr inbounds %main.T, ptr %11, i32 0, i32 2
-  %15 = getelementptr inbounds %main.T, ptr %11, i32 0, i32 3
-  store i64 10, ptr %12, align 4
-  store i64 20, ptr %13, align 4
-  %16 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %16, i32 0, i32 0
-  store ptr @1, ptr %17, align 8
-  %18 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %16, i32 0, i32 1
-  store i64 5, ptr %18, align 4
-  %19 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %16, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %19, ptr %14, align 8
-  %20 = load ptr, ptr @_llgo_int, align 8
-  %21 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %21, i32 0, i32 0
-  store ptr %20, ptr %22, align 8
-  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %21, i32 0, i32 1
-  store ptr inttoptr (i64 1 to ptr), ptr %23, align 8
-  %24 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %21, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %24, ptr %15, align 8
-  %25 = load %main.T, ptr %11, align 8
-  %26 = load ptr, ptr @_llgo_main.T, align 8
-  %27 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  store %main.T %25, ptr %27, align 8
-  %28 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %29 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %28, i32 0, i32 0
-  store ptr %26, ptr %29, align 8
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %28, i32 0, i32 1
-  store ptr %27, ptr %30, align 8
-  %31 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %28, align 8
-  %32 = alloca %main.T, align 8
-  call void @llvm.memset(ptr %32, i8 0, i64 48, i1 false)
-  %33 = getelementptr inbounds %main.T, ptr %32, i32 0, i32 0
-  %34 = getelementptr inbounds %main.T, ptr %32, i32 0, i32 1
-  %35 = getelementptr inbounds %main.T, ptr %32, i32 0, i32 2
-  %36 = getelementptr inbounds %main.T, ptr %32, i32 0, i32 3
-  store i64 10, ptr %33, align 4
-  store i64 20, ptr %34, align 4
-  %37 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %37, i32 0, i32 0
-  store ptr @1, ptr %38, align 8
-  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %37, i32 0, i32 1
-  store i64 5, ptr %39, align 4
-  %40 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %37, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %40, ptr %35, align 8
-  %41 = load ptr, ptr @_llgo_int, align 8
-  %42 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %42, i32 0, i32 0
-  store ptr %41, ptr %43, align 8
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %42, i32 0, i32 1
-  store ptr inttoptr (i64 1 to ptr), ptr %44, align 8
-  %45 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %42, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %45, ptr %36, align 8
-  %46 = alloca %main.T, align 8
-  call void @llvm.memset(ptr %46, i8 0, i64 48, i1 false)
-  %47 = getelementptr inbounds %main.T, ptr %46, i32 0, i32 0
-  %48 = getelementptr inbounds %main.T, ptr %46, i32 0, i32 1
-  %49 = getelementptr inbounds %main.T, ptr %46, i32 0, i32 2
-  %50 = getelementptr inbounds %main.T, ptr %46, i32 0, i32 3
-  store i64 10, ptr %47, align 4
-  store i64 20, ptr %48, align 4
-  %51 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %52 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %51, i32 0, i32 0
-  store ptr @1, ptr %52, align 8
-  %53 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %51, i32 0, i32 1
-  store i64 5, ptr %53, align 4
-  %54 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %51, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %54, ptr %49, align 8
-  %55 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 0
-  store ptr @2, ptr %56, align 8
-  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 1
-  store i64 2, ptr %57, align 4
-  %58 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %55, align 8
-  %59 = load ptr, ptr @_llgo_string, align 8
-  %60 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %58, ptr %60, align 8
-  %61 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %62 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %61, i32 0, i32 0
-  store ptr %59, ptr %62, align 8
-  %63 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %61, i32 0, i32 1
-  store ptr %60, ptr %63, align 8
-  %64 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %61, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %64, ptr %50, align 8
-  %65 = load ptr, ptr @_llgo_int, align 8
-  %66 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %67 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %66, i32 0, i32 0
-  store ptr %65, ptr %67, align 8
-  %68 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %66, i32 0, i32 1
-  store ptr inttoptr (i64 100 to ptr), ptr %68, align 8
-  %69 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %66, align 8
-  %70 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %4, %"github.com/goplus/llgo/internal/runtime.eface" %69)
-  call void @main.assert(i1 %70)
-  %71 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
-  %72 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  store {} zeroinitializer, ptr %72, align 1
-  %73 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %74 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %73, i32 0, i32 0
-  store ptr %71, ptr %74, align 8
-  %75 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %73, i32 0, i32 1
-  store ptr %72, ptr %75, align 8
-  %76 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %73, align 8
-  %77 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %10, %"github.com/goplus/llgo/internal/runtime.eface" %76)
-  call void @main.assert(i1 %77)
-  %78 = load ptr, ptr @_llgo_main.N, align 8
-  %79 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  store %main.N zeroinitializer, ptr %79, align 1
-  %80 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %81 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %80, i32 0, i32 0
-  store ptr %78, ptr %81, align 8
-  %82 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %80, i32 0, i32 1
-  store ptr %79, ptr %82, align 8
-  %83 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %80, align 8
-  %84 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %10, %"github.com/goplus/llgo/internal/runtime.eface" %83)
-  %85 = xor i1 %84, true
-  call void @main.assert(i1 %85)
-  %86 = load %main.T, ptr %32, align 8
-  %87 = load ptr, ptr @_llgo_main.T, align 8
-  %88 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  store %main.T %86, ptr %88, align 8
-  %89 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %90 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %89, i32 0, i32 0
-  store ptr %87, ptr %90, align 8
-  %91 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %89, i32 0, i32 1
-  store ptr %88, ptr %91, align 8
-  %92 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %89, align 8
-  %93 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %31, %"github.com/goplus/llgo/internal/runtime.eface" %92)
-  call void @main.assert(i1 %93)
-  %94 = load %main.T, ptr %46, align 8
-  %95 = load ptr, ptr @_llgo_main.T, align 8
-  %96 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  store %main.T %94, ptr %96, align 8
-  %97 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %98 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %97, i32 0, i32 0
-  store ptr %95, ptr %98, align 8
-  %99 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %97, i32 0, i32 1
-  store ptr %96, ptr %99, align 8
-  %100 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %97, align 8
-  %101 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %31, %"github.com/goplus/llgo/internal/runtime.eface" %100)
-  %102 = xor i1 %101, true
-  call void @main.assert(i1 %102)
+  %1 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %0, 0
+  %2 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %1, ptr inttoptr (i64 100 to ptr), 1
+  %3 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
+  %4 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  store {} zeroinitializer, ptr %4, align 1
+  %5 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %3, 0
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %5, ptr %4, 1
+  %7 = alloca %main.T, align 8
+  call void @llvm.memset(ptr %7, i8 0, i64 48, i1 false)
+  %8 = getelementptr inbounds %main.T, ptr %7, i32 0, i32 0
+  %9 = getelementptr inbounds %main.T, ptr %7, i32 0, i32 1
+  %10 = getelementptr inbounds %main.T, ptr %7, i32 0, i32 2
+  %11 = getelementptr inbounds %main.T, ptr %7, i32 0, i32 3
+  store i64 10, ptr %8, align 4
+  store i64 20, ptr %9, align 4
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 5 }, ptr %10, align 8
+  %12 = load ptr, ptr @_llgo_int, align 8
+  %13 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %12, 0
+  %14 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %13, ptr inttoptr (i64 1 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %14, ptr %11, align 8
+  %15 = load %main.T, ptr %7, align 8
+  %16 = load ptr, ptr @_llgo_main.T, align 8
+  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  store %main.T %15, ptr %17, align 8
+  %18 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %16, 0
+  %19 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %18, ptr %17, 1
+  %20 = alloca %main.T, align 8
+  call void @llvm.memset(ptr %20, i8 0, i64 48, i1 false)
+  %21 = getelementptr inbounds %main.T, ptr %20, i32 0, i32 0
+  %22 = getelementptr inbounds %main.T, ptr %20, i32 0, i32 1
+  %23 = getelementptr inbounds %main.T, ptr %20, i32 0, i32 2
+  %24 = getelementptr inbounds %main.T, ptr %20, i32 0, i32 3
+  store i64 10, ptr %21, align 4
+  store i64 20, ptr %22, align 4
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 5 }, ptr %23, align 8
+  %25 = load ptr, ptr @_llgo_int, align 8
+  %26 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %25, 0
+  %27 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %26, ptr inttoptr (i64 1 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %27, ptr %24, align 8
+  %28 = alloca %main.T, align 8
+  call void @llvm.memset(ptr %28, i8 0, i64 48, i1 false)
+  %29 = getelementptr inbounds %main.T, ptr %28, i32 0, i32 0
+  %30 = getelementptr inbounds %main.T, ptr %28, i32 0, i32 1
+  %31 = getelementptr inbounds %main.T, ptr %28, i32 0, i32 2
+  %32 = getelementptr inbounds %main.T, ptr %28, i32 0, i32 3
+  store i64 10, ptr %29, align 4
+  store i64 20, ptr %30, align 4
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 5 }, ptr %31, align 8
+  %33 = load ptr, ptr @_llgo_string, align 8
+  %34 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 2 }, ptr %34, align 8
+  %35 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %33, 0
+  %36 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %35, ptr %34, 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %36, ptr %32, align 8
+  %37 = load ptr, ptr @_llgo_int, align 8
+  %38 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %37, 0
+  %39 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %38, ptr inttoptr (i64 100 to ptr), 1
+  %40 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %2, %"github.com/goplus/llgo/internal/runtime.eface" %39)
+  call void @main.assert(i1 %40)
+  %41 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
+  %42 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  store {} zeroinitializer, ptr %42, align 1
+  %43 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %41, 0
+  %44 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %43, ptr %42, 1
+  %45 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %6, %"github.com/goplus/llgo/internal/runtime.eface" %44)
+  call void @main.assert(i1 %45)
+  %46 = load ptr, ptr @_llgo_main.N, align 8
+  %47 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  store %main.N zeroinitializer, ptr %47, align 1
+  %48 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %46, 0
+  %49 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %48, ptr %47, 1
+  %50 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %6, %"github.com/goplus/llgo/internal/runtime.eface" %49)
+  %51 = xor i1 %50, true
+  call void @main.assert(i1 %51)
+  %52 = load %main.T, ptr %20, align 8
+  %53 = load ptr, ptr @_llgo_main.T, align 8
+  %54 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  store %main.T %52, ptr %54, align 8
+  %55 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %53, 0
+  %56 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %55, ptr %54, 1
+  %57 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %19, %"github.com/goplus/llgo/internal/runtime.eface" %56)
+  call void @main.assert(i1 %57)
+  %58 = load %main.T, ptr %28, align 8
+  %59 = load ptr, ptr @_llgo_main.T, align 8
+  %60 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  store %main.T %58, ptr %60, align 8
+  %61 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %59, 0
+  %62 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %61, ptr %60, 1
+  %63 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %19, %"github.com/goplus/llgo/internal/runtime.eface" %62)
+  %64 = xor i1 %63, true
+  call void @main.assert(i1 %64)
   ret void
 }
 
@@ -595,333 +471,134 @@ _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
   br i1 %7, label %_llgo_5, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_4
-  %8 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %8, i32 0, i32 0
-  store ptr @3, ptr %9, align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %8, i32 0, i32 1
-  store i64 4, ptr %10, align 4
-  %11 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %8, align 8
-  %12 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %13 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %13, i32 0, i32 0
-  store ptr %12, ptr %14, align 8
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %13, i32 0, i32 1
-  store i64 0, ptr %15, align 4
-  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %13, i32 0, i32 2
-  store i64 0, ptr %16, align 4
-  %17 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %13, align 8
-  %18 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %11, i64 0, %"github.com/goplus/llgo/internal/runtime.Slice" %17)
-  store ptr %18, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
+  %8 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %8, 0
+  %10 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, i64 0, 1
+  %11 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %10, i64 0, 2
+  %12 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, i64 0, %"github.com/goplus/llgo/internal/runtime.Slice" %11)
+  store ptr %12, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %19 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %19, i32 0, i32 0
-  store ptr @4, ptr %20, align 8
-  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %19, i32 0, i32 1
-  store i64 6, ptr %21, align 4
-  %22 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %19, align 8
-  %23 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %22, i64 25, i64 48, i64 0, i64 0)
-  %24 = load ptr, ptr @_llgo_main.T, align 8
-  %25 = icmp eq ptr %24, null
-  br i1 %25, label %_llgo_7, label %_llgo_8
+  %13 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 6 }, i64 25, i64 48, i64 0, i64 0)
+  %14 = load ptr, ptr @_llgo_main.T, align 8
+  %15 = icmp eq ptr %14, null
+  br i1 %15, label %_llgo_7, label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_6
-  store ptr %23, ptr @_llgo_main.T, align 8
+  store ptr %13, ptr @_llgo_main.T, align 8
   br label %_llgo_8
 
 _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
-  %26 = load ptr, ptr @_llgo_any, align 8
-  %27 = icmp eq ptr %26, null
-  br i1 %27, label %_llgo_9, label %_llgo_10
+  %16 = load ptr, ptr @_llgo_any, align 8
+  %17 = icmp eq ptr %16, null
+  br i1 %17, label %_llgo_9, label %_llgo_10
 
 _llgo_9:                                          ; preds = %_llgo_8
-  %28 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %29 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %29, i32 0, i32 0
-  store ptr %28, ptr %30, align 8
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %29, i32 0, i32 1
-  store i64 0, ptr %31, align 4
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %29, i32 0, i32 2
-  store i64 0, ptr %32, align 4
-  %33 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %29, align 8
-  %34 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %34, i32 0, i32 0
-  store ptr @3, ptr %35, align 8
-  %36 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %34, i32 0, i32 1
-  store i64 4, ptr %36, align 4
-  %37 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %34, align 8
-  %38 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %38, i32 0, i32 0
-  store ptr null, ptr %39, align 8
-  %40 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %38, i32 0, i32 1
-  store i64 0, ptr %40, align 4
-  %41 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %38, align 8
-  %42 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %37, %"github.com/goplus/llgo/internal/runtime.String" %41, %"github.com/goplus/llgo/internal/runtime.Slice" %33)
-  store ptr %42, ptr @_llgo_any, align 8
+  %18 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %19 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %18, 0
+  %20 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %19, i64 0, 1
+  %21 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %20, i64 0, 2
+  %22 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %21)
+  store ptr %22, ptr @_llgo_any, align 8
   br label %_llgo_10
 
 _llgo_10:                                         ; preds = %_llgo_9, %_llgo_8
-  %43 = load ptr, ptr @_llgo_any, align 8
-  %44 = load ptr, ptr @"_llgo_struct$5D_KhR3tDEp-wpx9caTiVZca43wS-XW6slE9Bsr8rsk", align 8
-  %45 = icmp eq ptr %44, null
-  br i1 %45, label %_llgo_11, label %_llgo_12
+  %23 = load ptr, ptr @_llgo_any, align 8
+  %24 = load ptr, ptr @"_llgo_struct$5D_KhR3tDEp-wpx9caTiVZca43wS-XW6slE9Bsr8rsk", align 8
+  %25 = icmp eq ptr %24, null
+  br i1 %25, label %_llgo_11, label %_llgo_12
 
 _llgo_11:                                         ; preds = %_llgo_10
-  %46 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %47 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %46, i32 0, i32 0
-  store ptr @5, ptr %47, align 8
-  %48 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %46, i32 0, i32 1
-  store i64 1, ptr %48, align 4
-  %49 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %46, align 8
-  %50 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %50, i32 0, i32 0
-  store ptr null, ptr %51, align 8
-  %52 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %50, i32 0, i32 1
-  store i64 0, ptr %52, align 4
-  %53 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %50, align 8
-  %54 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %55 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %49, ptr %54, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %53, i1 false)
-  %56 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %56, i32 0, i32 0
-  store ptr @6, ptr %57, align 8
-  %58 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %56, i32 0, i32 1
-  store i64 1, ptr %58, align 4
-  %59 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %56, align 8
-  %60 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %61 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %60, i32 0, i32 0
-  store ptr null, ptr %61, align 8
-  %62 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %60, i32 0, i32 1
-  store i64 0, ptr %62, align 4
-  %63 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %60, align 8
-  %64 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %65 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %59, ptr %64, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %63, i1 false)
-  %66 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %67 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %66, i32 0, i32 0
-  store ptr @7, ptr %67, align 8
-  %68 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %66, i32 0, i32 1
-  store i64 1, ptr %68, align 4
-  %69 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %66, align 8
-  %70 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %71 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %70, i32 0, i32 0
-  store ptr null, ptr %71, align 8
-  %72 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %70, i32 0, i32 1
-  store i64 0, ptr %72, align 4
-  %73 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %70, align 8
-  %74 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %75 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %69, ptr %74, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %73, i1 false)
-  %76 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %77 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %76, i32 0, i32 0
-  store ptr @8, ptr %77, align 8
-  %78 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %76, i32 0, i32 1
-  store i64 1, ptr %78, align 4
-  %79 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %76, align 8
-  %80 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %81 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %80, i32 0, i32 0
-  store ptr null, ptr %81, align 8
-  %82 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %80, i32 0, i32 1
-  store i64 0, ptr %82, align 4
-  %83 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %80, align 8
-  %84 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %85 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %86 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %85, i32 0, i32 0
-  store ptr %84, ptr %86, align 8
-  %87 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %85, i32 0, i32 1
-  store i64 0, ptr %87, align 4
-  %88 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %85, i32 0, i32 2
-  store i64 0, ptr %88, align 4
-  %89 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %85, align 8
-  %90 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %91 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %90, i32 0, i32 0
-  store ptr @3, ptr %91, align 8
-  %92 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %90, i32 0, i32 1
-  store i64 4, ptr %92, align 4
-  %93 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %90, align 8
-  %94 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %95 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %94, i32 0, i32 0
-  store ptr null, ptr %95, align 8
-  %96 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %94, i32 0, i32 1
-  store i64 0, ptr %96, align 4
-  %97 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %94, align 8
-  %98 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %93, %"github.com/goplus/llgo/internal/runtime.String" %97, %"github.com/goplus/llgo/internal/runtime.Slice" %89)
-  %99 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %79, ptr %98, i64 32, %"github.com/goplus/llgo/internal/runtime.String" %83, i1 false)
-  %100 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %101 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %100, i32 0, i32 0
-  store ptr @3, ptr %101, align 8
-  %102 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %100, i32 0, i32 1
-  store i64 4, ptr %102, align 4
-  %103 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %100, align 8
-  %104 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
-  %105 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %104, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %55, ptr %105, align 8
-  %106 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %104, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %65, ptr %106, align 8
-  %107 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %104, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %75, ptr %107, align 8
-  %108 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %104, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %99, ptr %108, align 8
-  %109 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %110 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %109, i32 0, i32 0
-  store ptr %104, ptr %110, align 8
-  %111 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %109, i32 0, i32 1
-  store i64 4, ptr %111, align 4
-  %112 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %109, i32 0, i32 2
-  store i64 4, ptr %112, align 4
-  %113 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %109, align 8
-  %114 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %103, i64 48, %"github.com/goplus/llgo/internal/runtime.Slice" %113)
-  store ptr %114, ptr @"_llgo_struct$5D_KhR3tDEp-wpx9caTiVZca43wS-XW6slE9Bsr8rsk", align 8
+  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %27 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 1 }, ptr %26, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %28 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %29 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 1 }, ptr %28, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %31 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 1 }, ptr %30, i64 16, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %32 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %33 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %32, 0
+  %34 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %33, i64 0, 1
+  %35 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %34, i64 0, 2
+  %36 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %35)
+  %37 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 1 }, ptr %36, i64 32, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %38 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
+  %39 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %38, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %27, ptr %39, align 8
+  %40 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %38, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %29, ptr %40, align 8
+  %41 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %38, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %31, ptr %41, align 8
+  %42 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %38, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %37, ptr %42, align 8
+  %43 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %38, 0
+  %44 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %43, i64 4, 1
+  %45 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %44, i64 4, 2
+  %46 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, i64 48, %"github.com/goplus/llgo/internal/runtime.Slice" %45)
+  store ptr %46, ptr @"_llgo_struct$5D_KhR3tDEp-wpx9caTiVZca43wS-XW6slE9Bsr8rsk", align 8
   br label %_llgo_12
 
 _llgo_12:                                         ; preds = %_llgo_11, %_llgo_10
-  %115 = load ptr, ptr @"_llgo_struct$5D_KhR3tDEp-wpx9caTiVZca43wS-XW6slE9Bsr8rsk", align 8
-  br i1 %25, label %_llgo_13, label %_llgo_14
+  %47 = load ptr, ptr @"_llgo_struct$5D_KhR3tDEp-wpx9caTiVZca43wS-XW6slE9Bsr8rsk", align 8
+  br i1 %15, label %_llgo_13, label %_llgo_14
 
 _llgo_13:                                         ; preds = %_llgo_12
-  %116 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %117 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %116, i32 0, i32 0
-  store ptr @3, ptr %117, align 8
-  %118 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %116, i32 0, i32 1
-  store i64 4, ptr %118, align 4
-  %119 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %116, align 8
-  %120 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %121 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %120, i32 0, i32 0
-  store ptr @9, ptr %121, align 8
-  %122 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %120, i32 0, i32 1
-  store i64 1, ptr %122, align 4
-  %123 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %120, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %23, %"github.com/goplus/llgo/internal/runtime.String" %119, %"github.com/goplus/llgo/internal/runtime.String" %123, ptr %115, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %13, %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 1 }, ptr %47, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
   br label %_llgo_14
 
 _llgo_14:                                         ; preds = %_llgo_13, %_llgo_12
-  %124 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %125 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %124, i32 0, i32 0
-  store ptr @10, ptr %125, align 8
-  %126 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %124, i32 0, i32 1
-  store i64 6, ptr %126, align 4
-  %127 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %124, align 8
-  %128 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %127, i64 25, i64 0, i64 0, i64 0)
-  %129 = load ptr, ptr @_llgo_main.N, align 8
-  %130 = icmp eq ptr %129, null
-  br i1 %130, label %_llgo_15, label %_llgo_16
+  %48 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 6 }, i64 25, i64 0, i64 0, i64 0)
+  %49 = load ptr, ptr @_llgo_main.N, align 8
+  %50 = icmp eq ptr %49, null
+  br i1 %50, label %_llgo_15, label %_llgo_16
 
 _llgo_15:                                         ; preds = %_llgo_14
-  store ptr %128, ptr @_llgo_main.N, align 8
+  store ptr %48, ptr @_llgo_main.N, align 8
   br label %_llgo_16
 
 _llgo_16:                                         ; preds = %_llgo_15, %_llgo_14
-  %131 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
-  br i1 %130, label %_llgo_17, label %_llgo_18
+  %51 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
+  br i1 %50, label %_llgo_17, label %_llgo_18
 
 _llgo_17:                                         ; preds = %_llgo_16
-  %132 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %133 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %132, i32 0, i32 0
-  store ptr @3, ptr %133, align 8
-  %134 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %132, i32 0, i32 1
-  store i64 4, ptr %134, align 4
-  %135 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %132, align 8
-  %136 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %137 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %136, i32 0, i32 0
-  store ptr @11, ptr %137, align 8
-  %138 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %136, i32 0, i32 1
-  store i64 1, ptr %138, align 4
-  %139 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %136, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %128, %"github.com/goplus/llgo/internal/runtime.String" %135, %"github.com/goplus/llgo/internal/runtime.String" %139, ptr %131, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %48, %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 1 }, ptr %51, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
   br label %_llgo_18
 
 _llgo_18:                                         ; preds = %_llgo_17, %_llgo_16
-  %140 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
-  %141 = icmp eq ptr %140, null
-  br i1 %141, label %_llgo_19, label %_llgo_20
+  %52 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
+  %53 = icmp eq ptr %52, null
+  br i1 %53, label %_llgo_19, label %_llgo_20
 
 _llgo_19:                                         ; preds = %_llgo_18
-  %142 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %143 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %144 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %145 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %144, i32 0, i32 0
-  store ptr @12, ptr %145, align 8
-  %146 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %144, i32 0, i32 1
-  store i64 7, ptr %146, align 4
-  %147 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %144, align 8
-  %148 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %149 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %148, i32 0, i32 0
-  store ptr null, ptr %149, align 8
-  %150 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %148, i32 0, i32 1
-  store i64 0, ptr %150, align 4
-  %151 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %148, align 8
-  %152 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %153 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %152)
-  %154 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %147, ptr %153, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %151, i1 false)
-  %155 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %156 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %155, i32 0, i32 0
-  store ptr @13, ptr %156, align 8
-  %157 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %155, i32 0, i32 1
-  store i64 4, ptr %157, align 4
-  %158 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %155, align 8
-  %159 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %160 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %159, i32 0, i32 0
-  store ptr null, ptr %160, align 8
-  %161 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %159, i32 0, i32 1
-  store i64 0, ptr %161, align 4
-  %162 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %159, align 8
-  %163 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %164 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %163)
-  %165 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %158, ptr %164, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %162, i1 false)
-  %166 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %167 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %166, i32 0, i32 0
-  store ptr @14, ptr %167, align 8
-  %168 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %166, i32 0, i32 1
-  store i64 5, ptr %168, align 4
-  %169 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %166, align 8
-  %170 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %171 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %170, i32 0, i32 0
-  store ptr null, ptr %171, align 8
-  %172 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %170, i32 0, i32 1
-  store i64 0, ptr %172, align 4
-  %173 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %170, align 8
-  %174 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %175 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %174)
-  %176 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %169, ptr %175, i64 72, %"github.com/goplus/llgo/internal/runtime.String" %173, i1 false)
-  %177 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %178 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %177, i32 0, i32 0
-  store ptr @15, ptr %178, align 8
-  %179 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %177, i32 0, i32 1
-  store i64 8, ptr %179, align 4
-  %180 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %177, align 8
-  %181 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %182 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %181, i32 0, i32 0
-  store ptr null, ptr %182, align 8
-  %183 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %181, i32 0, i32 1
-  store i64 0, ptr %183, align 4
-  %184 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %181, align 8
-  %185 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %186 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %180, ptr %185, i64 200, %"github.com/goplus/llgo/internal/runtime.String" %184, i1 false)
-  %187 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %188 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %187, i32 0, i32 0
-  store ptr @3, ptr %188, align 8
-  %189 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %187, i32 0, i32 1
-  store i64 4, ptr %189, align 4
-  %190 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %187, align 8
-  %191 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
-  %192 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %191, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %154, ptr %192, align 8
-  %193 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %191, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %165, ptr %193, align 8
-  %194 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %191, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %176, ptr %194, align 8
-  %195 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %191, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %186, ptr %195, align 8
-  %196 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %197 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %196, i32 0, i32 0
-  store ptr %191, ptr %197, align 8
-  %198 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %196, i32 0, i32 1
-  store i64 4, ptr %198, align 4
-  %199 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %196, i32 0, i32 2
-  store i64 4, ptr %199, align 4
-  %200 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %196, align 8
-  %201 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %190, i64 208, %"github.com/goplus/llgo/internal/runtime.Slice" %200)
-  %202 = call ptr @"github.com/goplus/llgo/internal/runtime.MapOf"(ptr %142, ptr %143, ptr %201, i64 4)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %202)
-  store ptr %202, ptr @"map[_llgo_int]_llgo_string", align 8
+  %54 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %55 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %56 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %57 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %56)
+  %58 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @12, i64 7 }, ptr %57, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %59 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %60 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %59)
+  %61 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @13, i64 4 }, ptr %60, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %62 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %63 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %62)
+  %64 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @14, i64 5 }, ptr %63, i64 72, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %65 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %66 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @15, i64 8 }, ptr %65, i64 200, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %67 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
+  %68 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %67, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %58, ptr %68, align 8
+  %69 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %67, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %61, ptr %69, align 8
+  %70 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %67, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %64, ptr %70, align 8
+  %71 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %67, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %66, ptr %71, align 8
+  %72 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %67, 0
+  %73 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %72, i64 4, 1
+  %74 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %73, i64 4, 2
+  %75 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, i64 208, %"github.com/goplus/llgo/internal/runtime.Slice" %74)
+  %76 = call ptr @"github.com/goplus/llgo/internal/runtime.MapOf"(ptr %54, ptr %55, ptr %75, i64 4)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %76)
+  store ptr %76, ptr @"map[_llgo_int]_llgo_string", align 8
   br label %_llgo_20
 
 _llgo_20:                                         ; preds = %_llgo_19, %_llgo_18

--- a/cl/_testgo/errors/out.ll
+++ b/cl/_testgo/errors/out.ll
@@ -35,13 +35,9 @@ _llgo_0:
   %5 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
   %6 = load ptr, ptr @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU", align 8
   %7 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %6, ptr %4)
-  %8 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %8, i32 0, i32 0
-  store ptr %7, ptr %9, align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %8, i32 0, i32 1
-  store ptr %1, ptr %10, align 8
-  %11 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %8, align 8
-  ret %"github.com/goplus/llgo/internal/runtime.iface" %11
+  %8 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %7, 0
+  %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %8, ptr %1, 1
+  ret %"github.com/goplus/llgo/internal/runtime.iface" %9
 }
 
 define %"github.com/goplus/llgo/internal/runtime.String" @"main.(*errorString).Error"(ptr %0) {
@@ -71,29 +67,19 @@ _llgo_0:
   store ptr %1, ptr @__llgo_argv, align 8
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
-  %2 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 0
-  store ptr @5, ptr %3, align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 1
-  store i64 8, ptr %4, align 4
-  %5 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
-  %6 = call %"github.com/goplus/llgo/internal/runtime.iface" @main.New(%"github.com/goplus/llgo/internal/runtime.String" %5)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintIface"(%"github.com/goplus/llgo/internal/runtime.iface" %6)
+  %2 = call %"github.com/goplus/llgo/internal/runtime.iface" @main.New(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 8 })
+  call void @"github.com/goplus/llgo/internal/runtime.PrintIface"(%"github.com/goplus/llgo/internal/runtime.iface" %2)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %6)
-  %8 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %6, 0
-  %9 = getelementptr ptr, ptr %8, i64 3
-  %10 = load ptr, ptr %9, align 8
-  %11 = alloca { ptr, ptr }, align 8
-  %12 = getelementptr inbounds { ptr, ptr }, ptr %11, i32 0, i32 0
-  store ptr %10, ptr %12, align 8
-  %13 = getelementptr inbounds { ptr, ptr }, ptr %11, i32 0, i32 1
-  store ptr %7, ptr %13, align 8
-  %14 = load { ptr, ptr }, ptr %11, align 8
-  %15 = extractvalue { ptr, ptr } %14, 1
-  %16 = extractvalue { ptr, ptr } %14, 0
-  %17 = call %"github.com/goplus/llgo/internal/runtime.String" %16(ptr %15)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %17)
+  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %2)
+  %4 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %2, 0
+  %5 = getelementptr ptr, ptr %4, i64 3
+  %6 = load ptr, ptr %5, align 8
+  %7 = insertvalue { ptr, ptr } undef, ptr %6, 0
+  %8 = insertvalue { ptr, ptr } %7, ptr %3, 1
+  %9 = extractvalue { ptr, ptr } %8, 1
+  %10 = extractvalue { ptr, ptr } %8, 0
+  %11 = call %"github.com/goplus/llgo/internal/runtime.String" %10(ptr %9)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %11)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 }
@@ -102,185 +88,82 @@ declare ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64)
 
 define void @"main.init$after"() {
 _llgo_0:
-  %0 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 0
-  store ptr @0, ptr %1, align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 1
-  store i64 16, ptr %2, align 4
-  %3 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %0, align 8
-  %4 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3, i64 25, i64 16, i64 0, i64 1)
-  store ptr %4, ptr @_llgo_main.errorString, align 8
-  %5 = load ptr, ptr @_llgo_string, align 8
-  %6 = icmp eq ptr %5, null
-  br i1 %6, label %_llgo_1, label %_llgo_2
+  %0 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 16 }, i64 25, i64 16, i64 0, i64 1)
+  store ptr %0, ptr @_llgo_main.errorString, align 8
+  %1 = load ptr, ptr @_llgo_string, align 8
+  %2 = icmp eq ptr %1, null
+  br i1 %2, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  store ptr %7, ptr @_llgo_string, align 8
+  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  store ptr %3, ptr @_llgo_string, align 8
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-  %8 = load ptr, ptr @_llgo_string, align 8
-  %9 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %9, i32 0, i32 0
-  store ptr @1, ptr %10, align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %9, i32 0, i32 1
-  store i64 1, ptr %11, align 4
-  %12 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %9, align 8
-  %13 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %13, i32 0, i32 0
-  store ptr null, ptr %14, align 8
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %13, i32 0, i32 1
-  store i64 0, ptr %15, align 4
-  %16 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %13, align 8
-  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %18 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %12, ptr %17, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %16, i1 false)
-  %19 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %19, i32 0, i32 0
-  store ptr @2, ptr %20, align 8
-  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %19, i32 0, i32 1
-  store i64 4, ptr %21, align 4
-  %22 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %19, align 8
-  %23 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
-  %24 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %23, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %18, ptr %24, align 8
-  %25 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %25, i32 0, i32 0
-  store ptr %23, ptr %26, align 8
-  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %25, i32 0, i32 1
-  store i64 1, ptr %27, align 4
-  %28 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %25, i32 0, i32 2
-  store i64 1, ptr %28, align 4
-  %29 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %25, align 8
-  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %22, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %29)
-  store ptr %30, ptr @"main.struct$QTufDJA9wEDzuzgkA-ZSrLqW-B6lWN8O25mTSglAoLQ", align 8
-  %31 = load ptr, ptr @"main.struct$QTufDJA9wEDzuzgkA-ZSrLqW-B6lWN8O25mTSglAoLQ", align 8
-  %32 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %32, i32 0, i32 0
-  store ptr @3, ptr %33, align 8
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %32, i32 0, i32 1
-  store i64 5, ptr %34, align 4
-  %35 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %32, align 8
-  %36 = load ptr, ptr @_llgo_string, align 8
-  %37 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %38 = icmp eq ptr %37, null
-  br i1 %38, label %_llgo_3, label %_llgo_4
+  %4 = load ptr, ptr @_llgo_string, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %6 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 1 }, ptr %5, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
+  %8 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %7, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %6, ptr %8, align 8
+  %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %7, 0
+  %10 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, i64 1, 1
+  %11 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %10, i64 1, 2
+  %12 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %11)
+  store ptr %12, ptr @"main.struct$QTufDJA9wEDzuzgkA-ZSrLqW-B6lWN8O25mTSglAoLQ", align 8
+  %13 = load ptr, ptr @"main.struct$QTufDJA9wEDzuzgkA-ZSrLqW-B6lWN8O25mTSglAoLQ", align 8
+  %14 = load ptr, ptr @_llgo_string, align 8
+  %15 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %16 = icmp eq ptr %15, null
+  br i1 %16, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %40 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %41 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %40, i32 0, i32 0
-  store ptr %39, ptr %41, align 8
-  %42 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %40, i32 0, i32 1
-  store i64 0, ptr %42, align 4
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %40, i32 0, i32 2
-  store i64 0, ptr %43, align 4
-  %44 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %40, align 8
-  %45 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %46 = getelementptr ptr, ptr %45, i64 0
-  store ptr %36, ptr %46, align 8
-  %47 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %48 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %47, i32 0, i32 0
-  store ptr %45, ptr %48, align 8
-  %49 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %47, i32 0, i32 1
-  store i64 1, ptr %49, align 4
-  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %47, i32 0, i32 2
-  store i64 1, ptr %50, align 4
-  %51 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %47, align 8
-  %52 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %44, %"github.com/goplus/llgo/internal/runtime.Slice" %51, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %52)
-  store ptr %52, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %18 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %17, 0
+  %19 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %18, i64 0, 1
+  %20 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %19, i64 0, 2
+  %21 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %22 = getelementptr ptr, ptr %21, i64 0
+  store ptr %14, ptr %22, align 8
+  %23 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %21, 0
+  %24 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %23, i64 1, 1
+  %25 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %24, i64 1, 2
+  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %20, %"github.com/goplus/llgo/internal/runtime.Slice" %25, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %26)
+  store ptr %26, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
   br label %_llgo_4
 
 _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
-  %53 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %54 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %54, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %35, ptr %55, align 8
-  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %54, i32 0, i32 1
-  store ptr %53, ptr %56, align 8
-  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %54, i32 0, i32 2
-  store ptr @"main.(*errorString).Error", ptr %57, align 8
-  %58 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %54, i32 0, i32 3
-  store ptr @"main.(*errorString).Error", ptr %58, align 8
-  %59 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %54, align 8
-  %60 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %61 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %60, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %59, ptr %61, align 8
-  %62 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %63 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %62, i32 0, i32 0
-  store ptr %60, ptr %63, align 8
-  %64 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %62, i32 0, i32 1
-  store i64 1, ptr %64, align 4
-  %65 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %62, i32 0, i32 2
-  store i64 1, ptr %65, align 4
-  %66 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %62, align 8
-  %67 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %68 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %67, i32 0, i32 0
-  store ptr @2, ptr %68, align 8
-  %69 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %67, i32 0, i32 1
-  store i64 4, ptr %69, align 4
-  %70 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %67, align 8
-  %71 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %72 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %71, i32 0, i32 0
-  store ptr @4, ptr %72, align 8
-  %73 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %71, i32 0, i32 1
-  store i64 11, ptr %73, align 4
-  %74 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %71, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %4, %"github.com/goplus/llgo/internal/runtime.String" %70, %"github.com/goplus/llgo/internal/runtime.String" %74, ptr %31, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %66)
-  %75 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %76 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %75, i32 0, i32 0
-  store ptr @0, ptr %76, align 8
-  %77 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %75, i32 0, i32 1
-  store i64 16, ptr %77, align 4
-  %78 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %75, align 8
-  %79 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %78, i64 25, i64 16, i64 0, i64 1)
-  %80 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %79)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %80)
-  store ptr %80, ptr @"*_llgo_main.errorString", align 8
-  %81 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %82 = load ptr, ptr @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU", align 8
-  %83 = icmp eq ptr %82, null
-  br i1 %83, label %_llgo_5, label %_llgo_6
+  %27 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %28 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 5 }, ptr undef, ptr undef, ptr undef }, ptr %27, 1
+  %29 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %28, ptr @"main.(*errorString).Error", 2
+  %30 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %29, ptr @"main.(*errorString).Error", 3
+  %31 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %32 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %31, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %30, ptr %32, align 8
+  %33 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %31, 0
+  %34 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %33, i64 1, 1
+  %35 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %34, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %0, %"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 11 }, ptr %13, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %35)
+  %36 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 16 }, i64 25, i64 16, i64 0, i64 1)
+  %37 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %36)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %37)
+  store ptr %37, ptr @"*_llgo_main.errorString", align 8
+  %38 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %39 = load ptr, ptr @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU", align 8
+  %40 = icmp eq ptr %39, null
+  br i1 %40, label %_llgo_5, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_4
-  %84 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %85 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %84, i32 0, i32 0
-  store ptr @3, ptr %85, align 8
-  %86 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %84, i32 0, i32 1
-  store i64 5, ptr %86, align 4
-  %87 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %84, align 8
-  %88 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %89 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %88, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %87, ptr %89, align 8
-  %90 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %88, i32 0, i32 1
-  store ptr %81, ptr %90, align 8
-  %91 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %88, align 8
-  %92 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %93 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %92, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %91, ptr %93, align 8
-  %94 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %95 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %94, i32 0, i32 0
-  store ptr %92, ptr %95, align 8
-  %96 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %94, i32 0, i32 1
-  store i64 1, ptr %96, align 4
-  %97 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %94, i32 0, i32 2
-  store i64 1, ptr %97, align 4
-  %98 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %94, align 8
-  %99 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %100 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %99, i32 0, i32 0
-  store ptr @2, ptr %100, align 8
-  %101 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %99, i32 0, i32 1
-  store i64 4, ptr %101, align 4
-  %102 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %99, align 8
-  %103 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %104 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %103, i32 0, i32 0
-  store ptr null, ptr %104, align 8
-  %105 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %103, i32 0, i32 1
-  store i64 0, ptr %105, align 4
-  %106 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %103, align 8
-  %107 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %102, %"github.com/goplus/llgo/internal/runtime.String" %106, %"github.com/goplus/llgo/internal/runtime.Slice" %98)
-  store ptr %107, ptr @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU", align 8
+  %41 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 5 }, ptr undef }, ptr %38, 1
+  %42 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %43 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %42, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %41, ptr %43, align 8
+  %44 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %42, 0
+  %45 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %44, i64 1, 1
+  %46 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %45, i64 1, 2
+  %47 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %46)
+  store ptr %47, ptr @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU", align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4

--- a/cl/_testgo/goroutine/out.ll
+++ b/cl/_testgo/goroutine/out.ll
@@ -34,49 +34,26 @@ _llgo_0:
   %3 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
   %4 = getelementptr inbounds { ptr }, ptr %3, i32 0, i32 0
   store ptr %2, ptr %4, align 8
-  %5 = alloca { ptr, ptr }, align 8
-  %6 = getelementptr inbounds { ptr, ptr }, ptr %5, i32 0, i32 0
-  store ptr @"main.main$1", ptr %6, align 8
-  %7 = getelementptr inbounds { ptr, ptr }, ptr %5, i32 0, i32 1
-  store ptr %3, ptr %7, align 8
-  %8 = load { ptr, ptr }, ptr %5, align 8
-  %9 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %9, i32 0, i32 0
-  store ptr @0, ptr %10, align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %9, i32 0, i32 1
-  store i64 16, ptr %11, align 4
-  %12 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %9, align 8
-  %13 = call ptr @malloc(i64 32)
-  %14 = getelementptr inbounds { { ptr, ptr }, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %13, i32 0, i32 0
-  store { ptr, ptr } %8, ptr %14, align 8
-  %15 = getelementptr inbounds { { ptr, ptr }, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %13, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.String" %12, ptr %15, align 8
-  %16 = alloca i8, i64 8, align 1
-  %17 = alloca %"github.com/goplus/llgo/c/pthread.RoutineFunc", align 8
-  %18 = getelementptr inbounds %"github.com/goplus/llgo/c/pthread.RoutineFunc", ptr %17, i32 0, i32 0
-  store ptr @"__llgo_stub.main._llgo_routine$1", ptr %18, align 8
-  %19 = getelementptr inbounds %"github.com/goplus/llgo/c/pthread.RoutineFunc", ptr %17, i32 0, i32 1
-  store ptr null, ptr %19, align 8
-  %20 = load %"github.com/goplus/llgo/c/pthread.RoutineFunc", ptr %17, align 8
-  %21 = call i32 @"github.com/goplus/llgo/internal/runtime.CreateThread"(ptr %16, ptr null, %"github.com/goplus/llgo/c/pthread.RoutineFunc" %20, ptr %13)
+  %5 = insertvalue { ptr, ptr } { ptr @"main.main$1", ptr undef }, ptr %3, 1
+  %6 = call ptr @malloc(i64 32)
+  %7 = getelementptr inbounds { { ptr, ptr }, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %6, i32 0, i32 0
+  store { ptr, ptr } %5, ptr %7, align 8
+  %8 = getelementptr inbounds { { ptr, ptr }, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %6, i32 0, i32 1
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 16 }, ptr %8, align 8
+  %9 = alloca i8, i64 8, align 1
+  %10 = call i32 @"github.com/goplus/llgo/internal/runtime.CreateThread"(ptr %9, ptr null, %"github.com/goplus/llgo/c/pthread.RoutineFunc" { ptr @"__llgo_stub.main._llgo_routine$1", ptr null }, ptr %6)
   br label %_llgo_3
 
 _llgo_1:                                          ; preds = %_llgo_3
-  %22 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %22, i32 0, i32 0
-  store ptr @1, ptr %23, align 8
-  %24 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %22, i32 0, i32 1
-  store i64 1, ptr %24, align 4
-  %25 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %22, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %25)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 1 })
   br label %_llgo_3
 
 _llgo_2:                                          ; preds = %_llgo_3
   ret i32 0
 
 _llgo_3:                                          ; preds = %_llgo_1, %_llgo_0
-  %26 = load i1, ptr %2, align 1
-  br i1 %26, label %_llgo_2, label %_llgo_1
+  %11 = load i1, ptr %2, align 1
+  br i1 %11, label %_llgo_2, label %_llgo_1
 }
 
 define void @"main.main$1"(ptr %0, %"github.com/goplus/llgo/internal/runtime.String" %1) {

--- a/cl/_testgo/ifaceconv/out.ll
+++ b/cl/_testgo/ifaceconv/out.ll
@@ -110,647 +110,365 @@ _llgo_0:
   br i1 %3, label %_llgo_23, label %_llgo_24
 
 _llgo_1:                                          ; preds = %_llgo_25
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @2, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 21, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  %8 = load ptr, ptr @_llgo_string, align 8
-  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %7, ptr %9, align 8
-  %10 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 0
-  store ptr %8, ptr %11, align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 1
-  store ptr %9, ptr %12, align 8
-  %13 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %13)
+  %4 = load ptr, ptr @_llgo_string, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 21 }, ptr %5, align 8
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %4, 0
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %6, ptr %5, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %7)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_25
-  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
-  %15 = load ptr, ptr @_llgo_main.I1, align 8
-  %16 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %15, ptr %14)
-  br i1 %16, label %_llgo_26, label %_llgo_27
+  %8 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
+  %9 = load ptr, ptr @_llgo_main.I1, align 8
+  %10 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %9, ptr %8)
+  br i1 %10, label %_llgo_26, label %_llgo_27
 
 _llgo_3:                                          ; preds = %_llgo_28
-  %17 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %18 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %17, i32 0, i32 0
-  store ptr @5, ptr %18, align 8
-  %19 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %17, i32 0, i32 1
-  store i64 21, ptr %19, align 4
-  %20 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %17, align 8
-  %21 = load ptr, ptr @_llgo_string, align 8
-  %22 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %20, ptr %22, align 8
-  %23 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %24 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %23, i32 0, i32 0
-  store ptr %21, ptr %24, align 8
-  %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %23, i32 0, i32 1
-  store ptr %22, ptr %25, align 8
-  %26 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %23, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %26)
+  %11 = load ptr, ptr @_llgo_string, align 8
+  %12 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 21 }, ptr %12, align 8
+  %13 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %11, 0
+  %14 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %13, ptr %12, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %14)
   unreachable
 
 _llgo_4:                                          ; preds = %_llgo_28
-  %27 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
-  %28 = load ptr, ptr @_llgo_main.I2, align 8
-  %29 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %28, ptr %27)
-  br i1 %29, label %_llgo_29, label %_llgo_30
+  %15 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
+  %16 = load ptr, ptr @_llgo_main.I2, align 8
+  %17 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %16, ptr %15)
+  br i1 %17, label %_llgo_29, label %_llgo_30
 
 _llgo_5:                                          ; preds = %_llgo_31
-  %30 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %30, i32 0, i32 0
-  store ptr @8, ptr %31, align 8
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %30, i32 0, i32 1
-  store i64 21, ptr %32, align 4
-  %33 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %30, align 8
-  %34 = load ptr, ptr @_llgo_string, align 8
-  %35 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %33, ptr %35, align 8
-  %36 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %36, i32 0, i32 0
-  store ptr %34, ptr %37, align 8
-  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %36, i32 0, i32 1
-  store ptr %35, ptr %38, align 8
-  %39 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %36, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %39)
+  %18 = load ptr, ptr @_llgo_string, align 8
+  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 21 }, ptr %19, align 8
+  %20 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %18, 0
+  %21 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %20, ptr %19, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %21)
   unreachable
 
 _llgo_6:                                          ; preds = %_llgo_31
-  %40 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
-  %41 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %42 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %41, i32 0, i32 0
-  store ptr %40, ptr %42, align 8
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %41, i32 0, i32 1
-  store ptr null, ptr %43, align 8
-  %44 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %41, align 8
-  %45 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
-  %46 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %47 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %46, i32 0, i32 0
-  store ptr %45, ptr %47, align 8
-  %48 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %46, i32 0, i32 1
-  store ptr null, ptr %48, align 8
-  %49 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %46, align 8
-  %50 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
-  %51 = load ptr, ptr @"main.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", align 8
-  %52 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %51, ptr %50)
-  %53 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %54 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %53, i32 0, i32 0
-  store ptr %52, ptr %54, align 8
-  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %53, i32 0, i32 1
-  store ptr null, ptr %55, align 8
-  %56 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %53, align 8
-  %57 = load ptr, ptr @_llgo_main.C1, align 8
-  %58 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  store %main.C1 zeroinitializer, ptr %58, align 1
-  %59 = load ptr, ptr @"main.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", align 8
-  %60 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %59, ptr %57)
-  %61 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %62 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %61, i32 0, i32 0
-  store ptr %60, ptr %62, align 8
-  %63 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %61, i32 0, i32 1
-  store ptr %58, ptr %63, align 8
-  %64 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %61, align 8
-  %65 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %64)
-  %66 = load ptr, ptr @_llgo_main.I0, align 8
-  %67 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %66, ptr %65)
-  br i1 %67, label %_llgo_32, label %_llgo_33
+  %22 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
+  %23 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %22, 0
+  %24 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %23, ptr null, 1
+  %25 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
+  %26 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %25, 0
+  %27 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %26, ptr null, 1
+  %28 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
+  %29 = load ptr, ptr @"main.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", align 8
+  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %29, ptr %28)
+  %31 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %30, 0
+  %32 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %31, ptr null, 1
+  %33 = load ptr, ptr @_llgo_main.C1, align 8
+  %34 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  store %main.C1 zeroinitializer, ptr %34, align 1
+  %35 = load ptr, ptr @"main.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", align 8
+  %36 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %35, ptr %33)
+  %37 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %36, 0
+  %38 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %37, ptr %34, 1
+  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %38)
+  %40 = load ptr, ptr @_llgo_main.I0, align 8
+  %41 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %40, ptr %39)
+  br i1 %41, label %_llgo_32, label %_llgo_33
 
 _llgo_7:                                          ; preds = %_llgo_34
-  %68 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %69 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %68, i32 0, i32 0
-  store ptr @12, ptr %69, align 8
-  %70 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %68, i32 0, i32 1
-  store i64 17, ptr %70, align 4
-  %71 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %68, align 8
-  %72 = load ptr, ptr @_llgo_string, align 8
-  %73 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %71, ptr %73, align 8
-  %74 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %75 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %74, i32 0, i32 0
-  store ptr %72, ptr %75, align 8
-  %76 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %74, i32 0, i32 1
-  store ptr %73, ptr %76, align 8
-  %77 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %74, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %77)
+  %42 = load ptr, ptr @_llgo_string, align 8
+  %43 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @12, i64 17 }, ptr %43, align 8
+  %44 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %42, 0
+  %45 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %44, ptr %43, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %45)
   unreachable
 
 _llgo_8:                                          ; preds = %_llgo_34
-  %78 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %64)
-  %79 = load ptr, ptr @_llgo_main.I1, align 8
-  %80 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %79, ptr %78)
-  br i1 %80, label %_llgo_35, label %_llgo_36
+  %46 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %38)
+  %47 = load ptr, ptr @_llgo_main.I1, align 8
+  %48 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %47, ptr %46)
+  br i1 %48, label %_llgo_35, label %_llgo_36
 
 _llgo_9:                                          ; preds = %_llgo_37
-  %81 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %82 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %81, i32 0, i32 0
-  store ptr @13, ptr %82, align 8
-  %83 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %81, i32 0, i32 1
-  store i64 17, ptr %83, align 4
-  %84 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %81, align 8
-  %85 = load ptr, ptr @_llgo_string, align 8
-  %86 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %84, ptr %86, align 8
-  %87 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %88 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %87, i32 0, i32 0
-  store ptr %85, ptr %88, align 8
-  %89 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %87, i32 0, i32 1
-  store ptr %86, ptr %89, align 8
-  %90 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %87, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %90)
+  %49 = load ptr, ptr @_llgo_string, align 8
+  %50 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @13, i64 17 }, ptr %50, align 8
+  %51 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %49, 0
+  %52 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %51, ptr %50, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %52)
   unreachable
 
 _llgo_10:                                         ; preds = %_llgo_37
-  %91 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %64)
-  %92 = load ptr, ptr @_llgo_main.I2, align 8
-  %93 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %92, ptr %91)
-  br i1 %93, label %_llgo_38, label %_llgo_39
+  %53 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %38)
+  %54 = load ptr, ptr @_llgo_main.I2, align 8
+  %55 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %54, ptr %53)
+  br i1 %55, label %_llgo_38, label %_llgo_39
 
 _llgo_11:                                         ; preds = %_llgo_40
-  %94 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %95 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %94, i32 0, i32 0
-  store ptr @14, ptr %95, align 8
-  %96 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %94, i32 0, i32 1
-  store i64 20, ptr %96, align 4
-  %97 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %94, align 8
-  %98 = load ptr, ptr @_llgo_string, align 8
-  %99 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %97, ptr %99, align 8
-  %100 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %101 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %100, i32 0, i32 0
-  store ptr %98, ptr %101, align 8
-  %102 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %100, i32 0, i32 1
-  store ptr %99, ptr %102, align 8
-  %103 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %100, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %103)
+  %56 = load ptr, ptr @_llgo_string, align 8
+  %57 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @14, i64 20 }, ptr %57, align 8
+  %58 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %56, 0
+  %59 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %58, ptr %57, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %59)
   unreachable
 
 _llgo_12:                                         ; preds = %_llgo_40
-  %104 = load ptr, ptr @_llgo_main.C2, align 8
-  %105 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  store %main.C2 zeroinitializer, ptr %105, align 1
-  %106 = load ptr, ptr @"main.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", align 8
-  %107 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %106, ptr %104)
-  %108 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %109 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %108, i32 0, i32 0
-  store ptr %107, ptr %109, align 8
-  %110 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %108, i32 0, i32 1
-  store ptr %105, ptr %110, align 8
-  %111 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %108, align 8
-  %112 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %111)
-  %113 = load ptr, ptr @_llgo_main.I0, align 8
-  %114 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %113, ptr %112)
-  br i1 %114, label %_llgo_41, label %_llgo_42
+  %60 = load ptr, ptr @_llgo_main.C2, align 8
+  %61 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  store %main.C2 zeroinitializer, ptr %61, align 1
+  %62 = load ptr, ptr @"main.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", align 8
+  %63 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %62, ptr %60)
+  %64 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %63, 0
+  %65 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %64, ptr %61, 1
+  %66 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %65)
+  %67 = load ptr, ptr @_llgo_main.I0, align 8
+  %68 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %67, ptr %66)
+  br i1 %68, label %_llgo_41, label %_llgo_42
 
 _llgo_13:                                         ; preds = %_llgo_43
-  %115 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %116 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %115, i32 0, i32 0
-  store ptr @18, ptr %116, align 8
-  %117 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %115, i32 0, i32 1
-  store i64 17, ptr %117, align 4
-  %118 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %115, align 8
-  %119 = load ptr, ptr @_llgo_string, align 8
-  %120 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %118, ptr %120, align 8
-  %121 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %122 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %121, i32 0, i32 0
-  store ptr %119, ptr %122, align 8
-  %123 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %121, i32 0, i32 1
-  store ptr %120, ptr %123, align 8
-  %124 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %121, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %124)
+  %69 = load ptr, ptr @_llgo_string, align 8
+  %70 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @18, i64 17 }, ptr %70, align 8
+  %71 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %69, 0
+  %72 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %71, ptr %70, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %72)
   unreachable
 
 _llgo_14:                                         ; preds = %_llgo_43
-  %125 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %111)
-  %126 = load ptr, ptr @_llgo_main.I1, align 8
-  %127 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %126, ptr %125)
-  br i1 %127, label %_llgo_44, label %_llgo_45
+  %73 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %65)
+  %74 = load ptr, ptr @_llgo_main.I1, align 8
+  %75 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %74, ptr %73)
+  br i1 %75, label %_llgo_44, label %_llgo_45
 
 _llgo_15:                                         ; preds = %_llgo_46
-  %128 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %129 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %128, i32 0, i32 0
-  store ptr @19, ptr %129, align 8
-  %130 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %128, i32 0, i32 1
-  store i64 17, ptr %130, align 4
-  %131 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %128, align 8
-  %132 = load ptr, ptr @_llgo_string, align 8
-  %133 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %131, ptr %133, align 8
-  %134 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %135 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %134, i32 0, i32 0
-  store ptr %132, ptr %135, align 8
-  %136 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %134, i32 0, i32 1
-  store ptr %133, ptr %136, align 8
-  %137 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %134, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %137)
+  %76 = load ptr, ptr @_llgo_string, align 8
+  %77 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @19, i64 17 }, ptr %77, align 8
+  %78 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %76, 0
+  %79 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %78, ptr %77, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %79)
   unreachable
 
 _llgo_16:                                         ; preds = %_llgo_46
-  %138 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %111)
-  %139 = load ptr, ptr @_llgo_main.I2, align 8
-  %140 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %139, ptr %138)
-  br i1 %140, label %_llgo_47, label %_llgo_48
+  %80 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %65)
+  %81 = load ptr, ptr @_llgo_main.I2, align 8
+  %82 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %81, ptr %80)
+  br i1 %82, label %_llgo_47, label %_llgo_48
 
 _llgo_17:                                         ; preds = %_llgo_49
-  %141 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %142 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %141, i32 0, i32 0
-  store ptr @20, ptr %142, align 8
-  %143 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %141, i32 0, i32 1
-  store i64 17, ptr %143, align 4
-  %144 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %141, align 8
-  %145 = load ptr, ptr @_llgo_string, align 8
-  %146 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %144, ptr %146, align 8
-  %147 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %148 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %147, i32 0, i32 0
-  store ptr %145, ptr %148, align 8
-  %149 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %147, i32 0, i32 1
-  store ptr %146, ptr %149, align 8
-  %150 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %147, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %150)
+  %83 = load ptr, ptr @_llgo_string, align 8
+  %84 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @20, i64 17 }, ptr %84, align 8
+  %85 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %83, 0
+  %86 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %85, ptr %84, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %86)
   unreachable
 
 _llgo_18:                                         ; preds = %_llgo_49
-  %151 = load ptr, ptr @_llgo_main.C1, align 8
-  %152 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  store %main.C1 zeroinitializer, ptr %152, align 1
-  %153 = load ptr, ptr @"main.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", align 8
-  %154 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %153, ptr %151)
-  %155 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %156 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %155, i32 0, i32 0
-  store ptr %154, ptr %156, align 8
-  %157 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %155, i32 0, i32 1
-  store ptr %152, ptr %157, align 8
-  %158 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %155, align 8
-  %159 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %158)
-  %160 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %158, 1
-  %161 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %162 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %161, i32 0, i32 0
-  store ptr %159, ptr %162, align 8
-  %163 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %161, i32 0, i32 1
-  store ptr %160, ptr %163, align 8
-  %164 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %161, align 8
-  %165 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %164, %"github.com/goplus/llgo/internal/runtime.eface" zeroinitializer)
-  br i1 %165, label %_llgo_19, label %_llgo_20
+  %87 = load ptr, ptr @_llgo_main.C1, align 8
+  %88 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  store %main.C1 zeroinitializer, ptr %88, align 1
+  %89 = load ptr, ptr @"main.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", align 8
+  %90 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %89, ptr %87)
+  %91 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %90, 0
+  %92 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %91, ptr %88, 1
+  %93 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %92)
+  %94 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %92, 1
+  %95 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %93, 0
+  %96 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %95, ptr %94, 1
+  %97 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %96, %"github.com/goplus/llgo/internal/runtime.eface" zeroinitializer)
+  br i1 %97, label %_llgo_19, label %_llgo_20
 
 _llgo_19:                                         ; preds = %_llgo_18
-  %166 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %167 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %166, i32 0, i32 0
-  store ptr @21, ptr %167, align 8
-  %168 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %166, i32 0, i32 1
-  store i64 17, ptr %168, align 4
-  %169 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %166, align 8
-  %170 = load ptr, ptr @_llgo_string, align 8
-  %171 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %169, ptr %171, align 8
-  %172 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %173 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %172, i32 0, i32 0
-  store ptr %170, ptr %173, align 8
-  %174 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %172, i32 0, i32 1
-  store ptr %171, ptr %174, align 8
-  %175 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %172, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %175)
+  %98 = load ptr, ptr @_llgo_string, align 8
+  %99 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @21, i64 17 }, ptr %99, align 8
+  %100 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %98, 0
+  %101 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %100, ptr %99, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %101)
   unreachable
 
 _llgo_20:                                         ; preds = %_llgo_18
-  %176 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %158)
-  %177 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %158, 1
-  %178 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %179 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %178, i32 0, i32 0
-  store ptr %176, ptr %179, align 8
-  %180 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %178, i32 0, i32 1
-  store ptr %177, ptr %180, align 8
-  %181 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %178, align 8
-  %182 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
-  %183 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %184 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %183, i32 0, i32 0
-  store ptr %182, ptr %184, align 8
-  %185 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %183, i32 0, i32 1
-  store ptr null, ptr %185, align 8
-  %186 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %183, align 8
-  %187 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %181, %"github.com/goplus/llgo/internal/runtime.eface" %186)
-  br i1 %187, label %_llgo_21, label %_llgo_22
+  %102 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %92)
+  %103 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %92, 1
+  %104 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %102, 0
+  %105 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %104, ptr %103, 1
+  %106 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
+  %107 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %106, 0
+  %108 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %107, ptr null, 1
+  %109 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %105, %"github.com/goplus/llgo/internal/runtime.eface" %108)
+  br i1 %109, label %_llgo_21, label %_llgo_22
 
 _llgo_21:                                         ; preds = %_llgo_20
-  %188 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %189 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %188, i32 0, i32 0
-  store ptr @22, ptr %189, align 8
-  %190 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %188, i32 0, i32 1
-  store i64 17, ptr %190, align 4
-  %191 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %188, align 8
-  %192 = load ptr, ptr @_llgo_string, align 8
-  %193 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %191, ptr %193, align 8
-  %194 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %195 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %194, i32 0, i32 0
-  store ptr %192, ptr %195, align 8
-  %196 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %194, i32 0, i32 1
-  store ptr %193, ptr %196, align 8
-  %197 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %194, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %197)
+  %110 = load ptr, ptr @_llgo_string, align 8
+  %111 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @22, i64 17 }, ptr %111, align 8
+  %112 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %110, 0
+  %113 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %112, ptr %111, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %113)
   unreachable
 
 _llgo_22:                                         ; preds = %_llgo_20
-  %198 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %199 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %198, i32 0, i32 0
-  store ptr @23, ptr %199, align 8
-  %200 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %198, i32 0, i32 1
-  store i64 4, ptr %200, align 4
-  %201 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %198, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %201)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @23, i64 4 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 
 _llgo_23:                                         ; preds = %_llgo_0
-  %202 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %203 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %202, i32 0, i32 0
-  store ptr null, ptr %203, align 8
-  %204 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %202, i32 0, i32 1
-  store ptr null, ptr %204, align 8
-  %205 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %202, align 8
-  %206 = alloca { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, align 8
-  %207 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, ptr %206, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.eface" %205, ptr %207, align 8
-  %208 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, ptr %206, i32 0, i32 1
-  store i1 true, ptr %208, align 1
-  %209 = load { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, ptr %206, align 8
   br label %_llgo_25
 
 _llgo_24:                                         ; preds = %_llgo_0
-  %210 = alloca { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, align 8
-  %211 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, ptr %210, i32 0, i32 0
-  store { ptr, ptr } zeroinitializer, ptr %211, align 8
-  %212 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, ptr %210, i32 0, i32 1
-  store i1 false, ptr %212, align 1
-  %213 = load { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, ptr %210, align 8
   br label %_llgo_25
 
 _llgo_25:                                         ; preds = %_llgo_24, %_llgo_23
-  %214 = phi { %"github.com/goplus/llgo/internal/runtime.eface", i1 } [ %209, %_llgo_23 ], [ %213, %_llgo_24 ]
-  %215 = extractvalue { %"github.com/goplus/llgo/internal/runtime.eface", i1 } %214, 0
-  %216 = extractvalue { %"github.com/goplus/llgo/internal/runtime.eface", i1 } %214, 1
-  br i1 %216, label %_llgo_1, label %_llgo_2
+  %114 = phi { %"github.com/goplus/llgo/internal/runtime.eface", i1 } [ { %"github.com/goplus/llgo/internal/runtime.eface" zeroinitializer, i1 true }, %_llgo_23 ], [ zeroinitializer, %_llgo_24 ]
+  %115 = extractvalue { %"github.com/goplus/llgo/internal/runtime.eface", i1 } %114, 0
+  %116 = extractvalue { %"github.com/goplus/llgo/internal/runtime.eface", i1 } %114, 1
+  br i1 %116, label %_llgo_1, label %_llgo_2
 
 _llgo_26:                                         ; preds = %_llgo_2
-  %217 = load ptr, ptr @"main.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", align 8
-  %218 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %217, ptr %14)
-  %219 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %220 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %219, i32 0, i32 0
-  store ptr %218, ptr %220, align 8
-  %221 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %219, i32 0, i32 1
-  store ptr null, ptr %221, align 8
-  %222 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %219, align 8
-  %223 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
-  %224 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %223, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.iface" %222, ptr %224, align 8
-  %225 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %223, i32 0, i32 1
-  store i1 true, ptr %225, align 1
-  %226 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %223, align 8
+  %117 = load ptr, ptr @"main.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", align 8
+  %118 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %117, ptr %8)
+  %119 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %118, 0
+  %120 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %119, ptr null, 1
+  %121 = insertvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } undef, %"github.com/goplus/llgo/internal/runtime.iface" %120, 0
+  %122 = insertvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %121, i1 true, 1
   br label %_llgo_28
 
 _llgo_27:                                         ; preds = %_llgo_2
-  %227 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
-  %228 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %227, i32 0, i32 0
-  store { ptr, ptr } zeroinitializer, ptr %228, align 8
-  %229 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %227, i32 0, i32 1
-  store i1 false, ptr %229, align 1
-  %230 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %227, align 8
   br label %_llgo_28
 
 _llgo_28:                                         ; preds = %_llgo_27, %_llgo_26
-  %231 = phi { %"github.com/goplus/llgo/internal/runtime.iface", i1 } [ %226, %_llgo_26 ], [ %230, %_llgo_27 ]
-  %232 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %231, 0
-  %233 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %231, 1
-  br i1 %233, label %_llgo_3, label %_llgo_4
+  %123 = phi { %"github.com/goplus/llgo/internal/runtime.iface", i1 } [ %122, %_llgo_26 ], [ zeroinitializer, %_llgo_27 ]
+  %124 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %123, 0
+  %125 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %123, 1
+  br i1 %125, label %_llgo_3, label %_llgo_4
 
 _llgo_29:                                         ; preds = %_llgo_4
-  %234 = load ptr, ptr @"main.iface$gZBF8fFlqIMZ9M6lT2VWPyc3eu5Co6j0WoKGIEgDPAw", align 8
-  %235 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %234, ptr %27)
-  %236 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %237 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %236, i32 0, i32 0
-  store ptr %235, ptr %237, align 8
-  %238 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %236, i32 0, i32 1
-  store ptr null, ptr %238, align 8
-  %239 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %236, align 8
-  %240 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
-  %241 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %240, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.iface" %239, ptr %241, align 8
-  %242 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %240, i32 0, i32 1
-  store i1 true, ptr %242, align 1
-  %243 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %240, align 8
+  %126 = load ptr, ptr @"main.iface$gZBF8fFlqIMZ9M6lT2VWPyc3eu5Co6j0WoKGIEgDPAw", align 8
+  %127 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %126, ptr %15)
+  %128 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %127, 0
+  %129 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %128, ptr null, 1
+  %130 = insertvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } undef, %"github.com/goplus/llgo/internal/runtime.iface" %129, 0
+  %131 = insertvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %130, i1 true, 1
   br label %_llgo_31
 
 _llgo_30:                                         ; preds = %_llgo_4
-  %244 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
-  %245 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %244, i32 0, i32 0
-  store { ptr, ptr } zeroinitializer, ptr %245, align 8
-  %246 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %244, i32 0, i32 1
-  store i1 false, ptr %246, align 1
-  %247 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %244, align 8
   br label %_llgo_31
 
 _llgo_31:                                         ; preds = %_llgo_30, %_llgo_29
-  %248 = phi { %"github.com/goplus/llgo/internal/runtime.iface", i1 } [ %243, %_llgo_29 ], [ %247, %_llgo_30 ]
-  %249 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %248, 0
-  %250 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %248, 1
-  br i1 %250, label %_llgo_5, label %_llgo_6
+  %132 = phi { %"github.com/goplus/llgo/internal/runtime.iface", i1 } [ %131, %_llgo_29 ], [ zeroinitializer, %_llgo_30 ]
+  %133 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %132, 0
+  %134 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %132, 1
+  br i1 %134, label %_llgo_5, label %_llgo_6
 
 _llgo_32:                                         ; preds = %_llgo_6
-  %251 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %64, 1
-  %252 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %253 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %252, i32 0, i32 0
-  store ptr %65, ptr %253, align 8
-  %254 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %252, i32 0, i32 1
-  store ptr %251, ptr %254, align 8
-  %255 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %252, align 8
-  %256 = alloca { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, align 8
-  %257 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, ptr %256, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.eface" %255, ptr %257, align 8
-  %258 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, ptr %256, i32 0, i32 1
-  store i1 true, ptr %258, align 1
-  %259 = load { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, ptr %256, align 8
+  %135 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %38, 1
+  %136 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %39, 0
+  %137 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %136, ptr %135, 1
+  %138 = insertvalue { %"github.com/goplus/llgo/internal/runtime.eface", i1 } undef, %"github.com/goplus/llgo/internal/runtime.eface" %137, 0
+  %139 = insertvalue { %"github.com/goplus/llgo/internal/runtime.eface", i1 } %138, i1 true, 1
   br label %_llgo_34
 
 _llgo_33:                                         ; preds = %_llgo_6
-  %260 = alloca { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, align 8
-  %261 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, ptr %260, i32 0, i32 0
-  store { ptr, ptr } zeroinitializer, ptr %261, align 8
-  %262 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, ptr %260, i32 0, i32 1
-  store i1 false, ptr %262, align 1
-  %263 = load { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, ptr %260, align 8
   br label %_llgo_34
 
 _llgo_34:                                         ; preds = %_llgo_33, %_llgo_32
-  %264 = phi { %"github.com/goplus/llgo/internal/runtime.eface", i1 } [ %259, %_llgo_32 ], [ %263, %_llgo_33 ]
-  %265 = extractvalue { %"github.com/goplus/llgo/internal/runtime.eface", i1 } %264, 0
-  %266 = extractvalue { %"github.com/goplus/llgo/internal/runtime.eface", i1 } %264, 1
-  br i1 %266, label %_llgo_8, label %_llgo_7
+  %140 = phi { %"github.com/goplus/llgo/internal/runtime.eface", i1 } [ %139, %_llgo_32 ], [ zeroinitializer, %_llgo_33 ]
+  %141 = extractvalue { %"github.com/goplus/llgo/internal/runtime.eface", i1 } %140, 0
+  %142 = extractvalue { %"github.com/goplus/llgo/internal/runtime.eface", i1 } %140, 1
+  br i1 %142, label %_llgo_8, label %_llgo_7
 
 _llgo_35:                                         ; preds = %_llgo_8
-  %267 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %64, 1
-  %268 = load ptr, ptr @"main.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", align 8
-  %269 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %268, ptr %78)
-  %270 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %271 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %270, i32 0, i32 0
-  store ptr %269, ptr %271, align 8
-  %272 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %270, i32 0, i32 1
-  store ptr %267, ptr %272, align 8
-  %273 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %270, align 8
-  %274 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
-  %275 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %274, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.iface" %273, ptr %275, align 8
-  %276 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %274, i32 0, i32 1
-  store i1 true, ptr %276, align 1
-  %277 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %274, align 8
+  %143 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %38, 1
+  %144 = load ptr, ptr @"main.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", align 8
+  %145 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %144, ptr %46)
+  %146 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %145, 0
+  %147 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %146, ptr %143, 1
+  %148 = insertvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } undef, %"github.com/goplus/llgo/internal/runtime.iface" %147, 0
+  %149 = insertvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %148, i1 true, 1
   br label %_llgo_37
 
 _llgo_36:                                         ; preds = %_llgo_8
-  %278 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
-  %279 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %278, i32 0, i32 0
-  store { ptr, ptr } zeroinitializer, ptr %279, align 8
-  %280 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %278, i32 0, i32 1
-  store i1 false, ptr %280, align 1
-  %281 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %278, align 8
   br label %_llgo_37
 
 _llgo_37:                                         ; preds = %_llgo_36, %_llgo_35
-  %282 = phi { %"github.com/goplus/llgo/internal/runtime.iface", i1 } [ %277, %_llgo_35 ], [ %281, %_llgo_36 ]
-  %283 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %282, 0
-  %284 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %282, 1
-  br i1 %284, label %_llgo_10, label %_llgo_9
+  %150 = phi { %"github.com/goplus/llgo/internal/runtime.iface", i1 } [ %149, %_llgo_35 ], [ zeroinitializer, %_llgo_36 ]
+  %151 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %150, 0
+  %152 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %150, 1
+  br i1 %152, label %_llgo_10, label %_llgo_9
 
 _llgo_38:                                         ; preds = %_llgo_10
-  %285 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %64, 1
-  %286 = load ptr, ptr @"main.iface$gZBF8fFlqIMZ9M6lT2VWPyc3eu5Co6j0WoKGIEgDPAw", align 8
-  %287 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %286, ptr %91)
-  %288 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %289 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %288, i32 0, i32 0
-  store ptr %287, ptr %289, align 8
-  %290 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %288, i32 0, i32 1
-  store ptr %285, ptr %290, align 8
-  %291 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %288, align 8
-  %292 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
-  %293 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %292, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.iface" %291, ptr %293, align 8
-  %294 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %292, i32 0, i32 1
-  store i1 true, ptr %294, align 1
-  %295 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %292, align 8
+  %153 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %38, 1
+  %154 = load ptr, ptr @"main.iface$gZBF8fFlqIMZ9M6lT2VWPyc3eu5Co6j0WoKGIEgDPAw", align 8
+  %155 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %154, ptr %53)
+  %156 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %155, 0
+  %157 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %156, ptr %153, 1
+  %158 = insertvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } undef, %"github.com/goplus/llgo/internal/runtime.iface" %157, 0
+  %159 = insertvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %158, i1 true, 1
   br label %_llgo_40
 
 _llgo_39:                                         ; preds = %_llgo_10
-  %296 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
-  %297 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %296, i32 0, i32 0
-  store { ptr, ptr } zeroinitializer, ptr %297, align 8
-  %298 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %296, i32 0, i32 1
-  store i1 false, ptr %298, align 1
-  %299 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %296, align 8
   br label %_llgo_40
 
 _llgo_40:                                         ; preds = %_llgo_39, %_llgo_38
-  %300 = phi { %"github.com/goplus/llgo/internal/runtime.iface", i1 } [ %295, %_llgo_38 ], [ %299, %_llgo_39 ]
-  %301 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %300, 0
-  %302 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %300, 1
-  br i1 %302, label %_llgo_11, label %_llgo_12
+  %160 = phi { %"github.com/goplus/llgo/internal/runtime.iface", i1 } [ %159, %_llgo_38 ], [ zeroinitializer, %_llgo_39 ]
+  %161 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %160, 0
+  %162 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %160, 1
+  br i1 %162, label %_llgo_11, label %_llgo_12
 
 _llgo_41:                                         ; preds = %_llgo_12
-  %303 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %111, 1
-  %304 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %305 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %304, i32 0, i32 0
-  store ptr %112, ptr %305, align 8
-  %306 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %304, i32 0, i32 1
-  store ptr %303, ptr %306, align 8
-  %307 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %304, align 8
-  %308 = alloca { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, align 8
-  %309 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, ptr %308, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.eface" %307, ptr %309, align 8
-  %310 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, ptr %308, i32 0, i32 1
-  store i1 true, ptr %310, align 1
-  %311 = load { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, ptr %308, align 8
+  %163 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %65, 1
+  %164 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %66, 0
+  %165 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %164, ptr %163, 1
+  %166 = insertvalue { %"github.com/goplus/llgo/internal/runtime.eface", i1 } undef, %"github.com/goplus/llgo/internal/runtime.eface" %165, 0
+  %167 = insertvalue { %"github.com/goplus/llgo/internal/runtime.eface", i1 } %166, i1 true, 1
   br label %_llgo_43
 
 _llgo_42:                                         ; preds = %_llgo_12
-  %312 = alloca { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, align 8
-  %313 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, ptr %312, i32 0, i32 0
-  store { ptr, ptr } zeroinitializer, ptr %313, align 8
-  %314 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, ptr %312, i32 0, i32 1
-  store i1 false, ptr %314, align 1
-  %315 = load { %"github.com/goplus/llgo/internal/runtime.eface", i1 }, ptr %312, align 8
   br label %_llgo_43
 
 _llgo_43:                                         ; preds = %_llgo_42, %_llgo_41
-  %316 = phi { %"github.com/goplus/llgo/internal/runtime.eface", i1 } [ %311, %_llgo_41 ], [ %315, %_llgo_42 ]
-  %317 = extractvalue { %"github.com/goplus/llgo/internal/runtime.eface", i1 } %316, 0
-  %318 = extractvalue { %"github.com/goplus/llgo/internal/runtime.eface", i1 } %316, 1
-  br i1 %318, label %_llgo_14, label %_llgo_13
+  %168 = phi { %"github.com/goplus/llgo/internal/runtime.eface", i1 } [ %167, %_llgo_41 ], [ zeroinitializer, %_llgo_42 ]
+  %169 = extractvalue { %"github.com/goplus/llgo/internal/runtime.eface", i1 } %168, 0
+  %170 = extractvalue { %"github.com/goplus/llgo/internal/runtime.eface", i1 } %168, 1
+  br i1 %170, label %_llgo_14, label %_llgo_13
 
 _llgo_44:                                         ; preds = %_llgo_14
-  %319 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %111, 1
-  %320 = load ptr, ptr @"main.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", align 8
-  %321 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %320, ptr %125)
-  %322 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %323 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %322, i32 0, i32 0
-  store ptr %321, ptr %323, align 8
-  %324 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %322, i32 0, i32 1
-  store ptr %319, ptr %324, align 8
-  %325 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %322, align 8
-  %326 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
-  %327 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %326, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.iface" %325, ptr %327, align 8
-  %328 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %326, i32 0, i32 1
-  store i1 true, ptr %328, align 1
-  %329 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %326, align 8
+  %171 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %65, 1
+  %172 = load ptr, ptr @"main.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", align 8
+  %173 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %172, ptr %73)
+  %174 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %173, 0
+  %175 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %174, ptr %171, 1
+  %176 = insertvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } undef, %"github.com/goplus/llgo/internal/runtime.iface" %175, 0
+  %177 = insertvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %176, i1 true, 1
   br label %_llgo_46
 
 _llgo_45:                                         ; preds = %_llgo_14
-  %330 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
-  %331 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %330, i32 0, i32 0
-  store { ptr, ptr } zeroinitializer, ptr %331, align 8
-  %332 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %330, i32 0, i32 1
-  store i1 false, ptr %332, align 1
-  %333 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %330, align 8
   br label %_llgo_46
 
 _llgo_46:                                         ; preds = %_llgo_45, %_llgo_44
-  %334 = phi { %"github.com/goplus/llgo/internal/runtime.iface", i1 } [ %329, %_llgo_44 ], [ %333, %_llgo_45 ]
-  %335 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %334, 0
-  %336 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %334, 1
-  br i1 %336, label %_llgo_16, label %_llgo_15
+  %178 = phi { %"github.com/goplus/llgo/internal/runtime.iface", i1 } [ %177, %_llgo_44 ], [ zeroinitializer, %_llgo_45 ]
+  %179 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %178, 0
+  %180 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %178, 1
+  br i1 %180, label %_llgo_16, label %_llgo_15
 
 _llgo_47:                                         ; preds = %_llgo_16
-  %337 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %111, 1
-  %338 = load ptr, ptr @"main.iface$gZBF8fFlqIMZ9M6lT2VWPyc3eu5Co6j0WoKGIEgDPAw", align 8
-  %339 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %338, ptr %138)
-  %340 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %341 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %340, i32 0, i32 0
-  store ptr %339, ptr %341, align 8
-  %342 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %340, i32 0, i32 1
-  store ptr %337, ptr %342, align 8
-  %343 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %340, align 8
-  %344 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
-  %345 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %344, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.iface" %343, ptr %345, align 8
-  %346 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %344, i32 0, i32 1
-  store i1 true, ptr %346, align 1
-  %347 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %344, align 8
+  %181 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %65, 1
+  %182 = load ptr, ptr @"main.iface$gZBF8fFlqIMZ9M6lT2VWPyc3eu5Co6j0WoKGIEgDPAw", align 8
+  %183 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %182, ptr %80)
+  %184 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %183, 0
+  %185 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %184, ptr %181, 1
+  %186 = insertvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } undef, %"github.com/goplus/llgo/internal/runtime.iface" %185, 0
+  %187 = insertvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %186, i1 true, 1
   br label %_llgo_49
 
 _llgo_48:                                         ; preds = %_llgo_16
-  %348 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
-  %349 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %348, i32 0, i32 0
-  store { ptr, ptr } zeroinitializer, ptr %349, align 8
-  %350 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %348, i32 0, i32 1
-  store i1 false, ptr %350, align 1
-  %351 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %348, align 8
   br label %_llgo_49
 
 _llgo_49:                                         ; preds = %_llgo_48, %_llgo_47
-  %352 = phi { %"github.com/goplus/llgo/internal/runtime.iface", i1 } [ %347, %_llgo_47 ], [ %351, %_llgo_48 ]
-  %353 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %352, 0
-  %354 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %352, 1
-  br i1 %354, label %_llgo_18, label %_llgo_17
+  %188 = phi { %"github.com/goplus/llgo/internal/runtime.iface", i1 } [ %187, %_llgo_47 ], [ zeroinitializer, %_llgo_48 ]
+  %189 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %188, 0
+  %190 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %188, 1
+  br i1 %190, label %_llgo_18, label %_llgo_17
 }
 
 declare void @"github.com/goplus/llgo/internal/runtime.init"()
@@ -763,509 +481,203 @@ _llgo_0:
 
 _llgo_1:                                          ; preds = %_llgo_0
   %2 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %3 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3, i32 0, i32 0
-  store ptr %2, ptr %4, align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3, i32 0, i32 1
-  store i64 0, ptr %5, align 4
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3, i32 0, i32 2
-  store i64 0, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3, align 8
-  %8 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %8, i32 0, i32 0
-  store ptr @0, ptr %9, align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %8, i32 0, i32 1
-  store i64 4, ptr %10, align 4
-  %11 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %8, align 8
-  %12 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %12, i32 0, i32 0
-  store ptr @1, ptr %13, align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %12, i32 0, i32 1
-  store i64 7, ptr %14, align 4
-  %15 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %12, align 8
-  %16 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %11, %"github.com/goplus/llgo/internal/runtime.String" %15, %"github.com/goplus/llgo/internal/runtime.Slice" %7)
-  store ptr %16, ptr @_llgo_main.I0, align 8
+  %3 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %2, 0
+  %4 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %3, i64 0, 1
+  %5 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %4, i64 0, 2
+  %6 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 7 }, %"github.com/goplus/llgo/internal/runtime.Slice" %5)
+  store ptr %6, ptr @_llgo_main.I0, align 8
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-  %17 = load ptr, ptr @_llgo_string, align 8
-  %18 = icmp eq ptr %17, null
-  br i1 %18, label %_llgo_3, label %_llgo_4
+  %7 = load ptr, ptr @_llgo_string, align 8
+  %8 = icmp eq ptr %7, null
+  br i1 %8, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  store ptr %19, ptr @_llgo_string, align 8
+  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  store ptr %9, ptr @_llgo_string, align 8
   br label %_llgo_4
 
 _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
-  %20 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %21 = icmp eq ptr %20, null
-  br i1 %21, label %_llgo_5, label %_llgo_6
+  %10 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %11 = icmp eq ptr %10, null
+  br i1 %11, label %_llgo_5, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_4
-  %22 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %23 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %24 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %23, i32 0, i32 0
-  store ptr %22, ptr %24, align 8
-  %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %23, i32 0, i32 1
-  store i64 0, ptr %25, align 4
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %23, i32 0, i32 2
-  store i64 0, ptr %26, align 4
-  %27 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %23, align 8
-  %28 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %29 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %29, i32 0, i32 0
-  store ptr %28, ptr %30, align 8
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %29, i32 0, i32 1
-  store i64 0, ptr %31, align 4
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %29, i32 0, i32 2
-  store i64 0, ptr %32, align 4
-  %33 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %29, align 8
-  %34 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %27, %"github.com/goplus/llgo/internal/runtime.Slice" %33, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %34)
-  store ptr %34, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %12 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %13 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %12, 0
+  %14 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %13, i64 0, 1
+  %15 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %14, i64 0, 2
+  %16 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %17 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %16, 0
+  %18 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %17, i64 0, 1
+  %19 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %18, i64 0, 2
+  %20 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %15, %"github.com/goplus/llgo/internal/runtime.Slice" %19, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %20)
+  store ptr %20, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %35 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %36 = load ptr, ptr @_llgo_main.I1, align 8
-  %37 = icmp eq ptr %36, null
-  br i1 %37, label %_llgo_7, label %_llgo_8
+  %21 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %22 = load ptr, ptr @_llgo_main.I1, align 8
+  %23 = icmp eq ptr %22, null
+  br i1 %23, label %_llgo_7, label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_6
-  %38 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %38, i32 0, i32 0
-  store ptr @3, ptr %39, align 8
-  %40 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %38, i32 0, i32 1
-  store i64 6, ptr %40, align 4
-  %41 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %38, align 8
-  %42 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %42, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %41, ptr %43, align 8
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %42, i32 0, i32 1
-  store ptr %35, ptr %44, align 8
-  %45 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %42, align 8
-  %46 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %47 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %46, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %45, ptr %47, align 8
-  %48 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %49 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, i32 0, i32 0
-  store ptr %46, ptr %49, align 8
-  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, i32 0, i32 1
-  store i64 1, ptr %50, align 4
-  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, i32 0, i32 2
-  store i64 1, ptr %51, align 4
-  %52 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, align 8
-  %53 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %54 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %53, i32 0, i32 0
-  store ptr @0, ptr %54, align 8
-  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %53, i32 0, i32 1
-  store i64 4, ptr %55, align 4
-  %56 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %53, align 8
-  %57 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %58 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %57, i32 0, i32 0
-  store ptr @4, ptr %58, align 8
-  %59 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %57, i32 0, i32 1
-  store i64 7, ptr %59, align 4
-  %60 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %57, align 8
-  %61 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %56, %"github.com/goplus/llgo/internal/runtime.String" %60, %"github.com/goplus/llgo/internal/runtime.Slice" %52)
-  store ptr %61, ptr @_llgo_main.I1, align 8
+  %24 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 6 }, ptr undef }, ptr %21, 1
+  %25 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %26 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %25, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %24, ptr %26, align 8
+  %27 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %25, 0
+  %28 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %27, i64 1, 1
+  %29 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %28, i64 1, 2
+  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 7 }, %"github.com/goplus/llgo/internal/runtime.Slice" %29)
+  store ptr %30, ptr @_llgo_main.I1, align 8
   br label %_llgo_8
 
 _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
-  %62 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %63 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %64 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %63, i32 0, i32 0
-  store ptr @3, ptr %64, align 8
-  %65 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %63, i32 0, i32 1
-  store i64 6, ptr %65, align 4
-  %66 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %63, align 8
-  %67 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %68 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %67, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %66, ptr %68, align 8
-  %69 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %67, i32 0, i32 1
-  store ptr %62, ptr %69, align 8
-  %70 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %67, align 8
-  %71 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %72 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %71, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %70, ptr %72, align 8
-  %73 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %74 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %73, i32 0, i32 0
-  store ptr %71, ptr %74, align 8
-  %75 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %73, i32 0, i32 1
-  store i64 1, ptr %75, align 4
-  %76 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %73, i32 0, i32 2
-  store i64 1, ptr %76, align 4
-  %77 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %73, align 8
-  %78 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %79 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %78, i32 0, i32 0
-  store ptr @0, ptr %79, align 8
-  %80 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %78, i32 0, i32 1
-  store i64 4, ptr %80, align 4
-  %81 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %78, align 8
-  %82 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %83 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %82, i32 0, i32 0
-  store ptr null, ptr %83, align 8
-  %84 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %82, i32 0, i32 1
-  store i64 0, ptr %84, align 4
-  %85 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %82, align 8
-  %86 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %81, %"github.com/goplus/llgo/internal/runtime.String" %85, %"github.com/goplus/llgo/internal/runtime.Slice" %77)
-  store ptr %86, ptr @"main.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", align 8
-  %87 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %88 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %89 = load ptr, ptr @_llgo_main.I2, align 8
-  %90 = icmp eq ptr %89, null
-  br i1 %90, label %_llgo_9, label %_llgo_10
+  %31 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %32 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 6 }, ptr undef }, ptr %31, 1
+  %33 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %34 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %33, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %32, ptr %34, align 8
+  %35 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %33, 0
+  %36 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %35, i64 1, 1
+  %37 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %36, i64 1, 2
+  %38 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %37)
+  store ptr %38, ptr @"main.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", align 8
+  %39 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %40 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %41 = load ptr, ptr @_llgo_main.I2, align 8
+  %42 = icmp eq ptr %41, null
+  br i1 %42, label %_llgo_9, label %_llgo_10
 
 _llgo_9:                                          ; preds = %_llgo_8
-  %91 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %92 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %91, i32 0, i32 0
-  store ptr @3, ptr %92, align 8
-  %93 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %91, i32 0, i32 1
-  store i64 6, ptr %93, align 4
-  %94 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %91, align 8
-  %95 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %96 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %95, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %94, ptr %96, align 8
-  %97 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %95, i32 0, i32 1
-  store ptr %87, ptr %97, align 8
-  %98 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %95, align 8
-  %99 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %100 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %99, i32 0, i32 0
-  store ptr @6, ptr %100, align 8
-  %101 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %99, i32 0, i32 1
-  store i64 6, ptr %101, align 4
-  %102 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %99, align 8
-  %103 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %104 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %103, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %102, ptr %104, align 8
-  %105 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %103, i32 0, i32 1
-  store ptr %88, ptr %105, align 8
-  %106 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %103, align 8
-  %107 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  %108 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %107, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %98, ptr %108, align 8
-  %109 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %107, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %106, ptr %109, align 8
-  %110 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %111 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %110, i32 0, i32 0
-  store ptr %107, ptr %111, align 8
-  %112 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %110, i32 0, i32 1
-  store i64 2, ptr %112, align 4
-  %113 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %110, i32 0, i32 2
-  store i64 2, ptr %113, align 4
-  %114 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %110, align 8
-  %115 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %116 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %115, i32 0, i32 0
-  store ptr @0, ptr %116, align 8
-  %117 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %115, i32 0, i32 1
-  store i64 4, ptr %117, align 4
-  %118 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %115, align 8
-  %119 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %120 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %119, i32 0, i32 0
-  store ptr @7, ptr %120, align 8
-  %121 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %119, i32 0, i32 1
-  store i64 7, ptr %121, align 4
-  %122 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %119, align 8
-  %123 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %118, %"github.com/goplus/llgo/internal/runtime.String" %122, %"github.com/goplus/llgo/internal/runtime.Slice" %114)
-  store ptr %123, ptr @_llgo_main.I2, align 8
+  %43 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 6 }, ptr undef }, ptr %39, 1
+  %44 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 6 }, ptr undef }, ptr %40, 1
+  %45 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  %46 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %45, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %43, ptr %46, align 8
+  %47 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %45, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %44, ptr %47, align 8
+  %48 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %45, 0
+  %49 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %48, i64 2, 1
+  %50 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %49, i64 2, 2
+  %51 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 7 }, %"github.com/goplus/llgo/internal/runtime.Slice" %50)
+  store ptr %51, ptr @_llgo_main.I2, align 8
   br label %_llgo_10
 
 _llgo_10:                                         ; preds = %_llgo_9, %_llgo_8
-  %124 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %125 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %126 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %127 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %126, i32 0, i32 0
-  store ptr @3, ptr %127, align 8
-  %128 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %126, i32 0, i32 1
-  store i64 6, ptr %128, align 4
-  %129 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %126, align 8
-  %130 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %131 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %130, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %129, ptr %131, align 8
-  %132 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %130, i32 0, i32 1
-  store ptr %124, ptr %132, align 8
-  %133 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %130, align 8
-  %134 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %135 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %134, i32 0, i32 0
-  store ptr @6, ptr %135, align 8
-  %136 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %134, i32 0, i32 1
-  store i64 6, ptr %136, align 4
-  %137 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %134, align 8
-  %138 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %139 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %138, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %137, ptr %139, align 8
-  %140 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %138, i32 0, i32 1
-  store ptr %125, ptr %140, align 8
-  %141 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %138, align 8
-  %142 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  %143 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %142, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %133, ptr %143, align 8
-  %144 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %142, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %141, ptr %144, align 8
-  %145 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %146 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %145, i32 0, i32 0
-  store ptr %142, ptr %146, align 8
-  %147 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %145, i32 0, i32 1
-  store i64 2, ptr %147, align 4
-  %148 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %145, i32 0, i32 2
-  store i64 2, ptr %148, align 4
-  %149 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %145, align 8
-  %150 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %151 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %150, i32 0, i32 0
-  store ptr @0, ptr %151, align 8
-  %152 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %150, i32 0, i32 1
-  store i64 4, ptr %152, align 4
-  %153 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %150, align 8
-  %154 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %155 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %154, i32 0, i32 0
-  store ptr null, ptr %155, align 8
-  %156 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %154, i32 0, i32 1
-  store i64 0, ptr %156, align 4
-  %157 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %154, align 8
-  %158 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %153, %"github.com/goplus/llgo/internal/runtime.String" %157, %"github.com/goplus/llgo/internal/runtime.Slice" %149)
-  store ptr %158, ptr @"main.iface$gZBF8fFlqIMZ9M6lT2VWPyc3eu5Co6j0WoKGIEgDPAw", align 8
-  %159 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %160 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %159, i32 0, i32 0
-  store ptr @9, ptr %160, align 8
-  %161 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %159, i32 0, i32 1
-  store i64 7, ptr %161, align 4
-  %162 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %159, align 8
-  %163 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %162, i64 25, i64 0, i64 1, i64 1)
-  %164 = load ptr, ptr @_llgo_main.C1, align 8
-  %165 = icmp eq ptr %164, null
-  br i1 %165, label %_llgo_11, label %_llgo_12
+  %52 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %53 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %54 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 6 }, ptr undef }, ptr %52, 1
+  %55 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 6 }, ptr undef }, ptr %53, 1
+  %56 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  %57 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %56, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %54, ptr %57, align 8
+  %58 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %56, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %55, ptr %58, align 8
+  %59 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %56, 0
+  %60 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %59, i64 2, 1
+  %61 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %60, i64 2, 2
+  %62 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %61)
+  store ptr %62, ptr @"main.iface$gZBF8fFlqIMZ9M6lT2VWPyc3eu5Co6j0WoKGIEgDPAw", align 8
+  %63 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 7 }, i64 25, i64 0, i64 1, i64 1)
+  %64 = load ptr, ptr @_llgo_main.C1, align 8
+  %65 = icmp eq ptr %64, null
+  br i1 %65, label %_llgo_11, label %_llgo_12
 
 _llgo_11:                                         ; preds = %_llgo_10
-  store ptr %163, ptr @_llgo_main.C1, align 8
+  store ptr %63, ptr @_llgo_main.C1, align 8
   br label %_llgo_12
 
 _llgo_12:                                         ; preds = %_llgo_11, %_llgo_10
-  %166 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
-  %167 = icmp eq ptr %166, null
-  br i1 %167, label %_llgo_13, label %_llgo_14
+  %66 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
+  %67 = icmp eq ptr %66, null
+  br i1 %67, label %_llgo_13, label %_llgo_14
 
 _llgo_13:                                         ; preds = %_llgo_12
-  %168 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %169 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %168, i32 0, i32 0
-  store ptr @0, ptr %169, align 8
-  %170 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %168, i32 0, i32 1
-  store i64 4, ptr %170, align 4
-  %171 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %168, align 8
-  %172 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %173 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %174 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %173, i32 0, i32 0
-  store ptr %172, ptr %174, align 8
-  %175 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %173, i32 0, i32 1
-  store i64 0, ptr %175, align 4
-  %176 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %173, i32 0, i32 2
-  store i64 0, ptr %176, align 4
-  %177 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %173, align 8
-  %178 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %171, i64 0, %"github.com/goplus/llgo/internal/runtime.Slice" %177)
-  store ptr %178, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
+  %68 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %69 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %68, 0
+  %70 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %69, i64 0, 1
+  %71 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %70, i64 0, 2
+  %72 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, i64 0, %"github.com/goplus/llgo/internal/runtime.Slice" %71)
+  store ptr %72, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
   br label %_llgo_14
 
 _llgo_14:                                         ; preds = %_llgo_13, %_llgo_12
-  %179 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
-  br i1 %165, label %_llgo_15, label %_llgo_16
+  %73 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
+  br i1 %65, label %_llgo_15, label %_llgo_16
 
 _llgo_15:                                         ; preds = %_llgo_14
-  %180 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %181 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %180, i32 0, i32 0
-  store ptr @10, ptr %181, align 8
-  %182 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %180, i32 0, i32 1
-  store i64 1, ptr %182, align 4
-  %183 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %180, align 8
-  %184 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %185 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %184, i32 0, i32 0
-  store ptr @3, ptr %185, align 8
-  %186 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %184, i32 0, i32 1
-  store i64 6, ptr %186, align 4
-  %187 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %184, align 8
-  %188 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %189 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %190 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %189, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %187, ptr %190, align 8
-  %191 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %189, i32 0, i32 1
-  store ptr %188, ptr %191, align 8
-  %192 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %189, i32 0, i32 2
-  store ptr @"main.(*C1).f", ptr %192, align 8
-  %193 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %189, i32 0, i32 3
-  store ptr @"main.(*C1).f", ptr %193, align 8
-  %194 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %189, align 8
-  %195 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %196 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %195, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %187, ptr %196, align 8
-  %197 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %195, i32 0, i32 1
-  store ptr %188, ptr %197, align 8
-  %198 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %195, i32 0, i32 2
-  store ptr @"main.(*C1).f", ptr %198, align 8
-  %199 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %195, i32 0, i32 3
-  store ptr @main.C1.f, ptr %199, align 8
-  %200 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %195, align 8
-  %201 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %202 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %201, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %200, ptr %202, align 8
-  %203 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %204 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %203, i32 0, i32 0
-  store ptr %201, ptr %204, align 8
-  %205 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %203, i32 0, i32 1
-  store i64 1, ptr %205, align 4
-  %206 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %203, i32 0, i32 2
-  store i64 1, ptr %206, align 4
-  %207 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %203, align 8
-  %208 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %209 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %208, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %194, ptr %209, align 8
-  %210 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %211 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %210, i32 0, i32 0
-  store ptr %208, ptr %211, align 8
-  %212 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %210, i32 0, i32 1
-  store i64 1, ptr %212, align 4
-  %213 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %210, i32 0, i32 2
-  store i64 1, ptr %213, align 4
-  %214 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %210, align 8
-  %215 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %216 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %215, i32 0, i32 0
-  store ptr @0, ptr %216, align 8
-  %217 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %215, i32 0, i32 1
-  store i64 4, ptr %217, align 4
-  %218 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %215, align 8
-  %219 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %220 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %219, i32 0, i32 0
-  store ptr @11, ptr %220, align 8
-  %221 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %219, i32 0, i32 1
-  store i64 2, ptr %221, align 4
-  %222 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %219, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %163, %"github.com/goplus/llgo/internal/runtime.String" %218, %"github.com/goplus/llgo/internal/runtime.String" %222, ptr %179, %"github.com/goplus/llgo/internal/runtime.Slice" %207, %"github.com/goplus/llgo/internal/runtime.Slice" %214)
+  %74 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %75 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %74, 1
+  %76 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %75, ptr @"main.(*C1).f", 2
+  %77 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %76, ptr @"main.(*C1).f", 3
+  %78 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %74, 1
+  %79 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %78, ptr @"main.(*C1).f", 2
+  %80 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %79, ptr @main.C1.f, 3
+  %81 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %82 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %81, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %80, ptr %82, align 8
+  %83 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %81, 0
+  %84 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %83, i64 1, 1
+  %85 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %84, i64 1, 2
+  %86 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %87 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %86, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %77, ptr %87, align 8
+  %88 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %86, 0
+  %89 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %88, i64 1, 1
+  %90 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %89, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %63, %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 2 }, ptr %73, %"github.com/goplus/llgo/internal/runtime.Slice" %85, %"github.com/goplus/llgo/internal/runtime.Slice" %90)
   br label %_llgo_16
 
 _llgo_16:                                         ; preds = %_llgo_15, %_llgo_14
-  %223 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %224 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %223, i32 0, i32 0
-  store ptr @15, ptr %224, align 8
-  %225 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %223, i32 0, i32 1
-  store i64 7, ptr %225, align 4
-  %226 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %223, align 8
-  %227 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %226, i64 25, i64 0, i64 2, i64 2)
-  %228 = load ptr, ptr @_llgo_main.C2, align 8
-  %229 = icmp eq ptr %228, null
-  br i1 %229, label %_llgo_17, label %_llgo_18
+  %91 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @15, i64 7 }, i64 25, i64 0, i64 2, i64 2)
+  %92 = load ptr, ptr @_llgo_main.C2, align 8
+  %93 = icmp eq ptr %92, null
+  br i1 %93, label %_llgo_17, label %_llgo_18
 
 _llgo_17:                                         ; preds = %_llgo_16
-  store ptr %227, ptr @_llgo_main.C2, align 8
+  store ptr %91, ptr @_llgo_main.C2, align 8
   br label %_llgo_18
 
 _llgo_18:                                         ; preds = %_llgo_17, %_llgo_16
-  %230 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
-  br i1 %229, label %_llgo_19, label %_llgo_20
+  %94 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
+  br i1 %93, label %_llgo_19, label %_llgo_20
 
 _llgo_19:                                         ; preds = %_llgo_18
-  %231 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %232 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %231, i32 0, i32 0
-  store ptr @10, ptr %232, align 8
-  %233 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %231, i32 0, i32 1
-  store i64 1, ptr %233, align 4
-  %234 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %231, align 8
-  %235 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %236 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %235, i32 0, i32 0
-  store ptr @3, ptr %236, align 8
-  %237 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %235, i32 0, i32 1
-  store i64 6, ptr %237, align 4
-  %238 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %235, align 8
-  %239 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %240 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %241 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %240, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %238, ptr %241, align 8
-  %242 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %240, i32 0, i32 1
-  store ptr %239, ptr %242, align 8
-  %243 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %240, i32 0, i32 2
-  store ptr @"main.(*C2).f", ptr %243, align 8
-  %244 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %240, i32 0, i32 3
-  store ptr @"main.(*C2).f", ptr %244, align 8
-  %245 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %240, align 8
-  %246 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %247 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %246, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %238, ptr %247, align 8
-  %248 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %246, i32 0, i32 1
-  store ptr %239, ptr %248, align 8
-  %249 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %246, i32 0, i32 2
-  store ptr @"main.(*C2).f", ptr %249, align 8
-  %250 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %246, i32 0, i32 3
-  store ptr @main.C2.f, ptr %250, align 8
-  %251 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %246, align 8
-  %252 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %253 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %252, i32 0, i32 0
-  store ptr @16, ptr %253, align 8
-  %254 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %252, i32 0, i32 1
-  store i64 1, ptr %254, align 4
-  %255 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %252, align 8
-  %256 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %257 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %256, i32 0, i32 0
-  store ptr @6, ptr %257, align 8
-  %258 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %256, i32 0, i32 1
-  store i64 6, ptr %258, align 4
-  %259 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %256, align 8
-  %260 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %261 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %262 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %261, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %259, ptr %262, align 8
-  %263 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %261, i32 0, i32 1
-  store ptr %260, ptr %263, align 8
-  %264 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %261, i32 0, i32 2
-  store ptr @"main.(*C2).g", ptr %264, align 8
-  %265 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %261, i32 0, i32 3
-  store ptr @"main.(*C2).g", ptr %265, align 8
-  %266 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %261, align 8
-  %267 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %268 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %267, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %259, ptr %268, align 8
-  %269 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %267, i32 0, i32 1
-  store ptr %260, ptr %269, align 8
-  %270 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %267, i32 0, i32 2
-  store ptr @"main.(*C2).g", ptr %270, align 8
-  %271 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %267, i32 0, i32 3
-  store ptr @main.C2.g, ptr %271, align 8
-  %272 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %267, align 8
-  %273 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
-  %274 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %273, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %251, ptr %274, align 8
-  %275 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %273, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %272, ptr %275, align 8
-  %276 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %277 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %276, i32 0, i32 0
-  store ptr %273, ptr %277, align 8
-  %278 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %276, i32 0, i32 1
-  store i64 2, ptr %278, align 4
-  %279 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %276, i32 0, i32 2
-  store i64 2, ptr %279, align 4
-  %280 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %276, align 8
-  %281 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
-  %282 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %281, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %245, ptr %282, align 8
-  %283 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %281, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %266, ptr %283, align 8
-  %284 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %285 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %284, i32 0, i32 0
-  store ptr %281, ptr %285, align 8
-  %286 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %284, i32 0, i32 1
-  store i64 2, ptr %286, align 4
-  %287 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %284, i32 0, i32 2
-  store i64 2, ptr %287, align 4
-  %288 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %284, align 8
-  %289 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %290 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %289, i32 0, i32 0
-  store ptr @0, ptr %290, align 8
-  %291 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %289, i32 0, i32 1
-  store i64 4, ptr %291, align 4
-  %292 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %289, align 8
-  %293 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %294 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %293, i32 0, i32 0
-  store ptr @17, ptr %294, align 8
-  %295 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %293, i32 0, i32 1
-  store i64 2, ptr %295, align 4
-  %296 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %293, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %227, %"github.com/goplus/llgo/internal/runtime.String" %292, %"github.com/goplus/llgo/internal/runtime.String" %296, ptr %230, %"github.com/goplus/llgo/internal/runtime.Slice" %280, %"github.com/goplus/llgo/internal/runtime.Slice" %288)
+  %95 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %96 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %95, 1
+  %97 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %96, ptr @"main.(*C2).f", 2
+  %98 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %97, ptr @"main.(*C2).f", 3
+  %99 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %95, 1
+  %100 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %99, ptr @"main.(*C2).f", 2
+  %101 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %100, ptr @main.C2.f, 3
+  %102 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %103 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %102, 1
+  %104 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %103, ptr @"main.(*C2).g", 2
+  %105 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %104, ptr @"main.(*C2).g", 3
+  %106 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %102, 1
+  %107 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %106, ptr @"main.(*C2).g", 2
+  %108 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %107, ptr @main.C2.g, 3
+  %109 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
+  %110 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %109, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %101, ptr %110, align 8
+  %111 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %109, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %108, ptr %111, align 8
+  %112 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %109, 0
+  %113 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %112, i64 2, 1
+  %114 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %113, i64 2, 2
+  %115 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
+  %116 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %115, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %98, ptr %116, align 8
+  %117 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %115, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %105, ptr %117, align 8
+  %118 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %115, 0
+  %119 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %118, i64 2, 1
+  %120 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %119, i64 2, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %91, %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @17, i64 2 }, ptr %94, %"github.com/goplus/llgo/internal/runtime.Slice" %114, %"github.com/goplus/llgo/internal/runtime.Slice" %120)
   br label %_llgo_20
 
 _llgo_20:                                         ; preds = %_llgo_19, %_llgo_18

--- a/cl/_testgo/ifaceprom/out.ll
+++ b/cl/_testgo/ifaceprom/out.ll
@@ -44,16 +44,12 @@ _llgo_0:
   %5 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %3, 0
   %6 = getelementptr ptr, ptr %5, i64 3
   %7 = load ptr, ptr %6, align 8
-  %8 = alloca { ptr, ptr }, align 8
-  %9 = getelementptr inbounds { ptr, ptr }, ptr %8, i32 0, i32 0
-  store ptr %7, ptr %9, align 8
-  %10 = getelementptr inbounds { ptr, ptr }, ptr %8, i32 0, i32 1
-  store ptr %4, ptr %10, align 8
-  %11 = load { ptr, ptr }, ptr %8, align 8
-  %12 = extractvalue { ptr, ptr } %11, 1
-  %13 = extractvalue { ptr, ptr } %11, 0
-  %14 = call i64 %13(ptr %12)
-  ret i64 %14
+  %8 = insertvalue { ptr, ptr } undef, ptr %7, 0
+  %9 = insertvalue { ptr, ptr } %8, ptr %4, 1
+  %10 = extractvalue { ptr, ptr } %9, 1
+  %11 = extractvalue { ptr, ptr } %9, 0
+  %12 = call i64 %11(ptr %10)
+  ret i64 %12
 }
 
 define %"github.com/goplus/llgo/internal/runtime.String" @main.S.two(%main.S %0) {
@@ -67,16 +63,12 @@ _llgo_0:
   %5 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %3, 0
   %6 = getelementptr ptr, ptr %5, i64 4
   %7 = load ptr, ptr %6, align 8
-  %8 = alloca { ptr, ptr }, align 8
-  %9 = getelementptr inbounds { ptr, ptr }, ptr %8, i32 0, i32 0
-  store ptr %7, ptr %9, align 8
-  %10 = getelementptr inbounds { ptr, ptr }, ptr %8, i32 0, i32 1
-  store ptr %4, ptr %10, align 8
-  %11 = load { ptr, ptr }, ptr %8, align 8
-  %12 = extractvalue { ptr, ptr } %11, 1
-  %13 = extractvalue { ptr, ptr } %11, 0
-  %14 = call %"github.com/goplus/llgo/internal/runtime.String" %13(ptr %12)
-  ret %"github.com/goplus/llgo/internal/runtime.String" %14
+  %8 = insertvalue { ptr, ptr } undef, ptr %7, 0
+  %9 = insertvalue { ptr, ptr } %8, ptr %4, 1
+  %10 = extractvalue { ptr, ptr } %9, 1
+  %11 = extractvalue { ptr, ptr } %9, 0
+  %12 = call %"github.com/goplus/llgo/internal/runtime.String" %11(ptr %10)
+  ret %"github.com/goplus/llgo/internal/runtime.String" %12
 }
 
 define i64 @"main.(*S).one"(ptr %0) {
@@ -87,16 +79,12 @@ _llgo_0:
   %4 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %2, 0
   %5 = getelementptr ptr, ptr %4, i64 3
   %6 = load ptr, ptr %5, align 8
-  %7 = alloca { ptr, ptr }, align 8
-  %8 = getelementptr inbounds { ptr, ptr }, ptr %7, i32 0, i32 0
-  store ptr %6, ptr %8, align 8
-  %9 = getelementptr inbounds { ptr, ptr }, ptr %7, i32 0, i32 1
-  store ptr %3, ptr %9, align 8
-  %10 = load { ptr, ptr }, ptr %7, align 8
-  %11 = extractvalue { ptr, ptr } %10, 1
-  %12 = extractvalue { ptr, ptr } %10, 0
-  %13 = call i64 %12(ptr %11)
-  ret i64 %13
+  %7 = insertvalue { ptr, ptr } undef, ptr %6, 0
+  %8 = insertvalue { ptr, ptr } %7, ptr %3, 1
+  %9 = extractvalue { ptr, ptr } %8, 1
+  %10 = extractvalue { ptr, ptr } %8, 0
+  %11 = call i64 %10(ptr %9)
+  ret i64 %11
 }
 
 define %"github.com/goplus/llgo/internal/runtime.String" @"main.(*S).two"(ptr %0) {
@@ -107,16 +95,12 @@ _llgo_0:
   %4 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %2, 0
   %5 = getelementptr ptr, ptr %4, i64 4
   %6 = load ptr, ptr %5, align 8
-  %7 = alloca { ptr, ptr }, align 8
-  %8 = getelementptr inbounds { ptr, ptr }, ptr %7, i32 0, i32 0
-  store ptr %6, ptr %8, align 8
-  %9 = getelementptr inbounds { ptr, ptr }, ptr %7, i32 0, i32 1
-  store ptr %3, ptr %9, align 8
-  %10 = load { ptr, ptr }, ptr %7, align 8
-  %11 = extractvalue { ptr, ptr } %10, 1
-  %12 = extractvalue { ptr, ptr } %10, 0
-  %13 = call %"github.com/goplus/llgo/internal/runtime.String" %12(ptr %11)
-  ret %"github.com/goplus/llgo/internal/runtime.String" %13
+  %7 = insertvalue { ptr, ptr } undef, ptr %6, 0
+  %8 = insertvalue { ptr, ptr } %7, ptr %3, 1
+  %9 = extractvalue { ptr, ptr } %8, 1
+  %10 = extractvalue { ptr, ptr } %8, 0
+  %11 = call %"github.com/goplus/llgo/internal/runtime.String" %10(ptr %9)
+  ret %"github.com/goplus/llgo/internal/runtime.String" %11
 }
 
 define i64 @main.impl.one(%main.impl %0) {
@@ -126,13 +110,7 @@ _llgo_0:
 
 define %"github.com/goplus/llgo/internal/runtime.String" @main.impl.two(%main.impl %0) {
 _llgo_0:
-  %1 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1, i32 0, i32 0
-  store ptr @0, ptr %2, align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1, i32 0, i32 1
-  store i64 3, ptr %3, align 4
-  %4 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1, align 8
-  ret %"github.com/goplus/llgo/internal/runtime.String" %4
+  ret %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 3 }
 }
 
 define i64 @"main.(*impl).one"(ptr %0) {
@@ -179,433 +157,275 @@ _llgo_0:
   %7 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
   %8 = load ptr, ptr @"main.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", align 8
   %9 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %8, ptr %4)
-  %10 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %10, i32 0, i32 0
-  store ptr %9, ptr %11, align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %10, i32 0, i32 1
-  store ptr %5, ptr %12, align 8
-  %13 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %10, align 8
-  store %"github.com/goplus/llgo/internal/runtime.iface" %13, ptr %3, align 8
-  %14 = getelementptr inbounds %main.S, ptr %2, i32 0, i32 0
-  %15 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %14, align 8
-  %16 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %15)
-  %17 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %15, 0
-  %18 = getelementptr ptr, ptr %17, i64 3
-  %19 = load ptr, ptr %18, align 8
-  %20 = alloca { ptr, ptr }, align 8
-  %21 = getelementptr inbounds { ptr, ptr }, ptr %20, i32 0, i32 0
-  store ptr %19, ptr %21, align 8
-  %22 = getelementptr inbounds { ptr, ptr }, ptr %20, i32 0, i32 1
-  store ptr %16, ptr %22, align 8
-  %23 = load { ptr, ptr }, ptr %20, align 8
-  %24 = extractvalue { ptr, ptr } %23, 1
-  %25 = extractvalue { ptr, ptr } %23, 0
-  %26 = call i64 %25(ptr %24)
-  %27 = icmp ne i64 %26, 1
-  br i1 %27, label %_llgo_1, label %_llgo_2
+  %10 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %9, 0
+  %11 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %10, ptr %5, 1
+  store %"github.com/goplus/llgo/internal/runtime.iface" %11, ptr %3, align 8
+  %12 = getelementptr inbounds %main.S, ptr %2, i32 0, i32 0
+  %13 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %12, align 8
+  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %13)
+  %15 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %13, 0
+  %16 = getelementptr ptr, ptr %15, i64 3
+  %17 = load ptr, ptr %16, align 8
+  %18 = insertvalue { ptr, ptr } undef, ptr %17, 0
+  %19 = insertvalue { ptr, ptr } %18, ptr %14, 1
+  %20 = extractvalue { ptr, ptr } %19, 1
+  %21 = extractvalue { ptr, ptr } %19, 0
+  %22 = call i64 %21(ptr %20)
+  %23 = icmp ne i64 %22, 1
+  br i1 %23, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %28 = load ptr, ptr @_llgo_int, align 8
-  %29 = inttoptr i64 %26 to ptr
-  %30 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %30, i32 0, i32 0
-  store ptr %28, ptr %31, align 8
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %30, i32 0, i32 1
-  store ptr %29, ptr %32, align 8
-  %33 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %30, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %33)
+  %24 = load ptr, ptr @_llgo_int, align 8
+  %25 = inttoptr i64 %22 to ptr
+  %26 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %24, 0
+  %27 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %26, ptr %25, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %27)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %34 = load %main.S, ptr %2, align 8
-  %35 = extractvalue %main.S %34, 0
-  %36 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %35)
-  %37 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %35, 0
-  %38 = getelementptr ptr, ptr %37, i64 3
-  %39 = load ptr, ptr %38, align 8
-  %40 = alloca { ptr, ptr }, align 8
-  %41 = getelementptr inbounds { ptr, ptr }, ptr %40, i32 0, i32 0
-  store ptr %39, ptr %41, align 8
-  %42 = getelementptr inbounds { ptr, ptr }, ptr %40, i32 0, i32 1
-  store ptr %36, ptr %42, align 8
-  %43 = load { ptr, ptr }, ptr %40, align 8
-  %44 = extractvalue { ptr, ptr } %43, 1
-  %45 = extractvalue { ptr, ptr } %43, 0
-  %46 = call i64 %45(ptr %44)
-  %47 = icmp ne i64 %46, 1
-  br i1 %47, label %_llgo_3, label %_llgo_4
+  %28 = load %main.S, ptr %2, align 8
+  %29 = extractvalue %main.S %28, 0
+  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %29)
+  %31 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %29, 0
+  %32 = getelementptr ptr, ptr %31, i64 3
+  %33 = load ptr, ptr %32, align 8
+  %34 = insertvalue { ptr, ptr } undef, ptr %33, 0
+  %35 = insertvalue { ptr, ptr } %34, ptr %30, 1
+  %36 = extractvalue { ptr, ptr } %35, 1
+  %37 = extractvalue { ptr, ptr } %35, 0
+  %38 = call i64 %37(ptr %36)
+  %39 = icmp ne i64 %38, 1
+  br i1 %39, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %48 = load ptr, ptr @_llgo_int, align 8
-  %49 = inttoptr i64 %46 to ptr
-  %50 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %50, i32 0, i32 0
-  store ptr %48, ptr %51, align 8
-  %52 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %50, i32 0, i32 1
-  store ptr %49, ptr %52, align 8
-  %53 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %50, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %53)
+  %40 = load ptr, ptr @_llgo_int, align 8
+  %41 = inttoptr i64 %38 to ptr
+  %42 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %40, 0
+  %43 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %42, ptr %41, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %43)
   unreachable
 
 _llgo_4:                                          ; preds = %_llgo_2
-  %54 = getelementptr inbounds %main.S, ptr %2, i32 0, i32 0
-  %55 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %54, align 8
-  %56 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %55)
-  %57 = load ptr, ptr @_llgo_main.I, align 8
-  %58 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %57, ptr %56)
-  br i1 %58, label %_llgo_17, label %_llgo_18
+  %44 = getelementptr inbounds %main.S, ptr %2, i32 0, i32 0
+  %45 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %44, align 8
+  %46 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %45)
+  %47 = load ptr, ptr @_llgo_main.I, align 8
+  %48 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %47, ptr %46)
+  br i1 %48, label %_llgo_17, label %_llgo_18
 
 _llgo_5:                                          ; preds = %_llgo_17
-  %59 = load ptr, ptr @_llgo_int, align 8
-  %60 = inttoptr i64 %167 to ptr
-  %61 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %62 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %61, i32 0, i32 0
-  store ptr %59, ptr %62, align 8
-  %63 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %61, i32 0, i32 1
-  store ptr %60, ptr %63, align 8
-  %64 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %61, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %64)
+  %49 = load ptr, ptr @_llgo_int, align 8
+  %50 = inttoptr i64 %124 to ptr
+  %51 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %49, 0
+  %52 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %51, ptr %50, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %52)
   unreachable
 
 _llgo_6:                                          ; preds = %_llgo_17
-  %65 = load %main.S, ptr %2, align 8
-  %66 = extractvalue %main.S %65, 0
-  %67 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %66)
-  %68 = load ptr, ptr @_llgo_main.I, align 8
-  %69 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %68, ptr %67)
-  br i1 %69, label %_llgo_19, label %_llgo_20
+  %53 = load %main.S, ptr %2, align 8
+  %54 = extractvalue %main.S %53, 0
+  %55 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %54)
+  %56 = load ptr, ptr @_llgo_main.I, align 8
+  %57 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %56, ptr %55)
+  br i1 %57, label %_llgo_19, label %_llgo_20
 
 _llgo_7:                                          ; preds = %_llgo_19
-  %70 = load ptr, ptr @_llgo_int, align 8
-  %71 = inttoptr i64 %194 to ptr
-  %72 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %73 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %72, i32 0, i32 0
-  store ptr %70, ptr %73, align 8
-  %74 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %72, i32 0, i32 1
-  store ptr %71, ptr %74, align 8
-  %75 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %72, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %75)
+  %58 = load ptr, ptr @_llgo_int, align 8
+  %59 = inttoptr i64 %140 to ptr
+  %60 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %58, 0
+  %61 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %60, ptr %59, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %61)
   unreachable
 
 _llgo_8:                                          ; preds = %_llgo_19
-  %76 = getelementptr inbounds %main.S, ptr %2, i32 0, i32 0
-  %77 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %76, align 8
-  %78 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %77)
-  %79 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %77, 0
-  %80 = getelementptr ptr, ptr %79, i64 4
-  %81 = load ptr, ptr %80, align 8
-  %82 = alloca { ptr, ptr }, align 8
-  %83 = getelementptr inbounds { ptr, ptr }, ptr %82, i32 0, i32 0
-  store ptr %81, ptr %83, align 8
-  %84 = getelementptr inbounds { ptr, ptr }, ptr %82, i32 0, i32 1
-  store ptr %78, ptr %84, align 8
-  %85 = load { ptr, ptr }, ptr %82, align 8
-  %86 = extractvalue { ptr, ptr } %85, 1
-  %87 = extractvalue { ptr, ptr } %85, 0
-  %88 = call %"github.com/goplus/llgo/internal/runtime.String" %87(ptr %86)
-  %89 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %90 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %89, i32 0, i32 0
-  store ptr @0, ptr %90, align 8
-  %91 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %89, i32 0, i32 1
-  store i64 3, ptr %91, align 4
-  %92 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %89, align 8
-  %93 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %88, %"github.com/goplus/llgo/internal/runtime.String" %92)
-  %94 = xor i1 %93, true
-  br i1 %94, label %_llgo_9, label %_llgo_10
+  %62 = getelementptr inbounds %main.S, ptr %2, i32 0, i32 0
+  %63 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %62, align 8
+  %64 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %63)
+  %65 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %63, 0
+  %66 = getelementptr ptr, ptr %65, i64 4
+  %67 = load ptr, ptr %66, align 8
+  %68 = insertvalue { ptr, ptr } undef, ptr %67, 0
+  %69 = insertvalue { ptr, ptr } %68, ptr %64, 1
+  %70 = extractvalue { ptr, ptr } %69, 1
+  %71 = extractvalue { ptr, ptr } %69, 0
+  %72 = call %"github.com/goplus/llgo/internal/runtime.String" %71(ptr %70)
+  %73 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %72, %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 3 })
+  %74 = xor i1 %73, true
+  br i1 %74, label %_llgo_9, label %_llgo_10
 
 _llgo_9:                                          ; preds = %_llgo_8
-  %95 = load ptr, ptr @_llgo_string, align 8
-  %96 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %88, ptr %96, align 8
-  %97 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %98 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %97, i32 0, i32 0
-  store ptr %95, ptr %98, align 8
-  %99 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %97, i32 0, i32 1
-  store ptr %96, ptr %99, align 8
-  %100 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %97, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %100)
+  %75 = load ptr, ptr @_llgo_string, align 8
+  %76 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %72, ptr %76, align 8
+  %77 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %75, 0
+  %78 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %77, ptr %76, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %78)
   unreachable
 
 _llgo_10:                                         ; preds = %_llgo_8
-  %101 = load %main.S, ptr %2, align 8
-  %102 = extractvalue %main.S %101, 0
-  %103 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %102)
-  %104 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %102, 0
-  %105 = getelementptr ptr, ptr %104, i64 4
-  %106 = load ptr, ptr %105, align 8
-  %107 = alloca { ptr, ptr }, align 8
-  %108 = getelementptr inbounds { ptr, ptr }, ptr %107, i32 0, i32 0
-  store ptr %106, ptr %108, align 8
-  %109 = getelementptr inbounds { ptr, ptr }, ptr %107, i32 0, i32 1
-  store ptr %103, ptr %109, align 8
-  %110 = load { ptr, ptr }, ptr %107, align 8
-  %111 = extractvalue { ptr, ptr } %110, 1
-  %112 = extractvalue { ptr, ptr } %110, 0
-  %113 = call %"github.com/goplus/llgo/internal/runtime.String" %112(ptr %111)
-  %114 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %115 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %114, i32 0, i32 0
-  store ptr @0, ptr %115, align 8
-  %116 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %114, i32 0, i32 1
-  store i64 3, ptr %116, align 4
-  %117 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %114, align 8
-  %118 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %113, %"github.com/goplus/llgo/internal/runtime.String" %117)
-  %119 = xor i1 %118, true
-  br i1 %119, label %_llgo_11, label %_llgo_12
+  %79 = load %main.S, ptr %2, align 8
+  %80 = extractvalue %main.S %79, 0
+  %81 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %80)
+  %82 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %80, 0
+  %83 = getelementptr ptr, ptr %82, i64 4
+  %84 = load ptr, ptr %83, align 8
+  %85 = insertvalue { ptr, ptr } undef, ptr %84, 0
+  %86 = insertvalue { ptr, ptr } %85, ptr %81, 1
+  %87 = extractvalue { ptr, ptr } %86, 1
+  %88 = extractvalue { ptr, ptr } %86, 0
+  %89 = call %"github.com/goplus/llgo/internal/runtime.String" %88(ptr %87)
+  %90 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %89, %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 3 })
+  %91 = xor i1 %90, true
+  br i1 %91, label %_llgo_11, label %_llgo_12
 
 _llgo_11:                                         ; preds = %_llgo_10
-  %120 = load ptr, ptr @_llgo_string, align 8
-  %121 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %113, ptr %121, align 8
-  %122 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %123 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %122, i32 0, i32 0
-  store ptr %120, ptr %123, align 8
-  %124 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %122, i32 0, i32 1
-  store ptr %121, ptr %124, align 8
-  %125 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %122, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %125)
+  %92 = load ptr, ptr @_llgo_string, align 8
+  %93 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %89, ptr %93, align 8
+  %94 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %92, 0
+  %95 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %94, ptr %93, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %95)
   unreachable
 
 _llgo_12:                                         ; preds = %_llgo_10
-  %126 = getelementptr inbounds %main.S, ptr %2, i32 0, i32 0
-  %127 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %126, align 8
-  %128 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %127)
-  %129 = load ptr, ptr @_llgo_main.I, align 8
-  %130 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %129, ptr %128)
-  br i1 %130, label %_llgo_21, label %_llgo_22
+  %96 = getelementptr inbounds %main.S, ptr %2, i32 0, i32 0
+  %97 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %96, align 8
+  %98 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %97)
+  %99 = load ptr, ptr @_llgo_main.I, align 8
+  %100 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %99, ptr %98)
+  br i1 %100, label %_llgo_21, label %_llgo_22
 
 _llgo_13:                                         ; preds = %_llgo_21
-  %131 = load ptr, ptr @_llgo_string, align 8
-  %132 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %221, ptr %132, align 8
-  %133 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %134 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %133, i32 0, i32 0
-  store ptr %131, ptr %134, align 8
-  %135 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %133, i32 0, i32 1
-  store ptr %132, ptr %135, align 8
-  %136 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %133, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %136)
+  %101 = load ptr, ptr @_llgo_string, align 8
+  %102 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %156, ptr %102, align 8
+  %103 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %101, 0
+  %104 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %103, ptr %102, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %104)
   unreachable
 
 _llgo_14:                                         ; preds = %_llgo_21
-  %137 = load %main.S, ptr %2, align 8
-  %138 = extractvalue %main.S %137, 0
-  %139 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %138)
-  %140 = load ptr, ptr @_llgo_main.I, align 8
-  %141 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %140, ptr %139)
-  br i1 %141, label %_llgo_23, label %_llgo_24
+  %105 = load %main.S, ptr %2, align 8
+  %106 = extractvalue %main.S %105, 0
+  %107 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %106)
+  %108 = load ptr, ptr @_llgo_main.I, align 8
+  %109 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %108, ptr %107)
+  br i1 %109, label %_llgo_23, label %_llgo_24
 
 _llgo_15:                                         ; preds = %_llgo_23
-  %142 = load ptr, ptr @_llgo_string, align 8
-  %143 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %253, ptr %143, align 8
-  %144 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %145 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %144, i32 0, i32 0
-  store ptr %142, ptr %145, align 8
-  %146 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %144, i32 0, i32 1
-  store ptr %143, ptr %146, align 8
-  %147 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %144, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %147)
+  %110 = load ptr, ptr @_llgo_string, align 8
+  %111 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %173, ptr %111, align 8
+  %112 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %110, 0
+  %113 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %112, ptr %111, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %113)
   unreachable
 
 _llgo_16:                                         ; preds = %_llgo_23
-  %148 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %149 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %148, i32 0, i32 0
-  store ptr @9, ptr %149, align 8
-  %150 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %148, i32 0, i32 1
-  store i64 4, ptr %150, align 4
-  %151 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %148, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %151)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 4 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 
 _llgo_17:                                         ; preds = %_llgo_4
-  %152 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %55, 1
-  %153 = load ptr, ptr @"main.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", align 8
-  %154 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %153, ptr %56)
-  %155 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %156 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %155, i32 0, i32 0
-  store ptr %154, ptr %156, align 8
-  %157 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %155, i32 0, i32 1
-  store ptr %152, ptr %157, align 8
-  %158 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %155, align 8
-  %159 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %160 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %159, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.iface" %55, ptr %160, align 8
-  %161 = alloca { ptr, ptr }, align 8
-  %162 = getelementptr inbounds { ptr, ptr }, ptr %161, i32 0, i32 0
-  store ptr @"main.one$bound", ptr %162, align 8
-  %163 = getelementptr inbounds { ptr, ptr }, ptr %161, i32 0, i32 1
-  store ptr %159, ptr %163, align 8
-  %164 = load { ptr, ptr }, ptr %161, align 8
-  %165 = extractvalue { ptr, ptr } %164, 1
-  %166 = extractvalue { ptr, ptr } %164, 0
-  %167 = call i64 %166(ptr %165)
-  %168 = icmp ne i64 %167, 1
-  br i1 %168, label %_llgo_5, label %_llgo_6
+  %114 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %45, 1
+  %115 = load ptr, ptr @"main.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", align 8
+  %116 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %115, ptr %46)
+  %117 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %116, 0
+  %118 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %117, ptr %114, 1
+  %119 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %120 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %119, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.iface" %45, ptr %120, align 8
+  %121 = insertvalue { ptr, ptr } { ptr @"main.one$bound", ptr undef }, ptr %119, 1
+  %122 = extractvalue { ptr, ptr } %121, 1
+  %123 = extractvalue { ptr, ptr } %121, 0
+  %124 = call i64 %123(ptr %122)
+  %125 = icmp ne i64 %124, 1
+  br i1 %125, label %_llgo_5, label %_llgo_6
 
 _llgo_18:                                         ; preds = %_llgo_4
-  %169 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %170 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %169, i32 0, i32 0
-  store ptr @8, ptr %170, align 8
-  %171 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %169, i32 0, i32 1
-  store i64 21, ptr %171, align 4
-  %172 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %169, align 8
-  %173 = load ptr, ptr @_llgo_string, align 8
-  %174 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %172, ptr %174, align 8
-  %175 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %176 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %175, i32 0, i32 0
-  store ptr %173, ptr %176, align 8
-  %177 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %175, i32 0, i32 1
-  store ptr %174, ptr %177, align 8
-  %178 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %175, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %178)
+  %126 = load ptr, ptr @_llgo_string, align 8
+  %127 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 21 }, ptr %127, align 8
+  %128 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %126, 0
+  %129 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %128, ptr %127, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %129)
   unreachable
 
 _llgo_19:                                         ; preds = %_llgo_6
-  %179 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %66, 1
-  %180 = load ptr, ptr @"main.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", align 8
-  %181 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %180, ptr %67)
-  %182 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %183 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %182, i32 0, i32 0
-  store ptr %181, ptr %183, align 8
-  %184 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %182, i32 0, i32 1
-  store ptr %179, ptr %184, align 8
-  %185 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %182, align 8
-  %186 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %187 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %186, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.iface" %66, ptr %187, align 8
-  %188 = alloca { ptr, ptr }, align 8
-  %189 = getelementptr inbounds { ptr, ptr }, ptr %188, i32 0, i32 0
-  store ptr @"main.one$bound", ptr %189, align 8
-  %190 = getelementptr inbounds { ptr, ptr }, ptr %188, i32 0, i32 1
-  store ptr %186, ptr %190, align 8
-  %191 = load { ptr, ptr }, ptr %188, align 8
-  %192 = extractvalue { ptr, ptr } %191, 1
-  %193 = extractvalue { ptr, ptr } %191, 0
-  %194 = call i64 %193(ptr %192)
-  %195 = icmp ne i64 %194, 1
-  br i1 %195, label %_llgo_7, label %_llgo_8
+  %130 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %54, 1
+  %131 = load ptr, ptr @"main.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", align 8
+  %132 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %131, ptr %55)
+  %133 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %132, 0
+  %134 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %133, ptr %130, 1
+  %135 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %136 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %135, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.iface" %54, ptr %136, align 8
+  %137 = insertvalue { ptr, ptr } { ptr @"main.one$bound", ptr undef }, ptr %135, 1
+  %138 = extractvalue { ptr, ptr } %137, 1
+  %139 = extractvalue { ptr, ptr } %137, 0
+  %140 = call i64 %139(ptr %138)
+  %141 = icmp ne i64 %140, 1
+  br i1 %141, label %_llgo_7, label %_llgo_8
 
 _llgo_20:                                         ; preds = %_llgo_6
-  %196 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %197 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %196, i32 0, i32 0
-  store ptr @8, ptr %197, align 8
-  %198 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %196, i32 0, i32 1
-  store i64 21, ptr %198, align 4
-  %199 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %196, align 8
-  %200 = load ptr, ptr @_llgo_string, align 8
-  %201 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %199, ptr %201, align 8
-  %202 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %203 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %202, i32 0, i32 0
-  store ptr %200, ptr %203, align 8
-  %204 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %202, i32 0, i32 1
-  store ptr %201, ptr %204, align 8
-  %205 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %202, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %205)
+  %142 = load ptr, ptr @_llgo_string, align 8
+  %143 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 21 }, ptr %143, align 8
+  %144 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %142, 0
+  %145 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %144, ptr %143, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %145)
   unreachable
 
 _llgo_21:                                         ; preds = %_llgo_12
-  %206 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %127, 1
-  %207 = load ptr, ptr @"main.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", align 8
-  %208 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %207, ptr %128)
-  %209 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %210 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %209, i32 0, i32 0
-  store ptr %208, ptr %210, align 8
-  %211 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %209, i32 0, i32 1
-  store ptr %206, ptr %211, align 8
-  %212 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %209, align 8
-  %213 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %214 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %213, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.iface" %127, ptr %214, align 8
-  %215 = alloca { ptr, ptr }, align 8
-  %216 = getelementptr inbounds { ptr, ptr }, ptr %215, i32 0, i32 0
-  store ptr @"main.two$bound", ptr %216, align 8
-  %217 = getelementptr inbounds { ptr, ptr }, ptr %215, i32 0, i32 1
-  store ptr %213, ptr %217, align 8
-  %218 = load { ptr, ptr }, ptr %215, align 8
-  %219 = extractvalue { ptr, ptr } %218, 1
-  %220 = extractvalue { ptr, ptr } %218, 0
-  %221 = call %"github.com/goplus/llgo/internal/runtime.String" %220(ptr %219)
-  %222 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %223 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %222, i32 0, i32 0
-  store ptr @0, ptr %223, align 8
-  %224 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %222, i32 0, i32 1
-  store i64 3, ptr %224, align 4
-  %225 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %222, align 8
-  %226 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %221, %"github.com/goplus/llgo/internal/runtime.String" %225)
-  %227 = xor i1 %226, true
-  br i1 %227, label %_llgo_13, label %_llgo_14
+  %146 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %97, 1
+  %147 = load ptr, ptr @"main.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", align 8
+  %148 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %147, ptr %98)
+  %149 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %148, 0
+  %150 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %149, ptr %146, 1
+  %151 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %152 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %151, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.iface" %97, ptr %152, align 8
+  %153 = insertvalue { ptr, ptr } { ptr @"main.two$bound", ptr undef }, ptr %151, 1
+  %154 = extractvalue { ptr, ptr } %153, 1
+  %155 = extractvalue { ptr, ptr } %153, 0
+  %156 = call %"github.com/goplus/llgo/internal/runtime.String" %155(ptr %154)
+  %157 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %156, %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 3 })
+  %158 = xor i1 %157, true
+  br i1 %158, label %_llgo_13, label %_llgo_14
 
 _llgo_22:                                         ; preds = %_llgo_12
-  %228 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %229 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %228, i32 0, i32 0
-  store ptr @8, ptr %229, align 8
-  %230 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %228, i32 0, i32 1
-  store i64 21, ptr %230, align 4
-  %231 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %228, align 8
-  %232 = load ptr, ptr @_llgo_string, align 8
-  %233 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %231, ptr %233, align 8
-  %234 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %235 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %234, i32 0, i32 0
-  store ptr %232, ptr %235, align 8
-  %236 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %234, i32 0, i32 1
-  store ptr %233, ptr %236, align 8
-  %237 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %234, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %237)
+  %159 = load ptr, ptr @_llgo_string, align 8
+  %160 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 21 }, ptr %160, align 8
+  %161 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %159, 0
+  %162 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %161, ptr %160, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %162)
   unreachable
 
 _llgo_23:                                         ; preds = %_llgo_14
-  %238 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %138, 1
-  %239 = load ptr, ptr @"main.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", align 8
-  %240 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %239, ptr %139)
-  %241 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %242 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %241, i32 0, i32 0
-  store ptr %240, ptr %242, align 8
-  %243 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %241, i32 0, i32 1
-  store ptr %238, ptr %243, align 8
-  %244 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %241, align 8
-  %245 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %246 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %245, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.iface" %138, ptr %246, align 8
-  %247 = alloca { ptr, ptr }, align 8
-  %248 = getelementptr inbounds { ptr, ptr }, ptr %247, i32 0, i32 0
-  store ptr @"main.two$bound", ptr %248, align 8
-  %249 = getelementptr inbounds { ptr, ptr }, ptr %247, i32 0, i32 1
-  store ptr %245, ptr %249, align 8
-  %250 = load { ptr, ptr }, ptr %247, align 8
-  %251 = extractvalue { ptr, ptr } %250, 1
-  %252 = extractvalue { ptr, ptr } %250, 0
-  %253 = call %"github.com/goplus/llgo/internal/runtime.String" %252(ptr %251)
-  %254 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %255 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %254, i32 0, i32 0
-  store ptr @0, ptr %255, align 8
-  %256 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %254, i32 0, i32 1
-  store i64 3, ptr %256, align 4
-  %257 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %254, align 8
-  %258 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %253, %"github.com/goplus/llgo/internal/runtime.String" %257)
-  %259 = xor i1 %258, true
-  br i1 %259, label %_llgo_15, label %_llgo_16
+  %163 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %106, 1
+  %164 = load ptr, ptr @"main.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", align 8
+  %165 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %164, ptr %107)
+  %166 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %165, 0
+  %167 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %166, ptr %163, 1
+  %168 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %169 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %168, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.iface" %106, ptr %169, align 8
+  %170 = insertvalue { ptr, ptr } { ptr @"main.two$bound", ptr undef }, ptr %168, 1
+  %171 = extractvalue { ptr, ptr } %170, 1
+  %172 = extractvalue { ptr, ptr } %170, 0
+  %173 = call %"github.com/goplus/llgo/internal/runtime.String" %172(ptr %171)
+  %174 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %173, %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 3 })
+  %175 = xor i1 %174, true
+  br i1 %175, label %_llgo_15, label %_llgo_16
 
 _llgo_24:                                         ; preds = %_llgo_14
-  %260 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %261 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %260, i32 0, i32 0
-  store ptr @8, ptr %261, align 8
-  %262 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %260, i32 0, i32 1
-  store i64 21, ptr %262, align 4
-  %263 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %260, align 8
-  %264 = load ptr, ptr @_llgo_string, align 8
-  %265 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %263, ptr %265, align 8
-  %266 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %267 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %266, i32 0, i32 0
-  store ptr %264, ptr %267, align 8
-  %268 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %266, i32 0, i32 1
-  store ptr %265, ptr %268, align 8
-  %269 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %266, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %269)
+  %176 = load ptr, ptr @_llgo_string, align 8
+  %177 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 21 }, ptr %177, align 8
+  %178 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %176, 0
+  %179 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %178, ptr %177, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %179)
   unreachable
 }
 
@@ -618,342 +438,153 @@ declare void @"github.com/goplus/llgo/internal/runtime.init"()
 
 define void @"main.init$after"() {
 _llgo_0:
-  %0 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 0
-  store ptr @1, ptr %1, align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 1
-  store i64 9, ptr %2, align 4
-  %3 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %0, align 8
-  %4 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3, i64 25, i64 0, i64 2, i64 2)
-  store ptr %4, ptr @_llgo_main.impl, align 8
-  %5 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
-  %6 = icmp eq ptr %5, null
-  br i1 %6, label %_llgo_1, label %_llgo_2
+  %0 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 9 }, i64 25, i64 0, i64 2, i64 2)
+  store ptr %0, ptr @_llgo_main.impl, align 8
+  %1 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
+  %2 = icmp eq ptr %1, null
+  br i1 %2, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %7 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %7, i32 0, i32 0
-  store ptr @2, ptr %8, align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %7, i32 0, i32 1
-  store i64 4, ptr %9, align 4
-  %10 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %7, align 8
-  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %12 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %12, i32 0, i32 0
-  store ptr %11, ptr %13, align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %12, i32 0, i32 1
-  store i64 0, ptr %14, align 4
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %12, i32 0, i32 2
-  store i64 0, ptr %15, align 4
-  %16 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %12, align 8
-  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %10, i64 0, %"github.com/goplus/llgo/internal/runtime.Slice" %16)
-  store ptr %17, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
+  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %4 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %3, 0
+  %5 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %4, i64 0, 1
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %5, i64 0, 2
+  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, i64 0, %"github.com/goplus/llgo/internal/runtime.Slice" %6)
+  store ptr %7, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-  %18 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
-  %19 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %19, i32 0, i32 0
-  store ptr @3, ptr %20, align 8
-  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %19, i32 0, i32 1
-  store i64 3, ptr %21, align 4
-  %22 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %19, align 8
-  %23 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %24 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %23, i32 0, i32 0
-  store ptr @4, ptr %24, align 8
-  %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %23, i32 0, i32 1
-  store i64 8, ptr %25, align 4
-  %26 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %23, align 8
-  %27 = load ptr, ptr @_llgo_int, align 8
-  %28 = icmp eq ptr %27, null
-  br i1 %28, label %_llgo_3, label %_llgo_4
+  %8 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
+  %9 = load ptr, ptr @_llgo_int, align 8
+  %10 = icmp eq ptr %9, null
+  br i1 %10, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  store ptr %29, ptr @_llgo_int, align 8
+  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  store ptr %11, ptr @_llgo_int, align 8
   br label %_llgo_4
 
 _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
-  %30 = load ptr, ptr @_llgo_int, align 8
-  %31 = load ptr, ptr @_llgo_int, align 8
-  %32 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %33 = icmp eq ptr %32, null
-  br i1 %33, label %_llgo_5, label %_llgo_6
+  %12 = load ptr, ptr @_llgo_int, align 8
+  %13 = load ptr, ptr @_llgo_int, align 8
+  %14 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %15 = icmp eq ptr %14, null
+  br i1 %15, label %_llgo_5, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_4
-  %34 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %35 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %36 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %35, i32 0, i32 0
-  store ptr %34, ptr %36, align 8
-  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %35, i32 0, i32 1
-  store i64 0, ptr %37, align 4
-  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %35, i32 0, i32 2
-  store i64 0, ptr %38, align 4
-  %39 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %35, align 8
-  %40 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %41 = getelementptr ptr, ptr %40, i64 0
-  store ptr %31, ptr %41, align 8
-  %42 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, i32 0, i32 0
-  store ptr %40, ptr %43, align 8
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, i32 0, i32 1
-  store i64 1, ptr %44, align 4
-  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, i32 0, i32 2
-  store i64 1, ptr %45, align 4
-  %46 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, align 8
-  %47 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %39, %"github.com/goplus/llgo/internal/runtime.Slice" %46, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %47)
-  store ptr %47, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %16 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %17 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %16, 0
+  %18 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %17, i64 0, 1
+  %19 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %18, i64 0, 2
+  %20 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %21 = getelementptr ptr, ptr %20, i64 0
+  store ptr %13, ptr %21, align 8
+  %22 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %20, 0
+  %23 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %22, i64 1, 1
+  %24 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %23, i64 1, 2
+  %25 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %19, %"github.com/goplus/llgo/internal/runtime.Slice" %24, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %25)
+  store ptr %25, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %48 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %49 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %49, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %26, ptr %50, align 8
-  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %49, i32 0, i32 1
-  store ptr %48, ptr %51, align 8
-  %52 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %49, i32 0, i32 2
-  store ptr @"main.(*impl).one", ptr %52, align 8
-  %53 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %49, i32 0, i32 3
-  store ptr @"main.(*impl).one", ptr %53, align 8
-  %54 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %49, align 8
-  %55 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %55, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %26, ptr %56, align 8
-  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %55, i32 0, i32 1
-  store ptr %48, ptr %57, align 8
-  %58 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %55, i32 0, i32 2
-  store ptr @"main.(*impl).one", ptr %58, align 8
-  %59 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %55, i32 0, i32 3
-  store ptr @main.impl.one, ptr %59, align 8
-  %60 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %55, align 8
-  %61 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %62 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %61, i32 0, i32 0
-  store ptr @0, ptr %62, align 8
-  %63 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %61, i32 0, i32 1
-  store i64 3, ptr %63, align 4
-  %64 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %61, align 8
-  %65 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %66 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %65, i32 0, i32 0
-  store ptr @5, ptr %66, align 8
-  %67 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %65, i32 0, i32 1
-  store i64 8, ptr %67, align 4
-  %68 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %65, align 8
-  %69 = load ptr, ptr @_llgo_string, align 8
-  %70 = icmp eq ptr %69, null
-  br i1 %70, label %_llgo_7, label %_llgo_8
+  %26 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %27 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %26, 1
+  %28 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %27, ptr @"main.(*impl).one", 2
+  %29 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %28, ptr @"main.(*impl).one", 3
+  %30 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %26, 1
+  %31 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %30, ptr @"main.(*impl).one", 2
+  %32 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %31, ptr @main.impl.one, 3
+  %33 = load ptr, ptr @_llgo_string, align 8
+  %34 = icmp eq ptr %33, null
+  br i1 %34, label %_llgo_7, label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_6
-  %71 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  store ptr %71, ptr @_llgo_string, align 8
+  %35 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  store ptr %35, ptr @_llgo_string, align 8
   br label %_llgo_8
 
 _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
-  %72 = load ptr, ptr @_llgo_string, align 8
-  %73 = load ptr, ptr @_llgo_string, align 8
-  %74 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %75 = icmp eq ptr %74, null
-  br i1 %75, label %_llgo_9, label %_llgo_10
+  %36 = load ptr, ptr @_llgo_string, align 8
+  %37 = load ptr, ptr @_llgo_string, align 8
+  %38 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %39 = icmp eq ptr %38, null
+  br i1 %39, label %_llgo_9, label %_llgo_10
 
 _llgo_9:                                          ; preds = %_llgo_8
-  %76 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %77 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %78 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %77, i32 0, i32 0
-  store ptr %76, ptr %78, align 8
-  %79 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %77, i32 0, i32 1
-  store i64 0, ptr %79, align 4
-  %80 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %77, i32 0, i32 2
-  store i64 0, ptr %80, align 4
-  %81 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %77, align 8
-  %82 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %83 = getelementptr ptr, ptr %82, i64 0
-  store ptr %73, ptr %83, align 8
-  %84 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %85 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %84, i32 0, i32 0
-  store ptr %82, ptr %85, align 8
-  %86 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %84, i32 0, i32 1
-  store i64 1, ptr %86, align 4
-  %87 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %84, i32 0, i32 2
-  store i64 1, ptr %87, align 4
-  %88 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %84, align 8
-  %89 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %81, %"github.com/goplus/llgo/internal/runtime.Slice" %88, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %89)
-  store ptr %89, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %40 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %41 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %40, 0
+  %42 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %41, i64 0, 1
+  %43 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %42, i64 0, 2
+  %44 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %45 = getelementptr ptr, ptr %44, i64 0
+  store ptr %37, ptr %45, align 8
+  %46 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %44, 0
+  %47 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %46, i64 1, 1
+  %48 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %47, i64 1, 2
+  %49 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %43, %"github.com/goplus/llgo/internal/runtime.Slice" %48, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %49)
+  store ptr %49, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
   br label %_llgo_10
 
 _llgo_10:                                         ; preds = %_llgo_9, %_llgo_8
-  %90 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %91 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %92 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %91, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %68, ptr %92, align 8
-  %93 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %91, i32 0, i32 1
-  store ptr %90, ptr %93, align 8
-  %94 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %91, i32 0, i32 2
-  store ptr @"main.(*impl).two", ptr %94, align 8
-  %95 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %91, i32 0, i32 3
-  store ptr @"main.(*impl).two", ptr %95, align 8
-  %96 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %91, align 8
-  %97 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %98 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %97, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %68, ptr %98, align 8
-  %99 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %97, i32 0, i32 1
-  store ptr %90, ptr %99, align 8
-  %100 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %97, i32 0, i32 2
-  store ptr @"main.(*impl).two", ptr %100, align 8
-  %101 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %97, i32 0, i32 3
-  store ptr @main.impl.two, ptr %101, align 8
-  %102 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %97, align 8
-  %103 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
-  %104 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %103, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %60, ptr %104, align 8
-  %105 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %103, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %102, ptr %105, align 8
-  %106 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %107 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %106, i32 0, i32 0
-  store ptr %103, ptr %107, align 8
-  %108 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %106, i32 0, i32 1
-  store i64 2, ptr %108, align 4
-  %109 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %106, i32 0, i32 2
-  store i64 2, ptr %109, align 4
-  %110 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %106, align 8
-  %111 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
-  %112 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %111, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %54, ptr %112, align 8
-  %113 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %111, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %96, ptr %113, align 8
-  %114 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %115 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %114, i32 0, i32 0
-  store ptr %111, ptr %115, align 8
-  %116 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %114, i32 0, i32 1
-  store i64 2, ptr %116, align 4
-  %117 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %114, i32 0, i32 2
-  store i64 2, ptr %117, align 4
-  %118 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %114, align 8
-  %119 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %120 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %119, i32 0, i32 0
-  store ptr @2, ptr %120, align 8
-  %121 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %119, i32 0, i32 1
-  store i64 4, ptr %121, align 4
-  %122 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %119, align 8
-  %123 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %124 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %123, i32 0, i32 0
-  store ptr @6, ptr %124, align 8
-  %125 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %123, i32 0, i32 1
-  store i64 4, ptr %125, align 4
-  %126 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %123, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %4, %"github.com/goplus/llgo/internal/runtime.String" %122, %"github.com/goplus/llgo/internal/runtime.String" %126, ptr %18, %"github.com/goplus/llgo/internal/runtime.Slice" %110, %"github.com/goplus/llgo/internal/runtime.Slice" %118)
-  %127 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %128 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %129 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %130 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %129, i32 0, i32 0
-  store ptr @4, ptr %130, align 8
-  %131 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %129, i32 0, i32 1
-  store i64 8, ptr %131, align 4
-  %132 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %129, align 8
-  %133 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %134 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %133, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %132, ptr %134, align 8
-  %135 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %133, i32 0, i32 1
-  store ptr %127, ptr %135, align 8
-  %136 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %133, align 8
-  %137 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %138 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %137, i32 0, i32 0
-  store ptr @5, ptr %138, align 8
-  %139 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %137, i32 0, i32 1
-  store i64 8, ptr %139, align 4
-  %140 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %137, align 8
-  %141 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %142 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %141, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %140, ptr %142, align 8
-  %143 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %141, i32 0, i32 1
-  store ptr %128, ptr %143, align 8
-  %144 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %141, align 8
-  %145 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  %146 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %145, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %136, ptr %146, align 8
-  %147 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %145, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %144, ptr %147, align 8
-  %148 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %149 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %148, i32 0, i32 0
-  store ptr %145, ptr %149, align 8
-  %150 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %148, i32 0, i32 1
-  store i64 2, ptr %150, align 4
-  %151 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %148, i32 0, i32 2
-  store i64 2, ptr %151, align 4
-  %152 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %148, align 8
-  %153 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %154 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %153, i32 0, i32 0
-  store ptr @2, ptr %154, align 8
-  %155 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %153, i32 0, i32 1
-  store i64 4, ptr %155, align 4
-  %156 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %153, align 8
-  %157 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %158 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %157, i32 0, i32 0
-  store ptr null, ptr %158, align 8
-  %159 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %157, i32 0, i32 1
-  store i64 0, ptr %159, align 4
-  %160 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %157, align 8
-  %161 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %156, %"github.com/goplus/llgo/internal/runtime.String" %160, %"github.com/goplus/llgo/internal/runtime.Slice" %152)
-  store ptr %161, ptr @"main.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", align 8
-  %162 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %163 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %164 = load ptr, ptr @_llgo_main.I, align 8
-  %165 = icmp eq ptr %164, null
-  br i1 %165, label %_llgo_11, label %_llgo_12
+  %50 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %51 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %50, 1
+  %52 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %51, ptr @"main.(*impl).two", 2
+  %53 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %52, ptr @"main.(*impl).two", 3
+  %54 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %50, 1
+  %55 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %54, ptr @"main.(*impl).two", 2
+  %56 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %55, ptr @main.impl.two, 3
+  %57 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
+  %58 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %57, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %32, ptr %58, align 8
+  %59 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %57, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %56, ptr %59, align 8
+  %60 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %57, 0
+  %61 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %60, i64 2, 1
+  %62 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %61, i64 2, 2
+  %63 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
+  %64 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %63, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %29, ptr %64, align 8
+  %65 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %63, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %53, ptr %65, align 8
+  %66 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %63, 0
+  %67 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %66, i64 2, 1
+  %68 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %67, i64 2, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %0, %"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 4 }, ptr %8, %"github.com/goplus/llgo/internal/runtime.Slice" %62, %"github.com/goplus/llgo/internal/runtime.Slice" %68)
+  %69 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %70 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %71 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 8 }, ptr undef }, ptr %69, 1
+  %72 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 8 }, ptr undef }, ptr %70, 1
+  %73 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  %74 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %73, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %71, ptr %74, align 8
+  %75 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %73, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %72, ptr %75, align 8
+  %76 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %73, 0
+  %77 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %76, i64 2, 1
+  %78 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %77, i64 2, 2
+  %79 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %78)
+  store ptr %79, ptr @"main.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", align 8
+  %80 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %81 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %82 = load ptr, ptr @_llgo_main.I, align 8
+  %83 = icmp eq ptr %82, null
+  br i1 %83, label %_llgo_11, label %_llgo_12
 
 _llgo_11:                                         ; preds = %_llgo_10
-  %166 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %167 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %166, i32 0, i32 0
-  store ptr @4, ptr %167, align 8
-  %168 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %166, i32 0, i32 1
-  store i64 8, ptr %168, align 4
-  %169 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %166, align 8
-  %170 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %171 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %170, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %169, ptr %171, align 8
-  %172 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %170, i32 0, i32 1
-  store ptr %162, ptr %172, align 8
-  %173 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %170, align 8
-  %174 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %175 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %174, i32 0, i32 0
-  store ptr @5, ptr %175, align 8
-  %176 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %174, i32 0, i32 1
-  store i64 8, ptr %176, align 4
-  %177 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %174, align 8
-  %178 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %179 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %178, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %177, ptr %179, align 8
-  %180 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %178, i32 0, i32 1
-  store ptr %163, ptr %180, align 8
-  %181 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %178, align 8
-  %182 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  %183 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %182, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %173, ptr %183, align 8
-  %184 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %182, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %181, ptr %184, align 8
-  %185 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %186 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %185, i32 0, i32 0
-  store ptr %182, ptr %186, align 8
-  %187 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %185, i32 0, i32 1
-  store i64 2, ptr %187, align 4
-  %188 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %185, i32 0, i32 2
-  store i64 2, ptr %188, align 4
-  %189 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %185, align 8
-  %190 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %191 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %190, i32 0, i32 0
-  store ptr @2, ptr %191, align 8
-  %192 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %190, i32 0, i32 1
-  store i64 4, ptr %192, align 4
-  %193 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %190, align 8
-  %194 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %195 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %194, i32 0, i32 0
-  store ptr @7, ptr %195, align 8
-  %196 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %194, i32 0, i32 1
-  store i64 6, ptr %196, align 4
-  %197 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %194, align 8
-  %198 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %193, %"github.com/goplus/llgo/internal/runtime.String" %197, %"github.com/goplus/llgo/internal/runtime.Slice" %189)
-  store ptr %198, ptr @_llgo_main.I, align 8
+  %84 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 8 }, ptr undef }, ptr %80, 1
+  %85 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 8 }, ptr undef }, ptr %81, 1
+  %86 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  %87 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %86, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %84, ptr %87, align 8
+  %88 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %86, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %85, ptr %88, align 8
+  %89 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %86, 0
+  %90 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %89, i64 2, 1
+  %91 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %90, i64 2, 2
+  %92 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 6 }, %"github.com/goplus/llgo/internal/runtime.Slice" %91)
+  store ptr %92, ptr @_llgo_main.I, align 8
   br label %_llgo_12
 
 _llgo_12:                                         ; preds = %_llgo_11, %_llgo_10
@@ -994,16 +625,12 @@ _llgo_0:
   %4 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %2, 0
   %5 = getelementptr ptr, ptr %4, i64 3
   %6 = load ptr, ptr %5, align 8
-  %7 = alloca { ptr, ptr }, align 8
-  %8 = getelementptr inbounds { ptr, ptr }, ptr %7, i32 0, i32 0
-  store ptr %6, ptr %8, align 8
-  %9 = getelementptr inbounds { ptr, ptr }, ptr %7, i32 0, i32 1
-  store ptr %3, ptr %9, align 8
-  %10 = load { ptr, ptr }, ptr %7, align 8
-  %11 = extractvalue { ptr, ptr } %10, 1
-  %12 = extractvalue { ptr, ptr } %10, 0
-  %13 = call i64 %12(ptr %11)
-  ret i64 %13
+  %7 = insertvalue { ptr, ptr } undef, ptr %6, 0
+  %8 = insertvalue { ptr, ptr } %7, ptr %3, 1
+  %9 = extractvalue { ptr, ptr } %8, 1
+  %10 = extractvalue { ptr, ptr } %8, 0
+  %11 = call i64 %10(ptr %9)
+  ret i64 %11
 }
 
 declare i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.String")
@@ -1016,16 +643,12 @@ _llgo_0:
   %4 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %2, 0
   %5 = getelementptr ptr, ptr %4, i64 4
   %6 = load ptr, ptr %5, align 8
-  %7 = alloca { ptr, ptr }, align 8
-  %8 = getelementptr inbounds { ptr, ptr }, ptr %7, i32 0, i32 0
-  store ptr %6, ptr %8, align 8
-  %9 = getelementptr inbounds { ptr, ptr }, ptr %7, i32 0, i32 1
-  store ptr %3, ptr %9, align 8
-  %10 = load { ptr, ptr }, ptr %7, align 8
-  %11 = extractvalue { ptr, ptr } %10, 1
-  %12 = extractvalue { ptr, ptr } %10, 0
-  %13 = call %"github.com/goplus/llgo/internal/runtime.String" %12(ptr %11)
-  ret %"github.com/goplus/llgo/internal/runtime.String" %13
+  %7 = insertvalue { ptr, ptr } undef, ptr %6, 0
+  %8 = insertvalue { ptr, ptr } %7, ptr %3, 1
+  %9 = extractvalue { ptr, ptr } %8, 1
+  %10 = extractvalue { ptr, ptr } %8, 0
+  %11 = call %"github.com/goplus/llgo/internal/runtime.String" %10(ptr %9)
+  ret %"github.com/goplus/llgo/internal/runtime.String" %11
 }
 
 declare void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String")

--- a/cl/_testgo/interface/out.ll
+++ b/cl/_testgo/interface/out.ll
@@ -110,135 +110,83 @@ _llgo_0:
   store ptr %4, ptr %3, align 8
   %5 = load ptr, ptr @_llgo_main.Game1, align 8
   %6 = load ptr, ptr @"*_llgo_main.Game1", align 8
-  %7 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, i32 0, i32 0
-  store ptr %6, ptr %8, align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, i32 0, i32 1
-  store ptr %2, ptr %9, align 8
-  %10 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, align 8
-  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 0)
-  %12 = load ptr, ptr @_llgo_main.Game2, align 8
-  %13 = load ptr, ptr @"*_llgo_main.Game2", align 8
-  %14 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %14, i32 0, i32 0
-  store ptr %13, ptr %15, align 8
-  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %14, i32 0, i32 1
-  store ptr %11, ptr %16, align 8
-  %17 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %14, align 8
-  %18 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %10, 0
-  %19 = load ptr, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Gamer", align 8
-  %20 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %19, ptr %18)
-  br i1 %20, label %_llgo_3, label %_llgo_4
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %6, 0
+  %8 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %7, ptr %2, 1
+  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 0)
+  %10 = load ptr, ptr @_llgo_main.Game2, align 8
+  %11 = load ptr, ptr @"*_llgo_main.Game2", align 8
+  %12 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %11, 0
+  %13 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %12, ptr %9, 1
+  %14 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %8, 0
+  %15 = load ptr, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Gamer", align 8
+  %16 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %15, ptr %14)
+  br i1 %16, label %_llgo_3, label %_llgo_4
 
 _llgo_1:                                          ; preds = %_llgo_5
-  %21 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %50)
-  %22 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %50, 0
-  %23 = getelementptr ptr, ptr %22, i64 3
-  %24 = load ptr, ptr %23, align 8
-  %25 = alloca { ptr, ptr }, align 8
-  %26 = getelementptr inbounds { ptr, ptr }, ptr %25, i32 0, i32 0
-  store ptr %24, ptr %26, align 8
-  %27 = getelementptr inbounds { ptr, ptr }, ptr %25, i32 0, i32 1
-  store ptr %21, ptr %27, align 8
-  %28 = load { ptr, ptr }, ptr %25, align 8
-  %29 = extractvalue { ptr, ptr } %28, 1
-  %30 = extractvalue { ptr, ptr } %28, 0
-  call void %30(ptr %29)
+  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %36)
+  %18 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %36, 0
+  %19 = getelementptr ptr, ptr %18, i64 3
+  %20 = load ptr, ptr %19, align 8
+  %21 = insertvalue { ptr, ptr } undef, ptr %20, 0
+  %22 = insertvalue { ptr, ptr } %21, ptr %17, 1
+  %23 = extractvalue { ptr, ptr } %22, 1
+  %24 = extractvalue { ptr, ptr } %22, 0
+  call void %24(ptr %23)
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_5
-  %31 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %17, 0
-  %32 = load ptr, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Gamer", align 8
-  %33 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %32, ptr %31)
-  br i1 %33, label %_llgo_6, label %_llgo_7
+  %25 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %13, 0
+  %26 = load ptr, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Gamer", align 8
+  %27 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %26, ptr %25)
+  br i1 %27, label %_llgo_6, label %_llgo_7
 
 _llgo_3:                                          ; preds = %_llgo_0
-  %34 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %10, 1
-  %35 = load ptr, ptr @"main.iface$sO8a1LvuUsjXwiwaC6sR9-L4DiYgiOnZi7iosyShJXg", align 8
-  %36 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %35, ptr %18)
-  %37 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %37, i32 0, i32 0
-  store ptr %36, ptr %38, align 8
-  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %37, i32 0, i32 1
-  store ptr %34, ptr %39, align 8
-  %40 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %37, align 8
-  %41 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
-  %42 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %41, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.iface" %40, ptr %42, align 8
-  %43 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %41, i32 0, i32 1
-  store i1 true, ptr %43, align 1
-  %44 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %41, align 8
+  %28 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %8, 1
+  %29 = load ptr, ptr @"main.iface$sO8a1LvuUsjXwiwaC6sR9-L4DiYgiOnZi7iosyShJXg", align 8
+  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %29, ptr %14)
+  %31 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %30, 0
+  %32 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %31, ptr %28, 1
+  %33 = insertvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } undef, %"github.com/goplus/llgo/internal/runtime.iface" %32, 0
+  %34 = insertvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %33, i1 true, 1
   br label %_llgo_5
 
 _llgo_4:                                          ; preds = %_llgo_0
-  %45 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
-  %46 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %45, i32 0, i32 0
-  store { ptr, ptr } zeroinitializer, ptr %46, align 8
-  %47 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %45, i32 0, i32 1
-  store i1 false, ptr %47, align 1
-  %48 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %45, align 8
   br label %_llgo_5
 
 _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
-  %49 = phi { %"github.com/goplus/llgo/internal/runtime.iface", i1 } [ %44, %_llgo_3 ], [ %48, %_llgo_4 ]
-  %50 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %49, 0
-  %51 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %49, 1
-  %52 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %53 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %52, i32 0, i32 0
-  store ptr @13, ptr %53, align 8
-  %54 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %52, i32 0, i32 1
-  store i64 2, ptr %54, align 4
-  %55 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %52, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %55)
+  %35 = phi { %"github.com/goplus/llgo/internal/runtime.iface", i1 } [ %34, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
+  %36 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %35, 0
+  %37 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %35, 1
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @13, i64 2 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintIface"(%"github.com/goplus/llgo/internal/runtime.iface" %50)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintIface"(%"github.com/goplus/llgo/internal/runtime.iface" %36)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %51)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %37)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  br i1 %51, label %_llgo_1, label %_llgo_2
+  br i1 %37, label %_llgo_1, label %_llgo_2
 
 _llgo_6:                                          ; preds = %_llgo_2
-  %56 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %17, 1
-  %57 = load ptr, ptr @"main.iface$sO8a1LvuUsjXwiwaC6sR9-L4DiYgiOnZi7iosyShJXg", align 8
-  %58 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %57, ptr %31)
-  %59 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %59, i32 0, i32 0
-  store ptr %58, ptr %60, align 8
-  %61 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %59, i32 0, i32 1
-  store ptr %56, ptr %61, align 8
-  %62 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %59, align 8
-  %63 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
-  %64 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %63, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.iface" %62, ptr %64, align 8
-  %65 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %63, i32 0, i32 1
-  store i1 true, ptr %65, align 1
-  %66 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %63, align 8
+  %38 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %13, 1
+  %39 = load ptr, ptr @"main.iface$sO8a1LvuUsjXwiwaC6sR9-L4DiYgiOnZi7iosyShJXg", align 8
+  %40 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %39, ptr %25)
+  %41 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %40, 0
+  %42 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %41, ptr %38, 1
+  %43 = insertvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } undef, %"github.com/goplus/llgo/internal/runtime.iface" %42, 0
+  %44 = insertvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %43, i1 true, 1
   br label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_2
-  %67 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
-  %68 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %67, i32 0, i32 0
-  store { ptr, ptr } zeroinitializer, ptr %68, align 8
-  %69 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %67, i32 0, i32 1
-  store i1 false, ptr %69, align 1
-  %70 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %67, align 8
   br label %_llgo_8
 
 _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
-  %71 = phi { %"github.com/goplus/llgo/internal/runtime.iface", i1 } [ %66, %_llgo_6 ], [ %70, %_llgo_7 ]
-  %72 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %71, 0
-  %73 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %71, 1
-  %74 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %75 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %74, i32 0, i32 0
-  store ptr @14, ptr %75, align 8
-  %76 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %74, i32 0, i32 1
-  store i64 4, ptr %76, align 4
-  %77 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %74, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %77)
+  %45 = phi { %"github.com/goplus/llgo/internal/runtime.iface", i1 } [ %44, %_llgo_6 ], [ zeroinitializer, %_llgo_7 ]
+  %46 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %45, 0
+  %47 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %45, 1
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @14, i64 4 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintIface"(%"github.com/goplus/llgo/internal/runtime.iface" %72)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintIface"(%"github.com/goplus/llgo/internal/runtime.iface" %46)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %73)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %47)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 }
@@ -258,549 +206,239 @@ declare ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64)
 
 define void @"main.init$after"() {
 _llgo_0:
-  %0 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 0
-  store ptr @0, ptr %1, align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 1
-  store i64 10, ptr %2, align 4
-  %3 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %0, align 8
-  %4 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3, i64 25, i64 8, i64 2, i64 2)
-  %5 = load ptr, ptr @_llgo_main.Game1, align 8
-  %6 = icmp eq ptr %5, null
-  br i1 %6, label %_llgo_1, label %_llgo_2
+  %0 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 10 }, i64 25, i64 8, i64 2, i64 2)
+  %1 = load ptr, ptr @_llgo_main.Game1, align 8
+  %2 = icmp eq ptr %1, null
+  br i1 %2, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %4)
-  store ptr %4, ptr @_llgo_main.Game1, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %0)
+  store ptr %0, ptr @_llgo_main.Game1, align 8
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-  %7 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %7, i32 0, i32 0
-  store ptr @1, ptr %8, align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %7, i32 0, i32 1
-  store i64 43, ptr %9, align 4
-  %10 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %7, align 8
-  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %10, i64 25, i64 0, i64 0, i64 2)
-  %12 = load ptr, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Game", align 8
-  %13 = icmp eq ptr %12, null
-  br i1 %13, label %_llgo_3, label %_llgo_4
+  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 43 }, i64 25, i64 0, i64 0, i64 2)
+  %4 = load ptr, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Game", align 8
+  %5 = icmp eq ptr %4, null
+  br i1 %5, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  store ptr %11, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Game", align 8
+  store ptr %3, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Game", align 8
   br label %_llgo_4
 
 _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
-  %14 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
-  %15 = icmp eq ptr %14, null
-  br i1 %15, label %_llgo_5, label %_llgo_6
+  %6 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
+  %7 = icmp eq ptr %6, null
+  br i1 %7, label %_llgo_5, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_4
-  %16 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %16, i32 0, i32 0
-  store ptr @2, ptr %17, align 8
-  %18 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %16, i32 0, i32 1
-  store i64 4, ptr %18, align 4
-  %19 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %16, align 8
-  %20 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %21 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, i32 0, i32 0
-  store ptr %20, ptr %22, align 8
-  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, i32 0, i32 1
-  store i64 0, ptr %23, align 4
-  %24 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, i32 0, i32 2
-  store i64 0, ptr %24, align 4
-  %25 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, align 8
-  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %19, i64 0, %"github.com/goplus/llgo/internal/runtime.Slice" %25)
-  store ptr %26, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
+  %8 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %8, 0
+  %10 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, i64 0, 1
+  %11 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %10, i64 0, 2
+  %12 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, i64 0, %"github.com/goplus/llgo/internal/runtime.Slice" %11)
+  store ptr %12, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %27 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
-  br i1 %13, label %_llgo_7, label %_llgo_8
+  %13 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
+  br i1 %5, label %_llgo_7, label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_6
-  %28 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %29 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %28, i32 0, i32 0
-  store ptr @3, ptr %29, align 8
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %28, i32 0, i32 1
-  store i64 4, ptr %30, align 4
-  %31 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %28, align 8
-  %32 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %33 = icmp eq ptr %32, null
-  br i1 %33, label %_llgo_9, label %_llgo_10
+  %14 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %15 = icmp eq ptr %14, null
+  br i1 %15, label %_llgo_9, label %_llgo_10
 
 _llgo_8:                                          ; preds = %_llgo_10, %_llgo_6
-  %34 = load ptr, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Game", align 8
-  %35 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %36 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %35, i32 0, i32 0
-  store ptr @1, ptr %36, align 8
-  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %35, i32 0, i32 1
-  store i64 43, ptr %37, align 4
-  %38 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %35, align 8
-  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %38, i64 25, i64 0, i64 0, i64 2)
-  %40 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/cl/internal/foo.Game", align 8
-  %41 = icmp eq ptr %40, null
-  br i1 %41, label %_llgo_11, label %_llgo_12
+  %16 = load ptr, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Game", align 8
+  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 43 }, i64 25, i64 0, i64 0, i64 2)
+  %18 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/cl/internal/foo.Game", align 8
+  %19 = icmp eq ptr %18, null
+  br i1 %19, label %_llgo_11, label %_llgo_12
 
 _llgo_9:                                          ; preds = %_llgo_7
-  %42 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %43 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %43, i32 0, i32 0
-  store ptr %42, ptr %44, align 8
-  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %43, i32 0, i32 1
-  store i64 0, ptr %45, align 4
-  %46 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %43, i32 0, i32 2
-  store i64 0, ptr %46, align 4
-  %47 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %43, align 8
-  %48 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %49 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %49, i32 0, i32 0
-  store ptr %48, ptr %50, align 8
-  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %49, i32 0, i32 1
-  store i64 0, ptr %51, align 4
-  %52 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %49, i32 0, i32 2
-  store i64 0, ptr %52, align 4
-  %53 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %49, align 8
-  %54 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %47, %"github.com/goplus/llgo/internal/runtime.Slice" %53, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %54)
-  store ptr %54, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %20 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %21 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %20, 0
+  %22 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %21, i64 0, 1
+  %23 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %22, i64 0, 2
+  %24 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %25 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %24, 0
+  %26 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %25, i64 0, 1
+  %27 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %26, i64 0, 2
+  %28 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %23, %"github.com/goplus/llgo/internal/runtime.Slice" %27, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %28)
+  store ptr %28, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
   br label %_llgo_10
 
 _llgo_10:                                         ; preds = %_llgo_9, %_llgo_7
-  %55 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %56 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %56, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %31, ptr %57, align 8
-  %58 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %56, i32 0, i32 1
-  store ptr %55, ptr %58, align 8
-  %59 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %56, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/cl/internal/foo.(*Game).Load", ptr %59, align 8
-  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %56, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/cl/internal/foo.(*Game).Load", ptr %60, align 8
-  %61 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %56, align 8
-  %62 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %63 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %62, i32 0, i32 0
-  store ptr @4, ptr %63, align 8
-  %64 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %62, i32 0, i32 1
-  store i64 8, ptr %64, align 4
-  %65 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %62, align 8
-  %66 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %67 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %66, i32 0, i32 0
-  store ptr @5, ptr %67, align 8
-  %68 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %66, i32 0, i32 1
-  store i64 47, ptr %68, align 4
-  %69 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %66, align 8
-  %70 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %71 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %72 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %71, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %69, ptr %72, align 8
-  %73 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %71, i32 0, i32 1
-  store ptr %70, ptr %73, align 8
-  %74 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %71, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/cl/internal/foo.(*Game).initGame", ptr %74, align 8
-  %75 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %71, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/cl/internal/foo.(*Game).initGame", ptr %75, align 8
-  %76 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %71, align 8
-  %77 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
-  %78 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %77, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %61, ptr %78, align 8
-  %79 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %77, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %76, ptr %79, align 8
-  %80 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %81 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %80, i32 0, i32 0
-  store ptr %77, ptr %81, align 8
-  %82 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %80, i32 0, i32 1
-  store i64 2, ptr %82, align 4
-  %83 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %80, i32 0, i32 2
-  store i64 2, ptr %83, align 4
-  %84 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %80, align 8
-  %85 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %86 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %85, i32 0, i32 0
-  store ptr @6, ptr %86, align 8
-  %87 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %85, i32 0, i32 1
-  store i64 38, ptr %87, align 4
-  %88 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %85, align 8
-  %89 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %90 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %89, i32 0, i32 0
-  store ptr @7, ptr %90, align 8
-  %91 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %89, i32 0, i32 1
-  store i64 4, ptr %91, align 4
-  %92 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %89, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %11, %"github.com/goplus/llgo/internal/runtime.String" %88, %"github.com/goplus/llgo/internal/runtime.String" %92, ptr %27, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %84)
+  %29 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %30 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %29, 1
+  %31 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %30, ptr @"github.com/goplus/llgo/cl/internal/foo.(*Game).Load", 2
+  %32 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %31, ptr @"github.com/goplus/llgo/cl/internal/foo.(*Game).Load", 3
+  %33 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %34 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 47 }, ptr undef, ptr undef, ptr undef }, ptr %33, 1
+  %35 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %34, ptr @"github.com/goplus/llgo/cl/internal/foo.(*Game).initGame", 2
+  %36 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %35, ptr @"github.com/goplus/llgo/cl/internal/foo.(*Game).initGame", 3
+  %37 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
+  %38 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %37, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %32, ptr %38, align 8
+  %39 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %37, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %36, ptr %39, align 8
+  %40 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %37, 0
+  %41 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %40, i64 2, 1
+  %42 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %41, i64 2, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %3, %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 38 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 }, ptr %13, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %42)
   br label %_llgo_8
 
 _llgo_11:                                         ; preds = %_llgo_8
-  %93 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %39)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %93)
-  store ptr %93, ptr @"*_llgo_github.com/goplus/llgo/cl/internal/foo.Game", align 8
+  %43 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %17)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %43)
+  store ptr %43, ptr @"*_llgo_github.com/goplus/llgo/cl/internal/foo.Game", align 8
   br label %_llgo_12
 
 _llgo_12:                                         ; preds = %_llgo_11, %_llgo_8
-  %94 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/cl/internal/foo.Game", align 8
-  %95 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %96 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %95, i32 0, i32 0
-  store ptr @1, ptr %96, align 8
-  %97 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %95, i32 0, i32 1
-  store i64 43, ptr %97, align 4
-  %98 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %95, align 8
-  %99 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %98, i64 25, i64 0, i64 0, i64 2)
-  %100 = load ptr, ptr @"_llgo_struct$cJmCzeVn0orHWafCrTGAnbbAF46F2A4Fms4bJBm8ITI", align 8
-  %101 = icmp eq ptr %100, null
-  br i1 %101, label %_llgo_13, label %_llgo_14
+  %44 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/cl/internal/foo.Game", align 8
+  %45 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 43 }, i64 25, i64 0, i64 0, i64 2)
+  %46 = load ptr, ptr @"_llgo_struct$cJmCzeVn0orHWafCrTGAnbbAF46F2A4Fms4bJBm8ITI", align 8
+  %47 = icmp eq ptr %46, null
+  br i1 %47, label %_llgo_13, label %_llgo_14
 
 _llgo_13:                                         ; preds = %_llgo_12
-  %102 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %103 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %102, i32 0, i32 0
-  store ptr @7, ptr %103, align 8
-  %104 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %102, i32 0, i32 1
-  store i64 4, ptr %104, align 4
-  %105 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %102, align 8
-  %106 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %107 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %106, i32 0, i32 0
-  store ptr null, ptr %107, align 8
-  %108 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %106, i32 0, i32 1
-  store i64 0, ptr %108, align 4
-  %109 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %106, align 8
-  %110 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %99)
-  %111 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %105, ptr %110, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %109, i1 true)
-  %112 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %113 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %112, i32 0, i32 0
-  store ptr @2, ptr %113, align 8
-  %114 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %112, i32 0, i32 1
-  store i64 4, ptr %114, align 4
-  %115 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %112, align 8
-  %116 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
-  %117 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %116, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %111, ptr %117, align 8
-  %118 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %119 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %118, i32 0, i32 0
-  store ptr %116, ptr %119, align 8
-  %120 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %118, i32 0, i32 1
-  store i64 1, ptr %120, align 4
-  %121 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %118, i32 0, i32 2
-  store i64 1, ptr %121, align 4
-  %122 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %118, align 8
-  %123 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %115, i64 8, %"github.com/goplus/llgo/internal/runtime.Slice" %122)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %123)
-  store ptr %123, ptr @"_llgo_struct$cJmCzeVn0orHWafCrTGAnbbAF46F2A4Fms4bJBm8ITI", align 8
+  %48 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %45)
+  %49 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 }, ptr %48, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 true)
+  %50 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
+  %51 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %50, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %49, ptr %51, align 8
+  %52 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %50, 0
+  %53 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %52, i64 1, 1
+  %54 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %53, i64 1, 2
+  %55 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, i64 8, %"github.com/goplus/llgo/internal/runtime.Slice" %54)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %55)
+  store ptr %55, ptr @"_llgo_struct$cJmCzeVn0orHWafCrTGAnbbAF46F2A4Fms4bJBm8ITI", align 8
   br label %_llgo_14
 
 _llgo_14:                                         ; preds = %_llgo_13, %_llgo_12
-  %124 = load ptr, ptr @"_llgo_struct$cJmCzeVn0orHWafCrTGAnbbAF46F2A4Fms4bJBm8ITI", align 8
-  br i1 %6, label %_llgo_15, label %_llgo_16
+  %56 = load ptr, ptr @"_llgo_struct$cJmCzeVn0orHWafCrTGAnbbAF46F2A4Fms4bJBm8ITI", align 8
+  br i1 %2, label %_llgo_15, label %_llgo_16
 
 _llgo_15:                                         ; preds = %_llgo_14
-  %125 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %126 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %125, i32 0, i32 0
-  store ptr @3, ptr %126, align 8
-  %127 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %125, i32 0, i32 1
-  store i64 4, ptr %127, align 4
-  %128 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %125, align 8
-  %129 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %130 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %131 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %130, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %128, ptr %131, align 8
-  %132 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %130, i32 0, i32 1
-  store ptr %129, ptr %132, align 8
-  %133 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %130, i32 0, i32 2
-  store ptr @"main.(*Game1).Load", ptr %133, align 8
-  %134 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %130, i32 0, i32 3
-  store ptr @"main.(*Game1).Load", ptr %134, align 8
-  %135 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %130, align 8
-  %136 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %137 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %136, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %128, ptr %137, align 8
-  %138 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %136, i32 0, i32 1
-  store ptr %129, ptr %138, align 8
-  %139 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %136, i32 0, i32 2
-  store ptr @"main.(*Game1).Load", ptr %139, align 8
-  %140 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %136, i32 0, i32 3
-  store ptr @main.Game1.Load, ptr %140, align 8
-  %141 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %136, align 8
-  %142 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %143 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %142, i32 0, i32 0
-  store ptr @4, ptr %143, align 8
-  %144 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %142, i32 0, i32 1
-  store i64 8, ptr %144, align 4
-  %145 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %142, align 8
-  %146 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %147 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %146, i32 0, i32 0
-  store ptr @5, ptr %147, align 8
-  %148 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %146, i32 0, i32 1
-  store i64 47, ptr %148, align 4
-  %149 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %146, align 8
-  %150 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %151 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %152 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %151, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %149, ptr %152, align 8
-  %153 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %151, i32 0, i32 1
-  store ptr %150, ptr %153, align 8
-  %154 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %151, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/cl/internal/foo.(*Game).initGame", ptr %154, align 8
-  %155 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %151, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/cl/internal/foo.(*Game).initGame", ptr %155, align 8
-  %156 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %151, align 8
-  %157 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %158 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %157, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %141, ptr %158, align 8
-  %159 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %160 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %159, i32 0, i32 0
-  store ptr %157, ptr %160, align 8
-  %161 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %159, i32 0, i32 1
-  store i64 1, ptr %161, align 4
-  %162 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %159, i32 0, i32 2
-  store i64 1, ptr %162, align 4
-  %163 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %159, align 8
-  %164 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
-  %165 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %164, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %135, ptr %165, align 8
-  %166 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %164, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %156, ptr %166, align 8
-  %167 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %168 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %167, i32 0, i32 0
-  store ptr %164, ptr %168, align 8
-  %169 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %167, i32 0, i32 1
-  store i64 2, ptr %169, align 4
-  %170 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %167, i32 0, i32 2
-  store i64 2, ptr %170, align 4
-  %171 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %167, align 8
-  %172 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %173 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %172, i32 0, i32 0
-  store ptr @2, ptr %173, align 8
-  %174 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %172, i32 0, i32 1
-  store i64 4, ptr %174, align 4
-  %175 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %172, align 8
-  %176 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %177 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %176, i32 0, i32 0
-  store ptr @8, ptr %177, align 8
-  %178 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %176, i32 0, i32 1
-  store i64 5, ptr %178, align 4
-  %179 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %176, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %4, %"github.com/goplus/llgo/internal/runtime.String" %175, %"github.com/goplus/llgo/internal/runtime.String" %179, ptr %124, %"github.com/goplus/llgo/internal/runtime.Slice" %163, %"github.com/goplus/llgo/internal/runtime.Slice" %171)
+  %57 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %58 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %57, 1
+  %59 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %58, ptr @"main.(*Game1).Load", 2
+  %60 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %59, ptr @"main.(*Game1).Load", 3
+  %61 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %57, 1
+  %62 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %61, ptr @"main.(*Game1).Load", 2
+  %63 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %62, ptr @main.Game1.Load, 3
+  %64 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %65 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 47 }, ptr undef, ptr undef, ptr undef }, ptr %64, 1
+  %66 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %65, ptr @"github.com/goplus/llgo/cl/internal/foo.(*Game).initGame", 2
+  %67 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %66, ptr @"github.com/goplus/llgo/cl/internal/foo.(*Game).initGame", 3
+  %68 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %69 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %68, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %63, ptr %69, align 8
+  %70 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %68, 0
+  %71 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %70, i64 1, 1
+  %72 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %71, i64 1, 2
+  %73 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
+  %74 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %73, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %60, ptr %74, align 8
+  %75 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %73, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %67, ptr %75, align 8
+  %76 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %73, 0
+  %77 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %76, i64 2, 1
+  %78 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %77, i64 2, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %0, %"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 5 }, ptr %56, %"github.com/goplus/llgo/internal/runtime.Slice" %72, %"github.com/goplus/llgo/internal/runtime.Slice" %78)
   br label %_llgo_16
 
 _llgo_16:                                         ; preds = %_llgo_15, %_llgo_14
-  %180 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %181 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %180, i32 0, i32 0
-  store ptr @0, ptr %181, align 8
-  %182 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %180, i32 0, i32 1
-  store i64 10, ptr %182, align 4
-  %183 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %180, align 8
-  %184 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %183, i64 25, i64 8, i64 2, i64 2)
-  %185 = load ptr, ptr @"*_llgo_main.Game1", align 8
-  %186 = icmp eq ptr %185, null
-  br i1 %186, label %_llgo_17, label %_llgo_18
+  %79 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 10 }, i64 25, i64 8, i64 2, i64 2)
+  %80 = load ptr, ptr @"*_llgo_main.Game1", align 8
+  %81 = icmp eq ptr %80, null
+  br i1 %81, label %_llgo_17, label %_llgo_18
 
 _llgo_17:                                         ; preds = %_llgo_16
-  %187 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %184)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %187)
-  store ptr %187, ptr @"*_llgo_main.Game1", align 8
+  %82 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %79)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %82)
+  store ptr %82, ptr @"*_llgo_main.Game1", align 8
   br label %_llgo_18
 
 _llgo_18:                                         ; preds = %_llgo_17, %_llgo_16
-  %188 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %189 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %188, i32 0, i32 0
-  store ptr @9, ptr %189, align 8
-  %190 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %188, i32 0, i32 1
-  store i64 10, ptr %190, align 4
-  %191 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %188, align 8
-  %192 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %191, i64 25, i64 0, i64 0, i64 1)
-  %193 = load ptr, ptr @_llgo_main.Game2, align 8
-  %194 = icmp eq ptr %193, null
-  br i1 %194, label %_llgo_19, label %_llgo_20
+  %83 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 10 }, i64 25, i64 0, i64 0, i64 1)
+  %84 = load ptr, ptr @_llgo_main.Game2, align 8
+  %85 = icmp eq ptr %84, null
+  br i1 %85, label %_llgo_19, label %_llgo_20
 
 _llgo_19:                                         ; preds = %_llgo_18
-  store ptr %192, ptr @_llgo_main.Game2, align 8
+  store ptr %83, ptr @_llgo_main.Game2, align 8
   br label %_llgo_20
 
 _llgo_20:                                         ; preds = %_llgo_19, %_llgo_18
-  %195 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
-  br i1 %194, label %_llgo_21, label %_llgo_22
+  %86 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
+  br i1 %85, label %_llgo_21, label %_llgo_22
 
 _llgo_21:                                         ; preds = %_llgo_20
-  %196 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %197 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %196, i32 0, i32 0
-  store ptr @4, ptr %197, align 8
-  %198 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %196, i32 0, i32 1
-  store i64 8, ptr %198, align 4
-  %199 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %196, align 8
-  %200 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %201 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %200, i32 0, i32 0
-  store ptr @10, ptr %201, align 8
-  %202 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %200, i32 0, i32 1
-  store i64 13, ptr %202, align 4
-  %203 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %200, align 8
-  %204 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %205 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %206 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %205, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %203, ptr %206, align 8
-  %207 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %205, i32 0, i32 1
-  store ptr %204, ptr %207, align 8
-  %208 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %205, i32 0, i32 2
-  store ptr @"main.(*Game2).initGame", ptr %208, align 8
-  %209 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %205, i32 0, i32 3
-  store ptr @"main.(*Game2).initGame", ptr %209, align 8
-  %210 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %205, align 8
-  %211 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %212 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %211, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %210, ptr %212, align 8
-  %213 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %214 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %213, i32 0, i32 0
-  store ptr %211, ptr %214, align 8
-  %215 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %213, i32 0, i32 1
-  store i64 1, ptr %215, align 4
-  %216 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %213, i32 0, i32 2
-  store i64 1, ptr %216, align 4
-  %217 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %213, align 8
-  %218 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %219 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %218, i32 0, i32 0
-  store ptr @2, ptr %219, align 8
-  %220 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %218, i32 0, i32 1
-  store i64 4, ptr %220, align 4
-  %221 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %218, align 8
-  %222 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %223 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %222, i32 0, i32 0
-  store ptr @11, ptr %223, align 8
-  %224 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %222, i32 0, i32 1
-  store i64 5, ptr %224, align 4
-  %225 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %222, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %192, %"github.com/goplus/llgo/internal/runtime.String" %221, %"github.com/goplus/llgo/internal/runtime.String" %225, ptr %195, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %217)
+  %87 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %88 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 13 }, ptr undef, ptr undef, ptr undef }, ptr %87, 1
+  %89 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %88, ptr @"main.(*Game2).initGame", 2
+  %90 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %89, ptr @"main.(*Game2).initGame", 3
+  %91 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %92 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %91, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %90, ptr %92, align 8
+  %93 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %91, 0
+  %94 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %93, i64 1, 1
+  %95 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %94, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %83, %"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 5 }, ptr %86, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %95)
   br label %_llgo_22
 
 _llgo_22:                                         ; preds = %_llgo_21, %_llgo_20
-  %226 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %227 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %226, i32 0, i32 0
-  store ptr @9, ptr %227, align 8
-  %228 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %226, i32 0, i32 1
-  store i64 10, ptr %228, align 4
-  %229 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %226, align 8
-  %230 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %229, i64 25, i64 0, i64 0, i64 1)
-  %231 = load ptr, ptr @"*_llgo_main.Game2", align 8
-  %232 = icmp eq ptr %231, null
-  br i1 %232, label %_llgo_23, label %_llgo_24
+  %96 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 10 }, i64 25, i64 0, i64 0, i64 1)
+  %97 = load ptr, ptr @"*_llgo_main.Game2", align 8
+  %98 = icmp eq ptr %97, null
+  br i1 %98, label %_llgo_23, label %_llgo_24
 
 _llgo_23:                                         ; preds = %_llgo_22
-  %233 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %230)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %233)
-  store ptr %233, ptr @"*_llgo_main.Game2", align 8
+  %99 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %96)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %99)
+  store ptr %99, ptr @"*_llgo_main.Game2", align 8
   br label %_llgo_24
 
 _llgo_24:                                         ; preds = %_llgo_23, %_llgo_22
-  %234 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %235 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %236 = load ptr, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Gamer", align 8
-  %237 = icmp eq ptr %236, null
-  br i1 %237, label %_llgo_25, label %_llgo_26
+  %100 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %101 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %102 = load ptr, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Gamer", align 8
+  %103 = icmp eq ptr %102, null
+  br i1 %103, label %_llgo_25, label %_llgo_26
 
 _llgo_25:                                         ; preds = %_llgo_24
-  %238 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %239 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %238, i32 0, i32 0
-  store ptr @3, ptr %239, align 8
-  %240 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %238, i32 0, i32 1
-  store i64 4, ptr %240, align 4
-  %241 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %238, align 8
-  %242 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %243 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %242, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %241, ptr %243, align 8
-  %244 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %242, i32 0, i32 1
-  store ptr %234, ptr %244, align 8
-  %245 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %242, align 8
-  %246 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %247 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %246, i32 0, i32 0
-  store ptr @5, ptr %247, align 8
-  %248 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %246, i32 0, i32 1
-  store i64 47, ptr %248, align 4
-  %249 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %246, align 8
-  %250 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %251 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %250, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %249, ptr %251, align 8
-  %252 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %250, i32 0, i32 1
-  store ptr %235, ptr %252, align 8
-  %253 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %250, align 8
-  %254 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  %255 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %254, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %245, ptr %255, align 8
-  %256 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %254, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %253, ptr %256, align 8
-  %257 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %258 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %257, i32 0, i32 0
-  store ptr %254, ptr %258, align 8
-  %259 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %257, i32 0, i32 1
-  store i64 2, ptr %259, align 4
-  %260 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %257, i32 0, i32 2
-  store i64 2, ptr %260, align 4
-  %261 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %257, align 8
-  %262 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %263 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %262, i32 0, i32 0
-  store ptr @6, ptr %263, align 8
-  %264 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %262, i32 0, i32 1
-  store i64 38, ptr %264, align 4
-  %265 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %262, align 8
-  %266 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %267 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %266, i32 0, i32 0
-  store ptr @12, ptr %267, align 8
-  %268 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %266, i32 0, i32 1
-  store i64 44, ptr %268, align 4
-  %269 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %266, align 8
-  %270 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %265, %"github.com/goplus/llgo/internal/runtime.String" %269, %"github.com/goplus/llgo/internal/runtime.Slice" %261)
-  store ptr %270, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Gamer", align 8
+  %104 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, ptr undef }, ptr %100, 1
+  %105 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 47 }, ptr undef }, ptr %101, 1
+  %106 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  %107 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %106, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %104, ptr %107, align 8
+  %108 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %106, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %105, ptr %108, align 8
+  %109 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %106, 0
+  %110 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %109, i64 2, 1
+  %111 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %110, i64 2, 2
+  %112 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 38 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @12, i64 44 }, %"github.com/goplus/llgo/internal/runtime.Slice" %111)
+  store ptr %112, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Gamer", align 8
   br label %_llgo_26
 
 _llgo_26:                                         ; preds = %_llgo_25, %_llgo_24
-  %271 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %272 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %273 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %274 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %273, i32 0, i32 0
-  store ptr @3, ptr %274, align 8
-  %275 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %273, i32 0, i32 1
-  store i64 4, ptr %275, align 4
-  %276 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %273, align 8
-  %277 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %278 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %277, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %276, ptr %278, align 8
-  %279 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %277, i32 0, i32 1
-  store ptr %271, ptr %279, align 8
-  %280 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %277, align 8
-  %281 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %282 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %281, i32 0, i32 0
-  store ptr @5, ptr %282, align 8
-  %283 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %281, i32 0, i32 1
-  store i64 47, ptr %283, align 4
-  %284 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %281, align 8
-  %285 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %286 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %285, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %284, ptr %286, align 8
-  %287 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %285, i32 0, i32 1
-  store ptr %272, ptr %287, align 8
-  %288 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %285, align 8
-  %289 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  %290 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %289, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %280, ptr %290, align 8
-  %291 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %289, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %288, ptr %291, align 8
-  %292 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %293 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %292, i32 0, i32 0
-  store ptr %289, ptr %293, align 8
-  %294 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %292, i32 0, i32 1
-  store i64 2, ptr %294, align 4
-  %295 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %292, i32 0, i32 2
-  store i64 2, ptr %295, align 4
-  %296 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %292, align 8
-  %297 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %298 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %297, i32 0, i32 0
-  store ptr @2, ptr %298, align 8
-  %299 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %297, i32 0, i32 1
-  store i64 4, ptr %299, align 4
-  %300 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %297, align 8
-  %301 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %302 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %301, i32 0, i32 0
-  store ptr null, ptr %302, align 8
-  %303 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %301, i32 0, i32 1
-  store i64 0, ptr %303, align 4
-  %304 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %301, align 8
-  %305 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %300, %"github.com/goplus/llgo/internal/runtime.String" %304, %"github.com/goplus/llgo/internal/runtime.Slice" %296)
-  store ptr %305, ptr @"main.iface$sO8a1LvuUsjXwiwaC6sR9-L4DiYgiOnZi7iosyShJXg", align 8
+  %113 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %114 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %115 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, ptr undef }, ptr %113, 1
+  %116 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 47 }, ptr undef }, ptr %114, 1
+  %117 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  %118 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %117, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %115, ptr %118, align 8
+  %119 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %117, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %116, ptr %119, align 8
+  %120 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %117, 0
+  %121 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %120, i64 2, 1
+  %122 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %121, i64 2, 2
+  %123 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %122)
+  store ptr %123, ptr @"main.iface$sO8a1LvuUsjXwiwaC6sR9-L4DiYgiOnZi7iosyShJXg", align 8
   ret void
 }
 

--- a/cl/_testgo/invoke/out.ll
+++ b/cl/_testgo/invoke/out.ll
@@ -85,13 +85,7 @@ _llgo_0:
   store %main.T %0, ptr %1, align 8
   %2 = getelementptr inbounds %main.T, ptr %1, i32 0, i32 0
   %3 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @0, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 6, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %7)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 6 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %3)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
@@ -112,13 +106,7 @@ _llgo_0:
 
 define i64 @main.T1.Invoke(i64 %0) {
 _llgo_0:
-  %1 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1, i32 0, i32 0
-  store ptr @1, ptr %2, align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1, i32 0, i32 1
-  store i64 7, ptr %3, align 4
-  %4 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %4)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 7 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %0)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
@@ -134,13 +122,7 @@ _llgo_0:
 
 define i64 @main.T2.Invoke(double %0) {
 _llgo_0:
-  %1 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1, i32 0, i32 0
-  store ptr @2, ptr %2, align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1, i32 0, i32 1
-  store i64 7, ptr %3, align 4
-  %4 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %4)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 7 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %0)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
@@ -157,16 +139,10 @@ _llgo_0:
 define i64 @"main.(*T3).Invoke"(ptr %0) {
 _llgo_0:
   %1 = load i8, ptr %0, align 1
-  %2 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 0
-  store ptr @3, ptr %3, align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 1
-  store i64 7, ptr %4, align 4
-  %5 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %5)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 7 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  %6 = sext i8 %1 to i64
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %6)
+  %2 = sext i8 %1 to i64
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %2)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i64 3
 }
@@ -178,13 +154,7 @@ _llgo_0:
   store [1 x i64] %0, ptr %1, align 4
   %2 = getelementptr inbounds i64, ptr %1, i64 0
   %3 = load i64, ptr %2, align 4
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @4, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 7, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %7)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 7 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %3)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
@@ -205,13 +175,7 @@ _llgo_0:
   store %main.T5 %0, ptr %1, align 4
   %2 = getelementptr inbounds %main.T5, ptr %1, i32 0, i32 0
   %3 = load i64, ptr %2, align 4
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @5, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 7, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %7)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 7 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %3)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
@@ -230,13 +194,7 @@ _llgo_0:
   %1 = extractvalue %main.T6 %0, 1
   %2 = extractvalue %main.T6 %0, 0
   %3 = call i64 %2(ptr %1)
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @6, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 7, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %7)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 7 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %3)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
@@ -270,16 +228,12 @@ _llgo_0:
   %2 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %0, 0
   %3 = getelementptr ptr, ptr %2, i64 3
   %4 = load ptr, ptr %3, align 8
-  %5 = alloca { ptr, ptr }, align 8
-  %6 = getelementptr inbounds { ptr, ptr }, ptr %5, i32 0, i32 0
-  store ptr %4, ptr %6, align 8
-  %7 = getelementptr inbounds { ptr, ptr }, ptr %5, i32 0, i32 1
-  store ptr %1, ptr %7, align 8
-  %8 = load { ptr, ptr }, ptr %5, align 8
-  %9 = extractvalue { ptr, ptr } %8, 1
-  %10 = extractvalue { ptr, ptr } %8, 0
-  %11 = call i64 %10(ptr %9)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %11)
+  %5 = insertvalue { ptr, ptr } undef, ptr %4, 0
+  %6 = insertvalue { ptr, ptr } %5, ptr %1, 1
+  %7 = extractvalue { ptr, ptr } %6, 1
+  %8 = extractvalue { ptr, ptr } %6, 0
+  %9 = call i64 %8(ptr %7)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %9)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret void
 }
@@ -292,340 +246,212 @@ _llgo_0:
   call void @main.init()
   %2 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 16)
   %3 = getelementptr inbounds %main.T, ptr %2, i32 0, i32 0
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @7, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 5, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %7, ptr %3, align 8
-  %8 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 8)
-  store i64 100, ptr %8, align 4
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 5 }, ptr %3, align 8
+  %4 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 8)
+  store i64 100, ptr %4, align 4
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 8)
+  store double 1.001000e+02, ptr %5, align 8
+  %6 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 1)
+  store i8 127, ptr %6, align 1
+  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 8)
+  %8 = getelementptr inbounds i64, ptr %7, i64 0
+  store i64 200, ptr %8, align 4
   %9 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 8)
-  store double 1.001000e+02, ptr %9, align 8
-  %10 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 1)
-  store i8 127, ptr %10, align 1
-  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 8)
-  %12 = getelementptr inbounds i64, ptr %11, i64 0
-  store i64 200, ptr %12, align 4
-  %13 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 8)
-  %14 = getelementptr inbounds %main.T5, ptr %13, i32 0, i32 0
-  store i64 300, ptr %14, align 4
-  %15 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 16)
-  %16 = alloca %main.T6, align 8
-  %17 = getelementptr inbounds %main.T6, ptr %16, i32 0, i32 0
-  store ptr @"__llgo_stub.main.main$1", ptr %17, align 8
-  %18 = getelementptr inbounds %main.T6, ptr %16, i32 0, i32 1
-  store ptr null, ptr %18, align 8
-  %19 = load %main.T6, ptr %16, align 8
-  store %main.T6 %19, ptr %15, align 8
-  %20 = load %main.T, ptr %2, align 8
-  %21 = load ptr, ptr @_llgo_main.T, align 8
-  %22 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %main.T %20, ptr %22, align 8
-  %23 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %24 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
-  %25 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %24, ptr %21)
-  %26 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %26, i32 0, i32 0
-  store ptr %25, ptr %27, align 8
-  %28 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %26, i32 0, i32 1
-  store ptr %22, ptr %28, align 8
-  %29 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %26, align 8
-  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %29)
-  %30 = load ptr, ptr @"*_llgo_main.T", align 8
-  %31 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
-  %32 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %31, ptr %30)
-  %33 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %33, i32 0, i32 0
-  store ptr %32, ptr %34, align 8
-  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %33, i32 0, i32 1
-  store ptr %2, ptr %35, align 8
-  %36 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %33, align 8
+  %10 = getelementptr inbounds %main.T5, ptr %9, i32 0, i32 0
+  store i64 300, ptr %10, align 4
+  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 16)
+  store %main.T6 { ptr @"__llgo_stub.main.main$1", ptr null }, ptr %11, align 8
+  %12 = load %main.T, ptr %2, align 8
+  %13 = load ptr, ptr @_llgo_main.T, align 8
+  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %main.T %12, ptr %14, align 8
+  %15 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %16 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
+  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %16, ptr %13)
+  %18 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %17, 0
+  %19 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %18, ptr %14, 1
+  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %19)
+  %20 = load ptr, ptr @"*_llgo_main.T", align 8
+  %21 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
+  %22 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %21, ptr %20)
+  %23 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %22, 0
+  %24 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %23, ptr %2, 1
+  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %24)
+  %25 = load i64, ptr %4, align 4
+  %26 = load ptr, ptr @_llgo_main.T1, align 8
+  %27 = inttoptr i64 %25 to ptr
+  %28 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
+  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %28, ptr %26)
+  %30 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %29, 0
+  %31 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %30, ptr %27, 1
+  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %31)
+  %32 = load ptr, ptr @"*_llgo_main.T1", align 8
+  %33 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
+  %34 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %33, ptr %32)
+  %35 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %34, 0
+  %36 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %35, ptr %4, 1
   call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %36)
-  %37 = load i64, ptr %8, align 4
-  %38 = load ptr, ptr @_llgo_main.T1, align 8
-  %39 = inttoptr i64 %37 to ptr
-  %40 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
-  %41 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %40, ptr %38)
-  %42 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %42, i32 0, i32 0
-  store ptr %41, ptr %43, align 8
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %42, i32 0, i32 1
-  store ptr %39, ptr %44, align 8
-  %45 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %42, align 8
-  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %45)
-  %46 = load ptr, ptr @"*_llgo_main.T1", align 8
-  %47 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
-  %48 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %47, ptr %46)
-  %49 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %49, i32 0, i32 0
-  store ptr %48, ptr %50, align 8
-  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %49, i32 0, i32 1
-  store ptr %8, ptr %51, align 8
-  %52 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %49, align 8
-  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %52)
-  %53 = load double, ptr %9, align 8
-  %54 = load ptr, ptr @_llgo_main.T2, align 8
-  %55 = bitcast double %53 to i64
-  %56 = inttoptr i64 %55 to ptr
-  %57 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
-  %58 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %57, ptr %54)
-  %59 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %59, i32 0, i32 0
-  store ptr %58, ptr %60, align 8
-  %61 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %59, i32 0, i32 1
-  store ptr %56, ptr %61, align 8
-  %62 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %59, align 8
-  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %62)
-  %63 = load ptr, ptr @"*_llgo_main.T2", align 8
-  %64 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
-  %65 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %64, ptr %63)
-  %66 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %67 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %66, i32 0, i32 0
-  store ptr %65, ptr %67, align 8
-  %68 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %66, i32 0, i32 1
-  store ptr %9, ptr %68, align 8
-  %69 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %66, align 8
-  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %69)
-  %70 = load ptr, ptr @_llgo_main.T3, align 8
-  %71 = load ptr, ptr @"*_llgo_main.T3", align 8
-  %72 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
-  %73 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %72, ptr %71)
-  %74 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %75 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %74, i32 0, i32 0
-  store ptr %73, ptr %75, align 8
-  %76 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %74, i32 0, i32 1
-  store ptr %10, ptr %76, align 8
-  %77 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %74, align 8
-  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %77)
-  %78 = load [1 x i64], ptr %11, align 4
-  %79 = load ptr, ptr @_llgo_main.T4, align 8
-  %80 = extractvalue [1 x i64] %78, 0
-  %81 = inttoptr i64 %80 to ptr
-  %82 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
-  %83 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %82, ptr %79)
-  %84 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %85 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %84, i32 0, i32 0
-  store ptr %83, ptr %85, align 8
-  %86 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %84, i32 0, i32 1
-  store ptr %81, ptr %86, align 8
-  %87 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %84, align 8
-  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %87)
-  %88 = load ptr, ptr @"*_llgo_main.T4", align 8
-  %89 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
-  %90 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %89, ptr %88)
-  %91 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %92 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %91, i32 0, i32 0
-  store ptr %90, ptr %92, align 8
-  %93 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %91, i32 0, i32 1
-  store ptr %11, ptr %93, align 8
-  %94 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %91, align 8
-  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %94)
-  %95 = load %main.T5, ptr %13, align 4
-  %96 = load ptr, ptr @_llgo_main.T5, align 8
-  %97 = extractvalue %main.T5 %95, 0
-  %98 = inttoptr i64 %97 to ptr
-  %99 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
-  %100 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %99, ptr %96)
-  %101 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %102 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %101, i32 0, i32 0
-  store ptr %100, ptr %102, align 8
-  %103 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %101, i32 0, i32 1
-  store ptr %98, ptr %103, align 8
-  %104 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %101, align 8
-  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %104)
-  %105 = load ptr, ptr @"*_llgo_main.T5", align 8
-  %106 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
-  %107 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %106, ptr %105)
-  %108 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %109 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %108, i32 0, i32 0
-  store ptr %107, ptr %109, align 8
-  %110 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %108, i32 0, i32 1
-  store ptr %13, ptr %110, align 8
-  %111 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %108, align 8
-  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %111)
-  %112 = load %main.T6, ptr %15, align 8
-  %113 = load ptr, ptr @_llgo_main.T6, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr %113)
-  %114 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %main.T6 %112, ptr %114, align 8
-  %115 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
-  %116 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %115, ptr %113)
-  %117 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %118 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %117, i32 0, i32 0
-  store ptr %116, ptr %118, align 8
-  %119 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %117, i32 0, i32 1
-  store ptr %114, ptr %119, align 8
-  %120 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %117, align 8
-  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %120)
-  %121 = load ptr, ptr @"*_llgo_main.T6", align 8
-  %122 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
-  %123 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %122, ptr %121)
-  %124 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %125 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %124, i32 0, i32 0
-  store ptr %123, ptr %125, align 8
-  %126 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %124, i32 0, i32 1
-  store ptr %15, ptr %126, align 8
-  %127 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %124, align 8
-  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %127)
-  %128 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
-  %129 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
-  %130 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %129, ptr %128)
-  %131 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %132 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %131, i32 0, i32 0
-  store ptr %130, ptr %132, align 8
-  %133 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %131, i32 0, i32 1
-  store ptr null, ptr %133, align 8
-  %134 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %131, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintIface"(%"github.com/goplus/llgo/internal/runtime.iface" %134)
+  %37 = load double, ptr %5, align 8
+  %38 = load ptr, ptr @_llgo_main.T2, align 8
+  %39 = bitcast double %37 to i64
+  %40 = inttoptr i64 %39 to ptr
+  %41 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
+  %42 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %41, ptr %38)
+  %43 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %42, 0
+  %44 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %43, ptr %40, 1
+  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %44)
+  %45 = load ptr, ptr @"*_llgo_main.T2", align 8
+  %46 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
+  %47 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %46, ptr %45)
+  %48 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %47, 0
+  %49 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %48, ptr %5, 1
+  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %49)
+  %50 = load ptr, ptr @_llgo_main.T3, align 8
+  %51 = load ptr, ptr @"*_llgo_main.T3", align 8
+  %52 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
+  %53 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %52, ptr %51)
+  %54 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %53, 0
+  %55 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %54, ptr %6, 1
+  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %55)
+  %56 = load [1 x i64], ptr %7, align 4
+  %57 = load ptr, ptr @_llgo_main.T4, align 8
+  %58 = extractvalue [1 x i64] %56, 0
+  %59 = inttoptr i64 %58 to ptr
+  %60 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
+  %61 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %60, ptr %57)
+  %62 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %61, 0
+  %63 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %62, ptr %59, 1
+  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %63)
+  %64 = load ptr, ptr @"*_llgo_main.T4", align 8
+  %65 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
+  %66 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %65, ptr %64)
+  %67 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %66, 0
+  %68 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %67, ptr %7, 1
+  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %68)
+  %69 = load %main.T5, ptr %9, align 4
+  %70 = load ptr, ptr @_llgo_main.T5, align 8
+  %71 = extractvalue %main.T5 %69, 0
+  %72 = inttoptr i64 %71 to ptr
+  %73 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
+  %74 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %73, ptr %70)
+  %75 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %74, 0
+  %76 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %75, ptr %72, 1
+  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %76)
+  %77 = load ptr, ptr @"*_llgo_main.T5", align 8
+  %78 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
+  %79 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %78, ptr %77)
+  %80 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %79, 0
+  %81 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %80, ptr %9, 1
+  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %81)
+  %82 = load %main.T6, ptr %11, align 8
+  %83 = load ptr, ptr @_llgo_main.T6, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr %83)
+  %84 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %main.T6 %82, ptr %84, align 8
+  %85 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
+  %86 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %85, ptr %83)
+  %87 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %86, 0
+  %88 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %87, ptr %84, 1
+  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %88)
+  %89 = load ptr, ptr @"*_llgo_main.T6", align 8
+  %90 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
+  %91 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %90, ptr %89)
+  %92 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %91, 0
+  %93 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %92, ptr %11, 1
+  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %93)
+  %94 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
+  %95 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
+  %96 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %95, ptr %94)
+  %97 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %96, 0
+  %98 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %97, ptr null, 1
+  call void @"github.com/goplus/llgo/internal/runtime.PrintIface"(%"github.com/goplus/llgo/internal/runtime.iface" %98)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintIface"(%"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %135 = load ptr, ptr @"*_llgo_main.T", align 8
-  %136 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %137 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %138 = load ptr, ptr @"_llgo_iface$jwmSdgh1zvY_TDIgLzCkvkbiyrdwl9N806DH0JGcyMI", align 8
-  %139 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %138, ptr %135)
-  %140 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %141 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %140, i32 0, i32 0
-  store ptr %139, ptr %141, align 8
-  %142 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %140, i32 0, i32 1
-  store ptr %2, ptr %142, align 8
-  %143 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %140, align 8
-  %144 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %143)
-  %145 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %143, 1
-  %146 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
-  %147 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %146, ptr %144)
-  %148 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %149 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %148, i32 0, i32 0
-  store ptr %147, ptr %149, align 8
-  %150 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %148, i32 0, i32 1
-  store ptr %145, ptr %150, align 8
-  %151 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %148, align 8
-  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %151)
-  %152 = alloca %main.T, align 8
-  call void @llvm.memset(ptr %152, i8 0, i64 16, i1 false)
-  %153 = getelementptr inbounds %main.T, ptr %152, i32 0, i32 0
-  %154 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %155 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %154, i32 0, i32 0
-  store ptr @29, ptr %155, align 8
-  %156 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %154, i32 0, i32 1
-  store i64 5, ptr %156, align 4
-  %157 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %154, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %157, ptr %153, align 8
-  %158 = load %main.T, ptr %152, align 8
-  %159 = load ptr, ptr @_llgo_main.T, align 8
-  %160 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %main.T %158, ptr %160, align 8
-  %161 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %162 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %161, i32 0, i32 0
-  store ptr %159, ptr %162, align 8
-  %163 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %161, i32 0, i32 1
-  store ptr %160, ptr %163, align 8
-  %164 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %161, align 8
-  %165 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %164, 0
-  %166 = load ptr, ptr @_llgo_main.I, align 8
-  %167 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %166, ptr %165)
-  br i1 %167, label %_llgo_1, label %_llgo_2
+  %99 = load ptr, ptr @"*_llgo_main.T", align 8
+  %100 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %101 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %102 = load ptr, ptr @"_llgo_iface$jwmSdgh1zvY_TDIgLzCkvkbiyrdwl9N806DH0JGcyMI", align 8
+  %103 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %102, ptr %99)
+  %104 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %103, 0
+  %105 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %104, ptr %2, 1
+  %106 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %105)
+  %107 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %105, 1
+  %108 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
+  %109 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %108, ptr %106)
+  %110 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %109, 0
+  %111 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %110, ptr %107, 1
+  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %111)
+  %112 = alloca %main.T, align 8
+  call void @llvm.memset(ptr %112, i8 0, i64 16, i1 false)
+  %113 = getelementptr inbounds %main.T, ptr %112, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @29, i64 5 }, ptr %113, align 8
+  %114 = load %main.T, ptr %112, align 8
+  %115 = load ptr, ptr @_llgo_main.T, align 8
+  %116 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %main.T %114, ptr %116, align 8
+  %117 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %115, 0
+  %118 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %117, ptr %116, 1
+  %119 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %118, 0
+  %120 = load ptr, ptr @_llgo_main.I, align 8
+  %121 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %120, ptr %119)
+  br i1 %121, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %168 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %164, 1
-  %169 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
-  %170 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %169, ptr %165)
-  %171 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %172 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %171, i32 0, i32 0
-  store ptr %170, ptr %172, align 8
-  %173 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %171, i32 0, i32 1
-  store ptr %168, ptr %173, align 8
-  %174 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %171, align 8
-  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %174)
-  %175 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %164, 0
-  %176 = load ptr, ptr @_llgo_any, align 8
-  %177 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %176, ptr %175)
-  br i1 %177, label %_llgo_3, label %_llgo_4
+  %122 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %118, 1
+  %123 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
+  %124 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %123, ptr %119)
+  %125 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %124, 0
+  %126 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %125, ptr %122, 1
+  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %126)
+  %127 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %118, 0
+  %128 = load ptr, ptr @_llgo_any, align 8
+  %129 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %128, ptr %127)
+  br i1 %129, label %_llgo_3, label %_llgo_4
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %178 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %179 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %178, i32 0, i32 0
-  store ptr @31, ptr %179, align 8
-  %180 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %178, i32 0, i32 1
-  store i64 21, ptr %180, align 4
-  %181 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %178, align 8
-  %182 = load ptr, ptr @_llgo_string, align 8
-  %183 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %181, ptr %183, align 8
-  %184 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %185 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %184, i32 0, i32 0
-  store ptr %182, ptr %185, align 8
-  %186 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %184, i32 0, i32 1
-  store ptr %183, ptr %186, align 8
-  %187 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %184, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %187)
+  %130 = load ptr, ptr @_llgo_string, align 8
+  %131 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @31, i64 21 }, ptr %131, align 8
+  %132 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %130, 0
+  %133 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %132, ptr %131, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %133)
   unreachable
 
 _llgo_3:                                          ; preds = %_llgo_1
-  %188 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %164, 1
-  %189 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %190 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %189, i32 0, i32 0
-  store ptr %175, ptr %190, align 8
-  %191 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %189, i32 0, i32 1
-  store ptr %188, ptr %191, align 8
-  %192 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %189, align 8
-  %193 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %192, 0
-  %194 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
-  %195 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %194, ptr %193)
-  br i1 %195, label %_llgo_5, label %_llgo_6
+  %134 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %118, 1
+  %135 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %127, 0
+  %136 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %135, ptr %134, 1
+  %137 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %136, 0
+  %138 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
+  %139 = call i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr %138, ptr %137)
+  br i1 %139, label %_llgo_5, label %_llgo_6
 
 _llgo_4:                                          ; preds = %_llgo_1
-  %196 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %197 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %196, i32 0, i32 0
-  store ptr @31, ptr %197, align 8
-  %198 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %196, i32 0, i32 1
-  store i64 21, ptr %198, align 4
-  %199 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %196, align 8
-  %200 = load ptr, ptr @_llgo_string, align 8
-  %201 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %199, ptr %201, align 8
-  %202 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %203 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %202, i32 0, i32 0
-  store ptr %200, ptr %203, align 8
-  %204 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %202, i32 0, i32 1
-  store ptr %201, ptr %204, align 8
-  %205 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %202, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %205)
+  %140 = load ptr, ptr @_llgo_string, align 8
+  %141 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @31, i64 21 }, ptr %141, align 8
+  %142 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %140, 0
+  %143 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %142, ptr %141, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %143)
   unreachable
 
 _llgo_5:                                          ; preds = %_llgo_3
-  %206 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %192, 1
-  %207 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
-  %208 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %207, ptr %193)
-  %209 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %210 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %209, i32 0, i32 0
-  store ptr %208, ptr %210, align 8
-  %211 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %209, i32 0, i32 1
-  store ptr %206, ptr %211, align 8
-  %212 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %209, align 8
-  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %212)
+  %144 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %136, 1
+  %145 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
+  %146 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %145, ptr %137)
+  %147 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %146, 0
+  %148 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %147, ptr %144, 1
+  call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %148)
   ret i32 0
 
 _llgo_6:                                          ; preds = %_llgo_3
-  %213 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %214 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %213, i32 0, i32 0
-  store ptr @31, ptr %214, align 8
-  %215 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %213, i32 0, i32 1
-  store i64 21, ptr %215, align 4
-  %216 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %213, align 8
-  %217 = load ptr, ptr @_llgo_string, align 8
-  %218 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %216, ptr %218, align 8
-  %219 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %220 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %219, i32 0, i32 0
-  store ptr %217, ptr %220, align 8
-  %221 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %219, i32 0, i32 1
-  store ptr %218, ptr %221, align 8
-  %222 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %219, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %222)
+  %149 = load ptr, ptr @_llgo_string, align 8
+  %150 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @31, i64 21 }, ptr %150, align 8
+  %151 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %149, 0
+  %152 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %151, ptr %150, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %152)
   unreachable
 }
 
@@ -659,1207 +485,595 @@ _llgo_0:
 
 define void @"main.init$after"() {
 _llgo_0:
-  %0 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 0
-  store ptr @8, ptr %1, align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 1
-  store i64 6, ptr %2, align 4
-  %3 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %0, align 8
-  %4 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3, i64 25, i64 16, i64 1, i64 2)
-  %5 = load ptr, ptr @_llgo_main.T, align 8
-  %6 = icmp eq ptr %5, null
-  br i1 %6, label %_llgo_1, label %_llgo_2
+  %0 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 6 }, i64 25, i64 16, i64 1, i64 2)
+  %1 = load ptr, ptr @_llgo_main.T, align 8
+  %2 = icmp eq ptr %1, null
+  br i1 %2, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  store ptr %4, ptr @_llgo_main.T, align 8
+  store ptr %0, ptr @_llgo_main.T, align 8
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-  %7 = load ptr, ptr @_llgo_string, align 8
-  %8 = icmp eq ptr %7, null
-  br i1 %8, label %_llgo_3, label %_llgo_4
+  %3 = load ptr, ptr @_llgo_string, align 8
+  %4 = icmp eq ptr %3, null
+  br i1 %4, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  store ptr %9, ptr @_llgo_string, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  store ptr %5, ptr @_llgo_string, align 8
   br label %_llgo_4
 
 _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
-  %10 = load ptr, ptr @_llgo_string, align 8
-  %11 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %11, i32 0, i32 0
-  store ptr @9, ptr %12, align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %11, i32 0, i32 1
-  store i64 1, ptr %13, align 4
-  %14 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %11, align 8
-  %15 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %15, i32 0, i32 0
-  store ptr null, ptr %16, align 8
-  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %15, i32 0, i32 1
-  store i64 0, ptr %17, align 4
-  %18 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %15, align 8
-  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %20 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %14, ptr %19, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %18, i1 false)
-  %21 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %21, i32 0, i32 0
-  store ptr @10, ptr %22, align 8
-  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %21, i32 0, i32 1
-  store i64 4, ptr %23, align 4
-  %24 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %21, align 8
-  %25 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
-  %26 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %25, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %20, ptr %26, align 8
-  %27 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %28 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %27, i32 0, i32 0
-  store ptr %25, ptr %28, align 8
-  %29 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %27, i32 0, i32 1
-  store i64 1, ptr %29, align 4
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %27, i32 0, i32 2
-  store i64 1, ptr %30, align 4
-  %31 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %27, align 8
-  %32 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %24, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %31)
-  store ptr %32, ptr @"main.struct$QTufDJA9wEDzuzgkA-ZSrLqW-B6lWN8O25mTSglAoLQ", align 8
-  %33 = load ptr, ptr @"main.struct$QTufDJA9wEDzuzgkA-ZSrLqW-B6lWN8O25mTSglAoLQ", align 8
-  br i1 %6, label %_llgo_5, label %_llgo_6
+  %6 = load ptr, ptr @_llgo_string, align 8
+  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %8 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 1 }, ptr %7, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
+  %10 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %9, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %8, ptr %10, align 8
+  %11 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %9, 0
+  %12 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %11, i64 1, 1
+  %13 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %12, i64 1, 2
+  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %13)
+  store ptr %14, ptr @"main.struct$QTufDJA9wEDzuzgkA-ZSrLqW-B6lWN8O25mTSglAoLQ", align 8
+  %15 = load ptr, ptr @"main.struct$QTufDJA9wEDzuzgkA-ZSrLqW-B6lWN8O25mTSglAoLQ", align 8
+  br i1 %2, label %_llgo_5, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_4
-  %34 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %34, i32 0, i32 0
-  store ptr @11, ptr %35, align 8
-  %36 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %34, i32 0, i32 1
-  store i64 6, ptr %36, align 4
-  %37 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %34, align 8
-  %38 = load ptr, ptr @_llgo_int, align 8
-  %39 = icmp eq ptr %38, null
-  br i1 %39, label %_llgo_7, label %_llgo_8
+  %16 = load ptr, ptr @_llgo_int, align 8
+  %17 = icmp eq ptr %16, null
+  br i1 %17, label %_llgo_7, label %_llgo_8
 
 _llgo_6:                                          ; preds = %_llgo_12, %_llgo_4
-  %40 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %41 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
-  %42 = icmp eq ptr %41, null
-  br i1 %42, label %_llgo_13, label %_llgo_14
+  %18 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %19 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
+  %20 = icmp eq ptr %19, null
+  br i1 %20, label %_llgo_13, label %_llgo_14
 
 _llgo_7:                                          ; preds = %_llgo_5
-  %43 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  store ptr %43, ptr @_llgo_int, align 8
+  %21 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  store ptr %21, ptr @_llgo_int, align 8
   br label %_llgo_8
 
 _llgo_8:                                          ; preds = %_llgo_7, %_llgo_5
-  %44 = load ptr, ptr @_llgo_int, align 8
-  %45 = load ptr, ptr @_llgo_int, align 8
-  %46 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %47 = icmp eq ptr %46, null
-  br i1 %47, label %_llgo_9, label %_llgo_10
+  %22 = load ptr, ptr @_llgo_int, align 8
+  %23 = load ptr, ptr @_llgo_int, align 8
+  %24 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %25 = icmp eq ptr %24, null
+  br i1 %25, label %_llgo_9, label %_llgo_10
 
 _llgo_9:                                          ; preds = %_llgo_8
-  %48 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %49 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %49, i32 0, i32 0
-  store ptr %48, ptr %50, align 8
-  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %49, i32 0, i32 1
-  store i64 0, ptr %51, align 4
-  %52 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %49, i32 0, i32 2
-  store i64 0, ptr %52, align 4
-  %53 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %49, align 8
-  %54 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %55 = getelementptr ptr, ptr %54, i64 0
-  store ptr %45, ptr %55, align 8
-  %56 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %56, i32 0, i32 0
-  store ptr %54, ptr %57, align 8
-  %58 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %56, i32 0, i32 1
-  store i64 1, ptr %58, align 4
-  %59 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %56, i32 0, i32 2
-  store i64 1, ptr %59, align 4
-  %60 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %56, align 8
-  %61 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %53, %"github.com/goplus/llgo/internal/runtime.Slice" %60, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %61)
-  store ptr %61, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %27 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %26, 0
+  %28 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %27, i64 0, 1
+  %29 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %28, i64 0, 2
+  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %31 = getelementptr ptr, ptr %30, i64 0
+  store ptr %23, ptr %31, align 8
+  %32 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %30, 0
+  %33 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %32, i64 1, 1
+  %34 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %33, i64 1, 2
+  %35 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %29, %"github.com/goplus/llgo/internal/runtime.Slice" %34, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %35)
+  store ptr %35, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
   br label %_llgo_10
 
 _llgo_10:                                         ; preds = %_llgo_9, %_llgo_8
-  %62 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %63 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %64 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %63, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %37, ptr %64, align 8
-  %65 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %63, i32 0, i32 1
-  store ptr %62, ptr %65, align 8
-  %66 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %63, i32 0, i32 2
-  store ptr @"main.(*T).Invoke", ptr %66, align 8
-  %67 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %63, i32 0, i32 3
-  store ptr @"main.(*T).Invoke", ptr %67, align 8
-  %68 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %63, align 8
-  %69 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %70 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %69, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %37, ptr %70, align 8
-  %71 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %69, i32 0, i32 1
-  store ptr %62, ptr %71, align 8
-  %72 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %69, i32 0, i32 2
-  store ptr @"main.(*T).Invoke", ptr %72, align 8
-  %73 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %69, i32 0, i32 3
-  store ptr @main.T.Invoke, ptr %73, align 8
-  %74 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %69, align 8
-  %75 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %76 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %75, i32 0, i32 0
-  store ptr @12, ptr %76, align 8
-  %77 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %75, i32 0, i32 1
-  store i64 6, ptr %77, align 4
-  %78 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %75, align 8
-  %79 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %80 = icmp eq ptr %79, null
-  br i1 %80, label %_llgo_11, label %_llgo_12
+  %36 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %37 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %36, 1
+  %38 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %37, ptr @"main.(*T).Invoke", 2
+  %39 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %38, ptr @"main.(*T).Invoke", 3
+  %40 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %36, 1
+  %41 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %40, ptr @"main.(*T).Invoke", 2
+  %42 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %41, ptr @main.T.Invoke, 3
+  %43 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %44 = icmp eq ptr %43, null
+  br i1 %44, label %_llgo_11, label %_llgo_12
 
 _llgo_11:                                         ; preds = %_llgo_10
-  %81 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %82 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %83 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %82, i32 0, i32 0
-  store ptr %81, ptr %83, align 8
-  %84 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %82, i32 0, i32 1
-  store i64 0, ptr %84, align 4
-  %85 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %82, i32 0, i32 2
-  store i64 0, ptr %85, align 4
-  %86 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %82, align 8
-  %87 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %88 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %89 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %88, i32 0, i32 0
-  store ptr %87, ptr %89, align 8
-  %90 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %88, i32 0, i32 1
-  store i64 0, ptr %90, align 4
-  %91 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %88, i32 0, i32 2
-  store i64 0, ptr %91, align 4
-  %92 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %88, align 8
-  %93 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %86, %"github.com/goplus/llgo/internal/runtime.Slice" %92, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %93)
-  store ptr %93, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %45 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %46 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %45, 0
+  %47 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %46, i64 0, 1
+  %48 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %47, i64 0, 2
+  %49 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %50 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %49, 0
+  %51 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %50, i64 0, 1
+  %52 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %51, i64 0, 2
+  %53 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %48, %"github.com/goplus/llgo/internal/runtime.Slice" %52, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %53)
+  store ptr %53, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
   br label %_llgo_12
 
 _llgo_12:                                         ; preds = %_llgo_11, %_llgo_10
-  %94 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %95 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %96 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %95, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %78, ptr %96, align 8
-  %97 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %95, i32 0, i32 1
-  store ptr %94, ptr %97, align 8
-  %98 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %95, i32 0, i32 2
-  store ptr @"main.(*T).Method", ptr %98, align 8
-  %99 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %95, i32 0, i32 3
-  store ptr @"main.(*T).Method", ptr %99, align 8
-  %100 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %95, align 8
-  %101 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %102 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %101, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %74, ptr %102, align 8
-  %103 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %104 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %103, i32 0, i32 0
-  store ptr %101, ptr %104, align 8
-  %105 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %103, i32 0, i32 1
-  store i64 1, ptr %105, align 4
-  %106 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %103, i32 0, i32 2
-  store i64 1, ptr %106, align 4
-  %107 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %103, align 8
-  %108 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
-  %109 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %108, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %68, ptr %109, align 8
-  %110 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %108, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %100, ptr %110, align 8
-  %111 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %112 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %111, i32 0, i32 0
-  store ptr %108, ptr %112, align 8
-  %113 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %111, i32 0, i32 1
-  store i64 2, ptr %113, align 4
-  %114 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %111, i32 0, i32 2
-  store i64 2, ptr %114, align 4
-  %115 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %111, align 8
-  %116 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %117 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %116, i32 0, i32 0
-  store ptr @10, ptr %117, align 8
-  %118 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %116, i32 0, i32 1
-  store i64 4, ptr %118, align 4
-  %119 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %116, align 8
-  %120 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %121 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %120, i32 0, i32 0
-  store ptr @13, ptr %121, align 8
-  %122 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %120, i32 0, i32 1
-  store i64 1, ptr %122, align 4
-  %123 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %120, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %4, %"github.com/goplus/llgo/internal/runtime.String" %119, %"github.com/goplus/llgo/internal/runtime.String" %123, ptr %33, %"github.com/goplus/llgo/internal/runtime.Slice" %107, %"github.com/goplus/llgo/internal/runtime.Slice" %115)
+  %54 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %55 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @12, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %54, 1
+  %56 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %55, ptr @"main.(*T).Method", 2
+  %57 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %56, ptr @"main.(*T).Method", 3
+  %58 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %59 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %58, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %42, ptr %59, align 8
+  %60 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %58, 0
+  %61 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %60, i64 1, 1
+  %62 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %61, i64 1, 2
+  %63 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
+  %64 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %63, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %39, ptr %64, align 8
+  %65 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %63, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %57, ptr %65, align 8
+  %66 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %63, 0
+  %67 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %66, i64 2, 1
+  %68 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %67, i64 2, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %0, %"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @13, i64 1 }, ptr %15, %"github.com/goplus/llgo/internal/runtime.Slice" %62, %"github.com/goplus/llgo/internal/runtime.Slice" %68)
   br label %_llgo_6
 
 _llgo_13:                                         ; preds = %_llgo_6
-  %124 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %125 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %124, i32 0, i32 0
-  store ptr @11, ptr %125, align 8
-  %126 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %124, i32 0, i32 1
-  store i64 6, ptr %126, align 4
-  %127 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %124, align 8
-  %128 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %129 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %128, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %127, ptr %129, align 8
-  %130 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %128, i32 0, i32 1
-  store ptr %40, ptr %130, align 8
-  %131 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %128, align 8
-  %132 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %133 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %132, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %131, ptr %133, align 8
-  %134 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %135 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %134, i32 0, i32 0
-  store ptr %132, ptr %135, align 8
-  %136 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %134, i32 0, i32 1
-  store i64 1, ptr %136, align 4
-  %137 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %134, i32 0, i32 2
-  store i64 1, ptr %137, align 4
-  %138 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %134, align 8
-  %139 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %140 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %139, i32 0, i32 0
-  store ptr @10, ptr %140, align 8
-  %141 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %139, i32 0, i32 1
-  store i64 4, ptr %141, align 4
-  %142 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %139, align 8
-  %143 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %144 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %143, i32 0, i32 0
-  store ptr null, ptr %144, align 8
-  %145 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %143, i32 0, i32 1
-  store i64 0, ptr %145, align 4
-  %146 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %143, align 8
-  %147 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %142, %"github.com/goplus/llgo/internal/runtime.String" %146, %"github.com/goplus/llgo/internal/runtime.Slice" %138)
-  store ptr %147, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
+  %69 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 6 }, ptr undef }, ptr %18, 1
+  %70 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %71 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %70, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %69, ptr %71, align 8
+  %72 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %70, 0
+  %73 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %72, i64 1, 1
+  %74 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %73, i64 1, 2
+  %75 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %74)
+  store ptr %75, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
   br label %_llgo_14
 
 _llgo_14:                                         ; preds = %_llgo_13, %_llgo_6
-  %148 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %149 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %148, i32 0, i32 0
-  store ptr @8, ptr %149, align 8
-  %150 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %148, i32 0, i32 1
-  store i64 6, ptr %150, align 4
-  %151 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %148, align 8
-  %152 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %151, i64 25, i64 16, i64 1, i64 2)
-  %153 = load ptr, ptr @"*_llgo_main.T", align 8
-  %154 = icmp eq ptr %153, null
-  br i1 %154, label %_llgo_15, label %_llgo_16
+  %76 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 6 }, i64 25, i64 16, i64 1, i64 2)
+  %77 = load ptr, ptr @"*_llgo_main.T", align 8
+  %78 = icmp eq ptr %77, null
+  br i1 %78, label %_llgo_15, label %_llgo_16
 
 _llgo_15:                                         ; preds = %_llgo_14
-  %155 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %152)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %155)
-  store ptr %155, ptr @"*_llgo_main.T", align 8
+  %79 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %76)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %79)
+  store ptr %79, ptr @"*_llgo_main.T", align 8
   br label %_llgo_16
 
 _llgo_16:                                         ; preds = %_llgo_15, %_llgo_14
-  %156 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %157 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %156, i32 0, i32 0
-  store ptr @14, ptr %157, align 8
-  %158 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %156, i32 0, i32 1
-  store i64 7, ptr %158, align 4
-  %159 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %156, align 8
-  %160 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %159, i64 2, i64 8, i64 1, i64 1)
-  %161 = load ptr, ptr @_llgo_main.T1, align 8
-  %162 = icmp eq ptr %161, null
-  br i1 %162, label %_llgo_17, label %_llgo_18
+  %80 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @14, i64 7 }, i64 2, i64 8, i64 1, i64 1)
+  %81 = load ptr, ptr @_llgo_main.T1, align 8
+  %82 = icmp eq ptr %81, null
+  br i1 %82, label %_llgo_17, label %_llgo_18
 
 _llgo_17:                                         ; preds = %_llgo_16
-  store ptr %160, ptr @_llgo_main.T1, align 8
+  store ptr %80, ptr @_llgo_main.T1, align 8
   br label %_llgo_18
 
 _llgo_18:                                         ; preds = %_llgo_17, %_llgo_16
-  %163 = load ptr, ptr @_llgo_int, align 8
-  br i1 %162, label %_llgo_19, label %_llgo_20
+  %83 = load ptr, ptr @_llgo_int, align 8
+  br i1 %82, label %_llgo_19, label %_llgo_20
 
 _llgo_19:                                         ; preds = %_llgo_18
-  %164 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %165 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %164, i32 0, i32 0
-  store ptr @11, ptr %165, align 8
-  %166 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %164, i32 0, i32 1
-  store i64 6, ptr %166, align 4
-  %167 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %164, align 8
-  %168 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %169 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %170 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %169, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %167, ptr %170, align 8
-  %171 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %169, i32 0, i32 1
-  store ptr %168, ptr %171, align 8
-  %172 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %169, i32 0, i32 2
-  store ptr @"main.(*T1).Invoke", ptr %172, align 8
-  %173 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %169, i32 0, i32 3
-  store ptr @"main.(*T1).Invoke", ptr %173, align 8
-  %174 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %169, align 8
-  %175 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %176 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %175, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %167, ptr %176, align 8
-  %177 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %175, i32 0, i32 1
-  store ptr %168, ptr %177, align 8
-  %178 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %175, i32 0, i32 2
-  store ptr @"main.(*T1).Invoke", ptr %178, align 8
-  %179 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %175, i32 0, i32 3
-  store ptr @main.T1.Invoke, ptr %179, align 8
-  %180 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %175, align 8
-  %181 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %182 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %181, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %180, ptr %182, align 8
-  %183 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %184 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %183, i32 0, i32 0
-  store ptr %181, ptr %184, align 8
-  %185 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %183, i32 0, i32 1
-  store i64 1, ptr %185, align 4
-  %186 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %183, i32 0, i32 2
-  store i64 1, ptr %186, align 4
-  %187 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %183, align 8
-  %188 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %189 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %188, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %174, ptr %189, align 8
-  %190 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %191 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %190, i32 0, i32 0
-  store ptr %188, ptr %191, align 8
-  %192 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %190, i32 0, i32 1
-  store i64 1, ptr %192, align 4
-  %193 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %190, i32 0, i32 2
-  store i64 1, ptr %193, align 4
-  %194 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %190, align 8
-  %195 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %196 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %195, i32 0, i32 0
-  store ptr @10, ptr %196, align 8
-  %197 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %195, i32 0, i32 1
-  store i64 4, ptr %197, align 4
-  %198 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %195, align 8
-  %199 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %200 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %199, i32 0, i32 0
-  store ptr @15, ptr %200, align 8
-  %201 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %199, i32 0, i32 1
-  store i64 2, ptr %201, align 4
-  %202 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %199, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %160, %"github.com/goplus/llgo/internal/runtime.String" %198, %"github.com/goplus/llgo/internal/runtime.String" %202, ptr %163, %"github.com/goplus/llgo/internal/runtime.Slice" %187, %"github.com/goplus/llgo/internal/runtime.Slice" %194)
+  %84 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %85 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %84, 1
+  %86 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %85, ptr @"main.(*T1).Invoke", 2
+  %87 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %86, ptr @"main.(*T1).Invoke", 3
+  %88 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %84, 1
+  %89 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %88, ptr @"main.(*T1).Invoke", 2
+  %90 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %89, ptr @main.T1.Invoke, 3
+  %91 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %92 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %91, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %90, ptr %92, align 8
+  %93 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %91, 0
+  %94 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %93, i64 1, 1
+  %95 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %94, i64 1, 2
+  %96 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %97 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %96, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %87, ptr %97, align 8
+  %98 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %96, 0
+  %99 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %98, i64 1, 1
+  %100 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %99, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %80, %"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @15, i64 2 }, ptr %83, %"github.com/goplus/llgo/internal/runtime.Slice" %95, %"github.com/goplus/llgo/internal/runtime.Slice" %100)
   br label %_llgo_20
 
 _llgo_20:                                         ; preds = %_llgo_19, %_llgo_18
-  %203 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %204 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %203, i32 0, i32 0
-  store ptr @14, ptr %204, align 8
-  %205 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %203, i32 0, i32 1
-  store i64 7, ptr %205, align 4
-  %206 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %203, align 8
-  %207 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %206, i64 2, i64 8, i64 1, i64 1)
-  %208 = load ptr, ptr @"*_llgo_main.T1", align 8
-  %209 = icmp eq ptr %208, null
-  br i1 %209, label %_llgo_21, label %_llgo_22
+  %101 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @14, i64 7 }, i64 2, i64 8, i64 1, i64 1)
+  %102 = load ptr, ptr @"*_llgo_main.T1", align 8
+  %103 = icmp eq ptr %102, null
+  br i1 %103, label %_llgo_21, label %_llgo_22
 
 _llgo_21:                                         ; preds = %_llgo_20
-  %210 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %207)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %210)
-  store ptr %210, ptr @"*_llgo_main.T1", align 8
+  %104 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %101)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %104)
+  store ptr %104, ptr @"*_llgo_main.T1", align 8
   br label %_llgo_22
 
 _llgo_22:                                         ; preds = %_llgo_21, %_llgo_20
-  %211 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %212 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %211, i32 0, i32 0
-  store ptr @16, ptr %212, align 8
-  %213 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %211, i32 0, i32 1
-  store i64 7, ptr %213, align 4
-  %214 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %211, align 8
-  %215 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %214, i64 14, i64 8, i64 1, i64 1)
-  %216 = load ptr, ptr @_llgo_main.T2, align 8
-  %217 = icmp eq ptr %216, null
-  br i1 %217, label %_llgo_23, label %_llgo_24
+  %105 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @16, i64 7 }, i64 14, i64 8, i64 1, i64 1)
+  %106 = load ptr, ptr @_llgo_main.T2, align 8
+  %107 = icmp eq ptr %106, null
+  br i1 %107, label %_llgo_23, label %_llgo_24
 
 _llgo_23:                                         ; preds = %_llgo_22
-  store ptr %215, ptr @_llgo_main.T2, align 8
+  store ptr %105, ptr @_llgo_main.T2, align 8
   br label %_llgo_24
 
 _llgo_24:                                         ; preds = %_llgo_23, %_llgo_22
-  %218 = load ptr, ptr @_llgo_float64, align 8
-  %219 = icmp eq ptr %218, null
-  br i1 %219, label %_llgo_25, label %_llgo_26
+  %108 = load ptr, ptr @_llgo_float64, align 8
+  %109 = icmp eq ptr %108, null
+  br i1 %109, label %_llgo_25, label %_llgo_26
 
 _llgo_25:                                         ; preds = %_llgo_24
-  %220 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 46)
-  store ptr %220, ptr @_llgo_float64, align 8
+  %110 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 46)
+  store ptr %110, ptr @_llgo_float64, align 8
   br label %_llgo_26
 
 _llgo_26:                                         ; preds = %_llgo_25, %_llgo_24
-  %221 = load ptr, ptr @_llgo_float64, align 8
-  br i1 %217, label %_llgo_27, label %_llgo_28
+  %111 = load ptr, ptr @_llgo_float64, align 8
+  br i1 %107, label %_llgo_27, label %_llgo_28
 
 _llgo_27:                                         ; preds = %_llgo_26
-  %222 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %223 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %222, i32 0, i32 0
-  store ptr @11, ptr %223, align 8
-  %224 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %222, i32 0, i32 1
-  store i64 6, ptr %224, align 4
-  %225 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %222, align 8
-  %226 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %227 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %228 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %227, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %225, ptr %228, align 8
-  %229 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %227, i32 0, i32 1
-  store ptr %226, ptr %229, align 8
-  %230 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %227, i32 0, i32 2
-  store ptr @"main.(*T2).Invoke", ptr %230, align 8
-  %231 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %227, i32 0, i32 3
-  store ptr @"main.(*T2).Invoke", ptr %231, align 8
-  %232 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %227, align 8
-  %233 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %234 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %233, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %225, ptr %234, align 8
-  %235 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %233, i32 0, i32 1
-  store ptr %226, ptr %235, align 8
-  %236 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %233, i32 0, i32 2
-  store ptr @"main.(*T2).Invoke", ptr %236, align 8
-  %237 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %233, i32 0, i32 3
-  store ptr @main.T2.Invoke, ptr %237, align 8
-  %238 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %233, align 8
-  %239 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %240 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %239, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %238, ptr %240, align 8
-  %241 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %242 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %241, i32 0, i32 0
-  store ptr %239, ptr %242, align 8
-  %243 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %241, i32 0, i32 1
-  store i64 1, ptr %243, align 4
-  %244 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %241, i32 0, i32 2
-  store i64 1, ptr %244, align 4
-  %245 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %241, align 8
-  %246 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %247 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %246, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %232, ptr %247, align 8
-  %248 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %249 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %248, i32 0, i32 0
-  store ptr %246, ptr %249, align 8
-  %250 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %248, i32 0, i32 1
-  store i64 1, ptr %250, align 4
-  %251 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %248, i32 0, i32 2
-  store i64 1, ptr %251, align 4
-  %252 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %248, align 8
-  %253 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %254 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %253, i32 0, i32 0
-  store ptr @10, ptr %254, align 8
-  %255 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %253, i32 0, i32 1
-  store i64 4, ptr %255, align 4
-  %256 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %253, align 8
-  %257 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %258 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %257, i32 0, i32 0
-  store ptr @17, ptr %258, align 8
-  %259 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %257, i32 0, i32 1
-  store i64 2, ptr %259, align 4
-  %260 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %257, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %215, %"github.com/goplus/llgo/internal/runtime.String" %256, %"github.com/goplus/llgo/internal/runtime.String" %260, ptr %221, %"github.com/goplus/llgo/internal/runtime.Slice" %245, %"github.com/goplus/llgo/internal/runtime.Slice" %252)
+  %112 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %113 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %112, 1
+  %114 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %113, ptr @"main.(*T2).Invoke", 2
+  %115 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %114, ptr @"main.(*T2).Invoke", 3
+  %116 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %112, 1
+  %117 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %116, ptr @"main.(*T2).Invoke", 2
+  %118 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %117, ptr @main.T2.Invoke, 3
+  %119 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %120 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %119, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %118, ptr %120, align 8
+  %121 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %119, 0
+  %122 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %121, i64 1, 1
+  %123 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %122, i64 1, 2
+  %124 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %125 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %124, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %115, ptr %125, align 8
+  %126 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %124, 0
+  %127 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %126, i64 1, 1
+  %128 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %127, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %105, %"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @17, i64 2 }, ptr %111, %"github.com/goplus/llgo/internal/runtime.Slice" %123, %"github.com/goplus/llgo/internal/runtime.Slice" %128)
   br label %_llgo_28
 
 _llgo_28:                                         ; preds = %_llgo_27, %_llgo_26
-  %261 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %262 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %261, i32 0, i32 0
-  store ptr @16, ptr %262, align 8
-  %263 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %261, i32 0, i32 1
-  store i64 7, ptr %263, align 4
-  %264 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %261, align 8
-  %265 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %264, i64 14, i64 8, i64 1, i64 1)
-  %266 = load ptr, ptr @"*_llgo_main.T2", align 8
-  %267 = icmp eq ptr %266, null
-  br i1 %267, label %_llgo_29, label %_llgo_30
+  %129 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @16, i64 7 }, i64 14, i64 8, i64 1, i64 1)
+  %130 = load ptr, ptr @"*_llgo_main.T2", align 8
+  %131 = icmp eq ptr %130, null
+  br i1 %131, label %_llgo_29, label %_llgo_30
 
 _llgo_29:                                         ; preds = %_llgo_28
-  %268 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %265)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %268)
-  store ptr %268, ptr @"*_llgo_main.T2", align 8
+  %132 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %129)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %132)
+  store ptr %132, ptr @"*_llgo_main.T2", align 8
   br label %_llgo_30
 
 _llgo_30:                                         ; preds = %_llgo_29, %_llgo_28
-  %269 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %270 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %269, i32 0, i32 0
-  store ptr @18, ptr %270, align 8
-  %271 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %269, i32 0, i32 1
-  store i64 7, ptr %271, align 4
-  %272 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %269, align 8
-  %273 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %272, i64 3, i64 1, i64 0, i64 1)
-  %274 = load ptr, ptr @_llgo_main.T3, align 8
-  %275 = icmp eq ptr %274, null
-  br i1 %275, label %_llgo_31, label %_llgo_32
+  %133 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @18, i64 7 }, i64 3, i64 1, i64 0, i64 1)
+  %134 = load ptr, ptr @_llgo_main.T3, align 8
+  %135 = icmp eq ptr %134, null
+  br i1 %135, label %_llgo_31, label %_llgo_32
 
 _llgo_31:                                         ; preds = %_llgo_30
-  store ptr %273, ptr @_llgo_main.T3, align 8
+  store ptr %133, ptr @_llgo_main.T3, align 8
   br label %_llgo_32
 
 _llgo_32:                                         ; preds = %_llgo_31, %_llgo_30
-  %276 = load ptr, ptr @_llgo_int8, align 8
-  %277 = icmp eq ptr %276, null
-  br i1 %277, label %_llgo_33, label %_llgo_34
+  %136 = load ptr, ptr @_llgo_int8, align 8
+  %137 = icmp eq ptr %136, null
+  br i1 %137, label %_llgo_33, label %_llgo_34
 
 _llgo_33:                                         ; preds = %_llgo_32
-  %278 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 35)
-  store ptr %278, ptr @_llgo_int8, align 8
+  %138 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 35)
+  store ptr %138, ptr @_llgo_int8, align 8
   br label %_llgo_34
 
 _llgo_34:                                         ; preds = %_llgo_33, %_llgo_32
-  %279 = load ptr, ptr @_llgo_int8, align 8
-  br i1 %275, label %_llgo_35, label %_llgo_36
+  %139 = load ptr, ptr @_llgo_int8, align 8
+  br i1 %135, label %_llgo_35, label %_llgo_36
 
 _llgo_35:                                         ; preds = %_llgo_34
-  %280 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %281 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %280, i32 0, i32 0
-  store ptr @11, ptr %281, align 8
-  %282 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %280, i32 0, i32 1
-  store i64 6, ptr %282, align 4
-  %283 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %280, align 8
-  %284 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %285 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %286 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %285, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %283, ptr %286, align 8
-  %287 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %285, i32 0, i32 1
-  store ptr %284, ptr %287, align 8
-  %288 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %285, i32 0, i32 2
-  store ptr @"main.(*T3).Invoke", ptr %288, align 8
-  %289 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %285, i32 0, i32 3
-  store ptr @"main.(*T3).Invoke", ptr %289, align 8
-  %290 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %285, align 8
-  %291 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %292 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %291, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %290, ptr %292, align 8
-  %293 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %294 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %293, i32 0, i32 0
-  store ptr %291, ptr %294, align 8
-  %295 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %293, i32 0, i32 1
-  store i64 1, ptr %295, align 4
-  %296 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %293, i32 0, i32 2
-  store i64 1, ptr %296, align 4
-  %297 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %293, align 8
-  %298 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %299 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %298, i32 0, i32 0
-  store ptr @10, ptr %299, align 8
-  %300 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %298, i32 0, i32 1
-  store i64 4, ptr %300, align 4
-  %301 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %298, align 8
-  %302 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %303 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %302, i32 0, i32 0
-  store ptr @19, ptr %303, align 8
-  %304 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %302, i32 0, i32 1
-  store i64 2, ptr %304, align 4
-  %305 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %302, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %273, %"github.com/goplus/llgo/internal/runtime.String" %301, %"github.com/goplus/llgo/internal/runtime.String" %305, ptr %279, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %297)
+  %140 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %141 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %140, 1
+  %142 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %141, ptr @"main.(*T3).Invoke", 2
+  %143 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %142, ptr @"main.(*T3).Invoke", 3
+  %144 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %145 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %144, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %143, ptr %145, align 8
+  %146 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %144, 0
+  %147 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %146, i64 1, 1
+  %148 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %147, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %133, %"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @19, i64 2 }, ptr %139, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %148)
   br label %_llgo_36
 
 _llgo_36:                                         ; preds = %_llgo_35, %_llgo_34
-  %306 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %307 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %306, i32 0, i32 0
-  store ptr @18, ptr %307, align 8
-  %308 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %306, i32 0, i32 1
-  store i64 7, ptr %308, align 4
-  %309 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %306, align 8
-  %310 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %309, i64 3, i64 1, i64 0, i64 1)
-  %311 = load ptr, ptr @"*_llgo_main.T3", align 8
-  %312 = icmp eq ptr %311, null
-  br i1 %312, label %_llgo_37, label %_llgo_38
+  %149 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @18, i64 7 }, i64 3, i64 1, i64 0, i64 1)
+  %150 = load ptr, ptr @"*_llgo_main.T3", align 8
+  %151 = icmp eq ptr %150, null
+  br i1 %151, label %_llgo_37, label %_llgo_38
 
 _llgo_37:                                         ; preds = %_llgo_36
-  %313 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %310)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %313)
-  store ptr %313, ptr @"*_llgo_main.T3", align 8
+  %152 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %149)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %152)
+  store ptr %152, ptr @"*_llgo_main.T3", align 8
   br label %_llgo_38
 
 _llgo_38:                                         ; preds = %_llgo_37, %_llgo_36
-  %314 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %315 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %314, i32 0, i32 0
-  store ptr @20, ptr %315, align 8
-  %316 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %314, i32 0, i32 1
-  store i64 7, ptr %316, align 4
-  %317 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %314, align 8
-  %318 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %317, i64 17, i64 8, i64 1, i64 1)
-  %319 = load ptr, ptr @_llgo_main.T4, align 8
-  %320 = icmp eq ptr %319, null
-  br i1 %320, label %_llgo_39, label %_llgo_40
+  %153 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @20, i64 7 }, i64 17, i64 8, i64 1, i64 1)
+  %154 = load ptr, ptr @_llgo_main.T4, align 8
+  %155 = icmp eq ptr %154, null
+  br i1 %155, label %_llgo_39, label %_llgo_40
 
 _llgo_39:                                         ; preds = %_llgo_38
-  store ptr %318, ptr @_llgo_main.T4, align 8
+  store ptr %153, ptr @_llgo_main.T4, align 8
   br label %_llgo_40
 
 _llgo_40:                                         ; preds = %_llgo_39, %_llgo_38
-  %321 = load ptr, ptr @"[1]_llgo_int", align 8
-  %322 = icmp eq ptr %321, null
-  br i1 %322, label %_llgo_41, label %_llgo_42
+  %156 = load ptr, ptr @"[1]_llgo_int", align 8
+  %157 = icmp eq ptr %156, null
+  br i1 %157, label %_llgo_41, label %_llgo_42
 
 _llgo_41:                                         ; preds = %_llgo_40
-  %323 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %324 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 1, ptr %323)
-  store ptr %324, ptr @"[1]_llgo_int", align 8
+  %158 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %159 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 1, ptr %158)
+  store ptr %159, ptr @"[1]_llgo_int", align 8
   br label %_llgo_42
 
 _llgo_42:                                         ; preds = %_llgo_41, %_llgo_40
-  %325 = load ptr, ptr @"[1]_llgo_int", align 8
-  br i1 %320, label %_llgo_43, label %_llgo_44
+  %160 = load ptr, ptr @"[1]_llgo_int", align 8
+  br i1 %155, label %_llgo_43, label %_llgo_44
 
 _llgo_43:                                         ; preds = %_llgo_42
-  %326 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %327 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %326, i32 0, i32 0
-  store ptr @11, ptr %327, align 8
-  %328 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %326, i32 0, i32 1
-  store i64 6, ptr %328, align 4
-  %329 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %326, align 8
-  %330 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %331 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %332 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %331, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %329, ptr %332, align 8
-  %333 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %331, i32 0, i32 1
-  store ptr %330, ptr %333, align 8
-  %334 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %331, i32 0, i32 2
-  store ptr @"main.(*T4).Invoke", ptr %334, align 8
-  %335 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %331, i32 0, i32 3
-  store ptr @"main.(*T4).Invoke", ptr %335, align 8
-  %336 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %331, align 8
-  %337 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %338 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %337, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %329, ptr %338, align 8
-  %339 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %337, i32 0, i32 1
-  store ptr %330, ptr %339, align 8
-  %340 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %337, i32 0, i32 2
-  store ptr @"main.(*T4).Invoke", ptr %340, align 8
-  %341 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %337, i32 0, i32 3
-  store ptr @main.T4.Invoke, ptr %341, align 8
-  %342 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %337, align 8
-  %343 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %344 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %343, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %342, ptr %344, align 8
-  %345 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %346 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %345, i32 0, i32 0
-  store ptr %343, ptr %346, align 8
-  %347 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %345, i32 0, i32 1
-  store i64 1, ptr %347, align 4
-  %348 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %345, i32 0, i32 2
-  store i64 1, ptr %348, align 4
-  %349 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %345, align 8
-  %350 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %351 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %350, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %336, ptr %351, align 8
-  %352 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %353 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %352, i32 0, i32 0
-  store ptr %350, ptr %353, align 8
-  %354 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %352, i32 0, i32 1
-  store i64 1, ptr %354, align 4
-  %355 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %352, i32 0, i32 2
-  store i64 1, ptr %355, align 4
-  %356 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %352, align 8
-  %357 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %358 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %357, i32 0, i32 0
-  store ptr @10, ptr %358, align 8
-  %359 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %357, i32 0, i32 1
-  store i64 4, ptr %359, align 4
-  %360 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %357, align 8
-  %361 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %362 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %361, i32 0, i32 0
-  store ptr @21, ptr %362, align 8
-  %363 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %361, i32 0, i32 1
-  store i64 2, ptr %363, align 4
-  %364 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %361, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %318, %"github.com/goplus/llgo/internal/runtime.String" %360, %"github.com/goplus/llgo/internal/runtime.String" %364, ptr %325, %"github.com/goplus/llgo/internal/runtime.Slice" %349, %"github.com/goplus/llgo/internal/runtime.Slice" %356)
+  %161 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %162 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %161, 1
+  %163 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %162, ptr @"main.(*T4).Invoke", 2
+  %164 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %163, ptr @"main.(*T4).Invoke", 3
+  %165 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %161, 1
+  %166 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %165, ptr @"main.(*T4).Invoke", 2
+  %167 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %166, ptr @main.T4.Invoke, 3
+  %168 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %169 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %168, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %167, ptr %169, align 8
+  %170 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %168, 0
+  %171 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %170, i64 1, 1
+  %172 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %171, i64 1, 2
+  %173 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %174 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %173, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %164, ptr %174, align 8
+  %175 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %173, 0
+  %176 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %175, i64 1, 1
+  %177 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %176, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %153, %"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @21, i64 2 }, ptr %160, %"github.com/goplus/llgo/internal/runtime.Slice" %172, %"github.com/goplus/llgo/internal/runtime.Slice" %177)
   br label %_llgo_44
 
 _llgo_44:                                         ; preds = %_llgo_43, %_llgo_42
-  %365 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %366 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %365, i32 0, i32 0
-  store ptr @20, ptr %366, align 8
-  %367 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %365, i32 0, i32 1
-  store i64 7, ptr %367, align 4
-  %368 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %365, align 8
-  %369 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %368, i64 17, i64 8, i64 1, i64 1)
-  %370 = load ptr, ptr @"*_llgo_main.T4", align 8
-  %371 = icmp eq ptr %370, null
-  br i1 %371, label %_llgo_45, label %_llgo_46
+  %178 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @20, i64 7 }, i64 17, i64 8, i64 1, i64 1)
+  %179 = load ptr, ptr @"*_llgo_main.T4", align 8
+  %180 = icmp eq ptr %179, null
+  br i1 %180, label %_llgo_45, label %_llgo_46
 
 _llgo_45:                                         ; preds = %_llgo_44
-  %372 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %369)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %372)
-  store ptr %372, ptr @"*_llgo_main.T4", align 8
+  %181 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %178)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %181)
+  store ptr %181, ptr @"*_llgo_main.T4", align 8
   br label %_llgo_46
 
 _llgo_46:                                         ; preds = %_llgo_45, %_llgo_44
-  %373 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %374 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %373, i32 0, i32 0
-  store ptr @22, ptr %374, align 8
-  %375 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %373, i32 0, i32 1
-  store i64 7, ptr %375, align 4
-  %376 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %373, align 8
-  %377 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %376, i64 25, i64 8, i64 1, i64 1)
-  %378 = load ptr, ptr @_llgo_main.T5, align 8
-  %379 = icmp eq ptr %378, null
-  br i1 %379, label %_llgo_47, label %_llgo_48
+  %182 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @22, i64 7 }, i64 25, i64 8, i64 1, i64 1)
+  %183 = load ptr, ptr @_llgo_main.T5, align 8
+  %184 = icmp eq ptr %183, null
+  br i1 %184, label %_llgo_47, label %_llgo_48
 
 _llgo_47:                                         ; preds = %_llgo_46
-  store ptr %377, ptr @_llgo_main.T5, align 8
+  store ptr %182, ptr @_llgo_main.T5, align 8
   br label %_llgo_48
 
 _llgo_48:                                         ; preds = %_llgo_47, %_llgo_46
-  %380 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %381 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %380, i32 0, i32 0
-  store ptr @23, ptr %381, align 8
-  %382 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %380, i32 0, i32 1
-  store i64 1, ptr %382, align 4
-  %383 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %380, align 8
-  %384 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %385 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %384, i32 0, i32 0
-  store ptr null, ptr %385, align 8
-  %386 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %384, i32 0, i32 1
-  store i64 0, ptr %386, align 4
-  %387 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %384, align 8
-  %388 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %389 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %383, ptr %388, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %387, i1 false)
-  %390 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %391 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %390, i32 0, i32 0
-  store ptr @10, ptr %391, align 8
-  %392 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %390, i32 0, i32 1
-  store i64 4, ptr %392, align 4
-  %393 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %390, align 8
-  %394 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
-  %395 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %394, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %389, ptr %395, align 8
-  %396 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %397 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %396, i32 0, i32 0
-  store ptr %394, ptr %397, align 8
-  %398 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %396, i32 0, i32 1
-  store i64 1, ptr %398, align 4
-  %399 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %396, i32 0, i32 2
-  store i64 1, ptr %399, align 4
-  %400 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %396, align 8
-  %401 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %393, i64 8, %"github.com/goplus/llgo/internal/runtime.Slice" %400)
-  store ptr %401, ptr @"main.struct$eovYmOhZg4X0zMSsuscSshndnbbAGvB2E3cyG8E7Y4U", align 8
-  %402 = load ptr, ptr @"main.struct$eovYmOhZg4X0zMSsuscSshndnbbAGvB2E3cyG8E7Y4U", align 8
-  br i1 %379, label %_llgo_49, label %_llgo_50
+  %185 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %186 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @23, i64 1 }, ptr %185, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %187 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
+  %188 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %187, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %186, ptr %188, align 8
+  %189 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %187, 0
+  %190 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %189, i64 1, 1
+  %191 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %190, i64 1, 2
+  %192 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, i64 8, %"github.com/goplus/llgo/internal/runtime.Slice" %191)
+  store ptr %192, ptr @"main.struct$eovYmOhZg4X0zMSsuscSshndnbbAGvB2E3cyG8E7Y4U", align 8
+  %193 = load ptr, ptr @"main.struct$eovYmOhZg4X0zMSsuscSshndnbbAGvB2E3cyG8E7Y4U", align 8
+  br i1 %184, label %_llgo_49, label %_llgo_50
 
 _llgo_49:                                         ; preds = %_llgo_48
-  %403 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %404 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %403, i32 0, i32 0
-  store ptr @11, ptr %404, align 8
-  %405 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %403, i32 0, i32 1
-  store i64 6, ptr %405, align 4
-  %406 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %403, align 8
-  %407 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %408 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %409 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %408, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %406, ptr %409, align 8
-  %410 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %408, i32 0, i32 1
-  store ptr %407, ptr %410, align 8
-  %411 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %408, i32 0, i32 2
-  store ptr @"main.(*T5).Invoke", ptr %411, align 8
-  %412 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %408, i32 0, i32 3
-  store ptr @"main.(*T5).Invoke", ptr %412, align 8
-  %413 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %408, align 8
-  %414 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %415 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %414, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %406, ptr %415, align 8
-  %416 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %414, i32 0, i32 1
-  store ptr %407, ptr %416, align 8
-  %417 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %414, i32 0, i32 2
-  store ptr @"main.(*T5).Invoke", ptr %417, align 8
-  %418 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %414, i32 0, i32 3
-  store ptr @main.T5.Invoke, ptr %418, align 8
-  %419 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %414, align 8
-  %420 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %421 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %420, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %419, ptr %421, align 8
-  %422 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %423 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %422, i32 0, i32 0
-  store ptr %420, ptr %423, align 8
-  %424 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %422, i32 0, i32 1
-  store i64 1, ptr %424, align 4
-  %425 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %422, i32 0, i32 2
-  store i64 1, ptr %425, align 4
-  %426 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %422, align 8
-  %427 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %428 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %427, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %413, ptr %428, align 8
-  %429 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %430 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %429, i32 0, i32 0
-  store ptr %427, ptr %430, align 8
-  %431 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %429, i32 0, i32 1
-  store i64 1, ptr %431, align 4
-  %432 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %429, i32 0, i32 2
-  store i64 1, ptr %432, align 4
-  %433 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %429, align 8
-  %434 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %435 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %434, i32 0, i32 0
-  store ptr @10, ptr %435, align 8
-  %436 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %434, i32 0, i32 1
-  store i64 4, ptr %436, align 4
-  %437 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %434, align 8
-  %438 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %439 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %438, i32 0, i32 0
-  store ptr @24, ptr %439, align 8
-  %440 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %438, i32 0, i32 1
-  store i64 2, ptr %440, align 4
-  %441 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %438, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %377, %"github.com/goplus/llgo/internal/runtime.String" %437, %"github.com/goplus/llgo/internal/runtime.String" %441, ptr %402, %"github.com/goplus/llgo/internal/runtime.Slice" %426, %"github.com/goplus/llgo/internal/runtime.Slice" %433)
+  %194 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %195 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %194, 1
+  %196 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %195, ptr @"main.(*T5).Invoke", 2
+  %197 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %196, ptr @"main.(*T5).Invoke", 3
+  %198 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %194, 1
+  %199 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %198, ptr @"main.(*T5).Invoke", 2
+  %200 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %199, ptr @main.T5.Invoke, 3
+  %201 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %202 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %201, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %200, ptr %202, align 8
+  %203 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %201, 0
+  %204 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %203, i64 1, 1
+  %205 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %204, i64 1, 2
+  %206 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %207 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %206, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %197, ptr %207, align 8
+  %208 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %206, 0
+  %209 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %208, i64 1, 1
+  %210 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %209, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %182, %"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @24, i64 2 }, ptr %193, %"github.com/goplus/llgo/internal/runtime.Slice" %205, %"github.com/goplus/llgo/internal/runtime.Slice" %210)
   br label %_llgo_50
 
 _llgo_50:                                         ; preds = %_llgo_49, %_llgo_48
-  %442 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %443 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %442, i32 0, i32 0
-  store ptr @22, ptr %443, align 8
-  %444 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %442, i32 0, i32 1
-  store i64 7, ptr %444, align 4
-  %445 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %442, align 8
-  %446 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %445, i64 25, i64 8, i64 1, i64 1)
-  %447 = load ptr, ptr @"*_llgo_main.T5", align 8
-  %448 = icmp eq ptr %447, null
-  br i1 %448, label %_llgo_51, label %_llgo_52
+  %211 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @22, i64 7 }, i64 25, i64 8, i64 1, i64 1)
+  %212 = load ptr, ptr @"*_llgo_main.T5", align 8
+  %213 = icmp eq ptr %212, null
+  br i1 %213, label %_llgo_51, label %_llgo_52
 
 _llgo_51:                                         ; preds = %_llgo_50
-  %449 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %446)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %449)
-  store ptr %449, ptr @"*_llgo_main.T5", align 8
+  %214 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %211)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %214)
+  store ptr %214, ptr @"*_llgo_main.T5", align 8
   br label %_llgo_52
 
 _llgo_52:                                         ; preds = %_llgo_51, %_llgo_50
-  %450 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %451 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %450, i32 0, i32 0
-  store ptr @25, ptr %451, align 8
-  %452 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %450, i32 0, i32 1
-  store i64 7, ptr %452, align 4
-  %453 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %450, align 8
-  %454 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %453, i64 25, i64 24, i64 1, i64 1)
-  %455 = load ptr, ptr @_llgo_main.T6, align 8
-  %456 = icmp eq ptr %455, null
-  br i1 %456, label %_llgo_53, label %_llgo_54
+  %215 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @25, i64 7 }, i64 25, i64 24, i64 1, i64 1)
+  %216 = load ptr, ptr @_llgo_main.T6, align 8
+  %217 = icmp eq ptr %216, null
+  br i1 %217, label %_llgo_53, label %_llgo_54
 
 _llgo_53:                                         ; preds = %_llgo_52
-  store ptr %454, ptr @_llgo_main.T6, align 8
+  store ptr %215, ptr @_llgo_main.T6, align 8
   br label %_llgo_54
 
 _llgo_54:                                         ; preds = %_llgo_53, %_llgo_52
-  %457 = load ptr, ptr @_llgo_Pointer, align 8
-  %458 = icmp eq ptr %457, null
-  br i1 %458, label %_llgo_55, label %_llgo_56
+  %218 = load ptr, ptr @_llgo_Pointer, align 8
+  %219 = icmp eq ptr %218, null
+  br i1 %219, label %_llgo_55, label %_llgo_56
 
 _llgo_55:                                         ; preds = %_llgo_54
-  %459 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %459)
-  store ptr %459, ptr @_llgo_Pointer, align 8
+  %220 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %220)
+  store ptr %220, ptr @_llgo_Pointer, align 8
   br label %_llgo_56
 
 _llgo_56:                                         ; preds = %_llgo_55, %_llgo_54
-  %460 = load ptr, ptr @_llgo_Pointer, align 8
-  %461 = load ptr, ptr @_llgo_Pointer, align 8
-  %462 = load ptr, ptr @_llgo_int, align 8
-  %463 = load ptr, ptr @"_llgo_func$xDKPBz2TjGWCkfLQLcYQpZXP65A_RCdH__LHR-wvWiw", align 8
-  %464 = icmp eq ptr %463, null
-  br i1 %464, label %_llgo_57, label %_llgo_58
+  %221 = load ptr, ptr @_llgo_Pointer, align 8
+  %222 = load ptr, ptr @_llgo_Pointer, align 8
+  %223 = load ptr, ptr @_llgo_int, align 8
+  %224 = load ptr, ptr @"_llgo_func$xDKPBz2TjGWCkfLQLcYQpZXP65A_RCdH__LHR-wvWiw", align 8
+  %225 = icmp eq ptr %224, null
+  br i1 %225, label %_llgo_57, label %_llgo_58
 
 _llgo_57:                                         ; preds = %_llgo_56
-  %465 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %466 = getelementptr ptr, ptr %465, i64 0
-  store ptr %461, ptr %466, align 8
-  %467 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %468 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %467, i32 0, i32 0
-  store ptr %465, ptr %468, align 8
-  %469 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %467, i32 0, i32 1
-  store i64 1, ptr %469, align 4
-  %470 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %467, i32 0, i32 2
-  store i64 1, ptr %470, align 4
-  %471 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %467, align 8
-  %472 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %473 = getelementptr ptr, ptr %472, i64 0
-  store ptr %462, ptr %473, align 8
-  %474 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %475 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %474, i32 0, i32 0
-  store ptr %472, ptr %475, align 8
-  %476 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %474, i32 0, i32 1
-  store i64 1, ptr %476, align 4
-  %477 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %474, i32 0, i32 2
-  store i64 1, ptr %477, align 4
-  %478 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %474, align 8
-  %479 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %471, %"github.com/goplus/llgo/internal/runtime.Slice" %478, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %479)
-  store ptr %479, ptr @"_llgo_func$xDKPBz2TjGWCkfLQLcYQpZXP65A_RCdH__LHR-wvWiw", align 8
+  %226 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %227 = getelementptr ptr, ptr %226, i64 0
+  store ptr %222, ptr %227, align 8
+  %228 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %226, 0
+  %229 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %228, i64 1, 1
+  %230 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %229, i64 1, 2
+  %231 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %232 = getelementptr ptr, ptr %231, i64 0
+  store ptr %223, ptr %232, align 8
+  %233 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %231, 0
+  %234 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %233, i64 1, 1
+  %235 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %234, i64 1, 2
+  %236 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %230, %"github.com/goplus/llgo/internal/runtime.Slice" %235, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %236)
+  store ptr %236, ptr @"_llgo_func$xDKPBz2TjGWCkfLQLcYQpZXP65A_RCdH__LHR-wvWiw", align 8
   br label %_llgo_58
 
 _llgo_58:                                         ; preds = %_llgo_57, %_llgo_56
-  %480 = load ptr, ptr @"_llgo_func$xDKPBz2TjGWCkfLQLcYQpZXP65A_RCdH__LHR-wvWiw", align 8
-  %481 = load ptr, ptr @_llgo_Pointer, align 8
-  %482 = load ptr, ptr @_llgo_int, align 8
-  %483 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %484 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %483, i32 0, i32 0
-  store ptr @26, ptr %484, align 8
-  %485 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %483, i32 0, i32 1
-  store i64 1, ptr %485, align 4
-  %486 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %483, align 8
-  %487 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %488 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %487, i32 0, i32 0
-  store ptr null, ptr %488, align 8
-  %489 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %487, i32 0, i32 1
-  store i64 0, ptr %489, align 4
-  %490 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %487, align 8
-  %491 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %492 = getelementptr ptr, ptr %491, i64 0
-  store ptr %481, ptr %492, align 8
-  %493 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %494 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %493, i32 0, i32 0
-  store ptr %491, ptr %494, align 8
-  %495 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %493, i32 0, i32 1
-  store i64 1, ptr %495, align 4
-  %496 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %493, i32 0, i32 2
-  store i64 1, ptr %496, align 4
-  %497 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %493, align 8
-  %498 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %499 = getelementptr ptr, ptr %498, i64 0
-  store ptr %482, ptr %499, align 8
-  %500 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %501 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %500, i32 0, i32 0
-  store ptr %498, ptr %501, align 8
-  %502 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %500, i32 0, i32 1
-  store i64 1, ptr %502, align 4
-  %503 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %500, i32 0, i32 2
-  store i64 1, ptr %503, align 4
-  %504 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %500, align 8
-  %505 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %497, %"github.com/goplus/llgo/internal/runtime.Slice" %504, i1 false)
-  %506 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %486, ptr %505, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %490, i1 false)
-  %507 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %508 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %507, i32 0, i32 0
-  store ptr @27, ptr %508, align 8
-  %509 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %507, i32 0, i32 1
-  store i64 4, ptr %509, align 4
-  %510 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %507, align 8
-  %511 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %512 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %511, i32 0, i32 0
-  store ptr null, ptr %512, align 8
-  %513 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %511, i32 0, i32 1
-  store i64 0, ptr %513, align 4
-  %514 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %511, align 8
-  %515 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %516 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %510, ptr %515, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %514, i1 false)
-  %517 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %518 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %517, i32 0, i32 0
-  store ptr @10, ptr %518, align 8
-  %519 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %517, i32 0, i32 1
-  store i64 4, ptr %519, align 4
-  %520 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %517, align 8
-  %521 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %522 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %521, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %506, ptr %522, align 8
-  %523 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %521, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %516, ptr %523, align 8
-  %524 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %525 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %524, i32 0, i32 0
-  store ptr %521, ptr %525, align 8
-  %526 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %524, i32 0, i32 1
-  store i64 2, ptr %526, align 4
-  %527 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %524, i32 0, i32 2
-  store i64 2, ptr %527, align 4
-  %528 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %524, align 8
-  %529 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %520, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %528)
-  store ptr %529, ptr @"main.struct$2bSfJcCYDdttnIT-JASAjsTNUZvojBt4mPXFJdH4M10", align 8
-  %530 = load ptr, ptr @"main.struct$2bSfJcCYDdttnIT-JASAjsTNUZvojBt4mPXFJdH4M10", align 8
-  br i1 %456, label %_llgo_59, label %_llgo_60
+  %237 = load ptr, ptr @"_llgo_func$xDKPBz2TjGWCkfLQLcYQpZXP65A_RCdH__LHR-wvWiw", align 8
+  %238 = load ptr, ptr @_llgo_Pointer, align 8
+  %239 = load ptr, ptr @_llgo_int, align 8
+  %240 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %241 = getelementptr ptr, ptr %240, i64 0
+  store ptr %238, ptr %241, align 8
+  %242 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %240, 0
+  %243 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %242, i64 1, 1
+  %244 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %243, i64 1, 2
+  %245 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %246 = getelementptr ptr, ptr %245, i64 0
+  store ptr %239, ptr %246, align 8
+  %247 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %245, 0
+  %248 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %247, i64 1, 1
+  %249 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %248, i64 1, 2
+  %250 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %244, %"github.com/goplus/llgo/internal/runtime.Slice" %249, i1 false)
+  %251 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @26, i64 1 }, ptr %250, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %252 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %253 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @27, i64 4 }, ptr %252, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %254 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %255 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %254, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %251, ptr %255, align 8
+  %256 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %254, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %253, ptr %256, align 8
+  %257 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %254, 0
+  %258 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %257, i64 2, 1
+  %259 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %258, i64 2, 2
+  %260 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %259)
+  store ptr %260, ptr @"main.struct$2bSfJcCYDdttnIT-JASAjsTNUZvojBt4mPXFJdH4M10", align 8
+  %261 = load ptr, ptr @"main.struct$2bSfJcCYDdttnIT-JASAjsTNUZvojBt4mPXFJdH4M10", align 8
+  br i1 %217, label %_llgo_59, label %_llgo_60
 
 _llgo_59:                                         ; preds = %_llgo_58
-  %531 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %532 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %531, i32 0, i32 0
-  store ptr @11, ptr %532, align 8
-  %533 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %531, i32 0, i32 1
-  store i64 6, ptr %533, align 4
-  %534 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %531, align 8
-  %535 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %536 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %537 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %536, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %534, ptr %537, align 8
-  %538 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %536, i32 0, i32 1
-  store ptr %535, ptr %538, align 8
-  %539 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %536, i32 0, i32 2
-  store ptr @"main.(*T6).Invoke", ptr %539, align 8
-  %540 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %536, i32 0, i32 3
-  store ptr @"main.(*T6).Invoke", ptr %540, align 8
-  %541 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %536, align 8
-  %542 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %543 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %542, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %534, ptr %543, align 8
-  %544 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %542, i32 0, i32 1
-  store ptr %535, ptr %544, align 8
-  %545 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %542, i32 0, i32 2
-  store ptr @"main.(*T6).Invoke", ptr %545, align 8
-  %546 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %542, i32 0, i32 3
-  store ptr @main.T6.Invoke, ptr %546, align 8
-  %547 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %542, align 8
-  %548 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %549 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %548, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %547, ptr %549, align 8
-  %550 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %551 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %550, i32 0, i32 0
-  store ptr %548, ptr %551, align 8
-  %552 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %550, i32 0, i32 1
-  store i64 1, ptr %552, align 4
-  %553 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %550, i32 0, i32 2
-  store i64 1, ptr %553, align 4
-  %554 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %550, align 8
-  %555 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %556 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %555, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %541, ptr %556, align 8
-  %557 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %558 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %557, i32 0, i32 0
-  store ptr %555, ptr %558, align 8
-  %559 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %557, i32 0, i32 1
-  store i64 1, ptr %559, align 4
-  %560 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %557, i32 0, i32 2
-  store i64 1, ptr %560, align 4
-  %561 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %557, align 8
-  %562 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %563 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %562, i32 0, i32 0
-  store ptr @10, ptr %563, align 8
-  %564 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %562, i32 0, i32 1
-  store i64 4, ptr %564, align 4
-  %565 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %562, align 8
-  %566 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %567 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %566, i32 0, i32 0
-  store ptr @28, ptr %567, align 8
-  %568 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %566, i32 0, i32 1
-  store i64 2, ptr %568, align 4
-  %569 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %566, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %454, %"github.com/goplus/llgo/internal/runtime.String" %565, %"github.com/goplus/llgo/internal/runtime.String" %569, ptr %530, %"github.com/goplus/llgo/internal/runtime.Slice" %554, %"github.com/goplus/llgo/internal/runtime.Slice" %561)
+  %262 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %263 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %262, 1
+  %264 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %263, ptr @"main.(*T6).Invoke", 2
+  %265 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %264, ptr @"main.(*T6).Invoke", 3
+  %266 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %262, 1
+  %267 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %266, ptr @"main.(*T6).Invoke", 2
+  %268 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %267, ptr @main.T6.Invoke, 3
+  %269 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %270 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %269, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %268, ptr %270, align 8
+  %271 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %269, 0
+  %272 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %271, i64 1, 1
+  %273 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %272, i64 1, 2
+  %274 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %275 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %274, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %265, ptr %275, align 8
+  %276 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %274, 0
+  %277 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %276, i64 1, 1
+  %278 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %277, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %215, %"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @28, i64 2 }, ptr %261, %"github.com/goplus/llgo/internal/runtime.Slice" %273, %"github.com/goplus/llgo/internal/runtime.Slice" %278)
   br label %_llgo_60
 
 _llgo_60:                                         ; preds = %_llgo_59, %_llgo_58
-  %570 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %571 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %570, i32 0, i32 0
-  store ptr @25, ptr %571, align 8
-  %572 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %570, i32 0, i32 1
-  store i64 7, ptr %572, align 4
-  %573 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %570, align 8
-  %574 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %573, i64 25, i64 24, i64 1, i64 1)
-  %575 = load ptr, ptr @"*_llgo_main.T6", align 8
-  %576 = icmp eq ptr %575, null
-  br i1 %576, label %_llgo_61, label %_llgo_62
+  %279 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @25, i64 7 }, i64 25, i64 24, i64 1, i64 1)
+  %280 = load ptr, ptr @"*_llgo_main.T6", align 8
+  %281 = icmp eq ptr %280, null
+  br i1 %281, label %_llgo_61, label %_llgo_62
 
 _llgo_61:                                         ; preds = %_llgo_60
-  %577 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %574)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %577)
-  store ptr %577, ptr @"*_llgo_main.T6", align 8
+  %282 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %279)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %282)
+  store ptr %282, ptr @"*_llgo_main.T6", align 8
   br label %_llgo_62
 
 _llgo_62:                                         ; preds = %_llgo_61, %_llgo_60
-  %578 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %579 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %580 = load ptr, ptr @"_llgo_iface$jwmSdgh1zvY_TDIgLzCkvkbiyrdwl9N806DH0JGcyMI", align 8
-  %581 = icmp eq ptr %580, null
-  br i1 %581, label %_llgo_63, label %_llgo_64
+  %283 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %284 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %285 = load ptr, ptr @"_llgo_iface$jwmSdgh1zvY_TDIgLzCkvkbiyrdwl9N806DH0JGcyMI", align 8
+  %286 = icmp eq ptr %285, null
+  br i1 %286, label %_llgo_63, label %_llgo_64
 
 _llgo_63:                                         ; preds = %_llgo_62
-  %582 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %583 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %582, i32 0, i32 0
-  store ptr @11, ptr %583, align 8
-  %584 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %582, i32 0, i32 1
-  store i64 6, ptr %584, align 4
-  %585 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %582, align 8
-  %586 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %587 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %586, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %585, ptr %587, align 8
-  %588 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %586, i32 0, i32 1
-  store ptr %578, ptr %588, align 8
-  %589 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %586, align 8
-  %590 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %591 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %590, i32 0, i32 0
-  store ptr @12, ptr %591, align 8
-  %592 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %590, i32 0, i32 1
-  store i64 6, ptr %592, align 4
-  %593 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %590, align 8
-  %594 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %595 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %594, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %593, ptr %595, align 8
-  %596 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %594, i32 0, i32 1
-  store ptr %579, ptr %596, align 8
-  %597 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %594, align 8
-  %598 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  %599 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %598, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %589, ptr %599, align 8
-  %600 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %598, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %597, ptr %600, align 8
-  %601 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %602 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %601, i32 0, i32 0
-  store ptr %598, ptr %602, align 8
-  %603 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %601, i32 0, i32 1
-  store i64 2, ptr %603, align 4
-  %604 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %601, i32 0, i32 2
-  store i64 2, ptr %604, align 4
-  %605 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %601, align 8
-  %606 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %607 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %606, i32 0, i32 0
-  store ptr @10, ptr %607, align 8
-  %608 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %606, i32 0, i32 1
-  store i64 4, ptr %608, align 4
-  %609 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %606, align 8
-  %610 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %611 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %610, i32 0, i32 0
-  store ptr null, ptr %611, align 8
-  %612 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %610, i32 0, i32 1
-  store i64 0, ptr %612, align 4
-  %613 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %610, align 8
-  %614 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %609, %"github.com/goplus/llgo/internal/runtime.String" %613, %"github.com/goplus/llgo/internal/runtime.Slice" %605)
-  store ptr %614, ptr @"_llgo_iface$jwmSdgh1zvY_TDIgLzCkvkbiyrdwl9N806DH0JGcyMI", align 8
+  %287 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 6 }, ptr undef }, ptr %283, 1
+  %288 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @12, i64 6 }, ptr undef }, ptr %284, 1
+  %289 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  %290 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %289, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %287, ptr %290, align 8
+  %291 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %289, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %288, ptr %291, align 8
+  %292 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %289, 0
+  %293 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %292, i64 2, 1
+  %294 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %293, i64 2, 2
+  %295 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %294)
+  store ptr %295, ptr @"_llgo_iface$jwmSdgh1zvY_TDIgLzCkvkbiyrdwl9N806DH0JGcyMI", align 8
   br label %_llgo_64
 
 _llgo_64:                                         ; preds = %_llgo_63, %_llgo_62
-  %615 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %616 = load ptr, ptr @_llgo_main.I, align 8
-  %617 = icmp eq ptr %616, null
-  br i1 %617, label %_llgo_65, label %_llgo_66
+  %296 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %297 = load ptr, ptr @_llgo_main.I, align 8
+  %298 = icmp eq ptr %297, null
+  br i1 %298, label %_llgo_65, label %_llgo_66
 
 _llgo_65:                                         ; preds = %_llgo_64
-  %618 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %619 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %618, i32 0, i32 0
-  store ptr @11, ptr %619, align 8
-  %620 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %618, i32 0, i32 1
-  store i64 6, ptr %620, align 4
-  %621 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %618, align 8
-  %622 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %623 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %622, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %621, ptr %623, align 8
-  %624 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %622, i32 0, i32 1
-  store ptr %615, ptr %624, align 8
-  %625 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %622, align 8
-  %626 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %627 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %626, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %625, ptr %627, align 8
-  %628 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %629 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %628, i32 0, i32 0
-  store ptr %626, ptr %629, align 8
-  %630 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %628, i32 0, i32 1
-  store i64 1, ptr %630, align 4
-  %631 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %628, i32 0, i32 2
-  store i64 1, ptr %631, align 4
-  %632 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %628, align 8
-  %633 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %634 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %633, i32 0, i32 0
-  store ptr @10, ptr %634, align 8
-  %635 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %633, i32 0, i32 1
-  store i64 4, ptr %635, align 4
-  %636 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %633, align 8
-  %637 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %638 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %637, i32 0, i32 0
-  store ptr @30, ptr %638, align 8
-  %639 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %637, i32 0, i32 1
-  store i64 6, ptr %639, align 4
-  %640 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %637, align 8
-  %641 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %636, %"github.com/goplus/llgo/internal/runtime.String" %640, %"github.com/goplus/llgo/internal/runtime.Slice" %632)
-  store ptr %641, ptr @_llgo_main.I, align 8
+  %299 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 6 }, ptr undef }, ptr %296, 1
+  %300 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %301 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %300, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %299, ptr %301, align 8
+  %302 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %300, 0
+  %303 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %302, i64 1, 1
+  %304 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %303, i64 1, 2
+  %305 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @30, i64 6 }, %"github.com/goplus/llgo/internal/runtime.Slice" %304)
+  store ptr %305, ptr @_llgo_main.I, align 8
   br label %_llgo_66
 
 _llgo_66:                                         ; preds = %_llgo_65, %_llgo_64
-  %642 = load ptr, ptr @_llgo_any, align 8
-  %643 = icmp eq ptr %642, null
-  br i1 %643, label %_llgo_67, label %_llgo_68
+  %306 = load ptr, ptr @_llgo_any, align 8
+  %307 = icmp eq ptr %306, null
+  br i1 %307, label %_llgo_67, label %_llgo_68
 
 _llgo_67:                                         ; preds = %_llgo_66
-  %644 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %645 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %646 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %645, i32 0, i32 0
-  store ptr %644, ptr %646, align 8
-  %647 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %645, i32 0, i32 1
-  store i64 0, ptr %647, align 4
-  %648 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %645, i32 0, i32 2
-  store i64 0, ptr %648, align 4
-  %649 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %645, align 8
-  %650 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %651 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %650, i32 0, i32 0
-  store ptr @10, ptr %651, align 8
-  %652 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %650, i32 0, i32 1
-  store i64 4, ptr %652, align 4
-  %653 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %650, align 8
-  %654 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %655 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %654, i32 0, i32 0
-  store ptr null, ptr %655, align 8
-  %656 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %654, i32 0, i32 1
-  store i64 0, ptr %656, align 4
-  %657 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %654, align 8
-  %658 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %653, %"github.com/goplus/llgo/internal/runtime.String" %657, %"github.com/goplus/llgo/internal/runtime.Slice" %649)
-  store ptr %658, ptr @_llgo_any, align 8
+  %308 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %309 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %308, 0
+  %310 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %309, i64 0, 1
+  %311 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %310, i64 0, 2
+  %312 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %311)
+  store ptr %312, ptr @_llgo_any, align 8
   br label %_llgo_68
 
 _llgo_68:                                         ; preds = %_llgo_67, %_llgo_66

--- a/cl/_testgo/multiret/in.go
+++ b/cl/_testgo/multiret/in.go
@@ -1,0 +1,12 @@
+package main
+
+var a int = 1
+
+func foo(f float64) (int, float64) {
+	return a, f
+}
+
+func main() {
+	i, f := foo(2.0)
+	println(i, f)
+}

--- a/cl/_testgo/multiret/out.ll
+++ b/cl/_testgo/multiret/out.ll
@@ -1,12 +1,18 @@
 ; ModuleID = 'main'
 source_filename = "main"
 
-%"github.com/goplus/llgo/internal/runtime.String" = type { ptr, i64 }
-
+@main.a = global i64 0, align 8
 @"main.init$guard" = global i1 false, align 1
 @__llgo_argc = global i32 0, align 4
 @__llgo_argv = global ptr null, align 8
-@0 = private unnamed_addr constant [7 x i8] c"len > 0", align 1
+
+define { i64, double } @main.foo(double %0) {
+_llgo_0:
+  %1 = load i64, ptr @main.a, align 4
+  %2 = insertvalue { i64, double } undef, i64 %1, 0
+  %3 = insertvalue { i64, double } %2, double %0, 1
+  ret { i64, double } %3
+}
 
 define void @main.init() {
 _llgo_0:
@@ -15,6 +21,7 @@ _llgo_0:
 
 _llgo_1:                                          ; preds = %_llgo_0
   store i1 true, ptr @"main.init$guard", align 1
+  store i64 1, ptr @main.a, align 4
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
@@ -27,16 +34,13 @@ _llgo_0:
   store ptr %1, ptr @__llgo_argv, align 8
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 0)
+  %2 = call { i64, double } @main.foo(double 2.000000e+00)
+  %3 = extractvalue { i64, double } %2, 0
+  %4 = extractvalue { i64, double } %2, 1
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %3)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %4)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  br i1 false, label %_llgo_1, label %_llgo_2
-
-_llgo_1:                                          ; preds = %_llgo_0
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 7 })
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  br label %_llgo_2
-
-_llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret i32 0
 }
 
@@ -46,4 +50,4 @@ declare void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64)
 
 declare void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8)
 
-declare void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String")
+declare void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double)

--- a/cl/_testgo/out.ll
+++ b/cl/_testgo/out.ll
@@ -1,0 +1,64 @@
+; ModuleID = 'main'
+source_filename = "main"
+
+%"github.com/goplus/llgo/internal/runtime.String" = type { ptr, i64 }
+
+@"main.init$guard" = global i1 false, align 1
+@0 = private unnamed_addr constant [5 x i8] c"hello", align 1
+@__llgo_argc = global i32 0, align 4
+@__llgo_argv = global ptr null, align 8
+
+define i64 @main.Foo(%"github.com/goplus/llgo/internal/runtime.String" %0) {
+_llgo_0:
+  %1 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %0, 1
+  ret i64 %1
+}
+
+define void @main.Test() {
+_llgo_0:
+  br label %_llgo_3
+
+_llgo_1:                                          ; preds = %_llgo_3
+  %0 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
+  %1 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 0
+  store ptr @0, ptr %1, align 8
+  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 1
+  store i64 5, ptr %2, align 4
+  %3 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %0, align 8
+  %4 = call i64 @main.Foo(%"github.com/goplus/llgo/internal/runtime.String" %3)
+  %5 = add i64 %6, 1
+  br label %_llgo_3
+
+_llgo_2:                                          ; preds = %_llgo_3
+  ret void
+
+_llgo_3:                                          ; preds = %_llgo_1, %_llgo_0
+  %6 = phi i64 [ 0, %_llgo_0 ], [ %5, %_llgo_1 ]
+  %7 = icmp slt i64 %6, 1000000
+  br i1 %7, label %_llgo_1, label %_llgo_2
+}
+
+define void @main.init() {
+_llgo_0:
+  %0 = load i1, ptr @"main.init$guard", align 1
+  br i1 %0, label %_llgo_2, label %_llgo_1
+
+_llgo_1:                                          ; preds = %_llgo_0
+  store i1 true, ptr @"main.init$guard", align 1
+  br label %_llgo_2
+
+_llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+  ret void
+}
+
+define i32 @main(i32 %0, ptr %1) {
+_llgo_0:
+  store i32 %0, ptr @__llgo_argc, align 4
+  store ptr %1, ptr @__llgo_argv, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.init"()
+  call void @main.init()
+  call void @main.Test()
+  ret i32 0
+}
+
+declare void @"github.com/goplus/llgo/internal/runtime.init"()

--- a/cl/_testgo/reader/out.ll
+++ b/cl/_testgo/reader/out.ll
@@ -117,65 +117,43 @@ _llgo_1:                                          ; preds = %_llgo_5
   %9 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
   %10 = load ptr, ptr @"_llgo_iface$L2Ik-AJcd0jsoBw5fQ07pQpfUM-kh78Wn2bOeak6M3I", align 8
   %11 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %10, ptr %7)
-  %12 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %12, i32 0, i32 0
-  store ptr %11, ptr %13, align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %12, i32 0, i32 1
-  store ptr %8, ptr %14, align 8
-  %15 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %12, align 8
-  ret %"github.com/goplus/llgo/internal/runtime.iface" %15
+  %12 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %11, 0
+  %13 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %12, ptr %8, 1
+  ret %"github.com/goplus/llgo/internal/runtime.iface" %13
 
 _llgo_2:                                          ; preds = %_llgo_5
-  %16 = alloca %main.nopCloser, align 8
-  call void @llvm.memset(ptr %16, i8 0, i64 16, i1 false)
-  %17 = getelementptr inbounds %main.nopCloser, ptr %16, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.iface" %0, ptr %17, align 8
-  %18 = load %main.nopCloser, ptr %16, align 8
-  %19 = load ptr, ptr @_llgo_main.nopCloser, align 8
-  %20 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %main.nopCloser %18, ptr %20, align 8
-  %21 = load ptr, ptr @"_llgo_iface$L2Ik-AJcd0jsoBw5fQ07pQpfUM-kh78Wn2bOeak6M3I", align 8
-  %22 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %21, ptr %19)
-  %23 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %24 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %23, i32 0, i32 0
-  store ptr %22, ptr %24, align 8
-  %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %23, i32 0, i32 1
-  store ptr %20, ptr %25, align 8
-  %26 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %23, align 8
-  ret %"github.com/goplus/llgo/internal/runtime.iface" %26
+  %14 = alloca %main.nopCloser, align 8
+  call void @llvm.memset(ptr %14, i8 0, i64 16, i1 false)
+  %15 = getelementptr inbounds %main.nopCloser, ptr %14, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.iface" %0, ptr %15, align 8
+  %16 = load %main.nopCloser, ptr %14, align 8
+  %17 = load ptr, ptr @_llgo_main.nopCloser, align 8
+  %18 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %main.nopCloser %16, ptr %18, align 8
+  %19 = load ptr, ptr @"_llgo_iface$L2Ik-AJcd0jsoBw5fQ07pQpfUM-kh78Wn2bOeak6M3I", align 8
+  %20 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %19, ptr %17)
+  %21 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %20, 0
+  %22 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %21, ptr %18, 1
+  ret %"github.com/goplus/llgo/internal/runtime.iface" %22
 
 _llgo_3:                                          ; preds = %_llgo_0
-  %27 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %0, 1
-  %28 = load ptr, ptr @"_llgo_iface$eN81k1zqixGTyagHw_4nqH4mGfwwehTOCTXUlbT9kzk", align 8
-  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %28, ptr %1)
-  %30 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %30, i32 0, i32 0
-  store ptr %29, ptr %31, align 8
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %30, i32 0, i32 1
-  store ptr %27, ptr %32, align 8
-  %33 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %30, align 8
-  %34 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
-  %35 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %34, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.iface" %33, ptr %35, align 8
-  %36 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %34, i32 0, i32 1
-  store i1 true, ptr %36, align 1
-  %37 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %34, align 8
+  %23 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %0, 1
+  %24 = load ptr, ptr @"_llgo_iface$eN81k1zqixGTyagHw_4nqH4mGfwwehTOCTXUlbT9kzk", align 8
+  %25 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %24, ptr %1)
+  %26 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %25, 0
+  %27 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %26, ptr %23, 1
+  %28 = insertvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } undef, %"github.com/goplus/llgo/internal/runtime.iface" %27, 0
+  %29 = insertvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %28, i1 true, 1
   br label %_llgo_5
 
 _llgo_4:                                          ; preds = %_llgo_0
-  %38 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
-  %39 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %38, i32 0, i32 0
-  store { ptr, ptr } zeroinitializer, ptr %39, align 8
-  %40 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %38, i32 0, i32 1
-  store i1 false, ptr %40, align 1
-  %41 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %38, align 8
   br label %_llgo_5
 
 _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
-  %42 = phi { %"github.com/goplus/llgo/internal/runtime.iface", i1 } [ %37, %_llgo_3 ], [ %41, %_llgo_4 ]
-  %43 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %42, 0
-  %44 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %42, 1
-  br i1 %44, label %_llgo_1, label %_llgo_2
+  %30 = phi { %"github.com/goplus/llgo/internal/runtime.iface", i1 } [ %29, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
+  %31 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %30, 0
+  %32 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %30, 1
+  br i1 %32, label %_llgo_1, label %_llgo_2
 }
 
 define { %"github.com/goplus/llgo/internal/runtime.Slice", %"github.com/goplus/llgo/internal/runtime.iface" } @main.ReadAll(%"github.com/goplus/llgo/internal/runtime.iface" %0) {
@@ -185,7 +163,7 @@ _llgo_0:
   br label %_llgo_1
 
 _llgo_1:                                          ; preds = %_llgo_6, %_llgo_3, %_llgo_0
-  %3 = phi %"github.com/goplus/llgo/internal/runtime.Slice" [ %2, %_llgo_0 ], [ %26, %_llgo_3 ], [ %75, %_llgo_6 ]
+  %3 = phi %"github.com/goplus/llgo/internal/runtime.Slice" [ %2, %_llgo_0 ], [ %24, %_llgo_3 ], [ %61, %_llgo_6 ]
   %4 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %3, 1
   %5 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %3, 2
   %6 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %3, 2
@@ -195,100 +173,71 @@ _llgo_1:                                          ; preds = %_llgo_6, %_llgo_3, 
   %10 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %0, 0
   %11 = getelementptr ptr, ptr %10, i64 3
   %12 = load ptr, ptr %11, align 8
-  %13 = alloca { ptr, ptr }, align 8
-  %14 = getelementptr inbounds { ptr, ptr }, ptr %13, i32 0, i32 0
-  store ptr %12, ptr %14, align 8
-  %15 = getelementptr inbounds { ptr, ptr }, ptr %13, i32 0, i32 1
-  store ptr %9, ptr %15, align 8
-  %16 = load { ptr, ptr }, ptr %13, align 8
-  %17 = extractvalue { ptr, ptr } %16, 1
-  %18 = extractvalue { ptr, ptr } %16, 0
-  %19 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %18(ptr %17, %"github.com/goplus/llgo/internal/runtime.Slice" %8)
-  %20 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %19, 0
-  %21 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %19, 1
-  %22 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %3, 1
-  %23 = add i64 %22, %20
-  %24 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %3, 2
-  %25 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %3, 0
-  %26 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %25, i64 1, i64 %24, i64 0, i64 %23, i64 %24)
-  %27 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %21)
-  %28 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %21, 1
-  %29 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %29, i32 0, i32 0
-  store ptr %27, ptr %30, align 8
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %29, i32 0, i32 1
-  store ptr %28, ptr %31, align 8
-  %32 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %29, align 8
-  %33 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
-  %34 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %34, i32 0, i32 0
-  store ptr %33, ptr %35, align 8
-  %36 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %34, i32 0, i32 1
-  store ptr null, ptr %36, align 8
-  %37 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %34, align 8
-  %38 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %32, %"github.com/goplus/llgo/internal/runtime.eface" %37)
-  %39 = xor i1 %38, true
-  br i1 %39, label %_llgo_2, label %_llgo_3
+  %13 = insertvalue { ptr, ptr } undef, ptr %12, 0
+  %14 = insertvalue { ptr, ptr } %13, ptr %9, 1
+  %15 = extractvalue { ptr, ptr } %14, 1
+  %16 = extractvalue { ptr, ptr } %14, 0
+  %17 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %16(ptr %15, %"github.com/goplus/llgo/internal/runtime.Slice" %8)
+  %18 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %17, 0
+  %19 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %17, 1
+  %20 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %3, 1
+  %21 = add i64 %20, %18
+  %22 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %3, 2
+  %23 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %3, 0
+  %24 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %23, i64 1, i64 %22, i64 0, i64 %21, i64 %22)
+  %25 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %19)
+  %26 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %19, 1
+  %27 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %25, 0
+  %28 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %27, ptr %26, 1
+  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
+  %30 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %29, 0
+  %31 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %30, ptr null, 1
+  %32 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %28, %"github.com/goplus/llgo/internal/runtime.eface" %31)
+  %33 = xor i1 %32, true
+  br i1 %33, label %_llgo_2, label %_llgo_3
 
 _llgo_2:                                          ; preds = %_llgo_1
-  %40 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr @main.EOF, align 8
-  %41 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %21)
-  %42 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %21, 1
-  %43 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %43, i32 0, i32 0
-  store ptr %41, ptr %44, align 8
-  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %43, i32 0, i32 1
-  store ptr %42, ptr %45, align 8
-  %46 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %43, align 8
-  %47 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %40)
-  %48 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %40, 1
-  %49 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %49, i32 0, i32 0
-  store ptr %47, ptr %50, align 8
-  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %49, i32 0, i32 1
-  store ptr %48, ptr %51, align 8
-  %52 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %49, align 8
-  %53 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %46, %"github.com/goplus/llgo/internal/runtime.eface" %52)
-  br i1 %53, label %_llgo_4, label %_llgo_5
+  %34 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr @main.EOF, align 8
+  %35 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %19)
+  %36 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %19, 1
+  %37 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %35, 0
+  %38 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %37, ptr %36, 1
+  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %34)
+  %40 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %34, 1
+  %41 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %39, 0
+  %42 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %41, ptr %40, 1
+  %43 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %38, %"github.com/goplus/llgo/internal/runtime.eface" %42)
+  br i1 %43, label %_llgo_4, label %_llgo_5
 
 _llgo_3:                                          ; preds = %_llgo_1
-  %54 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %26, 1
-  %55 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %26, 2
-  %56 = icmp eq i64 %54, %55
-  br i1 %56, label %_llgo_6, label %_llgo_1
+  %44 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %24, 1
+  %45 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %24, 2
+  %46 = icmp eq i64 %44, %45
+  br i1 %46, label %_llgo_6, label %_llgo_1
 
 _llgo_4:                                          ; preds = %_llgo_2
   br label %_llgo_5
 
 _llgo_5:                                          ; preds = %_llgo_4, %_llgo_2
-  %57 = phi %"github.com/goplus/llgo/internal/runtime.iface" [ %21, %_llgo_2 ], [ zeroinitializer, %_llgo_4 ]
-  %58 = alloca { %"github.com/goplus/llgo/internal/runtime.Slice", %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %59 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.Slice", %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %58, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.Slice" %26, ptr %59, align 8
-  %60 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.Slice", %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %58, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" %57, ptr %60, align 8
-  %61 = load { %"github.com/goplus/llgo/internal/runtime.Slice", %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %58, align 8
-  ret { %"github.com/goplus/llgo/internal/runtime.Slice", %"github.com/goplus/llgo/internal/runtime.iface" } %61
+  %47 = phi %"github.com/goplus/llgo/internal/runtime.iface" [ %19, %_llgo_2 ], [ zeroinitializer, %_llgo_4 ]
+  %48 = insertvalue { %"github.com/goplus/llgo/internal/runtime.Slice", %"github.com/goplus/llgo/internal/runtime.iface" } undef, %"github.com/goplus/llgo/internal/runtime.Slice" %24, 0
+  %49 = insertvalue { %"github.com/goplus/llgo/internal/runtime.Slice", %"github.com/goplus/llgo/internal/runtime.iface" } %48, %"github.com/goplus/llgo/internal/runtime.iface" %47, 1
+  ret { %"github.com/goplus/llgo/internal/runtime.Slice", %"github.com/goplus/llgo/internal/runtime.iface" } %49
 
 _llgo_6:                                          ; preds = %_llgo_3
-  %62 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 1)
-  %63 = getelementptr inbounds i8, ptr %62, i64 0
-  store i8 0, ptr %63, align 1
-  %64 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %65 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %64, i32 0, i32 0
-  store ptr %62, ptr %65, align 8
-  %66 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %64, i32 0, i32 1
-  store i64 1, ptr %66, align 4
-  %67 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %64, i32 0, i32 2
-  store i64 1, ptr %67, align 4
-  %68 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %64, align 8
-  %69 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %68, 0
-  %70 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %68, 1
-  %71 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.SliceAppend"(%"github.com/goplus/llgo/internal/runtime.Slice" %26, ptr %69, i64 %70, i64 1)
-  %72 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %26, 1
-  %73 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %71, 2
-  %74 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %71, 0
-  %75 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %74, i64 1, i64 %73, i64 0, i64 %72, i64 %73)
+  %50 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 1)
+  %51 = getelementptr inbounds i8, ptr %50, i64 0
+  store i8 0, ptr %51, align 1
+  %52 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %50, 0
+  %53 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %52, i64 1, 1
+  %54 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %53, i64 1, 2
+  %55 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %54, 0
+  %56 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %54, 1
+  %57 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.SliceAppend"(%"github.com/goplus/llgo/internal/runtime.Slice" %24, ptr %55, i64 %56, i64 1)
+  %58 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %24, 1
+  %59 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %57, 2
+  %60 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %57, 0
+  %61 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %60, i64 1, i64 %59, i64 0, i64 %58, i64 %59)
   br label %_llgo_1
 }
 
@@ -300,86 +249,56 @@ _llgo_0:
   br i1 %4, label %_llgo_3, label %_llgo_4
 
 _llgo_1:                                          ; preds = %_llgo_5
-  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %56)
-  %6 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %56, 0
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %40)
+  %6 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %40, 0
   %7 = getelementptr ptr, ptr %6, i64 3
   %8 = load ptr, ptr %7, align 8
-  %9 = alloca { ptr, ptr }, align 8
-  %10 = getelementptr inbounds { ptr, ptr }, ptr %9, i32 0, i32 0
-  store ptr %8, ptr %10, align 8
-  %11 = getelementptr inbounds { ptr, ptr }, ptr %9, i32 0, i32 1
-  store ptr %5, ptr %11, align 8
-  %12 = load { ptr, ptr }, ptr %9, align 8
-  %13 = extractvalue { ptr, ptr } %12, 1
-  %14 = extractvalue { ptr, ptr } %12, 0
-  %15 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %14(ptr %13, %"github.com/goplus/llgo/internal/runtime.String" %1)
-  %16 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %15, 0
-  %17 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %15, 1
-  %18 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %19 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %18, i32 0, i32 0
-  store i64 %16, ptr %19, align 4
-  %20 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %18, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" %17, ptr %20, align 8
-  %21 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %18, align 8
-  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %21
+  %9 = insertvalue { ptr, ptr } undef, ptr %8, 0
+  %10 = insertvalue { ptr, ptr } %9, ptr %5, 1
+  %11 = extractvalue { ptr, ptr } %10, 1
+  %12 = extractvalue { ptr, ptr } %10, 0
+  %13 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %12(ptr %11, %"github.com/goplus/llgo/internal/runtime.String" %1)
+  %14 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %13, 0
+  %15 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %13, 1
+  %16 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } undef, i64 %14, 0
+  %17 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %16, %"github.com/goplus/llgo/internal/runtime.iface" %15, 1
+  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %17
 
 _llgo_2:                                          ; preds = %_llgo_5
-  %22 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/internal/runtime.String" %1)
-  %23 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %0)
-  %24 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %0, 0
-  %25 = getelementptr ptr, ptr %24, i64 3
-  %26 = load ptr, ptr %25, align 8
-  %27 = alloca { ptr, ptr }, align 8
-  %28 = getelementptr inbounds { ptr, ptr }, ptr %27, i32 0, i32 0
-  store ptr %26, ptr %28, align 8
-  %29 = getelementptr inbounds { ptr, ptr }, ptr %27, i32 0, i32 1
-  store ptr %23, ptr %29, align 8
-  %30 = load { ptr, ptr }, ptr %27, align 8
-  %31 = extractvalue { ptr, ptr } %30, 1
-  %32 = extractvalue { ptr, ptr } %30, 0
-  %33 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %32(ptr %31, %"github.com/goplus/llgo/internal/runtime.Slice" %22)
-  %34 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %33, 0
-  %35 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %33, 1
-  %36 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %37 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %36, i32 0, i32 0
-  store i64 %34, ptr %37, align 4
-  %38 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %36, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" %35, ptr %38, align 8
-  %39 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %36, align 8
-  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %39
+  %18 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/internal/runtime.String" %1)
+  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %0)
+  %20 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %0, 0
+  %21 = getelementptr ptr, ptr %20, i64 3
+  %22 = load ptr, ptr %21, align 8
+  %23 = insertvalue { ptr, ptr } undef, ptr %22, 0
+  %24 = insertvalue { ptr, ptr } %23, ptr %19, 1
+  %25 = extractvalue { ptr, ptr } %24, 1
+  %26 = extractvalue { ptr, ptr } %24, 0
+  %27 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %26(ptr %25, %"github.com/goplus/llgo/internal/runtime.Slice" %18)
+  %28 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %27, 0
+  %29 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %27, 1
+  %30 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } undef, i64 %28, 0
+  %31 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %30, %"github.com/goplus/llgo/internal/runtime.iface" %29, 1
+  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %31
 
 _llgo_3:                                          ; preds = %_llgo_0
-  %40 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %0, 1
-  %41 = load ptr, ptr @"_llgo_iface$Ly4zXiUMEac-hYAMw6b6miJ1JEhGfLyBWyBOhpsRZcU", align 8
-  %42 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %41, ptr %2)
-  %43 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %43, i32 0, i32 0
-  store ptr %42, ptr %44, align 8
-  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %43, i32 0, i32 1
-  store ptr %40, ptr %45, align 8
-  %46 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %43, align 8
-  %47 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
-  %48 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %47, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.iface" %46, ptr %48, align 8
-  %49 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %47, i32 0, i32 1
-  store i1 true, ptr %49, align 1
-  %50 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %47, align 8
+  %32 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %0, 1
+  %33 = load ptr, ptr @"_llgo_iface$Ly4zXiUMEac-hYAMw6b6miJ1JEhGfLyBWyBOhpsRZcU", align 8
+  %34 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %33, ptr %2)
+  %35 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %34, 0
+  %36 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %35, ptr %32, 1
+  %37 = insertvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } undef, %"github.com/goplus/llgo/internal/runtime.iface" %36, 0
+  %38 = insertvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %37, i1 true, 1
   br label %_llgo_5
 
 _llgo_4:                                          ; preds = %_llgo_0
-  %51 = alloca { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, align 8
-  %52 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %51, i32 0, i32 0
-  store { ptr, ptr } zeroinitializer, ptr %52, align 8
-  %53 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %51, i32 0, i32 1
-  store i1 false, ptr %53, align 1
-  %54 = load { %"github.com/goplus/llgo/internal/runtime.iface", i1 }, ptr %51, align 8
   br label %_llgo_5
 
 _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
-  %55 = phi { %"github.com/goplus/llgo/internal/runtime.iface", i1 } [ %50, %_llgo_3 ], [ %54, %_llgo_4 ]
-  %56 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %55, 0
-  %57 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %55, 1
-  br i1 %57, label %_llgo_1, label %_llgo_2
+  %39 = phi { %"github.com/goplus/llgo/internal/runtime.iface", i1 } [ %38, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
+  %40 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %39, 0
+  %41 = extractvalue { %"github.com/goplus/llgo/internal/runtime.iface", i1 } %39, 1
+  br i1 %41, label %_llgo_1, label %_llgo_2
 }
 
 define %"github.com/goplus/llgo/internal/runtime.String" @"main.(*errorString).Error"(ptr %0) {
@@ -398,22 +317,10 @@ _llgo_1:                                          ; preds = %_llgo_0
   store i1 true, ptr @"main.init$guard", align 1
   call void @"unicode/utf8.init"()
   call void @"main.init$after"()
-  %1 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1, i32 0, i32 0
-  store ptr @17, ptr %2, align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1, i32 0, i32 1
-  store i64 3, ptr %3, align 4
-  %4 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1, align 8
-  %5 = call %"github.com/goplus/llgo/internal/runtime.iface" @main.newError(%"github.com/goplus/llgo/internal/runtime.String" %4)
-  store %"github.com/goplus/llgo/internal/runtime.iface" %5, ptr @main.EOF, align 8
-  %6 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %6, i32 0, i32 0
-  store ptr @18, ptr %7, align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %6, i32 0, i32 1
-  store i64 11, ptr %8, align 4
-  %9 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %6, align 8
-  %10 = call %"github.com/goplus/llgo/internal/runtime.iface" @main.newError(%"github.com/goplus/llgo/internal/runtime.String" %9)
-  store %"github.com/goplus/llgo/internal/runtime.iface" %10, ptr @main.ErrShortWrite, align 8
+  %1 = call %"github.com/goplus/llgo/internal/runtime.iface" @main.newError(%"github.com/goplus/llgo/internal/runtime.String" { ptr @17, i64 3 })
+  store %"github.com/goplus/llgo/internal/runtime.iface" %1, ptr @main.EOF, align 8
+  %2 = call %"github.com/goplus/llgo/internal/runtime.iface" @main.newError(%"github.com/goplus/llgo/internal/runtime.String" { ptr @18, i64 11 })
+  store %"github.com/goplus/llgo/internal/runtime.iface" %2, ptr @main.ErrShortWrite, align 8
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
@@ -428,30 +335,20 @@ _llgo_0:
   call void @main.init()
   %2 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
   %3 = getelementptr inbounds %main.stringReader, ptr %2, i32 0, i32 0
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @19, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 11, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %7, ptr %3, align 8
-  %8 = load ptr, ptr @_llgo_main.stringReader, align 8
-  %9 = load ptr, ptr @"*_llgo_main.stringReader", align 8
-  %10 = load ptr, ptr @"_llgo_iface$OFO8Us9n8ajWCabGedeuoJ-Za2zAMk4Jh0FunAcUCFE", align 8
-  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %10, ptr %9)
-  %12 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %12, i32 0, i32 0
-  store ptr %11, ptr %13, align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %12, i32 0, i32 1
-  store ptr %2, ptr %14, align 8
-  %15 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %12, align 8
-  %16 = call { %"github.com/goplus/llgo/internal/runtime.Slice", %"github.com/goplus/llgo/internal/runtime.iface" } @main.ReadAll(%"github.com/goplus/llgo/internal/runtime.iface" %15)
-  %17 = extractvalue { %"github.com/goplus/llgo/internal/runtime.Slice", %"github.com/goplus/llgo/internal/runtime.iface" } %16, 0
-  %18 = extractvalue { %"github.com/goplus/llgo/internal/runtime.Slice", %"github.com/goplus/llgo/internal/runtime.iface" } %16, 1
-  %19 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringFromBytes"(%"github.com/goplus/llgo/internal/runtime.Slice" %17)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %19)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @19, i64 11 }, ptr %3, align 8
+  %4 = load ptr, ptr @_llgo_main.stringReader, align 8
+  %5 = load ptr, ptr @"*_llgo_main.stringReader", align 8
+  %6 = load ptr, ptr @"_llgo_iface$OFO8Us9n8ajWCabGedeuoJ-Za2zAMk4Jh0FunAcUCFE", align 8
+  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %6, ptr %5)
+  %8 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %7, 0
+  %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %8, ptr %2, 1
+  %10 = call { %"github.com/goplus/llgo/internal/runtime.Slice", %"github.com/goplus/llgo/internal/runtime.iface" } @main.ReadAll(%"github.com/goplus/llgo/internal/runtime.iface" %9)
+  %11 = extractvalue { %"github.com/goplus/llgo/internal/runtime.Slice", %"github.com/goplus/llgo/internal/runtime.iface" } %10, 0
+  %12 = extractvalue { %"github.com/goplus/llgo/internal/runtime.Slice", %"github.com/goplus/llgo/internal/runtime.iface" } %10, 1
+  %13 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringFromBytes"(%"github.com/goplus/llgo/internal/runtime.Slice" %11)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %13)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintIface"(%"github.com/goplus/llgo/internal/runtime.iface" %18)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintIface"(%"github.com/goplus/llgo/internal/runtime.iface" %12)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 }
@@ -465,13 +362,9 @@ _llgo_0:
   %4 = load ptr, ptr @"*_llgo_main.errorString", align 8
   %5 = load ptr, ptr @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU", align 8
   %6 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %5, ptr %4)
-  %7 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %7, i32 0, i32 0
-  store ptr %6, ptr %8, align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %7, i32 0, i32 1
-  store ptr %1, ptr %9, align 8
-  %10 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %7, align 8
-  ret %"github.com/goplus/llgo/internal/runtime.iface" %10
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %6, 0
+  %8 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %7, ptr %1, 1
+  ret %"github.com/goplus/llgo/internal/runtime.iface" %8
 }
 
 define %"github.com/goplus/llgo/internal/runtime.iface" @main.nopCloser.Close(%main.nopCloser %0) {
@@ -490,24 +383,16 @@ _llgo_0:
   %6 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %4, 0
   %7 = getelementptr ptr, ptr %6, i64 3
   %8 = load ptr, ptr %7, align 8
-  %9 = alloca { ptr, ptr }, align 8
-  %10 = getelementptr inbounds { ptr, ptr }, ptr %9, i32 0, i32 0
-  store ptr %8, ptr %10, align 8
-  %11 = getelementptr inbounds { ptr, ptr }, ptr %9, i32 0, i32 1
-  store ptr %5, ptr %11, align 8
-  %12 = load { ptr, ptr }, ptr %9, align 8
-  %13 = extractvalue { ptr, ptr } %12, 1
-  %14 = extractvalue { ptr, ptr } %12, 0
-  %15 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %14(ptr %13, %"github.com/goplus/llgo/internal/runtime.Slice" %1)
-  %16 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %15, 0
-  %17 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %15, 1
-  %18 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %19 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %18, i32 0, i32 0
-  store i64 %16, ptr %19, align 4
-  %20 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %18, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" %17, ptr %20, align 8
-  %21 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %18, align 8
-  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %21
+  %9 = insertvalue { ptr, ptr } undef, ptr %8, 0
+  %10 = insertvalue { ptr, ptr } %9, ptr %5, 1
+  %11 = extractvalue { ptr, ptr } %10, 1
+  %12 = extractvalue { ptr, ptr } %10, 0
+  %13 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %12(ptr %11, %"github.com/goplus/llgo/internal/runtime.Slice" %1)
+  %14 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %13, 0
+  %15 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %13, 1
+  %16 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } undef, i64 %14, 0
+  %17 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %16, %"github.com/goplus/llgo/internal/runtime.iface" %15, 1
+  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %17
 }
 
 define %"github.com/goplus/llgo/internal/runtime.iface" @"main.(*nopCloser).Close"(ptr %0) {
@@ -525,24 +410,16 @@ _llgo_0:
   %5 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %3, 0
   %6 = getelementptr ptr, ptr %5, i64 3
   %7 = load ptr, ptr %6, align 8
-  %8 = alloca { ptr, ptr }, align 8
-  %9 = getelementptr inbounds { ptr, ptr }, ptr %8, i32 0, i32 0
-  store ptr %7, ptr %9, align 8
-  %10 = getelementptr inbounds { ptr, ptr }, ptr %8, i32 0, i32 1
-  store ptr %4, ptr %10, align 8
-  %11 = load { ptr, ptr }, ptr %8, align 8
-  %12 = extractvalue { ptr, ptr } %11, 1
-  %13 = extractvalue { ptr, ptr } %11, 0
-  %14 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %13(ptr %12, %"github.com/goplus/llgo/internal/runtime.Slice" %1)
-  %15 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %14, 0
-  %16 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %14, 1
-  %17 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %18 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %17, i32 0, i32 0
-  store i64 %15, ptr %18, align 4
-  %19 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %17, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" %16, ptr %19, align 8
-  %20 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %17, align 8
-  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %20
+  %8 = insertvalue { ptr, ptr } undef, ptr %7, 0
+  %9 = insertvalue { ptr, ptr } %8, ptr %4, 1
+  %10 = extractvalue { ptr, ptr } %9, 1
+  %11 = extractvalue { ptr, ptr } %9, 0
+  %12 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %11(ptr %10, %"github.com/goplus/llgo/internal/runtime.Slice" %1)
+  %13 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %12, 0
+  %14 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %12, 1
+  %15 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } undef, i64 %13, 0
+  %16 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %15, %"github.com/goplus/llgo/internal/runtime.iface" %14, 1
+  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %16
 }
 
 define %"github.com/goplus/llgo/internal/runtime.iface" @main.nopCloserWriterTo.Close(%main.nopCloserWriterTo %0) {
@@ -561,24 +438,16 @@ _llgo_0:
   %6 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %4, 0
   %7 = getelementptr ptr, ptr %6, i64 3
   %8 = load ptr, ptr %7, align 8
-  %9 = alloca { ptr, ptr }, align 8
-  %10 = getelementptr inbounds { ptr, ptr }, ptr %9, i32 0, i32 0
-  store ptr %8, ptr %10, align 8
-  %11 = getelementptr inbounds { ptr, ptr }, ptr %9, i32 0, i32 1
-  store ptr %5, ptr %11, align 8
-  %12 = load { ptr, ptr }, ptr %9, align 8
-  %13 = extractvalue { ptr, ptr } %12, 1
-  %14 = extractvalue { ptr, ptr } %12, 0
-  %15 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %14(ptr %13, %"github.com/goplus/llgo/internal/runtime.Slice" %1)
-  %16 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %15, 0
-  %17 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %15, 1
-  %18 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %19 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %18, i32 0, i32 0
-  store i64 %16, ptr %19, align 4
-  %20 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %18, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" %17, ptr %20, align 8
-  %21 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %18, align 8
-  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %21
+  %9 = insertvalue { ptr, ptr } undef, ptr %8, 0
+  %10 = insertvalue { ptr, ptr } %9, ptr %5, 1
+  %11 = extractvalue { ptr, ptr } %10, 1
+  %12 = extractvalue { ptr, ptr } %10, 0
+  %13 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %12(ptr %11, %"github.com/goplus/llgo/internal/runtime.Slice" %1)
+  %14 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %13, 0
+  %15 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %13, 1
+  %16 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } undef, i64 %14, 0
+  %17 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %16, %"github.com/goplus/llgo/internal/runtime.iface" %15, 1
+  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %17
 }
 
 define { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @main.nopCloserWriterTo.WriteTo(%main.nopCloserWriterTo %0, %"github.com/goplus/llgo/internal/runtime.iface" %1) {
@@ -597,52 +466,30 @@ _llgo_1:                                          ; preds = %_llgo_0
   %8 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %4, 1
   %9 = load ptr, ptr @"_llgo_iface$eN81k1zqixGTyagHw_4nqH4mGfwwehTOCTXUlbT9kzk", align 8
   %10 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %9, ptr %5)
-  %11 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %11, i32 0, i32 0
-  store ptr %10, ptr %12, align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %11, i32 0, i32 1
-  store ptr %8, ptr %13, align 8
-  %14 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %11, align 8
-  %15 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %14)
-  %16 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %14, 0
-  %17 = getelementptr ptr, ptr %16, i64 3
-  %18 = load ptr, ptr %17, align 8
-  %19 = alloca { ptr, ptr }, align 8
-  %20 = getelementptr inbounds { ptr, ptr }, ptr %19, i32 0, i32 0
-  store ptr %18, ptr %20, align 8
-  %21 = getelementptr inbounds { ptr, ptr }, ptr %19, i32 0, i32 1
-  store ptr %15, ptr %21, align 8
-  %22 = load { ptr, ptr }, ptr %19, align 8
-  %23 = extractvalue { ptr, ptr } %22, 1
-  %24 = extractvalue { ptr, ptr } %22, 0
-  %25 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %24(ptr %23, %"github.com/goplus/llgo/internal/runtime.iface" %1)
-  %26 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %25, 0
-  %27 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %25, 1
-  %28 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %29 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %28, i32 0, i32 0
-  store i64 %26, ptr %29, align 4
-  %30 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %28, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" %27, ptr %30, align 8
-  %31 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %28, align 8
-  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %31
+  %11 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %10, 0
+  %12 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %11, ptr %8, 1
+  %13 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %12)
+  %14 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %12, 0
+  %15 = getelementptr ptr, ptr %14, i64 3
+  %16 = load ptr, ptr %15, align 8
+  %17 = insertvalue { ptr, ptr } undef, ptr %16, 0
+  %18 = insertvalue { ptr, ptr } %17, ptr %13, 1
+  %19 = extractvalue { ptr, ptr } %18, 1
+  %20 = extractvalue { ptr, ptr } %18, 0
+  %21 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %20(ptr %19, %"github.com/goplus/llgo/internal/runtime.iface" %1)
+  %22 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %21, 0
+  %23 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %21, 1
+  %24 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } undef, i64 %22, 0
+  %25 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %24, %"github.com/goplus/llgo/internal/runtime.iface" %23, 1
+  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %25
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %32 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %32, i32 0, i32 0
-  store ptr @35, ptr %33, align 8
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %32, i32 0, i32 1
-  store i64 21, ptr %34, align 4
-  %35 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %32, align 8
-  %36 = load ptr, ptr @_llgo_string, align 8
-  %37 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %35, ptr %37, align 8
-  %38 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i32 0, i32 0
-  store ptr %36, ptr %39, align 8
-  %40 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i32 0, i32 1
-  store ptr %37, ptr %40, align 8
-  %41 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %41)
+  %26 = load ptr, ptr @_llgo_string, align 8
+  %27 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @35, i64 21 }, ptr %27, align 8
+  %28 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %26, 0
+  %29 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %28, ptr %27, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %29)
   unreachable
 }
 
@@ -661,24 +508,16 @@ _llgo_0:
   %5 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %3, 0
   %6 = getelementptr ptr, ptr %5, i64 3
   %7 = load ptr, ptr %6, align 8
-  %8 = alloca { ptr, ptr }, align 8
-  %9 = getelementptr inbounds { ptr, ptr }, ptr %8, i32 0, i32 0
-  store ptr %7, ptr %9, align 8
-  %10 = getelementptr inbounds { ptr, ptr }, ptr %8, i32 0, i32 1
-  store ptr %4, ptr %10, align 8
-  %11 = load { ptr, ptr }, ptr %8, align 8
-  %12 = extractvalue { ptr, ptr } %11, 1
-  %13 = extractvalue { ptr, ptr } %11, 0
-  %14 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %13(ptr %12, %"github.com/goplus/llgo/internal/runtime.Slice" %1)
-  %15 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %14, 0
-  %16 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %14, 1
-  %17 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %18 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %17, i32 0, i32 0
-  store i64 %15, ptr %18, align 4
-  %19 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %17, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" %16, ptr %19, align 8
-  %20 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %17, align 8
-  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %20
+  %8 = insertvalue { ptr, ptr } undef, ptr %7, 0
+  %9 = insertvalue { ptr, ptr } %8, ptr %4, 1
+  %10 = extractvalue { ptr, ptr } %9, 1
+  %11 = extractvalue { ptr, ptr } %9, 0
+  %12 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %11(ptr %10, %"github.com/goplus/llgo/internal/runtime.Slice" %1)
+  %13 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %12, 0
+  %14 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %12, 1
+  %15 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } undef, i64 %13, 0
+  %16 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %15, %"github.com/goplus/llgo/internal/runtime.iface" %14, 1
+  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %16
 }
 
 define { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @"main.(*nopCloserWriterTo).WriteTo"(ptr %0, %"github.com/goplus/llgo/internal/runtime.iface" %1) {
@@ -687,13 +526,9 @@ _llgo_0:
   %3 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @main.nopCloserWriterTo.WriteTo(%main.nopCloserWriterTo %2, %"github.com/goplus/llgo/internal/runtime.iface" %1)
   %4 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %3, 0
   %5 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %3, 1
-  %6 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %7 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %6, i32 0, i32 0
-  store i64 %4, ptr %7, align 4
-  %8 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %6, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" %5, ptr %8, align 8
-  %9 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %6, align 8
-  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %9
+  %6 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } undef, i64 %4, 0
+  %7 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %6, %"github.com/goplus/llgo/internal/runtime.iface" %5, 1
+  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %7
 }
 
 define i64 @"main.(*stringReader).Len"(ptr %0) {
@@ -731,38 +566,29 @@ _llgo_0:
 
 _llgo_1:                                          ; preds = %_llgo_0
   %8 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr @main.EOF, align 8
-  %9 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %10 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %9, i32 0, i32 0
-  store i64 0, ptr %10, align 4
-  %11 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %9, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" %8, ptr %11, align 8
-  %12 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %9, align 8
-  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %12
+  %9 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } { i64 0, %"github.com/goplus/llgo/internal/runtime.iface" undef }, %"github.com/goplus/llgo/internal/runtime.iface" %8, 1
+  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %9
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %13 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 2
-  store i64 -1, ptr %13, align 4
-  %14 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
-  %15 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %14, align 8
-  %16 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
-  %17 = load i64, ptr %16, align 4
-  %18 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %15, 1
-  %19 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringSlice"(%"github.com/goplus/llgo/internal/runtime.String" %15, i64 %17, i64 %18)
-  %20 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %19, 0
-  %21 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %19, 1
-  %22 = call i64 @"github.com/goplus/llgo/internal/runtime.SliceCopy"(%"github.com/goplus/llgo/internal/runtime.Slice" %1, ptr %20, i64 %21, i64 1)
+  %10 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 2
+  store i64 -1, ptr %10, align 4
+  %11 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
+  %12 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %11, align 8
+  %13 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
+  %14 = load i64, ptr %13, align 4
+  %15 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %12, 1
+  %16 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringSlice"(%"github.com/goplus/llgo/internal/runtime.String" %12, i64 %14, i64 %15)
+  %17 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %16, 0
+  %18 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %16, 1
+  %19 = call i64 @"github.com/goplus/llgo/internal/runtime.SliceCopy"(%"github.com/goplus/llgo/internal/runtime.Slice" %1, ptr %17, i64 %18, i64 1)
+  %20 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
+  %21 = load i64, ptr %20, align 4
+  %22 = add i64 %21, %19
   %23 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
-  %24 = load i64, ptr %23, align 4
-  %25 = add i64 %24, %22
-  %26 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
-  store i64 %25, ptr %26, align 4
-  %27 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %28 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %27, i32 0, i32 0
-  store i64 %22, ptr %28, align 4
-  %29 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %27, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer, ptr %29, align 8
-  %30 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %27, align 8
-  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %30
+  store i64 %22, ptr %23, align 4
+  %24 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } undef, i64 %19, 0
+  %25 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %24, %"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer, 1
+  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %25
 }
 
 define { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @"main.(*stringReader).ReadAt"(ptr %0, %"github.com/goplus/llgo/internal/runtime.Slice" %1, i64 %2) {
@@ -771,63 +597,43 @@ _llgo_0:
   br i1 %3, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @36, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 37, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  %8 = call %"github.com/goplus/llgo/internal/runtime.iface" @main.newError(%"github.com/goplus/llgo/internal/runtime.String" %7)
-  %9 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %10 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %9, i32 0, i32 0
-  store i64 0, ptr %10, align 4
-  %11 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %9, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" %8, ptr %11, align 8
-  %12 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %9, align 8
-  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %12
+  %4 = call %"github.com/goplus/llgo/internal/runtime.iface" @main.newError(%"github.com/goplus/llgo/internal/runtime.String" { ptr @36, i64 37 })
+  %5 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } { i64 0, %"github.com/goplus/llgo/internal/runtime.iface" undef }, %"github.com/goplus/llgo/internal/runtime.iface" %4, 1
+  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %5
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %13 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
-  %14 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %13, align 8
-  %15 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %14, 1
-  %16 = icmp sge i64 %2, %15
-  br i1 %16, label %_llgo_3, label %_llgo_4
+  %6 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
+  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %6, align 8
+  %8 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %7, 1
+  %9 = icmp sge i64 %2, %8
+  br i1 %9, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %17 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr @main.EOF, align 8
-  %18 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %19 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %18, i32 0, i32 0
-  store i64 0, ptr %19, align 4
-  %20 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %18, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" %17, ptr %20, align 8
-  %21 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %18, align 8
-  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %21
+  %10 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr @main.EOF, align 8
+  %11 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } { i64 0, %"github.com/goplus/llgo/internal/runtime.iface" undef }, %"github.com/goplus/llgo/internal/runtime.iface" %10, 1
+  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %11
 
 _llgo_4:                                          ; preds = %_llgo_2
-  %22 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
-  %23 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %22, align 8
-  %24 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %23, 1
-  %25 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringSlice"(%"github.com/goplus/llgo/internal/runtime.String" %23, i64 %2, i64 %24)
-  %26 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %25, 0
-  %27 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %25, 1
-  %28 = call i64 @"github.com/goplus/llgo/internal/runtime.SliceCopy"(%"github.com/goplus/llgo/internal/runtime.Slice" %1, ptr %26, i64 %27, i64 1)
-  %29 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1, 1
-  %30 = icmp slt i64 %28, %29
-  br i1 %30, label %_llgo_5, label %_llgo_6
+  %12 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
+  %13 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %12, align 8
+  %14 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %13, 1
+  %15 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringSlice"(%"github.com/goplus/llgo/internal/runtime.String" %13, i64 %2, i64 %14)
+  %16 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %15, 0
+  %17 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %15, 1
+  %18 = call i64 @"github.com/goplus/llgo/internal/runtime.SliceCopy"(%"github.com/goplus/llgo/internal/runtime.Slice" %1, ptr %16, i64 %17, i64 1)
+  %19 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1, 1
+  %20 = icmp slt i64 %18, %19
+  br i1 %20, label %_llgo_5, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_4
-  %31 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr @main.EOF, align 8
+  %21 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr @main.EOF, align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %32 = phi %"github.com/goplus/llgo/internal/runtime.iface" [ zeroinitializer, %_llgo_4 ], [ %31, %_llgo_5 ]
-  %33 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %34 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %33, i32 0, i32 0
-  store i64 %28, ptr %34, align 4
-  %35 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %33, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" %32, ptr %35, align 8
-  %36 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %33, align 8
-  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %36
+  %22 = phi %"github.com/goplus/llgo/internal/runtime.iface" [ zeroinitializer, %_llgo_4 ], [ %21, %_llgo_5 ]
+  %23 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } undef, i64 %18, 0
+  %24 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %23, %"github.com/goplus/llgo/internal/runtime.iface" %22, 1
+  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %24
 }
 
 define { i8, %"github.com/goplus/llgo/internal/runtime.iface" } @"main.(*stringReader).ReadByte"(ptr %0) {
@@ -844,39 +650,30 @@ _llgo_0:
 
 _llgo_1:                                          ; preds = %_llgo_0
   %8 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr @main.EOF, align 8
-  %9 = alloca { i8, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %10 = getelementptr inbounds { i8, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %9, i32 0, i32 0
-  store i8 0, ptr %10, align 1
-  %11 = getelementptr inbounds { i8, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %9, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" %8, ptr %11, align 8
-  %12 = load { i8, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %9, align 8
-  ret { i8, %"github.com/goplus/llgo/internal/runtime.iface" } %12
+  %9 = insertvalue { i8, %"github.com/goplus/llgo/internal/runtime.iface" } { i8 0, %"github.com/goplus/llgo/internal/runtime.iface" undef }, %"github.com/goplus/llgo/internal/runtime.iface" %8, 1
+  ret { i8, %"github.com/goplus/llgo/internal/runtime.iface" } %9
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %13 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
-  %14 = load i64, ptr %13, align 4
-  %15 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
-  %16 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %15, align 8
-  %17 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %16, 0
-  %18 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %16, 1
-  %19 = icmp slt i64 %14, 0
-  %20 = icmp sge i64 %14, %18
-  %21 = or i1 %20, %19
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %21)
-  %22 = getelementptr inbounds i8, ptr %17, i64 %14
-  %23 = load i8, ptr %22, align 1
+  %10 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
+  %11 = load i64, ptr %10, align 4
+  %12 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
+  %13 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %12, align 8
+  %14 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %13, 0
+  %15 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %13, 1
+  %16 = icmp slt i64 %11, 0
+  %17 = icmp sge i64 %11, %15
+  %18 = or i1 %17, %16
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %18)
+  %19 = getelementptr inbounds i8, ptr %14, i64 %11
+  %20 = load i8, ptr %19, align 1
+  %21 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
+  %22 = load i64, ptr %21, align 4
+  %23 = add i64 %22, 1
   %24 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
-  %25 = load i64, ptr %24, align 4
-  %26 = add i64 %25, 1
-  %27 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
-  store i64 %26, ptr %27, align 4
-  %28 = alloca { i8, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %29 = getelementptr inbounds { i8, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %28, i32 0, i32 0
-  store i8 %23, ptr %29, align 1
-  %30 = getelementptr inbounds { i8, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %28, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer, ptr %30, align 8
-  %31 = load { i8, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %28, align 8
-  ret { i8, %"github.com/goplus/llgo/internal/runtime.iface" } %31
+  store i64 %23, ptr %24, align 4
+  %25 = insertvalue { i8, %"github.com/goplus/llgo/internal/runtime.iface" } undef, i8 %20, 0
+  %26 = insertvalue { i8, %"github.com/goplus/llgo/internal/runtime.iface" } %25, %"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer, 1
+  ret { i8, %"github.com/goplus/llgo/internal/runtime.iface" } %26
 }
 
 define { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" } @"main.(*stringReader).ReadRune"(ptr %0) {
@@ -893,77 +690,60 @@ _llgo_1:                                          ; preds = %_llgo_0
   %7 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 2
   store i64 -1, ptr %7, align 4
   %8 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr @main.EOF, align 8
-  %9 = alloca { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %10 = getelementptr inbounds { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %9, i32 0, i32 0
-  store i32 0, ptr %10, align 4
-  %11 = getelementptr inbounds { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %9, i32 0, i32 1
-  store i64 0, ptr %11, align 4
-  %12 = getelementptr inbounds { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %9, i32 0, i32 2
-  store %"github.com/goplus/llgo/internal/runtime.iface" %8, ptr %12, align 8
-  %13 = load { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %9, align 8
-  ret { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" } %13
+  %9 = insertvalue { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" } { i32 0, i64 0, %"github.com/goplus/llgo/internal/runtime.iface" undef }, %"github.com/goplus/llgo/internal/runtime.iface" %8, 2
+  ret { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" } %9
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %14 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
-  %15 = load i64, ptr %14, align 4
-  %16 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 2
-  store i64 %15, ptr %16, align 4
-  %17 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
-  %18 = load i64, ptr %17, align 4
-  %19 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
-  %20 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %19, align 8
-  %21 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %20, 0
-  %22 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %20, 1
-  %23 = icmp slt i64 %18, 0
-  %24 = icmp sge i64 %18, %22
-  %25 = or i1 %24, %23
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %25)
-  %26 = getelementptr inbounds i8, ptr %21, i64 %18
-  %27 = load i8, ptr %26, align 1
-  %28 = icmp ult i8 %27, -128
-  br i1 %28, label %_llgo_3, label %_llgo_4
+  %10 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
+  %11 = load i64, ptr %10, align 4
+  %12 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 2
+  store i64 %11, ptr %12, align 4
+  %13 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
+  %14 = load i64, ptr %13, align 4
+  %15 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
+  %16 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %15, align 8
+  %17 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %16, 0
+  %18 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %16, 1
+  %19 = icmp slt i64 %14, 0
+  %20 = icmp sge i64 %14, %18
+  %21 = or i1 %20, %19
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %21)
+  %22 = getelementptr inbounds i8, ptr %17, i64 %14
+  %23 = load i8, ptr %22, align 1
+  %24 = icmp ult i8 %23, -128
+  br i1 %24, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %29 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
-  %30 = load i64, ptr %29, align 4
-  %31 = add i64 %30, 1
-  %32 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
-  store i64 %31, ptr %32, align 4
-  %33 = sext i8 %27 to i32
-  %34 = alloca { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %35 = getelementptr inbounds { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %34, i32 0, i32 0
-  store i32 %33, ptr %35, align 4
-  %36 = getelementptr inbounds { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %34, i32 0, i32 1
-  store i64 1, ptr %36, align 4
-  %37 = getelementptr inbounds { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %34, i32 0, i32 2
-  store %"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer, ptr %37, align 8
-  %38 = load { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %34, align 8
-  ret { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" } %38
+  %25 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
+  %26 = load i64, ptr %25, align 4
+  %27 = add i64 %26, 1
+  %28 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
+  store i64 %27, ptr %28, align 4
+  %29 = sext i8 %23 to i32
+  %30 = insertvalue { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" } undef, i32 %29, 0
+  %31 = insertvalue { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" } %30, i64 1, 1
+  %32 = insertvalue { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" } %31, %"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer, 2
+  ret { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" } %32
 
 _llgo_4:                                          ; preds = %_llgo_2
-  %39 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
-  %40 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %39, align 8
-  %41 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
-  %42 = load i64, ptr %41, align 4
-  %43 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %40, 1
-  %44 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringSlice"(%"github.com/goplus/llgo/internal/runtime.String" %40, i64 %42, i64 %43)
-  %45 = call { i32, i64 } @"unicode/utf8.DecodeRuneInString"(%"github.com/goplus/llgo/internal/runtime.String" %44)
-  %46 = extractvalue { i32, i64 } %45, 0
-  %47 = extractvalue { i32, i64 } %45, 1
-  %48 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
-  %49 = load i64, ptr %48, align 4
-  %50 = add i64 %49, %47
-  %51 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
-  store i64 %50, ptr %51, align 4
-  %52 = alloca { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %53 = getelementptr inbounds { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %52, i32 0, i32 0
-  store i32 %46, ptr %53, align 4
-  %54 = getelementptr inbounds { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %52, i32 0, i32 1
-  store i64 %47, ptr %54, align 4
-  %55 = getelementptr inbounds { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %52, i32 0, i32 2
-  store %"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer, ptr %55, align 8
-  %56 = load { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %52, align 8
-  ret { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" } %56
+  %33 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
+  %34 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %33, align 8
+  %35 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
+  %36 = load i64, ptr %35, align 4
+  %37 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %34, 1
+  %38 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringSlice"(%"github.com/goplus/llgo/internal/runtime.String" %34, i64 %36, i64 %37)
+  %39 = call { i32, i64 } @"unicode/utf8.DecodeRuneInString"(%"github.com/goplus/llgo/internal/runtime.String" %38)
+  %40 = extractvalue { i32, i64 } %39, 0
+  %41 = extractvalue { i32, i64 } %39, 1
+  %42 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
+  %43 = load i64, ptr %42, align 4
+  %44 = add i64 %43, %41
+  %45 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
+  store i64 %44, ptr %45, align 4
+  %46 = insertvalue { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" } undef, i32 %40, 0
+  %47 = insertvalue { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" } %46, i64 %41, 1
+  %48 = insertvalue { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" } %47, %"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer, 2
+  ret { i32, i64, %"github.com/goplus/llgo/internal/runtime.iface" } %48
 }
 
 define { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @"main.(*stringReader).Seek"(ptr %0, i64 %1, i64 %2) {
@@ -1003,47 +783,21 @@ _llgo_6:                                          ; preds = %_llgo_4
   br i1 %15, label %_llgo_5, label %_llgo_7
 
 _llgo_7:                                          ; preds = %_llgo_6
-  %16 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %16, i32 0, i32 0
-  store ptr @37, ptr %17, align 8
-  %18 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %16, i32 0, i32 1
-  store i64 34, ptr %18, align 4
-  %19 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %16, align 8
-  %20 = call %"github.com/goplus/llgo/internal/runtime.iface" @main.newError(%"github.com/goplus/llgo/internal/runtime.String" %19)
-  %21 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %22 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %21, i32 0, i32 0
-  store i64 0, ptr %22, align 4
-  %23 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %21, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" %20, ptr %23, align 8
-  %24 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %21, align 8
-  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %24
+  %16 = call %"github.com/goplus/llgo/internal/runtime.iface" @main.newError(%"github.com/goplus/llgo/internal/runtime.String" { ptr @37, i64 34 })
+  %17 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } { i64 0, %"github.com/goplus/llgo/internal/runtime.iface" undef }, %"github.com/goplus/llgo/internal/runtime.iface" %16, 1
+  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %17
 
 _llgo_8:                                          ; preds = %_llgo_1
-  %25 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 0
-  store ptr @38, ptr %26, align 8
-  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 1
-  store i64 37, ptr %27, align 4
-  %28 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %25, align 8
-  %29 = call %"github.com/goplus/llgo/internal/runtime.iface" @main.newError(%"github.com/goplus/llgo/internal/runtime.String" %28)
-  %30 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %31 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %30, i32 0, i32 0
-  store i64 0, ptr %31, align 4
-  %32 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %30, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" %29, ptr %32, align 8
-  %33 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %30, align 8
-  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %33
+  %18 = call %"github.com/goplus/llgo/internal/runtime.iface" @main.newError(%"github.com/goplus/llgo/internal/runtime.String" { ptr @38, i64 37 })
+  %19 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } { i64 0, %"github.com/goplus/llgo/internal/runtime.iface" undef }, %"github.com/goplus/llgo/internal/runtime.iface" %18, 1
+  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %19
 
 _llgo_9:                                          ; preds = %_llgo_1
-  %34 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
-  store i64 %5, ptr %34, align 4
-  %35 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %36 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %35, i32 0, i32 0
-  store i64 %5, ptr %36, align 4
-  %37 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %35, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer, ptr %37, align 8
-  %38 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %35, align 8
-  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %38
+  %20 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
+  store i64 %5, ptr %20, align 4
+  %21 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } undef, i64 %5, 0
+  %22 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %21, %"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer, 1
+  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %22
 }
 
 define i64 @"main.(*stringReader).Size"(ptr %0) {
@@ -1062,23 +816,17 @@ _llgo_0:
   br i1 %3, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @39, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 48, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  %8 = call %"github.com/goplus/llgo/internal/runtime.iface" @main.newError(%"github.com/goplus/llgo/internal/runtime.String" %7)
-  ret %"github.com/goplus/llgo/internal/runtime.iface" %8
+  %4 = call %"github.com/goplus/llgo/internal/runtime.iface" @main.newError(%"github.com/goplus/llgo/internal/runtime.String" { ptr @39, i64 48 })
+  ret %"github.com/goplus/llgo/internal/runtime.iface" %4
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %9 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 2
-  store i64 -1, ptr %9, align 4
-  %10 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
-  %11 = load i64, ptr %10, align 4
-  %12 = sub i64 %11, 1
-  %13 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
-  store i64 %12, ptr %13, align 4
+  %5 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 2
+  store i64 -1, ptr %5, align 4
+  %6 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
+  %7 = load i64, ptr %6, align 4
+  %8 = sub i64 %7, 1
+  %9 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
+  store i64 %8, ptr %9, align 4
   ret %"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer
 }
 
@@ -1090,38 +838,26 @@ _llgo_0:
   br i1 %3, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @40, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 49, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  %8 = call %"github.com/goplus/llgo/internal/runtime.iface" @main.newError(%"github.com/goplus/llgo/internal/runtime.String" %7)
-  ret %"github.com/goplus/llgo/internal/runtime.iface" %8
+  %4 = call %"github.com/goplus/llgo/internal/runtime.iface" @main.newError(%"github.com/goplus/llgo/internal/runtime.String" { ptr @40, i64 49 })
+  ret %"github.com/goplus/llgo/internal/runtime.iface" %4
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %9 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 2
-  %10 = load i64, ptr %9, align 4
-  %11 = icmp slt i64 %10, 0
-  br i1 %11, label %_llgo_3, label %_llgo_4
+  %5 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 2
+  %6 = load i64, ptr %5, align 4
+  %7 = icmp slt i64 %6, 0
+  br i1 %7, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %12 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %12, i32 0, i32 0
-  store ptr @41, ptr %13, align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %12, i32 0, i32 1
-  store i64 62, ptr %14, align 4
-  %15 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %12, align 8
-  %16 = call %"github.com/goplus/llgo/internal/runtime.iface" @main.newError(%"github.com/goplus/llgo/internal/runtime.String" %15)
-  ret %"github.com/goplus/llgo/internal/runtime.iface" %16
+  %8 = call %"github.com/goplus/llgo/internal/runtime.iface" @main.newError(%"github.com/goplus/llgo/internal/runtime.String" { ptr @41, i64 62 })
+  ret %"github.com/goplus/llgo/internal/runtime.iface" %8
 
 _llgo_4:                                          ; preds = %_llgo_2
-  %17 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 2
-  %18 = load i64, ptr %17, align 4
-  %19 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
-  store i64 %18, ptr %19, align 4
-  %20 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 2
-  store i64 -1, ptr %20, align 4
+  %9 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 2
+  %10 = load i64, ptr %9, align 4
+  %11 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
+  store i64 %10, ptr %11, align 4
+  %12 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 2
+  store i64 -1, ptr %12, align 4
   ret %"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer
 }
 
@@ -1138,89 +874,61 @@ _llgo_0:
   br i1 %8, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %9 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %10 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %9, i32 0, i32 0
-  store i64 0, ptr %10, align 4
-  %11 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %9, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer, ptr %11, align 8
-  %12 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %9, align 8
-  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %12
+  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } zeroinitializer
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %13 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
-  %14 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %13, align 8
-  %15 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
-  %16 = load i64, ptr %15, align 4
-  %17 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %14, 1
-  %18 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringSlice"(%"github.com/goplus/llgo/internal/runtime.String" %14, i64 %16, i64 %17)
-  %19 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @main.WriteString(%"github.com/goplus/llgo/internal/runtime.iface" %1, %"github.com/goplus/llgo/internal/runtime.String" %18)
-  %20 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %19, 0
-  %21 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %19, 1
-  %22 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %18, 1
-  %23 = icmp sgt i64 %20, %22
-  br i1 %23, label %_llgo_3, label %_llgo_4
+  %9 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 0
+  %10 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %9, align 8
+  %11 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
+  %12 = load i64, ptr %11, align 4
+  %13 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %10, 1
+  %14 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringSlice"(%"github.com/goplus/llgo/internal/runtime.String" %10, i64 %12, i64 %13)
+  %15 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @main.WriteString(%"github.com/goplus/llgo/internal/runtime.iface" %1, %"github.com/goplus/llgo/internal/runtime.String" %14)
+  %16 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %15, 0
+  %17 = extractvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %15, 1
+  %18 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %14, 1
+  %19 = icmp sgt i64 %16, %18
+  br i1 %19, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %24 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %24, i32 0, i32 0
-  store ptr @42, ptr %25, align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %24, i32 0, i32 1
-  store i64 48, ptr %26, align 4
-  %27 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %24, align 8
-  %28 = load ptr, ptr @_llgo_string, align 8
-  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %27, ptr %29, align 8
-  %30 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %30, i32 0, i32 0
-  store ptr %28, ptr %31, align 8
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %30, i32 0, i32 1
-  store ptr %29, ptr %32, align 8
-  %33 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %30, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %33)
+  %20 = load ptr, ptr @_llgo_string, align 8
+  %21 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @42, i64 48 }, ptr %21, align 8
+  %22 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %20, 0
+  %23 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %22, ptr %21, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %23)
   unreachable
 
 _llgo_4:                                          ; preds = %_llgo_2
-  %34 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
-  %35 = load i64, ptr %34, align 4
-  %36 = add i64 %35, %20
-  %37 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
-  store i64 %36, ptr %37, align 4
-  %38 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %18, 1
-  %39 = icmp ne i64 %20, %38
-  br i1 %39, label %_llgo_7, label %_llgo_6
+  %24 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
+  %25 = load i64, ptr %24, align 4
+  %26 = add i64 %25, %16
+  %27 = getelementptr inbounds %main.stringReader, ptr %0, i32 0, i32 1
+  store i64 %26, ptr %27, align 4
+  %28 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %14, 1
+  %29 = icmp ne i64 %16, %28
+  br i1 %29, label %_llgo_7, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_7
-  %40 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr @main.ErrShortWrite, align 8
+  %30 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr @main.ErrShortWrite, align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_7, %_llgo_4
-  %41 = phi %"github.com/goplus/llgo/internal/runtime.iface" [ %21, %_llgo_4 ], [ %21, %_llgo_7 ], [ %40, %_llgo_5 ]
-  %42 = alloca { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, align 8
-  %43 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %42, i32 0, i32 0
-  store i64 %20, ptr %43, align 4
-  %44 = getelementptr inbounds { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %42, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.iface" %41, ptr %44, align 8
-  %45 = load { i64, %"github.com/goplus/llgo/internal/runtime.iface" }, ptr %42, align 8
-  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %45
+  %31 = phi %"github.com/goplus/llgo/internal/runtime.iface" [ %17, %_llgo_4 ], [ %17, %_llgo_7 ], [ %30, %_llgo_5 ]
+  %32 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } undef, i64 %16, 0
+  %33 = insertvalue { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %32, %"github.com/goplus/llgo/internal/runtime.iface" %31, 1
+  ret { i64, %"github.com/goplus/llgo/internal/runtime.iface" } %33
 
 _llgo_7:                                          ; preds = %_llgo_4
-  %46 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %21)
-  %47 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %21, 1
-  %48 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %49 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %48, i32 0, i32 0
-  store ptr %46, ptr %49, align 8
-  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %48, i32 0, i32 1
-  store ptr %47, ptr %50, align 8
-  %51 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %48, align 8
-  %52 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
-  %53 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %54 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %53, i32 0, i32 0
-  store ptr %52, ptr %54, align 8
-  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %53, i32 0, i32 1
-  store ptr null, ptr %55, align 8
-  %56 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %53, align 8
-  %57 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %51, %"github.com/goplus/llgo/internal/runtime.eface" %56)
-  br i1 %57, label %_llgo_5, label %_llgo_6
+  %34 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %17)
+  %35 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %17, 1
+  %36 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %34, 0
+  %37 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %36, ptr %35, 1
+  %38 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
+  %39 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %38, 0
+  %40 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %39, ptr null, 1
+  %41 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %37, %"github.com/goplus/llgo/internal/runtime.eface" %40)
+  br i1 %41, label %_llgo_5, label %_llgo_6
 }
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface")
@@ -1279,1597 +987,718 @@ _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
 
 _llgo_9:                                          ; preds = %_llgo_8
   %20 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %21 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, i32 0, i32 0
-  store ptr %20, ptr %22, align 8
-  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, i32 0, i32 1
-  store i64 0, ptr %23, align 4
-  %24 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, i32 0, i32 2
-  store i64 0, ptr %24, align 4
-  %25 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, align 8
-  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %27 = getelementptr ptr, ptr %26, i64 0
-  store ptr %17, ptr %27, align 8
-  %28 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %29 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %28, i32 0, i32 0
-  store ptr %26, ptr %29, align 8
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %28, i32 0, i32 1
-  store i64 1, ptr %30, align 4
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %28, i32 0, i32 2
-  store i64 1, ptr %31, align 4
-  %32 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %28, align 8
-  %33 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %25, %"github.com/goplus/llgo/internal/runtime.Slice" %32, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %33)
-  store ptr %33, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %21 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %20, 0
+  %22 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %21, i64 0, 1
+  %23 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %22, i64 0, 2
+  %24 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %25 = getelementptr ptr, ptr %24, i64 0
+  store ptr %17, ptr %25, align 8
+  %26 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %24, 0
+  %27 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %26, i64 1, 1
+  %28 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %27, i64 1, 2
+  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %23, %"github.com/goplus/llgo/internal/runtime.Slice" %28, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %29)
+  store ptr %29, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
   br label %_llgo_10
 
 _llgo_10:                                         ; preds = %_llgo_9, %_llgo_8
-  %34 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %35 = load ptr, ptr @_llgo_error, align 8
-  %36 = icmp eq ptr %35, null
-  br i1 %36, label %_llgo_11, label %_llgo_12
+  %30 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %31 = load ptr, ptr @_llgo_error, align 8
+  %32 = icmp eq ptr %31, null
+  br i1 %32, label %_llgo_11, label %_llgo_12
 
 _llgo_11:                                         ; preds = %_llgo_10
-  %37 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %37, i32 0, i32 0
-  store ptr @0, ptr %38, align 8
-  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %37, i32 0, i32 1
-  store i64 5, ptr %39, align 4
-  %40 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %37, align 8
-  %41 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %42 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %41, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %40, ptr %42, align 8
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %41, i32 0, i32 1
-  store ptr %34, ptr %43, align 8
-  %44 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %41, align 8
-  %45 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %46 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %45, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %44, ptr %46, align 8
-  %47 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %48 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %47, i32 0, i32 0
-  store ptr %45, ptr %48, align 8
-  %49 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %47, i32 0, i32 1
-  store i64 1, ptr %49, align 4
-  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %47, i32 0, i32 2
-  store i64 1, ptr %50, align 4
-  %51 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %47, align 8
-  %52 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %53 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %52, i32 0, i32 0
-  store ptr @1, ptr %53, align 8
-  %54 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %52, i32 0, i32 1
-  store i64 4, ptr %54, align 4
-  %55 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %52, align 8
-  %56 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %56, i32 0, i32 0
-  store ptr @2, ptr %57, align 8
-  %58 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %56, i32 0, i32 1
-  store i64 5, ptr %58, align 4
-  %59 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %56, align 8
-  %60 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %55, %"github.com/goplus/llgo/internal/runtime.String" %59, %"github.com/goplus/llgo/internal/runtime.Slice" %51)
-  store ptr %60, ptr @_llgo_error, align 8
+  %33 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr undef }, ptr %30, 1
+  %34 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %35 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %34, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %33, ptr %35, align 8
+  %36 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %34, 0
+  %37 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %36, i64 1, 1
+  %38 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %37, i64 1, 2
+  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 5 }, %"github.com/goplus/llgo/internal/runtime.Slice" %38)
+  store ptr %39, ptr @_llgo_error, align 8
   br label %_llgo_12
 
 _llgo_12:                                         ; preds = %_llgo_11, %_llgo_10
-  %61 = load ptr, ptr @_llgo_error, align 8
-  %62 = load ptr, ptr @"[]_llgo_byte", align 8
-  %63 = load ptr, ptr @_llgo_int, align 8
-  %64 = load ptr, ptr @_llgo_error, align 8
-  %65 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
-  %66 = icmp eq ptr %65, null
-  br i1 %66, label %_llgo_13, label %_llgo_14
+  %40 = load ptr, ptr @_llgo_error, align 8
+  %41 = load ptr, ptr @"[]_llgo_byte", align 8
+  %42 = load ptr, ptr @_llgo_int, align 8
+  %43 = load ptr, ptr @_llgo_error, align 8
+  %44 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
+  %45 = icmp eq ptr %44, null
+  br i1 %45, label %_llgo_13, label %_llgo_14
 
 _llgo_13:                                         ; preds = %_llgo_12
-  %67 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %68 = getelementptr ptr, ptr %67, i64 0
-  store ptr %62, ptr %68, align 8
-  %69 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %70 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %69, i32 0, i32 0
-  store ptr %67, ptr %70, align 8
-  %71 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %69, i32 0, i32 1
-  store i64 1, ptr %71, align 4
-  %72 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %69, i32 0, i32 2
-  store i64 1, ptr %72, align 4
-  %73 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %69, align 8
-  %74 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %75 = getelementptr ptr, ptr %74, i64 0
-  store ptr %63, ptr %75, align 8
-  %76 = getelementptr ptr, ptr %74, i64 1
-  store ptr %64, ptr %76, align 8
-  %77 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %78 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %77, i32 0, i32 0
-  store ptr %74, ptr %78, align 8
-  %79 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %77, i32 0, i32 1
-  store i64 2, ptr %79, align 4
-  %80 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %77, i32 0, i32 2
-  store i64 2, ptr %80, align 4
-  %81 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %77, align 8
-  %82 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %73, %"github.com/goplus/llgo/internal/runtime.Slice" %81, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %82)
-  store ptr %82, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
+  %46 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %47 = getelementptr ptr, ptr %46, i64 0
+  store ptr %41, ptr %47, align 8
+  %48 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %46, 0
+  %49 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %48, i64 1, 1
+  %50 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %49, i64 1, 2
+  %51 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %52 = getelementptr ptr, ptr %51, i64 0
+  store ptr %42, ptr %52, align 8
+  %53 = getelementptr ptr, ptr %51, i64 1
+  store ptr %43, ptr %53, align 8
+  %54 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %51, 0
+  %55 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %54, i64 2, 1
+  %56 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %55, i64 2, 2
+  %57 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %50, %"github.com/goplus/llgo/internal/runtime.Slice" %56, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %57)
+  store ptr %57, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
   br label %_llgo_14
 
 _llgo_14:                                         ; preds = %_llgo_13, %_llgo_12
-  %83 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
-  %84 = load ptr, ptr @_llgo_main.Writer, align 8
-  %85 = icmp eq ptr %84, null
-  br i1 %85, label %_llgo_15, label %_llgo_16
+  %58 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
+  %59 = load ptr, ptr @_llgo_main.Writer, align 8
+  %60 = icmp eq ptr %59, null
+  br i1 %60, label %_llgo_15, label %_llgo_16
 
 _llgo_15:                                         ; preds = %_llgo_14
-  %86 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %87 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %86, i32 0, i32 0
-  store ptr @3, ptr %87, align 8
-  %88 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %86, i32 0, i32 1
-  store i64 5, ptr %88, align 4
-  %89 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %86, align 8
-  %90 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %91 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %90, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %89, ptr %91, align 8
-  %92 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %90, i32 0, i32 1
-  store ptr %83, ptr %92, align 8
-  %93 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %90, align 8
-  %94 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %95 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %94, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %93, ptr %95, align 8
-  %96 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %97 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %96, i32 0, i32 0
-  store ptr %94, ptr %97, align 8
-  %98 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %96, i32 0, i32 1
-  store i64 1, ptr %98, align 4
-  %99 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %96, i32 0, i32 2
-  store i64 1, ptr %99, align 4
-  %100 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %96, align 8
-  %101 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %102 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %101, i32 0, i32 0
-  store ptr @1, ptr %102, align 8
-  %103 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %101, i32 0, i32 1
-  store i64 4, ptr %103, align 4
-  %104 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %101, align 8
-  %105 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %106 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %105, i32 0, i32 0
-  store ptr @4, ptr %106, align 8
-  %107 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %105, i32 0, i32 1
-  store i64 11, ptr %107, align 4
-  %108 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %105, align 8
-  %109 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %104, %"github.com/goplus/llgo/internal/runtime.String" %108, %"github.com/goplus/llgo/internal/runtime.Slice" %100)
-  store ptr %109, ptr @_llgo_main.Writer, align 8
+  %61 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 5 }, ptr undef }, ptr %58, 1
+  %62 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %63 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %62, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %61, ptr %63, align 8
+  %64 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %62, 0
+  %65 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %64, i64 1, 1
+  %66 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %65, i64 1, 2
+  %67 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 11 }, %"github.com/goplus/llgo/internal/runtime.Slice" %66)
+  store ptr %67, ptr @_llgo_main.Writer, align 8
   br label %_llgo_16
 
 _llgo_16:                                         ; preds = %_llgo_15, %_llgo_14
-  %110 = load ptr, ptr @_llgo_main.Writer, align 8
-  %111 = load ptr, ptr @_llgo_int64, align 8
-  %112 = icmp eq ptr %111, null
-  br i1 %112, label %_llgo_17, label %_llgo_18
+  %68 = load ptr, ptr @_llgo_main.Writer, align 8
+  %69 = load ptr, ptr @_llgo_int64, align 8
+  %70 = icmp eq ptr %69, null
+  br i1 %70, label %_llgo_17, label %_llgo_18
 
 _llgo_17:                                         ; preds = %_llgo_16
-  %113 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 38)
-  store ptr %113, ptr @_llgo_int64, align 8
+  %71 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 38)
+  store ptr %71, ptr @_llgo_int64, align 8
   br label %_llgo_18
 
 _llgo_18:                                         ; preds = %_llgo_17, %_llgo_16
-  %114 = load ptr, ptr @_llgo_int64, align 8
-  %115 = load ptr, ptr @_llgo_main.Writer, align 8
-  %116 = load ptr, ptr @_llgo_int64, align 8
-  %117 = load ptr, ptr @_llgo_error, align 8
-  %118 = load ptr, ptr @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk", align 8
-  %119 = icmp eq ptr %118, null
-  br i1 %119, label %_llgo_19, label %_llgo_20
+  %72 = load ptr, ptr @_llgo_int64, align 8
+  %73 = load ptr, ptr @_llgo_main.Writer, align 8
+  %74 = load ptr, ptr @_llgo_int64, align 8
+  %75 = load ptr, ptr @_llgo_error, align 8
+  %76 = load ptr, ptr @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk", align 8
+  %77 = icmp eq ptr %76, null
+  br i1 %77, label %_llgo_19, label %_llgo_20
 
 _llgo_19:                                         ; preds = %_llgo_18
-  %120 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %121 = getelementptr ptr, ptr %120, i64 0
-  store ptr %115, ptr %121, align 8
-  %122 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %123 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %122, i32 0, i32 0
-  store ptr %120, ptr %123, align 8
-  %124 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %122, i32 0, i32 1
-  store i64 1, ptr %124, align 4
-  %125 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %122, i32 0, i32 2
-  store i64 1, ptr %125, align 4
-  %126 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %122, align 8
-  %127 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %128 = getelementptr ptr, ptr %127, i64 0
-  store ptr %116, ptr %128, align 8
-  %129 = getelementptr ptr, ptr %127, i64 1
-  store ptr %117, ptr %129, align 8
-  %130 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %131 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %130, i32 0, i32 0
-  store ptr %127, ptr %131, align 8
-  %132 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %130, i32 0, i32 1
-  store i64 2, ptr %132, align 4
-  %133 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %130, i32 0, i32 2
-  store i64 2, ptr %133, align 4
-  %134 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %130, align 8
-  %135 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %126, %"github.com/goplus/llgo/internal/runtime.Slice" %134, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %135)
-  store ptr %135, ptr @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk", align 8
+  %78 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %79 = getelementptr ptr, ptr %78, i64 0
+  store ptr %73, ptr %79, align 8
+  %80 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %78, 0
+  %81 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %80, i64 1, 1
+  %82 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %81, i64 1, 2
+  %83 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %84 = getelementptr ptr, ptr %83, i64 0
+  store ptr %74, ptr %84, align 8
+  %85 = getelementptr ptr, ptr %83, i64 1
+  store ptr %75, ptr %85, align 8
+  %86 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %83, 0
+  %87 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %86, i64 2, 1
+  %88 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %87, i64 2, 2
+  %89 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %82, %"github.com/goplus/llgo/internal/runtime.Slice" %88, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %89)
+  store ptr %89, ptr @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk", align 8
   br label %_llgo_20
 
 _llgo_20:                                         ; preds = %_llgo_19, %_llgo_18
-  %136 = load ptr, ptr @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk", align 8
-  %137 = load ptr, ptr @_llgo_main.WriterTo, align 8
-  %138 = icmp eq ptr %137, null
-  br i1 %138, label %_llgo_21, label %_llgo_22
+  %90 = load ptr, ptr @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk", align 8
+  %91 = load ptr, ptr @_llgo_main.WriterTo, align 8
+  %92 = icmp eq ptr %91, null
+  br i1 %92, label %_llgo_21, label %_llgo_22
 
 _llgo_21:                                         ; preds = %_llgo_20
-  %139 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %140 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %139, i32 0, i32 0
-  store ptr @5, ptr %140, align 8
-  %141 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %139, i32 0, i32 1
-  store i64 7, ptr %141, align 4
-  %142 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %139, align 8
-  %143 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %144 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %143, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %142, ptr %144, align 8
-  %145 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %143, i32 0, i32 1
-  store ptr %136, ptr %145, align 8
-  %146 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %143, align 8
-  %147 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %148 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %147, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %146, ptr %148, align 8
-  %149 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %150 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %149, i32 0, i32 0
-  store ptr %147, ptr %150, align 8
-  %151 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %149, i32 0, i32 1
-  store i64 1, ptr %151, align 4
-  %152 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %149, i32 0, i32 2
-  store i64 1, ptr %152, align 4
-  %153 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %149, align 8
-  %154 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %155 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %154, i32 0, i32 0
-  store ptr @1, ptr %155, align 8
-  %156 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %154, i32 0, i32 1
-  store i64 4, ptr %156, align 4
-  %157 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %154, align 8
-  %158 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %159 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %158, i32 0, i32 0
-  store ptr @6, ptr %159, align 8
-  %160 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %158, i32 0, i32 1
-  store i64 13, ptr %160, align 4
-  %161 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %158, align 8
-  %162 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %157, %"github.com/goplus/llgo/internal/runtime.String" %161, %"github.com/goplus/llgo/internal/runtime.Slice" %153)
-  store ptr %162, ptr @_llgo_main.WriterTo, align 8
+  %93 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 7 }, ptr undef }, ptr %90, 1
+  %94 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %95 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %94, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %93, ptr %95, align 8
+  %96 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %94, 0
+  %97 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %96, i64 1, 1
+  %98 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %97, i64 1, 2
+  %99 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 13 }, %"github.com/goplus/llgo/internal/runtime.Slice" %98)
+  store ptr %99, ptr @_llgo_main.WriterTo, align 8
   br label %_llgo_22
 
 _llgo_22:                                         ; preds = %_llgo_21, %_llgo_20
-  %163 = load ptr, ptr @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk", align 8
-  %164 = load ptr, ptr @"_llgo_iface$eN81k1zqixGTyagHw_4nqH4mGfwwehTOCTXUlbT9kzk", align 8
-  %165 = icmp eq ptr %164, null
-  br i1 %165, label %_llgo_23, label %_llgo_24
+  %100 = load ptr, ptr @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk", align 8
+  %101 = load ptr, ptr @"_llgo_iface$eN81k1zqixGTyagHw_4nqH4mGfwwehTOCTXUlbT9kzk", align 8
+  %102 = icmp eq ptr %101, null
+  br i1 %102, label %_llgo_23, label %_llgo_24
 
 _llgo_23:                                         ; preds = %_llgo_22
-  %166 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %167 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %166, i32 0, i32 0
-  store ptr @5, ptr %167, align 8
-  %168 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %166, i32 0, i32 1
-  store i64 7, ptr %168, align 4
-  %169 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %166, align 8
-  %170 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %171 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %170, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %169, ptr %171, align 8
-  %172 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %170, i32 0, i32 1
-  store ptr %163, ptr %172, align 8
-  %173 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %170, align 8
-  %174 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %175 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %174, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %173, ptr %175, align 8
-  %176 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %177 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %176, i32 0, i32 0
-  store ptr %174, ptr %177, align 8
-  %178 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %176, i32 0, i32 1
-  store i64 1, ptr %178, align 4
-  %179 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %176, i32 0, i32 2
-  store i64 1, ptr %179, align 4
-  %180 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %176, align 8
-  %181 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %182 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %181, i32 0, i32 0
-  store ptr @1, ptr %182, align 8
-  %183 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %181, i32 0, i32 1
-  store i64 4, ptr %183, align 4
-  %184 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %181, align 8
-  %185 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %186 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %185, i32 0, i32 0
-  store ptr null, ptr %186, align 8
-  %187 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %185, i32 0, i32 1
-  store i64 0, ptr %187, align 4
-  %188 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %185, align 8
-  %189 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %184, %"github.com/goplus/llgo/internal/runtime.String" %188, %"github.com/goplus/llgo/internal/runtime.Slice" %180)
-  store ptr %189, ptr @"_llgo_iface$eN81k1zqixGTyagHw_4nqH4mGfwwehTOCTXUlbT9kzk", align 8
+  %103 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 7 }, ptr undef }, ptr %100, 1
+  %104 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %105 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %104, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %103, ptr %105, align 8
+  %106 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %104, 0
+  %107 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %106, i64 1, 1
+  %108 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %107, i64 1, 2
+  %109 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %108)
+  store ptr %109, ptr @"_llgo_iface$eN81k1zqixGTyagHw_4nqH4mGfwwehTOCTXUlbT9kzk", align 8
   br label %_llgo_24
 
 _llgo_24:                                         ; preds = %_llgo_23, %_llgo_22
-  %190 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %191 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %190, i32 0, i32 0
-  store ptr @7, ptr %191, align 8
-  %192 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %190, i32 0, i32 1
-  store i64 22, ptr %192, align 4
-  %193 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %190, align 8
-  %194 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %193, i64 25, i64 16, i64 3, i64 3)
-  store ptr %194, ptr @_llgo_main.nopCloserWriterTo, align 8
-  %195 = load ptr, ptr @"[]_llgo_byte", align 8
-  %196 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
-  %197 = load ptr, ptr @_llgo_main.Reader, align 8
-  %198 = icmp eq ptr %197, null
-  br i1 %198, label %_llgo_25, label %_llgo_26
+  %110 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 22 }, i64 25, i64 16, i64 3, i64 3)
+  store ptr %110, ptr @_llgo_main.nopCloserWriterTo, align 8
+  %111 = load ptr, ptr @"[]_llgo_byte", align 8
+  %112 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
+  %113 = load ptr, ptr @_llgo_main.Reader, align 8
+  %114 = icmp eq ptr %113, null
+  br i1 %114, label %_llgo_25, label %_llgo_26
 
 _llgo_25:                                         ; preds = %_llgo_24
-  %199 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %200 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %199, i32 0, i32 0
-  store ptr @8, ptr %200, align 8
-  %201 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %199, i32 0, i32 1
-  store i64 4, ptr %201, align 4
-  %202 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %199, align 8
-  %203 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %204 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %203, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %202, ptr %204, align 8
-  %205 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %203, i32 0, i32 1
-  store ptr %196, ptr %205, align 8
-  %206 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %203, align 8
-  %207 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %208 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %207, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %206, ptr %208, align 8
-  %209 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %210 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %209, i32 0, i32 0
-  store ptr %207, ptr %210, align 8
-  %211 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %209, i32 0, i32 1
-  store i64 1, ptr %211, align 4
-  %212 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %209, i32 0, i32 2
-  store i64 1, ptr %212, align 4
-  %213 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %209, align 8
-  %214 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %215 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %214, i32 0, i32 0
-  store ptr @1, ptr %215, align 8
-  %216 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %214, i32 0, i32 1
-  store i64 4, ptr %216, align 4
-  %217 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %214, align 8
-  %218 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %219 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %218, i32 0, i32 0
-  store ptr @9, ptr %219, align 8
-  %220 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %218, i32 0, i32 1
-  store i64 11, ptr %220, align 4
-  %221 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %218, align 8
-  %222 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %217, %"github.com/goplus/llgo/internal/runtime.String" %221, %"github.com/goplus/llgo/internal/runtime.Slice" %213)
-  store ptr %222, ptr @_llgo_main.Reader, align 8
+  %115 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 4 }, ptr undef }, ptr %112, 1
+  %116 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %117 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %116, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %115, ptr %117, align 8
+  %118 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %116, 0
+  %119 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %118, i64 1, 1
+  %120 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %119, i64 1, 2
+  %121 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 11 }, %"github.com/goplus/llgo/internal/runtime.Slice" %120)
+  store ptr %121, ptr @_llgo_main.Reader, align 8
   br label %_llgo_26
 
 _llgo_26:                                         ; preds = %_llgo_25, %_llgo_24
-  %223 = load ptr, ptr @_llgo_main.Reader, align 8
-  %224 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
-  %225 = load ptr, ptr @"_llgo_struct$_3ow4zXXILqvC0WDqDRNq5DPhjE1DInJgN924VHWc2Y", align 8
-  %226 = icmp eq ptr %225, null
-  br i1 %226, label %_llgo_27, label %_llgo_28
+  %122 = load ptr, ptr @_llgo_main.Reader, align 8
+  %123 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
+  %124 = load ptr, ptr @"_llgo_struct$_3ow4zXXILqvC0WDqDRNq5DPhjE1DInJgN924VHWc2Y", align 8
+  %125 = icmp eq ptr %124, null
+  br i1 %125, label %_llgo_27, label %_llgo_28
 
 _llgo_27:                                         ; preds = %_llgo_26
-  %227 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %228 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %227, i32 0, i32 0
-  store ptr @10, ptr %228, align 8
-  %229 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %227, i32 0, i32 1
-  store i64 6, ptr %229, align 4
-  %230 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %227, align 8
-  %231 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %232 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %231, i32 0, i32 0
-  store ptr null, ptr %232, align 8
-  %233 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %231, i32 0, i32 1
-  store i64 0, ptr %233, align 4
-  %234 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %231, align 8
-  %235 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %236 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %235, i32 0, i32 0
-  store ptr @8, ptr %236, align 8
-  %237 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %235, i32 0, i32 1
-  store i64 4, ptr %237, align 4
-  %238 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %235, align 8
-  %239 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %240 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %239, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %238, ptr %240, align 8
-  %241 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %239, i32 0, i32 1
-  store ptr %224, ptr %241, align 8
-  %242 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %239, align 8
-  %243 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %244 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %243, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %242, ptr %244, align 8
-  %245 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %246 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %245, i32 0, i32 0
-  store ptr %243, ptr %246, align 8
-  %247 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %245, i32 0, i32 1
-  store i64 1, ptr %247, align 4
-  %248 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %245, i32 0, i32 2
-  store i64 1, ptr %248, align 4
-  %249 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %245, align 8
-  %250 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %251 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %250, i32 0, i32 0
-  store ptr @1, ptr %251, align 8
-  %252 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %250, i32 0, i32 1
-  store i64 4, ptr %252, align 4
-  %253 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %250, align 8
-  %254 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %255 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %254, i32 0, i32 0
-  store ptr @9, ptr %255, align 8
-  %256 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %254, i32 0, i32 1
-  store i64 11, ptr %256, align 4
-  %257 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %254, align 8
-  %258 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %253, %"github.com/goplus/llgo/internal/runtime.String" %257, %"github.com/goplus/llgo/internal/runtime.Slice" %249)
-  %259 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %230, ptr %258, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %234, i1 true)
-  %260 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %261 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %260, i32 0, i32 0
-  store ptr @1, ptr %261, align 8
-  %262 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %260, i32 0, i32 1
-  store i64 4, ptr %262, align 4
-  %263 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %260, align 8
-  %264 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
-  %265 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %264, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %259, ptr %265, align 8
-  %266 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %267 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %266, i32 0, i32 0
-  store ptr %264, ptr %267, align 8
-  %268 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %266, i32 0, i32 1
-  store i64 1, ptr %268, align 4
-  %269 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %266, i32 0, i32 2
-  store i64 1, ptr %269, align 4
-  %270 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %266, align 8
-  %271 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %263, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %270)
-  store ptr %271, ptr @"_llgo_struct$_3ow4zXXILqvC0WDqDRNq5DPhjE1DInJgN924VHWc2Y", align 8
+  %126 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 4 }, ptr undef }, ptr %123, 1
+  %127 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %128 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %127, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %126, ptr %128, align 8
+  %129 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %127, 0
+  %130 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %129, i64 1, 1
+  %131 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %130, i64 1, 2
+  %132 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 11 }, %"github.com/goplus/llgo/internal/runtime.Slice" %131)
+  %133 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 6 }, ptr %132, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 true)
+  %134 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
+  %135 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %134, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %133, ptr %135, align 8
+  %136 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %134, 0
+  %137 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %136, i64 1, 1
+  %138 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %137, i64 1, 2
+  %139 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %138)
+  store ptr %139, ptr @"_llgo_struct$_3ow4zXXILqvC0WDqDRNq5DPhjE1DInJgN924VHWc2Y", align 8
   br label %_llgo_28
 
 _llgo_28:                                         ; preds = %_llgo_27, %_llgo_26
-  %272 = load ptr, ptr @"_llgo_struct$_3ow4zXXILqvC0WDqDRNq5DPhjE1DInJgN924VHWc2Y", align 8
-  %273 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %274 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %273, i32 0, i32 0
-  store ptr @11, ptr %274, align 8
-  %275 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %273, i32 0, i32 1
-  store i64 5, ptr %275, align 4
-  %276 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %273, align 8
-  %277 = load ptr, ptr @_llgo_error, align 8
-  %278 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
-  %279 = icmp eq ptr %278, null
-  br i1 %279, label %_llgo_29, label %_llgo_30
+  %140 = load ptr, ptr @"_llgo_struct$_3ow4zXXILqvC0WDqDRNq5DPhjE1DInJgN924VHWc2Y", align 8
+  %141 = load ptr, ptr @_llgo_error, align 8
+  %142 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
+  %143 = icmp eq ptr %142, null
+  br i1 %143, label %_llgo_29, label %_llgo_30
 
 _llgo_29:                                         ; preds = %_llgo_28
-  %280 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %281 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %282 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %281, i32 0, i32 0
-  store ptr %280, ptr %282, align 8
-  %283 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %281, i32 0, i32 1
-  store i64 0, ptr %283, align 4
-  %284 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %281, i32 0, i32 2
-  store i64 0, ptr %284, align 4
-  %285 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %281, align 8
-  %286 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %287 = getelementptr ptr, ptr %286, i64 0
-  store ptr %277, ptr %287, align 8
-  %288 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %289 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %288, i32 0, i32 0
-  store ptr %286, ptr %289, align 8
-  %290 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %288, i32 0, i32 1
-  store i64 1, ptr %290, align 4
-  %291 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %288, i32 0, i32 2
-  store i64 1, ptr %291, align 4
-  %292 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %288, align 8
-  %293 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %285, %"github.com/goplus/llgo/internal/runtime.Slice" %292, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %293)
-  store ptr %293, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
+  %144 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %145 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %144, 0
+  %146 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %145, i64 0, 1
+  %147 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %146, i64 0, 2
+  %148 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %149 = getelementptr ptr, ptr %148, i64 0
+  store ptr %141, ptr %149, align 8
+  %150 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %148, 0
+  %151 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %150, i64 1, 1
+  %152 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %151, i64 1, 2
+  %153 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %147, %"github.com/goplus/llgo/internal/runtime.Slice" %152, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %153)
+  store ptr %153, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
   br label %_llgo_30
 
 _llgo_30:                                         ; preds = %_llgo_29, %_llgo_28
-  %294 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
-  %295 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %296 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %295, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %276, ptr %296, align 8
-  %297 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %295, i32 0, i32 1
-  store ptr %294, ptr %297, align 8
-  %298 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %295, i32 0, i32 2
-  store ptr @"main.(*nopCloserWriterTo).Close", ptr %298, align 8
-  %299 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %295, i32 0, i32 3
-  store ptr @"main.(*nopCloserWriterTo).Close", ptr %299, align 8
-  %300 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %295, align 8
-  %301 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %302 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %301, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %276, ptr %302, align 8
-  %303 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %301, i32 0, i32 1
-  store ptr %294, ptr %303, align 8
-  %304 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %301, i32 0, i32 2
-  store ptr @"main.(*nopCloserWriterTo).Close", ptr %304, align 8
-  %305 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %301, i32 0, i32 3
-  store ptr @main.nopCloserWriterTo.Close, ptr %305, align 8
-  %306 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %301, align 8
-  %307 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %308 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %307, i32 0, i32 0
-  store ptr @8, ptr %308, align 8
-  %309 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %307, i32 0, i32 1
-  store i64 4, ptr %309, align 4
-  %310 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %307, align 8
-  %311 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
-  %312 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %313 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %312, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %310, ptr %313, align 8
-  %314 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %312, i32 0, i32 1
-  store ptr %311, ptr %314, align 8
-  %315 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %312, i32 0, i32 2
-  store ptr @"main.(*nopCloserWriterTo).Read", ptr %315, align 8
-  %316 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %312, i32 0, i32 3
-  store ptr @"main.(*nopCloserWriterTo).Read", ptr %316, align 8
-  %317 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %312, align 8
-  %318 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %319 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %318, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %310, ptr %319, align 8
-  %320 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %318, i32 0, i32 1
-  store ptr %311, ptr %320, align 8
-  %321 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %318, i32 0, i32 2
-  store ptr @"main.(*nopCloserWriterTo).Read", ptr %321, align 8
-  %322 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %318, i32 0, i32 3
-  store ptr @main.nopCloserWriterTo.Read, ptr %322, align 8
-  %323 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %318, align 8
-  %324 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %325 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %324, i32 0, i32 0
-  store ptr @5, ptr %325, align 8
-  %326 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %324, i32 0, i32 1
-  store i64 7, ptr %326, align 4
-  %327 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %324, align 8
-  %328 = load ptr, ptr @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk", align 8
-  %329 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %330 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %329, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %327, ptr %330, align 8
-  %331 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %329, i32 0, i32 1
-  store ptr %328, ptr %331, align 8
-  %332 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %329, i32 0, i32 2
-  store ptr @"main.(*nopCloserWriterTo).WriteTo", ptr %332, align 8
-  %333 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %329, i32 0, i32 3
-  store ptr @"main.(*nopCloserWriterTo).WriteTo", ptr %333, align 8
-  %334 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %329, align 8
-  %335 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %336 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %335, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %327, ptr %336, align 8
-  %337 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %335, i32 0, i32 1
-  store ptr %328, ptr %337, align 8
-  %338 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %335, i32 0, i32 2
-  store ptr @"main.(*nopCloserWriterTo).WriteTo", ptr %338, align 8
-  %339 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %335, i32 0, i32 3
-  store ptr @main.nopCloserWriterTo.WriteTo, ptr %339, align 8
-  %340 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %335, align 8
-  %341 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 120)
-  %342 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %341, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %306, ptr %342, align 8
-  %343 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %341, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %323, ptr %343, align 8
-  %344 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %341, i64 2
-  store %"github.com/goplus/llgo/internal/abi.Method" %340, ptr %344, align 8
-  %345 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %346 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %345, i32 0, i32 0
-  store ptr %341, ptr %346, align 8
-  %347 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %345, i32 0, i32 1
-  store i64 3, ptr %347, align 4
-  %348 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %345, i32 0, i32 2
-  store i64 3, ptr %348, align 4
-  %349 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %345, align 8
-  %350 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 120)
-  %351 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %350, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %300, ptr %351, align 8
-  %352 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %350, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %317, ptr %352, align 8
-  %353 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %350, i64 2
-  store %"github.com/goplus/llgo/internal/abi.Method" %334, ptr %353, align 8
-  %354 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %355 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %354, i32 0, i32 0
-  store ptr %350, ptr %355, align 8
-  %356 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %354, i32 0, i32 1
-  store i64 3, ptr %356, align 4
-  %357 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %354, i32 0, i32 2
-  store i64 3, ptr %357, align 4
-  %358 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %354, align 8
-  %359 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %360 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %359, i32 0, i32 0
-  store ptr @1, ptr %360, align 8
-  %361 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %359, i32 0, i32 1
-  store i64 4, ptr %361, align 4
-  %362 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %359, align 8
-  %363 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %364 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %363, i32 0, i32 0
-  store ptr @12, ptr %364, align 8
-  %365 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %363, i32 0, i32 1
-  store i64 17, ptr %365, align 4
-  %366 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %363, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %194, %"github.com/goplus/llgo/internal/runtime.String" %362, %"github.com/goplus/llgo/internal/runtime.String" %366, ptr %272, %"github.com/goplus/llgo/internal/runtime.Slice" %349, %"github.com/goplus/llgo/internal/runtime.Slice" %358)
-  %367 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
-  %368 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
-  %369 = load ptr, ptr @"_llgo_iface$L2Ik-AJcd0jsoBw5fQ07pQpfUM-kh78Wn2bOeak6M3I", align 8
-  %370 = icmp eq ptr %369, null
-  br i1 %370, label %_llgo_31, label %_llgo_32
+  %154 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
+  %155 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 5 }, ptr undef, ptr undef, ptr undef }, ptr %154, 1
+  %156 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %155, ptr @"main.(*nopCloserWriterTo).Close", 2
+  %157 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %156, ptr @"main.(*nopCloserWriterTo).Close", 3
+  %158 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 5 }, ptr undef, ptr undef, ptr undef }, ptr %154, 1
+  %159 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %158, ptr @"main.(*nopCloserWriterTo).Close", 2
+  %160 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %159, ptr @main.nopCloserWriterTo.Close, 3
+  %161 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
+  %162 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %161, 1
+  %163 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %162, ptr @"main.(*nopCloserWriterTo).Read", 2
+  %164 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %163, ptr @"main.(*nopCloserWriterTo).Read", 3
+  %165 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %161, 1
+  %166 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %165, ptr @"main.(*nopCloserWriterTo).Read", 2
+  %167 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %166, ptr @main.nopCloserWriterTo.Read, 3
+  %168 = load ptr, ptr @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk", align 8
+  %169 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %168, 1
+  %170 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %169, ptr @"main.(*nopCloserWriterTo).WriteTo", 2
+  %171 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %170, ptr @"main.(*nopCloserWriterTo).WriteTo", 3
+  %172 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %168, 1
+  %173 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %172, ptr @"main.(*nopCloserWriterTo).WriteTo", 2
+  %174 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %173, ptr @main.nopCloserWriterTo.WriteTo, 3
+  %175 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 120)
+  %176 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %175, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %160, ptr %176, align 8
+  %177 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %175, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %167, ptr %177, align 8
+  %178 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %175, i64 2
+  store %"github.com/goplus/llgo/internal/abi.Method" %174, ptr %178, align 8
+  %179 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %175, 0
+  %180 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %179, i64 3, 1
+  %181 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %180, i64 3, 2
+  %182 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 120)
+  %183 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %182, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %157, ptr %183, align 8
+  %184 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %182, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %164, ptr %184, align 8
+  %185 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %182, i64 2
+  store %"github.com/goplus/llgo/internal/abi.Method" %171, ptr %185, align 8
+  %186 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %182, 0
+  %187 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %186, i64 3, 1
+  %188 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %187, i64 3, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %110, %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @12, i64 17 }, ptr %140, %"github.com/goplus/llgo/internal/runtime.Slice" %181, %"github.com/goplus/llgo/internal/runtime.Slice" %188)
+  %189 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
+  %190 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
+  %191 = load ptr, ptr @"_llgo_iface$L2Ik-AJcd0jsoBw5fQ07pQpfUM-kh78Wn2bOeak6M3I", align 8
+  %192 = icmp eq ptr %191, null
+  br i1 %192, label %_llgo_31, label %_llgo_32
 
 _llgo_31:                                         ; preds = %_llgo_30
-  %371 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %372 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %371, i32 0, i32 0
-  store ptr @11, ptr %372, align 8
-  %373 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %371, i32 0, i32 1
-  store i64 5, ptr %373, align 4
-  %374 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %371, align 8
-  %375 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %376 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %375, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %374, ptr %376, align 8
-  %377 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %375, i32 0, i32 1
-  store ptr %367, ptr %377, align 8
-  %378 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %375, align 8
-  %379 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %380 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %379, i32 0, i32 0
-  store ptr @8, ptr %380, align 8
-  %381 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %379, i32 0, i32 1
-  store i64 4, ptr %381, align 4
-  %382 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %379, align 8
-  %383 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %384 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %383, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %382, ptr %384, align 8
-  %385 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %383, i32 0, i32 1
-  store ptr %368, ptr %385, align 8
-  %386 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %383, align 8
-  %387 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  %388 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %387, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %378, ptr %388, align 8
-  %389 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %387, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %386, ptr %389, align 8
-  %390 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %391 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %390, i32 0, i32 0
-  store ptr %387, ptr %391, align 8
-  %392 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %390, i32 0, i32 1
-  store i64 2, ptr %392, align 4
-  %393 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %390, i32 0, i32 2
-  store i64 2, ptr %393, align 4
-  %394 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %390, align 8
-  %395 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %396 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %395, i32 0, i32 0
-  store ptr @1, ptr %396, align 8
-  %397 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %395, i32 0, i32 1
-  store i64 4, ptr %397, align 4
-  %398 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %395, align 8
-  %399 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %400 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %399, i32 0, i32 0
-  store ptr null, ptr %400, align 8
-  %401 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %399, i32 0, i32 1
-  store i64 0, ptr %401, align 4
-  %402 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %399, align 8
-  %403 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %398, %"github.com/goplus/llgo/internal/runtime.String" %402, %"github.com/goplus/llgo/internal/runtime.Slice" %394)
-  store ptr %403, ptr @"_llgo_iface$L2Ik-AJcd0jsoBw5fQ07pQpfUM-kh78Wn2bOeak6M3I", align 8
+  %193 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 5 }, ptr undef }, ptr %189, 1
+  %194 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 4 }, ptr undef }, ptr %190, 1
+  %195 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  %196 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %195, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %193, ptr %196, align 8
+  %197 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %195, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %194, ptr %197, align 8
+  %198 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %195, 0
+  %199 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %198, i64 2, 1
+  %200 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %199, i64 2, 2
+  %201 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %200)
+  store ptr %201, ptr @"_llgo_iface$L2Ik-AJcd0jsoBw5fQ07pQpfUM-kh78Wn2bOeak6M3I", align 8
   br label %_llgo_32
 
 _llgo_32:                                         ; preds = %_llgo_31, %_llgo_30
-  %404 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %405 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %404, i32 0, i32 0
-  store ptr @13, ptr %405, align 8
-  %406 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %404, i32 0, i32 1
-  store i64 14, ptr %406, align 4
-  %407 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %404, align 8
-  %408 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %407, i64 25, i64 16, i64 2, i64 2)
-  store ptr %408, ptr @_llgo_main.nopCloser, align 8
-  %409 = load ptr, ptr @"_llgo_struct$_3ow4zXXILqvC0WDqDRNq5DPhjE1DInJgN924VHWc2Y", align 8
-  %410 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %411 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %410, i32 0, i32 0
-  store ptr @11, ptr %411, align 8
-  %412 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %410, i32 0, i32 1
-  store i64 5, ptr %412, align 4
-  %413 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %410, align 8
-  %414 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
-  %415 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %416 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %415, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %413, ptr %416, align 8
-  %417 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %415, i32 0, i32 1
-  store ptr %414, ptr %417, align 8
-  %418 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %415, i32 0, i32 2
-  store ptr @"main.(*nopCloser).Close", ptr %418, align 8
-  %419 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %415, i32 0, i32 3
-  store ptr @"main.(*nopCloser).Close", ptr %419, align 8
-  %420 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %415, align 8
-  %421 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %422 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %421, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %413, ptr %422, align 8
-  %423 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %421, i32 0, i32 1
-  store ptr %414, ptr %423, align 8
-  %424 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %421, i32 0, i32 2
-  store ptr @"main.(*nopCloser).Close", ptr %424, align 8
-  %425 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %421, i32 0, i32 3
-  store ptr @main.nopCloser.Close, ptr %425, align 8
-  %426 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %421, align 8
-  %427 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %428 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %427, i32 0, i32 0
-  store ptr @8, ptr %428, align 8
-  %429 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %427, i32 0, i32 1
-  store i64 4, ptr %429, align 4
-  %430 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %427, align 8
-  %431 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
-  %432 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %433 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %432, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %430, ptr %433, align 8
-  %434 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %432, i32 0, i32 1
-  store ptr %431, ptr %434, align 8
-  %435 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %432, i32 0, i32 2
-  store ptr @"main.(*nopCloser).Read", ptr %435, align 8
-  %436 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %432, i32 0, i32 3
-  store ptr @"main.(*nopCloser).Read", ptr %436, align 8
-  %437 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %432, align 8
-  %438 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %439 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %438, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %430, ptr %439, align 8
-  %440 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %438, i32 0, i32 1
-  store ptr %431, ptr %440, align 8
-  %441 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %438, i32 0, i32 2
-  store ptr @"main.(*nopCloser).Read", ptr %441, align 8
-  %442 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %438, i32 0, i32 3
-  store ptr @main.nopCloser.Read, ptr %442, align 8
-  %443 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %438, align 8
-  %444 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
-  %445 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %444, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %426, ptr %445, align 8
-  %446 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %444, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %443, ptr %446, align 8
-  %447 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %448 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %447, i32 0, i32 0
-  store ptr %444, ptr %448, align 8
-  %449 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %447, i32 0, i32 1
-  store i64 2, ptr %449, align 4
-  %450 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %447, i32 0, i32 2
-  store i64 2, ptr %450, align 4
-  %451 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %447, align 8
-  %452 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
-  %453 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %452, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %420, ptr %453, align 8
-  %454 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %452, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %437, ptr %454, align 8
-  %455 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %456 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %455, i32 0, i32 0
-  store ptr %452, ptr %456, align 8
-  %457 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %455, i32 0, i32 1
-  store i64 2, ptr %457, align 4
-  %458 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %455, i32 0, i32 2
-  store i64 2, ptr %458, align 4
-  %459 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %455, align 8
-  %460 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %461 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %460, i32 0, i32 0
-  store ptr @1, ptr %461, align 8
-  %462 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %460, i32 0, i32 1
-  store i64 4, ptr %462, align 4
-  %463 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %460, align 8
-  %464 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %465 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %464, i32 0, i32 0
-  store ptr @14, ptr %465, align 8
-  %466 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %464, i32 0, i32 1
-  store i64 9, ptr %466, align 4
-  %467 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %464, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %408, %"github.com/goplus/llgo/internal/runtime.String" %463, %"github.com/goplus/llgo/internal/runtime.String" %467, ptr %409, %"github.com/goplus/llgo/internal/runtime.Slice" %451, %"github.com/goplus/llgo/internal/runtime.Slice" %459)
-  %468 = load ptr, ptr @_llgo_string, align 8
-  %469 = load ptr, ptr @_llgo_int, align 8
-  %470 = load ptr, ptr @_llgo_error, align 8
-  %471 = load ptr, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw", align 8
-  %472 = icmp eq ptr %471, null
-  br i1 %472, label %_llgo_33, label %_llgo_34
+  %202 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @13, i64 14 }, i64 25, i64 16, i64 2, i64 2)
+  store ptr %202, ptr @_llgo_main.nopCloser, align 8
+  %203 = load ptr, ptr @"_llgo_struct$_3ow4zXXILqvC0WDqDRNq5DPhjE1DInJgN924VHWc2Y", align 8
+  %204 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
+  %205 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 5 }, ptr undef, ptr undef, ptr undef }, ptr %204, 1
+  %206 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %205, ptr @"main.(*nopCloser).Close", 2
+  %207 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %206, ptr @"main.(*nopCloser).Close", 3
+  %208 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 5 }, ptr undef, ptr undef, ptr undef }, ptr %204, 1
+  %209 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %208, ptr @"main.(*nopCloser).Close", 2
+  %210 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %209, ptr @main.nopCloser.Close, 3
+  %211 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
+  %212 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %211, 1
+  %213 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %212, ptr @"main.(*nopCloser).Read", 2
+  %214 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %213, ptr @"main.(*nopCloser).Read", 3
+  %215 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %211, 1
+  %216 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %215, ptr @"main.(*nopCloser).Read", 2
+  %217 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %216, ptr @main.nopCloser.Read, 3
+  %218 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
+  %219 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %218, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %210, ptr %219, align 8
+  %220 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %218, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %217, ptr %220, align 8
+  %221 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %218, 0
+  %222 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %221, i64 2, 1
+  %223 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %222, i64 2, 2
+  %224 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
+  %225 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %224, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %207, ptr %225, align 8
+  %226 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %224, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %214, ptr %226, align 8
+  %227 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %224, 0
+  %228 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %227, i64 2, 1
+  %229 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %228, i64 2, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %202, %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @14, i64 9 }, ptr %203, %"github.com/goplus/llgo/internal/runtime.Slice" %223, %"github.com/goplus/llgo/internal/runtime.Slice" %229)
+  %230 = load ptr, ptr @_llgo_string, align 8
+  %231 = load ptr, ptr @_llgo_int, align 8
+  %232 = load ptr, ptr @_llgo_error, align 8
+  %233 = load ptr, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw", align 8
+  %234 = icmp eq ptr %233, null
+  br i1 %234, label %_llgo_33, label %_llgo_34
 
 _llgo_33:                                         ; preds = %_llgo_32
-  %473 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %474 = getelementptr ptr, ptr %473, i64 0
-  store ptr %468, ptr %474, align 8
-  %475 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %476 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %475, i32 0, i32 0
-  store ptr %473, ptr %476, align 8
-  %477 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %475, i32 0, i32 1
-  store i64 1, ptr %477, align 4
-  %478 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %475, i32 0, i32 2
-  store i64 1, ptr %478, align 4
-  %479 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %475, align 8
-  %480 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %481 = getelementptr ptr, ptr %480, i64 0
-  store ptr %469, ptr %481, align 8
-  %482 = getelementptr ptr, ptr %480, i64 1
-  store ptr %470, ptr %482, align 8
-  %483 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %484 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %483, i32 0, i32 0
-  store ptr %480, ptr %484, align 8
-  %485 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %483, i32 0, i32 1
-  store i64 2, ptr %485, align 4
-  %486 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %483, i32 0, i32 2
-  store i64 2, ptr %486, align 4
-  %487 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %483, align 8
-  %488 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %479, %"github.com/goplus/llgo/internal/runtime.Slice" %487, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %488)
-  store ptr %488, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw", align 8
+  %235 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %236 = getelementptr ptr, ptr %235, i64 0
+  store ptr %230, ptr %236, align 8
+  %237 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %235, 0
+  %238 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %237, i64 1, 1
+  %239 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %238, i64 1, 2
+  %240 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %241 = getelementptr ptr, ptr %240, i64 0
+  store ptr %231, ptr %241, align 8
+  %242 = getelementptr ptr, ptr %240, i64 1
+  store ptr %232, ptr %242, align 8
+  %243 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %240, 0
+  %244 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %243, i64 2, 1
+  %245 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %244, i64 2, 2
+  %246 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %239, %"github.com/goplus/llgo/internal/runtime.Slice" %245, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %246)
+  store ptr %246, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw", align 8
   br label %_llgo_34
 
 _llgo_34:                                         ; preds = %_llgo_33, %_llgo_32
-  %489 = load ptr, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw", align 8
-  %490 = load ptr, ptr @_llgo_main.StringWriter, align 8
-  %491 = icmp eq ptr %490, null
-  br i1 %491, label %_llgo_35, label %_llgo_36
+  %247 = load ptr, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw", align 8
+  %248 = load ptr, ptr @_llgo_main.StringWriter, align 8
+  %249 = icmp eq ptr %248, null
+  br i1 %249, label %_llgo_35, label %_llgo_36
 
 _llgo_35:                                         ; preds = %_llgo_34
-  %492 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %493 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %492, i32 0, i32 0
-  store ptr @15, ptr %493, align 8
-  %494 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %492, i32 0, i32 1
-  store i64 11, ptr %494, align 4
-  %495 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %492, align 8
-  %496 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %497 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %496, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %495, ptr %497, align 8
-  %498 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %496, i32 0, i32 1
-  store ptr %489, ptr %498, align 8
-  %499 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %496, align 8
-  %500 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %501 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %500, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %499, ptr %501, align 8
-  %502 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %503 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %502, i32 0, i32 0
-  store ptr %500, ptr %503, align 8
-  %504 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %502, i32 0, i32 1
-  store i64 1, ptr %504, align 4
-  %505 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %502, i32 0, i32 2
-  store i64 1, ptr %505, align 4
-  %506 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %502, align 8
-  %507 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %508 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %507, i32 0, i32 0
-  store ptr @1, ptr %508, align 8
-  %509 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %507, i32 0, i32 1
-  store i64 4, ptr %509, align 4
-  %510 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %507, align 8
-  %511 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %512 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %511, i32 0, i32 0
-  store ptr @16, ptr %512, align 8
-  %513 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %511, i32 0, i32 1
-  store i64 17, ptr %513, align 4
-  %514 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %511, align 8
-  %515 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %510, %"github.com/goplus/llgo/internal/runtime.String" %514, %"github.com/goplus/llgo/internal/runtime.Slice" %506)
-  store ptr %515, ptr @_llgo_main.StringWriter, align 8
+  %250 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @15, i64 11 }, ptr undef }, ptr %247, 1
+  %251 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %252 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %251, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %250, ptr %252, align 8
+  %253 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %251, 0
+  %254 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %253, i64 1, 1
+  %255 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %254, i64 1, 2
+  %256 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @16, i64 17 }, %"github.com/goplus/llgo/internal/runtime.Slice" %255)
+  store ptr %256, ptr @_llgo_main.StringWriter, align 8
   br label %_llgo_36
 
 _llgo_36:                                         ; preds = %_llgo_35, %_llgo_34
-  %516 = load ptr, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw", align 8
-  %517 = load ptr, ptr @"_llgo_iface$Ly4zXiUMEac-hYAMw6b6miJ1JEhGfLyBWyBOhpsRZcU", align 8
-  %518 = icmp eq ptr %517, null
-  br i1 %518, label %_llgo_37, label %_llgo_38
+  %257 = load ptr, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw", align 8
+  %258 = load ptr, ptr @"_llgo_iface$Ly4zXiUMEac-hYAMw6b6miJ1JEhGfLyBWyBOhpsRZcU", align 8
+  %259 = icmp eq ptr %258, null
+  br i1 %259, label %_llgo_37, label %_llgo_38
 
 _llgo_37:                                         ; preds = %_llgo_36
-  %519 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %520 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %519, i32 0, i32 0
-  store ptr @15, ptr %520, align 8
-  %521 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %519, i32 0, i32 1
-  store i64 11, ptr %521, align 4
-  %522 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %519, align 8
-  %523 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %524 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %523, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %522, ptr %524, align 8
-  %525 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %523, i32 0, i32 1
-  store ptr %516, ptr %525, align 8
-  %526 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %523, align 8
-  %527 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %528 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %527, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %526, ptr %528, align 8
-  %529 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %530 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %529, i32 0, i32 0
-  store ptr %527, ptr %530, align 8
-  %531 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %529, i32 0, i32 1
-  store i64 1, ptr %531, align 4
-  %532 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %529, i32 0, i32 2
-  store i64 1, ptr %532, align 4
-  %533 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %529, align 8
-  %534 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %535 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %534, i32 0, i32 0
-  store ptr @1, ptr %535, align 8
-  %536 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %534, i32 0, i32 1
-  store i64 4, ptr %536, align 4
-  %537 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %534, align 8
-  %538 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %539 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %538, i32 0, i32 0
-  store ptr null, ptr %539, align 8
-  %540 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %538, i32 0, i32 1
-  store i64 0, ptr %540, align 4
-  %541 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %538, align 8
-  %542 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %537, %"github.com/goplus/llgo/internal/runtime.String" %541, %"github.com/goplus/llgo/internal/runtime.Slice" %533)
-  store ptr %542, ptr @"_llgo_iface$Ly4zXiUMEac-hYAMw6b6miJ1JEhGfLyBWyBOhpsRZcU", align 8
+  %260 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @15, i64 11 }, ptr undef }, ptr %257, 1
+  %261 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %262 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %261, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %260, ptr %262, align 8
+  %263 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %261, 0
+  %264 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %263, i64 1, 1
+  %265 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %264, i64 1, 2
+  %266 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %265)
+  store ptr %266, ptr @"_llgo_iface$Ly4zXiUMEac-hYAMw6b6miJ1JEhGfLyBWyBOhpsRZcU", align 8
   br label %_llgo_38
 
 _llgo_38:                                         ; preds = %_llgo_37, %_llgo_36
-  %543 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %544 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %543, i32 0, i32 0
-  store ptr @20, ptr %544, align 8
-  %545 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %543, i32 0, i32 1
-  store i64 17, ptr %545, align 4
-  %546 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %543, align 8
-  %547 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %546, i64 25, i64 32, i64 0, i64 10)
-  store ptr %547, ptr @_llgo_main.stringReader, align 8
-  %548 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %549 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %548, i32 0, i32 0
-  store ptr @21, ptr %549, align 8
-  %550 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %548, i32 0, i32 1
-  store i64 1, ptr %550, align 4
-  %551 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %548, align 8
-  %552 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %553 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %552, i32 0, i32 0
-  store ptr null, ptr %553, align 8
-  %554 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %552, i32 0, i32 1
-  store i64 0, ptr %554, align 4
-  %555 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %552, align 8
-  %556 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %557 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %551, ptr %556, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %555, i1 false)
-  %558 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %559 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %558, i32 0, i32 0
-  store ptr @22, ptr %559, align 8
-  %560 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %558, i32 0, i32 1
-  store i64 1, ptr %560, align 4
-  %561 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %558, align 8
-  %562 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %563 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %562, i32 0, i32 0
-  store ptr null, ptr %563, align 8
-  %564 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %562, i32 0, i32 1
-  store i64 0, ptr %564, align 4
-  %565 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %562, align 8
-  %566 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 38)
-  %567 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %561, ptr %566, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %565, i1 false)
-  %568 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %569 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %568, i32 0, i32 0
-  store ptr @23, ptr %569, align 8
-  %570 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %568, i32 0, i32 1
-  store i64 8, ptr %570, align 4
-  %571 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %568, align 8
-  %572 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %573 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %572, i32 0, i32 0
-  store ptr null, ptr %573, align 8
-  %574 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %572, i32 0, i32 1
-  store i64 0, ptr %574, align 4
-  %575 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %572, align 8
-  %576 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %577 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %571, ptr %576, i64 24, %"github.com/goplus/llgo/internal/runtime.String" %575, i1 false)
-  %578 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %579 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %578, i32 0, i32 0
-  store ptr @1, ptr %579, align 8
-  %580 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %578, i32 0, i32 1
-  store i64 4, ptr %580, align 4
-  %581 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %578, align 8
-  %582 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 168)
-  %583 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %582, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %557, ptr %583, align 8
-  %584 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %582, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %567, ptr %584, align 8
-  %585 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %582, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %577, ptr %585, align 8
-  %586 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %587 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %586, i32 0, i32 0
-  store ptr %582, ptr %587, align 8
-  %588 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %586, i32 0, i32 1
-  store i64 3, ptr %588, align 4
-  %589 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %586, i32 0, i32 2
-  store i64 3, ptr %589, align 4
-  %590 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %586, align 8
-  %591 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %581, i64 32, %"github.com/goplus/llgo/internal/runtime.Slice" %590)
-  store ptr %591, ptr @"main.struct$Mdt84yjYYwxF9D2i4cRmpEPiWaO6tsjtrbGUjyESypk", align 8
-  %592 = load ptr, ptr @"main.struct$Mdt84yjYYwxF9D2i4cRmpEPiWaO6tsjtrbGUjyESypk", align 8
-  %593 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %594 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %593, i32 0, i32 0
-  store ptr @24, ptr %594, align 8
-  %595 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %593, i32 0, i32 1
-  store i64 3, ptr %595, align 4
-  %596 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %593, align 8
-  %597 = load ptr, ptr @_llgo_int, align 8
-  %598 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %599 = icmp eq ptr %598, null
-  br i1 %599, label %_llgo_39, label %_llgo_40
+  %267 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @20, i64 17 }, i64 25, i64 32, i64 0, i64 10)
+  store ptr %267, ptr @_llgo_main.stringReader, align 8
+  %268 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %269 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @21, i64 1 }, ptr %268, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %270 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 38)
+  %271 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @22, i64 1 }, ptr %270, i64 16, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %272 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %273 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @23, i64 8 }, ptr %272, i64 24, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %274 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 168)
+  %275 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %274, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %269, ptr %275, align 8
+  %276 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %274, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %271, ptr %276, align 8
+  %277 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %274, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %273, ptr %277, align 8
+  %278 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %274, 0
+  %279 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %278, i64 3, 1
+  %280 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %279, i64 3, 2
+  %281 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, i64 32, %"github.com/goplus/llgo/internal/runtime.Slice" %280)
+  store ptr %281, ptr @"main.struct$Mdt84yjYYwxF9D2i4cRmpEPiWaO6tsjtrbGUjyESypk", align 8
+  %282 = load ptr, ptr @"main.struct$Mdt84yjYYwxF9D2i4cRmpEPiWaO6tsjtrbGUjyESypk", align 8
+  %283 = load ptr, ptr @_llgo_int, align 8
+  %284 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %285 = icmp eq ptr %284, null
+  br i1 %285, label %_llgo_39, label %_llgo_40
 
 _llgo_39:                                         ; preds = %_llgo_38
-  %600 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %601 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %602 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %601, i32 0, i32 0
-  store ptr %600, ptr %602, align 8
-  %603 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %601, i32 0, i32 1
-  store i64 0, ptr %603, align 4
-  %604 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %601, i32 0, i32 2
-  store i64 0, ptr %604, align 4
-  %605 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %601, align 8
-  %606 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %607 = getelementptr ptr, ptr %606, i64 0
-  store ptr %597, ptr %607, align 8
-  %608 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %609 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %608, i32 0, i32 0
-  store ptr %606, ptr %609, align 8
-  %610 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %608, i32 0, i32 1
-  store i64 1, ptr %610, align 4
-  %611 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %608, i32 0, i32 2
-  store i64 1, ptr %611, align 4
-  %612 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %608, align 8
-  %613 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %605, %"github.com/goplus/llgo/internal/runtime.Slice" %612, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %613)
-  store ptr %613, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %286 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %287 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %286, 0
+  %288 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %287, i64 0, 1
+  %289 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %288, i64 0, 2
+  %290 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %291 = getelementptr ptr, ptr %290, i64 0
+  store ptr %283, ptr %291, align 8
+  %292 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %290, 0
+  %293 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %292, i64 1, 1
+  %294 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %293, i64 1, 2
+  %295 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %289, %"github.com/goplus/llgo/internal/runtime.Slice" %294, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %295)
+  store ptr %295, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
   br label %_llgo_40
 
 _llgo_40:                                         ; preds = %_llgo_39, %_llgo_38
-  %614 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %615 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %616 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %615, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %596, ptr %616, align 8
-  %617 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %615, i32 0, i32 1
-  store ptr %614, ptr %617, align 8
-  %618 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %615, i32 0, i32 2
-  store ptr @"main.(*stringReader).Len", ptr %618, align 8
-  %619 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %615, i32 0, i32 3
-  store ptr @"main.(*stringReader).Len", ptr %619, align 8
-  %620 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %615, align 8
-  %621 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %622 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %621, i32 0, i32 0
-  store ptr @8, ptr %622, align 8
-  %623 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %621, i32 0, i32 1
-  store i64 4, ptr %623, align 4
-  %624 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %621, align 8
-  %625 = load ptr, ptr @"[]_llgo_byte", align 8
-  %626 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
-  %627 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %628 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %627, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %624, ptr %628, align 8
-  %629 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %627, i32 0, i32 1
-  store ptr %626, ptr %629, align 8
-  %630 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %627, i32 0, i32 2
-  store ptr @"main.(*stringReader).Read", ptr %630, align 8
-  %631 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %627, i32 0, i32 3
-  store ptr @"main.(*stringReader).Read", ptr %631, align 8
-  %632 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %627, align 8
-  %633 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %634 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %633, i32 0, i32 0
-  store ptr @25, ptr %634, align 8
-  %635 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %633, i32 0, i32 1
-  store i64 6, ptr %635, align 4
-  %636 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %633, align 8
-  %637 = load ptr, ptr @"[]_llgo_byte", align 8
-  %638 = load ptr, ptr @"[]_llgo_byte", align 8
-  %639 = load ptr, ptr @_llgo_int64, align 8
-  %640 = load ptr, ptr @_llgo_int, align 8
-  %641 = load ptr, ptr @_llgo_error, align 8
-  %642 = load ptr, ptr @"_llgo_func$TY5Etv7VBKM_-2um1BDEeQEE2lP06Pt6G54EuKiNC3c", align 8
-  %643 = icmp eq ptr %642, null
-  br i1 %643, label %_llgo_41, label %_llgo_42
+  %296 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %297 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @24, i64 3 }, ptr undef, ptr undef, ptr undef }, ptr %296, 1
+  %298 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %297, ptr @"main.(*stringReader).Len", 2
+  %299 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %298, ptr @"main.(*stringReader).Len", 3
+  %300 = load ptr, ptr @"[]_llgo_byte", align 8
+  %301 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
+  %302 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %301, 1
+  %303 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %302, ptr @"main.(*stringReader).Read", 2
+  %304 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %303, ptr @"main.(*stringReader).Read", 3
+  %305 = load ptr, ptr @"[]_llgo_byte", align 8
+  %306 = load ptr, ptr @"[]_llgo_byte", align 8
+  %307 = load ptr, ptr @_llgo_int64, align 8
+  %308 = load ptr, ptr @_llgo_int, align 8
+  %309 = load ptr, ptr @_llgo_error, align 8
+  %310 = load ptr, ptr @"_llgo_func$TY5Etv7VBKM_-2um1BDEeQEE2lP06Pt6G54EuKiNC3c", align 8
+  %311 = icmp eq ptr %310, null
+  br i1 %311, label %_llgo_41, label %_llgo_42
 
 _llgo_41:                                         ; preds = %_llgo_40
-  %644 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %645 = getelementptr ptr, ptr %644, i64 0
-  store ptr %638, ptr %645, align 8
-  %646 = getelementptr ptr, ptr %644, i64 1
-  store ptr %639, ptr %646, align 8
-  %647 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %648 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %647, i32 0, i32 0
-  store ptr %644, ptr %648, align 8
-  %649 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %647, i32 0, i32 1
-  store i64 2, ptr %649, align 4
-  %650 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %647, i32 0, i32 2
-  store i64 2, ptr %650, align 4
-  %651 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %647, align 8
-  %652 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %653 = getelementptr ptr, ptr %652, i64 0
-  store ptr %640, ptr %653, align 8
-  %654 = getelementptr ptr, ptr %652, i64 1
-  store ptr %641, ptr %654, align 8
-  %655 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %656 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %655, i32 0, i32 0
-  store ptr %652, ptr %656, align 8
-  %657 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %655, i32 0, i32 1
-  store i64 2, ptr %657, align 4
-  %658 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %655, i32 0, i32 2
-  store i64 2, ptr %658, align 4
-  %659 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %655, align 8
-  %660 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %651, %"github.com/goplus/llgo/internal/runtime.Slice" %659, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %660)
-  store ptr %660, ptr @"_llgo_func$TY5Etv7VBKM_-2um1BDEeQEE2lP06Pt6G54EuKiNC3c", align 8
+  %312 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %313 = getelementptr ptr, ptr %312, i64 0
+  store ptr %306, ptr %313, align 8
+  %314 = getelementptr ptr, ptr %312, i64 1
+  store ptr %307, ptr %314, align 8
+  %315 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %312, 0
+  %316 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %315, i64 2, 1
+  %317 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %316, i64 2, 2
+  %318 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %319 = getelementptr ptr, ptr %318, i64 0
+  store ptr %308, ptr %319, align 8
+  %320 = getelementptr ptr, ptr %318, i64 1
+  store ptr %309, ptr %320, align 8
+  %321 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %318, 0
+  %322 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %321, i64 2, 1
+  %323 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %322, i64 2, 2
+  %324 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %317, %"github.com/goplus/llgo/internal/runtime.Slice" %323, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %324)
+  store ptr %324, ptr @"_llgo_func$TY5Etv7VBKM_-2um1BDEeQEE2lP06Pt6G54EuKiNC3c", align 8
   br label %_llgo_42
 
 _llgo_42:                                         ; preds = %_llgo_41, %_llgo_40
-  %661 = load ptr, ptr @"_llgo_func$TY5Etv7VBKM_-2um1BDEeQEE2lP06Pt6G54EuKiNC3c", align 8
-  %662 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %663 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %662, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %636, ptr %663, align 8
-  %664 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %662, i32 0, i32 1
-  store ptr %661, ptr %664, align 8
-  %665 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %662, i32 0, i32 2
-  store ptr @"main.(*stringReader).ReadAt", ptr %665, align 8
-  %666 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %662, i32 0, i32 3
-  store ptr @"main.(*stringReader).ReadAt", ptr %666, align 8
-  %667 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %662, align 8
-  %668 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %669 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %668, i32 0, i32 0
-  store ptr @26, ptr %669, align 8
-  %670 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %668, i32 0, i32 1
-  store i64 8, ptr %670, align 4
-  %671 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %668, align 8
-  %672 = load ptr, ptr @_llgo_byte, align 8
-  %673 = load ptr, ptr @_llgo_error, align 8
-  %674 = load ptr, ptr @"_llgo_func$6bvVpCcGPUc3z_EmsQTHB0AVT1hP5-NNLVRgm43teCM", align 8
-  %675 = icmp eq ptr %674, null
-  br i1 %675, label %_llgo_43, label %_llgo_44
+  %325 = load ptr, ptr @"_llgo_func$TY5Etv7VBKM_-2um1BDEeQEE2lP06Pt6G54EuKiNC3c", align 8
+  %326 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @25, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %325, 1
+  %327 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %326, ptr @"main.(*stringReader).ReadAt", 2
+  %328 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %327, ptr @"main.(*stringReader).ReadAt", 3
+  %329 = load ptr, ptr @_llgo_byte, align 8
+  %330 = load ptr, ptr @_llgo_error, align 8
+  %331 = load ptr, ptr @"_llgo_func$6bvVpCcGPUc3z_EmsQTHB0AVT1hP5-NNLVRgm43teCM", align 8
+  %332 = icmp eq ptr %331, null
+  br i1 %332, label %_llgo_43, label %_llgo_44
 
 _llgo_43:                                         ; preds = %_llgo_42
-  %676 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %677 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %678 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %677, i32 0, i32 0
-  store ptr %676, ptr %678, align 8
-  %679 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %677, i32 0, i32 1
-  store i64 0, ptr %679, align 4
-  %680 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %677, i32 0, i32 2
-  store i64 0, ptr %680, align 4
-  %681 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %677, align 8
-  %682 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %683 = getelementptr ptr, ptr %682, i64 0
-  store ptr %672, ptr %683, align 8
-  %684 = getelementptr ptr, ptr %682, i64 1
-  store ptr %673, ptr %684, align 8
-  %685 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %686 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %685, i32 0, i32 0
-  store ptr %682, ptr %686, align 8
-  %687 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %685, i32 0, i32 1
-  store i64 2, ptr %687, align 4
-  %688 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %685, i32 0, i32 2
-  store i64 2, ptr %688, align 4
-  %689 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %685, align 8
-  %690 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %681, %"github.com/goplus/llgo/internal/runtime.Slice" %689, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %690)
-  store ptr %690, ptr @"_llgo_func$6bvVpCcGPUc3z_EmsQTHB0AVT1hP5-NNLVRgm43teCM", align 8
+  %333 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %334 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %333, 0
+  %335 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %334, i64 0, 1
+  %336 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %335, i64 0, 2
+  %337 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %338 = getelementptr ptr, ptr %337, i64 0
+  store ptr %329, ptr %338, align 8
+  %339 = getelementptr ptr, ptr %337, i64 1
+  store ptr %330, ptr %339, align 8
+  %340 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %337, 0
+  %341 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %340, i64 2, 1
+  %342 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %341, i64 2, 2
+  %343 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %336, %"github.com/goplus/llgo/internal/runtime.Slice" %342, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %343)
+  store ptr %343, ptr @"_llgo_func$6bvVpCcGPUc3z_EmsQTHB0AVT1hP5-NNLVRgm43teCM", align 8
   br label %_llgo_44
 
 _llgo_44:                                         ; preds = %_llgo_43, %_llgo_42
-  %691 = load ptr, ptr @"_llgo_func$6bvVpCcGPUc3z_EmsQTHB0AVT1hP5-NNLVRgm43teCM", align 8
-  %692 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %693 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %692, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %671, ptr %693, align 8
-  %694 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %692, i32 0, i32 1
-  store ptr %691, ptr %694, align 8
-  %695 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %692, i32 0, i32 2
-  store ptr @"main.(*stringReader).ReadByte", ptr %695, align 8
-  %696 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %692, i32 0, i32 3
-  store ptr @"main.(*stringReader).ReadByte", ptr %696, align 8
-  %697 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %692, align 8
-  %698 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %699 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %698, i32 0, i32 0
-  store ptr @27, ptr %699, align 8
-  %700 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %698, i32 0, i32 1
-  store i64 8, ptr %700, align 4
-  %701 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %698, align 8
-  %702 = load ptr, ptr @_llgo_rune, align 8
-  %703 = icmp eq ptr %702, null
-  br i1 %703, label %_llgo_45, label %_llgo_46
+  %344 = load ptr, ptr @"_llgo_func$6bvVpCcGPUc3z_EmsQTHB0AVT1hP5-NNLVRgm43teCM", align 8
+  %345 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @26, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %344, 1
+  %346 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %345, ptr @"main.(*stringReader).ReadByte", 2
+  %347 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %346, ptr @"main.(*stringReader).ReadByte", 3
+  %348 = load ptr, ptr @_llgo_rune, align 8
+  %349 = icmp eq ptr %348, null
+  br i1 %349, label %_llgo_45, label %_llgo_46
 
 _llgo_45:                                         ; preds = %_llgo_44
-  %704 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 37)
-  store ptr %704, ptr @_llgo_rune, align 8
+  %350 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 37)
+  store ptr %350, ptr @_llgo_rune, align 8
   br label %_llgo_46
 
 _llgo_46:                                         ; preds = %_llgo_45, %_llgo_44
-  %705 = load ptr, ptr @_llgo_rune, align 8
-  %706 = load ptr, ptr @_llgo_rune, align 8
-  %707 = load ptr, ptr @_llgo_int, align 8
-  %708 = load ptr, ptr @_llgo_error, align 8
-  %709 = load ptr, ptr @"_llgo_func$CB0CO6hV_feSzhi4pz1P4omza2fKNK930wvOR1T33fU", align 8
-  %710 = icmp eq ptr %709, null
-  br i1 %710, label %_llgo_47, label %_llgo_48
+  %351 = load ptr, ptr @_llgo_rune, align 8
+  %352 = load ptr, ptr @_llgo_rune, align 8
+  %353 = load ptr, ptr @_llgo_int, align 8
+  %354 = load ptr, ptr @_llgo_error, align 8
+  %355 = load ptr, ptr @"_llgo_func$CB0CO6hV_feSzhi4pz1P4omza2fKNK930wvOR1T33fU", align 8
+  %356 = icmp eq ptr %355, null
+  br i1 %356, label %_llgo_47, label %_llgo_48
 
 _llgo_47:                                         ; preds = %_llgo_46
-  %711 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %712 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %713 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %712, i32 0, i32 0
-  store ptr %711, ptr %713, align 8
-  %714 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %712, i32 0, i32 1
-  store i64 0, ptr %714, align 4
-  %715 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %712, i32 0, i32 2
-  store i64 0, ptr %715, align 4
-  %716 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %712, align 8
-  %717 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %718 = getelementptr ptr, ptr %717, i64 0
-  store ptr %706, ptr %718, align 8
-  %719 = getelementptr ptr, ptr %717, i64 1
-  store ptr %707, ptr %719, align 8
-  %720 = getelementptr ptr, ptr %717, i64 2
-  store ptr %708, ptr %720, align 8
-  %721 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %722 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %721, i32 0, i32 0
-  store ptr %717, ptr %722, align 8
-  %723 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %721, i32 0, i32 1
-  store i64 3, ptr %723, align 4
-  %724 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %721, i32 0, i32 2
-  store i64 3, ptr %724, align 4
-  %725 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %721, align 8
-  %726 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %716, %"github.com/goplus/llgo/internal/runtime.Slice" %725, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %726)
-  store ptr %726, ptr @"_llgo_func$CB0CO6hV_feSzhi4pz1P4omza2fKNK930wvOR1T33fU", align 8
+  %357 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %358 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %357, 0
+  %359 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %358, i64 0, 1
+  %360 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %359, i64 0, 2
+  %361 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %362 = getelementptr ptr, ptr %361, i64 0
+  store ptr %352, ptr %362, align 8
+  %363 = getelementptr ptr, ptr %361, i64 1
+  store ptr %353, ptr %363, align 8
+  %364 = getelementptr ptr, ptr %361, i64 2
+  store ptr %354, ptr %364, align 8
+  %365 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %361, 0
+  %366 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %365, i64 3, 1
+  %367 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %366, i64 3, 2
+  %368 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %360, %"github.com/goplus/llgo/internal/runtime.Slice" %367, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %368)
+  store ptr %368, ptr @"_llgo_func$CB0CO6hV_feSzhi4pz1P4omza2fKNK930wvOR1T33fU", align 8
   br label %_llgo_48
 
 _llgo_48:                                         ; preds = %_llgo_47, %_llgo_46
-  %727 = load ptr, ptr @"_llgo_func$CB0CO6hV_feSzhi4pz1P4omza2fKNK930wvOR1T33fU", align 8
-  %728 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %729 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %728, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %701, ptr %729, align 8
-  %730 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %728, i32 0, i32 1
-  store ptr %727, ptr %730, align 8
-  %731 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %728, i32 0, i32 2
-  store ptr @"main.(*stringReader).ReadRune", ptr %731, align 8
-  %732 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %728, i32 0, i32 3
-  store ptr @"main.(*stringReader).ReadRune", ptr %732, align 8
-  %733 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %728, align 8
-  %734 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %735 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %734, i32 0, i32 0
-  store ptr @28, ptr %735, align 8
-  %736 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %734, i32 0, i32 1
-  store i64 4, ptr %736, align 4
-  %737 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %734, align 8
-  %738 = load ptr, ptr @_llgo_int64, align 8
-  %739 = load ptr, ptr @_llgo_int, align 8
-  %740 = load ptr, ptr @_llgo_int64, align 8
-  %741 = load ptr, ptr @_llgo_error, align 8
-  %742 = load ptr, ptr @"_llgo_func$HE7H49xPa1uXmrkMDpqB3RCRGf3qzhLGrxKCEXOYjms", align 8
-  %743 = icmp eq ptr %742, null
-  br i1 %743, label %_llgo_49, label %_llgo_50
+  %369 = load ptr, ptr @"_llgo_func$CB0CO6hV_feSzhi4pz1P4omza2fKNK930wvOR1T33fU", align 8
+  %370 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @27, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %369, 1
+  %371 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %370, ptr @"main.(*stringReader).ReadRune", 2
+  %372 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %371, ptr @"main.(*stringReader).ReadRune", 3
+  %373 = load ptr, ptr @_llgo_int64, align 8
+  %374 = load ptr, ptr @_llgo_int, align 8
+  %375 = load ptr, ptr @_llgo_int64, align 8
+  %376 = load ptr, ptr @_llgo_error, align 8
+  %377 = load ptr, ptr @"_llgo_func$HE7H49xPa1uXmrkMDpqB3RCRGf3qzhLGrxKCEXOYjms", align 8
+  %378 = icmp eq ptr %377, null
+  br i1 %378, label %_llgo_49, label %_llgo_50
 
 _llgo_49:                                         ; preds = %_llgo_48
-  %744 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %745 = getelementptr ptr, ptr %744, i64 0
-  store ptr %738, ptr %745, align 8
-  %746 = getelementptr ptr, ptr %744, i64 1
-  store ptr %739, ptr %746, align 8
-  %747 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %748 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %747, i32 0, i32 0
-  store ptr %744, ptr %748, align 8
-  %749 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %747, i32 0, i32 1
-  store i64 2, ptr %749, align 4
-  %750 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %747, i32 0, i32 2
-  store i64 2, ptr %750, align 4
-  %751 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %747, align 8
-  %752 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %753 = getelementptr ptr, ptr %752, i64 0
-  store ptr %740, ptr %753, align 8
-  %754 = getelementptr ptr, ptr %752, i64 1
-  store ptr %741, ptr %754, align 8
-  %755 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %756 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %755, i32 0, i32 0
-  store ptr %752, ptr %756, align 8
-  %757 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %755, i32 0, i32 1
-  store i64 2, ptr %757, align 4
-  %758 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %755, i32 0, i32 2
-  store i64 2, ptr %758, align 4
-  %759 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %755, align 8
-  %760 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %751, %"github.com/goplus/llgo/internal/runtime.Slice" %759, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %760)
-  store ptr %760, ptr @"_llgo_func$HE7H49xPa1uXmrkMDpqB3RCRGf3qzhLGrxKCEXOYjms", align 8
+  %379 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %380 = getelementptr ptr, ptr %379, i64 0
+  store ptr %373, ptr %380, align 8
+  %381 = getelementptr ptr, ptr %379, i64 1
+  store ptr %374, ptr %381, align 8
+  %382 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %379, 0
+  %383 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %382, i64 2, 1
+  %384 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %383, i64 2, 2
+  %385 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %386 = getelementptr ptr, ptr %385, i64 0
+  store ptr %375, ptr %386, align 8
+  %387 = getelementptr ptr, ptr %385, i64 1
+  store ptr %376, ptr %387, align 8
+  %388 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %385, 0
+  %389 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %388, i64 2, 1
+  %390 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %389, i64 2, 2
+  %391 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %384, %"github.com/goplus/llgo/internal/runtime.Slice" %390, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %391)
+  store ptr %391, ptr @"_llgo_func$HE7H49xPa1uXmrkMDpqB3RCRGf3qzhLGrxKCEXOYjms", align 8
   br label %_llgo_50
 
 _llgo_50:                                         ; preds = %_llgo_49, %_llgo_48
-  %761 = load ptr, ptr @"_llgo_func$HE7H49xPa1uXmrkMDpqB3RCRGf3qzhLGrxKCEXOYjms", align 8
-  %762 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %763 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %762, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %737, ptr %763, align 8
-  %764 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %762, i32 0, i32 1
-  store ptr %761, ptr %764, align 8
-  %765 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %762, i32 0, i32 2
-  store ptr @"main.(*stringReader).Seek", ptr %765, align 8
-  %766 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %762, i32 0, i32 3
-  store ptr @"main.(*stringReader).Seek", ptr %766, align 8
-  %767 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %762, align 8
-  %768 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %769 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %768, i32 0, i32 0
-  store ptr @29, ptr %769, align 8
-  %770 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %768, i32 0, i32 1
-  store i64 4, ptr %770, align 4
-  %771 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %768, align 8
-  %772 = load ptr, ptr @_llgo_int64, align 8
-  %773 = load ptr, ptr @"_llgo_func$Eoig9xhJM5GShHH5aNPxTZZXp1IZxprRl4zPuv2hkug", align 8
-  %774 = icmp eq ptr %773, null
-  br i1 %774, label %_llgo_51, label %_llgo_52
+  %392 = load ptr, ptr @"_llgo_func$HE7H49xPa1uXmrkMDpqB3RCRGf3qzhLGrxKCEXOYjms", align 8
+  %393 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @28, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %392, 1
+  %394 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %393, ptr @"main.(*stringReader).Seek", 2
+  %395 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %394, ptr @"main.(*stringReader).Seek", 3
+  %396 = load ptr, ptr @_llgo_int64, align 8
+  %397 = load ptr, ptr @"_llgo_func$Eoig9xhJM5GShHH5aNPxTZZXp1IZxprRl4zPuv2hkug", align 8
+  %398 = icmp eq ptr %397, null
+  br i1 %398, label %_llgo_51, label %_llgo_52
 
 _llgo_51:                                         ; preds = %_llgo_50
-  %775 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %776 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %777 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %776, i32 0, i32 0
-  store ptr %775, ptr %777, align 8
-  %778 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %776, i32 0, i32 1
-  store i64 0, ptr %778, align 4
-  %779 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %776, i32 0, i32 2
-  store i64 0, ptr %779, align 4
-  %780 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %776, align 8
-  %781 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %782 = getelementptr ptr, ptr %781, i64 0
-  store ptr %772, ptr %782, align 8
-  %783 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %784 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %783, i32 0, i32 0
-  store ptr %781, ptr %784, align 8
-  %785 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %783, i32 0, i32 1
-  store i64 1, ptr %785, align 4
-  %786 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %783, i32 0, i32 2
-  store i64 1, ptr %786, align 4
-  %787 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %783, align 8
-  %788 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %780, %"github.com/goplus/llgo/internal/runtime.Slice" %787, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %788)
-  store ptr %788, ptr @"_llgo_func$Eoig9xhJM5GShHH5aNPxTZZXp1IZxprRl4zPuv2hkug", align 8
+  %399 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %400 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %399, 0
+  %401 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %400, i64 0, 1
+  %402 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %401, i64 0, 2
+  %403 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %404 = getelementptr ptr, ptr %403, i64 0
+  store ptr %396, ptr %404, align 8
+  %405 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %403, 0
+  %406 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %405, i64 1, 1
+  %407 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %406, i64 1, 2
+  %408 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %402, %"github.com/goplus/llgo/internal/runtime.Slice" %407, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %408)
+  store ptr %408, ptr @"_llgo_func$Eoig9xhJM5GShHH5aNPxTZZXp1IZxprRl4zPuv2hkug", align 8
   br label %_llgo_52
 
 _llgo_52:                                         ; preds = %_llgo_51, %_llgo_50
-  %789 = load ptr, ptr @"_llgo_func$Eoig9xhJM5GShHH5aNPxTZZXp1IZxprRl4zPuv2hkug", align 8
-  %790 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %791 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %790, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %771, ptr %791, align 8
-  %792 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %790, i32 0, i32 1
-  store ptr %789, ptr %792, align 8
-  %793 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %790, i32 0, i32 2
-  store ptr @"main.(*stringReader).Size", ptr %793, align 8
-  %794 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %790, i32 0, i32 3
-  store ptr @"main.(*stringReader).Size", ptr %794, align 8
-  %795 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %790, align 8
-  %796 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %797 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %796, i32 0, i32 0
-  store ptr @30, ptr %797, align 8
-  %798 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %796, i32 0, i32 1
-  store i64 10, ptr %798, align 4
-  %799 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %796, align 8
-  %800 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
-  %801 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %802 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %801, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %799, ptr %802, align 8
-  %803 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %801, i32 0, i32 1
-  store ptr %800, ptr %803, align 8
-  %804 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %801, i32 0, i32 2
-  store ptr @"main.(*stringReader).UnreadByte", ptr %804, align 8
-  %805 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %801, i32 0, i32 3
-  store ptr @"main.(*stringReader).UnreadByte", ptr %805, align 8
-  %806 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %801, align 8
-  %807 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %808 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %807, i32 0, i32 0
-  store ptr @31, ptr %808, align 8
-  %809 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %807, i32 0, i32 1
-  store i64 10, ptr %809, align 4
-  %810 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %807, align 8
-  %811 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
-  %812 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %813 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %812, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %810, ptr %813, align 8
-  %814 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %812, i32 0, i32 1
-  store ptr %811, ptr %814, align 8
-  %815 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %812, i32 0, i32 2
-  store ptr @"main.(*stringReader).UnreadRune", ptr %815, align 8
-  %816 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %812, i32 0, i32 3
-  store ptr @"main.(*stringReader).UnreadRune", ptr %816, align 8
-  %817 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %812, align 8
-  %818 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %819 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %818, i32 0, i32 0
-  store ptr @5, ptr %819, align 8
-  %820 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %818, i32 0, i32 1
-  store i64 7, ptr %820, align 4
-  %821 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %818, align 8
-  %822 = load ptr, ptr @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk", align 8
-  %823 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %824 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %823, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %821, ptr %824, align 8
-  %825 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %823, i32 0, i32 1
-  store ptr %822, ptr %825, align 8
-  %826 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %823, i32 0, i32 2
-  store ptr @"main.(*stringReader).WriteTo", ptr %826, align 8
-  %827 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %823, i32 0, i32 3
-  store ptr @"main.(*stringReader).WriteTo", ptr %827, align 8
-  %828 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %823, align 8
-  %829 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 400)
-  %830 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %829, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %620, ptr %830, align 8
-  %831 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %829, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %632, ptr %831, align 8
-  %832 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %829, i64 2
-  store %"github.com/goplus/llgo/internal/abi.Method" %667, ptr %832, align 8
-  %833 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %829, i64 3
-  store %"github.com/goplus/llgo/internal/abi.Method" %697, ptr %833, align 8
-  %834 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %829, i64 4
-  store %"github.com/goplus/llgo/internal/abi.Method" %733, ptr %834, align 8
-  %835 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %829, i64 5
-  store %"github.com/goplus/llgo/internal/abi.Method" %767, ptr %835, align 8
-  %836 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %829, i64 6
-  store %"github.com/goplus/llgo/internal/abi.Method" %795, ptr %836, align 8
-  %837 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %829, i64 7
-  store %"github.com/goplus/llgo/internal/abi.Method" %806, ptr %837, align 8
-  %838 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %829, i64 8
-  store %"github.com/goplus/llgo/internal/abi.Method" %817, ptr %838, align 8
-  %839 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %829, i64 9
-  store %"github.com/goplus/llgo/internal/abi.Method" %828, ptr %839, align 8
-  %840 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %841 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %840, i32 0, i32 0
-  store ptr %829, ptr %841, align 8
-  %842 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %840, i32 0, i32 1
-  store i64 10, ptr %842, align 4
-  %843 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %840, i32 0, i32 2
-  store i64 10, ptr %843, align 4
-  %844 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %840, align 8
-  %845 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %846 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %845, i32 0, i32 0
-  store ptr @1, ptr %846, align 8
-  %847 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %845, i32 0, i32 1
-  store i64 4, ptr %847, align 4
-  %848 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %845, align 8
-  %849 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %850 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %849, i32 0, i32 0
-  store ptr @32, ptr %850, align 8
-  %851 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %849, i32 0, i32 1
-  store i64 12, ptr %851, align 4
-  %852 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %849, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %547, %"github.com/goplus/llgo/internal/runtime.String" %848, %"github.com/goplus/llgo/internal/runtime.String" %852, ptr %592, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %844)
-  %853 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %854 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %853, i32 0, i32 0
-  store ptr @20, ptr %854, align 8
-  %855 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %853, i32 0, i32 1
-  store i64 17, ptr %855, align 4
-  %856 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %853, align 8
-  %857 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %856, i64 25, i64 32, i64 0, i64 10)
-  %858 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %857)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %858)
-  store ptr %858, ptr @"*_llgo_main.stringReader", align 8
-  %859 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
-  %860 = load ptr, ptr @"_llgo_iface$OFO8Us9n8ajWCabGedeuoJ-Za2zAMk4Jh0FunAcUCFE", align 8
-  %861 = icmp eq ptr %860, null
-  br i1 %861, label %_llgo_53, label %_llgo_54
+  %409 = load ptr, ptr @"_llgo_func$Eoig9xhJM5GShHH5aNPxTZZXp1IZxprRl4zPuv2hkug", align 8
+  %410 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @29, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %409, 1
+  %411 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %410, ptr @"main.(*stringReader).Size", 2
+  %412 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %411, ptr @"main.(*stringReader).Size", 3
+  %413 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
+  %414 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @30, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %413, 1
+  %415 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %414, ptr @"main.(*stringReader).UnreadByte", 2
+  %416 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %415, ptr @"main.(*stringReader).UnreadByte", 3
+  %417 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
+  %418 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @31, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %417, 1
+  %419 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %418, ptr @"main.(*stringReader).UnreadRune", 2
+  %420 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %419, ptr @"main.(*stringReader).UnreadRune", 3
+  %421 = load ptr, ptr @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk", align 8
+  %422 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %421, 1
+  %423 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %422, ptr @"main.(*stringReader).WriteTo", 2
+  %424 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %423, ptr @"main.(*stringReader).WriteTo", 3
+  %425 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 400)
+  %426 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %425, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %299, ptr %426, align 8
+  %427 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %425, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %304, ptr %427, align 8
+  %428 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %425, i64 2
+  store %"github.com/goplus/llgo/internal/abi.Method" %328, ptr %428, align 8
+  %429 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %425, i64 3
+  store %"github.com/goplus/llgo/internal/abi.Method" %347, ptr %429, align 8
+  %430 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %425, i64 4
+  store %"github.com/goplus/llgo/internal/abi.Method" %372, ptr %430, align 8
+  %431 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %425, i64 5
+  store %"github.com/goplus/llgo/internal/abi.Method" %395, ptr %431, align 8
+  %432 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %425, i64 6
+  store %"github.com/goplus/llgo/internal/abi.Method" %412, ptr %432, align 8
+  %433 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %425, i64 7
+  store %"github.com/goplus/llgo/internal/abi.Method" %416, ptr %433, align 8
+  %434 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %425, i64 8
+  store %"github.com/goplus/llgo/internal/abi.Method" %420, ptr %434, align 8
+  %435 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %425, i64 9
+  store %"github.com/goplus/llgo/internal/abi.Method" %424, ptr %435, align 8
+  %436 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %425, 0
+  %437 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %436, i64 10, 1
+  %438 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %437, i64 10, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %267, %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @32, i64 12 }, ptr %282, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %438)
+  %439 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @20, i64 17 }, i64 25, i64 32, i64 0, i64 10)
+  %440 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %439)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %440)
+  store ptr %440, ptr @"*_llgo_main.stringReader", align 8
+  %441 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
+  %442 = load ptr, ptr @"_llgo_iface$OFO8Us9n8ajWCabGedeuoJ-Za2zAMk4Jh0FunAcUCFE", align 8
+  %443 = icmp eq ptr %442, null
+  br i1 %443, label %_llgo_53, label %_llgo_54
 
 _llgo_53:                                         ; preds = %_llgo_52
-  %862 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %863 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %862, i32 0, i32 0
-  store ptr @8, ptr %863, align 8
-  %864 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %862, i32 0, i32 1
-  store i64 4, ptr %864, align 4
-  %865 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %862, align 8
-  %866 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %867 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %866, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %865, ptr %867, align 8
-  %868 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %866, i32 0, i32 1
-  store ptr %859, ptr %868, align 8
-  %869 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %866, align 8
-  %870 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %871 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %870, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %869, ptr %871, align 8
-  %872 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %873 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %872, i32 0, i32 0
-  store ptr %870, ptr %873, align 8
-  %874 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %872, i32 0, i32 1
-  store i64 1, ptr %874, align 4
-  %875 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %872, i32 0, i32 2
-  store i64 1, ptr %875, align 4
-  %876 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %872, align 8
-  %877 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %878 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %877, i32 0, i32 0
-  store ptr @1, ptr %878, align 8
-  %879 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %877, i32 0, i32 1
-  store i64 4, ptr %879, align 4
-  %880 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %877, align 8
-  %881 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %882 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %881, i32 0, i32 0
-  store ptr null, ptr %882, align 8
-  %883 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %881, i32 0, i32 1
-  store i64 0, ptr %883, align 4
-  %884 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %881, align 8
-  %885 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %880, %"github.com/goplus/llgo/internal/runtime.String" %884, %"github.com/goplus/llgo/internal/runtime.Slice" %876)
-  store ptr %885, ptr @"_llgo_iface$OFO8Us9n8ajWCabGedeuoJ-Za2zAMk4Jh0FunAcUCFE", align 8
+  %444 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 4 }, ptr undef }, ptr %441, 1
+  %445 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %446 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %445, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %444, ptr %446, align 8
+  %447 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %445, 0
+  %448 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %447, i64 1, 1
+  %449 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %448, i64 1, 2
+  %450 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %449)
+  store ptr %450, ptr @"_llgo_iface$OFO8Us9n8ajWCabGedeuoJ-Za2zAMk4Jh0FunAcUCFE", align 8
   br label %_llgo_54
 
 _llgo_54:                                         ; preds = %_llgo_53, %_llgo_52
-  %886 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %887 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %886, i32 0, i32 0
-  store ptr @33, ptr %887, align 8
-  %888 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %886, i32 0, i32 1
-  store i64 16, ptr %888, align 4
-  %889 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %886, align 8
-  %890 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %889, i64 25, i64 16, i64 0, i64 1)
-  store ptr %890, ptr @_llgo_main.errorString, align 8
-  %891 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %892 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %891, i32 0, i32 0
-  store ptr @21, ptr %892, align 8
-  %893 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %891, i32 0, i32 1
-  store i64 1, ptr %893, align 4
-  %894 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %891, align 8
-  %895 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %896 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %895, i32 0, i32 0
-  store ptr null, ptr %896, align 8
-  %897 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %895, i32 0, i32 1
-  store i64 0, ptr %897, align 4
-  %898 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %895, align 8
-  %899 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %900 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %894, ptr %899, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %898, i1 false)
-  %901 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %902 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %901, i32 0, i32 0
-  store ptr @1, ptr %902, align 8
-  %903 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %901, i32 0, i32 1
-  store i64 4, ptr %903, align 4
-  %904 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %901, align 8
-  %905 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
-  %906 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %905, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %900, ptr %906, align 8
-  %907 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %908 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %907, i32 0, i32 0
-  store ptr %905, ptr %908, align 8
-  %909 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %907, i32 0, i32 1
-  store i64 1, ptr %909, align 4
-  %910 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %907, i32 0, i32 2
-  store i64 1, ptr %910, align 4
-  %911 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %907, align 8
-  %912 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %904, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %911)
-  store ptr %912, ptr @"main.struct$QTufDJA9wEDzuzgkA-ZSrLqW-B6lWN8O25mTSglAoLQ", align 8
-  %913 = load ptr, ptr @"main.struct$QTufDJA9wEDzuzgkA-ZSrLqW-B6lWN8O25mTSglAoLQ", align 8
-  %914 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %915 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %914, i32 0, i32 0
-  store ptr @0, ptr %915, align 8
-  %916 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %914, i32 0, i32 1
-  store i64 5, ptr %916, align 4
-  %917 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %914, align 8
-  %918 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %919 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %920 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %919, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %917, ptr %920, align 8
-  %921 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %919, i32 0, i32 1
-  store ptr %918, ptr %921, align 8
-  %922 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %919, i32 0, i32 2
-  store ptr @"main.(*errorString).Error", ptr %922, align 8
-  %923 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %919, i32 0, i32 3
-  store ptr @"main.(*errorString).Error", ptr %923, align 8
-  %924 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %919, align 8
-  %925 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %926 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %925, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %924, ptr %926, align 8
-  %927 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %928 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %927, i32 0, i32 0
-  store ptr %925, ptr %928, align 8
-  %929 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %927, i32 0, i32 1
-  store i64 1, ptr %929, align 4
-  %930 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %927, i32 0, i32 2
-  store i64 1, ptr %930, align 4
-  %931 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %927, align 8
-  %932 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %933 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %932, i32 0, i32 0
-  store ptr @1, ptr %933, align 8
-  %934 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %932, i32 0, i32 1
-  store i64 4, ptr %934, align 4
-  %935 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %932, align 8
-  %936 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %937 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %936, i32 0, i32 0
-  store ptr @34, ptr %937, align 8
-  %938 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %936, i32 0, i32 1
-  store i64 11, ptr %938, align 4
-  %939 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %936, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %890, %"github.com/goplus/llgo/internal/runtime.String" %935, %"github.com/goplus/llgo/internal/runtime.String" %939, ptr %913, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %931)
-  %940 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %941 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %940, i32 0, i32 0
-  store ptr @33, ptr %941, align 8
-  %942 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %940, i32 0, i32 1
-  store i64 16, ptr %942, align 4
-  %943 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %940, align 8
-  %944 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %943, i64 25, i64 16, i64 0, i64 1)
-  %945 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %944)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %945)
-  store ptr %945, ptr @"*_llgo_main.errorString", align 8
-  %946 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %947 = load ptr, ptr @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU", align 8
-  %948 = icmp eq ptr %947, null
-  br i1 %948, label %_llgo_55, label %_llgo_56
+  %451 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @33, i64 16 }, i64 25, i64 16, i64 0, i64 1)
+  store ptr %451, ptr @_llgo_main.errorString, align 8
+  %452 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %453 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @21, i64 1 }, ptr %452, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %454 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
+  %455 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %454, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %453, ptr %455, align 8
+  %456 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %454, 0
+  %457 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %456, i64 1, 1
+  %458 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %457, i64 1, 2
+  %459 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %458)
+  store ptr %459, ptr @"main.struct$QTufDJA9wEDzuzgkA-ZSrLqW-B6lWN8O25mTSglAoLQ", align 8
+  %460 = load ptr, ptr @"main.struct$QTufDJA9wEDzuzgkA-ZSrLqW-B6lWN8O25mTSglAoLQ", align 8
+  %461 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %462 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr undef, ptr undef, ptr undef }, ptr %461, 1
+  %463 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %462, ptr @"main.(*errorString).Error", 2
+  %464 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %463, ptr @"main.(*errorString).Error", 3
+  %465 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %466 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %465, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %464, ptr %466, align 8
+  %467 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %465, 0
+  %468 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %467, i64 1, 1
+  %469 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %468, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %451, %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @34, i64 11 }, ptr %460, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %469)
+  %470 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @33, i64 16 }, i64 25, i64 16, i64 0, i64 1)
+  %471 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %470)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %471)
+  store ptr %471, ptr @"*_llgo_main.errorString", align 8
+  %472 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %473 = load ptr, ptr @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU", align 8
+  %474 = icmp eq ptr %473, null
+  br i1 %474, label %_llgo_55, label %_llgo_56
 
 _llgo_55:                                         ; preds = %_llgo_54
-  %949 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %950 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %949, i32 0, i32 0
-  store ptr @0, ptr %950, align 8
-  %951 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %949, i32 0, i32 1
-  store i64 5, ptr %951, align 4
-  %952 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %949, align 8
-  %953 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %954 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %953, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %952, ptr %954, align 8
-  %955 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %953, i32 0, i32 1
-  store ptr %946, ptr %955, align 8
-  %956 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %953, align 8
-  %957 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %958 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %957, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %956, ptr %958, align 8
-  %959 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %960 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %959, i32 0, i32 0
-  store ptr %957, ptr %960, align 8
-  %961 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %959, i32 0, i32 1
-  store i64 1, ptr %961, align 4
-  %962 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %959, i32 0, i32 2
-  store i64 1, ptr %962, align 4
-  %963 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %959, align 8
-  %964 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %965 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %964, i32 0, i32 0
-  store ptr @1, ptr %965, align 8
-  %966 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %964, i32 0, i32 1
-  store i64 4, ptr %966, align 4
-  %967 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %964, align 8
-  %968 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %969 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %968, i32 0, i32 0
-  store ptr null, ptr %969, align 8
-  %970 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %968, i32 0, i32 1
-  store i64 0, ptr %970, align 4
-  %971 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %968, align 8
-  %972 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %967, %"github.com/goplus/llgo/internal/runtime.String" %971, %"github.com/goplus/llgo/internal/runtime.Slice" %963)
-  store ptr %972, ptr @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU", align 8
+  %475 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr undef }, ptr %472, 1
+  %476 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %477 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %476, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %475, ptr %477, align 8
+  %478 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %476, 0
+  %479 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %478, i64 1, 1
+  %480 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %479, i64 1, 2
+  %481 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %480)
+  store ptr %481, ptr @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU", align 8
   br label %_llgo_56
 
 _llgo_56:                                         ; preds = %_llgo_55, %_llgo_54

--- a/cl/_testgo/reflect/out.ll
+++ b/cl/_testgo/reflect/out.ll
@@ -42,22 +42,16 @@ source_filename = "main"
 
 define i64 @"main.(*T).Add"(ptr %0, i64 %1) {
 _llgo_0:
-  %2 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 0
-  store ptr @0, ptr %3, align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 1
-  store i64 11, ptr %4, align 4
-  %5 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %5)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 11 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
+  %2 = getelementptr inbounds %main.T, ptr %0, i32 0, i32 0
+  %3 = load i64, ptr %2, align 4
+  %4 = add i64 %3, %1
+  %5 = getelementptr inbounds %main.T, ptr %0, i32 0, i32 0
+  store i64 %4, ptr %5, align 4
   %6 = getelementptr inbounds %main.T, ptr %0, i32 0, i32 0
   %7 = load i64, ptr %6, align 4
-  %8 = add i64 %7, %1
-  %9 = getelementptr inbounds %main.T, ptr %0, i32 0, i32 0
-  store i64 %8, ptr %9, align 4
-  %10 = getelementptr inbounds %main.T, ptr %0, i32 0, i32 0
-  %11 = load i64, ptr %10, align 4
-  ret i64 %11
+  ret i64 %7
 }
 
 define void @main.callClosure() {
@@ -67,303 +61,194 @@ _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
   %2 = getelementptr inbounds { ptr }, ptr %1, i32 0, i32 0
   store ptr %0, ptr %2, align 8
-  %3 = alloca { ptr, ptr }, align 8
-  %4 = getelementptr inbounds { ptr, ptr }, ptr %3, i32 0, i32 0
-  store ptr @"main.callClosure$1", ptr %4, align 8
-  %5 = getelementptr inbounds { ptr, ptr }, ptr %3, i32 0, i32 1
-  store ptr %1, ptr %5, align 8
-  %6 = load { ptr, ptr }, ptr %3, align 8
-  %7 = load ptr, ptr @_llgo_Pointer, align 8
-  %8 = load ptr, ptr @_llgo_int, align 8
-  %9 = load ptr, ptr @"_llgo_func$LW7NaHY4krmx4VSCwrrjp23xg526aJ8NlR7kN98tIyE", align 8
-  %10 = load ptr, ptr @"main.struct$J4GOle3xvLePlAXZSFNKiHRJ-WQyyOMhvl8OQfxW2Q8", align 8
-  call void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr %10)
-  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store { ptr, ptr } %6, ptr %11, align 8
-  %12 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %12, i32 0, i32 0
-  store ptr %10, ptr %13, align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %12, i32 0, i32 1
-  store ptr %11, ptr %14, align 8
-  %15 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %12, align 8
-  %16 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %15)
-  %17 = call i64 @reflect.Value.Kind(%reflect.Value %16)
-  %18 = call %"github.com/goplus/llgo/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %16)
-  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %18)
-  %20 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %18, 0
-  %21 = getelementptr ptr, ptr %20, i64 31
-  %22 = load ptr, ptr %21, align 8
-  %23 = alloca { ptr, ptr }, align 8
-  %24 = getelementptr inbounds { ptr, ptr }, ptr %23, i32 0, i32 0
-  store ptr %22, ptr %24, align 8
-  %25 = getelementptr inbounds { ptr, ptr }, ptr %23, i32 0, i32 1
-  store ptr %19, ptr %25, align 8
-  %26 = load { ptr, ptr }, ptr %23, align 8
-  %27 = extractvalue { ptr, ptr } %26, 1
-  %28 = extractvalue { ptr, ptr } %26, 0
-  %29 = call %"github.com/goplus/llgo/internal/runtime.String" %28(ptr %27)
-  %30 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %30, i32 0, i32 0
-  store ptr @4, ptr %31, align 8
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %30, i32 0, i32 1
-  store i64 7, ptr %32, align 4
-  %33 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %30, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %33)
+  %3 = insertvalue { ptr, ptr } { ptr @"main.callClosure$1", ptr undef }, ptr %1, 1
+  %4 = load ptr, ptr @_llgo_Pointer, align 8
+  %5 = load ptr, ptr @_llgo_int, align 8
+  %6 = load ptr, ptr @"_llgo_func$LW7NaHY4krmx4VSCwrrjp23xg526aJ8NlR7kN98tIyE", align 8
+  %7 = load ptr, ptr @"main.struct$J4GOle3xvLePlAXZSFNKiHRJ-WQyyOMhvl8OQfxW2Q8", align 8
+  call void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr %7)
+  %8 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store { ptr, ptr } %3, ptr %8, align 8
+  %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %7, 0
+  %10 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %9, ptr %8, 1
+  %11 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %10)
+  %12 = call i64 @reflect.Value.Kind(%reflect.Value %11)
+  %13 = call %"github.com/goplus/llgo/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %11)
+  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %13)
+  %15 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %13, 0
+  %16 = getelementptr ptr, ptr %15, i64 31
+  %17 = load ptr, ptr %16, align 8
+  %18 = insertvalue { ptr, ptr } undef, ptr %17, 0
+  %19 = insertvalue { ptr, ptr } %18, ptr %14, 1
+  %20 = extractvalue { ptr, ptr } %19, 1
+  %21 = extractvalue { ptr, ptr } %19, 0
+  %22 = call %"github.com/goplus/llgo/internal/runtime.String" %21(ptr %20)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 7 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 %17)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 %12)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %29)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %22)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %34 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
-  %35 = getelementptr inbounds %reflect.Value, ptr %34, i64 0
-  %36 = load ptr, ptr @_llgo_int, align 8
-  %37 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %37, i32 0, i32 0
-  store ptr %36, ptr %38, align 8
-  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %37, i32 0, i32 1
-  store ptr inttoptr (i64 100 to ptr), ptr %39, align 8
-  %40 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %37, align 8
-  %41 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %40)
-  store %reflect.Value %41, ptr %35, align 8
-  %42 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, i32 0, i32 0
-  store ptr %34, ptr %43, align 8
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, i32 0, i32 1
-  store i64 1, ptr %44, align 4
-  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, i32 0, i32 2
-  store i64 1, ptr %45, align 4
-  %46 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, align 8
-  %47 = call %"github.com/goplus/llgo/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %16, %"github.com/goplus/llgo/internal/runtime.Slice" %46)
-  %48 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %47, 0
-  %49 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %47, 1
-  %50 = icmp sge i64 0, %49
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %50)
-  %51 = getelementptr inbounds %reflect.Value, ptr %48, i64 0
-  %52 = load %reflect.Value, ptr %51, align 8
-  %53 = call i64 @reflect.Value.Int(%reflect.Value %52)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %53)
+  %23 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
+  %24 = getelementptr inbounds %reflect.Value, ptr %23, i64 0
+  %25 = load ptr, ptr @_llgo_int, align 8
+  %26 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %25, 0
+  %27 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %26, ptr inttoptr (i64 100 to ptr), 1
+  %28 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %27)
+  store %reflect.Value %28, ptr %24, align 8
+  %29 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %23, 0
+  %30 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %29, i64 1, 1
+  %31 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %30, i64 1, 2
+  %32 = call %"github.com/goplus/llgo/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %11, %"github.com/goplus/llgo/internal/runtime.Slice" %31)
+  %33 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %32, 0
+  %34 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %32, 1
+  %35 = icmp sge i64 0, %34
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %35)
+  %36 = getelementptr inbounds %reflect.Value, ptr %33, i64 0
+  %37 = load %reflect.Value, ptr %36, align 8
+  %38 = call i64 @reflect.Value.Int(%reflect.Value %37)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %38)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %54 = call %"github.com/goplus/llgo/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %16)
-  %55 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %54, 0
-  %56 = load ptr, ptr @"main.struct$J4GOle3xvLePlAXZSFNKiHRJ-WQyyOMhvl8OQfxW2Q8", align 8
-  %57 = icmp eq ptr %55, %56
-  br i1 %57, label %_llgo_3, label %_llgo_4
+  %39 = call %"github.com/goplus/llgo/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %11)
+  %40 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %39, 0
+  %41 = load ptr, ptr @"main.struct$J4GOle3xvLePlAXZSFNKiHRJ-WQyyOMhvl8OQfxW2Q8", align 8
+  %42 = icmp eq ptr %40, %41
+  br i1 %42, label %_llgo_3, label %_llgo_4
 
 _llgo_1:                                          ; preds = %_llgo_5
-  %58 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %59 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %58, i32 0, i32 0
-  store ptr @5, ptr %59, align 8
-  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %58, i32 0, i32 1
-  store i64 5, ptr %60, align 4
-  %61 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %58, align 8
-  %62 = load ptr, ptr @_llgo_string, align 8
-  %63 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %61, ptr %63, align 8
-  %64 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %65 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %64, i32 0, i32 0
-  store ptr %62, ptr %65, align 8
-  %66 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %64, i32 0, i32 1
-  store ptr %63, ptr %66, align 8
-  %67 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %64, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %67)
+  %43 = load ptr, ptr @_llgo_string, align 8
+  %44 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 5 }, ptr %44, align 8
+  %45 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %43, 0
+  %46 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %45, ptr %44, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %46)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_5
-  %68 = extractvalue { ptr, ptr } %82, 1
-  %69 = extractvalue { ptr, ptr } %82, 0
-  %70 = call i64 %69(ptr %68, i64 100)
+  %47 = extractvalue { ptr, ptr } %55, 1
+  %48 = extractvalue { ptr, ptr } %55, 0
+  %49 = call i64 %48(ptr %47, i64 100)
   ret void
 
 _llgo_3:                                          ; preds = %_llgo_0
-  %71 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %54, 1
-  %72 = load { ptr, ptr }, ptr %71, align 8
-  %73 = alloca { { ptr, ptr }, i1 }, align 8
-  %74 = getelementptr inbounds { { ptr, ptr }, i1 }, ptr %73, i32 0, i32 0
-  store { ptr, ptr } %72, ptr %74, align 8
-  %75 = getelementptr inbounds { { ptr, ptr }, i1 }, ptr %73, i32 0, i32 1
-  store i1 true, ptr %75, align 1
-  %76 = load { { ptr, ptr }, i1 }, ptr %73, align 8
+  %50 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %39, 1
+  %51 = load { ptr, ptr }, ptr %50, align 8
+  %52 = insertvalue { { ptr, ptr }, i1 } undef, { ptr, ptr } %51, 0
+  %53 = insertvalue { { ptr, ptr }, i1 } %52, i1 true, 1
   br label %_llgo_5
 
 _llgo_4:                                          ; preds = %_llgo_0
-  %77 = alloca { { ptr, ptr }, i1 }, align 8
-  %78 = getelementptr inbounds { { ptr, ptr }, i1 }, ptr %77, i32 0, i32 0
-  store { ptr, ptr } zeroinitializer, ptr %78, align 8
-  %79 = getelementptr inbounds { { ptr, ptr }, i1 }, ptr %77, i32 0, i32 1
-  store i1 false, ptr %79, align 1
-  %80 = load { { ptr, ptr }, i1 }, ptr %77, align 8
   br label %_llgo_5
 
 _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
-  %81 = phi { { ptr, ptr }, i1 } [ %76, %_llgo_3 ], [ %80, %_llgo_4 ]
-  %82 = extractvalue { { ptr, ptr }, i1 } %81, 0
-  %83 = extractvalue { { ptr, ptr }, i1 } %81, 1
-  br i1 %83, label %_llgo_2, label %_llgo_1
+  %54 = phi { { ptr, ptr }, i1 } [ %53, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
+  %55 = extractvalue { { ptr, ptr }, i1 } %54, 0
+  %56 = extractvalue { { ptr, ptr }, i1 } %54, 1
+  br i1 %56, label %_llgo_2, label %_llgo_1
 }
 
 define i64 @"main.callClosure$1"(ptr %0, i64 %1) {
 _llgo_0:
-  %2 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 0
-  store ptr @6, ptr %3, align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 1
-  store i64 12, ptr %4, align 4
-  %5 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %5)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 12 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %6 = load { ptr }, ptr %0, align 8
-  %7 = extractvalue { ptr } %6, 0
-  %8 = load i64, ptr %7, align 4
-  %9 = add i64 %8, %1
-  %10 = add i64 %9, 1
-  ret i64 %10
+  %2 = load { ptr }, ptr %0, align 8
+  %3 = extractvalue { ptr } %2, 0
+  %4 = load i64, ptr %3, align 4
+  %5 = add i64 %4, %1
+  %6 = add i64 %5, 1
+  ret i64 %6
 }
 
 define void @main.callFunc() {
 _llgo_0:
-  %0 = alloca { ptr, ptr }, align 8
-  %1 = getelementptr inbounds { ptr, ptr }, ptr %0, i32 0, i32 0
-  store ptr @"__llgo_stub.main.callFunc$1", ptr %1, align 8
-  %2 = getelementptr inbounds { ptr, ptr }, ptr %0, i32 0, i32 1
-  store ptr null, ptr %2, align 8
-  %3 = load { ptr, ptr }, ptr %0, align 8
-  %4 = load ptr, ptr @"main.struct$J4GOle3xvLePlAXZSFNKiHRJ-WQyyOMhvl8OQfxW2Q8", align 8
-  call void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr %4)
-  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store { ptr, ptr } %3, ptr %5, align 8
-  %6 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %6, i32 0, i32 0
-  store ptr %4, ptr %7, align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %6, i32 0, i32 1
-  store ptr %5, ptr %8, align 8
-  %9 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %6, align 8
-  %10 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %9)
-  %11 = call i64 @reflect.Value.Kind(%reflect.Value %10)
-  %12 = call %"github.com/goplus/llgo/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %10)
-  %13 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %12)
-  %14 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %12, 0
-  %15 = getelementptr ptr, ptr %14, i64 31
-  %16 = load ptr, ptr %15, align 8
-  %17 = alloca { ptr, ptr }, align 8
-  %18 = getelementptr inbounds { ptr, ptr }, ptr %17, i32 0, i32 0
-  store ptr %16, ptr %18, align 8
-  %19 = getelementptr inbounds { ptr, ptr }, ptr %17, i32 0, i32 1
-  store ptr %13, ptr %19, align 8
-  %20 = load { ptr, ptr }, ptr %17, align 8
-  %21 = extractvalue { ptr, ptr } %20, 1
-  %22 = extractvalue { ptr, ptr } %20, 0
-  %23 = call %"github.com/goplus/llgo/internal/runtime.String" %22(ptr %21)
-  %24 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %24, i32 0, i32 0
-  store ptr @7, ptr %25, align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %24, i32 0, i32 1
-  store i64 4, ptr %26, align 4
-  %27 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %24, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %27)
+  %0 = load ptr, ptr @"main.struct$J4GOle3xvLePlAXZSFNKiHRJ-WQyyOMhvl8OQfxW2Q8", align 8
+  call void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr %0)
+  %1 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store { ptr, ptr } { ptr @"__llgo_stub.main.callFunc$1", ptr null }, ptr %1, align 8
+  %2 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %0, 0
+  %3 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %2, ptr %1, 1
+  %4 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %3)
+  %5 = call i64 @reflect.Value.Kind(%reflect.Value %4)
+  %6 = call %"github.com/goplus/llgo/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %4)
+  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %6)
+  %8 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %6, 0
+  %9 = getelementptr ptr, ptr %8, i64 31
+  %10 = load ptr, ptr %9, align 8
+  %11 = insertvalue { ptr, ptr } undef, ptr %10, 0
+  %12 = insertvalue { ptr, ptr } %11, ptr %7, 1
+  %13 = extractvalue { ptr, ptr } %12, 1
+  %14 = extractvalue { ptr, ptr } %12, 0
+  %15 = call %"github.com/goplus/llgo/internal/runtime.String" %14(ptr %13)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 %11)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 %5)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %23)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %15)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %28 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
-  %29 = getelementptr inbounds %reflect.Value, ptr %28, i64 0
-  %30 = load ptr, ptr @_llgo_int, align 8
-  %31 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %31, i32 0, i32 0
-  store ptr %30, ptr %32, align 8
-  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %31, i32 0, i32 1
-  store ptr inttoptr (i64 100 to ptr), ptr %33, align 8
-  %34 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %31, align 8
-  %35 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %34)
-  store %reflect.Value %35, ptr %29, align 8
-  %36 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %36, i32 0, i32 0
-  store ptr %28, ptr %37, align 8
-  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %36, i32 0, i32 1
-  store i64 1, ptr %38, align 4
-  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %36, i32 0, i32 2
-  store i64 1, ptr %39, align 4
-  %40 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %36, align 8
-  %41 = call %"github.com/goplus/llgo/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %10, %"github.com/goplus/llgo/internal/runtime.Slice" %40)
-  %42 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %41, 0
-  %43 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %41, 1
-  %44 = icmp sge i64 0, %43
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %44)
-  %45 = getelementptr inbounds %reflect.Value, ptr %42, i64 0
-  %46 = load %reflect.Value, ptr %45, align 8
-  %47 = call i64 @reflect.Value.Int(%reflect.Value %46)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %47)
+  %16 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
+  %17 = getelementptr inbounds %reflect.Value, ptr %16, i64 0
+  %18 = load ptr, ptr @_llgo_int, align 8
+  %19 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %18, 0
+  %20 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %19, ptr inttoptr (i64 100 to ptr), 1
+  %21 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %20)
+  store %reflect.Value %21, ptr %17, align 8
+  %22 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %16, 0
+  %23 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %22, i64 1, 1
+  %24 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %23, i64 1, 2
+  %25 = call %"github.com/goplus/llgo/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %4, %"github.com/goplus/llgo/internal/runtime.Slice" %24)
+  %26 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %25, 0
+  %27 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %25, 1
+  %28 = icmp sge i64 0, %27
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %28)
+  %29 = getelementptr inbounds %reflect.Value, ptr %26, i64 0
+  %30 = load %reflect.Value, ptr %29, align 8
+  %31 = call i64 @reflect.Value.Int(%reflect.Value %30)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %31)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %48 = call %"github.com/goplus/llgo/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %10)
-  %49 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %48, 0
-  %50 = load ptr, ptr @"main.struct$J4GOle3xvLePlAXZSFNKiHRJ-WQyyOMhvl8OQfxW2Q8", align 8
-  %51 = icmp eq ptr %49, %50
-  br i1 %51, label %_llgo_3, label %_llgo_4
+  %32 = call %"github.com/goplus/llgo/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %4)
+  %33 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %32, 0
+  %34 = load ptr, ptr @"main.struct$J4GOle3xvLePlAXZSFNKiHRJ-WQyyOMhvl8OQfxW2Q8", align 8
+  %35 = icmp eq ptr %33, %34
+  br i1 %35, label %_llgo_3, label %_llgo_4
 
 _llgo_1:                                          ; preds = %_llgo_5
-  %52 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %53 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %52, i32 0, i32 0
-  store ptr @5, ptr %53, align 8
-  %54 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %52, i32 0, i32 1
-  store i64 5, ptr %54, align 4
-  %55 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %52, align 8
-  %56 = load ptr, ptr @_llgo_string, align 8
-  %57 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %55, ptr %57, align 8
-  %58 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %59 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %58, i32 0, i32 0
-  store ptr %56, ptr %59, align 8
-  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %58, i32 0, i32 1
-  store ptr %57, ptr %60, align 8
-  %61 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %58, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %61)
+  %36 = load ptr, ptr @_llgo_string, align 8
+  %37 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 5 }, ptr %37, align 8
+  %38 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %36, 0
+  %39 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %38, ptr %37, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %39)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_5
-  %62 = extractvalue { ptr, ptr } %76, 1
-  %63 = extractvalue { ptr, ptr } %76, 0
-  %64 = call i64 %63(ptr %62, i64 100)
+  %40 = extractvalue { ptr, ptr } %48, 1
+  %41 = extractvalue { ptr, ptr } %48, 0
+  %42 = call i64 %41(ptr %40, i64 100)
   ret void
 
 _llgo_3:                                          ; preds = %_llgo_0
-  %65 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %48, 1
-  %66 = load { ptr, ptr }, ptr %65, align 8
-  %67 = alloca { { ptr, ptr }, i1 }, align 8
-  %68 = getelementptr inbounds { { ptr, ptr }, i1 }, ptr %67, i32 0, i32 0
-  store { ptr, ptr } %66, ptr %68, align 8
-  %69 = getelementptr inbounds { { ptr, ptr }, i1 }, ptr %67, i32 0, i32 1
-  store i1 true, ptr %69, align 1
-  %70 = load { { ptr, ptr }, i1 }, ptr %67, align 8
+  %43 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %32, 1
+  %44 = load { ptr, ptr }, ptr %43, align 8
+  %45 = insertvalue { { ptr, ptr }, i1 } undef, { ptr, ptr } %44, 0
+  %46 = insertvalue { { ptr, ptr }, i1 } %45, i1 true, 1
   br label %_llgo_5
 
 _llgo_4:                                          ; preds = %_llgo_0
-  %71 = alloca { { ptr, ptr }, i1 }, align 8
-  %72 = getelementptr inbounds { { ptr, ptr }, i1 }, ptr %71, i32 0, i32 0
-  store { ptr, ptr } zeroinitializer, ptr %72, align 8
-  %73 = getelementptr inbounds { { ptr, ptr }, i1 }, ptr %71, i32 0, i32 1
-  store i1 false, ptr %73, align 1
-  %74 = load { { ptr, ptr }, i1 }, ptr %71, align 8
   br label %_llgo_5
 
 _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
-  %75 = phi { { ptr, ptr }, i1 } [ %70, %_llgo_3 ], [ %74, %_llgo_4 ]
-  %76 = extractvalue { { ptr, ptr }, i1 } %75, 0
-  %77 = extractvalue { { ptr, ptr }, i1 } %75, 1
-  br i1 %77, label %_llgo_2, label %_llgo_1
+  %47 = phi { { ptr, ptr }, i1 } [ %46, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
+  %48 = extractvalue { { ptr, ptr }, i1 } %47, 0
+  %49 = extractvalue { { ptr, ptr }, i1 } %47, 1
+  br i1 %49, label %_llgo_2, label %_llgo_1
 }
 
 define i64 @"main.callFunc$1"(i64 %0) {
 _llgo_0:
-  %1 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1, i32 0, i32 0
-  store ptr @8, ptr %2, align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1, i32 0, i32 1
-  store i64 9, ptr %3, align 4
-  %4 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %4)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 9 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %5 = add i64 %0, 1
-  ret i64 %5
+  %1 = add i64 %0, 1
+  ret i64 %1
 }
 
 define void @main.callIMethod() {
@@ -376,108 +261,72 @@ _llgo_0:
   %4 = load ptr, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU", align 8
   %5 = load ptr, ptr @"_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A", align 8
   %6 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %5, ptr %3)
-  %7 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %7, i32 0, i32 0
-  store ptr %6, ptr %8, align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %7, i32 0, i32 1
-  store ptr %0, ptr %9, align 8
-  %10 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %7, align 8
-  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %10)
-  %12 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %10, 1
-  %13 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %13, i32 0, i32 0
-  store ptr %11, ptr %14, align 8
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %13, i32 0, i32 1
-  store ptr %12, ptr %15, align 8
-  %16 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %13, align 8
-  %17 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %16)
-  %18 = call %reflect.Value @reflect.Value.Method(%reflect.Value %17, i64 0)
-  %19 = call i64 @reflect.Value.Kind(%reflect.Value %18)
-  %20 = call %"github.com/goplus/llgo/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %18)
-  %21 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %20)
-  %22 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %20, 0
-  %23 = getelementptr ptr, ptr %22, i64 31
-  %24 = load ptr, ptr %23, align 8
-  %25 = alloca { ptr, ptr }, align 8
-  %26 = getelementptr inbounds { ptr, ptr }, ptr %25, i32 0, i32 0
-  store ptr %24, ptr %26, align 8
-  %27 = getelementptr inbounds { ptr, ptr }, ptr %25, i32 0, i32 1
-  store ptr %21, ptr %27, align 8
-  %28 = load { ptr, ptr }, ptr %25, align 8
-  %29 = extractvalue { ptr, ptr } %28, 1
-  %30 = extractvalue { ptr, ptr } %28, 0
-  %31 = call %"github.com/goplus/llgo/internal/runtime.String" %30(ptr %29)
-  %32 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %32, i32 0, i32 0
-  store ptr @13, ptr %33, align 8
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %32, i32 0, i32 1
-  store i64 7, ptr %34, align 4
-  %35 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %32, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %35)
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %6, 0
+  %8 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %7, ptr %0, 1
+  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %8)
+  %10 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %8, 1
+  %11 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %9, 0
+  %12 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %11, ptr %10, 1
+  %13 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %12)
+  %14 = call %reflect.Value @reflect.Value.Method(%reflect.Value %13, i64 0)
+  %15 = call i64 @reflect.Value.Kind(%reflect.Value %14)
+  %16 = call %"github.com/goplus/llgo/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %14)
+  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %16)
+  %18 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %16, 0
+  %19 = getelementptr ptr, ptr %18, i64 31
+  %20 = load ptr, ptr %19, align 8
+  %21 = insertvalue { ptr, ptr } undef, ptr %20, 0
+  %22 = insertvalue { ptr, ptr } %21, ptr %17, 1
+  %23 = extractvalue { ptr, ptr } %22, 1
+  %24 = extractvalue { ptr, ptr } %22, 0
+  %25 = call %"github.com/goplus/llgo/internal/runtime.String" %24(ptr %23)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @13, i64 7 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 %19)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 %15)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %31)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %25)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %36 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
-  %37 = getelementptr inbounds %reflect.Value, ptr %36, i64 0
-  %38 = load ptr, ptr @_llgo_int, align 8
-  %39 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %40 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %39, i32 0, i32 0
-  store ptr %38, ptr %40, align 8
-  %41 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %39, i32 0, i32 1
-  store ptr inttoptr (i64 100 to ptr), ptr %41, align 8
-  %42 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %39, align 8
+  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
+  %27 = getelementptr inbounds %reflect.Value, ptr %26, i64 0
+  %28 = load ptr, ptr @_llgo_int, align 8
+  %29 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %28, 0
+  %30 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %29, ptr inttoptr (i64 100 to ptr), 1
+  %31 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %30)
+  store %reflect.Value %31, ptr %27, align 8
+  %32 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %26, 0
+  %33 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %32, i64 1, 1
+  %34 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %33, i64 1, 2
+  %35 = call %"github.com/goplus/llgo/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %14, %"github.com/goplus/llgo/internal/runtime.Slice" %34)
+  %36 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %35, 0
+  %37 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %35, 1
+  %38 = icmp sge i64 0, %37
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %38)
+  %39 = getelementptr inbounds %reflect.Value, ptr %36, i64 0
+  %40 = load %reflect.Value, ptr %39, align 8
+  %41 = call i64 @reflect.Value.Int(%reflect.Value %40)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %41)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
+  %42 = call %"github.com/goplus/llgo/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %14)
   %43 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %42)
-  store %reflect.Value %43, ptr %37, align 8
-  %44 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %44, i32 0, i32 0
-  store ptr %36, ptr %45, align 8
-  %46 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %44, i32 0, i32 1
-  store i64 1, ptr %46, align 4
-  %47 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %44, i32 0, i32 2
-  store i64 1, ptr %47, align 4
-  %48 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %44, align 8
-  %49 = call %"github.com/goplus/llgo/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %18, %"github.com/goplus/llgo/internal/runtime.Slice" %48)
-  %50 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %49, 0
-  %51 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %49, 1
-  %52 = icmp sge i64 0, %51
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %52)
-  %53 = getelementptr inbounds %reflect.Value, ptr %50, i64 0
-  %54 = load %reflect.Value, ptr %53, align 8
-  %55 = call i64 @reflect.Value.Int(%reflect.Value %54)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %55)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %56 = call %"github.com/goplus/llgo/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %18)
-  %57 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %56)
-  %58 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
-  %59 = getelementptr inbounds %reflect.Value, ptr %58, i64 0
-  %60 = load ptr, ptr @_llgo_int, align 8
-  %61 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %62 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %61, i32 0, i32 0
-  store ptr %60, ptr %62, align 8
-  %63 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %61, i32 0, i32 1
-  store ptr inttoptr (i64 100 to ptr), ptr %63, align 8
-  %64 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %61, align 8
-  %65 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %64)
-  store %reflect.Value %65, ptr %59, align 8
-  %66 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %67 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %66, i32 0, i32 0
-  store ptr %58, ptr %67, align 8
-  %68 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %66, i32 0, i32 1
-  store i64 1, ptr %68, align 4
-  %69 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %66, i32 0, i32 2
-  store i64 1, ptr %69, align 4
-  %70 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %66, align 8
-  %71 = call %"github.com/goplus/llgo/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %57, %"github.com/goplus/llgo/internal/runtime.Slice" %70)
-  %72 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %71, 0
-  %73 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %71, 1
-  %74 = icmp sge i64 0, %73
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %74)
-  %75 = getelementptr inbounds %reflect.Value, ptr %72, i64 0
-  %76 = load %reflect.Value, ptr %75, align 8
-  %77 = call i64 @reflect.Value.Int(%reflect.Value %76)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %77)
+  %44 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
+  %45 = getelementptr inbounds %reflect.Value, ptr %44, i64 0
+  %46 = load ptr, ptr @_llgo_int, align 8
+  %47 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %46, 0
+  %48 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %47, ptr inttoptr (i64 100 to ptr), 1
+  %49 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %48)
+  store %reflect.Value %49, ptr %45, align 8
+  %50 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %44, 0
+  %51 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %50, i64 1, 1
+  %52 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %51, i64 1, 2
+  %53 = call %"github.com/goplus/llgo/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %43, %"github.com/goplus/llgo/internal/runtime.Slice" %52)
+  %54 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %53, 0
+  %55 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %53, 1
+  %56 = icmp sge i64 0, %55
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %56)
+  %57 = getelementptr inbounds %reflect.Value, ptr %54, i64 0
+  %58 = load %reflect.Value, ptr %57, align 8
+  %59 = call i64 @reflect.Value.Int(%reflect.Value %58)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %59)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret void
 }
@@ -488,100 +337,68 @@ _llgo_0:
   %1 = getelementptr inbounds %main.T, ptr %0, i32 0, i32 0
   store i64 1, ptr %1, align 4
   %2 = load ptr, ptr @"*_llgo_main.T", align 8
-  %3 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %3, i32 0, i32 0
-  store ptr %2, ptr %4, align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %3, i32 0, i32 1
-  store ptr %0, ptr %5, align 8
-  %6 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %3, align 8
-  %7 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %6)
-  %8 = call %reflect.Value @reflect.Value.Method(%reflect.Value %7, i64 0)
-  %9 = call i64 @reflect.Value.Kind(%reflect.Value %8)
-  %10 = call %"github.com/goplus/llgo/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %8)
-  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %10)
-  %12 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %10, 0
-  %13 = getelementptr ptr, ptr %12, i64 31
-  %14 = load ptr, ptr %13, align 8
-  %15 = alloca { ptr, ptr }, align 8
-  %16 = getelementptr inbounds { ptr, ptr }, ptr %15, i32 0, i32 0
-  store ptr %14, ptr %16, align 8
-  %17 = getelementptr inbounds { ptr, ptr }, ptr %15, i32 0, i32 1
-  store ptr %11, ptr %17, align 8
-  %18 = load { ptr, ptr }, ptr %15, align 8
-  %19 = extractvalue { ptr, ptr } %18, 1
-  %20 = extractvalue { ptr, ptr } %18, 0
-  %21 = call %"github.com/goplus/llgo/internal/runtime.String" %20(ptr %19)
-  %22 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %22, i32 0, i32 0
-  store ptr @14, ptr %23, align 8
-  %24 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %22, i32 0, i32 1
-  store i64 6, ptr %24, align 4
-  %25 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %22, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %25)
+  %3 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %2, 0
+  %4 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %3, ptr %0, 1
+  %5 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %4)
+  %6 = call %reflect.Value @reflect.Value.Method(%reflect.Value %5, i64 0)
+  %7 = call i64 @reflect.Value.Kind(%reflect.Value %6)
+  %8 = call %"github.com/goplus/llgo/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %6)
+  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %8)
+  %10 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %8, 0
+  %11 = getelementptr ptr, ptr %10, i64 31
+  %12 = load ptr, ptr %11, align 8
+  %13 = insertvalue { ptr, ptr } undef, ptr %12, 0
+  %14 = insertvalue { ptr, ptr } %13, ptr %9, 1
+  %15 = extractvalue { ptr, ptr } %14, 1
+  %16 = extractvalue { ptr, ptr } %14, 0
+  %17 = call %"github.com/goplus/llgo/internal/runtime.String" %16(ptr %15)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @14, i64 6 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 %9)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 %7)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %21)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %17)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
-  %27 = getelementptr inbounds %reflect.Value, ptr %26, i64 0
-  %28 = load ptr, ptr @_llgo_int, align 8
-  %29 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %29, i32 0, i32 0
-  store ptr %28, ptr %30, align 8
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %29, i32 0, i32 1
-  store ptr inttoptr (i64 100 to ptr), ptr %31, align 8
-  %32 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %29, align 8
-  %33 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %32)
-  store %reflect.Value %33, ptr %27, align 8
-  %34 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %34, i32 0, i32 0
-  store ptr %26, ptr %35, align 8
-  %36 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %34, i32 0, i32 1
-  store i64 1, ptr %36, align 4
-  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %34, i32 0, i32 2
-  store i64 1, ptr %37, align 4
-  %38 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %34, align 8
-  %39 = call %"github.com/goplus/llgo/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %8, %"github.com/goplus/llgo/internal/runtime.Slice" %38)
-  %40 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %39, 0
-  %41 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %39, 1
-  %42 = icmp sge i64 0, %41
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %42)
-  %43 = getelementptr inbounds %reflect.Value, ptr %40, i64 0
-  %44 = load %reflect.Value, ptr %43, align 8
-  %45 = call i64 @reflect.Value.Int(%reflect.Value %44)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %45)
+  %18 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
+  %19 = getelementptr inbounds %reflect.Value, ptr %18, i64 0
+  %20 = load ptr, ptr @_llgo_int, align 8
+  %21 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %20, 0
+  %22 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %21, ptr inttoptr (i64 100 to ptr), 1
+  %23 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %22)
+  store %reflect.Value %23, ptr %19, align 8
+  %24 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %18, 0
+  %25 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %24, i64 1, 1
+  %26 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %25, i64 1, 2
+  %27 = call %"github.com/goplus/llgo/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %6, %"github.com/goplus/llgo/internal/runtime.Slice" %26)
+  %28 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %27, 0
+  %29 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %27, 1
+  %30 = icmp sge i64 0, %29
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %30)
+  %31 = getelementptr inbounds %reflect.Value, ptr %28, i64 0
+  %32 = load %reflect.Value, ptr %31, align 8
+  %33 = call i64 @reflect.Value.Int(%reflect.Value %32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %33)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %46 = call %"github.com/goplus/llgo/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %8)
-  %47 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %46)
-  %48 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
-  %49 = getelementptr inbounds %reflect.Value, ptr %48, i64 0
-  %50 = load ptr, ptr @_llgo_int, align 8
-  %51 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %52 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %51, i32 0, i32 0
-  store ptr %50, ptr %52, align 8
-  %53 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %51, i32 0, i32 1
-  store ptr inttoptr (i64 100 to ptr), ptr %53, align 8
-  %54 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %51, align 8
-  %55 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %54)
-  store %reflect.Value %55, ptr %49, align 8
-  %56 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %56, i32 0, i32 0
-  store ptr %48, ptr %57, align 8
-  %58 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %56, i32 0, i32 1
-  store i64 1, ptr %58, align 4
-  %59 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %56, i32 0, i32 2
-  store i64 1, ptr %59, align 4
-  %60 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %56, align 8
-  %61 = call %"github.com/goplus/llgo/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %47, %"github.com/goplus/llgo/internal/runtime.Slice" %60)
-  %62 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %61, 0
-  %63 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %61, 1
-  %64 = icmp sge i64 0, %63
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %64)
-  %65 = getelementptr inbounds %reflect.Value, ptr %62, i64 0
-  %66 = load %reflect.Value, ptr %65, align 8
-  %67 = call i64 @reflect.Value.Int(%reflect.Value %66)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %67)
+  %34 = call %"github.com/goplus/llgo/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %6)
+  %35 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %34)
+  %36 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
+  %37 = getelementptr inbounds %reflect.Value, ptr %36, i64 0
+  %38 = load ptr, ptr @_llgo_int, align 8
+  %39 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %38, 0
+  %40 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %39, ptr inttoptr (i64 100 to ptr), 1
+  %41 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %40)
+  store %reflect.Value %41, ptr %37, align 8
+  %42 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %36, 0
+  %43 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %42, i64 1, 1
+  %44 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %43, i64 1, 2
+  %45 = call %"github.com/goplus/llgo/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %35, %"github.com/goplus/llgo/internal/runtime.Slice" %44)
+  %46 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %45, 0
+  %47 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %45, 1
+  %48 = icmp sge i64 0, %47
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %48)
+  %49 = getelementptr inbounds %reflect.Value, ptr %46, i64 0
+  %50 = load %reflect.Value, ptr %49, align 8
+  %51 = call i64 @reflect.Value.Int(%reflect.Value %50)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %51)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret void
 }
@@ -660,310 +477,152 @@ _llgo_5:                                          ; preds = %_llgo_4
   store ptr %6, ptr %12, align 8
   %13 = getelementptr ptr, ptr %11, i64 1
   store ptr %7, ptr %13, align 8
-  %14 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %14, i32 0, i32 0
-  store ptr %11, ptr %15, align 8
-  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %14, i32 0, i32 1
-  store i64 2, ptr %16, align 4
-  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %14, i32 0, i32 2
-  store i64 2, ptr %17, align 4
-  %18 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %14, align 8
-  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %20 = getelementptr ptr, ptr %19, i64 0
-  store ptr %8, ptr %20, align 8
-  %21 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, i32 0, i32 0
-  store ptr %19, ptr %22, align 8
-  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, i32 0, i32 1
-  store i64 1, ptr %23, align 4
-  %24 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, i32 0, i32 2
-  store i64 1, ptr %24, align 4
-  %25 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, align 8
-  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %18, %"github.com/goplus/llgo/internal/runtime.Slice" %25, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %26)
-  store ptr %26, ptr @"_llgo_func$LW7NaHY4krmx4VSCwrrjp23xg526aJ8NlR7kN98tIyE", align 8
+  %14 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %11, 0
+  %15 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %14, i64 2, 1
+  %16 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %15, i64 2, 2
+  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %18 = getelementptr ptr, ptr %17, i64 0
+  store ptr %8, ptr %18, align 8
+  %19 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %17, 0
+  %20 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %19, i64 1, 1
+  %21 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %20, i64 1, 2
+  %22 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %16, %"github.com/goplus/llgo/internal/runtime.Slice" %21, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %22)
+  store ptr %22, ptr @"_llgo_func$LW7NaHY4krmx4VSCwrrjp23xg526aJ8NlR7kN98tIyE", align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %27 = load ptr, ptr @_llgo_Pointer, align 8
-  %28 = load ptr, ptr @_llgo_int, align 8
-  %29 = load ptr, ptr @_llgo_int, align 8
-  %30 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %30, i32 0, i32 0
-  store ptr @1, ptr %31, align 8
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %30, i32 0, i32 1
-  store i64 1, ptr %32, align 4
-  %33 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %30, align 8
-  %34 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %34, i32 0, i32 0
-  store ptr null, ptr %35, align 8
-  %36 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %34, i32 0, i32 1
-  store i64 0, ptr %36, align 4
-  %37 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %34, align 8
-  %38 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %39 = getelementptr ptr, ptr %38, i64 0
-  store ptr %27, ptr %39, align 8
-  %40 = getelementptr ptr, ptr %38, i64 1
-  store ptr %28, ptr %40, align 8
-  %41 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %42 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %41, i32 0, i32 0
-  store ptr %38, ptr %42, align 8
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %41, i32 0, i32 1
-  store i64 2, ptr %43, align 4
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %41, i32 0, i32 2
-  store i64 2, ptr %44, align 4
-  %45 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %41, align 8
-  %46 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %47 = getelementptr ptr, ptr %46, i64 0
-  store ptr %29, ptr %47, align 8
-  %48 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %49 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, i32 0, i32 0
-  store ptr %46, ptr %49, align 8
-  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, i32 0, i32 1
-  store i64 1, ptr %50, align 4
-  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, i32 0, i32 2
-  store i64 1, ptr %51, align 4
-  %52 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, align 8
-  %53 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %45, %"github.com/goplus/llgo/internal/runtime.Slice" %52, i1 false)
-  %54 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %33, ptr %53, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %37, i1 false)
-  %55 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 0
-  store ptr @2, ptr %56, align 8
-  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 1
-  store i64 4, ptr %57, align 4
-  %58 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %55, align 8
-  %59 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %59, i32 0, i32 0
-  store ptr null, ptr %60, align 8
-  %61 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %59, i32 0, i32 1
-  store i64 0, ptr %61, align 4
-  %62 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %59, align 8
-  %63 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %64 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %58, ptr %63, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %62, i1 false)
-  %65 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %66 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %65, i32 0, i32 0
-  store ptr @3, ptr %66, align 8
-  %67 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %65, i32 0, i32 1
-  store i64 4, ptr %67, align 4
-  %68 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %65, align 8
-  %69 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %70 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %69, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %54, ptr %70, align 8
-  %71 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %69, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %64, ptr %71, align 8
-  %72 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %73 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %72, i32 0, i32 0
-  store ptr %69, ptr %73, align 8
-  %74 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %72, i32 0, i32 1
-  store i64 2, ptr %74, align 4
-  %75 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %72, i32 0, i32 2
-  store i64 2, ptr %75, align 4
-  %76 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %72, align 8
-  %77 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %68, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %76)
-  store ptr %77, ptr @"main.struct$J4GOle3xvLePlAXZSFNKiHRJ-WQyyOMhvl8OQfxW2Q8", align 8
-  %78 = load ptr, ptr @_llgo_string, align 8
-  %79 = icmp eq ptr %78, null
-  br i1 %79, label %_llgo_7, label %_llgo_8
+  %23 = load ptr, ptr @_llgo_Pointer, align 8
+  %24 = load ptr, ptr @_llgo_int, align 8
+  %25 = load ptr, ptr @_llgo_int, align 8
+  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %27 = getelementptr ptr, ptr %26, i64 0
+  store ptr %23, ptr %27, align 8
+  %28 = getelementptr ptr, ptr %26, i64 1
+  store ptr %24, ptr %28, align 8
+  %29 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %26, 0
+  %30 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %29, i64 2, 1
+  %31 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %30, i64 2, 2
+  %32 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %33 = getelementptr ptr, ptr %32, i64 0
+  store ptr %25, ptr %33, align 8
+  %34 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %32, 0
+  %35 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %34, i64 1, 1
+  %36 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %35, i64 1, 2
+  %37 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %31, %"github.com/goplus/llgo/internal/runtime.Slice" %36, i1 false)
+  %38 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 1 }, ptr %37, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %40 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, ptr %39, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %41 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %42 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %41, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %38, ptr %42, align 8
+  %43 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %41, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %40, ptr %43, align 8
+  %44 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %41, 0
+  %45 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %44, i64 2, 1
+  %46 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %45, i64 2, 2
+  %47 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %46)
+  store ptr %47, ptr @"main.struct$J4GOle3xvLePlAXZSFNKiHRJ-WQyyOMhvl8OQfxW2Q8", align 8
+  %48 = load ptr, ptr @_llgo_string, align 8
+  %49 = icmp eq ptr %48, null
+  br i1 %49, label %_llgo_7, label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_6
-  %80 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  store ptr %80, ptr @_llgo_string, align 8
+  %50 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  store ptr %50, ptr @_llgo_string, align 8
   br label %_llgo_8
 
 _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
-  %81 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %82 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %81, i32 0, i32 0
-  store ptr @9, ptr %82, align 8
-  %83 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %81, i32 0, i32 1
-  store i64 6, ptr %83, align 4
-  %84 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %81, align 8
-  %85 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %84, i64 25, i64 8, i64 0, i64 1)
-  %86 = load ptr, ptr @_llgo_main.T, align 8
-  %87 = icmp eq ptr %86, null
-  br i1 %87, label %_llgo_9, label %_llgo_10
+  %51 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 6 }, i64 25, i64 8, i64 0, i64 1)
+  %52 = load ptr, ptr @_llgo_main.T, align 8
+  %53 = icmp eq ptr %52, null
+  br i1 %53, label %_llgo_9, label %_llgo_10
 
 _llgo_9:                                          ; preds = %_llgo_8
-  store ptr %85, ptr @_llgo_main.T, align 8
+  store ptr %51, ptr @_llgo_main.T, align 8
   br label %_llgo_10
 
 _llgo_10:                                         ; preds = %_llgo_9, %_llgo_8
-  %88 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %89 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %88, i32 0, i32 0
-  store ptr @10, ptr %89, align 8
-  %90 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %88, i32 0, i32 1
-  store i64 1, ptr %90, align 4
-  %91 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %88, align 8
-  %92 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %93 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %92, i32 0, i32 0
-  store ptr null, ptr %93, align 8
-  %94 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %92, i32 0, i32 1
-  store i64 0, ptr %94, align 4
-  %95 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %92, align 8
-  %96 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %97 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %91, ptr %96, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %95, i1 false)
-  %98 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %99 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %98, i32 0, i32 0
-  store ptr @3, ptr %99, align 8
-  %100 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %98, i32 0, i32 1
-  store i64 4, ptr %100, align 4
-  %101 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %98, align 8
-  %102 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
-  %103 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %102, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %97, ptr %103, align 8
-  %104 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %105 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %104, i32 0, i32 0
-  store ptr %102, ptr %105, align 8
-  %106 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %104, i32 0, i32 1
-  store i64 1, ptr %106, align 4
-  %107 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %104, i32 0, i32 2
-  store i64 1, ptr %107, align 4
-  %108 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %104, align 8
-  %109 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %101, i64 8, %"github.com/goplus/llgo/internal/runtime.Slice" %108)
-  store ptr %109, ptr @"main.struct$eovYmOhZg4X0zMSsuscSshndnbbAGvB2E3cyG8E7Y4U", align 8
-  %110 = load ptr, ptr @"main.struct$eovYmOhZg4X0zMSsuscSshndnbbAGvB2E3cyG8E7Y4U", align 8
-  br i1 %87, label %_llgo_11, label %_llgo_12
+  %54 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %55 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 1 }, ptr %54, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %56 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
+  %57 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %56, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %55, ptr %57, align 8
+  %58 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %56, 0
+  %59 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %58, i64 1, 1
+  %60 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %59, i64 1, 2
+  %61 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, i64 8, %"github.com/goplus/llgo/internal/runtime.Slice" %60)
+  store ptr %61, ptr @"main.struct$eovYmOhZg4X0zMSsuscSshndnbbAGvB2E3cyG8E7Y4U", align 8
+  %62 = load ptr, ptr @"main.struct$eovYmOhZg4X0zMSsuscSshndnbbAGvB2E3cyG8E7Y4U", align 8
+  br i1 %53, label %_llgo_11, label %_llgo_12
 
 _llgo_11:                                         ; preds = %_llgo_10
-  %111 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %112 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %111, i32 0, i32 0
-  store ptr @11, ptr %112, align 8
-  %113 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %111, i32 0, i32 1
-  store i64 3, ptr %113, align 4
-  %114 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %111, align 8
-  %115 = load ptr, ptr @_llgo_int, align 8
-  %116 = load ptr, ptr @_llgo_int, align 8
-  %117 = load ptr, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU", align 8
-  %118 = icmp eq ptr %117, null
-  br i1 %118, label %_llgo_13, label %_llgo_14
+  %63 = load ptr, ptr @_llgo_int, align 8
+  %64 = load ptr, ptr @_llgo_int, align 8
+  %65 = load ptr, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU", align 8
+  %66 = icmp eq ptr %65, null
+  br i1 %66, label %_llgo_13, label %_llgo_14
 
 _llgo_12:                                         ; preds = %_llgo_14, %_llgo_10
-  %119 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %120 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %119, i32 0, i32 0
-  store ptr @9, ptr %120, align 8
-  %121 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %119, i32 0, i32 1
-  store i64 6, ptr %121, align 4
-  %122 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %119, align 8
-  %123 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %122, i64 25, i64 8, i64 0, i64 1)
-  %124 = load ptr, ptr @"*_llgo_main.T", align 8
-  %125 = icmp eq ptr %124, null
-  br i1 %125, label %_llgo_15, label %_llgo_16
+  %67 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 6 }, i64 25, i64 8, i64 0, i64 1)
+  %68 = load ptr, ptr @"*_llgo_main.T", align 8
+  %69 = icmp eq ptr %68, null
+  br i1 %69, label %_llgo_15, label %_llgo_16
 
 _llgo_13:                                         ; preds = %_llgo_11
-  %126 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %127 = getelementptr ptr, ptr %126, i64 0
-  store ptr %115, ptr %127, align 8
-  %128 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %129 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %128, i32 0, i32 0
-  store ptr %126, ptr %129, align 8
-  %130 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %128, i32 0, i32 1
-  store i64 1, ptr %130, align 4
-  %131 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %128, i32 0, i32 2
-  store i64 1, ptr %131, align 4
-  %132 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %128, align 8
-  %133 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %134 = getelementptr ptr, ptr %133, i64 0
-  store ptr %116, ptr %134, align 8
-  %135 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %136 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %135, i32 0, i32 0
-  store ptr %133, ptr %136, align 8
-  %137 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %135, i32 0, i32 1
-  store i64 1, ptr %137, align 4
-  %138 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %135, i32 0, i32 2
-  store i64 1, ptr %138, align 4
-  %139 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %135, align 8
-  %140 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %132, %"github.com/goplus/llgo/internal/runtime.Slice" %139, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %140)
-  store ptr %140, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU", align 8
+  %70 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %71 = getelementptr ptr, ptr %70, i64 0
+  store ptr %63, ptr %71, align 8
+  %72 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %70, 0
+  %73 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %72, i64 1, 1
+  %74 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %73, i64 1, 2
+  %75 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %76 = getelementptr ptr, ptr %75, i64 0
+  store ptr %64, ptr %76, align 8
+  %77 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %75, 0
+  %78 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %77, i64 1, 1
+  %79 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %78, i64 1, 2
+  %80 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %74, %"github.com/goplus/llgo/internal/runtime.Slice" %79, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %80)
+  store ptr %80, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU", align 8
   br label %_llgo_14
 
 _llgo_14:                                         ; preds = %_llgo_13, %_llgo_11
-  %141 = load ptr, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU", align 8
-  %142 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %143 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %142, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %114, ptr %143, align 8
-  %144 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %142, i32 0, i32 1
-  store ptr %141, ptr %144, align 8
-  %145 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %142, i32 0, i32 2
-  store ptr @"main.(*T).Add", ptr %145, align 8
-  %146 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %142, i32 0, i32 3
-  store ptr @"main.(*T).Add", ptr %146, align 8
-  %147 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %142, align 8
-  %148 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %149 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %148, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %147, ptr %149, align 8
-  %150 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %151 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %150, i32 0, i32 0
-  store ptr %148, ptr %151, align 8
-  %152 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %150, i32 0, i32 1
-  store i64 1, ptr %152, align 4
-  %153 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %150, i32 0, i32 2
-  store i64 1, ptr %153, align 4
-  %154 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %150, align 8
-  %155 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %156 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %155, i32 0, i32 0
-  store ptr @3, ptr %156, align 8
-  %157 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %155, i32 0, i32 1
-  store i64 4, ptr %157, align 4
-  %158 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %155, align 8
-  %159 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %160 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %159, i32 0, i32 0
-  store ptr @12, ptr %160, align 8
-  %161 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %159, i32 0, i32 1
-  store i64 1, ptr %161, align 4
-  %162 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %159, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %85, %"github.com/goplus/llgo/internal/runtime.String" %158, %"github.com/goplus/llgo/internal/runtime.String" %162, ptr %110, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %154)
+  %81 = load ptr, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU", align 8
+  %82 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 3 }, ptr undef, ptr undef, ptr undef }, ptr %81, 1
+  %83 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %82, ptr @"main.(*T).Add", 2
+  %84 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %83, ptr @"main.(*T).Add", 3
+  %85 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %86 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %85, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %84, ptr %86, align 8
+  %87 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %85, 0
+  %88 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %87, i64 1, 1
+  %89 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %88, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %51, %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @12, i64 1 }, ptr %62, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %89)
   br label %_llgo_12
 
 _llgo_15:                                         ; preds = %_llgo_12
-  %163 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %123)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %163)
-  store ptr %163, ptr @"*_llgo_main.T", align 8
+  %90 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %67)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %90)
+  store ptr %90, ptr @"*_llgo_main.T", align 8
   br label %_llgo_16
 
 _llgo_16:                                         ; preds = %_llgo_15, %_llgo_12
-  %164 = load ptr, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU", align 8
-  %165 = load ptr, ptr @"_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A", align 8
-  %166 = icmp eq ptr %165, null
-  br i1 %166, label %_llgo_17, label %_llgo_18
+  %91 = load ptr, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU", align 8
+  %92 = load ptr, ptr @"_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A", align 8
+  %93 = icmp eq ptr %92, null
+  br i1 %93, label %_llgo_17, label %_llgo_18
 
 _llgo_17:                                         ; preds = %_llgo_16
-  %167 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %168 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %167, i32 0, i32 0
-  store ptr @11, ptr %168, align 8
-  %169 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %167, i32 0, i32 1
-  store i64 3, ptr %169, align 4
-  %170 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %167, align 8
-  %171 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %172 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %171, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %170, ptr %172, align 8
-  %173 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %171, i32 0, i32 1
-  store ptr %164, ptr %173, align 8
-  %174 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %171, align 8
-  %175 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %176 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %175, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %174, ptr %176, align 8
-  %177 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %178 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %177, i32 0, i32 0
-  store ptr %175, ptr %178, align 8
-  %179 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %177, i32 0, i32 1
-  store i64 1, ptr %179, align 4
-  %180 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %177, i32 0, i32 2
-  store i64 1, ptr %180, align 4
-  %181 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %177, align 8
-  %182 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %183 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %182, i32 0, i32 0
-  store ptr @3, ptr %183, align 8
-  %184 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %182, i32 0, i32 1
-  store i64 4, ptr %184, align 4
-  %185 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %182, align 8
-  %186 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %187 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %186, i32 0, i32 0
-  store ptr null, ptr %187, align 8
-  %188 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %186, i32 0, i32 1
-  store i64 0, ptr %188, align 4
-  %189 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %186, align 8
-  %190 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %185, %"github.com/goplus/llgo/internal/runtime.String" %189, %"github.com/goplus/llgo/internal/runtime.Slice" %181)
-  store ptr %190, ptr @"_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A", align 8
+  %94 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 3 }, ptr undef }, ptr %91, 1
+  %95 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %96 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %95, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %94, ptr %96, align 8
+  %97 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %95, 0
+  %98 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %97, i64 1, 1
+  %99 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %98, i64 1, 2
+  %100 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %99)
+  store ptr %100, ptr @"_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A", align 8
   br label %_llgo_18
 
 _llgo_18:                                         ; preds = %_llgo_17, %_llgo_16

--- a/cl/_testgo/selects/out.ll
+++ b/cl/_testgo/selects/out.ll
@@ -56,141 +56,79 @@ _llgo_0:
   store ptr %4, ptr %11, align 8
   %12 = getelementptr inbounds { ptr, ptr, ptr }, ptr %9, i32 0, i32 2
   store ptr %6, ptr %12, align 8
-  %13 = alloca { ptr, ptr }, align 8
-  %14 = getelementptr inbounds { ptr, ptr }, ptr %13, i32 0, i32 0
-  store ptr @"main.main$1", ptr %14, align 8
-  %15 = getelementptr inbounds { ptr, ptr }, ptr %13, i32 0, i32 1
-  store ptr %9, ptr %15, align 8
-  %16 = load { ptr, ptr }, ptr %13, align 8
-  %17 = call ptr @malloc(i64 16)
-  %18 = getelementptr inbounds { { ptr, ptr } }, ptr %17, i32 0, i32 0
-  store { ptr, ptr } %16, ptr %18, align 8
-  %19 = alloca i8, i64 8, align 1
-  %20 = alloca %"github.com/goplus/llgo/c/pthread.RoutineFunc", align 8
-  %21 = getelementptr inbounds %"github.com/goplus/llgo/c/pthread.RoutineFunc", ptr %20, i32 0, i32 0
-  store ptr @"__llgo_stub.main._llgo_routine$1", ptr %21, align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/c/pthread.RoutineFunc", ptr %20, i32 0, i32 1
-  store ptr null, ptr %22, align 8
-  %23 = load %"github.com/goplus/llgo/c/pthread.RoutineFunc", ptr %20, align 8
-  %24 = call i32 @"github.com/goplus/llgo/internal/runtime.CreateThread"(ptr %19, ptr null, %"github.com/goplus/llgo/c/pthread.RoutineFunc" %23, ptr %17)
-  %25 = load ptr, ptr %2, align 8
-  %26 = alloca {}, align 8
-  call void @llvm.memset(ptr %26, i8 0, i64 0, i1 false)
-  store {} zeroinitializer, ptr %26, align 1
-  %27 = call i1 @"github.com/goplus/llgo/internal/runtime.ChanSend"(ptr %25, ptr %26, i64 0)
-  %28 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %29 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %28, i32 0, i32 0
-  store ptr @0, ptr %29, align 8
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %28, i32 0, i32 1
-  store i64 4, ptr %30, align 4
-  %31 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %28, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %31)
+  %13 = insertvalue { ptr, ptr } { ptr @"main.main$1", ptr undef }, ptr %9, 1
+  %14 = call ptr @malloc(i64 16)
+  %15 = getelementptr inbounds { { ptr, ptr } }, ptr %14, i32 0, i32 0
+  store { ptr, ptr } %13, ptr %15, align 8
+  %16 = alloca i8, i64 8, align 1
+  %17 = call i32 @"github.com/goplus/llgo/internal/runtime.CreateThread"(ptr %16, ptr null, %"github.com/goplus/llgo/c/pthread.RoutineFunc" { ptr @"__llgo_stub.main._llgo_routine$1", ptr null }, ptr %14)
+  %18 = load ptr, ptr %2, align 8
+  %19 = alloca {}, align 8
+  call void @llvm.memset(ptr %19, i8 0, i64 0, i1 false)
+  store {} zeroinitializer, ptr %19, align 1
+  %20 = call i1 @"github.com/goplus/llgo/internal/runtime.ChanSend"(ptr %18, ptr %19, i64 0)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %32 = load ptr, ptr %4, align 8
-  %33 = alloca {}, align 8
-  call void @llvm.memset(ptr %33, i8 0, i64 0, i1 false)
-  %34 = alloca %"github.com/goplus/llgo/internal/runtime.ChanOp", align 8
-  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %34, i32 0, i32 0
-  store ptr %32, ptr %35, align 8
-  %36 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %34, i32 0, i32 1
-  store ptr %33, ptr %36, align 8
-  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %34, i32 0, i32 2
-  store i32 0, ptr %37, align 4
-  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %34, i32 0, i32 3
-  store i1 false, ptr %38, align 1
-  %39 = load %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %34, align 8
-  %40 = alloca {}, align 8
-  call void @llvm.memset(ptr %40, i8 0, i64 0, i1 false)
-  %41 = alloca %"github.com/goplus/llgo/internal/runtime.ChanOp", align 8
-  %42 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %41, i32 0, i32 0
-  store ptr %8, ptr %42, align 8
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %41, i32 0, i32 1
-  store ptr %40, ptr %43, align 8
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %41, i32 0, i32 2
-  store i32 0, ptr %44, align 4
-  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %41, i32 0, i32 3
-  store i1 false, ptr %45, align 1
-  %46 = load %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %41, align 8
-  %47 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  %48 = getelementptr %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %47, i64 0
-  store %"github.com/goplus/llgo/internal/runtime.ChanOp" %39, ptr %48, align 8
-  %49 = getelementptr %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %47, i64 1
-  store %"github.com/goplus/llgo/internal/runtime.ChanOp" %46, ptr %49, align 8
-  %50 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %50, i32 0, i32 0
-  store ptr %47, ptr %51, align 8
-  %52 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %50, i32 0, i32 1
-  store i64 2, ptr %52, align 4
-  %53 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %50, i32 0, i32 2
-  store i64 2, ptr %53, align 4
-  %54 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %50, align 8
-  %55 = call { i64, i1 } @"github.com/goplus/llgo/internal/runtime.Select"(%"github.com/goplus/llgo/internal/runtime.Slice" %54)
-  %56 = extractvalue { i64, i1 } %55, 0
-  %57 = extractvalue { i64, i1 } %55, 1
-  %58 = extractvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %39, 1
-  %59 = load {}, ptr %58, align 1
-  %60 = extractvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %46, 1
-  %61 = load {}, ptr %60, align 1
-  %62 = alloca { i64, i1, {}, {} }, align 8
-  %63 = getelementptr inbounds { i64, i1, {}, {} }, ptr %62, i32 0, i32 0
-  store i64 %56, ptr %63, align 4
-  %64 = getelementptr inbounds { i64, i1, {}, {} }, ptr %62, i32 0, i32 1
-  store i1 %57, ptr %64, align 1
-  %65 = getelementptr inbounds { i64, i1, {}, {} }, ptr %62, i32 0, i32 2
-  store {} %59, ptr %65, align 1
-  %66 = getelementptr inbounds { i64, i1, {}, {} }, ptr %62, i32 0, i32 3
-  store {} %61, ptr %66, align 1
-  %67 = load { i64, i1, {}, {} }, ptr %62, align 4
-  %68 = extractvalue { i64, i1, {}, {} } %67, 0
-  %69 = icmp eq i64 %68, 0
-  br i1 %69, label %_llgo_2, label %_llgo_3
+  %21 = load ptr, ptr %4, align 8
+  %22 = alloca {}, align 8
+  call void @llvm.memset(ptr %22, i8 0, i64 0, i1 false)
+  %23 = insertvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" undef, ptr %21, 0
+  %24 = insertvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %23, ptr %22, 1
+  %25 = insertvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %24, i32 0, 2
+  %26 = insertvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %25, i1 false, 3
+  %27 = alloca {}, align 8
+  call void @llvm.memset(ptr %27, i8 0, i64 0, i1 false)
+  %28 = insertvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" undef, ptr %8, 0
+  %29 = insertvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %28, ptr %27, 1
+  %30 = insertvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %29, i32 0, 2
+  %31 = insertvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %30, i1 false, 3
+  %32 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  %33 = getelementptr %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %32, i64 0
+  store %"github.com/goplus/llgo/internal/runtime.ChanOp" %26, ptr %33, align 8
+  %34 = getelementptr %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %32, i64 1
+  store %"github.com/goplus/llgo/internal/runtime.ChanOp" %31, ptr %34, align 8
+  %35 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %32, 0
+  %36 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %35, i64 2, 1
+  %37 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %36, i64 2, 2
+  %38 = call { i64, i1 } @"github.com/goplus/llgo/internal/runtime.Select"(%"github.com/goplus/llgo/internal/runtime.Slice" %37)
+  %39 = extractvalue { i64, i1 } %38, 0
+  %40 = extractvalue { i64, i1 } %38, 1
+  %41 = extractvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %26, 1
+  %42 = load {}, ptr %41, align 1
+  %43 = extractvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %31, 1
+  %44 = load {}, ptr %43, align 1
+  %45 = insertvalue { i64, i1, {}, {} } undef, i64 %39, 0
+  %46 = insertvalue { i64, i1, {}, {} } %45, i1 %40, 1
+  %47 = insertvalue { i64, i1, {}, {} } %46, {} %42, 2
+  %48 = insertvalue { i64, i1, {}, {} } %47, {} %44, 3
+  %49 = extractvalue { i64, i1, {}, {} } %48, 0
+  %50 = icmp eq i64 %49, 0
+  br i1 %50, label %_llgo_2, label %_llgo_3
 
 _llgo_1:                                          ; preds = %_llgo_4, %_llgo_2
   ret i32 0
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %70 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %71 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %70, i32 0, i32 0
-  store ptr @1, ptr %71, align 8
-  %72 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %70, i32 0, i32 1
-  store i64 4, ptr %72, align 4
-  %73 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %70, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %73)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_1
 
 _llgo_3:                                          ; preds = %_llgo_0
-  %74 = icmp eq i64 %68, 1
-  br i1 %74, label %_llgo_4, label %_llgo_5
+  %51 = icmp eq i64 %49, 1
+  br i1 %51, label %_llgo_4, label %_llgo_5
 
 _llgo_4:                                          ; preds = %_llgo_3
-  %75 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %76 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %75, i32 0, i32 0
-  store ptr @2, ptr %76, align 8
-  %77 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %75, i32 0, i32 1
-  store i64 4, ptr %77, align 4
-  %78 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %75, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %78)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_1
 
 _llgo_5:                                          ; preds = %_llgo_3
-  %79 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %80 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %79, i32 0, i32 0
-  store ptr @3, ptr %80, align 8
-  %81 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %79, i32 0, i32 1
-  store i64 31, ptr %81, align 4
-  %82 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %79, align 8
-  %83 = load ptr, ptr @_llgo_string, align 8
-  %84 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %82, ptr %84, align 8
-  %85 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %86 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %85, i32 0, i32 0
-  store ptr %83, ptr %86, align 8
-  %87 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %85, i32 0, i32 1
-  store ptr %84, ptr %87, align 8
-  %88 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %85, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %88)
+  %52 = load ptr, ptr @_llgo_string, align 8
+  %53 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 31 }, ptr %53, align 8
+  %54 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %52, 0
+  %55 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %54, ptr %53, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %55)
   unreachable
 }
 
@@ -203,119 +141,69 @@ _llgo_0:
   call void @llvm.memset(ptr %4, i8 0, i64 0, i1 false)
   %5 = call i1 @"github.com/goplus/llgo/internal/runtime.ChanRecv"(ptr %3, ptr %4, i64 0)
   %6 = load {}, ptr %4, align 1
-  %7 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %7, i32 0, i32 0
-  store ptr @4, ptr %8, align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %7, i32 0, i32 1
-  store i64 4, ptr %9, align 4
-  %10 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %7, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %10)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %11 = extractvalue { ptr, ptr, ptr } %1, 1
-  %12 = load ptr, ptr %11, align 8
-  %13 = extractvalue { ptr, ptr, ptr } %1, 2
-  %14 = load ptr, ptr %13, align 8
-  %15 = alloca {}, align 8
-  call void @llvm.memset(ptr %15, i8 0, i64 0, i1 false)
-  store {} zeroinitializer, ptr %15, align 1
-  %16 = alloca %"github.com/goplus/llgo/internal/runtime.ChanOp", align 8
-  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %16, i32 0, i32 0
-  store ptr %12, ptr %17, align 8
-  %18 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %16, i32 0, i32 1
-  store ptr %15, ptr %18, align 8
-  %19 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %16, i32 0, i32 2
-  store i32 0, ptr %19, align 4
-  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %16, i32 0, i32 3
-  store i1 true, ptr %20, align 1
-  %21 = load %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %16, align 8
-  %22 = alloca {}, align 8
-  call void @llvm.memset(ptr %22, i8 0, i64 0, i1 false)
-  %23 = alloca %"github.com/goplus/llgo/internal/runtime.ChanOp", align 8
-  %24 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %23, i32 0, i32 0
-  store ptr %14, ptr %24, align 8
-  %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %23, i32 0, i32 1
-  store ptr %22, ptr %25, align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %23, i32 0, i32 2
-  store i32 0, ptr %26, align 4
-  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %23, i32 0, i32 3
-  store i1 false, ptr %27, align 1
-  %28 = load %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %23, align 8
-  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  %30 = getelementptr %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %29, i64 0
-  store %"github.com/goplus/llgo/internal/runtime.ChanOp" %21, ptr %30, align 8
-  %31 = getelementptr %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %29, i64 1
-  store %"github.com/goplus/llgo/internal/runtime.ChanOp" %28, ptr %31, align 8
-  %32 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %32, i32 0, i32 0
-  store ptr %29, ptr %33, align 8
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %32, i32 0, i32 1
-  store i64 2, ptr %34, align 4
-  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %32, i32 0, i32 2
-  store i64 2, ptr %35, align 4
-  %36 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %32, align 8
-  %37 = call { i64, i1 } @"github.com/goplus/llgo/internal/runtime.Select"(%"github.com/goplus/llgo/internal/runtime.Slice" %36)
-  %38 = extractvalue { i64, i1 } %37, 0
-  %39 = extractvalue { i64, i1 } %37, 1
-  %40 = extractvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %28, 1
-  %41 = load {}, ptr %40, align 1
-  %42 = alloca { i64, i1, {} }, align 8
-  %43 = getelementptr inbounds { i64, i1, {} }, ptr %42, i32 0, i32 0
-  store i64 %38, ptr %43, align 4
-  %44 = getelementptr inbounds { i64, i1, {} }, ptr %42, i32 0, i32 1
-  store i1 %39, ptr %44, align 1
-  %45 = getelementptr inbounds { i64, i1, {} }, ptr %42, i32 0, i32 2
-  store {} %41, ptr %45, align 1
-  %46 = load { i64, i1, {} }, ptr %42, align 4
-  %47 = extractvalue { i64, i1, {} } %46, 0
-  %48 = icmp eq i64 %47, 0
-  br i1 %48, label %_llgo_2, label %_llgo_3
+  %7 = extractvalue { ptr, ptr, ptr } %1, 1
+  %8 = load ptr, ptr %7, align 8
+  %9 = extractvalue { ptr, ptr, ptr } %1, 2
+  %10 = load ptr, ptr %9, align 8
+  %11 = alloca {}, align 8
+  call void @llvm.memset(ptr %11, i8 0, i64 0, i1 false)
+  store {} zeroinitializer, ptr %11, align 1
+  %12 = insertvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" undef, ptr %8, 0
+  %13 = insertvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %12, ptr %11, 1
+  %14 = insertvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %13, i32 0, 2
+  %15 = insertvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %14, i1 true, 3
+  %16 = alloca {}, align 8
+  call void @llvm.memset(ptr %16, i8 0, i64 0, i1 false)
+  %17 = insertvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" undef, ptr %10, 0
+  %18 = insertvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %17, ptr %16, 1
+  %19 = insertvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %18, i32 0, 2
+  %20 = insertvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %19, i1 false, 3
+  %21 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  %22 = getelementptr %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %21, i64 0
+  store %"github.com/goplus/llgo/internal/runtime.ChanOp" %15, ptr %22, align 8
+  %23 = getelementptr %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %21, i64 1
+  store %"github.com/goplus/llgo/internal/runtime.ChanOp" %20, ptr %23, align 8
+  %24 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %21, 0
+  %25 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %24, i64 2, 1
+  %26 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %25, i64 2, 2
+  %27 = call { i64, i1 } @"github.com/goplus/llgo/internal/runtime.Select"(%"github.com/goplus/llgo/internal/runtime.Slice" %26)
+  %28 = extractvalue { i64, i1 } %27, 0
+  %29 = extractvalue { i64, i1 } %27, 1
+  %30 = extractvalue %"github.com/goplus/llgo/internal/runtime.ChanOp" %20, 1
+  %31 = load {}, ptr %30, align 1
+  %32 = insertvalue { i64, i1, {} } undef, i64 %28, 0
+  %33 = insertvalue { i64, i1, {} } %32, i1 %29, 1
+  %34 = insertvalue { i64, i1, {} } %33, {} %31, 2
+  %35 = extractvalue { i64, i1, {} } %34, 0
+  %36 = icmp eq i64 %35, 0
+  br i1 %36, label %_llgo_2, label %_llgo_3
 
 _llgo_1:                                          ; preds = %_llgo_4, %_llgo_2
   ret void
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %49 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %49, i32 0, i32 0
-  store ptr @5, ptr %50, align 8
-  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %49, i32 0, i32 1
-  store i64 4, ptr %51, align 4
-  %52 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %49, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %52)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 4 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_1
 
 _llgo_3:                                          ; preds = %_llgo_0
-  %53 = icmp eq i64 %47, 1
-  br i1 %53, label %_llgo_4, label %_llgo_5
+  %37 = icmp eq i64 %35, 1
+  br i1 %37, label %_llgo_4, label %_llgo_5
 
 _llgo_4:                                          ; preds = %_llgo_3
-  %54 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %54, i32 0, i32 0
-  store ptr @6, ptr %55, align 8
-  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %54, i32 0, i32 1
-  store i64 4, ptr %56, align 4
-  %57 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %54, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %57)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 4 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_1
 
 _llgo_5:                                          ; preds = %_llgo_3
-  %58 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %59 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %58, i32 0, i32 0
-  store ptr @3, ptr %59, align 8
-  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %58, i32 0, i32 1
-  store i64 31, ptr %60, align 4
-  %61 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %58, align 8
-  %62 = load ptr, ptr @_llgo_string, align 8
-  %63 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %61, ptr %63, align 8
-  %64 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %65 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %64, i32 0, i32 0
-  store ptr %62, ptr %65, align 8
-  %66 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %64, i32 0, i32 1
-  store ptr %63, ptr %66, align 8
-  %67 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %64, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %67)
+  %38 = load ptr, ptr @_llgo_string, align 8
+  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 31 }, ptr %39, align 8
+  %40 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %38, 0
+  %41 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %40, ptr %39, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %41)
   unreachable
 }
 

--- a/cl/_testgo/selects/out.ll
+++ b/cl/_testgo/selects/out.ll
@@ -95,7 +95,7 @@ _llgo_0:
   %36 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %34, i32 0, i32 1
   store ptr %33, ptr %36, align 8
   %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %34, i32 0, i32 2
-  store i64 0, ptr %37, align 4
+  store i32 0, ptr %37, align 4
   %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %34, i32 0, i32 3
   store i1 false, ptr %38, align 1
   %39 = load %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %34, align 8
@@ -107,7 +107,7 @@ _llgo_0:
   %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %41, i32 0, i32 1
   store ptr %40, ptr %43, align 8
   %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %41, i32 0, i32 2
-  store i64 0, ptr %44, align 4
+  store i32 0, ptr %44, align 4
   %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %41, i32 0, i32 3
   store i1 false, ptr %45, align 1
   %46 = load %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %41, align 8
@@ -236,7 +236,7 @@ _llgo_0:
   %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %23, i32 0, i32 1
   store ptr %22, ptr %25, align 8
   %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %23, i32 0, i32 2
-  store i64 0, ptr %26, align 4
+  store i32 0, ptr %26, align 4
   %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %23, i32 0, i32 3
   store i1 false, ptr %27, align 1
   %28 = load %"github.com/goplus/llgo/internal/runtime.ChanOp", ptr %23, align 8

--- a/cl/_testgo/strucintf/out.ll
+++ b/cl/_testgo/strucintf/out.ll
@@ -30,13 +30,9 @@ _llgo_0:
   %4 = load ptr, ptr @"main.struct$MYpsoM99ZwFY087IpUOkIw1zjBA_sgFXVodmn1m-G88", align 8
   %5 = extractvalue { i64 } %2, 0
   %6 = inttoptr i64 %5 to ptr
-  %7 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, i32 0, i32 0
-  store ptr %4, ptr %8, align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, i32 0, i32 1
-  store ptr %6, ptr %9, align 8
-  %10 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, align 8
-  ret %"github.com/goplus/llgo/internal/runtime.eface" %10
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %4, 0
+  %8 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %7, ptr %6, 1
+  ret %"github.com/goplus/llgo/internal/runtime.eface" %8
 }
 
 define void @main.init() {
@@ -85,47 +81,35 @@ _llgo_2:                                          ; preds = %_llgo_3, %_llgo_1
   br i1 %13, label %_llgo_13, label %_llgo_14
 
 _llgo_3:                                          ; preds = %_llgo_12
-  %14 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %14, i32 0, i32 0
-  store ptr @2, ptr %15, align 8
-  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %14, i32 0, i32 1
-  store i64 11, ptr %16, align 4
-  %17 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %14, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %17)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 11 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_2
 
 _llgo_4:                                          ; preds = %_llgo_15
-  %18 = getelementptr inbounds { i64 }, ptr %10, i32 0, i32 0
-  %19 = load i64, ptr %18, align 4
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %19)
+  %14 = getelementptr inbounds { i64 }, ptr %10, i32 0, i32 0
+  %15 = load i64, ptr %14, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %15)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_5
 
 _llgo_5:                                          ; preds = %_llgo_6, %_llgo_4
-  %20 = alloca { i64 }, align 8
-  call void @llvm.memset(ptr %20, i8 0, i64 8, i1 false)
-  %21 = call %"github.com/goplus/llgo/internal/runtime.eface" @"github.com/goplus/llgo/cl/internal/foo.F"()
-  %22 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %21, 0
-  %23 = load ptr, ptr @"main.struct$MYpsoM99ZwFY087IpUOkIw1zjBA_sgFXVodmn1m-G88", align 8
-  %24 = icmp eq ptr %22, %23
-  br i1 %24, label %_llgo_16, label %_llgo_17
+  %16 = alloca { i64 }, align 8
+  call void @llvm.memset(ptr %16, i8 0, i64 8, i1 false)
+  %17 = call %"github.com/goplus/llgo/internal/runtime.eface" @"github.com/goplus/llgo/cl/internal/foo.F"()
+  %18 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %17, 0
+  %19 = load ptr, ptr @"main.struct$MYpsoM99ZwFY087IpUOkIw1zjBA_sgFXVodmn1m-G88", align 8
+  %20 = icmp eq ptr %18, %19
+  br i1 %20, label %_llgo_16, label %_llgo_17
 
 _llgo_6:                                          ; preds = %_llgo_15
-  %25 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 0
-  store ptr @4, ptr %26, align 8
-  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 1
-  store i64 11, ptr %27, align 4
-  %28 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %25, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %28)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 11 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_5
 
 _llgo_7:                                          ; preds = %_llgo_18
-  %29 = getelementptr inbounds { i64 }, ptr %20, i32 0, i32 0
-  %30 = load i64, ptr %29, align 4
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %30)
+  %21 = getelementptr inbounds { i64 }, ptr %16, i32 0, i32 0
+  %22 = load i64, ptr %21, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %22)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_8
 
@@ -133,108 +117,63 @@ _llgo_8:                                          ; preds = %_llgo_9, %_llgo_7
   ret i32 0
 
 _llgo_9:                                          ; preds = %_llgo_18
-  %31 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %31, i32 0, i32 0
-  store ptr @5, ptr %32, align 8
-  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %31, i32 0, i32 1
-  store i64 9, ptr %33, align 4
-  %34 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %31, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %34)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 9 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_8
 
 _llgo_10:                                         ; preds = %_llgo_0
-  %35 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %2, 1
-  %36 = ptrtoint ptr %35 to i64
-  %37 = alloca { i64 }, align 8
-  %38 = getelementptr inbounds { i64 }, ptr %37, i32 0, i32 0
-  store i64 %36, ptr %38, align 4
-  %39 = load { i64 }, ptr %37, align 4
-  %40 = alloca { { i64 }, i1 }, align 8
-  %41 = getelementptr inbounds { { i64 }, i1 }, ptr %40, i32 0, i32 0
-  store { i64 } %39, ptr %41, align 4
-  %42 = getelementptr inbounds { { i64 }, i1 }, ptr %40, i32 0, i32 1
-  store i1 true, ptr %42, align 1
-  %43 = load { { i64 }, i1 }, ptr %40, align 4
+  %23 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %2, 1
+  %24 = ptrtoint ptr %23 to i64
+  %25 = insertvalue { i64 } undef, i64 %24, 0
+  %26 = insertvalue { { i64 }, i1 } undef, { i64 } %25, 0
+  %27 = insertvalue { { i64 }, i1 } %26, i1 true, 1
   br label %_llgo_12
 
 _llgo_11:                                         ; preds = %_llgo_0
-  %44 = alloca { { i64 }, i1 }, align 8
-  %45 = getelementptr inbounds { { i64 }, i1 }, ptr %44, i32 0, i32 0
-  store { i64 } zeroinitializer, ptr %45, align 4
-  %46 = getelementptr inbounds { { i64 }, i1 }, ptr %44, i32 0, i32 1
-  store i1 false, ptr %46, align 1
-  %47 = load { { i64 }, i1 }, ptr %44, align 4
   br label %_llgo_12
 
 _llgo_12:                                         ; preds = %_llgo_11, %_llgo_10
-  %48 = phi { { i64 }, i1 } [ %43, %_llgo_10 ], [ %47, %_llgo_11 ]
-  %49 = extractvalue { { i64 }, i1 } %48, 0
-  store { i64 } %49, ptr %3, align 4
-  %50 = extractvalue { { i64 }, i1 } %48, 1
-  br i1 %50, label %_llgo_1, label %_llgo_3
+  %28 = phi { { i64 }, i1 } [ %27, %_llgo_10 ], [ zeroinitializer, %_llgo_11 ]
+  %29 = extractvalue { { i64 }, i1 } %28, 0
+  store { i64 } %29, ptr %3, align 4
+  %30 = extractvalue { { i64 }, i1 } %28, 1
+  br i1 %30, label %_llgo_1, label %_llgo_3
 
 _llgo_13:                                         ; preds = %_llgo_2
-  %51 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %9, 1
-  %52 = ptrtoint ptr %51 to i64
-  %53 = alloca { i64 }, align 8
-  %54 = getelementptr inbounds { i64 }, ptr %53, i32 0, i32 0
-  store i64 %52, ptr %54, align 4
-  %55 = load { i64 }, ptr %53, align 4
-  %56 = alloca { { i64 }, i1 }, align 8
-  %57 = getelementptr inbounds { { i64 }, i1 }, ptr %56, i32 0, i32 0
-  store { i64 } %55, ptr %57, align 4
-  %58 = getelementptr inbounds { { i64 }, i1 }, ptr %56, i32 0, i32 1
-  store i1 true, ptr %58, align 1
-  %59 = load { { i64 }, i1 }, ptr %56, align 4
+  %31 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %9, 1
+  %32 = ptrtoint ptr %31 to i64
+  %33 = insertvalue { i64 } undef, i64 %32, 0
+  %34 = insertvalue { { i64 }, i1 } undef, { i64 } %33, 0
+  %35 = insertvalue { { i64 }, i1 } %34, i1 true, 1
   br label %_llgo_15
 
 _llgo_14:                                         ; preds = %_llgo_2
-  %60 = alloca { { i64 }, i1 }, align 8
-  %61 = getelementptr inbounds { { i64 }, i1 }, ptr %60, i32 0, i32 0
-  store { i64 } zeroinitializer, ptr %61, align 4
-  %62 = getelementptr inbounds { { i64 }, i1 }, ptr %60, i32 0, i32 1
-  store i1 false, ptr %62, align 1
-  %63 = load { { i64 }, i1 }, ptr %60, align 4
   br label %_llgo_15
 
 _llgo_15:                                         ; preds = %_llgo_14, %_llgo_13
-  %64 = phi { { i64 }, i1 } [ %59, %_llgo_13 ], [ %63, %_llgo_14 ]
-  %65 = extractvalue { { i64 }, i1 } %64, 0
-  store { i64 } %65, ptr %10, align 4
-  %66 = extractvalue { { i64 }, i1 } %64, 1
-  br i1 %66, label %_llgo_4, label %_llgo_6
+  %36 = phi { { i64 }, i1 } [ %35, %_llgo_13 ], [ zeroinitializer, %_llgo_14 ]
+  %37 = extractvalue { { i64 }, i1 } %36, 0
+  store { i64 } %37, ptr %10, align 4
+  %38 = extractvalue { { i64 }, i1 } %36, 1
+  br i1 %38, label %_llgo_4, label %_llgo_6
 
 _llgo_16:                                         ; preds = %_llgo_5
-  %67 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %21, 1
-  %68 = ptrtoint ptr %67 to i64
-  %69 = alloca { i64 }, align 8
-  %70 = getelementptr inbounds { i64 }, ptr %69, i32 0, i32 0
-  store i64 %68, ptr %70, align 4
-  %71 = load { i64 }, ptr %69, align 4
-  %72 = alloca { { i64 }, i1 }, align 8
-  %73 = getelementptr inbounds { { i64 }, i1 }, ptr %72, i32 0, i32 0
-  store { i64 } %71, ptr %73, align 4
-  %74 = getelementptr inbounds { { i64 }, i1 }, ptr %72, i32 0, i32 1
-  store i1 true, ptr %74, align 1
-  %75 = load { { i64 }, i1 }, ptr %72, align 4
+  %39 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %17, 1
+  %40 = ptrtoint ptr %39 to i64
+  %41 = insertvalue { i64 } undef, i64 %40, 0
+  %42 = insertvalue { { i64 }, i1 } undef, { i64 } %41, 0
+  %43 = insertvalue { { i64 }, i1 } %42, i1 true, 1
   br label %_llgo_18
 
 _llgo_17:                                         ; preds = %_llgo_5
-  %76 = alloca { { i64 }, i1 }, align 8
-  %77 = getelementptr inbounds { { i64 }, i1 }, ptr %76, i32 0, i32 0
-  store { i64 } zeroinitializer, ptr %77, align 4
-  %78 = getelementptr inbounds { { i64 }, i1 }, ptr %76, i32 0, i32 1
-  store i1 false, ptr %78, align 1
-  %79 = load { { i64 }, i1 }, ptr %76, align 4
   br label %_llgo_18
 
 _llgo_18:                                         ; preds = %_llgo_17, %_llgo_16
-  %80 = phi { { i64 }, i1 } [ %75, %_llgo_16 ], [ %79, %_llgo_17 ]
-  %81 = extractvalue { { i64 }, i1 } %80, 0
-  store { i64 } %81, ptr %20, align 4
-  %82 = extractvalue { { i64 }, i1 } %80, 1
-  br i1 %82, label %_llgo_7, label %_llgo_9
+  %44 = phi { { i64 }, i1 } [ %43, %_llgo_16 ], [ zeroinitializer, %_llgo_17 ]
+  %45 = extractvalue { { i64 }, i1 } %44, 0
+  store { i64 } %45, ptr %16, align 4
+  %46 = extractvalue { { i64 }, i1 } %44, 1
+  br i1 %46, label %_llgo_7, label %_llgo_9
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
@@ -252,77 +191,31 @@ _llgo_1:                                          ; preds = %_llgo_0
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-  %3 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3, i32 0, i32 0
-  store ptr @0, ptr %4, align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3, i32 0, i32 1
-  store i64 1, ptr %5, align 4
-  %6 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3, align 8
-  %7 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %7, i32 0, i32 0
-  store ptr null, ptr %8, align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %7, i32 0, i32 1
-  store i64 0, ptr %9, align 4
-  %10 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %7, align 8
-  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %12 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %6, ptr %11, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %10, i1 false)
-  %13 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %13, i32 0, i32 0
-  store ptr @1, ptr %14, align 8
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %13, i32 0, i32 1
-  store i64 4, ptr %15, align 4
-  %16 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %13, align 8
-  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
-  %18 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %17, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %12, ptr %18, align 8
-  %19 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %19, i32 0, i32 0
-  store ptr %17, ptr %20, align 8
-  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %19, i32 0, i32 1
-  store i64 1, ptr %21, align 4
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %19, i32 0, i32 2
-  store i64 1, ptr %22, align 4
-  %23 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %19, align 8
-  %24 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %16, i64 8, %"github.com/goplus/llgo/internal/runtime.Slice" %23)
-  store ptr %24, ptr @"main.struct$MYpsoM99ZwFY087IpUOkIw1zjBA_sgFXVodmn1m-G88", align 8
-  %25 = load ptr, ptr @"_llgo_struct$K-dZ9QotZfVPz2a0YdRa9vmZUuDXPTqZOlMShKEDJtk", align 8
-  %26 = icmp eq ptr %25, null
-  br i1 %26, label %_llgo_3, label %_llgo_4
+  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %4 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 1 }, ptr %3, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
+  %6 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %5, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %4, ptr %6, align 8
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %5, 0
+  %8 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %7, i64 1, 1
+  %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %8, i64 1, 2
+  %10 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, i64 8, %"github.com/goplus/llgo/internal/runtime.Slice" %9)
+  store ptr %10, ptr @"main.struct$MYpsoM99ZwFY087IpUOkIw1zjBA_sgFXVodmn1m-G88", align 8
+  %11 = load ptr, ptr @"_llgo_struct$K-dZ9QotZfVPz2a0YdRa9vmZUuDXPTqZOlMShKEDJtk", align 8
+  %12 = icmp eq ptr %11, null
+  br i1 %12, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %27 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %28 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %27, i32 0, i32 0
-  store ptr @3, ptr %28, align 8
-  %29 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %27, i32 0, i32 1
-  store i64 1, ptr %29, align 4
-  %30 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %27, align 8
-  %31 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %31, i32 0, i32 0
-  store ptr null, ptr %32, align 8
-  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %31, i32 0, i32 1
-  store i64 0, ptr %33, align 4
-  %34 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %31, align 8
-  %35 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %36 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %30, ptr %35, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %34, i1 false)
-  %37 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %37, i32 0, i32 0
-  store ptr @1, ptr %38, align 8
-  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %37, i32 0, i32 1
-  store i64 4, ptr %39, align 4
-  %40 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %37, align 8
-  %41 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
-  %42 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %41, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %36, ptr %42, align 8
-  %43 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %43, i32 0, i32 0
-  store ptr %41, ptr %44, align 8
-  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %43, i32 0, i32 1
-  store i64 1, ptr %45, align 4
-  %46 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %43, i32 0, i32 2
-  store i64 1, ptr %46, align 4
-  %47 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %43, align 8
-  %48 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %40, i64 8, %"github.com/goplus/llgo/internal/runtime.Slice" %47)
-  store ptr %48, ptr @"_llgo_struct$K-dZ9QotZfVPz2a0YdRa9vmZUuDXPTqZOlMShKEDJtk", align 8
+  %13 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %14 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 1 }, ptr %13, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %15 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
+  %16 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %15, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %14, ptr %16, align 8
+  %17 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %15, 0
+  %18 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %17, i64 1, 1
+  %19 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %18, i64 1, 2
+  %20 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, i64 8, %"github.com/goplus/llgo/internal/runtime.Slice" %19)
+  store ptr %20, ptr @"_llgo_struct$K-dZ9QotZfVPz2a0YdRa9vmZUuDXPTqZOlMShKEDJtk", align 8
   br label %_llgo_4
 
 _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2

--- a/cl/_testgo/struczero/out.ll
+++ b/cl/_testgo/struczero/out.ll
@@ -42,34 +42,20 @@ _llgo_0:
 _llgo_1:                                          ; preds = %_llgo_0
   %4 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
   %5 = load %"github.com/goplus/llgo/cl/internal/foo.Foo", ptr %4, align 8
-  %6 = alloca { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 }, align 8
-  %7 = getelementptr inbounds { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 }, ptr %6, i32 0, i32 0
-  store %"github.com/goplus/llgo/cl/internal/foo.Foo" %5, ptr %7, align 8
-  %8 = getelementptr inbounds { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 }, ptr %6, i32 0, i32 1
-  store i1 true, ptr %8, align 1
-  %9 = load { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 }, ptr %6, align 8
+  %6 = insertvalue { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } undef, %"github.com/goplus/llgo/cl/internal/foo.Foo" %5, 0
+  %7 = insertvalue { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } %6, i1 true, 1
   br label %_llgo_3
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %10 = alloca { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 }, align 8
-  %11 = getelementptr inbounds { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 }, ptr %10, i32 0, i32 0
-  store { ptr, double } zeroinitializer, ptr %11, align 8
-  %12 = getelementptr inbounds { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 }, ptr %10, i32 0, i32 1
-  store i1 false, ptr %12, align 1
-  %13 = load { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 }, ptr %10, align 8
   br label %_llgo_3
 
 _llgo_3:                                          ; preds = %_llgo_2, %_llgo_1
-  %14 = phi { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } [ %9, %_llgo_1 ], [ %13, %_llgo_2 ]
-  %15 = extractvalue { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } %14, 0
-  %16 = extractvalue { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } %14, 1
-  %17 = alloca { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 }, align 8
-  %18 = getelementptr inbounds { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 }, ptr %17, i32 0, i32 0
-  store %"github.com/goplus/llgo/cl/internal/foo.Foo" %15, ptr %18, align 8
-  %19 = getelementptr inbounds { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 }, ptr %17, i32 0, i32 1
-  store i1 %16, ptr %19, align 1
-  %20 = load { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 }, ptr %17, align 8
-  ret { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } %20
+  %8 = phi { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } [ %7, %_llgo_1 ], [ zeroinitializer, %_llgo_2 ]
+  %9 = extractvalue { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } %8, 0
+  %10 = extractvalue { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } %8, 1
+  %11 = insertvalue { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } undef, %"github.com/goplus/llgo/cl/internal/foo.Foo" %9, 0
+  %12 = insertvalue { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } %11, i1 %10, 1
+  ret { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } %12
 }
 
 define { %main.bar, i1 } @main.Foo(%"github.com/goplus/llgo/internal/runtime.eface" %0) {
@@ -82,34 +68,20 @@ _llgo_0:
 _llgo_1:                                          ; preds = %_llgo_0
   %4 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
   %5 = load %main.bar, ptr %4, align 8
-  %6 = alloca { %main.bar, i1 }, align 8
-  %7 = getelementptr inbounds { %main.bar, i1 }, ptr %6, i32 0, i32 0
-  store %main.bar %5, ptr %7, align 8
-  %8 = getelementptr inbounds { %main.bar, i1 }, ptr %6, i32 0, i32 1
-  store i1 true, ptr %8, align 1
-  %9 = load { %main.bar, i1 }, ptr %6, align 8
+  %6 = insertvalue { %main.bar, i1 } undef, %main.bar %5, 0
+  %7 = insertvalue { %main.bar, i1 } %6, i1 true, 1
   br label %_llgo_3
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %10 = alloca { %main.bar, i1 }, align 8
-  %11 = getelementptr inbounds { %main.bar, i1 }, ptr %10, i32 0, i32 0
-  store { ptr, double } zeroinitializer, ptr %11, align 8
-  %12 = getelementptr inbounds { %main.bar, i1 }, ptr %10, i32 0, i32 1
-  store i1 false, ptr %12, align 1
-  %13 = load { %main.bar, i1 }, ptr %10, align 8
   br label %_llgo_3
 
 _llgo_3:                                          ; preds = %_llgo_2, %_llgo_1
-  %14 = phi { %main.bar, i1 } [ %9, %_llgo_1 ], [ %13, %_llgo_2 ]
-  %15 = extractvalue { %main.bar, i1 } %14, 0
-  %16 = extractvalue { %main.bar, i1 } %14, 1
-  %17 = alloca { %main.bar, i1 }, align 8
-  %18 = getelementptr inbounds { %main.bar, i1 }, ptr %17, i32 0, i32 0
-  store %main.bar %15, ptr %18, align 8
-  %19 = getelementptr inbounds { %main.bar, i1 }, ptr %17, i32 0, i32 1
-  store i1 %16, ptr %19, align 1
-  %20 = load { %main.bar, i1 }, ptr %17, align 8
-  ret { %main.bar, i1 } %20
+  %8 = phi { %main.bar, i1 } [ %7, %_llgo_1 ], [ zeroinitializer, %_llgo_2 ]
+  %9 = extractvalue { %main.bar, i1 } %8, 0
+  %10 = extractvalue { %main.bar, i1 } %8, 1
+  %11 = insertvalue { %main.bar, i1 } undef, %main.bar %9, 0
+  %12 = insertvalue { %main.bar, i1 } %11, i1 %10, 1
+  ret { %main.bar, i1 } %12
 }
 
 define void @main.init() {
@@ -144,328 +116,172 @@ _llgo_0:
   %8 = getelementptr inbounds %main.bar, ptr %2, i32 0, i32 1
   %9 = load float, ptr %8, align 4
   %10 = xor i1 %5, true
-  %11 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %11, i32 0, i32 0
-  store ptr @10, ptr %12, align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %11, i32 0, i32 1
-  store i64 6, ptr %13, align 4
-  %14 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %11, align 8
   call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %7)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  %15 = fpext float %9 to double
-  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %15)
+  %11 = fpext float %9 to double
+  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %11)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %14)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 6 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %10)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %16 = alloca %"github.com/goplus/llgo/cl/internal/foo.Foo", align 8
-  call void @llvm.memset(ptr %16, i8 0, i64 16, i1 false)
-  %17 = load ptr, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Foo", align 8
-  %18 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/cl/internal/foo.Foo" zeroinitializer, ptr %18, align 8
-  %19 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %19, i32 0, i32 0
-  store ptr %17, ptr %20, align 8
-  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %19, i32 0, i32 1
-  store ptr %18, ptr %21, align 8
-  %22 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %19, align 8
-  %23 = call { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } @main.Bar(%"github.com/goplus/llgo/internal/runtime.eface" %22)
-  %24 = extractvalue { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } %23, 0
-  store %"github.com/goplus/llgo/cl/internal/foo.Foo" %24, ptr %16, align 8
-  %25 = extractvalue { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } %23, 1
-  %26 = load %"github.com/goplus/llgo/cl/internal/foo.Foo", ptr %16, align 8
-  %27 = call ptr @"github.com/goplus/llgo/cl/internal/foo.Foo.Pb"(%"github.com/goplus/llgo/cl/internal/foo.Foo" %26)
-  %28 = getelementptr inbounds %"github.com/goplus/llgo/cl/internal/foo.Foo", ptr %16, i32 0, i32 1
-  %29 = load float, ptr %28, align 4
-  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %27)
+  %12 = alloca %"github.com/goplus/llgo/cl/internal/foo.Foo", align 8
+  call void @llvm.memset(ptr %12, i8 0, i64 16, i1 false)
+  %13 = load ptr, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Foo", align 8
+  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/cl/internal/foo.Foo" zeroinitializer, ptr %14, align 8
+  %15 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %13, 0
+  %16 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %15, ptr %14, 1
+  %17 = call { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } @main.Bar(%"github.com/goplus/llgo/internal/runtime.eface" %16)
+  %18 = extractvalue { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } %17, 0
+  store %"github.com/goplus/llgo/cl/internal/foo.Foo" %18, ptr %12, align 8
+  %19 = extractvalue { %"github.com/goplus/llgo/cl/internal/foo.Foo", i1 } %17, 1
+  %20 = load %"github.com/goplus/llgo/cl/internal/foo.Foo", ptr %12, align 8
+  %21 = call ptr @"github.com/goplus/llgo/cl/internal/foo.Foo.Pb"(%"github.com/goplus/llgo/cl/internal/foo.Foo" %20)
+  %22 = getelementptr inbounds %"github.com/goplus/llgo/cl/internal/foo.Foo", ptr %12, i32 0, i32 1
+  %23 = load float, ptr %22, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %21)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  %30 = fpext float %29 to double
-  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %30)
+  %24 = fpext float %23 to double
+  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %24)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %25)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %19)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 }
 
 define void @"main.init$after"() {
 _llgo_0:
-  %0 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 0
-  store ptr @0, ptr %1, align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 1
-  store i64 42, ptr %2, align 4
-  %3 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %0, align 8
-  %4 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3, i64 25, i64 16, i64 1, i64 1)
-  %5 = load ptr, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Foo", align 8
-  %6 = icmp eq ptr %5, null
-  br i1 %6, label %_llgo_1, label %_llgo_2
+  %0 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 42 }, i64 25, i64 16, i64 1, i64 1)
+  %1 = load ptr, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Foo", align 8
+  %2 = icmp eq ptr %1, null
+  br i1 %2, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  store ptr %4, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Foo", align 8
+  store ptr %0, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Foo", align 8
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-  %7 = load ptr, ptr @_llgo_byte, align 8
-  %8 = icmp eq ptr %7, null
-  br i1 %8, label %_llgo_3, label %_llgo_4
+  %3 = load ptr, ptr @_llgo_byte, align 8
+  %4 = icmp eq ptr %3, null
+  br i1 %4, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  store ptr %9, ptr @_llgo_byte, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  store ptr %5, ptr @_llgo_byte, align 8
   br label %_llgo_4
 
 _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
-  %10 = load ptr, ptr @_llgo_byte, align 8
-  %11 = load ptr, ptr @"*_llgo_byte", align 8
-  %12 = icmp eq ptr %11, null
-  br i1 %12, label %_llgo_5, label %_llgo_6
+  %6 = load ptr, ptr @_llgo_byte, align 8
+  %7 = load ptr, ptr @"*_llgo_byte", align 8
+  %8 = icmp eq ptr %7, null
+  br i1 %8, label %_llgo_5, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_4
-  %13 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %13)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %14)
-  store ptr %14, ptr @"*_llgo_byte", align 8
+  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %10 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %9)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %10)
+  store ptr %10, ptr @"*_llgo_byte", align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %15 = load ptr, ptr @"*_llgo_byte", align 8
-  %16 = load ptr, ptr @_llgo_float32, align 8
-  %17 = icmp eq ptr %16, null
-  br i1 %17, label %_llgo_7, label %_llgo_8
+  %11 = load ptr, ptr @"*_llgo_byte", align 8
+  %12 = load ptr, ptr @_llgo_float32, align 8
+  %13 = icmp eq ptr %12, null
+  br i1 %13, label %_llgo_7, label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_6
-  %18 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 45)
-  store ptr %18, ptr @_llgo_float32, align 8
+  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 45)
+  store ptr %14, ptr @_llgo_float32, align 8
   br label %_llgo_8
 
 _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
-  %19 = load ptr, ptr @_llgo_float32, align 8
-  %20 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %20, i32 0, i32 0
-  store ptr @1, ptr %21, align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %20, i32 0, i32 1
-  store i64 2, ptr %22, align 4
-  %23 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %20, align 8
-  %24 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %24, i32 0, i32 0
-  store ptr null, ptr %25, align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %24, i32 0, i32 1
-  store i64 0, ptr %26, align 4
-  %27 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %24, align 8
-  %28 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %28)
-  %30 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %23, ptr %29, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %27, i1 false)
-  %31 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %31, i32 0, i32 0
-  store ptr @2, ptr %32, align 8
-  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %31, i32 0, i32 1
-  store i64 1, ptr %33, align 4
-  %34 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %31, align 8
-  %35 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %36 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %35, i32 0, i32 0
-  store ptr null, ptr %36, align 8
-  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %35, i32 0, i32 1
-  store i64 0, ptr %37, align 4
-  %38 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %35, align 8
-  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 45)
-  %40 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %34, ptr %39, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %38, i1 false)
-  %41 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %42 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %41, i32 0, i32 0
-  store ptr @3, ptr %42, align 8
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %41, i32 0, i32 1
-  store i64 4, ptr %43, align 4
-  %44 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %41, align 8
-  %45 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %46 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %45, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %30, ptr %46, align 8
-  %47 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %45, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %40, ptr %47, align 8
-  %48 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %49 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, i32 0, i32 0
-  store ptr %45, ptr %49, align 8
-  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, i32 0, i32 1
-  store i64 2, ptr %50, align 4
-  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, i32 0, i32 2
-  store i64 2, ptr %51, align 4
-  %52 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, align 8
-  %53 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %44, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %52)
-  store ptr %53, ptr @"main.struct$qQwZyFy_4JRalRxVVsVD8R09X5t58tWjTrtJPtHbEjs", align 8
-  %54 = load ptr, ptr @"main.struct$qQwZyFy_4JRalRxVVsVD8R09X5t58tWjTrtJPtHbEjs", align 8
-  br i1 %6, label %_llgo_9, label %_llgo_10
+  %15 = load ptr, ptr @_llgo_float32, align 8
+  %16 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %16)
+  %18 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 2 }, ptr %17, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 45)
+  %20 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 1 }, ptr %19, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %21 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %22 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %21, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %18, ptr %22, align 8
+  %23 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %21, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %20, ptr %23, align 8
+  %24 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %21, 0
+  %25 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %24, i64 2, 1
+  %26 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %25, i64 2, 2
+  %27 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %26)
+  store ptr %27, ptr @"main.struct$qQwZyFy_4JRalRxVVsVD8R09X5t58tWjTrtJPtHbEjs", align 8
+  %28 = load ptr, ptr @"main.struct$qQwZyFy_4JRalRxVVsVD8R09X5t58tWjTrtJPtHbEjs", align 8
+  br i1 %2, label %_llgo_9, label %_llgo_10
 
 _llgo_9:                                          ; preds = %_llgo_8
-  %55 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 0
-  store ptr @4, ptr %56, align 8
-  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 1
-  store i64 2, ptr %57, align 4
-  %58 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %55, align 8
-  %59 = load ptr, ptr @"*_llgo_byte", align 8
-  %60 = load ptr, ptr @"*_llgo_byte", align 8
-  %61 = load ptr, ptr @"_llgo_func$NfGSLZ1QiKRoFkKeqYSXE5hUU5bpeteSJKrbMNUzYRE", align 8
-  %62 = icmp eq ptr %61, null
-  br i1 %62, label %_llgo_11, label %_llgo_12
+  %29 = load ptr, ptr @"*_llgo_byte", align 8
+  %30 = load ptr, ptr @"*_llgo_byte", align 8
+  %31 = load ptr, ptr @"_llgo_func$NfGSLZ1QiKRoFkKeqYSXE5hUU5bpeteSJKrbMNUzYRE", align 8
+  %32 = icmp eq ptr %31, null
+  br i1 %32, label %_llgo_11, label %_llgo_12
 
 _llgo_10:                                         ; preds = %_llgo_12, %_llgo_8
-  %63 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %64 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %63, i32 0, i32 0
-  store ptr @7, ptr %64, align 8
-  %65 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %63, i32 0, i32 1
-  store i64 8, ptr %65, align 4
-  %66 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %63, align 8
-  %67 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %66, i64 25, i64 16, i64 0, i64 0)
-  store ptr %67, ptr @_llgo_main.bar, align 8
-  %68 = load ptr, ptr @"*_llgo_byte", align 8
-  %69 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %70 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %69, i32 0, i32 0
-  store ptr @1, ptr %70, align 8
-  %71 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %69, i32 0, i32 1
-  store i64 2, ptr %71, align 4
-  %72 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %69, align 8
-  %73 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %74 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %73, i32 0, i32 0
-  store ptr null, ptr %74, align 8
-  %75 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %73, i32 0, i32 1
-  store i64 0, ptr %75, align 4
-  %76 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %73, align 8
-  %77 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %78 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %77)
-  %79 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %72, ptr %78, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %76, i1 false)
-  %80 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %81 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %80, i32 0, i32 0
-  store ptr @8, ptr %81, align 8
-  %82 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %80, i32 0, i32 1
-  store i64 1, ptr %82, align 4
-  %83 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %80, align 8
-  %84 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %85 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %84, i32 0, i32 0
-  store ptr null, ptr %85, align 8
-  %86 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %84, i32 0, i32 1
-  store i64 0, ptr %86, align 4
-  %87 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %84, align 8
-  %88 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 45)
-  %89 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %83, ptr %88, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %87, i1 false)
-  %90 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %91 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %90, i32 0, i32 0
-  store ptr @3, ptr %91, align 8
-  %92 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %90, i32 0, i32 1
-  store i64 4, ptr %92, align 4
-  %93 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %90, align 8
-  %94 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %95 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %94, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %79, ptr %95, align 8
-  %96 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %94, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %89, ptr %96, align 8
-  %97 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %98 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %97, i32 0, i32 0
-  store ptr %94, ptr %98, align 8
-  %99 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %97, i32 0, i32 1
-  store i64 2, ptr %99, align 4
-  %100 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %97, i32 0, i32 2
-  store i64 2, ptr %100, align 4
-  %101 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %97, align 8
-  %102 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %93, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %101)
-  store ptr %102, ptr @"main.struct$Ci43nzKYkRLddRL_N4mkykxLXfJlqJGS5n04LKThPNo", align 8
-  %103 = load ptr, ptr @"main.struct$Ci43nzKYkRLddRL_N4mkykxLXfJlqJGS5n04LKThPNo", align 8
-  %104 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %105 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %104, i32 0, i32 0
-  store ptr @3, ptr %105, align 8
-  %106 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %104, i32 0, i32 1
-  store i64 4, ptr %106, align 4
-  %107 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %104, align 8
-  %108 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %109 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %108, i32 0, i32 0
-  store ptr @9, ptr %109, align 8
-  %110 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %108, i32 0, i32 1
-  store i64 3, ptr %110, align 4
-  %111 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %108, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %67, %"github.com/goplus/llgo/internal/runtime.String" %107, %"github.com/goplus/llgo/internal/runtime.String" %111, ptr %103, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  %33 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 8 }, i64 25, i64 16, i64 0, i64 0)
+  store ptr %33, ptr @_llgo_main.bar, align 8
+  %34 = load ptr, ptr @"*_llgo_byte", align 8
+  %35 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %36 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %35)
+  %37 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 2 }, ptr %36, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %38 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 45)
+  %39 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 1 }, ptr %38, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %40 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %41 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %40, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %37, ptr %41, align 8
+  %42 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %40, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %39, ptr %42, align 8
+  %43 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %40, 0
+  %44 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %43, i64 2, 1
+  %45 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %44, i64 2, 2
+  %46 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %45)
+  store ptr %46, ptr @"main.struct$Ci43nzKYkRLddRL_N4mkykxLXfJlqJGS5n04LKThPNo", align 8
+  %47 = load ptr, ptr @"main.struct$Ci43nzKYkRLddRL_N4mkykxLXfJlqJGS5n04LKThPNo", align 8
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %33, %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 3 }, ptr %47, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
   ret void
 
 _llgo_11:                                         ; preds = %_llgo_9
-  %112 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %113 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %114 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %113, i32 0, i32 0
-  store ptr %112, ptr %114, align 8
-  %115 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %113, i32 0, i32 1
-  store i64 0, ptr %115, align 4
-  %116 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %113, i32 0, i32 2
-  store i64 0, ptr %116, align 4
-  %117 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %113, align 8
-  %118 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %119 = getelementptr ptr, ptr %118, i64 0
-  store ptr %60, ptr %119, align 8
-  %120 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %121 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %120, i32 0, i32 0
-  store ptr %118, ptr %121, align 8
-  %122 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %120, i32 0, i32 1
-  store i64 1, ptr %122, align 4
-  %123 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %120, i32 0, i32 2
-  store i64 1, ptr %123, align 4
-  %124 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %120, align 8
-  %125 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %117, %"github.com/goplus/llgo/internal/runtime.Slice" %124, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %125)
-  store ptr %125, ptr @"_llgo_func$NfGSLZ1QiKRoFkKeqYSXE5hUU5bpeteSJKrbMNUzYRE", align 8
+  %48 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %49 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %48, 0
+  %50 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %49, i64 0, 1
+  %51 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %50, i64 0, 2
+  %52 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %53 = getelementptr ptr, ptr %52, i64 0
+  store ptr %30, ptr %53, align 8
+  %54 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %52, 0
+  %55 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %54, i64 1, 1
+  %56 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %55, i64 1, 2
+  %57 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %51, %"github.com/goplus/llgo/internal/runtime.Slice" %56, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %57)
+  store ptr %57, ptr @"_llgo_func$NfGSLZ1QiKRoFkKeqYSXE5hUU5bpeteSJKrbMNUzYRE", align 8
   br label %_llgo_12
 
 _llgo_12:                                         ; preds = %_llgo_11, %_llgo_9
-  %126 = load ptr, ptr @"_llgo_func$NfGSLZ1QiKRoFkKeqYSXE5hUU5bpeteSJKrbMNUzYRE", align 8
-  %127 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %128 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %127, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %58, ptr %128, align 8
-  %129 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %127, i32 0, i32 1
-  store ptr %126, ptr %129, align 8
-  %130 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %127, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/cl/internal/foo.(*Foo).Pb", ptr %130, align 8
-  %131 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %127, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/cl/internal/foo.(*Foo).Pb", ptr %131, align 8
-  %132 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %127, align 8
-  %133 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %134 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %133, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %58, ptr %134, align 8
-  %135 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %133, i32 0, i32 1
-  store ptr %126, ptr %135, align 8
-  %136 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %133, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/cl/internal/foo.(*Foo).Pb", ptr %136, align 8
-  %137 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %133, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/cl/internal/foo.Foo.Pb", ptr %137, align 8
-  %138 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %133, align 8
-  %139 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %140 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %139, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %138, ptr %140, align 8
-  %141 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %142 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %141, i32 0, i32 0
-  store ptr %139, ptr %142, align 8
-  %143 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %141, i32 0, i32 1
-  store i64 1, ptr %143, align 4
-  %144 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %141, i32 0, i32 2
-  store i64 1, ptr %144, align 4
-  %145 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %141, align 8
-  %146 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %147 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %146, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %132, ptr %147, align 8
-  %148 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %149 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %148, i32 0, i32 0
-  store ptr %146, ptr %149, align 8
-  %150 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %148, i32 0, i32 1
-  store i64 1, ptr %150, align 4
-  %151 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %148, i32 0, i32 2
-  store i64 1, ptr %151, align 4
-  %152 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %148, align 8
-  %153 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %154 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %153, i32 0, i32 0
-  store ptr @5, ptr %154, align 8
-  %155 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %153, i32 0, i32 1
-  store i64 38, ptr %155, align 4
-  %156 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %153, align 8
-  %157 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %158 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %157, i32 0, i32 0
-  store ptr @6, ptr %158, align 8
-  %159 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %157, i32 0, i32 1
-  store i64 3, ptr %159, align 4
-  %160 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %157, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %4, %"github.com/goplus/llgo/internal/runtime.String" %156, %"github.com/goplus/llgo/internal/runtime.String" %160, ptr %54, %"github.com/goplus/llgo/internal/runtime.Slice" %145, %"github.com/goplus/llgo/internal/runtime.Slice" %152)
+  %58 = load ptr, ptr @"_llgo_func$NfGSLZ1QiKRoFkKeqYSXE5hUU5bpeteSJKrbMNUzYRE", align 8
+  %59 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 2 }, ptr undef, ptr undef, ptr undef }, ptr %58, 1
+  %60 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %59, ptr @"github.com/goplus/llgo/cl/internal/foo.(*Foo).Pb", 2
+  %61 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %60, ptr @"github.com/goplus/llgo/cl/internal/foo.(*Foo).Pb", 3
+  %62 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 2 }, ptr undef, ptr undef, ptr undef }, ptr %58, 1
+  %63 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %62, ptr @"github.com/goplus/llgo/cl/internal/foo.(*Foo).Pb", 2
+  %64 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %63, ptr @"github.com/goplus/llgo/cl/internal/foo.Foo.Pb", 3
+  %65 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %66 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %65, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %64, ptr %66, align 8
+  %67 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %65, 0
+  %68 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %67, i64 1, 1
+  %69 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %68, i64 1, 2
+  %70 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %71 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %70, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %61, ptr %71, align 8
+  %72 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %70, 0
+  %73 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %72, i64 1, 1
+  %74 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %73, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %0, %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 38 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 3 }, ptr %28, %"github.com/goplus/llgo/internal/runtime.Slice" %69, %"github.com/goplus/llgo/internal/runtime.Slice" %74)
   br label %_llgo_10
 }
 

--- a/cl/_testgo/syncmap/out.ll
+++ b/cl/_testgo/syncmap/out.ll
@@ -40,99 +40,46 @@ _llgo_0:
   call void @main.init()
   %2 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
   %3 = load ptr, ptr @_llgo_int, align 8
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %4, i32 0, i32 0
-  store ptr %3, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %4, i32 0, i32 1
-  store ptr inttoptr (i64 1 to ptr), ptr %6, align 8
-  %7 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %4, align 8
-  %8 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %8, i32 0, i32 0
-  store ptr @0, ptr %9, align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %8, i32 0, i32 1
-  store i64 5, ptr %10, align 4
-  %11 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %8, align 8
-  %12 = load ptr, ptr @_llgo_string, align 8
-  %13 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %11, ptr %13, align 8
-  %14 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %14, i32 0, i32 0
-  store ptr %12, ptr %15, align 8
-  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %14, i32 0, i32 1
-  store ptr %13, ptr %16, align 8
-  %17 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %14, align 8
-  call void @"sync.(*Map).Store"(ptr %2, %"github.com/goplus/llgo/internal/runtime.eface" %7, %"github.com/goplus/llgo/internal/runtime.eface" %17)
-  %18 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %19 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %18, i32 0, i32 0
-  store ptr @1, ptr %19, align 8
-  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %18, i32 0, i32 1
-  store i64 1, ptr %20, align 4
-  %21 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %18, align 8
-  %22 = load ptr, ptr @_llgo_string, align 8
-  %23 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %21, ptr %23, align 8
-  %24 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %24, i32 0, i32 0
-  store ptr %22, ptr %25, align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %24, i32 0, i32 1
-  store ptr %23, ptr %26, align 8
-  %27 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %24, align 8
-  %28 = load ptr, ptr @_llgo_int, align 8
-  %29 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %29, i32 0, i32 0
-  store ptr %28, ptr %30, align 8
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %29, i32 0, i32 1
-  store ptr inttoptr (i64 100 to ptr), ptr %31, align 8
-  %32 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %29, align 8
-  call void @"sync.(*Map).Store"(ptr %2, %"github.com/goplus/llgo/internal/runtime.eface" %27, %"github.com/goplus/llgo/internal/runtime.eface" %32)
-  %33 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %33, i32 0, i32 0
-  store ptr @1, ptr %34, align 8
-  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %33, i32 0, i32 1
-  store i64 1, ptr %35, align 4
-  %36 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %33, align 8
-  %37 = load ptr, ptr @_llgo_string, align 8
-  %38 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %36, ptr %38, align 8
-  %39 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %40 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %39, i32 0, i32 0
-  store ptr %37, ptr %40, align 8
-  %41 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %39, i32 0, i32 1
-  store ptr %38, ptr %41, align 8
-  %42 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %39, align 8
-  %43 = call { %"github.com/goplus/llgo/internal/runtime.eface", i1 } @"sync.(*Map).Load"(ptr %2, %"github.com/goplus/llgo/internal/runtime.eface" %42)
-  %44 = extractvalue { %"github.com/goplus/llgo/internal/runtime.eface", i1 } %43, 0
-  %45 = extractvalue { %"github.com/goplus/llgo/internal/runtime.eface", i1 } %43, 1
-  %46 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
-  %47 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %46, i64 0
-  store %"github.com/goplus/llgo/internal/runtime.eface" %44, ptr %47, align 8
-  %48 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %46, i64 1
-  %49 = load ptr, ptr @_llgo_bool, align 8
-  %50 = sext i1 %45 to i64
-  %51 = inttoptr i64 %50 to ptr
-  %52 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %53 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %52, i32 0, i32 0
-  store ptr %49, ptr %53, align 8
-  %54 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %52, i32 0, i32 1
-  store ptr %51, ptr %54, align 8
-  %55 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %52, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %55, ptr %48, align 8
-  %56 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %56, i32 0, i32 0
-  store ptr %46, ptr %57, align 8
-  %58 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %56, i32 0, i32 1
-  store i64 2, ptr %58, align 4
-  %59 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %56, i32 0, i32 2
-  store i64 2, ptr %59, align 4
-  %60 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %56, align 8
-  %61 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @fmt.Println(%"github.com/goplus/llgo/internal/runtime.Slice" %60)
-  %62 = alloca { ptr, ptr }, align 8
-  %63 = getelementptr inbounds { ptr, ptr }, ptr %62, i32 0, i32 0
-  store ptr @"__llgo_stub.main.main$1", ptr %63, align 8
-  %64 = getelementptr inbounds { ptr, ptr }, ptr %62, i32 0, i32 1
-  store ptr null, ptr %64, align 8
-  %65 = load { ptr, ptr }, ptr %62, align 8
-  call void @"sync.(*Map).Range"(ptr %2, { ptr, ptr } %65)
+  %4 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %3, 0
+  %5 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %4, ptr inttoptr (i64 1 to ptr), 1
+  %6 = load ptr, ptr @_llgo_string, align 8
+  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %7, align 8
+  %8 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %6, 0
+  %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %8, ptr %7, 1
+  call void @"sync.(*Map).Store"(ptr %2, %"github.com/goplus/llgo/internal/runtime.eface" %5, %"github.com/goplus/llgo/internal/runtime.eface" %9)
+  %10 = load ptr, ptr @_llgo_string, align 8
+  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 1 }, ptr %11, align 8
+  %12 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %10, 0
+  %13 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %12, ptr %11, 1
+  %14 = load ptr, ptr @_llgo_int, align 8
+  %15 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %14, 0
+  %16 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %15, ptr inttoptr (i64 100 to ptr), 1
+  call void @"sync.(*Map).Store"(ptr %2, %"github.com/goplus/llgo/internal/runtime.eface" %13, %"github.com/goplus/llgo/internal/runtime.eface" %16)
+  %17 = load ptr, ptr @_llgo_string, align 8
+  %18 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 1 }, ptr %18, align 8
+  %19 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %17, 0
+  %20 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %19, ptr %18, 1
+  %21 = call { %"github.com/goplus/llgo/internal/runtime.eface", i1 } @"sync.(*Map).Load"(ptr %2, %"github.com/goplus/llgo/internal/runtime.eface" %20)
+  %22 = extractvalue { %"github.com/goplus/llgo/internal/runtime.eface", i1 } %21, 0
+  %23 = extractvalue { %"github.com/goplus/llgo/internal/runtime.eface", i1 } %21, 1
+  %24 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
+  %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %24, i64 0
+  store %"github.com/goplus/llgo/internal/runtime.eface" %22, ptr %25, align 8
+  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %24, i64 1
+  %27 = load ptr, ptr @_llgo_bool, align 8
+  %28 = sext i1 %23 to i64
+  %29 = inttoptr i64 %28 to ptr
+  %30 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %27, 0
+  %31 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %30, ptr %29, 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %31, ptr %26, align 8
+  %32 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %24, 0
+  %33 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %32, i64 2, 1
+  %34 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %33, i64 2, 2
+  %35 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @fmt.Println(%"github.com/goplus/llgo/internal/runtime.Slice" %34)
+  call void @"sync.(*Map).Range"(ptr %2, { ptr, ptr } { ptr @"__llgo_stub.main.main$1", ptr null })
   ret i32 0
 }
 
@@ -143,21 +90,10 @@ _llgo_0:
   store %"github.com/goplus/llgo/internal/runtime.eface" %0, ptr %3, align 8
   %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %2, i64 1
   store %"github.com/goplus/llgo/internal/runtime.eface" %1, ptr %4, align 8
-  %5 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %5, i32 0, i32 0
-  store ptr %2, ptr %6, align 8
-  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %5, i32 0, i32 1
-  store i64 2, ptr %7, align 4
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %5, i32 0, i32 2
-  store i64 2, ptr %8, align 4
-  %9 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %5, align 8
-  %10 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %10, i32 0, i32 0
-  store ptr @2, ptr %11, align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %10, i32 0, i32 1
-  store i64 7, ptr %12, align 4
-  %13 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %10, align 8
-  %14 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @fmt.Printf(%"github.com/goplus/llgo/internal/runtime.String" %13, %"github.com/goplus/llgo/internal/runtime.Slice" %9)
+  %5 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %2, 0
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %5, i64 2, 1
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %6, i64 2, 2
+  %8 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @fmt.Printf(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 7 }, %"github.com/goplus/llgo/internal/runtime.Slice" %7)
   ret i1 true
 }
 

--- a/cl/_testgo/tpindex/out.ll
+++ b/cl/_testgo/tpindex/out.ll
@@ -37,19 +37,14 @@ _llgo_0:
   store i64 2, ptr %6, align 4
   %7 = getelementptr inbounds i64, ptr %2, i64 4
   store i64 4, ptr %7, align 4
-  %8 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %8, i32 0, i32 0
-  store ptr %2, ptr %9, align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %8, i32 0, i32 1
-  store i64 5, ptr %10, align 4
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %8, i32 0, i32 2
-  store i64 5, ptr %11, align 4
-  %12 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %8, align 8
-  %13 = call i64 @"main.index[int]"(%"github.com/goplus/llgo/internal/runtime.Slice" %12, i64 3)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %13)
+  %8 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %2, 0
+  %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %8, i64 5, 1
+  %10 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, i64 5, 2
+  %11 = call i64 @"main.index[int]"(%"github.com/goplus/llgo/internal/runtime.Slice" %10, i64 3)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %11)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %14 = call i64 @"main.index[int]"(%"github.com/goplus/llgo/internal/runtime.Slice" %12, i64 6)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %14)
+  %12 = call i64 @"main.index[int]"(%"github.com/goplus/llgo/internal/runtime.Slice" %10, i64 6)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %12)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 }

--- a/cl/_testgo/tpnamed/out.ll
+++ b/cl/_testgo/tpnamed/out.ll
@@ -14,24 +14,12 @@ source_filename = "main"
 
 define %"main.IO[error]" @main.WriteFile(%"github.com/goplus/llgo/internal/runtime.String" %0) {
 _llgo_0:
-  %1 = alloca %"main.IO[error]", align 8
-  %2 = getelementptr inbounds %"main.IO[error]", ptr %1, i32 0, i32 0
-  store ptr @"__llgo_stub.main.WriteFile$1", ptr %2, align 8
-  %3 = getelementptr inbounds %"main.IO[error]", ptr %1, i32 0, i32 1
-  store ptr null, ptr %3, align 8
-  %4 = load %"main.IO[error]", ptr %1, align 8
-  ret %"main.IO[error]" %4
+  ret %"main.IO[error]" { ptr @"__llgo_stub.main.WriteFile$1", ptr null }
 }
 
 define %"main.Future[error]" @"main.WriteFile$1"() {
 _llgo_0:
-  %0 = alloca %"main.Future[error]", align 8
-  %1 = getelementptr inbounds %"main.Future[error]", ptr %0, i32 0, i32 0
-  store ptr @"__llgo_stub.main.WriteFile$1$1", ptr %1, align 8
-  %2 = getelementptr inbounds %"main.Future[error]", ptr %0, i32 0, i32 1
-  store ptr null, ptr %2, align 8
-  %3 = load %"main.Future[error]", ptr %0, align 8
-  ret %"main.Future[error]" %3
+  ret %"main.Future[error]" { ptr @"__llgo_stub.main.WriteFile$1$1", ptr null }
 }
 
 define %"github.com/goplus/llgo/internal/runtime.iface" @"main.WriteFile$1$1"() {
@@ -58,25 +46,13 @@ _llgo_0:
   store ptr %1, ptr @__llgo_argv, align 8
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
-  %2 = alloca %"main.IO[[0]byte]", align 8
-  %3 = getelementptr inbounds %"main.IO[[0]byte]", ptr %2, i32 0, i32 0
-  store ptr @"__llgo_stub.main.main$1", ptr %3, align 8
-  %4 = getelementptr inbounds %"main.IO[[0]byte]", ptr %2, i32 0, i32 1
-  store ptr null, ptr %4, align 8
-  %5 = load %"main.IO[[0]byte]", ptr %2, align 8
-  %6 = call [0 x i8] @"main.RunIO[[0]byte]"(%"main.IO[[0]byte]" %5)
+  %2 = call [0 x i8] @"main.RunIO[[0]byte]"(%"main.IO[[0]byte]" { ptr @"__llgo_stub.main.main$1", ptr null })
   ret i32 0
 }
 
 define %"main.Future[[0]byte]" @"main.main$1"() {
 _llgo_0:
-  %0 = alloca %"main.Future[[0]byte]", align 8
-  %1 = getelementptr inbounds %"main.Future[[0]byte]", ptr %0, i32 0, i32 0
-  store ptr @"__llgo_stub.main.main$1$1", ptr %1, align 8
-  %2 = getelementptr inbounds %"main.Future[[0]byte]", ptr %0, i32 0, i32 1
-  store ptr null, ptr %2, align 8
-  %3 = load %"main.Future[[0]byte]", ptr %0, align 8
-  ret %"main.Future[[0]byte]" %3
+  ret %"main.Future[[0]byte]" { ptr @"__llgo_stub.main.main$1$1", ptr null }
 }
 
 define [0 x i8] @"main.main$1$1"() {

--- a/cl/_testgo/tprecur/out.ll
+++ b/cl/_testgo/tprecur/out.ll
@@ -42,22 +42,12 @@ _llgo_0:
   br i1 %1, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %2 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 0
-  store ptr @0, ptr %3, align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 1
-  store i64 5, ptr %4, align 4
-  %5 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
-  %6 = load ptr, ptr @_llgo_string, align 8
-  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %5, ptr %7, align 8
-  %8 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, i32 0, i32 0
-  store ptr %6, ptr %9, align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, i32 0, i32 1
-  store ptr %7, ptr %10, align 8
-  %11 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %11)
+  %2 = load ptr, ptr @_llgo_string, align 8
+  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %3, align 8
+  %4 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %2, 0
+  %5 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %4, ptr %3, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %5)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_0

--- a/cl/_testgo/tprecurfn/out.ll
+++ b/cl/_testgo/tprecurfn/out.ll
@@ -30,21 +30,15 @@ _llgo_0:
   %3 = getelementptr inbounds %"main.My[int]", ptr %2, i32 0, i32 1
   %4 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
   %5 = getelementptr inbounds %"main.My[int]", ptr %4, i32 0, i32 0
-  %6 = alloca { ptr, ptr }, align 8
-  %7 = getelementptr inbounds { ptr, ptr }, ptr %6, i32 0, i32 0
-  store ptr @"__llgo_stub.main.main$1", ptr %7, align 8
-  %8 = getelementptr inbounds { ptr, ptr }, ptr %6, i32 0, i32 1
-  store ptr null, ptr %8, align 8
-  %9 = load { ptr, ptr }, ptr %6, align 8
-  store { ptr, ptr } %9, ptr %5, align 8
+  store { ptr, ptr } { ptr @"__llgo_stub.main.main$1", ptr null }, ptr %5, align 8
   store ptr %4, ptr %3, align 8
-  %10 = getelementptr inbounds %"main.My[int]", ptr %2, i32 0, i32 1
-  %11 = load ptr, ptr %10, align 8
-  %12 = getelementptr inbounds %"main.My[int]", ptr %11, i32 0, i32 0
-  %13 = load { ptr, ptr }, ptr %12, align 8
-  %14 = extractvalue { ptr, ptr } %13, 1
-  %15 = extractvalue { ptr, ptr } %13, 0
-  call void %15(ptr %14, i64 100)
+  %6 = getelementptr inbounds %"main.My[int]", ptr %2, i32 0, i32 1
+  %7 = load ptr, ptr %6, align 8
+  %8 = getelementptr inbounds %"main.My[int]", ptr %7, i32 0, i32 0
+  %9 = load { ptr, ptr }, ptr %8, align 8
+  %10 = extractvalue { ptr, ptr } %9, 1
+  %11 = extractvalue { ptr, ptr } %9, 0
+  call void %11(ptr %10, i64 100)
   ret i32 0
 }
 

--- a/cl/_testgo/tptypes/out.ll
+++ b/cl/_testgo/tptypes/out.ll
@@ -43,151 +43,113 @@ _llgo_0:
   %6 = alloca %"main.Data[string]", align 8
   call void @llvm.memset(ptr %6, i8 0, i64 16, i1 false)
   %7 = getelementptr inbounds %"main.Data[string]", ptr %6, i32 0, i32 0
-  %8 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %8, i32 0, i32 0
-  store ptr @0, ptr %9, align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %8, i32 0, i32 1
-  store i64 5, ptr %10, align 4
-  %11 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %8, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %11, ptr %7, align 8
-  %12 = load %"main.Data[string]", ptr %6, align 8
-  %13 = extractvalue %"main.Data[string]" %12, 0
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %13)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %7, align 8
+  %8 = load %"main.Data[string]", ptr %6, align 8
+  %9 = extractvalue %"main.Data[string]" %8, 0
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %9)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %14 = alloca %"main.Data[int]", align 8
-  call void @llvm.memset(ptr %14, i8 0, i64 8, i1 false)
-  %15 = getelementptr inbounds %"main.Data[int]", ptr %14, i32 0, i32 0
-  store i64 100, ptr %15, align 4
-  %16 = load %"main.Data[int]", ptr %14, align 4
-  %17 = extractvalue %"main.Data[int]" %16, 0
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %17)
+  %10 = alloca %"main.Data[int]", align 8
+  call void @llvm.memset(ptr %10, i8 0, i64 8, i1 false)
+  %11 = getelementptr inbounds %"main.Data[int]", ptr %10, i32 0, i32 0
+  store i64 100, ptr %11, align 4
+  %12 = load %"main.Data[int]", ptr %10, align 4
+  %13 = extractvalue %"main.Data[int]" %12, 0
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %13)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %18 = alloca %"main.Data[string]", align 8
-  call void @llvm.memset(ptr %18, i8 0, i64 16, i1 false)
-  %19 = getelementptr inbounds %"main.Data[string]", ptr %18, i32 0, i32 0
-  %20 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %20, i32 0, i32 0
-  store ptr @0, ptr %21, align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %20, i32 0, i32 1
-  store i64 5, ptr %22, align 4
-  %23 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %20, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %23, ptr %19, align 8
-  %24 = load %"main.Data[string]", ptr %18, align 8
-  %25 = extractvalue %"main.Data[string]" %24, 0
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %25)
+  %14 = alloca %"main.Data[string]", align 8
+  call void @llvm.memset(ptr %14, i8 0, i64 16, i1 false)
+  %15 = getelementptr inbounds %"main.Data[string]", ptr %14, i32 0, i32 0
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %15, align 8
+  %16 = load %"main.Data[string]", ptr %14, align 8
+  %17 = extractvalue %"main.Data[string]" %16, 0
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %17)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 0)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
-  %27 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 8)
-  %28 = getelementptr inbounds i64, ptr %27, i64 0
-  store i64 100, ptr %28, align 4
-  %29 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %29, i32 0, i32 0
-  store ptr %27, ptr %30, align 8
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %29, i32 0, i32 1
-  store i64 1, ptr %31, align 4
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %29, i32 0, i32 2
-  store i64 1, ptr %32, align 4
-  %33 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %29, align 8
-  %34 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"main.(*Slice[[]int,int]).Append"(ptr %26, %"github.com/goplus/llgo/internal/runtime.Slice" %33)
-  %35 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
-  %36 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 16)
-  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %36, i64 0
-  %38 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %38, i32 0, i32 0
-  store ptr @0, ptr %39, align 8
-  %40 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %38, i32 0, i32 1
-  store i64 5, ptr %40, align 4
-  %41 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %38, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %41, ptr %37, align 8
-  %42 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, i32 0, i32 0
-  store ptr %36, ptr %43, align 8
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, i32 0, i32 1
-  store i64 1, ptr %44, align 4
-  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, i32 0, i32 2
-  store i64 1, ptr %45, align 4
-  %46 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, align 8
-  %47 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"main.(*Slice[[]string,string]).Append"(ptr %35, %"github.com/goplus/llgo/internal/runtime.Slice" %46)
-  %48 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
-  %49 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
-  %50 = getelementptr inbounds i64, ptr %49, i64 0
-  store i64 1, ptr %50, align 4
-  %51 = getelementptr inbounds i64, ptr %49, i64 1
-  store i64 2, ptr %51, align 4
-  %52 = getelementptr inbounds i64, ptr %49, i64 2
-  store i64 3, ptr %52, align 4
-  %53 = getelementptr inbounds i64, ptr %49, i64 3
-  store i64 4, ptr %53, align 4
-  %54 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %54, i32 0, i32 0
-  store ptr %49, ptr %55, align 8
-  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %54, i32 0, i32 1
-  store i64 4, ptr %56, align 4
-  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %54, i32 0, i32 2
-  store i64 4, ptr %57, align 4
-  %58 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %54, align 8
-  %59 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"main.(*Slice[[]int,int]).Append"(ptr %48, %"github.com/goplus/llgo/internal/runtime.Slice" %58)
-  %60 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
-  %61 = getelementptr inbounds i64, ptr %60, i64 0
-  store i64 1, ptr %61, align 4
-  %62 = getelementptr inbounds i64, ptr %60, i64 1
-  store i64 2, ptr %62, align 4
-  %63 = getelementptr inbounds i64, ptr %60, i64 2
-  store i64 3, ptr %63, align 4
-  %64 = getelementptr inbounds i64, ptr %60, i64 3
-  store i64 4, ptr %64, align 4
-  %65 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %66 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %65, i32 0, i32 0
-  store ptr %60, ptr %66, align 8
-  %67 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %65, i32 0, i32 1
-  store i64 4, ptr %67, align 4
-  %68 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %65, i32 0, i32 2
-  store i64 4, ptr %68, align 4
-  %69 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %65, align 8
-  %70 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"main.(*Slice[[]int,int]).Append2"(ptr %48, %"github.com/goplus/llgo/internal/runtime.Slice" %69)
-  %71 = getelementptr inbounds %"main.Slice[[]int,int]", ptr %26, i32 0, i32 0
+  %18 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
+  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 8)
+  %20 = getelementptr inbounds i64, ptr %19, i64 0
+  store i64 100, ptr %20, align 4
+  %21 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %19, 0
+  %22 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %21, i64 1, 1
+  %23 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %22, i64 1, 2
+  %24 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"main.(*Slice[[]int,int]).Append"(ptr %18, %"github.com/goplus/llgo/internal/runtime.Slice" %23)
+  %25 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
+  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 16)
+  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %26, i64 0
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %27, align 8
+  %28 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %26, 0
+  %29 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %28, i64 1, 1
+  %30 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %29, i64 1, 2
+  %31 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"main.(*Slice[[]string,string]).Append"(ptr %25, %"github.com/goplus/llgo/internal/runtime.Slice" %30)
+  %32 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
+  %33 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
+  %34 = getelementptr inbounds i64, ptr %33, i64 0
+  store i64 1, ptr %34, align 4
+  %35 = getelementptr inbounds i64, ptr %33, i64 1
+  store i64 2, ptr %35, align 4
+  %36 = getelementptr inbounds i64, ptr %33, i64 2
+  store i64 3, ptr %36, align 4
+  %37 = getelementptr inbounds i64, ptr %33, i64 3
+  store i64 4, ptr %37, align 4
+  %38 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %33, 0
+  %39 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %38, i64 4, 1
+  %40 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %39, i64 4, 2
+  %41 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"main.(*Slice[[]int,int]).Append"(ptr %32, %"github.com/goplus/llgo/internal/runtime.Slice" %40)
+  %42 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
+  %43 = getelementptr inbounds i64, ptr %42, i64 0
+  store i64 1, ptr %43, align 4
+  %44 = getelementptr inbounds i64, ptr %42, i64 1
+  store i64 2, ptr %44, align 4
+  %45 = getelementptr inbounds i64, ptr %42, i64 2
+  store i64 3, ptr %45, align 4
+  %46 = getelementptr inbounds i64, ptr %42, i64 3
+  store i64 4, ptr %46, align 4
+  %47 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %42, 0
+  %48 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %47, i64 4, 1
+  %49 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %48, i64 4, 2
+  %50 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"main.(*Slice[[]int,int]).Append2"(ptr %32, %"github.com/goplus/llgo/internal/runtime.Slice" %49)
+  %51 = getelementptr inbounds %"main.Slice[[]int,int]", ptr %18, i32 0, i32 0
+  %52 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %51, align 8
+  %53 = getelementptr inbounds %"main.Slice[[]int,int]", ptr %18, i32 0, i32 0
+  %54 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %53, align 8
+  %55 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %54, 0
+  %56 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %54, 1
+  %57 = icmp sge i64 0, %56
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %57)
+  %58 = getelementptr inbounds i64, ptr %55, i64 0
+  %59 = load i64, ptr %58, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %52)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %59)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
+  %60 = getelementptr inbounds %"main.Slice[[]string,string]", ptr %25, i32 0, i32 0
+  %61 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %60, align 8
+  %62 = getelementptr inbounds %"main.Slice[[]string,string]", ptr %25, i32 0, i32 0
+  %63 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %62, align 8
+  %64 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %63, 0
+  %65 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %63, 1
+  %66 = icmp sge i64 0, %65
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %66)
+  %67 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %64, i64 0
+  %68 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %67, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %61)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %68)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
+  %69 = getelementptr inbounds %"main.Slice[[]int,int]", ptr %32, i32 0, i32 0
+  %70 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %69, align 8
+  %71 = getelementptr inbounds %"main.Slice[[]int,int]", ptr %32, i32 0, i32 0
   %72 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %71, align 8
-  %73 = getelementptr inbounds %"main.Slice[[]int,int]", ptr %26, i32 0, i32 0
-  %74 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %73, align 8
-  %75 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %74, 0
-  %76 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %74, 1
-  %77 = icmp sge i64 0, %76
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %77)
-  %78 = getelementptr inbounds i64, ptr %75, i64 0
-  %79 = load i64, ptr %78, align 4
-  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %72)
+  %73 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %72, 0
+  %74 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %72, 1
+  %75 = icmp sge i64 0, %74
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %75)
+  %76 = getelementptr inbounds i64, ptr %73, i64 0
+  %77 = load i64, ptr %76, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %70)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %79)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %80 = getelementptr inbounds %"main.Slice[[]string,string]", ptr %35, i32 0, i32 0
-  %81 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %80, align 8
-  %82 = getelementptr inbounds %"main.Slice[[]string,string]", ptr %35, i32 0, i32 0
-  %83 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %82, align 8
-  %84 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %83, 0
-  %85 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %83, 1
-  %86 = icmp sge i64 0, %85
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %86)
-  %87 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %84, i64 0
-  %88 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %87, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %81)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %88)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %89 = getelementptr inbounds %"main.Slice[[]int,int]", ptr %48, i32 0, i32 0
-  %90 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %89, align 8
-  %91 = getelementptr inbounds %"main.Slice[[]int,int]", ptr %48, i32 0, i32 0
-  %92 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %91, align 8
-  %93 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %92, 0
-  %94 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %92, 1
-  %95 = icmp sge i64 0, %94
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %95)
-  %96 = getelementptr inbounds i64, ptr %93, i64 0
-  %97 = load i64, ptr %96, align 4
-  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %90)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %97)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %77)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 }

--- a/cl/_testlibc/allocacstrs/out.ll
+++ b/cl/_testlibc/allocacstrs/out.ll
@@ -33,83 +33,60 @@ _llgo_0:
   call void @main.init()
   %2 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 48)
   %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i64 0
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @0, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 1, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %7, ptr %3, align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i64 1
-  %9 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %9, i32 0, i32 0
-  store ptr @1, ptr %10, align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %9, i32 0, i32 1
-  store i64 1, ptr %11, align 4
-  %12 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %9, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %12, ptr %8, align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i64 2
-  %14 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %14, i32 0, i32 0
-  store ptr @2, ptr %15, align 8
-  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %14, i32 0, i32 1
-  store i64 1, ptr %16, align 4
-  %17 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %14, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %17, ptr %13, align 8
-  %18 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %19 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %18, i32 0, i32 0
-  store ptr %2, ptr %19, align 8
-  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %18, i32 0, i32 1
-  store i64 3, ptr %20, align 4
-  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %18, i32 0, i32 2
-  store i64 3, ptr %21, align 4
-  %22 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %18, align 8
-  %23 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %22, 1
-  %24 = add i64 %23, 1
-  %25 = alloca ptr, i64 %24, align 8
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 1 }, ptr %3, align 8
+  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i64 1
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 1 }, ptr %4, align 8
+  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i64 2
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 1 }, ptr %5, align 8
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %2, 0
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %6, i64 3, 1
+  %8 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %7, i64 3, 2
+  %9 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %8, 1
+  %10 = add i64 %9, 1
+  %11 = alloca ptr, i64 %10, align 8
   br label %_llgo_4
 
 _llgo_1:                                          ; preds = %_llgo_3, %_llgo_6
-  %26 = phi i64 [ 0, %_llgo_6 ], [ %31, %_llgo_3 ]
-  %27 = getelementptr ptr, ptr %25, i64 %26
-  %28 = load ptr, ptr %27, align 8
-  %29 = icmp eq ptr %28, null
-  br i1 %29, label %_llgo_2, label %_llgo_3
+  %12 = phi i64 [ 0, %_llgo_6 ], [ %17, %_llgo_3 ]
+  %13 = getelementptr ptr, ptr %11, i64 %12
+  %14 = load ptr, ptr %13, align 8
+  %15 = icmp eq ptr %14, null
+  br i1 %15, label %_llgo_2, label %_llgo_3
 
 _llgo_2:                                          ; preds = %_llgo_1
   ret i32 0
 
 _llgo_3:                                          ; preds = %_llgo_1
-  %30 = call i32 (ptr, ...) @printf(ptr @3, ptr %28)
-  %31 = add i64 %26, 1
+  %16 = call i32 (ptr, ...) @printf(ptr @3, ptr %14)
+  %17 = add i64 %12, 1
   br label %_llgo_1
 
 _llgo_4:                                          ; preds = %_llgo_5, %_llgo_0
-  %32 = phi i64 [ 0, %_llgo_0 ], [ %46, %_llgo_5 ]
-  %33 = icmp slt i64 %32, %23
-  br i1 %33, label %_llgo_5, label %_llgo_6
+  %18 = phi i64 [ 0, %_llgo_0 ], [ %32, %_llgo_5 ]
+  %19 = icmp slt i64 %18, %9
+  br i1 %19, label %_llgo_5, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_4
-  %34 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %22, 0
-  %35 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %22, 1
-  %36 = icmp slt i64 %32, 0
-  %37 = icmp sge i64 %32, %35
-  %38 = or i1 %37, %36
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %38)
-  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %34, i64 %32
-  %40 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %39, align 8
-  %41 = getelementptr ptr, ptr %25, i64 %32
-  %42 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %40, 1
-  %43 = add i64 %42, 1
-  %44 = alloca i8, i64 %43, align 1
-  %45 = call ptr @"github.com/goplus/llgo/internal/runtime.CStrCopy"(ptr %44, %"github.com/goplus/llgo/internal/runtime.String" %40)
-  store ptr %45, ptr %41, align 8
-  %46 = add i64 %32, 1
+  %20 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %8, 0
+  %21 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %8, 1
+  %22 = icmp slt i64 %18, 0
+  %23 = icmp sge i64 %18, %21
+  %24 = or i1 %23, %22
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %24)
+  %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %20, i64 %18
+  %26 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %25, align 8
+  %27 = getelementptr ptr, ptr %11, i64 %18
+  %28 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %26, 1
+  %29 = add i64 %28, 1
+  %30 = alloca i8, i64 %29, align 1
+  %31 = call ptr @"github.com/goplus/llgo/internal/runtime.CStrCopy"(ptr %30, %"github.com/goplus/llgo/internal/runtime.String" %26)
+  store ptr %31, ptr %27, align 8
+  %32 = add i64 %18, 1
   br label %_llgo_4
 
 _llgo_6:                                          ; preds = %_llgo_4
-  %47 = getelementptr ptr, ptr %25, i64 %23
-  store ptr null, ptr %47, align 8
+  %33 = getelementptr ptr, ptr %11, i64 %9
+  store ptr null, ptr %33, align 8
   br label %_llgo_1
 }
 

--- a/cl/_testlibc/complex/out.ll
+++ b/cl/_testlibc/complex/out.ll
@@ -13,51 +13,27 @@ source_filename = "main"
 
 define void @main.f({ float, float } %0, { float, float } %1, ptr %2) {
 _llgo_0:
-  %3 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3, i32 0, i32 0
-  store ptr @0, ptr %4, align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3, i32 0, i32 1
-  store i64 5, ptr %5, align 4
-  %6 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %6)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %2)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %7 = call float @cabsf({ float, float } %0)
-  %8 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %8, i32 0, i32 0
-  store ptr @1, ptr %9, align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %8, i32 0, i32 1
-  store i64 10, ptr %10, align 4
-  %11 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %8, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %11)
+  %3 = call float @cabsf({ float, float } %0)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 10 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  %12 = fpext float %7 to double
-  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %12)
+  %4 = fpext float %3 to double
+  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %4)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %13 = extractvalue { float, float } %1, 0
-  %14 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %14, i32 0, i32 0
-  store ptr @2, ptr %15, align 8
-  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %14, i32 0, i32 1
-  store i64 11, ptr %16, align 4
-  %17 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %14, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %17)
+  %5 = extractvalue { float, float } %1, 0
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 11 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  %18 = fpext float %13 to double
-  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %18)
+  %6 = fpext float %5 to double
+  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %6)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %19 = extractvalue { float, float } %1, 1
-  %20 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %20, i32 0, i32 0
-  store ptr @3, ptr %21, align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %20, i32 0, i32 1
-  store i64 11, ptr %22, align 4
-  %23 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %20, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %23)
+  %7 = extractvalue { float, float } %1, 1
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 11 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  %24 = fpext float %19 to double
-  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %24)
+  %8 = fpext float %7 to double
+  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %8)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret void
 }
@@ -81,13 +57,7 @@ _llgo_0:
   store ptr %1, ptr @__llgo_argv, align 8
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
-  %2 = alloca { float, float }, align 8
-  %3 = getelementptr inbounds { float, float }, ptr %2, i32 0, i32 0
-  store float 3.000000e+00, ptr %3, align 4
-  %4 = getelementptr inbounds { float, float }, ptr %2, i32 0, i32 1
-  store float 4.000000e+00, ptr %4, align 4
-  %5 = load { float, float }, ptr %2, align 4
-  call void @main.f({ float, float } %5, { float, float } { float 3.000000e+00, float 4.000000e+00 }, ptr @main.f)
+  call void @main.f({ float, float } { float 3.000000e+00, float 4.000000e+00 }, { float, float } { float 3.000000e+00, float 4.000000e+00 }, ptr @main.f)
   ret i32 0
 }
 

--- a/cl/_testlibc/demangle/out.ll
+++ b/cl/_testlibc/demangle/out.ll
@@ -29,31 +29,19 @@ _llgo_0:
   store ptr %1, ptr @__llgo_argv, align 8
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
-  %2 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 0
-  store ptr @0, ptr %3, align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 1
-  store i64 29, ptr %4, align 4
-  %5 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
-  %6 = call ptr @_ZN4llvm15itaniumDemangleENSt3__117basic_string_viewIcNS0_11char_traitsIcEEEEb(%"github.com/goplus/llgo/internal/runtime.String" %5, i1 true)
-  %7 = icmp ne ptr %6, null
-  br i1 %7, label %_llgo_1, label %_llgo_3
+  %2 = call ptr @_ZN4llvm15itaniumDemangleENSt3__117basic_string_viewIcNS0_11char_traitsIcEEEEb(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 29 }, i1 true)
+  %3 = icmp ne ptr %2, null
+  br i1 %3, label %_llgo_1, label %_llgo_3
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %8 = call i32 (ptr, ...) @printf(ptr @1, ptr %6)
+  %4 = call i32 (ptr, ...) @printf(ptr @1, ptr %2)
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_3, %_llgo_1
   ret i32 0
 
 _llgo_3:                                          ; preds = %_llgo_0
-  %9 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %9, i32 0, i32 0
-  store ptr @2, ptr %10, align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %9, i32 0, i32 1
-  store i64 18, ptr %11, align 4
-  %12 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %9, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %12)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 18 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_2
 }

--- a/cl/_testlibgo/atomic/out.ll
+++ b/cl/_testlibgo/atomic/out.ll
@@ -34,103 +34,49 @@ _llgo_0:
   %2 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 8)
   call void @"sync/atomic.StoreInt64"(ptr %2, i64 100)
   %3 = call i64 @"sync/atomic.LoadInt64"(ptr %2)
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @0, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 6, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %7)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 6 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %3)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %8 = call i64 @"sync/atomic.AddInt64"(ptr %2, i64 1)
+  %4 = call i64 @"sync/atomic.AddInt64"(ptr %2, i64 1)
+  %5 = load i64, ptr %2, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 })
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %4)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 2 })
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %5)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
+  %6 = call i1 @"sync/atomic.CompareAndSwapInt64"(ptr %2, i64 100, i64 102)
+  %7 = load i64, ptr %2, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 })
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %6)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 2 })
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %7)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
+  %8 = call i1 @"sync/atomic.CompareAndSwapInt64"(ptr %2, i64 101, i64 102)
   %9 = load i64, ptr %2, align 4
-  %10 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %10, i32 0, i32 0
-  store ptr @1, ptr %11, align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %10, i32 0, i32 1
-  store i64 4, ptr %12, align 4
-  %13 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %10, align 8
-  %14 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %14, i32 0, i32 0
-  store ptr @2, ptr %15, align 8
-  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %14, i32 0, i32 1
-  store i64 2, ptr %16, align 4
-  %17 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %14, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %13)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %8)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %8)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %17)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 2 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %9)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %18 = call i1 @"sync/atomic.CompareAndSwapInt64"(ptr %2, i64 100, i64 102)
-  %19 = load i64, ptr %2, align 4
-  %20 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %20, i32 0, i32 0
-  store ptr @3, ptr %21, align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %20, i32 0, i32 1
-  store i64 4, ptr %22, align 4
-  %23 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %20, align 8
-  %24 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %24, i32 0, i32 0
-  store ptr @2, ptr %25, align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %24, i32 0, i32 1
-  store i64 2, ptr %26, align 4
-  %27 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %24, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %23)
+  %10 = call i64 @"sync/atomic.AddInt64"(ptr %2, i64 -1)
+  %11 = load i64, ptr %2, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %18)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %10)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %27)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 2 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %19)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %28 = call i1 @"sync/atomic.CompareAndSwapInt64"(ptr %2, i64 101, i64 102)
-  %29 = load i64, ptr %2, align 4
-  %30 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %30, i32 0, i32 0
-  store ptr @3, ptr %31, align 8
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %30, i32 0, i32 1
-  store i64 4, ptr %32, align 4
-  %33 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %30, align 8
-  %34 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %34, i32 0, i32 0
-  store ptr @2, ptr %35, align 8
-  %36 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %34, i32 0, i32 1
-  store i64 2, ptr %36, align 4
-  %37 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %34, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %33)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %28)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %37)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %29)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %38 = call i64 @"sync/atomic.AddInt64"(ptr %2, i64 -1)
-  %39 = load i64, ptr %2, align 4
-  %40 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %41 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %40, i32 0, i32 0
-  store ptr @1, ptr %41, align 8
-  %42 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %40, i32 0, i32 1
-  store i64 4, ptr %42, align 4
-  %43 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %40, align 8
-  %44 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %44, i32 0, i32 0
-  store ptr @2, ptr %45, align 8
-  %46 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %44, i32 0, i32 1
-  store i64 2, ptr %46, align 4
-  %47 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %44, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %43)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %38)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %47)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %39)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %11)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 }

--- a/cl/_testlibgo/bytes/out.ll
+++ b/cl/_testlibgo/bytes/out.ll
@@ -1,8 +1,8 @@
 ; ModuleID = 'main'
 source_filename = "main"
 
-%"github.com/goplus/llgo/internal/runtime.String" = type { ptr, i64 }
 %"github.com/goplus/llgo/internal/runtime.Slice" = type { ptr, i64, i64 }
+%"github.com/goplus/llgo/internal/runtime.String" = type { ptr, i64 }
 %"github.com/goplus/llgo/internal/runtime.iface" = type { ptr, ptr }
 
 @"main.init$guard" = global i1 false, align 1
@@ -35,51 +35,21 @@ _llgo_0:
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
   %2 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 40)
-  %3 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3, i32 0, i32 0
-  store ptr @0, ptr %4, align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3, i32 0, i32 1
-  store i64 6, ptr %5, align 4
-  %6 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3, align 8
-  %7 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/internal/runtime.String" %6)
-  %8 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @"bytes.(*Buffer).Write"(ptr %2, %"github.com/goplus/llgo/internal/runtime.Slice" %7)
-  %9 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %9, i32 0, i32 0
-  store ptr @1, ptr %10, align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %9, i32 0, i32 1
-  store i64 5, ptr %11, align 4
-  %12 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %9, align 8
-  %13 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @"bytes.(*Buffer).WriteString"(ptr %2, %"github.com/goplus/llgo/internal/runtime.String" %12)
-  %14 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"bytes.(*Buffer).Bytes"(ptr %2)
-  %15 = call %"github.com/goplus/llgo/internal/runtime.String" @"bytes.(*Buffer).String"(ptr %2)
-  %16 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %16, i32 0, i32 0
-  store ptr @2, ptr %17, align 8
-  %18 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %16, i32 0, i32 1
-  store i64 3, ptr %18, align 4
-  %19 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %16, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %19)
+  %3 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 6 })
+  %4 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @"bytes.(*Buffer).Write"(ptr %2, %"github.com/goplus/llgo/internal/runtime.Slice" %3)
+  %5 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @"bytes.(*Buffer).WriteString"(ptr %2, %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 5 })
+  %6 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"bytes.(*Buffer).Bytes"(ptr %2)
+  %7 = call %"github.com/goplus/llgo/internal/runtime.String" @"bytes.(*Buffer).String"(ptr %2)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 3 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %14)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %6)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %15)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %7)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %20 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %20, i32 0, i32 0
-  store ptr @3, ptr %21, align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %20, i32 0, i32 1
-  store i64 2, ptr %22, align 4
-  %23 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %20, align 8
-  %24 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/internal/runtime.String" %23)
-  %25 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 0
-  store ptr @4, ptr %26, align 8
-  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 1
-  store i64 2, ptr %27, align 4
-  %28 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %25, align 8
-  %29 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/internal/runtime.String" %28)
-  %30 = call i1 @bytes.EqualFold(%"github.com/goplus/llgo/internal/runtime.Slice" %24, %"github.com/goplus/llgo/internal/runtime.Slice" %29)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %30)
+  %8 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 2 })
+  %9 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 2 })
+  %10 = call i1 @bytes.EqualFold(%"github.com/goplus/llgo/internal/runtime.Slice" %8, %"github.com/goplus/llgo/internal/runtime.Slice" %9)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %10)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 }

--- a/cl/_testlibgo/complex/out.ll
+++ b/cl/_testlibgo/complex/out.ll
@@ -13,37 +13,19 @@ source_filename = "main"
 define void @main.f({ double, double } %0, { double, double } %1) {
 _llgo_0:
   %2 = call double @"math/cmplx.Abs"({ double, double } %0)
-  %3 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3, i32 0, i32 0
-  store ptr @0, ptr %4, align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3, i32 0, i32 1
-  store i64 10, ptr %5, align 4
-  %6 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %6)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 10 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %2)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %7 = extractvalue { double, double } %1, 0
-  %8 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %8, i32 0, i32 0
-  store ptr @1, ptr %9, align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %8, i32 0, i32 1
-  store i64 11, ptr %10, align 4
-  %11 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %8, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %11)
+  %3 = extractvalue { double, double } %1, 0
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 11 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %7)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %3)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %12 = extractvalue { double, double } %1, 1
-  %13 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %13, i32 0, i32 0
-  store ptr @2, ptr %14, align 8
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %13, i32 0, i32 1
-  store i64 11, ptr %15, align 4
-  %16 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %13, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %16)
+  %4 = extractvalue { double, double } %1, 1
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 11 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %12)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %4)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret void
 }
@@ -68,13 +50,7 @@ _llgo_0:
   store ptr %1, ptr @__llgo_argv, align 8
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
-  %2 = alloca { double, double }, align 8
-  %3 = getelementptr inbounds { double, double }, ptr %2, i32 0, i32 0
-  store double 3.000000e+00, ptr %3, align 8
-  %4 = getelementptr inbounds { double, double }, ptr %2, i32 0, i32 1
-  store double 4.000000e+00, ptr %4, align 8
-  %5 = load { double, double }, ptr %2, align 8
-  call void @main.f({ double, double } %5, { double, double } { double 3.000000e+00, double 4.000000e+00 })
+  call void @main.f({ double, double } { double 3.000000e+00, double 4.000000e+00 }, { double, double } { double 3.000000e+00, double 4.000000e+00 })
   ret i32 0
 }
 

--- a/cl/_testlibgo/errors/out.ll
+++ b/cl/_testlibgo/errors/out.ll
@@ -1,8 +1,8 @@
 ; ModuleID = 'main'
 source_filename = "main"
 
-%"github.com/goplus/llgo/internal/runtime.String" = type { ptr, i64 }
 %"github.com/goplus/llgo/internal/runtime.iface" = type { ptr, ptr }
+%"github.com/goplus/llgo/internal/runtime.String" = type { ptr, i64 }
 %"github.com/goplus/llgo/internal/runtime.eface" = type { ptr, ptr }
 
 @"main.init$guard" = global i1 false, align 1
@@ -30,22 +30,12 @@ _llgo_0:
   store ptr %1, ptr @__llgo_argv, align 8
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
-  %2 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 0
-  store ptr @0, ptr %3, align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 1
-  store i64 5, ptr %4, align 4
-  %5 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
-  %6 = call %"github.com/goplus/llgo/internal/runtime.iface" @errors.New(%"github.com/goplus/llgo/internal/runtime.String" %5)
-  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %6)
-  %8 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %6, 1
-  %9 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %9, i32 0, i32 0
-  store ptr %7, ptr %10, align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %9, i32 0, i32 1
-  store ptr %8, ptr %11, align 8
-  %12 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %9, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %12)
+  %2 = call %"github.com/goplus/llgo/internal/runtime.iface" @errors.New(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 })
+  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %2)
+  %4 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %2, 1
+  %5 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %3, 0
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %5, ptr %4, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %6)
   unreachable
 }
 

--- a/cl/_testlibgo/nettextproto/out.ll
+++ b/cl/_testlibgo/nettextproto/out.ll
@@ -28,14 +28,8 @@ _llgo_0:
   store ptr %1, ptr @__llgo_argv, align 8
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
-  %2 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 0
-  store ptr @0, ptr %3, align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 1
-  store i64 4, ptr %4, align 4
-  %5 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
-  %6 = call %"github.com/goplus/llgo/internal/runtime.String" @"net/textproto.CanonicalMIMEHeaderKey"(%"github.com/goplus/llgo/internal/runtime.String" %5)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %6)
+  %2 = call %"github.com/goplus/llgo/internal/runtime.String" @"net/textproto.CanonicalMIMEHeaderKey"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 })
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %2)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 }

--- a/cl/_testlibgo/os/out.ll
+++ b/cl/_testlibgo/os/out.ll
@@ -35,43 +35,25 @@ _llgo_0:
   %4 = extractvalue { %"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.iface" } %2, 1
   %5 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %4)
   %6 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %4, 1
-  %7 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, i32 0, i32 0
-  store ptr %5, ptr %8, align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, i32 0, i32 1
-  store ptr %6, ptr %9, align 8
-  %10 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, align 8
-  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
-  %12 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %12, i32 0, i32 0
-  store ptr %11, ptr %13, align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %12, i32 0, i32 1
-  store ptr null, ptr %14, align 8
-  %15 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %12, align 8
-  %16 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %10, %"github.com/goplus/llgo/internal/runtime.eface" %15)
-  %17 = xor i1 %16, true
-  br i1 %17, label %_llgo_1, label %_llgo_2
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %5, 0
+  %8 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %7, ptr %6, 1
+  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
+  %10 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %9, 0
+  %11 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %10, ptr null, 1
+  %12 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %8, %"github.com/goplus/llgo/internal/runtime.eface" %11)
+  %13 = xor i1 %12, true
+  br i1 %13, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %18 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %4)
-  %19 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %4, 1
-  %20 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %20, i32 0, i32 0
-  store ptr %18, ptr %21, align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %20, i32 0, i32 1
-  store ptr %19, ptr %22, align 8
-  %23 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %20, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %23)
+  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %4)
+  %15 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %4, 1
+  %16 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %14, 0
+  %17 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %16, ptr %15, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %17)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %24 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %24, i32 0, i32 0
-  store ptr @0, ptr %25, align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %24, i32 0, i32 1
-  store i64 4, ptr %26, align 4
-  %27 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %24, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %27)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %3)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)

--- a/cl/_testlibgo/strings/out.ll
+++ b/cl/_testlibgo/strings/out.ll
@@ -1,8 +1,8 @@
 ; ModuleID = 'main'
 source_filename = "main"
 
-%"github.com/goplus/llgo/internal/runtime.String" = type { ptr, i64 }
 %"github.com/goplus/llgo/internal/runtime.Slice" = type { ptr, i64, i64 }
+%"github.com/goplus/llgo/internal/runtime.String" = type { ptr, i64 }
 %"github.com/goplus/llgo/internal/runtime.iface" = type { ptr, ptr }
 
 @"main.init$guard" = global i1 false, align 1
@@ -39,83 +39,29 @@ _llgo_0:
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
   %2 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
-  %3 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3, i32 0, i32 0
-  store ptr @0, ptr %4, align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3, i32 0, i32 1
-  store i64 6, ptr %5, align 4
-  %6 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3, align 8
-  %7 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/internal/runtime.String" %6)
-  %8 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @"strings.(*Builder).Write"(ptr %2, %"github.com/goplus/llgo/internal/runtime.Slice" %7)
-  %9 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %9, i32 0, i32 0
-  store ptr @1, ptr %10, align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %9, i32 0, i32 1
-  store i64 5, ptr %11, align 4
-  %12 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %9, align 8
-  %13 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @"strings.(*Builder).WriteString"(ptr %2, %"github.com/goplus/llgo/internal/runtime.String" %12)
-  %14 = call i64 @"strings.(*Builder).Len"(ptr %2)
-  %15 = call i64 @"strings.(*Builder).Cap"(ptr %2)
-  %16 = call %"github.com/goplus/llgo/internal/runtime.String" @"strings.(*Builder).String"(ptr %2)
-  %17 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %18 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %17, i32 0, i32 0
-  store ptr @2, ptr %18, align 8
-  %19 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %17, i32 0, i32 1
-  store i64 4, ptr %19, align 4
-  %20 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %17, align 8
-  %21 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %21, i32 0, i32 0
-  store ptr @3, ptr %22, align 8
-  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %21, i32 0, i32 1
-  store i64 4, ptr %23, align 4
-  %24 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %21, align 8
-  %25 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 0
-  store ptr @4, ptr %26, align 8
-  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 1
-  store i64 7, ptr %27, align 4
-  %28 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %25, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %20)
+  %3 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 6 })
+  %4 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @"strings.(*Builder).Write"(ptr %2, %"github.com/goplus/llgo/internal/runtime.Slice" %3)
+  %5 = call { i64, %"github.com/goplus/llgo/internal/runtime.iface" } @"strings.(*Builder).WriteString"(ptr %2, %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 5 })
+  %6 = call i64 @"strings.(*Builder).Len"(ptr %2)
+  %7 = call i64 @"strings.(*Builder).Cap"(ptr %2)
+  %8 = call %"github.com/goplus/llgo/internal/runtime.String" @"strings.(*Builder).String"(ptr %2)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %14)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %6)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %24)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %15)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %7)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %28)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 7 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %16)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %8)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %29 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %29, i32 0, i32 0
-  store ptr @5, ptr %30, align 8
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %29, i32 0, i32 1
-  store i64 13, ptr %31, align 4
-  %32 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %29, align 8
-  %33 = alloca { ptr, ptr }, align 8
-  %34 = getelementptr inbounds { ptr, ptr }, ptr %33, i32 0, i32 0
-  store ptr @"__llgo_stub.main.main$1", ptr %34, align 8
-  %35 = getelementptr inbounds { ptr, ptr }, ptr %33, i32 0, i32 1
-  store ptr null, ptr %35, align 8
-  %36 = load { ptr, ptr }, ptr %33, align 8
-  %37 = call i64 @strings.IndexFunc(%"github.com/goplus/llgo/internal/runtime.String" %32, { ptr, ptr } %36)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %37)
+  %9 = call i64 @strings.IndexFunc(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 13 }, { ptr, ptr } { ptr @"__llgo_stub.main.main$1", ptr null })
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %9)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %38 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %38, i32 0, i32 0
-  store ptr @6, ptr %39, align 8
-  %40 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %38, i32 0, i32 1
-  store i64 12, ptr %40, align 4
-  %41 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %38, align 8
-  %42 = alloca { ptr, ptr }, align 8
-  %43 = getelementptr inbounds { ptr, ptr }, ptr %42, i32 0, i32 0
-  store ptr @"__llgo_stub.main.main$1", ptr %43, align 8
-  %44 = getelementptr inbounds { ptr, ptr }, ptr %42, i32 0, i32 1
-  store ptr null, ptr %44, align 8
-  %45 = load { ptr, ptr }, ptr %42, align 8
-  %46 = call i64 @strings.IndexFunc(%"github.com/goplus/llgo/internal/runtime.String" %41, { ptr, ptr } %45)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %46)
+  %10 = call i64 @strings.IndexFunc(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 12 }, { ptr, ptr } { ptr @"__llgo_stub.main.main$1", ptr null })
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %10)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 }

--- a/cl/_testrt/abinamed/out.ll
+++ b/cl/_testrt/abinamed/out.ll
@@ -208,275 +208,207 @@ _llgo_0:
   %2 = load ptr, ptr @_llgo_main.T, align 8
   %3 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
   store %main.T zeroinitializer, ptr %3, align 8
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %4, i32 0, i32 0
-  store ptr %2, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %4, i32 0, i32 1
-  store ptr %3, ptr %6, align 8
-  %7 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %4, align 8
-  %8 = call ptr @main.toEface(%"github.com/goplus/llgo/internal/runtime.eface" %7)
-  %9 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %10 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 72)
-  store %"github.com/goplus/llgo/internal/abi.Type" zeroinitializer, ptr %10, align 8
-  %11 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %11, i32 0, i32 0
-  store ptr %9, ptr %12, align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %11, i32 0, i32 1
-  store ptr %10, ptr %13, align 8
-  %14 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %11, align 8
-  %15 = call ptr @main.toEface(%"github.com/goplus/llgo/internal/runtime.eface" %14)
-  %16 = getelementptr inbounds %main.eface, ptr %8, i32 0, i32 0
+  %4 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %2, 0
+  %5 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %4, ptr %3, 1
+  %6 = call ptr @main.toEface(%"github.com/goplus/llgo/internal/runtime.eface" %5)
+  %7 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %8 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 72)
+  store %"github.com/goplus/llgo/internal/abi.Type" zeroinitializer, ptr %8, align 8
+  %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %7, 0
+  %10 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %9, ptr %8, 1
+  %11 = call ptr @main.toEface(%"github.com/goplus/llgo/internal/runtime.eface" %10)
+  %12 = getelementptr inbounds %main.eface, ptr %6, i32 0, i32 0
+  %13 = load ptr, ptr %12, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %13)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
+  %14 = getelementptr inbounds %main.eface, ptr %6, i32 0, i32 0
+  %15 = load ptr, ptr %14, align 8
+  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Type", ptr %15, i32 0, i32 10
   %17 = load ptr, ptr %16, align 8
   call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %17)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %18 = getelementptr inbounds %main.eface, ptr %8, i32 0, i32 0
+  %18 = getelementptr inbounds %main.eface, ptr %11, i32 0, i32 0
   %19 = load ptr, ptr %18, align 8
-  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Type", ptr %19, i32 0, i32 10
-  %21 = load ptr, ptr %20, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %21)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %19)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %22 = getelementptr inbounds %main.eface, ptr %15, i32 0, i32 0
+  %20 = getelementptr inbounds %main.eface, ptr %11, i32 0, i32 0
+  %21 = load ptr, ptr %20, align 8
+  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Type", ptr %21, i32 0, i32 10
   %23 = load ptr, ptr %22, align 8
   call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %23)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %24 = getelementptr inbounds %main.eface, ptr %15, i32 0, i32 0
-  %25 = load ptr, ptr %24, align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Type", ptr %25, i32 0, i32 10
-  %27 = load ptr, ptr %26, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %27)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %28 = alloca %"github.com/goplus/llgo/internal/abi.StructField", align 8
-  call void @llvm.memset(ptr %28, i8 0, i64 56, i1 false)
-  %29 = getelementptr inbounds %main.eface, ptr %8, i32 0, i32 0
-  %30 = load ptr, ptr %29, align 8
-  %31 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType"(ptr %30)
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructType", ptr %31, i32 0, i32 2
-  %33 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %32, align 8
-  %34 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %33, 0
-  %35 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %33, 1
-  %36 = icmp sge i64 0, %35
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %36)
-  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %34, i64 0
-  %38 = load %"github.com/goplus/llgo/internal/abi.StructField", ptr %37, align 8
-  store %"github.com/goplus/llgo/internal/abi.StructField" %38, ptr %28, align 8
-  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %28, i32 0, i32 1
+  %24 = alloca %"github.com/goplus/llgo/internal/abi.StructField", align 8
+  call void @llvm.memset(ptr %24, i8 0, i64 56, i1 false)
+  %25 = getelementptr inbounds %main.eface, ptr %6, i32 0, i32 0
+  %26 = load ptr, ptr %25, align 8
+  %27 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType"(ptr %26)
+  %28 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructType", ptr %27, i32 0, i32 2
+  %29 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %28, align 8
+  %30 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %29, 0
+  %31 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %29, 1
+  %32 = icmp sge i64 0, %31
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %32)
+  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %30, i64 0
+  %34 = load %"github.com/goplus/llgo/internal/abi.StructField", ptr %33, align 8
+  store %"github.com/goplus/llgo/internal/abi.StructField" %34, ptr %24, align 8
+  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %24, i32 0, i32 1
+  %36 = load ptr, ptr %35, align 8
+  %37 = getelementptr inbounds %main.eface, ptr %6, i32 0, i32 0
+  %38 = load ptr, ptr %37, align 8
+  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Type", ptr %38, i32 0, i32 10
   %40 = load ptr, ptr %39, align 8
-  %41 = getelementptr inbounds %main.eface, ptr %8, i32 0, i32 0
-  %42 = load ptr, ptr %41, align 8
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Type", ptr %42, i32 0, i32 10
-  %44 = load ptr, ptr %43, align 8
-  %45 = icmp ne ptr %40, %44
-  br i1 %45, label %_llgo_1, label %_llgo_2
+  %41 = icmp ne ptr %36, %40
+  br i1 %41, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %46 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %47 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %46, i32 0, i32 0
-  store ptr @96, ptr %47, align 8
-  %48 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %46, i32 0, i32 1
-  store i64 13, ptr %48, align 4
-  %49 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %46, align 8
-  %50 = load ptr, ptr @_llgo_string, align 8
-  %51 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %49, ptr %51, align 8
-  %52 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %53 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %52, i32 0, i32 0
-  store ptr %50, ptr %53, align 8
-  %54 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %52, i32 0, i32 1
-  store ptr %51, ptr %54, align 8
-  %55 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %52, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %55)
+  %42 = load ptr, ptr @_llgo_string, align 8
+  %43 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @96, i64 13 }, ptr %43, align 8
+  %44 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %42, 0
+  %45 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %44, ptr %43, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %45)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %28, i32 0, i32 1
-  %57 = load ptr, ptr %56, align 8
-  %58 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).Elem"(ptr %57)
-  %59 = getelementptr inbounds %main.eface, ptr %8, i32 0, i32 0
-  %60 = load ptr, ptr %59, align 8
-  %61 = icmp ne ptr %58, %60
-  br i1 %61, label %_llgo_3, label %_llgo_4
+  %46 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %24, i32 0, i32 1
+  %47 = load ptr, ptr %46, align 8
+  %48 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).Elem"(ptr %47)
+  %49 = getelementptr inbounds %main.eface, ptr %6, i32 0, i32 0
+  %50 = load ptr, ptr %49, align 8
+  %51 = icmp ne ptr %48, %50
+  br i1 %51, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %62 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %63 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %62, i32 0, i32 0
-  store ptr @97, ptr %63, align 8
-  %64 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %62, i32 0, i32 1
-  store i64 18, ptr %64, align 4
-  %65 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %62, align 8
-  %66 = load ptr, ptr @_llgo_string, align 8
-  %67 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %65, ptr %67, align 8
-  %68 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %69 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i32 0, i32 0
-  store ptr %66, ptr %69, align 8
-  %70 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i32 0, i32 1
-  store ptr %67, ptr %70, align 8
-  %71 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %71)
+  %52 = load ptr, ptr @_llgo_string, align 8
+  %53 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @97, i64 18 }, ptr %53, align 8
+  %54 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %52, 0
+  %55 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %54, ptr %53, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %55)
   unreachable
 
 _llgo_4:                                          ; preds = %_llgo_2
-  %72 = alloca %"github.com/goplus/llgo/internal/abi.StructField", align 8
-  call void @llvm.memset(ptr %72, i8 0, i64 56, i1 false)
-  %73 = getelementptr inbounds %main.eface, ptr %8, i32 0, i32 0
-  %74 = load ptr, ptr %73, align 8
-  %75 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType"(ptr %74)
-  %76 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructType", ptr %75, i32 0, i32 2
-  %77 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %76, align 8
-  %78 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %77, 0
-  %79 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %77, 1
-  %80 = icmp sge i64 1, %79
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %80)
-  %81 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %78, i64 1
-  %82 = load %"github.com/goplus/llgo/internal/abi.StructField", ptr %81, align 8
-  store %"github.com/goplus/llgo/internal/abi.StructField" %82, ptr %72, align 8
-  %83 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %72, i32 0, i32 1
-  %84 = load ptr, ptr %83, align 8
-  %85 = getelementptr inbounds %main.eface, ptr %15, i32 0, i32 0
-  %86 = load ptr, ptr %85, align 8
-  %87 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Type", ptr %86, i32 0, i32 10
-  %88 = load ptr, ptr %87, align 8
-  %89 = icmp ne ptr %84, %88
-  br i1 %89, label %_llgo_5, label %_llgo_6
+  %56 = alloca %"github.com/goplus/llgo/internal/abi.StructField", align 8
+  call void @llvm.memset(ptr %56, i8 0, i64 56, i1 false)
+  %57 = getelementptr inbounds %main.eface, ptr %6, i32 0, i32 0
+  %58 = load ptr, ptr %57, align 8
+  %59 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType"(ptr %58)
+  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructType", ptr %59, i32 0, i32 2
+  %61 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %60, align 8
+  %62 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %61, 0
+  %63 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %61, 1
+  %64 = icmp sge i64 1, %63
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %64)
+  %65 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %62, i64 1
+  %66 = load %"github.com/goplus/llgo/internal/abi.StructField", ptr %65, align 8
+  store %"github.com/goplus/llgo/internal/abi.StructField" %66, ptr %56, align 8
+  %67 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %56, i32 0, i32 1
+  %68 = load ptr, ptr %67, align 8
+  %69 = getelementptr inbounds %main.eface, ptr %11, i32 0, i32 0
+  %70 = load ptr, ptr %69, align 8
+  %71 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Type", ptr %70, i32 0, i32 10
+  %72 = load ptr, ptr %71, align 8
+  %73 = icmp ne ptr %68, %72
+  br i1 %73, label %_llgo_5, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_4
-  %90 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %91 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %90, i32 0, i32 0
-  store ptr @98, ptr %91, align 8
-  %92 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %90, i32 0, i32 1
-  store i64 13, ptr %92, align 4
-  %93 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %90, align 8
-  %94 = load ptr, ptr @_llgo_string, align 8
-  %95 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %93, ptr %95, align 8
-  %96 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %97 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %96, i32 0, i32 0
-  store ptr %94, ptr %97, align 8
-  %98 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %96, i32 0, i32 1
-  store ptr %95, ptr %98, align 8
-  %99 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %96, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %99)
+  %74 = load ptr, ptr @_llgo_string, align 8
+  %75 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @98, i64 13 }, ptr %75, align 8
+  %76 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %74, 0
+  %77 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %76, ptr %75, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %77)
   unreachable
 
 _llgo_6:                                          ; preds = %_llgo_4
-  %100 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %72, i32 0, i32 1
-  %101 = load ptr, ptr %100, align 8
-  %102 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).Elem"(ptr %101)
-  %103 = getelementptr inbounds %main.eface, ptr %15, i32 0, i32 0
-  %104 = load ptr, ptr %103, align 8
-  %105 = icmp ne ptr %102, %104
-  br i1 %105, label %_llgo_7, label %_llgo_8
+  %78 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %56, i32 0, i32 1
+  %79 = load ptr, ptr %78, align 8
+  %80 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).Elem"(ptr %79)
+  %81 = getelementptr inbounds %main.eface, ptr %11, i32 0, i32 0
+  %82 = load ptr, ptr %81, align 8
+  %83 = icmp ne ptr %80, %82
+  br i1 %83, label %_llgo_7, label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_6
-  %106 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %107 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %106, i32 0, i32 0
-  store ptr @99, ptr %107, align 8
-  %108 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %106, i32 0, i32 1
-  store i64 18, ptr %108, align 4
-  %109 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %106, align 8
-  %110 = load ptr, ptr @_llgo_string, align 8
-  %111 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %109, ptr %111, align 8
-  %112 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %113 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %112, i32 0, i32 0
-  store ptr %110, ptr %113, align 8
-  %114 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %112, i32 0, i32 1
-  store ptr %111, ptr %114, align 8
-  %115 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %112, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %115)
+  %84 = load ptr, ptr @_llgo_string, align 8
+  %85 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @99, i64 18 }, ptr %85, align 8
+  %86 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %84, 0
+  %87 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %86, ptr %85, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %87)
   unreachable
 
 _llgo_8:                                          ; preds = %_llgo_6
-  %116 = alloca %"github.com/goplus/llgo/internal/abi.StructField", align 8
-  call void @llvm.memset(ptr %116, i8 0, i64 56, i1 false)
-  %117 = getelementptr inbounds %main.eface, ptr %8, i32 0, i32 0
-  %118 = load ptr, ptr %117, align 8
-  %119 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType"(ptr %118)
-  %120 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructType", ptr %119, i32 0, i32 2
-  %121 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %120, align 8
-  %122 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %121, 0
-  %123 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %121, 1
-  %124 = icmp sge i64 2, %123
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %124)
-  %125 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %122, i64 2
-  %126 = load %"github.com/goplus/llgo/internal/abi.StructField", ptr %125, align 8
-  store %"github.com/goplus/llgo/internal/abi.StructField" %126, ptr %116, align 8
-  %127 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %116, i32 0, i32 1
-  %128 = load ptr, ptr %127, align 8
-  %129 = getelementptr inbounds %main.eface, ptr %15, i32 0, i32 0
-  %130 = load ptr, ptr %129, align 8
-  %131 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType"(ptr %130)
-  %132 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructType", ptr %131, i32 0, i32 2
-  %133 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %132, align 8
-  %134 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %133, 0
-  %135 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %133, 1
-  %136 = icmp sge i64 0, %135
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %136)
-  %137 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %134, i64 0
-  %138 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %137, i32 0, i32 1
-  %139 = load ptr, ptr %138, align 8
-  %140 = icmp ne ptr %128, %139
-  br i1 %140, label %_llgo_9, label %_llgo_10
+  %88 = alloca %"github.com/goplus/llgo/internal/abi.StructField", align 8
+  call void @llvm.memset(ptr %88, i8 0, i64 56, i1 false)
+  %89 = getelementptr inbounds %main.eface, ptr %6, i32 0, i32 0
+  %90 = load ptr, ptr %89, align 8
+  %91 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType"(ptr %90)
+  %92 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructType", ptr %91, i32 0, i32 2
+  %93 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %92, align 8
+  %94 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %93, 0
+  %95 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %93, 1
+  %96 = icmp sge i64 2, %95
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %96)
+  %97 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %94, i64 2
+  %98 = load %"github.com/goplus/llgo/internal/abi.StructField", ptr %97, align 8
+  store %"github.com/goplus/llgo/internal/abi.StructField" %98, ptr %88, align 8
+  %99 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %88, i32 0, i32 1
+  %100 = load ptr, ptr %99, align 8
+  %101 = getelementptr inbounds %main.eface, ptr %11, i32 0, i32 0
+  %102 = load ptr, ptr %101, align 8
+  %103 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType"(ptr %102)
+  %104 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructType", ptr %103, i32 0, i32 2
+  %105 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %104, align 8
+  %106 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %105, 0
+  %107 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %105, 1
+  %108 = icmp sge i64 0, %107
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %108)
+  %109 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %106, i64 0
+  %110 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %109, i32 0, i32 1
+  %111 = load ptr, ptr %110, align 8
+  %112 = icmp ne ptr %100, %111
+  br i1 %112, label %_llgo_9, label %_llgo_10
 
 _llgo_9:                                          ; preds = %_llgo_8
-  %141 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %142 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %141, i32 0, i32 0
-  store ptr @100, ptr %142, align 8
-  %143 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %141, i32 0, i32 1
-  store i64 13, ptr %143, align 4
-  %144 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %141, align 8
-  %145 = load ptr, ptr @_llgo_string, align 8
-  %146 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %144, ptr %146, align 8
-  %147 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %148 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %147, i32 0, i32 0
-  store ptr %145, ptr %148, align 8
-  %149 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %147, i32 0, i32 1
-  store ptr %146, ptr %149, align 8
-  %150 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %147, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %150)
+  %113 = load ptr, ptr @_llgo_string, align 8
+  %114 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @100, i64 13 }, ptr %114, align 8
+  %115 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %113, 0
+  %116 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %115, ptr %114, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %116)
   unreachable
 
 _llgo_10:                                         ; preds = %_llgo_8
-  %151 = alloca %"github.com/goplus/llgo/internal/abi.StructField", align 8
-  call void @llvm.memset(ptr %151, i8 0, i64 56, i1 false)
-  %152 = getelementptr inbounds %main.eface, ptr %8, i32 0, i32 0
-  %153 = load ptr, ptr %152, align 8
-  %154 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType"(ptr %153)
-  %155 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructType", ptr %154, i32 0, i32 2
-  %156 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %155, align 8
-  %157 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %156, 0
-  %158 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %156, 1
-  %159 = icmp sge i64 3, %158
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %159)
-  %160 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %157, i64 3
-  %161 = load %"github.com/goplus/llgo/internal/abi.StructField", ptr %160, align 8
-  store %"github.com/goplus/llgo/internal/abi.StructField" %161, ptr %151, align 8
-  %162 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %151, i32 0, i32 1
-  %163 = load ptr, ptr %162, align 8
-  %164 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).Elem"(ptr %163)
-  %165 = getelementptr inbounds %main.eface, ptr %8, i32 0, i32 0
-  %166 = load ptr, ptr %165, align 8
-  %167 = icmp ne ptr %164, %166
-  br i1 %167, label %_llgo_11, label %_llgo_12
+  %117 = alloca %"github.com/goplus/llgo/internal/abi.StructField", align 8
+  call void @llvm.memset(ptr %117, i8 0, i64 56, i1 false)
+  %118 = getelementptr inbounds %main.eface, ptr %6, i32 0, i32 0
+  %119 = load ptr, ptr %118, align 8
+  %120 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType"(ptr %119)
+  %121 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructType", ptr %120, i32 0, i32 2
+  %122 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %121, align 8
+  %123 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %122, 0
+  %124 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %122, 1
+  %125 = icmp sge i64 3, %124
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %125)
+  %126 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %123, i64 3
+  %127 = load %"github.com/goplus/llgo/internal/abi.StructField", ptr %126, align 8
+  store %"github.com/goplus/llgo/internal/abi.StructField" %127, ptr %117, align 8
+  %128 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.StructField", ptr %117, i32 0, i32 1
+  %129 = load ptr, ptr %128, align 8
+  %130 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).Elem"(ptr %129)
+  %131 = getelementptr inbounds %main.eface, ptr %6, i32 0, i32 0
+  %132 = load ptr, ptr %131, align 8
+  %133 = icmp ne ptr %130, %132
+  br i1 %133, label %_llgo_11, label %_llgo_12
 
 _llgo_11:                                         ; preds = %_llgo_10
-  %168 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %169 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %168, i32 0, i32 0
-  store ptr @101, ptr %169, align 8
-  %170 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %168, i32 0, i32 1
-  store i64 13, ptr %170, align 4
-  %171 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %168, align 8
-  %172 = load ptr, ptr @_llgo_string, align 8
-  %173 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %171, ptr %173, align 8
-  %174 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %175 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %174, i32 0, i32 0
-  store ptr %172, ptr %175, align 8
-  %176 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %174, i32 0, i32 1
-  store ptr %173, ptr %176, align 8
-  %177 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %174, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %177)
+  %134 = load ptr, ptr @_llgo_string, align 8
+  %135 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @101, i64 13 }, ptr %135, align 8
+  %136 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %134, 0
+  %137 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %136, ptr %135, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %137)
   unreachable
 
 _llgo_12:                                         ; preds = %_llgo_10
@@ -496,6015 +428,2438 @@ declare void @"github.com/goplus/llgo/internal/runtime.init"()
 
 define void @"main.init$after"() {
 _llgo_0:
-  %0 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 0
-  store ptr @0, ptr %1, align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 1
-  store i64 6, ptr %2, align 4
-  %3 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %0, align 8
-  %4 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3, i64 25, i64 48, i64 0, i64 0)
-  %5 = load ptr, ptr @_llgo_main.T, align 8
-  %6 = icmp eq ptr %5, null
-  br i1 %6, label %_llgo_1, label %_llgo_2
+  %0 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 6 }, i64 25, i64 48, i64 0, i64 0)
+  %1 = load ptr, ptr @_llgo_main.T, align 8
+  %2 = icmp eq ptr %1, null
+  br i1 %2, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  store ptr %4, ptr @_llgo_main.T, align 8
+  store ptr %0, ptr @_llgo_main.T, align 8
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-  %7 = load ptr, ptr @_llgo_main.T, align 8
-  %8 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %8, i32 0, i32 0
-  store ptr @0, ptr %9, align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %8, i32 0, i32 1
-  store i64 6, ptr %10, align 4
-  %11 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %8, align 8
-  %12 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %11, i64 25, i64 48, i64 0, i64 0)
-  %13 = load ptr, ptr @"*_llgo_main.T", align 8
-  %14 = icmp eq ptr %13, null
-  br i1 %14, label %_llgo_3, label %_llgo_4
+  %3 = load ptr, ptr @_llgo_main.T, align 8
+  %4 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 6 }, i64 25, i64 48, i64 0, i64 0)
+  %5 = load ptr, ptr @"*_llgo_main.T", align 8
+  %6 = icmp eq ptr %5, null
+  br i1 %6, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %15 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %12)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %15)
-  store ptr %15, ptr @"*_llgo_main.T", align 8
+  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %4)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %7)
+  store ptr %7, ptr @"*_llgo_main.T", align 8
   br label %_llgo_4
 
 _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
-  %16 = load ptr, ptr @"*_llgo_main.T", align 8
-  %17 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %18 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %17, i32 0, i32 0
-  store ptr @1, ptr %18, align 8
-  %19 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %17, i32 0, i32 1
-  store i64 40, ptr %19, align 4
-  %20 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %17, align 8
-  %21 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %20, i64 25, i64 80, i64 0, i64 23)
-  %22 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %23 = icmp eq ptr %22, null
-  br i1 %23, label %_llgo_5, label %_llgo_6
+  %8 = load ptr, ptr @"*_llgo_main.T", align 8
+  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 40 }, i64 25, i64 80, i64 0, i64 23)
+  %10 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %11 = icmp eq ptr %10, null
+  br i1 %11, label %_llgo_5, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_4
-  store ptr %21, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  store ptr %9, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %24 = load ptr, ptr @_llgo_uintptr, align 8
-  %25 = icmp eq ptr %24, null
-  br i1 %25, label %_llgo_7, label %_llgo_8
+  %12 = load ptr, ptr @_llgo_uintptr, align 8
+  %13 = icmp eq ptr %12, null
+  br i1 %13, label %_llgo_7, label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_6
-  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
-  store ptr %26, ptr @_llgo_uintptr, align 8
+  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
+  store ptr %14, ptr @_llgo_uintptr, align 8
   br label %_llgo_8
 
 _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
-  %27 = load ptr, ptr @_llgo_uintptr, align 8
-  %28 = load ptr, ptr @_llgo_uint32, align 8
-  %29 = icmp eq ptr %28, null
-  br i1 %29, label %_llgo_9, label %_llgo_10
+  %15 = load ptr, ptr @_llgo_uintptr, align 8
+  %16 = load ptr, ptr @_llgo_uint32, align 8
+  %17 = icmp eq ptr %16, null
+  br i1 %17, label %_llgo_9, label %_llgo_10
 
 _llgo_9:                                          ; preds = %_llgo_8
-  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 42)
-  store ptr %30, ptr @_llgo_uint32, align 8
+  %18 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 42)
+  store ptr %18, ptr @_llgo_uint32, align 8
   br label %_llgo_10
 
 _llgo_10:                                         ; preds = %_llgo_9, %_llgo_8
-  %31 = load ptr, ptr @_llgo_uint32, align 8
-  %32 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %32, i32 0, i32 0
-  store ptr @2, ptr %33, align 8
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %32, i32 0, i32 1
-  store i64 41, ptr %34, align 4
-  %35 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %32, align 8
-  %36 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %35, i64 8, i64 1, i64 0, i64 0)
-  %37 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.TFlag", align 8
-  %38 = icmp eq ptr %37, null
-  br i1 %38, label %_llgo_11, label %_llgo_12
+  %19 = load ptr, ptr @_llgo_uint32, align 8
+  %20 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 41 }, i64 8, i64 1, i64 0, i64 0)
+  %21 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.TFlag", align 8
+  %22 = icmp eq ptr %21, null
+  br i1 %22, label %_llgo_11, label %_llgo_12
 
 _llgo_11:                                         ; preds = %_llgo_10
-  store ptr %36, ptr @"_llgo_github.com/goplus/llgo/internal/abi.TFlag", align 8
+  store ptr %20, ptr @"_llgo_github.com/goplus/llgo/internal/abi.TFlag", align 8
   br label %_llgo_12
 
 _llgo_12:                                         ; preds = %_llgo_11, %_llgo_10
-  %39 = load ptr, ptr @_llgo_uint8, align 8
-  %40 = icmp eq ptr %39, null
-  br i1 %40, label %_llgo_13, label %_llgo_14
+  %23 = load ptr, ptr @_llgo_uint8, align 8
+  %24 = icmp eq ptr %23, null
+  br i1 %24, label %_llgo_13, label %_llgo_14
 
 _llgo_13:                                         ; preds = %_llgo_12
-  %41 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  store ptr %41, ptr @_llgo_uint8, align 8
+  %25 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  store ptr %25, ptr @_llgo_uint8, align 8
   br label %_llgo_14
 
 _llgo_14:                                         ; preds = %_llgo_13, %_llgo_12
-  %42 = load ptr, ptr @_llgo_uint8, align 8
-  br i1 %38, label %_llgo_15, label %_llgo_16
+  %26 = load ptr, ptr @_llgo_uint8, align 8
+  br i1 %22, label %_llgo_15, label %_llgo_16
 
 _llgo_15:                                         ; preds = %_llgo_14
-  %43 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %43, i32 0, i32 0
-  store ptr @3, ptr %44, align 8
-  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %43, i32 0, i32 1
-  store i64 35, ptr %45, align 4
-  %46 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %43, align 8
-  %47 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %48 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %47, i32 0, i32 0
-  store ptr @4, ptr %48, align 8
-  %49 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %47, i32 0, i32 1
-  store i64 5, ptr %49, align 4
-  %50 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %47, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %36, %"github.com/goplus/llgo/internal/runtime.String" %46, %"github.com/goplus/llgo/internal/runtime.String" %50, ptr %42, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %20, %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 35 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 5 }, ptr %26, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
   br label %_llgo_16
 
 _llgo_16:                                         ; preds = %_llgo_15, %_llgo_14
-  %51 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.TFlag", align 8
-  %52 = load ptr, ptr @_llgo_Pointer, align 8
-  %53 = icmp eq ptr %52, null
-  br i1 %53, label %_llgo_17, label %_llgo_18
+  %27 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.TFlag", align 8
+  %28 = load ptr, ptr @_llgo_Pointer, align 8
+  %29 = icmp eq ptr %28, null
+  br i1 %29, label %_llgo_17, label %_llgo_18
 
 _llgo_17:                                         ; preds = %_llgo_16
-  %54 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %54)
-  store ptr %54, ptr @_llgo_Pointer, align 8
+  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %30)
+  store ptr %30, ptr @_llgo_Pointer, align 8
   br label %_llgo_18
 
 _llgo_18:                                         ; preds = %_llgo_17, %_llgo_16
-  %55 = load ptr, ptr @_llgo_Pointer, align 8
-  %56 = load ptr, ptr @_llgo_bool, align 8
-  %57 = icmp eq ptr %56, null
-  br i1 %57, label %_llgo_19, label %_llgo_20
+  %31 = load ptr, ptr @_llgo_Pointer, align 8
+  %32 = load ptr, ptr @_llgo_bool, align 8
+  %33 = icmp eq ptr %32, null
+  br i1 %33, label %_llgo_19, label %_llgo_20
 
 _llgo_19:                                         ; preds = %_llgo_18
-  %58 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 33)
-  store ptr %58, ptr @_llgo_bool, align 8
+  %34 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 33)
+  store ptr %34, ptr @_llgo_bool, align 8
   br label %_llgo_20
 
 _llgo_20:                                         ; preds = %_llgo_19, %_llgo_18
-  %59 = load ptr, ptr @_llgo_bool, align 8
-  %60 = load ptr, ptr @_llgo_Pointer, align 8
-  %61 = load ptr, ptr @_llgo_Pointer, align 8
-  %62 = load ptr, ptr @_llgo_Pointer, align 8
-  %63 = load ptr, ptr @_llgo_bool, align 8
-  %64 = load ptr, ptr @"_llgo_func$QUW0mAalenD4Bc6QsairPZ_HOMzGmcNs0GCyMzTNFig", align 8
-  %65 = icmp eq ptr %64, null
-  br i1 %65, label %_llgo_21, label %_llgo_22
+  %35 = load ptr, ptr @_llgo_bool, align 8
+  %36 = load ptr, ptr @_llgo_Pointer, align 8
+  %37 = load ptr, ptr @_llgo_Pointer, align 8
+  %38 = load ptr, ptr @_llgo_Pointer, align 8
+  %39 = load ptr, ptr @_llgo_bool, align 8
+  %40 = load ptr, ptr @"_llgo_func$QUW0mAalenD4Bc6QsairPZ_HOMzGmcNs0GCyMzTNFig", align 8
+  %41 = icmp eq ptr %40, null
+  br i1 %41, label %_llgo_21, label %_llgo_22
 
 _llgo_21:                                         ; preds = %_llgo_20
-  %66 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %67 = getelementptr ptr, ptr %66, i64 0
-  store ptr %60, ptr %67, align 8
-  %68 = getelementptr ptr, ptr %66, i64 1
-  store ptr %61, ptr %68, align 8
-  %69 = getelementptr ptr, ptr %66, i64 2
-  store ptr %62, ptr %69, align 8
-  %70 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %71 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %70, i32 0, i32 0
-  store ptr %66, ptr %71, align 8
-  %72 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %70, i32 0, i32 1
-  store i64 3, ptr %72, align 4
-  %73 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %70, i32 0, i32 2
-  store i64 3, ptr %73, align 4
-  %74 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %70, align 8
-  %75 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %76 = getelementptr ptr, ptr %75, i64 0
-  store ptr %63, ptr %76, align 8
-  %77 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %78 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %77, i32 0, i32 0
-  store ptr %75, ptr %78, align 8
-  %79 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %77, i32 0, i32 1
-  store i64 1, ptr %79, align 4
-  %80 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %77, i32 0, i32 2
-  store i64 1, ptr %80, align 4
-  %81 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %77, align 8
-  %82 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %74, %"github.com/goplus/llgo/internal/runtime.Slice" %81, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %82)
-  store ptr %82, ptr @"_llgo_func$QUW0mAalenD4Bc6QsairPZ_HOMzGmcNs0GCyMzTNFig", align 8
+  %42 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %43 = getelementptr ptr, ptr %42, i64 0
+  store ptr %36, ptr %43, align 8
+  %44 = getelementptr ptr, ptr %42, i64 1
+  store ptr %37, ptr %44, align 8
+  %45 = getelementptr ptr, ptr %42, i64 2
+  store ptr %38, ptr %45, align 8
+  %46 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %42, 0
+  %47 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %46, i64 3, 1
+  %48 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %47, i64 3, 2
+  %49 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %50 = getelementptr ptr, ptr %49, i64 0
+  store ptr %39, ptr %50, align 8
+  %51 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %49, 0
+  %52 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %51, i64 1, 1
+  %53 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %52, i64 1, 2
+  %54 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %48, %"github.com/goplus/llgo/internal/runtime.Slice" %53, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %54)
+  store ptr %54, ptr @"_llgo_func$QUW0mAalenD4Bc6QsairPZ_HOMzGmcNs0GCyMzTNFig", align 8
   br label %_llgo_22
 
 _llgo_22:                                         ; preds = %_llgo_21, %_llgo_20
-  %83 = load ptr, ptr @"_llgo_func$QUW0mAalenD4Bc6QsairPZ_HOMzGmcNs0GCyMzTNFig", align 8
-  %84 = load ptr, ptr @_llgo_Pointer, align 8
-  %85 = load ptr, ptr @_llgo_Pointer, align 8
-  %86 = load ptr, ptr @_llgo_Pointer, align 8
-  %87 = load ptr, ptr @_llgo_bool, align 8
-  %88 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %89 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %88, i32 0, i32 0
-  store ptr @5, ptr %89, align 8
-  %90 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %88, i32 0, i32 1
-  store i64 1, ptr %90, align 4
-  %91 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %88, align 8
-  %92 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %93 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %92, i32 0, i32 0
-  store ptr null, ptr %93, align 8
-  %94 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %92, i32 0, i32 1
-  store i64 0, ptr %94, align 4
-  %95 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %92, align 8
-  %96 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %97 = getelementptr ptr, ptr %96, i64 0
-  store ptr %84, ptr %97, align 8
-  %98 = getelementptr ptr, ptr %96, i64 1
-  store ptr %85, ptr %98, align 8
-  %99 = getelementptr ptr, ptr %96, i64 2
-  store ptr %86, ptr %99, align 8
-  %100 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %101 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %100, i32 0, i32 0
-  store ptr %96, ptr %101, align 8
-  %102 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %100, i32 0, i32 1
-  store i64 3, ptr %102, align 4
-  %103 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %100, i32 0, i32 2
-  store i64 3, ptr %103, align 4
-  %104 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %100, align 8
-  %105 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %106 = getelementptr ptr, ptr %105, i64 0
-  store ptr %87, ptr %106, align 8
-  %107 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %108 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %107, i32 0, i32 0
-  store ptr %105, ptr %108, align 8
-  %109 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %107, i32 0, i32 1
-  store i64 1, ptr %109, align 4
-  %110 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %107, i32 0, i32 2
-  store i64 1, ptr %110, align 4
-  %111 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %107, align 8
-  %112 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %104, %"github.com/goplus/llgo/internal/runtime.Slice" %111, i1 false)
-  %113 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %91, ptr %112, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %95, i1 false)
-  %114 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %115 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %114, i32 0, i32 0
-  store ptr @6, ptr %115, align 8
-  %116 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %114, i32 0, i32 1
-  store i64 4, ptr %116, align 4
-  %117 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %114, align 8
-  %118 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %119 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %118, i32 0, i32 0
-  store ptr null, ptr %119, align 8
-  %120 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %118, i32 0, i32 1
-  store i64 0, ptr %120, align 4
-  %121 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %118, align 8
-  %122 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %123 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %117, ptr %122, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %121, i1 false)
-  %124 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %125 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %124, i32 0, i32 0
-  store ptr @7, ptr %125, align 8
-  %126 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %124, i32 0, i32 1
-  store i64 4, ptr %126, align 4
-  %127 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %124, align 8
-  %128 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %129 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %128, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %113, ptr %129, align 8
-  %130 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %128, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %123, ptr %130, align 8
-  %131 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %132 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %131, i32 0, i32 0
-  store ptr %128, ptr %132, align 8
-  %133 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %131, i32 0, i32 1
-  store i64 2, ptr %133, align 4
-  %134 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %131, i32 0, i32 2
-  store i64 2, ptr %134, align 4
-  %135 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %131, align 8
-  %136 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %127, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %135)
-  store ptr %136, ptr @"main.struct$p9hq6rduefaRA0UGJ6DazYUtteEOtDFu7UHk5jhDUV4", align 8
-  %137 = load ptr, ptr @"main.struct$p9hq6rduefaRA0UGJ6DazYUtteEOtDFu7UHk5jhDUV4", align 8
-  %138 = load ptr, ptr @_llgo_byte, align 8
-  %139 = icmp eq ptr %138, null
-  br i1 %139, label %_llgo_23, label %_llgo_24
+  %55 = load ptr, ptr @"_llgo_func$QUW0mAalenD4Bc6QsairPZ_HOMzGmcNs0GCyMzTNFig", align 8
+  %56 = load ptr, ptr @_llgo_Pointer, align 8
+  %57 = load ptr, ptr @_llgo_Pointer, align 8
+  %58 = load ptr, ptr @_llgo_Pointer, align 8
+  %59 = load ptr, ptr @_llgo_bool, align 8
+  %60 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %61 = getelementptr ptr, ptr %60, i64 0
+  store ptr %56, ptr %61, align 8
+  %62 = getelementptr ptr, ptr %60, i64 1
+  store ptr %57, ptr %62, align 8
+  %63 = getelementptr ptr, ptr %60, i64 2
+  store ptr %58, ptr %63, align 8
+  %64 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %60, 0
+  %65 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %64, i64 3, 1
+  %66 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %65, i64 3, 2
+  %67 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %68 = getelementptr ptr, ptr %67, i64 0
+  store ptr %59, ptr %68, align 8
+  %69 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %67, 0
+  %70 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %69, i64 1, 1
+  %71 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %70, i64 1, 2
+  %72 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %66, %"github.com/goplus/llgo/internal/runtime.Slice" %71, i1 false)
+  %73 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 1 }, ptr %72, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %74 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %75 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 4 }, ptr %74, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %76 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %77 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %76, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %73, ptr %77, align 8
+  %78 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %76, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %75, ptr %78, align 8
+  %79 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %76, 0
+  %80 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %79, i64 2, 1
+  %81 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %80, i64 2, 2
+  %82 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %81)
+  store ptr %82, ptr @"main.struct$p9hq6rduefaRA0UGJ6DazYUtteEOtDFu7UHk5jhDUV4", align 8
+  %83 = load ptr, ptr @"main.struct$p9hq6rduefaRA0UGJ6DazYUtteEOtDFu7UHk5jhDUV4", align 8
+  %84 = load ptr, ptr @_llgo_byte, align 8
+  %85 = icmp eq ptr %84, null
+  br i1 %85, label %_llgo_23, label %_llgo_24
 
 _llgo_23:                                         ; preds = %_llgo_22
-  %140 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  store ptr %140, ptr @_llgo_byte, align 8
+  %86 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  store ptr %86, ptr @_llgo_byte, align 8
   br label %_llgo_24
 
 _llgo_24:                                         ; preds = %_llgo_23, %_llgo_22
-  %141 = load ptr, ptr @_llgo_byte, align 8
-  %142 = load ptr, ptr @"*_llgo_byte", align 8
-  %143 = icmp eq ptr %142, null
-  br i1 %143, label %_llgo_25, label %_llgo_26
+  %87 = load ptr, ptr @_llgo_byte, align 8
+  %88 = load ptr, ptr @"*_llgo_byte", align 8
+  %89 = icmp eq ptr %88, null
+  br i1 %89, label %_llgo_25, label %_llgo_26
 
 _llgo_25:                                         ; preds = %_llgo_24
-  %144 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %145 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %144)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %145)
-  store ptr %145, ptr @"*_llgo_byte", align 8
+  %90 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %91 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %90)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %91)
+  store ptr %91, ptr @"*_llgo_byte", align 8
   br label %_llgo_26
 
 _llgo_26:                                         ; preds = %_llgo_25, %_llgo_24
-  %146 = load ptr, ptr @"*_llgo_byte", align 8
-  %147 = load ptr, ptr @_llgo_string, align 8
-  %148 = icmp eq ptr %147, null
-  br i1 %148, label %_llgo_27, label %_llgo_28
+  %92 = load ptr, ptr @"*_llgo_byte", align 8
+  %93 = load ptr, ptr @_llgo_string, align 8
+  %94 = icmp eq ptr %93, null
+  br i1 %94, label %_llgo_27, label %_llgo_28
 
 _llgo_27:                                         ; preds = %_llgo_26
-  %149 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  store ptr %149, ptr @_llgo_string, align 8
+  %95 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  store ptr %95, ptr @_llgo_string, align 8
   br label %_llgo_28
 
 _llgo_28:                                         ; preds = %_llgo_27, %_llgo_26
-  %150 = load ptr, ptr @_llgo_string, align 8
-  %151 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %152 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %153 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %152, i32 0, i32 0
-  store ptr @1, ptr %153, align 8
-  %154 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %152, i32 0, i32 1
-  store i64 40, ptr %154, align 4
-  %155 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %152, align 8
-  %156 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %155, i64 25, i64 72, i64 0, i64 23)
-  %157 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %158 = icmp eq ptr %157, null
-  br i1 %158, label %_llgo_29, label %_llgo_30
+  %96 = load ptr, ptr @_llgo_string, align 8
+  %97 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %98 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 40 }, i64 25, i64 72, i64 0, i64 23)
+  %99 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %100 = icmp eq ptr %99, null
+  br i1 %100, label %_llgo_29, label %_llgo_30
 
 _llgo_29:                                         ; preds = %_llgo_28
-  %159 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %156)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %159)
-  store ptr %159, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %101 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %98)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %101)
+  store ptr %101, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
   br label %_llgo_30
 
 _llgo_30:                                         ; preds = %_llgo_29, %_llgo_28
-  %160 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %161 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %162 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %161, i32 0, i32 0
-  store ptr @2, ptr %162, align 8
-  %163 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %161, i32 0, i32 1
-  store i64 41, ptr %163, align 4
-  %164 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %161, align 8
-  %165 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %164, i64 8, i64 1, i64 0, i64 0)
-  %166 = load ptr, ptr @_llgo_Pointer, align 8
-  %167 = load ptr, ptr @_llgo_Pointer, align 8
-  %168 = load ptr, ptr @_llgo_Pointer, align 8
-  %169 = load ptr, ptr @_llgo_bool, align 8
-  %170 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %171 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %170, i32 0, i32 0
-  store ptr @1, ptr %171, align 8
-  %172 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %170, i32 0, i32 1
-  store i64 40, ptr %172, align 4
-  %173 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %170, align 8
-  %174 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %173, i64 25, i64 72, i64 0, i64 23)
-  %175 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %176 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %175, i32 0, i32 0
-  store ptr @8, ptr %176, align 8
-  %177 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %175, i32 0, i32 1
-  store i64 5, ptr %177, align 4
-  %178 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %175, align 8
-  %179 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %180 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %179, i32 0, i32 0
-  store ptr null, ptr %180, align 8
-  %181 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %179, i32 0, i32 1
-  store i64 0, ptr %181, align 4
-  %182 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %179, align 8
-  %183 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
-  %184 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %178, ptr %183, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %182, i1 false)
-  %185 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %186 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %185, i32 0, i32 0
-  store ptr @9, ptr %186, align 8
-  %187 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %185, i32 0, i32 1
-  store i64 8, ptr %187, align 4
-  %188 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %185, align 8
-  %189 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %190 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %189, i32 0, i32 0
-  store ptr null, ptr %190, align 8
-  %191 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %189, i32 0, i32 1
-  store i64 0, ptr %191, align 4
-  %192 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %189, align 8
-  %193 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
-  %194 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %188, ptr %193, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %192, i1 false)
-  %195 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %196 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %195, i32 0, i32 0
-  store ptr @10, ptr %196, align 8
-  %197 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %195, i32 0, i32 1
-  store i64 4, ptr %197, align 4
-  %198 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %195, align 8
-  %199 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %200 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %199, i32 0, i32 0
-  store ptr null, ptr %200, align 8
-  %201 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %199, i32 0, i32 1
-  store i64 0, ptr %201, align 4
-  %202 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %199, align 8
-  %203 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 42)
-  %204 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %198, ptr %203, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %202, i1 false)
-  %205 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %206 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %205, i32 0, i32 0
-  store ptr @4, ptr %206, align 8
-  %207 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %205, i32 0, i32 1
-  store i64 5, ptr %207, align 4
-  %208 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %205, align 8
-  %209 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %210 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %209, i32 0, i32 0
-  store ptr null, ptr %210, align 8
-  %211 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %209, i32 0, i32 1
-  store i64 0, ptr %211, align 4
-  %212 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %209, align 8
-  %213 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %208, ptr %165, i64 20, %"github.com/goplus/llgo/internal/runtime.String" %212, i1 false)
-  %214 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %215 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %214, i32 0, i32 0
-  store ptr @11, ptr %215, align 8
-  %216 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %214, i32 0, i32 1
-  store i64 6, ptr %216, align 4
-  %217 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %214, align 8
-  %218 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %219 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %218, i32 0, i32 0
-  store ptr null, ptr %219, align 8
-  %220 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %218, i32 0, i32 1
-  store i64 0, ptr %220, align 4
-  %221 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %218, align 8
-  %222 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %223 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %217, ptr %222, i64 21, %"github.com/goplus/llgo/internal/runtime.String" %221, i1 false)
-  %224 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %225 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %224, i32 0, i32 0
-  store ptr @12, ptr %225, align 8
-  %226 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %224, i32 0, i32 1
-  store i64 11, ptr %226, align 4
-  %227 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %224, align 8
-  %228 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %229 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %228, i32 0, i32 0
-  store ptr null, ptr %229, align 8
-  %230 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %228, i32 0, i32 1
-  store i64 0, ptr %230, align 4
-  %231 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %228, align 8
-  %232 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %233 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %227, ptr %232, i64 22, %"github.com/goplus/llgo/internal/runtime.String" %231, i1 false)
-  %234 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %235 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %234, i32 0, i32 0
-  store ptr @13, ptr %235, align 8
-  %236 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %234, i32 0, i32 1
-  store i64 5, ptr %236, align 4
-  %237 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %234, align 8
-  %238 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %239 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %238, i32 0, i32 0
-  store ptr null, ptr %239, align 8
-  %240 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %238, i32 0, i32 1
-  store i64 0, ptr %240, align 4
-  %241 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %238, align 8
-  %242 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %243 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %237, ptr %242, i64 23, %"github.com/goplus/llgo/internal/runtime.String" %241, i1 false)
-  %244 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %245 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %244, i32 0, i32 0
-  store ptr @14, ptr %245, align 8
-  %246 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %244, i32 0, i32 1
-  store i64 5, ptr %246, align 4
-  %247 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %244, align 8
-  %248 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %249 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %248, i32 0, i32 0
-  store ptr null, ptr %249, align 8
-  %250 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %248, i32 0, i32 1
-  store i64 0, ptr %250, align 4
-  %251 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %248, align 8
-  %252 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %253 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %252, i32 0, i32 0
-  store ptr @5, ptr %253, align 8
-  %254 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %252, i32 0, i32 1
-  store i64 1, ptr %254, align 4
-  %255 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %252, align 8
-  %256 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %257 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %256, i32 0, i32 0
-  store ptr null, ptr %257, align 8
-  %258 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %256, i32 0, i32 1
-  store i64 0, ptr %258, align 4
-  %259 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %256, align 8
-  %260 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %261 = getelementptr ptr, ptr %260, i64 0
-  store ptr %166, ptr %261, align 8
-  %262 = getelementptr ptr, ptr %260, i64 1
-  store ptr %167, ptr %262, align 8
-  %263 = getelementptr ptr, ptr %260, i64 2
-  store ptr %168, ptr %263, align 8
-  %264 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %265 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %264, i32 0, i32 0
-  store ptr %260, ptr %265, align 8
-  %266 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %264, i32 0, i32 1
-  store i64 3, ptr %266, align 4
-  %267 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %264, i32 0, i32 2
-  store i64 3, ptr %267, align 4
-  %268 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %264, align 8
-  %269 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %270 = getelementptr ptr, ptr %269, i64 0
-  store ptr %169, ptr %270, align 8
-  %271 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %272 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %271, i32 0, i32 0
-  store ptr %269, ptr %272, align 8
-  %273 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %271, i32 0, i32 1
-  store i64 1, ptr %273, align 4
-  %274 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %271, i32 0, i32 2
-  store i64 1, ptr %274, align 4
-  %275 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %271, align 8
-  %276 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %268, %"github.com/goplus/llgo/internal/runtime.Slice" %275, i1 false)
-  %277 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %255, ptr %276, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %259, i1 false)
-  %278 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %279 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %278, i32 0, i32 0
-  store ptr @6, ptr %279, align 8
-  %280 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %278, i32 0, i32 1
-  store i64 4, ptr %280, align 4
-  %281 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %278, align 8
-  %282 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %283 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %282, i32 0, i32 0
-  store ptr null, ptr %283, align 8
-  %284 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %282, i32 0, i32 1
-  store i64 0, ptr %284, align 4
-  %285 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %282, align 8
-  %286 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %287 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %281, ptr %286, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %285, i1 false)
-  %288 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %289 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %288, i32 0, i32 0
-  store ptr @7, ptr %289, align 8
-  %290 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %288, i32 0, i32 1
-  store i64 4, ptr %290, align 4
-  %291 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %288, align 8
-  %292 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %293 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %292, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %277, ptr %293, align 8
-  %294 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %292, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %287, ptr %294, align 8
-  %295 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %296 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %295, i32 0, i32 0
-  store ptr %292, ptr %296, align 8
-  %297 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %295, i32 0, i32 1
-  store i64 2, ptr %297, align 4
-  %298 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %295, i32 0, i32 2
-  store i64 2, ptr %298, align 4
-  %299 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %295, align 8
-  %300 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %291, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %299)
-  %301 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %247, ptr %300, i64 24, %"github.com/goplus/llgo/internal/runtime.String" %251, i1 false)
-  %302 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %303 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %302, i32 0, i32 0
-  store ptr @15, ptr %303, align 8
-  %304 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %302, i32 0, i32 1
-  store i64 6, ptr %304, align 4
-  %305 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %302, align 8
-  %306 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %307 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %306, i32 0, i32 0
-  store ptr null, ptr %307, align 8
-  %308 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %306, i32 0, i32 1
-  store i64 0, ptr %308, align 4
-  %309 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %306, align 8
-  %310 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %311 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %310)
-  %312 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %305, ptr %311, i64 40, %"github.com/goplus/llgo/internal/runtime.String" %309, i1 false)
-  %313 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %314 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %313, i32 0, i32 0
-  store ptr @16, ptr %314, align 8
-  %315 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %313, i32 0, i32 1
-  store i64 4, ptr %315, align 4
-  %316 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %313, align 8
-  %317 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %318 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %317, i32 0, i32 0
-  store ptr null, ptr %318, align 8
-  %319 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %317, i32 0, i32 1
-  store i64 0, ptr %319, align 4
-  %320 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %317, align 8
-  %321 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %322 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %316, ptr %321, i64 48, %"github.com/goplus/llgo/internal/runtime.String" %320, i1 false)
-  %323 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %324 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %323, i32 0, i32 0
-  store ptr @17, ptr %324, align 8
-  %325 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %323, i32 0, i32 1
-  store i64 10, ptr %325, align 4
-  %326 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %323, align 8
-  %327 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %328 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %327, i32 0, i32 0
-  store ptr null, ptr %328, align 8
-  %329 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %327, i32 0, i32 1
-  store i64 0, ptr %329, align 4
-  %330 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %327, align 8
-  %331 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %174)
-  %332 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %326, ptr %331, i64 64, %"github.com/goplus/llgo/internal/runtime.String" %330, i1 false)
-  %333 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %334 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %333, i32 0, i32 0
-  store ptr @7, ptr %334, align 8
-  %335 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %333, i32 0, i32 1
-  store i64 4, ptr %335, align 4
-  %336 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %333, align 8
-  %337 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 616)
-  %338 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %337, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %184, ptr %338, align 8
-  %339 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %337, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %194, ptr %339, align 8
-  %340 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %337, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %204, ptr %340, align 8
-  %341 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %337, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %213, ptr %341, align 8
-  %342 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %337, i64 4
-  store %"github.com/goplus/llgo/internal/abi.StructField" %223, ptr %342, align 8
-  %343 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %337, i64 5
-  store %"github.com/goplus/llgo/internal/abi.StructField" %233, ptr %343, align 8
-  %344 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %337, i64 6
-  store %"github.com/goplus/llgo/internal/abi.StructField" %243, ptr %344, align 8
-  %345 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %337, i64 7
-  store %"github.com/goplus/llgo/internal/abi.StructField" %301, ptr %345, align 8
-  %346 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %337, i64 8
-  store %"github.com/goplus/llgo/internal/abi.StructField" %312, ptr %346, align 8
-  %347 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %337, i64 9
-  store %"github.com/goplus/llgo/internal/abi.StructField" %322, ptr %347, align 8
-  %348 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %337, i64 10
-  store %"github.com/goplus/llgo/internal/abi.StructField" %332, ptr %348, align 8
-  %349 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %350 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %349, i32 0, i32 0
-  store ptr %337, ptr %350, align 8
-  %351 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %349, i32 0, i32 1
-  store i64 11, ptr %351, align 4
-  %352 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %349, i32 0, i32 2
-  store i64 11, ptr %352, align 4
-  %353 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %349, align 8
-  %354 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %336, i64 72, %"github.com/goplus/llgo/internal/runtime.Slice" %353)
-  store ptr %354, ptr @"main.struct$13P_TvKNXommvK6tKt3eRNnJqTcPEFYrHagFiHeRpb0", align 8
-  %355 = load ptr, ptr @"main.struct$13P_TvKNXommvK6tKt3eRNnJqTcPEFYrHagFiHeRpb0", align 8
-  br i1 %23, label %_llgo_31, label %_llgo_32
+  %102 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %103 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 41 }, i64 8, i64 1, i64 0, i64 0)
+  %104 = load ptr, ptr @_llgo_Pointer, align 8
+  %105 = load ptr, ptr @_llgo_Pointer, align 8
+  %106 = load ptr, ptr @_llgo_Pointer, align 8
+  %107 = load ptr, ptr @_llgo_bool, align 8
+  %108 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 40 }, i64 25, i64 72, i64 0, i64 23)
+  %109 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
+  %110 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 5 }, ptr %109, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %111 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
+  %112 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 8 }, ptr %111, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %113 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 42)
+  %114 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, ptr %113, i64 16, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %115 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 5 }, ptr %103, i64 20, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %116 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %117 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 6 }, ptr %116, i64 21, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %118 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %119 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @12, i64 11 }, ptr %118, i64 22, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %120 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %121 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @13, i64 5 }, ptr %120, i64 23, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %122 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %123 = getelementptr ptr, ptr %122, i64 0
+  store ptr %104, ptr %123, align 8
+  %124 = getelementptr ptr, ptr %122, i64 1
+  store ptr %105, ptr %124, align 8
+  %125 = getelementptr ptr, ptr %122, i64 2
+  store ptr %106, ptr %125, align 8
+  %126 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %122, 0
+  %127 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %126, i64 3, 1
+  %128 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %127, i64 3, 2
+  %129 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %130 = getelementptr ptr, ptr %129, i64 0
+  store ptr %107, ptr %130, align 8
+  %131 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %129, 0
+  %132 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %131, i64 1, 1
+  %133 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %132, i64 1, 2
+  %134 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %128, %"github.com/goplus/llgo/internal/runtime.Slice" %133, i1 false)
+  %135 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 1 }, ptr %134, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %136 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %137 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 4 }, ptr %136, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %138 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %139 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %138, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %135, ptr %139, align 8
+  %140 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %138, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %137, ptr %140, align 8
+  %141 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %138, 0
+  %142 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %141, i64 2, 1
+  %143 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %142, i64 2, 2
+  %144 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %143)
+  %145 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @14, i64 5 }, ptr %144, i64 24, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %146 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %147 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %146)
+  %148 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @15, i64 6 }, ptr %147, i64 40, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %149 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %150 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @16, i64 4 }, ptr %149, i64 48, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %151 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %108)
+  %152 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @17, i64 10 }, ptr %151, i64 64, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %153 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 616)
+  %154 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %153, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %110, ptr %154, align 8
+  %155 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %153, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %112, ptr %155, align 8
+  %156 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %153, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %114, ptr %156, align 8
+  %157 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %153, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %115, ptr %157, align 8
+  %158 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %153, i64 4
+  store %"github.com/goplus/llgo/internal/abi.StructField" %117, ptr %158, align 8
+  %159 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %153, i64 5
+  store %"github.com/goplus/llgo/internal/abi.StructField" %119, ptr %159, align 8
+  %160 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %153, i64 6
+  store %"github.com/goplus/llgo/internal/abi.StructField" %121, ptr %160, align 8
+  %161 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %153, i64 7
+  store %"github.com/goplus/llgo/internal/abi.StructField" %145, ptr %161, align 8
+  %162 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %153, i64 8
+  store %"github.com/goplus/llgo/internal/abi.StructField" %148, ptr %162, align 8
+  %163 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %153, i64 9
+  store %"github.com/goplus/llgo/internal/abi.StructField" %150, ptr %163, align 8
+  %164 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %153, i64 10
+  store %"github.com/goplus/llgo/internal/abi.StructField" %152, ptr %164, align 8
+  %165 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %153, 0
+  %166 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %165, i64 11, 1
+  %167 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %166, i64 11, 2
+  %168 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 }, i64 72, %"github.com/goplus/llgo/internal/runtime.Slice" %167)
+  store ptr %168, ptr @"main.struct$13P_TvKNXommvK6tKt3eRNnJqTcPEFYrHagFiHeRpb0", align 8
+  %169 = load ptr, ptr @"main.struct$13P_TvKNXommvK6tKt3eRNnJqTcPEFYrHagFiHeRpb0", align 8
+  br i1 %11, label %_llgo_31, label %_llgo_32
 
 _llgo_31:                                         ; preds = %_llgo_30
-  %356 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %357 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %356, i32 0, i32 0
-  store ptr @18, ptr %357, align 8
-  %358 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %356, i32 0, i32 1
-  store i64 5, ptr %358, align 4
-  %359 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %356, align 8
-  %360 = load ptr, ptr @_llgo_int, align 8
-  %361 = icmp eq ptr %360, null
-  br i1 %361, label %_llgo_33, label %_llgo_34
+  %170 = load ptr, ptr @_llgo_int, align 8
+  %171 = icmp eq ptr %170, null
+  br i1 %171, label %_llgo_33, label %_llgo_34
 
 _llgo_32:                                         ; preds = %_llgo_42, %_llgo_30
-  %362 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %363 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %364 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %365 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %364, i32 0, i32 0
-  store ptr @0, ptr %365, align 8
-  %366 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %364, i32 0, i32 1
-  store i64 6, ptr %366, align 4
-  %367 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %364, align 8
-  %368 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %367, i64 25, i64 48, i64 0, i64 0)
-  %369 = load ptr, ptr @"[]_llgo_main.T", align 8
-  %370 = icmp eq ptr %369, null
-  br i1 %370, label %_llgo_149, label %_llgo_150
+  %172 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %173 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %174 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 6 }, i64 25, i64 48, i64 0, i64 0)
+  %175 = load ptr, ptr @"[]_llgo_main.T", align 8
+  %176 = icmp eq ptr %175, null
+  br i1 %176, label %_llgo_149, label %_llgo_150
 
 _llgo_33:                                         ; preds = %_llgo_31
-  %371 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  store ptr %371, ptr @_llgo_int, align 8
+  %177 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  store ptr %177, ptr @_llgo_int, align 8
   br label %_llgo_34
 
 _llgo_34:                                         ; preds = %_llgo_33, %_llgo_31
-  %372 = load ptr, ptr @_llgo_int, align 8
-  %373 = load ptr, ptr @_llgo_int, align 8
-  %374 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %375 = icmp eq ptr %374, null
-  br i1 %375, label %_llgo_35, label %_llgo_36
+  %178 = load ptr, ptr @_llgo_int, align 8
+  %179 = load ptr, ptr @_llgo_int, align 8
+  %180 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %181 = icmp eq ptr %180, null
+  br i1 %181, label %_llgo_35, label %_llgo_36
 
 _llgo_35:                                         ; preds = %_llgo_34
-  %376 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %377 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %378 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %377, i32 0, i32 0
-  store ptr %376, ptr %378, align 8
-  %379 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %377, i32 0, i32 1
-  store i64 0, ptr %379, align 4
-  %380 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %377, i32 0, i32 2
-  store i64 0, ptr %380, align 4
-  %381 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %377, align 8
-  %382 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %383 = getelementptr ptr, ptr %382, i64 0
-  store ptr %373, ptr %383, align 8
-  %384 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %385 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %384, i32 0, i32 0
-  store ptr %382, ptr %385, align 8
-  %386 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %384, i32 0, i32 1
-  store i64 1, ptr %386, align 4
-  %387 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %384, i32 0, i32 2
-  store i64 1, ptr %387, align 4
-  %388 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %384, align 8
-  %389 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %381, %"github.com/goplus/llgo/internal/runtime.Slice" %388, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %389)
-  store ptr %389, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %182 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %183 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %182, 0
+  %184 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %183, i64 0, 1
+  %185 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %184, i64 0, 2
+  %186 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %187 = getelementptr ptr, ptr %186, i64 0
+  store ptr %179, ptr %187, align 8
+  %188 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %186, 0
+  %189 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %188, i64 1, 1
+  %190 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %189, i64 1, 2
+  %191 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %185, %"github.com/goplus/llgo/internal/runtime.Slice" %190, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %191)
+  store ptr %191, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
   br label %_llgo_36
 
 _llgo_36:                                         ; preds = %_llgo_35, %_llgo_34
-  %390 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %391 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %392 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %391, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %359, ptr %392, align 8
-  %393 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %391, i32 0, i32 1
-  store ptr %390, ptr %393, align 8
-  %394 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %391, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Align", ptr %394, align 8
-  %395 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %391, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Align", ptr %395, align 8
-  %396 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %391, align 8
-  %397 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %398 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %397, i32 0, i32 0
-  store ptr @19, ptr %398, align 8
-  %399 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %397, i32 0, i32 1
-  store i64 9, ptr %399, align 4
-  %400 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %397, align 8
-  %401 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %402 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %401, i32 0, i32 0
-  store ptr @20, ptr %402, align 8
-  %403 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %401, i32 0, i32 1
-  store i64 45, ptr %403, align 4
-  %404 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %401, align 8
-  %405 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %404, i64 25, i64 104, i64 0, i64 21)
-  %406 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
-  %407 = icmp eq ptr %406, null
-  br i1 %407, label %_llgo_37, label %_llgo_38
+  %192 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %193 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @18, i64 5 }, ptr undef, ptr undef, ptr undef }, ptr %192, 1
+  %194 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %193, ptr @"github.com/goplus/llgo/internal/abi.(*Type).Align", 2
+  %195 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %194, ptr @"github.com/goplus/llgo/internal/abi.(*Type).Align", 3
+  %196 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @20, i64 45 }, i64 25, i64 104, i64 0, i64 21)
+  %197 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  %198 = icmp eq ptr %197, null
+  br i1 %198, label %_llgo_37, label %_llgo_38
 
 _llgo_37:                                         ; preds = %_llgo_36
-  store ptr %405, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  store ptr %196, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
   br label %_llgo_38
 
 _llgo_38:                                         ; preds = %_llgo_37, %_llgo_36
-  %408 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %409 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %410 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %411 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %410, i32 0, i32 0
-  store ptr @1, ptr %411, align 8
-  %412 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %410, i32 0, i32 1
-  store i64 40, ptr %412, align 4
-  %413 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %410, align 8
-  %414 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %413, i64 25, i64 80, i64 0, i64 23)
-  %415 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %416 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %415, i32 0, i32 0
-  store ptr @1, ptr %416, align 8
-  %417 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %415, i32 0, i32 1
-  store i64 40, ptr %417, align 4
-  %418 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %415, align 8
-  %419 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %418, i64 25, i64 80, i64 0, i64 23)
-  %420 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %421 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %420, i32 0, i32 0
-  store ptr @1, ptr %421, align 8
-  %422 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %420, i32 0, i32 1
-  store i64 40, ptr %422, align 4
-  %423 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %420, align 8
-  %424 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %423, i64 25, i64 80, i64 0, i64 23)
-  %425 = load ptr, ptr @"_llgo_struct$eLreYy_0Tx9Ip-rgTmC6_uCvf27HVl_zBUTfLS0WYaY", align 8
-  %426 = icmp eq ptr %425, null
-  br i1 %426, label %_llgo_39, label %_llgo_40
+  %199 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %200 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %201 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 40 }, i64 25, i64 80, i64 0, i64 23)
+  %202 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 40 }, i64 25, i64 80, i64 0, i64 23)
+  %203 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 40 }, i64 25, i64 80, i64 0, i64 23)
+  %204 = load ptr, ptr @"_llgo_struct$eLreYy_0Tx9Ip-rgTmC6_uCvf27HVl_zBUTfLS0WYaY", align 8
+  %205 = icmp eq ptr %204, null
+  br i1 %205, label %_llgo_39, label %_llgo_40
 
 _llgo_39:                                         ; preds = %_llgo_38
-  %427 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %428 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %427, i32 0, i32 0
-  store ptr @21, ptr %428, align 8
-  %429 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %427, i32 0, i32 1
-  store i64 4, ptr %429, align 4
-  %430 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %427, align 8
-  %431 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %432 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %431, i32 0, i32 0
-  store ptr null, ptr %432, align 8
-  %433 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %431, i32 0, i32 1
-  store i64 0, ptr %433, align 4
-  %434 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %431, align 8
-  %435 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %430, ptr %414, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %434, i1 true)
-  %436 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %437 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %436, i32 0, i32 0
-  store ptr @22, ptr %437, align 8
-  %438 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %436, i32 0, i32 1
-  store i64 4, ptr %438, align 4
-  %439 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %436, align 8
-  %440 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %441 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %440, i32 0, i32 0
-  store ptr null, ptr %441, align 8
-  %442 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %440, i32 0, i32 1
-  store i64 0, ptr %442, align 4
-  %443 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %440, align 8
-  %444 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %419)
-  %445 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %439, ptr %444, i64 72, %"github.com/goplus/llgo/internal/runtime.String" %443, i1 false)
-  %446 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %447 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %446, i32 0, i32 0
-  store ptr @23, ptr %447, align 8
-  %448 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %446, i32 0, i32 1
-  store i64 5, ptr %448, align 4
-  %449 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %446, align 8
-  %450 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %451 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %450, i32 0, i32 0
-  store ptr null, ptr %451, align 8
-  %452 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %450, i32 0, i32 1
-  store i64 0, ptr %452, align 4
-  %453 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %450, align 8
-  %454 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %424)
-  %455 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %449, ptr %454, i64 80, %"github.com/goplus/llgo/internal/runtime.String" %453, i1 false)
-  %456 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %457 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %456, i32 0, i32 0
-  store ptr @24, ptr %457, align 8
-  %458 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %456, i32 0, i32 1
-  store i64 3, ptr %458, align 4
-  %459 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %456, align 8
-  %460 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %461 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %460, i32 0, i32 0
-  store ptr null, ptr %461, align 8
-  %462 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %460, i32 0, i32 1
-  store i64 0, ptr %462, align 4
-  %463 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %460, align 8
-  %464 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
-  %465 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %459, ptr %464, i64 88, %"github.com/goplus/llgo/internal/runtime.String" %463, i1 false)
-  %466 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %467 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %466, i32 0, i32 0
-  store ptr @7, ptr %467, align 8
-  %468 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %466, i32 0, i32 1
-  store i64 4, ptr %468, align 4
-  %469 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %466, align 8
-  %470 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
-  %471 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %470, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %435, ptr %471, align 8
-  %472 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %470, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %445, ptr %472, align 8
-  %473 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %470, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %455, ptr %473, align 8
-  %474 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %470, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %465, ptr %474, align 8
-  %475 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %476 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %475, i32 0, i32 0
-  store ptr %470, ptr %476, align 8
-  %477 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %475, i32 0, i32 1
-  store i64 4, ptr %477, align 4
-  %478 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %475, i32 0, i32 2
-  store i64 4, ptr %478, align 4
-  %479 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %475, align 8
-  %480 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %469, i64 96, %"github.com/goplus/llgo/internal/runtime.Slice" %479)
-  store ptr %480, ptr @"_llgo_struct$eLreYy_0Tx9Ip-rgTmC6_uCvf27HVl_zBUTfLS0WYaY", align 8
+  %206 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @21, i64 4 }, ptr %201, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 true)
+  %207 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %202)
+  %208 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @22, i64 4 }, ptr %207, i64 72, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %209 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %203)
+  %210 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @23, i64 5 }, ptr %209, i64 80, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %211 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
+  %212 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @24, i64 3 }, ptr %211, i64 88, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %213 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
+  %214 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %213, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %206, ptr %214, align 8
+  %215 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %213, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %208, ptr %215, align 8
+  %216 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %213, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %210, ptr %216, align 8
+  %217 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %213, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %212, ptr %217, align 8
+  %218 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %213, 0
+  %219 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %218, i64 4, 1
+  %220 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %219, i64 4, 2
+  %221 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 }, i64 96, %"github.com/goplus/llgo/internal/runtime.Slice" %220)
+  store ptr %221, ptr @"_llgo_struct$eLreYy_0Tx9Ip-rgTmC6_uCvf27HVl_zBUTfLS0WYaY", align 8
   br label %_llgo_40
 
 _llgo_40:                                         ; preds = %_llgo_39, %_llgo_38
-  %481 = load ptr, ptr @"_llgo_struct$eLreYy_0Tx9Ip-rgTmC6_uCvf27HVl_zBUTfLS0WYaY", align 8
-  br i1 %407, label %_llgo_41, label %_llgo_42
+  %222 = load ptr, ptr @"_llgo_struct$eLreYy_0Tx9Ip-rgTmC6_uCvf27HVl_zBUTfLS0WYaY", align 8
+  br i1 %198, label %_llgo_41, label %_llgo_42
 
 _llgo_41:                                         ; preds = %_llgo_40
-  %482 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %483 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %482, i32 0, i32 0
-  store ptr @18, ptr %483, align 8
-  %484 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %482, i32 0, i32 1
-  store i64 5, ptr %484, align 4
-  %485 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %482, align 8
-  %486 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %487 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %488 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %487, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %485, ptr %488, align 8
-  %489 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %487, i32 0, i32 1
-  store ptr %486, ptr %489, align 8
-  %490 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %487, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Align", ptr %490, align 8
-  %491 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %487, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Align", ptr %491, align 8
-  %492 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %487, align 8
-  %493 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %494 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %493, i32 0, i32 0
-  store ptr @19, ptr %494, align 8
-  %495 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %493, i32 0, i32 1
-  store i64 9, ptr %495, align 4
-  %496 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %493, align 8
-  %497 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %498 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %497, i32 0, i32 0
-  store ptr @20, ptr %498, align 8
-  %499 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %497, i32 0, i32 1
-  store i64 45, ptr %499, align 4
-  %500 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %497, align 8
-  %501 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %500, i64 25, i64 104, i64 0, i64 21)
-  %502 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
-  %503 = icmp eq ptr %502, null
-  br i1 %503, label %_llgo_43, label %_llgo_44
+  %223 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %224 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @18, i64 5 }, ptr undef, ptr undef, ptr undef }, ptr %223, 1
+  %225 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %224, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Align", 2
+  %226 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %225, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Align", 3
+  %227 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @20, i64 45 }, i64 25, i64 104, i64 0, i64 21)
+  %228 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  %229 = icmp eq ptr %228, null
+  br i1 %229, label %_llgo_43, label %_llgo_44
 
 _llgo_42:                                         ; preds = %_llgo_148, %_llgo_40
-  %504 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
-  %505 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
-  %506 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
-  %507 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %508 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %507, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %400, ptr %508, align 8
-  %509 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %507, i32 0, i32 1
-  store ptr %506, ptr %509, align 8
-  %510 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %507, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).ArrayType", ptr %510, align 8
-  %511 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %507, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).ArrayType", ptr %511, align 8
-  %512 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %507, align 8
-  %513 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %514 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %513, i32 0, i32 0
-  store ptr @25, ptr %514, align 8
-  %515 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %513, i32 0, i32 1
-  store i64 7, ptr %515, align 4
-  %516 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %513, align 8
-  %517 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
-  %518 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %519 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %518, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %516, ptr %519, align 8
-  %520 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %518, i32 0, i32 1
-  store ptr %517, ptr %520, align 8
-  %521 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %518, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).ChanDir", ptr %521, align 8
-  %522 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %518, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).ChanDir", ptr %522, align 8
-  %523 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %518, align 8
-  %524 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %525 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %524, i32 0, i32 0
-  store ptr @27, ptr %525, align 8
-  %526 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %524, i32 0, i32 1
-  store i64 6, ptr %526, align 4
-  %527 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %524, align 8
-  %528 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %529 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %530 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %531 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %530, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %527, ptr %531, align 8
-  %532 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %530, i32 0, i32 1
-  store ptr %529, ptr %532, align 8
-  %533 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %530, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Common", ptr %533, align 8
-  %534 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %530, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Common", ptr %534, align 8
-  %535 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %530, align 8
-  %536 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %537 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %536, i32 0, i32 0
-  store ptr @22, ptr %537, align 8
-  %538 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %536, i32 0, i32 1
-  store i64 4, ptr %538, align 4
-  %539 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %536, align 8
-  %540 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %541 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %542 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %543 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %542, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %539, ptr %543, align 8
-  %544 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %542, i32 0, i32 1
-  store ptr %541, ptr %544, align 8
-  %545 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %542, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Elem", ptr %545, align 8
-  %546 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %542, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Elem", ptr %546, align 8
-  %547 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %542, align 8
-  %548 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %549 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %548, i32 0, i32 0
-  store ptr @28, ptr %549, align 8
-  %550 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %548, i32 0, i32 1
-  store i64 15, ptr %550, align 4
-  %551 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %548, align 8
-  %552 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %553 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
-  %554 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %555 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %554, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %551, ptr %555, align 8
-  %556 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %554, i32 0, i32 1
-  store ptr %553, ptr %556, align 8
-  %557 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %554, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).ExportedMethods", ptr %557, align 8
-  %558 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %554, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).ExportedMethods", ptr %558, align 8
-  %559 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %554, align 8
-  %560 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %561 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %560, i32 0, i32 0
-  store ptr @33, ptr %561, align 8
-  %562 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %560, i32 0, i32 1
-  store i64 10, ptr %562, align 4
-  %563 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %560, align 8
-  %564 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %565 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %566 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %565, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %563, ptr %566, align 8
-  %567 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %565, i32 0, i32 1
-  store ptr %564, ptr %567, align 8
-  %568 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %565, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).FieldAlign", ptr %568, align 8
-  %569 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %565, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).FieldAlign", ptr %569, align 8
-  %570 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %565, align 8
-  %571 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %572 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %571, i32 0, i32 0
-  store ptr @34, ptr %572, align 8
-  %573 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %571, i32 0, i32 1
-  store i64 8, ptr %573, align 4
-  %574 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %571, align 8
-  %575 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %576 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
-  %577 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %578 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %577, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %574, ptr %578, align 8
-  %579 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %577, i32 0, i32 1
-  store ptr %576, ptr %579, align 8
-  %580 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %577, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).FuncType", ptr %580, align 8
-  %581 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %577, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).FuncType", ptr %581, align 8
-  %582 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %577, align 8
-  %583 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %584 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %583, i32 0, i32 0
-  store ptr @35, ptr %584, align 8
-  %585 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %583, i32 0, i32 1
-  store i64 7, ptr %585, align 4
-  %586 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %583, align 8
-  %587 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %588 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %589 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %588, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %586, ptr %589, align 8
-  %590 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %588, i32 0, i32 1
-  store ptr %587, ptr %590, align 8
-  %591 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %588, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).HasName", ptr %591, align 8
-  %592 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %588, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).HasName", ptr %592, align 8
-  %593 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %588, align 8
-  %594 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %595 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %594, i32 0, i32 0
-  store ptr @36, ptr %595, align 8
-  %596 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %594, i32 0, i32 1
-  store i64 10, ptr %596, align 4
-  %597 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %594, align 8
-  %598 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %599 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %600 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %599, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %597, ptr %600, align 8
-  %601 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %599, i32 0, i32 1
-  store ptr %598, ptr %601, align 8
-  %602 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %599, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).IfaceIndir", ptr %602, align 8
-  %603 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %599, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).IfaceIndir", ptr %603, align 8
-  %604 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %599, align 8
-  %605 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %606 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %605, i32 0, i32 0
-  store ptr @37, ptr %606, align 8
-  %607 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %605, i32 0, i32 1
-  store i64 13, ptr %607, align 4
-  %608 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %605, align 8
-  %609 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
-  %610 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
-  %611 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %612 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %611, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %608, ptr %612, align 8
-  %613 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %611, i32 0, i32 1
-  store ptr %610, ptr %613, align 8
-  %614 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %611, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).InterfaceType", ptr %614, align 8
-  %615 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %611, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).InterfaceType", ptr %615, align 8
-  %616 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %611, align 8
-  %617 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %618 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %617, i32 0, i32 0
-  store ptr @48, ptr %618, align 8
-  %619 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %617, i32 0, i32 1
-  store i64 9, ptr %619, align 4
-  %620 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %617, align 8
-  %621 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %622 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %623 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %622, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %620, ptr %623, align 8
-  %624 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %622, i32 0, i32 1
-  store ptr %621, ptr %624, align 8
-  %625 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %622, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).IsClosure", ptr %625, align 8
-  %626 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %622, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).IsClosure", ptr %626, align 8
-  %627 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %622, align 8
-  %628 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %629 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %628, i32 0, i32 0
-  store ptr @49, ptr %629, align 8
-  %630 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %628, i32 0, i32 1
-  store i64 13, ptr %630, align 4
-  %631 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %628, align 8
-  %632 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %633 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %634 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %633, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %631, ptr %634, align 8
-  %635 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %633, i32 0, i32 1
-  store ptr %632, ptr %635, align 8
-  %636 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %633, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).IsDirectIface", ptr %636, align 8
-  %637 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %633, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).IsDirectIface", ptr %637, align 8
-  %638 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %633, align 8
-  %639 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %640 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %639, i32 0, i32 0
-  store ptr @50, ptr %640, align 8
-  %641 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %639, i32 0, i32 1
-  store i64 3, ptr %641, align 4
-  %642 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %639, align 8
-  %643 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %644 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %645 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %646 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %645, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %642, ptr %646, align 8
-  %647 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %645, i32 0, i32 1
-  store ptr %644, ptr %647, align 8
-  %648 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %645, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Key", ptr %648, align 8
-  %649 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %645, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Key", ptr %649, align 8
-  %650 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %645, align 8
-  %651 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %652 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %651, i32 0, i32 0
-  store ptr @51, ptr %652, align 8
-  %653 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %651, i32 0, i32 1
-  store i64 4, ptr %653, align 4
-  %654 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %651, align 8
-  %655 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
-  %656 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %657 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %656, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %654, ptr %657, align 8
-  %658 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %656, i32 0, i32 1
-  store ptr %655, ptr %658, align 8
-  %659 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %656, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Kind", ptr %659, align 8
-  %660 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %656, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Kind", ptr %660, align 8
-  %661 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %656, align 8
-  %662 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %663 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %662, i32 0, i32 0
-  store ptr @24, ptr %663, align 8
-  %664 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %662, i32 0, i32 1
-  store i64 3, ptr %664, align 4
-  %665 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %662, align 8
-  %666 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %667 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %668 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %667, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %665, ptr %668, align 8
-  %669 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %667, i32 0, i32 1
-  store ptr %666, ptr %669, align 8
-  %670 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %667, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Len", ptr %670, align 8
-  %671 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %667, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Len", ptr %671, align 8
-  %672 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %667, align 8
-  %673 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %674 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %673, i32 0, i32 0
-  store ptr @54, ptr %674, align 8
-  %675 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %673, i32 0, i32 1
-  store i64 7, ptr %675, align 4
-  %676 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %673, align 8
-  %677 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
-  %678 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
-  %679 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %680 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %679, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %676, ptr %680, align 8
-  %681 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %679, i32 0, i32 1
-  store ptr %678, ptr %681, align 8
-  %682 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %679, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).MapType", ptr %682, align 8
-  %683 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %679, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).MapType", ptr %683, align 8
-  %684 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %679, align 8
-  %685 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %686 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %685, i32 0, i32 0
-  store ptr @66, ptr %686, align 8
-  %687 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %685, i32 0, i32 1
-  store i64 9, ptr %687, align 4
-  %688 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %685, align 8
-  %689 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %690 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %691 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %690, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %688, ptr %691, align 8
-  %692 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %690, i32 0, i32 1
-  store ptr %689, ptr %692, align 8
-  %693 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %690, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).NumMethod", ptr %693, align 8
-  %694 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %690, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).NumMethod", ptr %694, align 8
-  %695 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %690, align 8
-  %696 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %697 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %696, i32 0, i32 0
-  store ptr @67, ptr %697, align 8
-  %698 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %696, i32 0, i32 1
-  store i64 8, ptr %698, align 4
-  %699 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %696, align 8
-  %700 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %701 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %702 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %701, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %699, ptr %702, align 8
-  %703 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %701, i32 0, i32 1
-  store ptr %700, ptr %703, align 8
-  %704 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %701, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Pointers", ptr %704, align 8
-  %705 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %701, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Pointers", ptr %705, align 8
-  %706 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %701, align 8
-  %707 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %708 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %707, i32 0, i32 0
-  store ptr @69, ptr %708, align 8
-  %709 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %707, i32 0, i32 1
-  store i64 4, ptr %709, align 4
-  %710 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %707, align 8
-  %711 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
-  %712 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %713 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %712, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %710, ptr %713, align 8
-  %714 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %712, i32 0, i32 1
-  store ptr %711, ptr %714, align 8
-  %715 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %712, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Size", ptr %715, align 8
-  %716 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %712, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Size", ptr %716, align 8
-  %717 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %712, align 8
-  %718 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %719 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %718, i32 0, i32 0
-  store ptr @53, ptr %719, align 8
-  %720 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %718, i32 0, i32 1
-  store i64 6, ptr %720, align 4
-  %721 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %718, align 8
-  %722 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %723 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %724 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %723, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %721, ptr %724, align 8
-  %725 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %723, i32 0, i32 1
-  store ptr %722, ptr %725, align 8
-  %726 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %723, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).String", ptr %726, align 8
-  %727 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %723, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).String", ptr %727, align 8
-  %728 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %723, align 8
-  %729 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %730 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %729, i32 0, i32 0
-  store ptr @70, ptr %730, align 8
-  %731 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %729, i32 0, i32 1
-  store i64 10, ptr %731, align 4
-  %732 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %729, align 8
-  %733 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
-  %734 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
-  %735 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %736 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %735, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %732, ptr %736, align 8
-  %737 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %735, i32 0, i32 1
-  store ptr %734, ptr %737, align 8
-  %738 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %735, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType", ptr %738, align 8
-  %739 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %735, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType", ptr %739, align 8
-  %740 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %735, align 8
-  %741 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %742 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %741, i32 0, i32 0
-  store ptr @80, ptr %742, align 8
-  %743 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %741, i32 0, i32 1
-  store i64 8, ptr %743, align 4
-  %744 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %741, align 8
-  %745 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
-  %746 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %747 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %746, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %744, ptr %747, align 8
-  %748 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %746, i32 0, i32 1
-  store ptr %745, ptr %748, align 8
-  %749 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %746, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Uncommon", ptr %749, align 8
-  %750 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %746, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Type).Uncommon", ptr %750, align 8
-  %751 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %746, align 8
-  %752 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 920)
-  %753 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %752, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %396, ptr %753, align 8
-  %754 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %752, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %512, ptr %754, align 8
-  %755 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %752, i64 2
-  store %"github.com/goplus/llgo/internal/abi.Method" %523, ptr %755, align 8
-  %756 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %752, i64 3
-  store %"github.com/goplus/llgo/internal/abi.Method" %535, ptr %756, align 8
-  %757 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %752, i64 4
-  store %"github.com/goplus/llgo/internal/abi.Method" %547, ptr %757, align 8
-  %758 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %752, i64 5
-  store %"github.com/goplus/llgo/internal/abi.Method" %559, ptr %758, align 8
-  %759 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %752, i64 6
-  store %"github.com/goplus/llgo/internal/abi.Method" %570, ptr %759, align 8
-  %760 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %752, i64 7
-  store %"github.com/goplus/llgo/internal/abi.Method" %582, ptr %760, align 8
-  %761 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %752, i64 8
-  store %"github.com/goplus/llgo/internal/abi.Method" %593, ptr %761, align 8
-  %762 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %752, i64 9
-  store %"github.com/goplus/llgo/internal/abi.Method" %604, ptr %762, align 8
-  %763 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %752, i64 10
-  store %"github.com/goplus/llgo/internal/abi.Method" %616, ptr %763, align 8
-  %764 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %752, i64 11
-  store %"github.com/goplus/llgo/internal/abi.Method" %627, ptr %764, align 8
-  %765 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %752, i64 12
-  store %"github.com/goplus/llgo/internal/abi.Method" %638, ptr %765, align 8
-  %766 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %752, i64 13
-  store %"github.com/goplus/llgo/internal/abi.Method" %650, ptr %766, align 8
-  %767 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %752, i64 14
-  store %"github.com/goplus/llgo/internal/abi.Method" %661, ptr %767, align 8
-  %768 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %752, i64 15
-  store %"github.com/goplus/llgo/internal/abi.Method" %672, ptr %768, align 8
-  %769 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %752, i64 16
-  store %"github.com/goplus/llgo/internal/abi.Method" %684, ptr %769, align 8
-  %770 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %752, i64 17
-  store %"github.com/goplus/llgo/internal/abi.Method" %695, ptr %770, align 8
-  %771 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %752, i64 18
-  store %"github.com/goplus/llgo/internal/abi.Method" %706, ptr %771, align 8
-  %772 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %752, i64 19
-  store %"github.com/goplus/llgo/internal/abi.Method" %717, ptr %772, align 8
-  %773 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %752, i64 20
-  store %"github.com/goplus/llgo/internal/abi.Method" %728, ptr %773, align 8
-  %774 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %752, i64 21
-  store %"github.com/goplus/llgo/internal/abi.Method" %740, ptr %774, align 8
-  %775 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %752, i64 22
-  store %"github.com/goplus/llgo/internal/abi.Method" %751, ptr %775, align 8
-  %776 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %777 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %776, i32 0, i32 0
-  store ptr %752, ptr %777, align 8
-  %778 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %776, i32 0, i32 1
-  store i64 23, ptr %778, align 4
-  %779 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %776, i32 0, i32 2
-  store i64 23, ptr %779, align 4
-  %780 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %776, align 8
-  %781 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %782 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %781, i32 0, i32 0
-  store ptr @3, ptr %782, align 8
-  %783 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %781, i32 0, i32 1
-  store i64 35, ptr %783, align 4
-  %784 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %781, align 8
-  %785 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %786 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %785, i32 0, i32 0
-  store ptr @21, ptr %786, align 8
-  %787 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %785, i32 0, i32 1
-  store i64 4, ptr %787, align 4
-  %788 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %785, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %21, %"github.com/goplus/llgo/internal/runtime.String" %784, %"github.com/goplus/llgo/internal/runtime.String" %788, ptr %355, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %780)
+  %230 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  %231 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  %232 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
+  %233 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @19, i64 9 }, ptr undef, ptr undef, ptr undef }, ptr %232, 1
+  %234 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %233, ptr @"github.com/goplus/llgo/internal/abi.(*Type).ArrayType", 2
+  %235 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %234, ptr @"github.com/goplus/llgo/internal/abi.(*Type).ArrayType", 3
+  %236 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
+  %237 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @25, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %236, 1
+  %238 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %237, ptr @"github.com/goplus/llgo/internal/abi.(*Type).ChanDir", 2
+  %239 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %238, ptr @"github.com/goplus/llgo/internal/abi.(*Type).ChanDir", 3
+  %240 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %241 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %242 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @27, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %241, 1
+  %243 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %242, ptr @"github.com/goplus/llgo/internal/abi.(*Type).Common", 2
+  %244 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %243, ptr @"github.com/goplus/llgo/internal/abi.(*Type).Common", 3
+  %245 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %246 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %247 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @22, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %246, 1
+  %248 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %247, ptr @"github.com/goplus/llgo/internal/abi.(*Type).Elem", 2
+  %249 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %248, ptr @"github.com/goplus/llgo/internal/abi.(*Type).Elem", 3
+  %250 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %251 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
+  %252 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @28, i64 15 }, ptr undef, ptr undef, ptr undef }, ptr %251, 1
+  %253 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %252, ptr @"github.com/goplus/llgo/internal/abi.(*Type).ExportedMethods", 2
+  %254 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %253, ptr @"github.com/goplus/llgo/internal/abi.(*Type).ExportedMethods", 3
+  %255 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %256 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @33, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %255, 1
+  %257 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %256, ptr @"github.com/goplus/llgo/internal/abi.(*Type).FieldAlign", 2
+  %258 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %257, ptr @"github.com/goplus/llgo/internal/abi.(*Type).FieldAlign", 3
+  %259 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %260 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
+  %261 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @34, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %260, 1
+  %262 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %261, ptr @"github.com/goplus/llgo/internal/abi.(*Type).FuncType", 2
+  %263 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %262, ptr @"github.com/goplus/llgo/internal/abi.(*Type).FuncType", 3
+  %264 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %265 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @35, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %264, 1
+  %266 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %265, ptr @"github.com/goplus/llgo/internal/abi.(*Type).HasName", 2
+  %267 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %266, ptr @"github.com/goplus/llgo/internal/abi.(*Type).HasName", 3
+  %268 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %269 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @36, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %268, 1
+  %270 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %269, ptr @"github.com/goplus/llgo/internal/abi.(*Type).IfaceIndir", 2
+  %271 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %270, ptr @"github.com/goplus/llgo/internal/abi.(*Type).IfaceIndir", 3
+  %272 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  %273 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
+  %274 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @37, i64 13 }, ptr undef, ptr undef, ptr undef }, ptr %273, 1
+  %275 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %274, ptr @"github.com/goplus/llgo/internal/abi.(*Type).InterfaceType", 2
+  %276 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %275, ptr @"github.com/goplus/llgo/internal/abi.(*Type).InterfaceType", 3
+  %277 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %278 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @48, i64 9 }, ptr undef, ptr undef, ptr undef }, ptr %277, 1
+  %279 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %278, ptr @"github.com/goplus/llgo/internal/abi.(*Type).IsClosure", 2
+  %280 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %279, ptr @"github.com/goplus/llgo/internal/abi.(*Type).IsClosure", 3
+  %281 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %282 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @49, i64 13 }, ptr undef, ptr undef, ptr undef }, ptr %281, 1
+  %283 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %282, ptr @"github.com/goplus/llgo/internal/abi.(*Type).IsDirectIface", 2
+  %284 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %283, ptr @"github.com/goplus/llgo/internal/abi.(*Type).IsDirectIface", 3
+  %285 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %286 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %287 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @50, i64 3 }, ptr undef, ptr undef, ptr undef }, ptr %286, 1
+  %288 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %287, ptr @"github.com/goplus/llgo/internal/abi.(*Type).Key", 2
+  %289 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %288, ptr @"github.com/goplus/llgo/internal/abi.(*Type).Key", 3
+  %290 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
+  %291 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @51, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %290, 1
+  %292 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %291, ptr @"github.com/goplus/llgo/internal/abi.(*Type).Kind", 2
+  %293 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %292, ptr @"github.com/goplus/llgo/internal/abi.(*Type).Kind", 3
+  %294 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %295 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @24, i64 3 }, ptr undef, ptr undef, ptr undef }, ptr %294, 1
+  %296 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %295, ptr @"github.com/goplus/llgo/internal/abi.(*Type).Len", 2
+  %297 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %296, ptr @"github.com/goplus/llgo/internal/abi.(*Type).Len", 3
+  %298 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  %299 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
+  %300 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @54, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %299, 1
+  %301 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %300, ptr @"github.com/goplus/llgo/internal/abi.(*Type).MapType", 2
+  %302 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %301, ptr @"github.com/goplus/llgo/internal/abi.(*Type).MapType", 3
+  %303 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %304 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @66, i64 9 }, ptr undef, ptr undef, ptr undef }, ptr %303, 1
+  %305 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %304, ptr @"github.com/goplus/llgo/internal/abi.(*Type).NumMethod", 2
+  %306 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %305, ptr @"github.com/goplus/llgo/internal/abi.(*Type).NumMethod", 3
+  %307 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %308 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @67, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %307, 1
+  %309 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %308, ptr @"github.com/goplus/llgo/internal/abi.(*Type).Pointers", 2
+  %310 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %309, ptr @"github.com/goplus/llgo/internal/abi.(*Type).Pointers", 3
+  %311 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
+  %312 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @69, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %311, 1
+  %313 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %312, ptr @"github.com/goplus/llgo/internal/abi.(*Type).Size", 2
+  %314 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %313, ptr @"github.com/goplus/llgo/internal/abi.(*Type).Size", 3
+  %315 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %316 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @53, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %315, 1
+  %317 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %316, ptr @"github.com/goplus/llgo/internal/abi.(*Type).String", 2
+  %318 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %317, ptr @"github.com/goplus/llgo/internal/abi.(*Type).String", 3
+  %319 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  %320 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
+  %321 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @70, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %320, 1
+  %322 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %321, ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType", 2
+  %323 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %322, ptr @"github.com/goplus/llgo/internal/abi.(*Type).StructType", 3
+  %324 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
+  %325 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @80, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %324, 1
+  %326 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %325, ptr @"github.com/goplus/llgo/internal/abi.(*Type).Uncommon", 2
+  %327 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %326, ptr @"github.com/goplus/llgo/internal/abi.(*Type).Uncommon", 3
+  %328 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 920)
+  %329 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %328, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %195, ptr %329, align 8
+  %330 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %328, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %235, ptr %330, align 8
+  %331 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %328, i64 2
+  store %"github.com/goplus/llgo/internal/abi.Method" %239, ptr %331, align 8
+  %332 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %328, i64 3
+  store %"github.com/goplus/llgo/internal/abi.Method" %244, ptr %332, align 8
+  %333 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %328, i64 4
+  store %"github.com/goplus/llgo/internal/abi.Method" %249, ptr %333, align 8
+  %334 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %328, i64 5
+  store %"github.com/goplus/llgo/internal/abi.Method" %254, ptr %334, align 8
+  %335 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %328, i64 6
+  store %"github.com/goplus/llgo/internal/abi.Method" %258, ptr %335, align 8
+  %336 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %328, i64 7
+  store %"github.com/goplus/llgo/internal/abi.Method" %263, ptr %336, align 8
+  %337 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %328, i64 8
+  store %"github.com/goplus/llgo/internal/abi.Method" %267, ptr %337, align 8
+  %338 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %328, i64 9
+  store %"github.com/goplus/llgo/internal/abi.Method" %271, ptr %338, align 8
+  %339 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %328, i64 10
+  store %"github.com/goplus/llgo/internal/abi.Method" %276, ptr %339, align 8
+  %340 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %328, i64 11
+  store %"github.com/goplus/llgo/internal/abi.Method" %280, ptr %340, align 8
+  %341 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %328, i64 12
+  store %"github.com/goplus/llgo/internal/abi.Method" %284, ptr %341, align 8
+  %342 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %328, i64 13
+  store %"github.com/goplus/llgo/internal/abi.Method" %289, ptr %342, align 8
+  %343 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %328, i64 14
+  store %"github.com/goplus/llgo/internal/abi.Method" %293, ptr %343, align 8
+  %344 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %328, i64 15
+  store %"github.com/goplus/llgo/internal/abi.Method" %297, ptr %344, align 8
+  %345 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %328, i64 16
+  store %"github.com/goplus/llgo/internal/abi.Method" %302, ptr %345, align 8
+  %346 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %328, i64 17
+  store %"github.com/goplus/llgo/internal/abi.Method" %306, ptr %346, align 8
+  %347 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %328, i64 18
+  store %"github.com/goplus/llgo/internal/abi.Method" %310, ptr %347, align 8
+  %348 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %328, i64 19
+  store %"github.com/goplus/llgo/internal/abi.Method" %314, ptr %348, align 8
+  %349 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %328, i64 20
+  store %"github.com/goplus/llgo/internal/abi.Method" %318, ptr %349, align 8
+  %350 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %328, i64 21
+  store %"github.com/goplus/llgo/internal/abi.Method" %323, ptr %350, align 8
+  %351 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %328, i64 22
+  store %"github.com/goplus/llgo/internal/abi.Method" %327, ptr %351, align 8
+  %352 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %328, 0
+  %353 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %352, i64 23, 1
+  %354 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %353, i64 23, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %9, %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 35 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @21, i64 4 }, ptr %169, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %354)
   br label %_llgo_32
 
 _llgo_43:                                         ; preds = %_llgo_41
-  %789 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %501)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %789)
-  store ptr %789, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  %355 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %227)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %355)
+  store ptr %355, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
   br label %_llgo_44
 
 _llgo_44:                                         ; preds = %_llgo_43, %_llgo_41
-  %790 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
-  %791 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
-  %792 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
-  %793 = icmp eq ptr %792, null
-  br i1 %793, label %_llgo_45, label %_llgo_46
+  %356 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  %357 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  %358 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
+  %359 = icmp eq ptr %358, null
+  br i1 %359, label %_llgo_45, label %_llgo_46
 
 _llgo_45:                                         ; preds = %_llgo_44
-  %794 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %795 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %796 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %795, i32 0, i32 0
-  store ptr %794, ptr %796, align 8
-  %797 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %795, i32 0, i32 1
-  store i64 0, ptr %797, align 4
-  %798 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %795, i32 0, i32 2
-  store i64 0, ptr %798, align 4
-  %799 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %795, align 8
-  %800 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %801 = getelementptr ptr, ptr %800, i64 0
-  store ptr %791, ptr %801, align 8
-  %802 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %803 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %802, i32 0, i32 0
-  store ptr %800, ptr %803, align 8
-  %804 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %802, i32 0, i32 1
-  store i64 1, ptr %804, align 4
-  %805 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %802, i32 0, i32 2
-  store i64 1, ptr %805, align 4
-  %806 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %802, align 8
-  %807 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %799, %"github.com/goplus/llgo/internal/runtime.Slice" %806, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %807)
-  store ptr %807, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
+  %360 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %361 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %360, 0
+  %362 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %361, i64 0, 1
+  %363 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %362, i64 0, 2
+  %364 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %365 = getelementptr ptr, ptr %364, i64 0
+  store ptr %357, ptr %365, align 8
+  %366 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %364, 0
+  %367 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %366, i64 1, 1
+  %368 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %367, i64 1, 2
+  %369 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %363, %"github.com/goplus/llgo/internal/runtime.Slice" %368, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %369)
+  store ptr %369, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
   br label %_llgo_46
 
 _llgo_46:                                         ; preds = %_llgo_45, %_llgo_44
-  %808 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
-  %809 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %810 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %809, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %496, ptr %810, align 8
-  %811 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %809, i32 0, i32 1
-  store ptr %808, ptr %811, align 8
-  %812 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %809, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ArrayType", ptr %812, align 8
-  %813 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %809, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ArrayType", ptr %813, align 8
-  %814 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %809, align 8
-  %815 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %816 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %815, i32 0, i32 0
-  store ptr @25, ptr %816, align 8
-  %817 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %815, i32 0, i32 1
-  store i64 7, ptr %817, align 4
-  %818 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %815, align 8
-  %819 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %820 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %819, i32 0, i32 0
-  store ptr @26, ptr %820, align 8
-  %821 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %819, i32 0, i32 1
-  store i64 43, ptr %821, align 4
-  %822 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %819, align 8
-  %823 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %822, i64 2, i64 8, i64 0, i64 0)
-  %824 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ChanDir", align 8
-  %825 = icmp eq ptr %824, null
-  br i1 %825, label %_llgo_47, label %_llgo_48
+  %370 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
+  %371 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @19, i64 9 }, ptr undef, ptr undef, ptr undef }, ptr %370, 1
+  %372 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %371, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ArrayType", 2
+  %373 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %372, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ArrayType", 3
+  %374 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @26, i64 43 }, i64 2, i64 8, i64 0, i64 0)
+  %375 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ChanDir", align 8
+  %376 = icmp eq ptr %375, null
+  br i1 %376, label %_llgo_47, label %_llgo_48
 
 _llgo_47:                                         ; preds = %_llgo_46
-  store ptr %823, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ChanDir", align 8
+  store ptr %374, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ChanDir", align 8
   br label %_llgo_48
 
 _llgo_48:                                         ; preds = %_llgo_47, %_llgo_46
-  %826 = load ptr, ptr @_llgo_int, align 8
-  br i1 %825, label %_llgo_49, label %_llgo_50
+  %377 = load ptr, ptr @_llgo_int, align 8
+  br i1 %376, label %_llgo_49, label %_llgo_50
 
 _llgo_49:                                         ; preds = %_llgo_48
-  %827 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %828 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %827, i32 0, i32 0
-  store ptr @3, ptr %828, align 8
-  %829 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %827, i32 0, i32 1
-  store i64 35, ptr %829, align 4
-  %830 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %827, align 8
-  %831 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %832 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %831, i32 0, i32 0
-  store ptr @25, ptr %832, align 8
-  %833 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %831, i32 0, i32 1
-  store i64 7, ptr %833, align 4
-  %834 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %831, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %823, %"github.com/goplus/llgo/internal/runtime.String" %830, %"github.com/goplus/llgo/internal/runtime.String" %834, ptr %826, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %374, %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 35 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @25, i64 7 }, ptr %377, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
   br label %_llgo_50
 
 _llgo_50:                                         ; preds = %_llgo_49, %_llgo_48
-  %835 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ChanDir", align 8
-  %836 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ChanDir", align 8
-  %837 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
-  %838 = icmp eq ptr %837, null
-  br i1 %838, label %_llgo_51, label %_llgo_52
+  %378 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ChanDir", align 8
+  %379 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.ChanDir", align 8
+  %380 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
+  %381 = icmp eq ptr %380, null
+  br i1 %381, label %_llgo_51, label %_llgo_52
 
 _llgo_51:                                         ; preds = %_llgo_50
-  %839 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %840 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %841 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %840, i32 0, i32 0
-  store ptr %839, ptr %841, align 8
-  %842 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %840, i32 0, i32 1
-  store i64 0, ptr %842, align 4
-  %843 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %840, i32 0, i32 2
-  store i64 0, ptr %843, align 4
-  %844 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %840, align 8
-  %845 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %846 = getelementptr ptr, ptr %845, i64 0
-  store ptr %836, ptr %846, align 8
-  %847 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %848 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %847, i32 0, i32 0
-  store ptr %845, ptr %848, align 8
-  %849 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %847, i32 0, i32 1
-  store i64 1, ptr %849, align 4
-  %850 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %847, i32 0, i32 2
-  store i64 1, ptr %850, align 4
-  %851 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %847, align 8
-  %852 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %844, %"github.com/goplus/llgo/internal/runtime.Slice" %851, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %852)
-  store ptr %852, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
+  %382 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %383 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %382, 0
+  %384 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %383, i64 0, 1
+  %385 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %384, i64 0, 2
+  %386 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %387 = getelementptr ptr, ptr %386, i64 0
+  store ptr %379, ptr %387, align 8
+  %388 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %386, 0
+  %389 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %388, i64 1, 1
+  %390 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %389, i64 1, 2
+  %391 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %385, %"github.com/goplus/llgo/internal/runtime.Slice" %390, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %391)
+  store ptr %391, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
   br label %_llgo_52
 
 _llgo_52:                                         ; preds = %_llgo_51, %_llgo_50
-  %853 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
-  %854 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %855 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %854, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %818, ptr %855, align 8
-  %856 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %854, i32 0, i32 1
-  store ptr %853, ptr %856, align 8
-  %857 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %854, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ChanDir", ptr %857, align 8
-  %858 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %854, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ChanDir", ptr %858, align 8
-  %859 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %854, align 8
-  %860 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %861 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %860, i32 0, i32 0
-  store ptr @27, ptr %861, align 8
-  %862 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %860, i32 0, i32 1
-  store i64 6, ptr %862, align 4
-  %863 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %860, align 8
-  %864 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %865 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %866 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %867 = icmp eq ptr %866, null
-  br i1 %867, label %_llgo_53, label %_llgo_54
+  %392 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
+  %393 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @25, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %392, 1
+  %394 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %393, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ChanDir", 2
+  %395 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %394, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ChanDir", 3
+  %396 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %397 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %398 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %399 = icmp eq ptr %398, null
+  br i1 %399, label %_llgo_53, label %_llgo_54
 
 _llgo_53:                                         ; preds = %_llgo_52
-  %868 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %869 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %870 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %869, i32 0, i32 0
-  store ptr %868, ptr %870, align 8
-  %871 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %869, i32 0, i32 1
-  store i64 0, ptr %871, align 4
-  %872 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %869, i32 0, i32 2
-  store i64 0, ptr %872, align 4
-  %873 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %869, align 8
-  %874 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %875 = getelementptr ptr, ptr %874, i64 0
-  store ptr %865, ptr %875, align 8
-  %876 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %877 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %876, i32 0, i32 0
-  store ptr %874, ptr %877, align 8
-  %878 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %876, i32 0, i32 1
-  store i64 1, ptr %878, align 4
-  %879 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %876, i32 0, i32 2
-  store i64 1, ptr %879, align 4
-  %880 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %876, align 8
-  %881 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %873, %"github.com/goplus/llgo/internal/runtime.Slice" %880, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %881)
-  store ptr %881, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %400 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %401 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %400, 0
+  %402 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %401, i64 0, 1
+  %403 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %402, i64 0, 2
+  %404 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %405 = getelementptr ptr, ptr %404, i64 0
+  store ptr %397, ptr %405, align 8
+  %406 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %404, 0
+  %407 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %406, i64 1, 1
+  %408 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %407, i64 1, 2
+  %409 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %403, %"github.com/goplus/llgo/internal/runtime.Slice" %408, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %409)
+  store ptr %409, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
   br label %_llgo_54
 
 _llgo_54:                                         ; preds = %_llgo_53, %_llgo_52
-  %882 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %883 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %884 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %883, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %863, ptr %884, align 8
-  %885 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %883, i32 0, i32 1
-  store ptr %882, ptr %885, align 8
-  %886 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %883, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Common", ptr %886, align 8
-  %887 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %883, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Common", ptr %887, align 8
-  %888 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %883, align 8
-  %889 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %890 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %889, i32 0, i32 0
-  store ptr @28, ptr %890, align 8
-  %891 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %889, i32 0, i32 1
-  store i64 15, ptr %891, align 4
-  %892 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %889, align 8
-  %893 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %894 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %893, i32 0, i32 0
-  store ptr @29, ptr %894, align 8
-  %895 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %893, i32 0, i32 1
-  store i64 42, ptr %895, align 4
-  %896 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %893, align 8
-  %897 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %896, i64 25, i64 40, i64 0, i64 3)
-  %898 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %899 = icmp eq ptr %898, null
-  br i1 %899, label %_llgo_55, label %_llgo_56
+  %410 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %411 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @27, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %410, 1
+  %412 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %411, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Common", 2
+  %413 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %412, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Common", 3
+  %414 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @29, i64 42 }, i64 25, i64 40, i64 0, i64 3)
+  %415 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %416 = icmp eq ptr %415, null
+  br i1 %416, label %_llgo_55, label %_llgo_56
 
 _llgo_55:                                         ; preds = %_llgo_54
-  store ptr %897, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  store ptr %414, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
   br label %_llgo_56
 
 _llgo_56:                                         ; preds = %_llgo_55, %_llgo_54
-  %900 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %901 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %900, i32 0, i32 0
-  store ptr @30, ptr %901, align 8
-  %902 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %900, i32 0, i32 1
-  store i64 44, ptr %902, align 4
-  %903 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %900, align 8
-  %904 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %903, i64 25, i64 128, i64 0, i64 24)
-  %905 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %906 = icmp eq ptr %905, null
-  br i1 %906, label %_llgo_57, label %_llgo_58
+  %417 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @30, i64 44 }, i64 25, i64 128, i64 0, i64 24)
+  %418 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %419 = icmp eq ptr %418, null
+  br i1 %419, label %_llgo_57, label %_llgo_58
 
 _llgo_57:                                         ; preds = %_llgo_56
-  store ptr %904, ptr @"_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  store ptr %417, ptr @"_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
   br label %_llgo_58
 
 _llgo_58:                                         ; preds = %_llgo_57, %_llgo_56
-  %907 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %908 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %909 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %908, i32 0, i32 0
-  store ptr @1, ptr %909, align 8
-  %910 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %908, i32 0, i32 1
-  store i64 40, ptr %910, align 4
-  %911 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %908, align 8
-  %912 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %911, i64 25, i64 80, i64 0, i64 23)
-  %913 = load ptr, ptr @"[]*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %914 = icmp eq ptr %913, null
-  br i1 %914, label %_llgo_59, label %_llgo_60
+  %420 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %421 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 40 }, i64 25, i64 80, i64 0, i64 23)
+  %422 = load ptr, ptr @"[]*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %423 = icmp eq ptr %422, null
+  br i1 %423, label %_llgo_59, label %_llgo_60
 
 _llgo_59:                                         ; preds = %_llgo_58
-  %915 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %912)
-  %916 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %915)
-  store ptr %916, ptr @"[]*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %424 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %421)
+  %425 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %424)
+  store ptr %425, ptr @"[]*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
   br label %_llgo_60
 
 _llgo_60:                                         ; preds = %_llgo_59, %_llgo_58
-  %917 = load ptr, ptr @"[]*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %918 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %919 = load ptr, ptr @"[]*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %920 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %921 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %920, i32 0, i32 0
-  store ptr @1, ptr %921, align 8
-  %922 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %920, i32 0, i32 1
-  store i64 40, ptr %922, align 4
-  %923 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %920, align 8
-  %924 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %923, i64 25, i64 80, i64 0, i64 23)
-  %925 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %926 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %925, i32 0, i32 0
-  store ptr @1, ptr %926, align 8
-  %927 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %925, i32 0, i32 1
-  store i64 40, ptr %927, align 4
-  %928 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %925, align 8
-  %929 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %928, i64 25, i64 80, i64 0, i64 23)
-  %930 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %931 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %930, i32 0, i32 0
-  store ptr @1, ptr %931, align 8
-  %932 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %930, i32 0, i32 1
-  store i64 40, ptr %932, align 4
-  %933 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %930, align 8
-  %934 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %933, i64 25, i64 80, i64 0, i64 23)
-  %935 = load ptr, ptr @"_llgo_struct$wRu7InfmQeSkq7akLN3soDNninnS1dQajawdYvmHbzw", align 8
-  %936 = icmp eq ptr %935, null
-  br i1 %936, label %_llgo_61, label %_llgo_62
+  %426 = load ptr, ptr @"[]*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %427 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %428 = load ptr, ptr @"[]*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %429 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 40 }, i64 25, i64 80, i64 0, i64 23)
+  %430 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 40 }, i64 25, i64 80, i64 0, i64 23)
+  %431 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 40 }, i64 25, i64 80, i64 0, i64 23)
+  %432 = load ptr, ptr @"_llgo_struct$wRu7InfmQeSkq7akLN3soDNninnS1dQajawdYvmHbzw", align 8
+  %433 = icmp eq ptr %432, null
+  br i1 %433, label %_llgo_61, label %_llgo_62
 
 _llgo_61:                                         ; preds = %_llgo_60
-  %937 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %938 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %937, i32 0, i32 0
-  store ptr @21, ptr %938, align 8
-  %939 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %937, i32 0, i32 1
-  store i64 4, ptr %939, align 4
-  %940 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %937, align 8
-  %941 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %942 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %941, i32 0, i32 0
-  store ptr null, ptr %942, align 8
-  %943 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %941, i32 0, i32 1
-  store i64 0, ptr %943, align 4
-  %944 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %941, align 8
-  %945 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %940, ptr %924, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %944, i1 true)
-  %946 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %947 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %946, i32 0, i32 0
-  store ptr @31, ptr %947, align 8
-  %948 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %946, i32 0, i32 1
-  store i64 2, ptr %948, align 4
-  %949 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %946, align 8
-  %950 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %951 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %950, i32 0, i32 0
-  store ptr null, ptr %951, align 8
-  %952 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %950, i32 0, i32 1
-  store i64 0, ptr %952, align 4
-  %953 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %950, align 8
-  %954 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %929)
-  %955 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %954)
-  %956 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %949, ptr %955, i64 72, %"github.com/goplus/llgo/internal/runtime.String" %953, i1 false)
-  %957 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %958 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %957, i32 0, i32 0
-  store ptr @32, ptr %958, align 8
-  %959 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %957, i32 0, i32 1
-  store i64 3, ptr %959, align 4
-  %960 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %957, align 8
-  %961 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %962 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %961, i32 0, i32 0
-  store ptr null, ptr %962, align 8
-  %963 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %961, i32 0, i32 1
-  store i64 0, ptr %963, align 4
-  %964 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %961, align 8
-  %965 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %934)
-  %966 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %965)
-  %967 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %960, ptr %966, i64 96, %"github.com/goplus/llgo/internal/runtime.String" %964, i1 false)
-  %968 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %969 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %968, i32 0, i32 0
-  store ptr @7, ptr %969, align 8
-  %970 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %968, i32 0, i32 1
-  store i64 4, ptr %970, align 4
-  %971 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %968, align 8
-  %972 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 168)
-  %973 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %972, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %945, ptr %973, align 8
-  %974 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %972, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %956, ptr %974, align 8
-  %975 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %972, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %967, ptr %975, align 8
-  %976 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %977 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %976, i32 0, i32 0
-  store ptr %972, ptr %977, align 8
-  %978 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %976, i32 0, i32 1
-  store i64 3, ptr %978, align 4
-  %979 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %976, i32 0, i32 2
-  store i64 3, ptr %979, align 4
-  %980 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %976, align 8
-  %981 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %971, i64 120, %"github.com/goplus/llgo/internal/runtime.Slice" %980)
-  store ptr %981, ptr @"_llgo_struct$wRu7InfmQeSkq7akLN3soDNninnS1dQajawdYvmHbzw", align 8
+  %434 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @21, i64 4 }, ptr %429, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 true)
+  %435 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %430)
+  %436 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %435)
+  %437 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @31, i64 2 }, ptr %436, i64 72, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %438 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %431)
+  %439 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %438)
+  %440 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @32, i64 3 }, ptr %439, i64 96, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %441 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 168)
+  %442 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %441, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %434, ptr %442, align 8
+  %443 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %441, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %437, ptr %443, align 8
+  %444 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %441, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %440, ptr %444, align 8
+  %445 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %441, 0
+  %446 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %445, i64 3, 1
+  %447 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %446, i64 3, 2
+  %448 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 }, i64 120, %"github.com/goplus/llgo/internal/runtime.Slice" %447)
+  store ptr %448, ptr @"_llgo_struct$wRu7InfmQeSkq7akLN3soDNninnS1dQajawdYvmHbzw", align 8
   br label %_llgo_62
 
 _llgo_62:                                         ; preds = %_llgo_61, %_llgo_60
-  %982 = load ptr, ptr @"_llgo_struct$wRu7InfmQeSkq7akLN3soDNninnS1dQajawdYvmHbzw", align 8
-  br i1 %906, label %_llgo_63, label %_llgo_64
+  %449 = load ptr, ptr @"_llgo_struct$wRu7InfmQeSkq7akLN3soDNninnS1dQajawdYvmHbzw", align 8
+  br i1 %419, label %_llgo_63, label %_llgo_64
 
 _llgo_63:                                         ; preds = %_llgo_62
-  %983 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %984 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %983, i32 0, i32 0
-  store ptr @18, ptr %984, align 8
-  %985 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %983, i32 0, i32 1
-  store i64 5, ptr %985, align 4
-  %986 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %983, align 8
-  %987 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %988 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %989 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %988, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %986, ptr %989, align 8
-  %990 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %988, i32 0, i32 1
-  store ptr %987, ptr %990, align 8
-  %991 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %988, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Align", ptr %991, align 8
-  %992 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %988, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Align", ptr %992, align 8
-  %993 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %988, align 8
-  %994 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %995 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %994, i32 0, i32 0
-  store ptr @19, ptr %995, align 8
-  %996 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %994, i32 0, i32 1
-  store i64 9, ptr %996, align 4
-  %997 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %994, align 8
-  %998 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
-  %999 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
-  %1000 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1001 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1000, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %997, ptr %1001, align 8
-  %1002 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1000, i32 0, i32 1
-  store ptr %999, ptr %1002, align 8
-  %1003 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1000, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ArrayType", ptr %1003, align 8
-  %1004 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1000, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ArrayType", ptr %1004, align 8
-  %1005 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1000, align 8
-  %1006 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1007 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1006, i32 0, i32 0
-  store ptr @25, ptr %1007, align 8
-  %1008 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1006, i32 0, i32 1
-  store i64 7, ptr %1008, align 4
-  %1009 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1006, align 8
-  %1010 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
-  %1011 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1012 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1011, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1009, ptr %1012, align 8
-  %1013 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1011, i32 0, i32 1
-  store ptr %1010, ptr %1013, align 8
-  %1014 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1011, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ChanDir", ptr %1014, align 8
-  %1015 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1011, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ChanDir", ptr %1015, align 8
-  %1016 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1011, align 8
-  %1017 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1018 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1017, i32 0, i32 0
-  store ptr @27, ptr %1018, align 8
-  %1019 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1017, i32 0, i32 1
-  store i64 6, ptr %1019, align 4
-  %1020 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1017, align 8
-  %1021 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %1022 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %1023 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1024 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1023, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1020, ptr %1024, align 8
-  %1025 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1023, i32 0, i32 1
-  store ptr %1022, ptr %1025, align 8
-  %1026 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1023, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Common", ptr %1026, align 8
-  %1027 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1023, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Common", ptr %1027, align 8
-  %1028 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1023, align 8
-  %1029 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1030 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1029, i32 0, i32 0
-  store ptr @22, ptr %1030, align 8
-  %1031 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1029, i32 0, i32 1
-  store i64 4, ptr %1031, align 4
-  %1032 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1029, align 8
-  %1033 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %1034 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %1035 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1036 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1035, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1032, ptr %1036, align 8
-  %1037 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1035, i32 0, i32 1
-  store ptr %1034, ptr %1037, align 8
-  %1038 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1035, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Elem", ptr %1038, align 8
-  %1039 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1035, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Elem", ptr %1039, align 8
-  %1040 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1035, align 8
-  %1041 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1042 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1041, i32 0, i32 0
-  store ptr @28, ptr %1042, align 8
-  %1043 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1041, i32 0, i32 1
-  store i64 15, ptr %1043, align 4
-  %1044 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1041, align 8
-  %1045 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1046 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1045, i32 0, i32 0
-  store ptr @29, ptr %1046, align 8
-  %1047 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1045, i32 0, i32 1
-  store i64 42, ptr %1047, align 4
-  %1048 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1045, align 8
-  %1049 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1048, i64 25, i64 40, i64 0, i64 3)
-  %1050 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %1051 = icmp eq ptr %1050, null
-  br i1 %1051, label %_llgo_65, label %_llgo_66
+  %450 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %451 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @18, i64 5 }, ptr undef, ptr undef, ptr undef }, ptr %450, 1
+  %452 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %451, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Align", 2
+  %453 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %452, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Align", 3
+  %454 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  %455 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
+  %456 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @19, i64 9 }, ptr undef, ptr undef, ptr undef }, ptr %455, 1
+  %457 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %456, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ArrayType", 2
+  %458 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %457, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ArrayType", 3
+  %459 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
+  %460 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @25, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %459, 1
+  %461 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %460, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ChanDir", 2
+  %462 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %461, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ChanDir", 3
+  %463 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %464 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %465 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @27, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %464, 1
+  %466 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %465, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Common", 2
+  %467 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %466, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Common", 3
+  %468 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %469 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %470 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @22, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %469, 1
+  %471 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %470, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Elem", 2
+  %472 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %471, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Elem", 3
+  %473 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @29, i64 42 }, i64 25, i64 40, i64 0, i64 3)
+  %474 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %475 = icmp eq ptr %474, null
+  br i1 %475, label %_llgo_65, label %_llgo_66
 
 _llgo_64:                                         ; preds = %_llgo_90, %_llgo_62
-  %1052 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %1053 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %1054 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1055 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1054, i32 0, i32 0
-  store ptr @30, ptr %1055, align 8
-  %1056 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1054, i32 0, i32 1
-  store i64 44, ptr %1056, align 4
-  %1057 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1054, align 8
-  %1058 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1057, i64 25, i64 128, i64 0, i64 24)
-  %1059 = load ptr, ptr @"_llgo_struct$SDp3TNnYnxb26MhB1v8VMbmY71BX77YOaY7lgS1cFx0", align 8
-  %1060 = icmp eq ptr %1059, null
-  br i1 %1060, label %_llgo_145, label %_llgo_146
+  %476 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %477 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %478 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @30, i64 44 }, i64 25, i64 128, i64 0, i64 24)
+  %479 = load ptr, ptr @"_llgo_struct$SDp3TNnYnxb26MhB1v8VMbmY71BX77YOaY7lgS1cFx0", align 8
+  %480 = icmp eq ptr %479, null
+  br i1 %480, label %_llgo_145, label %_llgo_146
 
 _llgo_65:                                         ; preds = %_llgo_63
-  %1061 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %1049)
-  store ptr %1061, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %481 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %473)
+  store ptr %481, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
   br label %_llgo_66
 
 _llgo_66:                                         ; preds = %_llgo_65, %_llgo_63
-  %1062 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %1063 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %1064 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
-  %1065 = icmp eq ptr %1064, null
-  br i1 %1065, label %_llgo_67, label %_llgo_68
+  %482 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %483 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %484 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
+  %485 = icmp eq ptr %484, null
+  br i1 %485, label %_llgo_67, label %_llgo_68
 
 _llgo_67:                                         ; preds = %_llgo_66
-  %1066 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %1067 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1068 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1067, i32 0, i32 0
-  store ptr %1066, ptr %1068, align 8
-  %1069 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1067, i32 0, i32 1
-  store i64 0, ptr %1069, align 4
-  %1070 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1067, i32 0, i32 2
-  store i64 0, ptr %1070, align 4
-  %1071 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1067, align 8
-  %1072 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %1073 = getelementptr ptr, ptr %1072, i64 0
-  store ptr %1063, ptr %1073, align 8
-  %1074 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1075 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1074, i32 0, i32 0
-  store ptr %1072, ptr %1075, align 8
-  %1076 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1074, i32 0, i32 1
-  store i64 1, ptr %1076, align 4
-  %1077 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1074, i32 0, i32 2
-  store i64 1, ptr %1077, align 4
-  %1078 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1074, align 8
-  %1079 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1071, %"github.com/goplus/llgo/internal/runtime.Slice" %1078, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1079)
-  store ptr %1079, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
+  %486 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %487 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %486, 0
+  %488 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %487, i64 0, 1
+  %489 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %488, i64 0, 2
+  %490 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %491 = getelementptr ptr, ptr %490, i64 0
+  store ptr %483, ptr %491, align 8
+  %492 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %490, 0
+  %493 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %492, i64 1, 1
+  %494 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %493, i64 1, 2
+  %495 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %489, %"github.com/goplus/llgo/internal/runtime.Slice" %494, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %495)
+  store ptr %495, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
   br label %_llgo_68
 
 _llgo_68:                                         ; preds = %_llgo_67, %_llgo_66
-  %1080 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
-  %1081 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1082 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1081, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1044, ptr %1082, align 8
-  %1083 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1081, i32 0, i32 1
-  store ptr %1080, ptr %1083, align 8
-  %1084 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1081, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ExportedMethods", ptr %1084, align 8
-  %1085 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1081, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ExportedMethods", ptr %1085, align 8
-  %1086 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1081, align 8
-  %1087 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1088 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1087, i32 0, i32 0
-  store ptr @33, ptr %1088, align 8
-  %1089 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1087, i32 0, i32 1
-  store i64 10, ptr %1089, align 4
-  %1090 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1087, align 8
-  %1091 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %1092 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1093 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1092, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1090, ptr %1093, align 8
-  %1094 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1092, i32 0, i32 1
-  store ptr %1091, ptr %1094, align 8
-  %1095 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1092, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).FieldAlign", ptr %1095, align 8
-  %1096 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1092, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).FieldAlign", ptr %1096, align 8
-  %1097 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1092, align 8
-  %1098 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1099 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1098, i32 0, i32 0
-  store ptr @34, ptr %1099, align 8
-  %1100 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1098, i32 0, i32 1
-  store i64 8, ptr %1100, align 4
-  %1101 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1098, align 8
-  %1102 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1103 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1102, i32 0, i32 0
-  store ptr @30, ptr %1103, align 8
-  %1104 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1102, i32 0, i32 1
-  store i64 44, ptr %1104, align 4
-  %1105 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1102, align 8
-  %1106 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1105, i64 25, i64 128, i64 0, i64 24)
-  %1107 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %1108 = icmp eq ptr %1107, null
-  br i1 %1108, label %_llgo_69, label %_llgo_70
+  %496 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
+  %497 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @28, i64 15 }, ptr undef, ptr undef, ptr undef }, ptr %496, 1
+  %498 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %497, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ExportedMethods", 2
+  %499 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %498, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).ExportedMethods", 3
+  %500 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %501 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @33, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %500, 1
+  %502 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %501, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).FieldAlign", 2
+  %503 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %502, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).FieldAlign", 3
+  %504 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @30, i64 44 }, i64 25, i64 128, i64 0, i64 24)
+  %505 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %506 = icmp eq ptr %505, null
+  br i1 %506, label %_llgo_69, label %_llgo_70
 
 _llgo_69:                                         ; preds = %_llgo_68
-  %1109 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1106)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1109)
-  store ptr %1109, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %507 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %504)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %507)
+  store ptr %507, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
   br label %_llgo_70
 
 _llgo_70:                                         ; preds = %_llgo_69, %_llgo_68
-  %1110 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %1111 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %1112 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
-  %1113 = icmp eq ptr %1112, null
-  br i1 %1113, label %_llgo_71, label %_llgo_72
+  %508 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %509 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %510 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
+  %511 = icmp eq ptr %510, null
+  br i1 %511, label %_llgo_71, label %_llgo_72
 
 _llgo_71:                                         ; preds = %_llgo_70
-  %1114 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %1115 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1116 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1115, i32 0, i32 0
-  store ptr %1114, ptr %1116, align 8
-  %1117 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1115, i32 0, i32 1
-  store i64 0, ptr %1117, align 4
-  %1118 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1115, i32 0, i32 2
-  store i64 0, ptr %1118, align 4
-  %1119 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1115, align 8
-  %1120 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %1121 = getelementptr ptr, ptr %1120, i64 0
-  store ptr %1111, ptr %1121, align 8
-  %1122 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1123 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1122, i32 0, i32 0
-  store ptr %1120, ptr %1123, align 8
-  %1124 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1122, i32 0, i32 1
-  store i64 1, ptr %1124, align 4
-  %1125 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1122, i32 0, i32 2
-  store i64 1, ptr %1125, align 4
-  %1126 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1122, align 8
-  %1127 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1119, %"github.com/goplus/llgo/internal/runtime.Slice" %1126, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1127)
-  store ptr %1127, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
+  %512 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %513 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %512, 0
+  %514 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %513, i64 0, 1
+  %515 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %514, i64 0, 2
+  %516 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %517 = getelementptr ptr, ptr %516, i64 0
+  store ptr %509, ptr %517, align 8
+  %518 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %516, 0
+  %519 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %518, i64 1, 1
+  %520 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %519, i64 1, 2
+  %521 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %515, %"github.com/goplus/llgo/internal/runtime.Slice" %520, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %521)
+  store ptr %521, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
   br label %_llgo_72
 
 _llgo_72:                                         ; preds = %_llgo_71, %_llgo_70
-  %1128 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
-  %1129 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1130 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1129, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1101, ptr %1130, align 8
-  %1131 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1129, i32 0, i32 1
-  store ptr %1128, ptr %1131, align 8
-  %1132 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1129, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).FuncType", ptr %1132, align 8
-  %1133 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1129, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).FuncType", ptr %1133, align 8
-  %1134 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1129, align 8
-  %1135 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1136 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1135, i32 0, i32 0
-  store ptr @35, ptr %1136, align 8
-  %1137 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1135, i32 0, i32 1
-  store i64 7, ptr %1137, align 4
-  %1138 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1135, align 8
-  %1139 = load ptr, ptr @_llgo_bool, align 8
-  %1140 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %1141 = icmp eq ptr %1140, null
-  br i1 %1141, label %_llgo_73, label %_llgo_74
+  %522 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
+  %523 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @34, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %522, 1
+  %524 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %523, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).FuncType", 2
+  %525 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %524, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).FuncType", 3
+  %526 = load ptr, ptr @_llgo_bool, align 8
+  %527 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %528 = icmp eq ptr %527, null
+  br i1 %528, label %_llgo_73, label %_llgo_74
 
 _llgo_73:                                         ; preds = %_llgo_72
-  %1142 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %1143 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1144 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1143, i32 0, i32 0
-  store ptr %1142, ptr %1144, align 8
-  %1145 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1143, i32 0, i32 1
-  store i64 0, ptr %1145, align 4
-  %1146 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1143, i32 0, i32 2
-  store i64 0, ptr %1146, align 4
-  %1147 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1143, align 8
-  %1148 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %1149 = getelementptr ptr, ptr %1148, i64 0
-  store ptr %1139, ptr %1149, align 8
-  %1150 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1151 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1150, i32 0, i32 0
-  store ptr %1148, ptr %1151, align 8
-  %1152 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1150, i32 0, i32 1
-  store i64 1, ptr %1152, align 4
-  %1153 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1150, i32 0, i32 2
-  store i64 1, ptr %1153, align 4
-  %1154 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1150, align 8
-  %1155 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1147, %"github.com/goplus/llgo/internal/runtime.Slice" %1154, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1155)
-  store ptr %1155, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %529 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %530 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %529, 0
+  %531 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %530, i64 0, 1
+  %532 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %531, i64 0, 2
+  %533 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %534 = getelementptr ptr, ptr %533, i64 0
+  store ptr %526, ptr %534, align 8
+  %535 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %533, 0
+  %536 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %535, i64 1, 1
+  %537 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %536, i64 1, 2
+  %538 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %532, %"github.com/goplus/llgo/internal/runtime.Slice" %537, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %538)
+  store ptr %538, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
   br label %_llgo_74
 
 _llgo_74:                                         ; preds = %_llgo_73, %_llgo_72
-  %1156 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %1157 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1158 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1157, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1138, ptr %1158, align 8
-  %1159 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1157, i32 0, i32 1
-  store ptr %1156, ptr %1159, align 8
-  %1160 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1157, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).HasName", ptr %1160, align 8
-  %1161 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1157, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).HasName", ptr %1161, align 8
-  %1162 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1157, align 8
-  %1163 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1164 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1163, i32 0, i32 0
-  store ptr @36, ptr %1164, align 8
-  %1165 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1163, i32 0, i32 1
-  store i64 10, ptr %1165, align 4
-  %1166 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1163, align 8
-  %1167 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %1168 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1169 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1168, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1166, ptr %1169, align 8
-  %1170 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1168, i32 0, i32 1
-  store ptr %1167, ptr %1170, align 8
-  %1171 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1168, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).IfaceIndir", ptr %1171, align 8
-  %1172 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1168, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).IfaceIndir", ptr %1172, align 8
-  %1173 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1168, align 8
-  %1174 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1175 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1174, i32 0, i32 0
-  store ptr @37, ptr %1175, align 8
-  %1176 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1174, i32 0, i32 1
-  store i64 13, ptr %1176, align 4
-  %1177 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1174, align 8
-  %1178 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1179 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1178, i32 0, i32 0
-  store ptr @38, ptr %1179, align 8
-  %1180 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1178, i32 0, i32 1
-  store i64 49, ptr %1180, align 4
-  %1181 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1178, align 8
-  %1182 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1181, i64 25, i64 120, i64 0, i64 23)
-  %1183 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
-  %1184 = icmp eq ptr %1183, null
-  br i1 %1184, label %_llgo_75, label %_llgo_76
+  %539 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %540 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @35, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %539, 1
+  %541 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %540, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).HasName", 2
+  %542 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %541, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).HasName", 3
+  %543 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %544 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @36, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %543, 1
+  %545 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %544, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).IfaceIndir", 2
+  %546 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %545, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).IfaceIndir", 3
+  %547 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @38, i64 49 }, i64 25, i64 120, i64 0, i64 23)
+  %548 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  %549 = icmp eq ptr %548, null
+  br i1 %549, label %_llgo_75, label %_llgo_76
 
 _llgo_75:                                         ; preds = %_llgo_74
-  store ptr %1182, ptr @"_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  store ptr %547, ptr @"_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
   br label %_llgo_76
 
 _llgo_76:                                         ; preds = %_llgo_75, %_llgo_74
-  %1185 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1186 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1185, i32 0, i32 0
-  store ptr @39, ptr %1186, align 8
-  %1187 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1185, i32 0, i32 1
-  store i64 43, ptr %1187, align 4
-  %1188 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1185, align 8
-  %1189 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1188, i64 25, i64 24, i64 0, i64 3)
-  %1190 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %1191 = icmp eq ptr %1190, null
-  br i1 %1191, label %_llgo_77, label %_llgo_78
+  %550 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @39, i64 43 }, i64 25, i64 24, i64 0, i64 3)
+  %551 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
+  %552 = icmp eq ptr %551, null
+  br i1 %552, label %_llgo_77, label %_llgo_78
 
 _llgo_77:                                         ; preds = %_llgo_76
-  store ptr %1189, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
+  store ptr %550, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
   br label %_llgo_78
 
 _llgo_78:                                         ; preds = %_llgo_77, %_llgo_76
-  %1192 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %1193 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1194 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1193, i32 0, i32 0
-  store ptr @30, ptr %1194, align 8
-  %1195 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1193, i32 0, i32 1
-  store i64 44, ptr %1195, align 4
-  %1196 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1193, align 8
-  %1197 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1196, i64 25, i64 128, i64 0, i64 24)
-  %1198 = load ptr, ptr @"_llgo_struct$-SVMNS9vOT5F9q4yodRiL9MFhdPf0tfZ2Cx2o7KjSDw", align 8
-  %1199 = icmp eq ptr %1198, null
-  br i1 %1199, label %_llgo_79, label %_llgo_80
+  %553 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %554 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @30, i64 44 }, i64 25, i64 128, i64 0, i64 24)
+  %555 = load ptr, ptr @"_llgo_struct$-SVMNS9vOT5F9q4yodRiL9MFhdPf0tfZ2Cx2o7KjSDw", align 8
+  %556 = icmp eq ptr %555, null
+  br i1 %556, label %_llgo_79, label %_llgo_80
 
 _llgo_79:                                         ; preds = %_llgo_78
-  %1200 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1201 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1200, i32 0, i32 0
-  store ptr @40, ptr %1201, align 8
-  %1202 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1200, i32 0, i32 1
-  store i64 5, ptr %1202, align 4
-  %1203 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1200, align 8
-  %1204 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1205 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1204, i32 0, i32 0
-  store ptr null, ptr %1205, align 8
-  %1206 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1204, i32 0, i32 1
-  store i64 0, ptr %1206, align 4
-  %1207 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1204, align 8
-  %1208 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %1209 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1203, ptr %1208, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %1207, i1 false)
-  %1210 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1211 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1210, i32 0, i32 0
-  store ptr @41, ptr %1211, align 8
-  %1212 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1210, i32 0, i32 1
-  store i64 4, ptr %1212, align 4
-  %1213 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1210, align 8
-  %1214 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1215 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1214, i32 0, i32 0
-  store ptr null, ptr %1215, align 8
-  %1216 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1214, i32 0, i32 1
-  store i64 0, ptr %1216, align 4
-  %1217 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1214, align 8
-  %1218 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1197)
-  %1219 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1213, ptr %1218, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %1217, i1 false)
-  %1220 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1221 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1220, i32 0, i32 0
-  store ptr @7, ptr %1221, align 8
-  %1222 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1220, i32 0, i32 1
-  store i64 4, ptr %1222, align 4
-  %1223 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1220, align 8
-  %1224 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %1225 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1224, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %1209, ptr %1225, align 8
-  %1226 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1224, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %1219, ptr %1226, align 8
-  %1227 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1228 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1227, i32 0, i32 0
-  store ptr %1224, ptr %1228, align 8
-  %1229 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1227, i32 0, i32 1
-  store i64 2, ptr %1229, align 4
-  %1230 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1227, i32 0, i32 2
-  store i64 2, ptr %1230, align 4
-  %1231 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1227, align 8
-  %1232 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %1223, i64 24, %"github.com/goplus/llgo/internal/runtime.Slice" %1231)
-  store ptr %1232, ptr @"_llgo_struct$-SVMNS9vOT5F9q4yodRiL9MFhdPf0tfZ2Cx2o7KjSDw", align 8
+  %557 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %558 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @40, i64 5 }, ptr %557, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %559 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %554)
+  %560 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @41, i64 4 }, ptr %559, i64 16, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %561 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %562 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %561, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %558, ptr %562, align 8
+  %563 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %561, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %560, ptr %563, align 8
+  %564 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %561, 0
+  %565 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %564, i64 2, 1
+  %566 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %565, i64 2, 2
+  %567 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 }, i64 24, %"github.com/goplus/llgo/internal/runtime.Slice" %566)
+  store ptr %567, ptr @"_llgo_struct$-SVMNS9vOT5F9q4yodRiL9MFhdPf0tfZ2Cx2o7KjSDw", align 8
   br label %_llgo_80
 
 _llgo_80:                                         ; preds = %_llgo_79, %_llgo_78
-  %1233 = load ptr, ptr @"_llgo_struct$-SVMNS9vOT5F9q4yodRiL9MFhdPf0tfZ2Cx2o7KjSDw", align 8
-  br i1 %1191, label %_llgo_81, label %_llgo_82
+  %568 = load ptr, ptr @"_llgo_struct$-SVMNS9vOT5F9q4yodRiL9MFhdPf0tfZ2Cx2o7KjSDw", align 8
+  br i1 %552, label %_llgo_81, label %_llgo_82
 
 _llgo_81:                                         ; preds = %_llgo_80
-  %1234 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1235 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1234, i32 0, i32 0
-  store ptr @42, ptr %1235, align 8
-  %1236 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1234, i32 0, i32 1
-  store i64 8, ptr %1236, align 4
-  %1237 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1234, align 8
-  %1238 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %1239 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1240 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1239, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1237, ptr %1240, align 8
-  %1241 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1239, i32 0, i32 1
-  store ptr %1238, ptr %1241, align 8
-  %1242 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1239, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).Exported", ptr %1242, align 8
-  %1243 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1239, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).Exported", ptr %1243, align 8
-  %1244 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1239, align 8
-  %1245 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1246 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1245, i32 0, i32 0
-  store ptr @43, ptr %1246, align 8
-  %1247 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1245, i32 0, i32 1
-  store i64 4, ptr %1247, align 4
-  %1248 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1245, align 8
-  %1249 = load ptr, ptr @_llgo_string, align 8
-  %1250 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %1251 = icmp eq ptr %1250, null
-  br i1 %1251, label %_llgo_83, label %_llgo_84
+  %569 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %570 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @42, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %569, 1
+  %571 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %570, ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).Exported", 2
+  %572 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %571, ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).Exported", 3
+  %573 = load ptr, ptr @_llgo_string, align 8
+  %574 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %575 = icmp eq ptr %574, null
+  br i1 %575, label %_llgo_83, label %_llgo_84
 
 _llgo_82:                                         ; preds = %_llgo_84, %_llgo_80
-  %1252 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %1253 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1254 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1253, i32 0, i32 0
-  store ptr @39, ptr %1254, align 8
-  %1255 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1253, i32 0, i32 1
-  store i64 43, ptr %1255, align 4
-  %1256 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1253, align 8
-  %1257 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1256, i64 25, i64 24, i64 0, i64 3)
-  %1258 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %1259 = icmp eq ptr %1258, null
-  br i1 %1259, label %_llgo_85, label %_llgo_86
+  %576 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
+  %577 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @39, i64 43 }, i64 25, i64 24, i64 0, i64 3)
+  %578 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
+  %579 = icmp eq ptr %578, null
+  br i1 %579, label %_llgo_85, label %_llgo_86
 
 _llgo_83:                                         ; preds = %_llgo_81
-  %1260 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %1261 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1262 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1261, i32 0, i32 0
-  store ptr %1260, ptr %1262, align 8
-  %1263 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1261, i32 0, i32 1
-  store i64 0, ptr %1263, align 4
-  %1264 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1261, i32 0, i32 2
-  store i64 0, ptr %1264, align 4
-  %1265 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1261, align 8
-  %1266 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %1267 = getelementptr ptr, ptr %1266, i64 0
-  store ptr %1249, ptr %1267, align 8
-  %1268 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1269 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1268, i32 0, i32 0
-  store ptr %1266, ptr %1269, align 8
-  %1270 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1268, i32 0, i32 1
-  store i64 1, ptr %1270, align 4
-  %1271 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1268, i32 0, i32 2
-  store i64 1, ptr %1271, align 4
-  %1272 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1268, align 8
-  %1273 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1265, %"github.com/goplus/llgo/internal/runtime.Slice" %1272, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1273)
-  store ptr %1273, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %580 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %581 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %580, 0
+  %582 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %581, i64 0, 1
+  %583 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %582, i64 0, 2
+  %584 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %585 = getelementptr ptr, ptr %584, i64 0
+  store ptr %573, ptr %585, align 8
+  %586 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %584, 0
+  %587 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %586, i64 1, 1
+  %588 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %587, i64 1, 2
+  %589 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %583, %"github.com/goplus/llgo/internal/runtime.Slice" %588, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %589)
+  store ptr %589, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
   br label %_llgo_84
 
 _llgo_84:                                         ; preds = %_llgo_83, %_llgo_81
-  %1274 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %1275 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1276 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1275, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1248, ptr %1276, align 8
-  %1277 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1275, i32 0, i32 1
-  store ptr %1274, ptr %1277, align 8
-  %1278 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1275, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).Name", ptr %1278, align 8
-  %1279 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1275, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).Name", ptr %1279, align 8
-  %1280 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1275, align 8
-  %1281 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1282 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1281, i32 0, i32 0
-  store ptr @44, ptr %1282, align 8
-  %1283 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1281, i32 0, i32 1
-  store i64 7, ptr %1283, align 4
-  %1284 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1281, align 8
-  %1285 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %1286 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1287 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1286, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1284, ptr %1287, align 8
-  %1288 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1286, i32 0, i32 1
-  store ptr %1285, ptr %1288, align 8
-  %1289 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1286, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).PkgPath", ptr %1289, align 8
-  %1290 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1286, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).PkgPath", ptr %1290, align 8
-  %1291 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1286, align 8
-  %1292 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 120)
-  %1293 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1292, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %1244, ptr %1293, align 8
-  %1294 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1292, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %1280, ptr %1294, align 8
-  %1295 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1292, i64 2
-  store %"github.com/goplus/llgo/internal/abi.Method" %1291, ptr %1295, align 8
-  %1296 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1297 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1296, i32 0, i32 0
-  store ptr %1292, ptr %1297, align 8
-  %1298 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1296, i32 0, i32 1
-  store i64 3, ptr %1298, align 4
-  %1299 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1296, i32 0, i32 2
-  store i64 3, ptr %1299, align 4
-  %1300 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1296, align 8
-  %1301 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1302 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1301, i32 0, i32 0
-  store ptr @3, ptr %1302, align 8
-  %1303 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1301, i32 0, i32 1
-  store i64 35, ptr %1303, align 4
-  %1304 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1301, align 8
-  %1305 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1306 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1305, i32 0, i32 0
-  store ptr @45, ptr %1306, align 8
-  %1307 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1305, i32 0, i32 1
-  store i64 7, ptr %1307, align 4
-  %1308 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1305, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %1189, %"github.com/goplus/llgo/internal/runtime.String" %1304, %"github.com/goplus/llgo/internal/runtime.String" %1308, ptr %1233, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %1300)
+  %590 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %591 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @43, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %590, 1
+  %592 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %591, ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).Name", 2
+  %593 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %592, ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).Name", 3
+  %594 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %595 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @44, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %594, 1
+  %596 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %595, ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).PkgPath", 2
+  %597 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %596, ptr @"github.com/goplus/llgo/internal/abi.(*Imethod).PkgPath", 3
+  %598 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 120)
+  %599 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %598, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %572, ptr %599, align 8
+  %600 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %598, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %593, ptr %600, align 8
+  %601 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %598, i64 2
+  store %"github.com/goplus/llgo/internal/abi.Method" %597, ptr %601, align 8
+  %602 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %598, 0
+  %603 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %602, i64 3, 1
+  %604 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %603, i64 3, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %550, %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 35 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @45, i64 7 }, ptr %568, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %604)
   br label %_llgo_82
 
 _llgo_85:                                         ; preds = %_llgo_82
-  %1309 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %1257)
-  store ptr %1309, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
+  %605 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %577)
+  store ptr %605, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
   br label %_llgo_86
 
 _llgo_86:                                         ; preds = %_llgo_85, %_llgo_82
-  %1310 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %1311 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1312 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1311, i32 0, i32 0
-  store ptr @1, ptr %1312, align 8
-  %1313 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1311, i32 0, i32 1
-  store i64 40, ptr %1313, align 4
-  %1314 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1311, align 8
-  %1315 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1314, i64 25, i64 80, i64 0, i64 23)
-  %1316 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1317 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1316, i32 0, i32 0
-  store ptr @39, ptr %1317, align 8
-  %1318 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1316, i32 0, i32 1
-  store i64 43, ptr %1318, align 4
-  %1319 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1316, align 8
-  %1320 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1319, i64 25, i64 24, i64 0, i64 3)
-  %1321 = load ptr, ptr @"_llgo_struct$mWxYYevLxpL1wQyiQtAy4OszkqTlHtrmEcPpzW9Air4", align 8
-  %1322 = icmp eq ptr %1321, null
-  br i1 %1322, label %_llgo_87, label %_llgo_88
+  %606 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Imethod", align 8
+  %607 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 40 }, i64 25, i64 80, i64 0, i64 23)
+  %608 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @39, i64 43 }, i64 25, i64 24, i64 0, i64 3)
+  %609 = load ptr, ptr @"_llgo_struct$mWxYYevLxpL1wQyiQtAy4OszkqTlHtrmEcPpzW9Air4", align 8
+  %610 = icmp eq ptr %609, null
+  br i1 %610, label %_llgo_87, label %_llgo_88
 
 _llgo_87:                                         ; preds = %_llgo_86
-  %1323 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1324 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1323, i32 0, i32 0
-  store ptr @21, ptr %1324, align 8
-  %1325 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1323, i32 0, i32 1
-  store i64 4, ptr %1325, align 4
-  %1326 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1323, align 8
-  %1327 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1328 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1327, i32 0, i32 0
-  store ptr null, ptr %1328, align 8
-  %1329 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1327, i32 0, i32 1
-  store i64 0, ptr %1329, align 4
-  %1330 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1327, align 8
-  %1331 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1326, ptr %1315, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %1330, i1 true)
-  %1332 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1333 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1332, i32 0, i32 0
-  store ptr @46, ptr %1333, align 8
-  %1334 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1332, i32 0, i32 1
-  store i64 8, ptr %1334, align 4
-  %1335 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1332, align 8
-  %1336 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1337 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1336, i32 0, i32 0
-  store ptr null, ptr %1337, align 8
-  %1338 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1336, i32 0, i32 1
-  store i64 0, ptr %1338, align 4
-  %1339 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1336, align 8
-  %1340 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %1341 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1335, ptr %1340, i64 72, %"github.com/goplus/llgo/internal/runtime.String" %1339, i1 false)
-  %1342 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1343 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1342, i32 0, i32 0
-  store ptr @47, ptr %1343, align 8
-  %1344 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1342, i32 0, i32 1
-  store i64 7, ptr %1344, align 4
-  %1345 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1342, align 8
-  %1346 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1347 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1346, i32 0, i32 0
-  store ptr null, ptr %1347, align 8
-  %1348 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1346, i32 0, i32 1
-  store i64 0, ptr %1348, align 4
-  %1349 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1346, align 8
-  %1350 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %1320)
-  %1351 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1345, ptr %1350, i64 88, %"github.com/goplus/llgo/internal/runtime.String" %1349, i1 false)
-  %1352 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1353 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1352, i32 0, i32 0
-  store ptr @7, ptr %1353, align 8
-  %1354 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1352, i32 0, i32 1
-  store i64 4, ptr %1354, align 4
-  %1355 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1352, align 8
-  %1356 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 168)
-  %1357 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1356, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %1331, ptr %1357, align 8
-  %1358 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1356, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %1341, ptr %1358, align 8
-  %1359 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1356, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %1351, ptr %1359, align 8
-  %1360 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1361 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1360, i32 0, i32 0
-  store ptr %1356, ptr %1361, align 8
-  %1362 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1360, i32 0, i32 1
-  store i64 3, ptr %1362, align 4
-  %1363 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1360, i32 0, i32 2
-  store i64 3, ptr %1363, align 4
-  %1364 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1360, align 8
-  %1365 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %1355, i64 112, %"github.com/goplus/llgo/internal/runtime.Slice" %1364)
-  store ptr %1365, ptr @"_llgo_struct$mWxYYevLxpL1wQyiQtAy4OszkqTlHtrmEcPpzW9Air4", align 8
+  %611 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @21, i64 4 }, ptr %607, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 true)
+  %612 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %613 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @46, i64 8 }, ptr %612, i64 72, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %614 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %608)
+  %615 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @47, i64 7 }, ptr %614, i64 88, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %616 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 168)
+  %617 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %616, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %611, ptr %617, align 8
+  %618 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %616, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %613, ptr %618, align 8
+  %619 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %616, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %615, ptr %619, align 8
+  %620 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %616, 0
+  %621 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %620, i64 3, 1
+  %622 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %621, i64 3, 2
+  %623 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 }, i64 112, %"github.com/goplus/llgo/internal/runtime.Slice" %622)
+  store ptr %623, ptr @"_llgo_struct$mWxYYevLxpL1wQyiQtAy4OszkqTlHtrmEcPpzW9Air4", align 8
   br label %_llgo_88
 
 _llgo_88:                                         ; preds = %_llgo_87, %_llgo_86
-  %1366 = load ptr, ptr @"_llgo_struct$mWxYYevLxpL1wQyiQtAy4OszkqTlHtrmEcPpzW9Air4", align 8
-  br i1 %1184, label %_llgo_89, label %_llgo_90
+  %624 = load ptr, ptr @"_llgo_struct$mWxYYevLxpL1wQyiQtAy4OszkqTlHtrmEcPpzW9Air4", align 8
+  br i1 %549, label %_llgo_89, label %_llgo_90
 
 _llgo_89:                                         ; preds = %_llgo_88
-  %1367 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1368 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1367, i32 0, i32 0
-  store ptr @18, ptr %1368, align 8
-  %1369 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1367, i32 0, i32 1
-  store i64 5, ptr %1369, align 4
-  %1370 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1367, align 8
-  %1371 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %1372 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1373 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1372, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1370, ptr %1373, align 8
-  %1374 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1372, i32 0, i32 1
-  store ptr %1371, ptr %1374, align 8
-  %1375 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1372, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Align", ptr %1375, align 8
-  %1376 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1372, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Align", ptr %1376, align 8
-  %1377 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1372, align 8
-  %1378 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1379 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1378, i32 0, i32 0
-  store ptr @19, ptr %1379, align 8
-  %1380 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1378, i32 0, i32 1
-  store i64 9, ptr %1380, align 4
-  %1381 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1378, align 8
-  %1382 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
-  %1383 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
-  %1384 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1385 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1384, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1381, ptr %1385, align 8
-  %1386 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1384, i32 0, i32 1
-  store ptr %1383, ptr %1386, align 8
-  %1387 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1384, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ArrayType", ptr %1387, align 8
-  %1388 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1384, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ArrayType", ptr %1388, align 8
-  %1389 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1384, align 8
-  %1390 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1391 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1390, i32 0, i32 0
-  store ptr @25, ptr %1391, align 8
-  %1392 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1390, i32 0, i32 1
-  store i64 7, ptr %1392, align 4
-  %1393 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1390, align 8
-  %1394 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
-  %1395 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1396 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1395, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1393, ptr %1396, align 8
-  %1397 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1395, i32 0, i32 1
-  store ptr %1394, ptr %1397, align 8
-  %1398 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1395, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ChanDir", ptr %1398, align 8
-  %1399 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1395, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ChanDir", ptr %1399, align 8
-  %1400 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1395, align 8
-  %1401 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1402 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1401, i32 0, i32 0
-  store ptr @27, ptr %1402, align 8
-  %1403 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1401, i32 0, i32 1
-  store i64 6, ptr %1403, align 4
-  %1404 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1401, align 8
-  %1405 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %1406 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %1407 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1408 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1407, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1404, ptr %1408, align 8
-  %1409 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1407, i32 0, i32 1
-  store ptr %1406, ptr %1409, align 8
-  %1410 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1407, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Common", ptr %1410, align 8
-  %1411 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1407, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Common", ptr %1411, align 8
-  %1412 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1407, align 8
-  %1413 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1414 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1413, i32 0, i32 0
-  store ptr @22, ptr %1414, align 8
-  %1415 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1413, i32 0, i32 1
-  store i64 4, ptr %1415, align 4
-  %1416 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1413, align 8
-  %1417 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %1418 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %1419 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1420 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1419, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1416, ptr %1420, align 8
-  %1421 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1419, i32 0, i32 1
-  store ptr %1418, ptr %1421, align 8
-  %1422 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1419, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Elem", ptr %1422, align 8
-  %1423 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1419, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Elem", ptr %1423, align 8
-  %1424 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1419, align 8
-  %1425 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1426 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1425, i32 0, i32 0
-  store ptr @28, ptr %1426, align 8
-  %1427 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1425, i32 0, i32 1
-  store i64 15, ptr %1427, align 4
-  %1428 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1425, align 8
-  %1429 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %1430 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
-  %1431 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1432 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1431, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1428, ptr %1432, align 8
-  %1433 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1431, i32 0, i32 1
-  store ptr %1430, ptr %1433, align 8
-  %1434 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1431, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ExportedMethods", ptr %1434, align 8
-  %1435 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1431, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ExportedMethods", ptr %1435, align 8
-  %1436 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1431, align 8
-  %1437 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1438 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1437, i32 0, i32 0
-  store ptr @33, ptr %1438, align 8
-  %1439 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1437, i32 0, i32 1
-  store i64 10, ptr %1439, align 4
-  %1440 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1437, align 8
-  %1441 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %1442 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1443 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1442, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1440, ptr %1443, align 8
-  %1444 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1442, i32 0, i32 1
-  store ptr %1441, ptr %1444, align 8
-  %1445 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1442, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).FieldAlign", ptr %1445, align 8
-  %1446 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1442, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).FieldAlign", ptr %1446, align 8
-  %1447 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1442, align 8
-  %1448 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1449 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1448, i32 0, i32 0
-  store ptr @34, ptr %1449, align 8
-  %1450 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1448, i32 0, i32 1
-  store i64 8, ptr %1450, align 4
-  %1451 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1448, align 8
-  %1452 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %1453 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
-  %1454 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1455 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1454, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1451, ptr %1455, align 8
-  %1456 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1454, i32 0, i32 1
-  store ptr %1453, ptr %1456, align 8
-  %1457 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1454, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).FuncType", ptr %1457, align 8
-  %1458 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1454, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).FuncType", ptr %1458, align 8
-  %1459 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1454, align 8
-  %1460 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1461 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1460, i32 0, i32 0
-  store ptr @35, ptr %1461, align 8
-  %1462 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1460, i32 0, i32 1
-  store i64 7, ptr %1462, align 4
-  %1463 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1460, align 8
-  %1464 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %1465 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1466 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1465, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1463, ptr %1466, align 8
-  %1467 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1465, i32 0, i32 1
-  store ptr %1464, ptr %1467, align 8
-  %1468 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1465, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).HasName", ptr %1468, align 8
-  %1469 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1465, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).HasName", ptr %1469, align 8
-  %1470 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1465, align 8
-  %1471 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1472 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1471, i32 0, i32 0
-  store ptr @36, ptr %1472, align 8
-  %1473 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1471, i32 0, i32 1
-  store i64 10, ptr %1473, align 4
-  %1474 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1471, align 8
-  %1475 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %1476 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1477 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1476, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1474, ptr %1477, align 8
-  %1478 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1476, i32 0, i32 1
-  store ptr %1475, ptr %1478, align 8
-  %1479 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1476, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).IfaceIndir", ptr %1479, align 8
-  %1480 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1476, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).IfaceIndir", ptr %1480, align 8
-  %1481 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1476, align 8
-  %1482 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1483 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1482, i32 0, i32 0
-  store ptr @37, ptr %1483, align 8
-  %1484 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1482, i32 0, i32 1
-  store i64 13, ptr %1484, align 4
-  %1485 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1482, align 8
-  %1486 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1487 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1486, i32 0, i32 0
-  store ptr @38, ptr %1487, align 8
-  %1488 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1486, i32 0, i32 1
-  store i64 49, ptr %1488, align 4
-  %1489 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1486, align 8
-  %1490 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1489, i64 25, i64 120, i64 0, i64 23)
-  %1491 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
-  %1492 = icmp eq ptr %1491, null
-  br i1 %1492, label %_llgo_91, label %_llgo_92
+  %625 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %626 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @18, i64 5 }, ptr undef, ptr undef, ptr undef }, ptr %625, 1
+  %627 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %626, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Align", 2
+  %628 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %627, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Align", 3
+  %629 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  %630 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
+  %631 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @19, i64 9 }, ptr undef, ptr undef, ptr undef }, ptr %630, 1
+  %632 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %631, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ArrayType", 2
+  %633 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %632, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ArrayType", 3
+  %634 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
+  %635 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @25, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %634, 1
+  %636 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %635, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ChanDir", 2
+  %637 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %636, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ChanDir", 3
+  %638 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %639 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %640 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @27, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %639, 1
+  %641 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %640, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Common", 2
+  %642 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %641, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Common", 3
+  %643 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %644 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %645 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @22, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %644, 1
+  %646 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %645, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Elem", 2
+  %647 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %646, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Elem", 3
+  %648 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %649 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
+  %650 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @28, i64 15 }, ptr undef, ptr undef, ptr undef }, ptr %649, 1
+  %651 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %650, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ExportedMethods", 2
+  %652 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %651, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).ExportedMethods", 3
+  %653 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %654 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @33, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %653, 1
+  %655 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %654, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).FieldAlign", 2
+  %656 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %655, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).FieldAlign", 3
+  %657 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %658 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
+  %659 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @34, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %658, 1
+  %660 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %659, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).FuncType", 2
+  %661 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %660, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).FuncType", 3
+  %662 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %663 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @35, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %662, 1
+  %664 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %663, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).HasName", 2
+  %665 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %664, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).HasName", 3
+  %666 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %667 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @36, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %666, 1
+  %668 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %667, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).IfaceIndir", 2
+  %669 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %668, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).IfaceIndir", 3
+  %670 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @38, i64 49 }, i64 25, i64 120, i64 0, i64 23)
+  %671 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  %672 = icmp eq ptr %671, null
+  br i1 %672, label %_llgo_91, label %_llgo_92
 
 _llgo_90:                                         ; preds = %_llgo_110, %_llgo_88
-  %1493 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
-  %1494 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
-  %1495 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
-  %1496 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1497 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1496, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1177, ptr %1497, align 8
-  %1498 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1496, i32 0, i32 1
-  store ptr %1495, ptr %1498, align 8
-  %1499 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1496, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).InterfaceType", ptr %1499, align 8
-  %1500 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1496, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).InterfaceType", ptr %1500, align 8
-  %1501 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1496, align 8
-  %1502 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1503 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1502, i32 0, i32 0
-  store ptr @48, ptr %1503, align 8
-  %1504 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1502, i32 0, i32 1
-  store i64 9, ptr %1504, align 4
-  %1505 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1502, align 8
-  %1506 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %1507 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1508 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1507, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1505, ptr %1508, align 8
-  %1509 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1507, i32 0, i32 1
-  store ptr %1506, ptr %1509, align 8
-  %1510 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1507, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).IsClosure", ptr %1510, align 8
-  %1511 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1507, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).IsClosure", ptr %1511, align 8
-  %1512 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1507, align 8
-  %1513 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1514 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1513, i32 0, i32 0
-  store ptr @49, ptr %1514, align 8
-  %1515 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1513, i32 0, i32 1
-  store i64 13, ptr %1515, align 4
-  %1516 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1513, align 8
-  %1517 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %1518 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1519 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1518, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1516, ptr %1519, align 8
-  %1520 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1518, i32 0, i32 1
-  store ptr %1517, ptr %1520, align 8
-  %1521 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1518, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).IsDirectIface", ptr %1521, align 8
-  %1522 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1518, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).IsDirectIface", ptr %1522, align 8
-  %1523 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1518, align 8
-  %1524 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1525 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1524, i32 0, i32 0
-  store ptr @50, ptr %1525, align 8
-  %1526 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1524, i32 0, i32 1
-  store i64 3, ptr %1526, align 4
-  %1527 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1524, align 8
-  %1528 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %1529 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %1530 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1531 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1530, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1527, ptr %1531, align 8
-  %1532 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1530, i32 0, i32 1
-  store ptr %1529, ptr %1532, align 8
-  %1533 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1530, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Key", ptr %1533, align 8
-  %1534 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1530, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Key", ptr %1534, align 8
-  %1535 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1530, align 8
-  %1536 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1537 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1536, i32 0, i32 0
-  store ptr @51, ptr %1537, align 8
-  %1538 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1536, i32 0, i32 1
-  store i64 4, ptr %1538, align 4
-  %1539 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1536, align 8
-  %1540 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
-  %1541 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1542 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1541, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1539, ptr %1542, align 8
-  %1543 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1541, i32 0, i32 1
-  store ptr %1540, ptr %1543, align 8
-  %1544 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1541, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Kind", ptr %1544, align 8
-  %1545 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1541, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Kind", ptr %1545, align 8
-  %1546 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1541, align 8
-  %1547 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1548 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1547, i32 0, i32 0
-  store ptr @24, ptr %1548, align 8
-  %1549 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1547, i32 0, i32 1
-  store i64 3, ptr %1549, align 4
-  %1550 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1547, align 8
-  %1551 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %1552 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1553 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1552, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1550, ptr %1553, align 8
-  %1554 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1552, i32 0, i32 1
-  store ptr %1551, ptr %1554, align 8
-  %1555 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1552, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Len", ptr %1555, align 8
-  %1556 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1552, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Len", ptr %1556, align 8
-  %1557 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1552, align 8
-  %1558 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1559 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1558, i32 0, i32 0
-  store ptr @54, ptr %1559, align 8
-  %1560 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1558, i32 0, i32 1
-  store i64 7, ptr %1560, align 4
-  %1561 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1558, align 8
-  %1562 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
-  %1563 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
-  %1564 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1565 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1564, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1561, ptr %1565, align 8
-  %1566 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1564, i32 0, i32 1
-  store ptr %1563, ptr %1566, align 8
-  %1567 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1564, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).MapType", ptr %1567, align 8
-  %1568 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1564, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).MapType", ptr %1568, align 8
-  %1569 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1564, align 8
-  %1570 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1571 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1570, i32 0, i32 0
-  store ptr @66, ptr %1571, align 8
-  %1572 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1570, i32 0, i32 1
-  store i64 9, ptr %1572, align 4
-  %1573 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1570, align 8
-  %1574 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %1575 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1576 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1575, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1573, ptr %1576, align 8
-  %1577 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1575, i32 0, i32 1
-  store ptr %1574, ptr %1577, align 8
-  %1578 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1575, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).NumMethod", ptr %1578, align 8
-  %1579 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1575, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).NumMethod", ptr %1579, align 8
-  %1580 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1575, align 8
-  %1581 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1582 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1581, i32 0, i32 0
-  store ptr @67, ptr %1582, align 8
-  %1583 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1581, i32 0, i32 1
-  store i64 8, ptr %1583, align 4
-  %1584 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1581, align 8
-  %1585 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %1586 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1587 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1586, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1584, ptr %1587, align 8
-  %1588 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1586, i32 0, i32 1
-  store ptr %1585, ptr %1588, align 8
-  %1589 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1586, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Pointers", ptr %1589, align 8
-  %1590 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1586, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Pointers", ptr %1590, align 8
-  %1591 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1586, align 8
-  %1592 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1593 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1592, i32 0, i32 0
-  store ptr @69, ptr %1593, align 8
-  %1594 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1592, i32 0, i32 1
-  store i64 4, ptr %1594, align 4
-  %1595 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1592, align 8
-  %1596 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
-  %1597 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1598 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1597, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1595, ptr %1598, align 8
-  %1599 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1597, i32 0, i32 1
-  store ptr %1596, ptr %1599, align 8
-  %1600 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1597, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Size", ptr %1600, align 8
-  %1601 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1597, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Size", ptr %1601, align 8
-  %1602 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1597, align 8
-  %1603 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1604 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1603, i32 0, i32 0
-  store ptr @53, ptr %1604, align 8
-  %1605 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1603, i32 0, i32 1
-  store i64 6, ptr %1605, align 4
-  %1606 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1603, align 8
-  %1607 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %1608 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1609 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1608, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1606, ptr %1609, align 8
-  %1610 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1608, i32 0, i32 1
-  store ptr %1607, ptr %1610, align 8
-  %1611 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1608, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).String", ptr %1611, align 8
-  %1612 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1608, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).String", ptr %1612, align 8
-  %1613 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1608, align 8
-  %1614 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1615 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1614, i32 0, i32 0
-  store ptr @70, ptr %1615, align 8
-  %1616 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1614, i32 0, i32 1
-  store i64 10, ptr %1616, align 4
-  %1617 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1614, align 8
-  %1618 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
-  %1619 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
-  %1620 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1621 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1620, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1617, ptr %1621, align 8
-  %1622 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1620, i32 0, i32 1
-  store ptr %1619, ptr %1622, align 8
-  %1623 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1620, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).StructType", ptr %1623, align 8
-  %1624 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1620, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).StructType", ptr %1624, align 8
-  %1625 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1620, align 8
-  %1626 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1627 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1626, i32 0, i32 0
-  store ptr @80, ptr %1627, align 8
-  %1628 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1626, i32 0, i32 1
-  store i64 8, ptr %1628, align 4
-  %1629 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1626, align 8
-  %1630 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
-  %1631 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1632 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1631, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1629, ptr %1632, align 8
-  %1633 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1631, i32 0, i32 1
-  store ptr %1630, ptr %1633, align 8
-  %1634 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1631, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Uncommon", ptr %1634, align 8
-  %1635 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1631, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Uncommon", ptr %1635, align 8
-  %1636 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1631, align 8
-  %1637 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1638 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1637, i32 0, i32 0
-  store ptr @86, ptr %1638, align 8
-  %1639 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1637, i32 0, i32 1
-  store i64 8, ptr %1639, align 4
-  %1640 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1637, align 8
-  %1641 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %1642 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1643 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1642, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1640, ptr %1643, align 8
-  %1644 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1642, i32 0, i32 1
-  store ptr %1641, ptr %1644, align 8
-  %1645 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1642, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Variadic", ptr %1645, align 8
-  %1646 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1642, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Variadic", ptr %1646, align 8
-  %1647 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1642, align 8
-  %1648 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 960)
-  %1649 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %993, ptr %1649, align 8
-  %1650 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %1005, ptr %1650, align 8
-  %1651 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 2
-  store %"github.com/goplus/llgo/internal/abi.Method" %1016, ptr %1651, align 8
-  %1652 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 3
-  store %"github.com/goplus/llgo/internal/abi.Method" %1028, ptr %1652, align 8
-  %1653 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 4
-  store %"github.com/goplus/llgo/internal/abi.Method" %1040, ptr %1653, align 8
-  %1654 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 5
-  store %"github.com/goplus/llgo/internal/abi.Method" %1086, ptr %1654, align 8
-  %1655 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 6
-  store %"github.com/goplus/llgo/internal/abi.Method" %1097, ptr %1655, align 8
-  %1656 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 7
-  store %"github.com/goplus/llgo/internal/abi.Method" %1134, ptr %1656, align 8
-  %1657 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 8
-  store %"github.com/goplus/llgo/internal/abi.Method" %1162, ptr %1657, align 8
-  %1658 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 9
-  store %"github.com/goplus/llgo/internal/abi.Method" %1173, ptr %1658, align 8
-  %1659 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 10
-  store %"github.com/goplus/llgo/internal/abi.Method" %1501, ptr %1659, align 8
-  %1660 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 11
-  store %"github.com/goplus/llgo/internal/abi.Method" %1512, ptr %1660, align 8
-  %1661 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 12
-  store %"github.com/goplus/llgo/internal/abi.Method" %1523, ptr %1661, align 8
-  %1662 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 13
-  store %"github.com/goplus/llgo/internal/abi.Method" %1535, ptr %1662, align 8
-  %1663 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 14
-  store %"github.com/goplus/llgo/internal/abi.Method" %1546, ptr %1663, align 8
-  %1664 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 15
-  store %"github.com/goplus/llgo/internal/abi.Method" %1557, ptr %1664, align 8
-  %1665 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 16
-  store %"github.com/goplus/llgo/internal/abi.Method" %1569, ptr %1665, align 8
-  %1666 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 17
-  store %"github.com/goplus/llgo/internal/abi.Method" %1580, ptr %1666, align 8
-  %1667 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 18
-  store %"github.com/goplus/llgo/internal/abi.Method" %1591, ptr %1667, align 8
-  %1668 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 19
-  store %"github.com/goplus/llgo/internal/abi.Method" %1602, ptr %1668, align 8
-  %1669 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 20
-  store %"github.com/goplus/llgo/internal/abi.Method" %1613, ptr %1669, align 8
-  %1670 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 21
-  store %"github.com/goplus/llgo/internal/abi.Method" %1625, ptr %1670, align 8
-  %1671 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 22
-  store %"github.com/goplus/llgo/internal/abi.Method" %1636, ptr %1671, align 8
-  %1672 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1648, i64 23
-  store %"github.com/goplus/llgo/internal/abi.Method" %1647, ptr %1672, align 8
-  %1673 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1674 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1673, i32 0, i32 0
-  store ptr %1648, ptr %1674, align 8
-  %1675 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1673, i32 0, i32 1
-  store i64 24, ptr %1675, align 4
-  %1676 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1673, i32 0, i32 2
-  store i64 24, ptr %1676, align 4
-  %1677 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1673, align 8
-  %1678 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1679 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1678, i32 0, i32 0
-  store ptr @3, ptr %1679, align 8
-  %1680 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1678, i32 0, i32 1
-  store i64 35, ptr %1680, align 4
-  %1681 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1678, align 8
-  %1682 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1683 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1682, i32 0, i32 0
-  store ptr @34, ptr %1683, align 8
-  %1684 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1682, i32 0, i32 1
-  store i64 8, ptr %1684, align 4
-  %1685 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1682, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %904, %"github.com/goplus/llgo/internal/runtime.String" %1681, %"github.com/goplus/llgo/internal/runtime.String" %1685, ptr %982, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %1677)
+  %673 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  %674 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  %675 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
+  %676 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @37, i64 13 }, ptr undef, ptr undef, ptr undef }, ptr %675, 1
+  %677 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %676, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).InterfaceType", 2
+  %678 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %677, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).InterfaceType", 3
+  %679 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %680 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @48, i64 9 }, ptr undef, ptr undef, ptr undef }, ptr %679, 1
+  %681 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %680, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).IsClosure", 2
+  %682 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %681, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).IsClosure", 3
+  %683 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %684 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @49, i64 13 }, ptr undef, ptr undef, ptr undef }, ptr %683, 1
+  %685 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %684, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).IsDirectIface", 2
+  %686 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %685, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).IsDirectIface", 3
+  %687 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %688 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %689 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @50, i64 3 }, ptr undef, ptr undef, ptr undef }, ptr %688, 1
+  %690 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %689, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Key", 2
+  %691 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %690, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Key", 3
+  %692 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
+  %693 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @51, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %692, 1
+  %694 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %693, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Kind", 2
+  %695 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %694, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Kind", 3
+  %696 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %697 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @24, i64 3 }, ptr undef, ptr undef, ptr undef }, ptr %696, 1
+  %698 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %697, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Len", 2
+  %699 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %698, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Len", 3
+  %700 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  %701 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
+  %702 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @54, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %701, 1
+  %703 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %702, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).MapType", 2
+  %704 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %703, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).MapType", 3
+  %705 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %706 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @66, i64 9 }, ptr undef, ptr undef, ptr undef }, ptr %705, 1
+  %707 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %706, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).NumMethod", 2
+  %708 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %707, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).NumMethod", 3
+  %709 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %710 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @67, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %709, 1
+  %711 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %710, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Pointers", 2
+  %712 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %711, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Pointers", 3
+  %713 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
+  %714 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @69, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %713, 1
+  %715 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %714, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Size", 2
+  %716 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %715, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Size", 3
+  %717 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %718 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @53, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %717, 1
+  %719 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %718, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).String", 2
+  %720 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %719, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).String", 3
+  %721 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  %722 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
+  %723 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @70, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %722, 1
+  %724 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %723, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).StructType", 2
+  %725 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %724, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).StructType", 3
+  %726 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
+  %727 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @80, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %726, 1
+  %728 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %727, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Uncommon", 2
+  %729 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %728, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Uncommon", 3
+  %730 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %731 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @86, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %730, 1
+  %732 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %731, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Variadic", 2
+  %733 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %732, ptr @"github.com/goplus/llgo/internal/abi.(*FuncType).Variadic", 3
+  %734 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 960)
+  %735 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %453, ptr %735, align 8
+  %736 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %458, ptr %736, align 8
+  %737 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 2
+  store %"github.com/goplus/llgo/internal/abi.Method" %462, ptr %737, align 8
+  %738 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 3
+  store %"github.com/goplus/llgo/internal/abi.Method" %467, ptr %738, align 8
+  %739 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 4
+  store %"github.com/goplus/llgo/internal/abi.Method" %472, ptr %739, align 8
+  %740 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 5
+  store %"github.com/goplus/llgo/internal/abi.Method" %499, ptr %740, align 8
+  %741 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 6
+  store %"github.com/goplus/llgo/internal/abi.Method" %503, ptr %741, align 8
+  %742 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 7
+  store %"github.com/goplus/llgo/internal/abi.Method" %525, ptr %742, align 8
+  %743 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 8
+  store %"github.com/goplus/llgo/internal/abi.Method" %542, ptr %743, align 8
+  %744 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 9
+  store %"github.com/goplus/llgo/internal/abi.Method" %546, ptr %744, align 8
+  %745 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 10
+  store %"github.com/goplus/llgo/internal/abi.Method" %678, ptr %745, align 8
+  %746 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 11
+  store %"github.com/goplus/llgo/internal/abi.Method" %682, ptr %746, align 8
+  %747 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 12
+  store %"github.com/goplus/llgo/internal/abi.Method" %686, ptr %747, align 8
+  %748 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 13
+  store %"github.com/goplus/llgo/internal/abi.Method" %691, ptr %748, align 8
+  %749 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 14
+  store %"github.com/goplus/llgo/internal/abi.Method" %695, ptr %749, align 8
+  %750 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 15
+  store %"github.com/goplus/llgo/internal/abi.Method" %699, ptr %750, align 8
+  %751 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 16
+  store %"github.com/goplus/llgo/internal/abi.Method" %704, ptr %751, align 8
+  %752 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 17
+  store %"github.com/goplus/llgo/internal/abi.Method" %708, ptr %752, align 8
+  %753 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 18
+  store %"github.com/goplus/llgo/internal/abi.Method" %712, ptr %753, align 8
+  %754 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 19
+  store %"github.com/goplus/llgo/internal/abi.Method" %716, ptr %754, align 8
+  %755 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 20
+  store %"github.com/goplus/llgo/internal/abi.Method" %720, ptr %755, align 8
+  %756 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 21
+  store %"github.com/goplus/llgo/internal/abi.Method" %725, ptr %756, align 8
+  %757 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 22
+  store %"github.com/goplus/llgo/internal/abi.Method" %729, ptr %757, align 8
+  %758 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %734, i64 23
+  store %"github.com/goplus/llgo/internal/abi.Method" %733, ptr %758, align 8
+  %759 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %734, 0
+  %760 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %759, i64 24, 1
+  %761 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %760, i64 24, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %417, %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 35 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @34, i64 8 }, ptr %449, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %761)
   br label %_llgo_64
 
 _llgo_91:                                         ; preds = %_llgo_89
-  %1686 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1490)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1686)
-  store ptr %1686, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  %762 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %670)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %762)
+  store ptr %762, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
   br label %_llgo_92
 
 _llgo_92:                                         ; preds = %_llgo_91, %_llgo_89
-  %1687 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
-  %1688 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
-  %1689 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
-  %1690 = icmp eq ptr %1689, null
-  br i1 %1690, label %_llgo_93, label %_llgo_94
+  %763 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  %764 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  %765 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
+  %766 = icmp eq ptr %765, null
+  br i1 %766, label %_llgo_93, label %_llgo_94
 
 _llgo_93:                                         ; preds = %_llgo_92
-  %1691 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %1692 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1693 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1692, i32 0, i32 0
-  store ptr %1691, ptr %1693, align 8
-  %1694 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1692, i32 0, i32 1
-  store i64 0, ptr %1694, align 4
-  %1695 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1692, i32 0, i32 2
-  store i64 0, ptr %1695, align 4
-  %1696 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1692, align 8
-  %1697 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %1698 = getelementptr ptr, ptr %1697, i64 0
-  store ptr %1688, ptr %1698, align 8
-  %1699 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1700 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1699, i32 0, i32 0
-  store ptr %1697, ptr %1700, align 8
-  %1701 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1699, i32 0, i32 1
-  store i64 1, ptr %1701, align 4
-  %1702 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1699, i32 0, i32 2
-  store i64 1, ptr %1702, align 4
-  %1703 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1699, align 8
-  %1704 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1696, %"github.com/goplus/llgo/internal/runtime.Slice" %1703, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1704)
-  store ptr %1704, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
+  %767 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %768 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %767, 0
+  %769 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %768, i64 0, 1
+  %770 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %769, i64 0, 2
+  %771 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %772 = getelementptr ptr, ptr %771, i64 0
+  store ptr %764, ptr %772, align 8
+  %773 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %771, 0
+  %774 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %773, i64 1, 1
+  %775 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %774, i64 1, 2
+  %776 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %770, %"github.com/goplus/llgo/internal/runtime.Slice" %775, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %776)
+  store ptr %776, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
   br label %_llgo_94
 
 _llgo_94:                                         ; preds = %_llgo_93, %_llgo_92
-  %1705 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
-  %1706 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1707 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1706, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1485, ptr %1707, align 8
-  %1708 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1706, i32 0, i32 1
-  store ptr %1705, ptr %1708, align 8
-  %1709 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1706, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).InterfaceType", ptr %1709, align 8
-  %1710 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1706, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).InterfaceType", ptr %1710, align 8
-  %1711 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1706, align 8
-  %1712 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1713 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1712, i32 0, i32 0
-  store ptr @48, ptr %1713, align 8
-  %1714 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1712, i32 0, i32 1
-  store i64 9, ptr %1714, align 4
-  %1715 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1712, align 8
-  %1716 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %1717 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1718 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1717, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1715, ptr %1718, align 8
-  %1719 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1717, i32 0, i32 1
-  store ptr %1716, ptr %1719, align 8
-  %1720 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1717, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).IsClosure", ptr %1720, align 8
-  %1721 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1717, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).IsClosure", ptr %1721, align 8
-  %1722 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1717, align 8
-  %1723 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1724 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1723, i32 0, i32 0
-  store ptr @49, ptr %1724, align 8
-  %1725 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1723, i32 0, i32 1
-  store i64 13, ptr %1725, align 4
-  %1726 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1723, align 8
-  %1727 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %1728 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1729 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1728, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1726, ptr %1729, align 8
-  %1730 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1728, i32 0, i32 1
-  store ptr %1727, ptr %1730, align 8
-  %1731 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1728, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).IsDirectIface", ptr %1731, align 8
-  %1732 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1728, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).IsDirectIface", ptr %1732, align 8
-  %1733 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1728, align 8
-  %1734 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1735 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1734, i32 0, i32 0
-  store ptr @50, ptr %1735, align 8
-  %1736 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1734, i32 0, i32 1
-  store i64 3, ptr %1736, align 4
-  %1737 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1734, align 8
-  %1738 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %1739 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %1740 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1741 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1740, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1737, ptr %1741, align 8
-  %1742 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1740, i32 0, i32 1
-  store ptr %1739, ptr %1742, align 8
-  %1743 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1740, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Key", ptr %1743, align 8
-  %1744 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1740, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Key", ptr %1744, align 8
-  %1745 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1740, align 8
-  %1746 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1747 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1746, i32 0, i32 0
-  store ptr @51, ptr %1747, align 8
-  %1748 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1746, i32 0, i32 1
-  store i64 4, ptr %1748, align 4
-  %1749 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1746, align 8
-  %1750 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1751 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1750, i32 0, i32 0
-  store ptr @52, ptr %1751, align 8
-  %1752 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1750, i32 0, i32 1
-  store i64 40, ptr %1752, align 4
-  %1753 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1750, align 8
-  %1754 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1753, i64 7, i64 8, i64 1, i64 1)
-  %1755 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Kind", align 8
-  %1756 = icmp eq ptr %1755, null
-  br i1 %1756, label %_llgo_95, label %_llgo_96
+  %777 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
+  %778 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @37, i64 13 }, ptr undef, ptr undef, ptr undef }, ptr %777, 1
+  %779 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %778, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).InterfaceType", 2
+  %780 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %779, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).InterfaceType", 3
+  %781 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %782 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @48, i64 9 }, ptr undef, ptr undef, ptr undef }, ptr %781, 1
+  %783 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %782, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).IsClosure", 2
+  %784 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %783, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).IsClosure", 3
+  %785 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %786 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @49, i64 13 }, ptr undef, ptr undef, ptr undef }, ptr %785, 1
+  %787 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %786, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).IsDirectIface", 2
+  %788 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %787, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).IsDirectIface", 3
+  %789 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %790 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %791 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @50, i64 3 }, ptr undef, ptr undef, ptr undef }, ptr %790, 1
+  %792 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %791, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Key", 2
+  %793 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %792, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Key", 3
+  %794 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @52, i64 40 }, i64 7, i64 8, i64 1, i64 1)
+  %795 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Kind", align 8
+  %796 = icmp eq ptr %795, null
+  br i1 %796, label %_llgo_95, label %_llgo_96
 
 _llgo_95:                                         ; preds = %_llgo_94
-  store ptr %1754, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Kind", align 8
+  store ptr %794, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Kind", align 8
   br label %_llgo_96
 
 _llgo_96:                                         ; preds = %_llgo_95, %_llgo_94
-  %1757 = load ptr, ptr @_llgo_uint, align 8
-  %1758 = icmp eq ptr %1757, null
-  br i1 %1758, label %_llgo_97, label %_llgo_98
+  %797 = load ptr, ptr @_llgo_uint, align 8
+  %798 = icmp eq ptr %797, null
+  br i1 %798, label %_llgo_97, label %_llgo_98
 
 _llgo_97:                                         ; preds = %_llgo_96
-  %1759 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 39)
-  store ptr %1759, ptr @_llgo_uint, align 8
+  %799 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 39)
+  store ptr %799, ptr @_llgo_uint, align 8
   br label %_llgo_98
 
 _llgo_98:                                         ; preds = %_llgo_97, %_llgo_96
-  %1760 = load ptr, ptr @_llgo_uint, align 8
-  br i1 %1756, label %_llgo_99, label %_llgo_100
+  %800 = load ptr, ptr @_llgo_uint, align 8
+  br i1 %796, label %_llgo_99, label %_llgo_100
 
 _llgo_99:                                         ; preds = %_llgo_98
-  %1761 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1762 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1761, i32 0, i32 0
-  store ptr @53, ptr %1762, align 8
-  %1763 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1761, i32 0, i32 1
-  store i64 6, ptr %1763, align 4
-  %1764 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1761, align 8
-  %1765 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %1766 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1767 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1766, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1764, ptr %1767, align 8
-  %1768 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1766, i32 0, i32 1
-  store ptr %1765, ptr %1768, align 8
-  %1769 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1766, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Kind).String", ptr %1769, align 8
-  %1770 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1766, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Kind).String", ptr %1770, align 8
-  %1771 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1766, align 8
-  %1772 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1773 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1772, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1764, ptr %1773, align 8
-  %1774 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1772, i32 0, i32 1
-  store ptr %1765, ptr %1774, align 8
-  %1775 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1772, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Kind).String", ptr %1775, align 8
-  %1776 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1772, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.Kind.String", ptr %1776, align 8
-  %1777 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1772, align 8
-  %1778 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %1779 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1778, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %1777, ptr %1779, align 8
-  %1780 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1781 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1780, i32 0, i32 0
-  store ptr %1778, ptr %1781, align 8
-  %1782 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1780, i32 0, i32 1
-  store i64 1, ptr %1782, align 4
-  %1783 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1780, i32 0, i32 2
-  store i64 1, ptr %1783, align 4
-  %1784 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1780, align 8
-  %1785 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %1786 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1785, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %1771, ptr %1786, align 8
-  %1787 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1788 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1787, i32 0, i32 0
-  store ptr %1785, ptr %1788, align 8
-  %1789 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1787, i32 0, i32 1
-  store i64 1, ptr %1789, align 4
-  %1790 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1787, i32 0, i32 2
-  store i64 1, ptr %1790, align 4
-  %1791 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1787, align 8
-  %1792 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1793 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1792, i32 0, i32 0
-  store ptr @3, ptr %1793, align 8
-  %1794 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1792, i32 0, i32 1
-  store i64 35, ptr %1794, align 4
-  %1795 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1792, align 8
-  %1796 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1797 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1796, i32 0, i32 0
-  store ptr @51, ptr %1797, align 8
-  %1798 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1796, i32 0, i32 1
-  store i64 4, ptr %1798, align 4
-  %1799 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1796, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %1754, %"github.com/goplus/llgo/internal/runtime.String" %1795, %"github.com/goplus/llgo/internal/runtime.String" %1799, ptr %1760, %"github.com/goplus/llgo/internal/runtime.Slice" %1784, %"github.com/goplus/llgo/internal/runtime.Slice" %1791)
+  %801 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %802 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @53, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %801, 1
+  %803 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %802, ptr @"github.com/goplus/llgo/internal/abi.(*Kind).String", 2
+  %804 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %803, ptr @"github.com/goplus/llgo/internal/abi.(*Kind).String", 3
+  %805 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @53, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %801, 1
+  %806 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %805, ptr @"github.com/goplus/llgo/internal/abi.(*Kind).String", 2
+  %807 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %806, ptr @"github.com/goplus/llgo/internal/abi.Kind.String", 3
+  %808 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %809 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %808, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %807, ptr %809, align 8
+  %810 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %808, 0
+  %811 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %810, i64 1, 1
+  %812 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %811, i64 1, 2
+  %813 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %814 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %813, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %804, ptr %814, align 8
+  %815 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %813, 0
+  %816 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %815, i64 1, 1
+  %817 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %816, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %794, %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 35 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @51, i64 4 }, ptr %800, %"github.com/goplus/llgo/internal/runtime.Slice" %812, %"github.com/goplus/llgo/internal/runtime.Slice" %817)
   br label %_llgo_100
 
 _llgo_100:                                        ; preds = %_llgo_99, %_llgo_98
-  %1800 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Kind", align 8
-  %1801 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Kind", align 8
-  %1802 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
-  %1803 = icmp eq ptr %1802, null
-  br i1 %1803, label %_llgo_101, label %_llgo_102
+  %818 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Kind", align 8
+  %819 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Kind", align 8
+  %820 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
+  %821 = icmp eq ptr %820, null
+  br i1 %821, label %_llgo_101, label %_llgo_102
 
 _llgo_101:                                        ; preds = %_llgo_100
-  %1804 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %1805 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1806 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1805, i32 0, i32 0
-  store ptr %1804, ptr %1806, align 8
-  %1807 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1805, i32 0, i32 1
-  store i64 0, ptr %1807, align 4
-  %1808 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1805, i32 0, i32 2
-  store i64 0, ptr %1808, align 4
-  %1809 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1805, align 8
-  %1810 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %1811 = getelementptr ptr, ptr %1810, i64 0
-  store ptr %1801, ptr %1811, align 8
-  %1812 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1813 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1812, i32 0, i32 0
-  store ptr %1810, ptr %1813, align 8
-  %1814 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1812, i32 0, i32 1
-  store i64 1, ptr %1814, align 4
-  %1815 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1812, i32 0, i32 2
-  store i64 1, ptr %1815, align 4
-  %1816 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1812, align 8
-  %1817 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1809, %"github.com/goplus/llgo/internal/runtime.Slice" %1816, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1817)
-  store ptr %1817, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
+  %822 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %823 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %822, 0
+  %824 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %823, i64 0, 1
+  %825 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %824, i64 0, 2
+  %826 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %827 = getelementptr ptr, ptr %826, i64 0
+  store ptr %819, ptr %827, align 8
+  %828 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %826, 0
+  %829 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %828, i64 1, 1
+  %830 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %829, i64 1, 2
+  %831 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %825, %"github.com/goplus/llgo/internal/runtime.Slice" %830, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %831)
+  store ptr %831, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
   br label %_llgo_102
 
 _llgo_102:                                        ; preds = %_llgo_101, %_llgo_100
-  %1818 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
-  %1819 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1820 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1819, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1749, ptr %1820, align 8
-  %1821 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1819, i32 0, i32 1
-  store ptr %1818, ptr %1821, align 8
-  %1822 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1819, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Kind", ptr %1822, align 8
-  %1823 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1819, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Kind", ptr %1823, align 8
-  %1824 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1819, align 8
-  %1825 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1826 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1825, i32 0, i32 0
-  store ptr @24, ptr %1826, align 8
-  %1827 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1825, i32 0, i32 1
-  store i64 3, ptr %1827, align 4
-  %1828 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1825, align 8
-  %1829 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %1830 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %1831 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1830, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1828, ptr %1831, align 8
-  %1832 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1830, i32 0, i32 1
-  store ptr %1829, ptr %1832, align 8
-  %1833 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1830, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Len", ptr %1833, align 8
-  %1834 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %1830, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Len", ptr %1834, align 8
-  %1835 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %1830, align 8
-  %1836 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1837 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1836, i32 0, i32 0
-  store ptr @54, ptr %1837, align 8
-  %1838 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1836, i32 0, i32 1
-  store i64 7, ptr %1838, align 4
-  %1839 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1836, align 8
-  %1840 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1841 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1840, i32 0, i32 0
-  store ptr @55, ptr %1841, align 8
-  %1842 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1840, i32 0, i32 1
-  store i64 43, ptr %1842, align 4
-  %1843 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1840, align 8
-  %1844 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1843, i64 25, i64 136, i64 0, i64 26)
-  %1845 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
-  %1846 = icmp eq ptr %1845, null
-  br i1 %1846, label %_llgo_103, label %_llgo_104
+  %832 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
+  %833 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @51, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %832, 1
+  %834 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %833, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Kind", 2
+  %835 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %834, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Kind", 3
+  %836 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %837 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @24, i64 3 }, ptr undef, ptr undef, ptr undef }, ptr %836, 1
+  %838 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %837, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Len", 2
+  %839 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %838, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Len", 3
+  %840 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @55, i64 43 }, i64 25, i64 136, i64 0, i64 26)
+  %841 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  %842 = icmp eq ptr %841, null
+  br i1 %842, label %_llgo_103, label %_llgo_104
 
 _llgo_103:                                        ; preds = %_llgo_102
-  store ptr %1844, ptr @"_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  store ptr %840, ptr @"_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
   br label %_llgo_104
 
 _llgo_104:                                        ; preds = %_llgo_103, %_llgo_102
-  %1847 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %1848 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %1849 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %1850 = load ptr, ptr @_llgo_Pointer, align 8
-  %1851 = load ptr, ptr @_llgo_Pointer, align 8
-  %1852 = load ptr, ptr @_llgo_uintptr, align 8
-  %1853 = load ptr, ptr @_llgo_uintptr, align 8
-  %1854 = load ptr, ptr @"_llgo_func$cAvVsWLgvZTNybpI-5Hj9CeBwW9xcw6i77GFRvp83mY", align 8
-  %1855 = icmp eq ptr %1854, null
-  br i1 %1855, label %_llgo_105, label %_llgo_106
+  %843 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %844 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %845 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %846 = load ptr, ptr @_llgo_Pointer, align 8
+  %847 = load ptr, ptr @_llgo_Pointer, align 8
+  %848 = load ptr, ptr @_llgo_uintptr, align 8
+  %849 = load ptr, ptr @_llgo_uintptr, align 8
+  %850 = load ptr, ptr @"_llgo_func$cAvVsWLgvZTNybpI-5Hj9CeBwW9xcw6i77GFRvp83mY", align 8
+  %851 = icmp eq ptr %850, null
+  br i1 %851, label %_llgo_105, label %_llgo_106
 
 _llgo_105:                                        ; preds = %_llgo_104
-  %1856 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %1857 = getelementptr ptr, ptr %1856, i64 0
-  store ptr %1850, ptr %1857, align 8
-  %1858 = getelementptr ptr, ptr %1856, i64 1
-  store ptr %1851, ptr %1858, align 8
-  %1859 = getelementptr ptr, ptr %1856, i64 2
-  store ptr %1852, ptr %1859, align 8
-  %1860 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1861 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1860, i32 0, i32 0
-  store ptr %1856, ptr %1861, align 8
-  %1862 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1860, i32 0, i32 1
-  store i64 3, ptr %1862, align 4
-  %1863 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1860, i32 0, i32 2
-  store i64 3, ptr %1863, align 4
-  %1864 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1860, align 8
-  %1865 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %1866 = getelementptr ptr, ptr %1865, i64 0
-  store ptr %1853, ptr %1866, align 8
-  %1867 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1868 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1867, i32 0, i32 0
-  store ptr %1865, ptr %1868, align 8
-  %1869 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1867, i32 0, i32 1
-  store i64 1, ptr %1869, align 4
-  %1870 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1867, i32 0, i32 2
-  store i64 1, ptr %1870, align 4
-  %1871 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1867, align 8
-  %1872 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1864, %"github.com/goplus/llgo/internal/runtime.Slice" %1871, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1872)
-  store ptr %1872, ptr @"_llgo_func$cAvVsWLgvZTNybpI-5Hj9CeBwW9xcw6i77GFRvp83mY", align 8
+  %852 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %853 = getelementptr ptr, ptr %852, i64 0
+  store ptr %846, ptr %853, align 8
+  %854 = getelementptr ptr, ptr %852, i64 1
+  store ptr %847, ptr %854, align 8
+  %855 = getelementptr ptr, ptr %852, i64 2
+  store ptr %848, ptr %855, align 8
+  %856 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %852, 0
+  %857 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %856, i64 3, 1
+  %858 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %857, i64 3, 2
+  %859 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %860 = getelementptr ptr, ptr %859, i64 0
+  store ptr %849, ptr %860, align 8
+  %861 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %859, 0
+  %862 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %861, i64 1, 1
+  %863 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %862, i64 1, 2
+  %864 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %858, %"github.com/goplus/llgo/internal/runtime.Slice" %863, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %864)
+  store ptr %864, ptr @"_llgo_func$cAvVsWLgvZTNybpI-5Hj9CeBwW9xcw6i77GFRvp83mY", align 8
   br label %_llgo_106
 
 _llgo_106:                                        ; preds = %_llgo_105, %_llgo_104
-  %1873 = load ptr, ptr @"_llgo_func$cAvVsWLgvZTNybpI-5Hj9CeBwW9xcw6i77GFRvp83mY", align 8
-  %1874 = load ptr, ptr @_llgo_Pointer, align 8
-  %1875 = load ptr, ptr @_llgo_Pointer, align 8
-  %1876 = load ptr, ptr @_llgo_uintptr, align 8
-  %1877 = load ptr, ptr @_llgo_uintptr, align 8
-  %1878 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1879 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1878, i32 0, i32 0
-  store ptr @5, ptr %1879, align 8
-  %1880 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1878, i32 0, i32 1
-  store i64 1, ptr %1880, align 4
-  %1881 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1878, align 8
-  %1882 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1883 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1882, i32 0, i32 0
-  store ptr null, ptr %1883, align 8
-  %1884 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1882, i32 0, i32 1
-  store i64 0, ptr %1884, align 4
-  %1885 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1882, align 8
-  %1886 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %1887 = getelementptr ptr, ptr %1886, i64 0
-  store ptr %1874, ptr %1887, align 8
-  %1888 = getelementptr ptr, ptr %1886, i64 1
-  store ptr %1875, ptr %1888, align 8
-  %1889 = getelementptr ptr, ptr %1886, i64 2
-  store ptr %1876, ptr %1889, align 8
-  %1890 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1891 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1890, i32 0, i32 0
-  store ptr %1886, ptr %1891, align 8
-  %1892 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1890, i32 0, i32 1
-  store i64 3, ptr %1892, align 4
-  %1893 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1890, i32 0, i32 2
-  store i64 3, ptr %1893, align 4
-  %1894 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1890, align 8
-  %1895 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %1896 = getelementptr ptr, ptr %1895, i64 0
-  store ptr %1877, ptr %1896, align 8
-  %1897 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1898 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1897, i32 0, i32 0
-  store ptr %1895, ptr %1898, align 8
-  %1899 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1897, i32 0, i32 1
-  store i64 1, ptr %1899, align 4
-  %1900 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1897, i32 0, i32 2
-  store i64 1, ptr %1900, align 4
-  %1901 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1897, align 8
-  %1902 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1894, %"github.com/goplus/llgo/internal/runtime.Slice" %1901, i1 false)
-  %1903 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1881, ptr %1902, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %1885, i1 false)
-  %1904 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1905 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1904, i32 0, i32 0
-  store ptr @6, ptr %1905, align 8
-  %1906 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1904, i32 0, i32 1
-  store i64 4, ptr %1906, align 4
-  %1907 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1904, align 8
-  %1908 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1909 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1908, i32 0, i32 0
-  store ptr null, ptr %1909, align 8
-  %1910 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1908, i32 0, i32 1
-  store i64 0, ptr %1910, align 4
-  %1911 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1908, align 8
-  %1912 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %1913 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1907, ptr %1912, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %1911, i1 false)
-  %1914 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1915 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1914, i32 0, i32 0
-  store ptr @7, ptr %1915, align 8
-  %1916 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1914, i32 0, i32 1
-  store i64 4, ptr %1916, align 4
-  %1917 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1914, align 8
-  %1918 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %1919 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1918, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %1903, ptr %1919, align 8
-  %1920 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1918, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %1913, ptr %1920, align 8
-  %1921 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %1922 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1921, i32 0, i32 0
-  store ptr %1918, ptr %1922, align 8
-  %1923 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1921, i32 0, i32 1
-  store i64 2, ptr %1923, align 4
-  %1924 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1921, i32 0, i32 2
-  store i64 2, ptr %1924, align 4
-  %1925 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %1921, align 8
-  %1926 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %1917, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %1925)
-  store ptr %1926, ptr @"main.struct$uDDWukIj6_GRAIQyJjrj0CZt1Ru2uIDU1N9fcbR_jCg", align 8
-  %1927 = load ptr, ptr @"main.struct$uDDWukIj6_GRAIQyJjrj0CZt1Ru2uIDU1N9fcbR_jCg", align 8
-  %1928 = load ptr, ptr @_llgo_uint16, align 8
-  %1929 = icmp eq ptr %1928, null
-  br i1 %1929, label %_llgo_107, label %_llgo_108
+  %865 = load ptr, ptr @"_llgo_func$cAvVsWLgvZTNybpI-5Hj9CeBwW9xcw6i77GFRvp83mY", align 8
+  %866 = load ptr, ptr @_llgo_Pointer, align 8
+  %867 = load ptr, ptr @_llgo_Pointer, align 8
+  %868 = load ptr, ptr @_llgo_uintptr, align 8
+  %869 = load ptr, ptr @_llgo_uintptr, align 8
+  %870 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %871 = getelementptr ptr, ptr %870, i64 0
+  store ptr %866, ptr %871, align 8
+  %872 = getelementptr ptr, ptr %870, i64 1
+  store ptr %867, ptr %872, align 8
+  %873 = getelementptr ptr, ptr %870, i64 2
+  store ptr %868, ptr %873, align 8
+  %874 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %870, 0
+  %875 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %874, i64 3, 1
+  %876 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %875, i64 3, 2
+  %877 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %878 = getelementptr ptr, ptr %877, i64 0
+  store ptr %869, ptr %878, align 8
+  %879 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %877, 0
+  %880 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %879, i64 1, 1
+  %881 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %880, i64 1, 2
+  %882 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %876, %"github.com/goplus/llgo/internal/runtime.Slice" %881, i1 false)
+  %883 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 1 }, ptr %882, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %884 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %885 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 4 }, ptr %884, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %886 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %887 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %886, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %883, ptr %887, align 8
+  %888 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %886, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %885, ptr %888, align 8
+  %889 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %886, 0
+  %890 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %889, i64 2, 1
+  %891 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %890, i64 2, 2
+  %892 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %891)
+  store ptr %892, ptr @"main.struct$uDDWukIj6_GRAIQyJjrj0CZt1Ru2uIDU1N9fcbR_jCg", align 8
+  %893 = load ptr, ptr @"main.struct$uDDWukIj6_GRAIQyJjrj0CZt1Ru2uIDU1N9fcbR_jCg", align 8
+  %894 = load ptr, ptr @_llgo_uint16, align 8
+  %895 = icmp eq ptr %894, null
+  br i1 %895, label %_llgo_107, label %_llgo_108
 
 _llgo_107:                                        ; preds = %_llgo_106
-  %1930 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 41)
-  store ptr %1930, ptr @_llgo_uint16, align 8
+  %896 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 41)
+  store ptr %896, ptr @_llgo_uint16, align 8
   br label %_llgo_108
 
 _llgo_108:                                        ; preds = %_llgo_107, %_llgo_106
-  %1931 = load ptr, ptr @_llgo_uint16, align 8
-  %1932 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1933 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1932, i32 0, i32 0
-  store ptr @1, ptr %1933, align 8
-  %1934 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1932, i32 0, i32 1
-  store i64 40, ptr %1934, align 4
-  %1935 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1932, align 8
-  %1936 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1935, i64 25, i64 80, i64 0, i64 23)
-  %1937 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1938 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1937, i32 0, i32 0
-  store ptr @1, ptr %1938, align 8
-  %1939 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1937, i32 0, i32 1
-  store i64 40, ptr %1939, align 4
-  %1940 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1937, align 8
-  %1941 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1940, i64 25, i64 80, i64 0, i64 23)
-  %1942 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1943 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1942, i32 0, i32 0
-  store ptr @1, ptr %1943, align 8
-  %1944 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1942, i32 0, i32 1
-  store i64 40, ptr %1944, align 4
-  %1945 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1942, align 8
-  %1946 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1945, i64 25, i64 80, i64 0, i64 23)
-  %1947 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1948 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1947, i32 0, i32 0
-  store ptr @1, ptr %1948, align 8
-  %1949 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1947, i32 0, i32 1
-  store i64 40, ptr %1949, align 4
-  %1950 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1947, align 8
-  %1951 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %1950, i64 25, i64 80, i64 0, i64 23)
-  %1952 = load ptr, ptr @_llgo_Pointer, align 8
-  %1953 = load ptr, ptr @_llgo_Pointer, align 8
-  %1954 = load ptr, ptr @_llgo_uintptr, align 8
-  %1955 = load ptr, ptr @_llgo_uintptr, align 8
-  %1956 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1957 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1956, i32 0, i32 0
-  store ptr @21, ptr %1957, align 8
-  %1958 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1956, i32 0, i32 1
-  store i64 4, ptr %1958, align 4
-  %1959 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1956, align 8
-  %1960 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1961 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1960, i32 0, i32 0
-  store ptr null, ptr %1961, align 8
-  %1962 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1960, i32 0, i32 1
-  store i64 0, ptr %1962, align 4
-  %1963 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1960, align 8
-  %1964 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1959, ptr %1936, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %1963, i1 true)
-  %1965 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1966 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1965, i32 0, i32 0
-  store ptr @50, ptr %1966, align 8
-  %1967 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1965, i32 0, i32 1
-  store i64 3, ptr %1967, align 4
-  %1968 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1965, align 8
-  %1969 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1970 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1969, i32 0, i32 0
-  store ptr null, ptr %1970, align 8
-  %1971 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1969, i32 0, i32 1
-  store i64 0, ptr %1971, align 4
-  %1972 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1969, align 8
-  %1973 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1941)
-  %1974 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1968, ptr %1973, i64 72, %"github.com/goplus/llgo/internal/runtime.String" %1972, i1 false)
-  %1975 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1976 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1975, i32 0, i32 0
-  store ptr @22, ptr %1976, align 8
-  %1977 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1975, i32 0, i32 1
-  store i64 4, ptr %1977, align 4
-  %1978 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1975, align 8
-  %1979 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1980 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1979, i32 0, i32 0
-  store ptr null, ptr %1980, align 8
-  %1981 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1979, i32 0, i32 1
-  store i64 0, ptr %1981, align 4
-  %1982 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1979, align 8
-  %1983 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1946)
-  %1984 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1978, ptr %1983, i64 80, %"github.com/goplus/llgo/internal/runtime.String" %1982, i1 false)
-  %1985 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1986 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1985, i32 0, i32 0
-  store ptr @56, ptr %1986, align 8
-  %1987 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1985, i32 0, i32 1
-  store i64 6, ptr %1987, align 4
-  %1988 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1985, align 8
-  %1989 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1990 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1989, i32 0, i32 0
-  store ptr null, ptr %1990, align 8
-  %1991 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1989, i32 0, i32 1
-  store i64 0, ptr %1991, align 4
-  %1992 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1989, align 8
-  %1993 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1951)
-  %1994 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1988, ptr %1993, i64 88, %"github.com/goplus/llgo/internal/runtime.String" %1992, i1 false)
-  %1995 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1996 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1995, i32 0, i32 0
-  store ptr @57, ptr %1996, align 8
-  %1997 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1995, i32 0, i32 1
-  store i64 6, ptr %1997, align 4
-  %1998 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1995, align 8
-  %1999 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2000 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1999, i32 0, i32 0
-  store ptr null, ptr %2000, align 8
-  %2001 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1999, i32 0, i32 1
-  store i64 0, ptr %2001, align 4
-  %2002 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1999, align 8
-  %2003 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2004 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2003, i32 0, i32 0
-  store ptr @5, ptr %2004, align 8
-  %2005 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2003, i32 0, i32 1
-  store i64 1, ptr %2005, align 4
-  %2006 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2003, align 8
-  %2007 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2008 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2007, i32 0, i32 0
-  store ptr null, ptr %2008, align 8
-  %2009 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2007, i32 0, i32 1
-  store i64 0, ptr %2009, align 4
-  %2010 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2007, align 8
-  %2011 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %2012 = getelementptr ptr, ptr %2011, i64 0
-  store ptr %1952, ptr %2012, align 8
-  %2013 = getelementptr ptr, ptr %2011, i64 1
-  store ptr %1953, ptr %2013, align 8
-  %2014 = getelementptr ptr, ptr %2011, i64 2
-  store ptr %1954, ptr %2014, align 8
-  %2015 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2016 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2015, i32 0, i32 0
-  store ptr %2011, ptr %2016, align 8
-  %2017 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2015, i32 0, i32 1
-  store i64 3, ptr %2017, align 4
-  %2018 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2015, i32 0, i32 2
-  store i64 3, ptr %2018, align 4
-  %2019 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2015, align 8
-  %2020 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %2021 = getelementptr ptr, ptr %2020, i64 0
-  store ptr %1955, ptr %2021, align 8
-  %2022 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2023 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2022, i32 0, i32 0
-  store ptr %2020, ptr %2023, align 8
-  %2024 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2022, i32 0, i32 1
-  store i64 1, ptr %2024, align 4
-  %2025 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2022, i32 0, i32 2
-  store i64 1, ptr %2025, align 4
-  %2026 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2022, align 8
-  %2027 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %2019, %"github.com/goplus/llgo/internal/runtime.Slice" %2026, i1 false)
-  %2028 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2006, ptr %2027, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %2010, i1 false)
-  %2029 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2030 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2029, i32 0, i32 0
-  store ptr @6, ptr %2030, align 8
-  %2031 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2029, i32 0, i32 1
-  store i64 4, ptr %2031, align 4
-  %2032 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2029, align 8
-  %2033 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2034 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2033, i32 0, i32 0
-  store ptr null, ptr %2034, align 8
-  %2035 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2033, i32 0, i32 1
-  store i64 0, ptr %2035, align 4
-  %2036 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2033, align 8
-  %2037 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %2038 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2032, ptr %2037, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %2036, i1 false)
-  %2039 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2040 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2039, i32 0, i32 0
-  store ptr @7, ptr %2040, align 8
-  %2041 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2039, i32 0, i32 1
-  store i64 4, ptr %2041, align 4
-  %2042 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2039, align 8
-  %2043 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %2044 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2043, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2028, ptr %2044, align 8
-  %2045 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2043, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2038, ptr %2045, align 8
-  %2046 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2047 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2046, i32 0, i32 0
-  store ptr %2043, ptr %2047, align 8
-  %2048 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2046, i32 0, i32 1
-  store i64 2, ptr %2048, align 4
-  %2049 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2046, i32 0, i32 2
-  store i64 2, ptr %2049, align 4
-  %2050 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2046, align 8
-  %2051 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %2042, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %2050)
-  %2052 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %1998, ptr %2051, i64 96, %"github.com/goplus/llgo/internal/runtime.String" %2002, i1 false)
-  %2053 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2054 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2053, i32 0, i32 0
-  store ptr @58, ptr %2054, align 8
-  %2055 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2053, i32 0, i32 1
-  store i64 7, ptr %2055, align 4
-  %2056 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2053, align 8
-  %2057 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2058 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2057, i32 0, i32 0
-  store ptr null, ptr %2058, align 8
-  %2059 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2057, i32 0, i32 1
-  store i64 0, ptr %2059, align 4
-  %2060 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2057, align 8
-  %2061 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %2062 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2056, ptr %2061, i64 112, %"github.com/goplus/llgo/internal/runtime.String" %2060, i1 false)
-  %2063 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2064 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2063, i32 0, i32 0
-  store ptr @59, ptr %2064, align 8
-  %2065 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2063, i32 0, i32 1
-  store i64 9, ptr %2065, align 4
-  %2066 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2063, align 8
-  %2067 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2068 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2067, i32 0, i32 0
-  store ptr null, ptr %2068, align 8
-  %2069 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2067, i32 0, i32 1
-  store i64 0, ptr %2069, align 4
-  %2070 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2067, align 8
-  %2071 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %2072 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2066, ptr %2071, i64 113, %"github.com/goplus/llgo/internal/runtime.String" %2070, i1 false)
-  %2073 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2074 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2073, i32 0, i32 0
-  store ptr @60, ptr %2074, align 8
-  %2075 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2073, i32 0, i32 1
-  store i64 10, ptr %2075, align 4
-  %2076 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2073, align 8
-  %2077 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2078 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2077, i32 0, i32 0
-  store ptr null, ptr %2078, align 8
-  %2079 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2077, i32 0, i32 1
-  store i64 0, ptr %2079, align 4
-  %2080 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2077, align 8
-  %2081 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 41)
-  %2082 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2076, ptr %2081, i64 114, %"github.com/goplus/llgo/internal/runtime.String" %2080, i1 false)
-  %2083 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2084 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2083, i32 0, i32 0
-  store ptr @61, ptr %2084, align 8
-  %2085 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2083, i32 0, i32 1
-  store i64 5, ptr %2085, align 4
-  %2086 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2083, align 8
-  %2087 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2088 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2087, i32 0, i32 0
-  store ptr null, ptr %2088, align 8
-  %2089 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2087, i32 0, i32 1
-  store i64 0, ptr %2089, align 4
-  %2090 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2087, align 8
-  %2091 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 42)
-  %2092 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2086, ptr %2091, i64 116, %"github.com/goplus/llgo/internal/runtime.String" %2090, i1 false)
-  %2093 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2094 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2093, i32 0, i32 0
-  store ptr @7, ptr %2094, align 8
-  %2095 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2093, i32 0, i32 1
-  store i64 4, ptr %2095, align 4
-  %2096 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2093, align 8
-  %2097 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 504)
-  %2098 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2097, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %1964, ptr %2098, align 8
-  %2099 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2097, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %1974, ptr %2099, align 8
-  %2100 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2097, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %1984, ptr %2100, align 8
-  %2101 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2097, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %1994, ptr %2101, align 8
-  %2102 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2097, i64 4
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2052, ptr %2102, align 8
-  %2103 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2097, i64 5
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2062, ptr %2103, align 8
-  %2104 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2097, i64 6
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2072, ptr %2104, align 8
-  %2105 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2097, i64 7
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2082, ptr %2105, align 8
-  %2106 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2097, i64 8
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2092, ptr %2106, align 8
-  %2107 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2108 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2107, i32 0, i32 0
-  store ptr %2097, ptr %2108, align 8
-  %2109 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2107, i32 0, i32 1
-  store i64 9, ptr %2109, align 4
-  %2110 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2107, i32 0, i32 2
-  store i64 9, ptr %2110, align 4
-  %2111 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2107, align 8
-  %2112 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %2096, i64 120, %"github.com/goplus/llgo/internal/runtime.Slice" %2111)
-  store ptr %2112, ptr @"main.struct$Yk42tBqeO4BzIoRAwt__cbPj2UwIDCP07Kg_SR7sBZM", align 8
-  %2113 = load ptr, ptr @"main.struct$Yk42tBqeO4BzIoRAwt__cbPj2UwIDCP07Kg_SR7sBZM", align 8
-  br i1 %1846, label %_llgo_109, label %_llgo_110
+  %897 = load ptr, ptr @_llgo_uint16, align 8
+  %898 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 40 }, i64 25, i64 80, i64 0, i64 23)
+  %899 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 40 }, i64 25, i64 80, i64 0, i64 23)
+  %900 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 40 }, i64 25, i64 80, i64 0, i64 23)
+  %901 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 40 }, i64 25, i64 80, i64 0, i64 23)
+  %902 = load ptr, ptr @_llgo_Pointer, align 8
+  %903 = load ptr, ptr @_llgo_Pointer, align 8
+  %904 = load ptr, ptr @_llgo_uintptr, align 8
+  %905 = load ptr, ptr @_llgo_uintptr, align 8
+  %906 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @21, i64 4 }, ptr %898, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 true)
+  %907 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %899)
+  %908 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @50, i64 3 }, ptr %907, i64 72, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %909 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %900)
+  %910 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @22, i64 4 }, ptr %909, i64 80, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %911 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %901)
+  %912 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @56, i64 6 }, ptr %911, i64 88, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %913 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %914 = getelementptr ptr, ptr %913, i64 0
+  store ptr %902, ptr %914, align 8
+  %915 = getelementptr ptr, ptr %913, i64 1
+  store ptr %903, ptr %915, align 8
+  %916 = getelementptr ptr, ptr %913, i64 2
+  store ptr %904, ptr %916, align 8
+  %917 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %913, 0
+  %918 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %917, i64 3, 1
+  %919 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %918, i64 3, 2
+  %920 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %921 = getelementptr ptr, ptr %920, i64 0
+  store ptr %905, ptr %921, align 8
+  %922 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %920, 0
+  %923 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %922, i64 1, 1
+  %924 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %923, i64 1, 2
+  %925 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %919, %"github.com/goplus/llgo/internal/runtime.Slice" %924, i1 false)
+  %926 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 1 }, ptr %925, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %927 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %928 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 4 }, ptr %927, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %929 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %930 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %929, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %926, ptr %930, align 8
+  %931 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %929, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %928, ptr %931, align 8
+  %932 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %929, 0
+  %933 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %932, i64 2, 1
+  %934 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %933, i64 2, 2
+  %935 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %934)
+  %936 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @57, i64 6 }, ptr %935, i64 96, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %937 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %938 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @58, i64 7 }, ptr %937, i64 112, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %939 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %940 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @59, i64 9 }, ptr %939, i64 113, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %941 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 41)
+  %942 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @60, i64 10 }, ptr %941, i64 114, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %943 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 42)
+  %944 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @61, i64 5 }, ptr %943, i64 116, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %945 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 504)
+  %946 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %945, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %906, ptr %946, align 8
+  %947 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %945, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %908, ptr %947, align 8
+  %948 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %945, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %910, ptr %948, align 8
+  %949 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %945, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %912, ptr %949, align 8
+  %950 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %945, i64 4
+  store %"github.com/goplus/llgo/internal/abi.StructField" %936, ptr %950, align 8
+  %951 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %945, i64 5
+  store %"github.com/goplus/llgo/internal/abi.StructField" %938, ptr %951, align 8
+  %952 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %945, i64 6
+  store %"github.com/goplus/llgo/internal/abi.StructField" %940, ptr %952, align 8
+  %953 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %945, i64 7
+  store %"github.com/goplus/llgo/internal/abi.StructField" %942, ptr %953, align 8
+  %954 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %945, i64 8
+  store %"github.com/goplus/llgo/internal/abi.StructField" %944, ptr %954, align 8
+  %955 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %945, 0
+  %956 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %955, i64 9, 1
+  %957 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %956, i64 9, 2
+  %958 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 }, i64 120, %"github.com/goplus/llgo/internal/runtime.Slice" %957)
+  store ptr %958, ptr @"main.struct$Yk42tBqeO4BzIoRAwt__cbPj2UwIDCP07Kg_SR7sBZM", align 8
+  %959 = load ptr, ptr @"main.struct$Yk42tBqeO4BzIoRAwt__cbPj2UwIDCP07Kg_SR7sBZM", align 8
+  br i1 %842, label %_llgo_109, label %_llgo_110
 
 _llgo_109:                                        ; preds = %_llgo_108
-  %2114 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2115 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2114, i32 0, i32 0
-  store ptr @18, ptr %2115, align 8
-  %2116 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2114, i32 0, i32 1
-  store i64 5, ptr %2116, align 4
-  %2117 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2114, align 8
-  %2118 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %2119 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2120 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2119, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2117, ptr %2120, align 8
-  %2121 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2119, i32 0, i32 1
-  store ptr %2118, ptr %2121, align 8
-  %2122 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2119, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Align", ptr %2122, align 8
-  %2123 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2119, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Align", ptr %2123, align 8
-  %2124 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2119, align 8
-  %2125 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2126 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2125, i32 0, i32 0
-  store ptr @19, ptr %2126, align 8
-  %2127 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2125, i32 0, i32 1
-  store i64 9, ptr %2127, align 4
-  %2128 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2125, align 8
-  %2129 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
-  %2130 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
-  %2131 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2132 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2131, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2128, ptr %2132, align 8
-  %2133 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2131, i32 0, i32 1
-  store ptr %2130, ptr %2133, align 8
-  %2134 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2131, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ArrayType", ptr %2134, align 8
-  %2135 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2131, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ArrayType", ptr %2135, align 8
-  %2136 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2131, align 8
-  %2137 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2138 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2137, i32 0, i32 0
-  store ptr @25, ptr %2138, align 8
-  %2139 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2137, i32 0, i32 1
-  store i64 7, ptr %2139, align 4
-  %2140 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2137, align 8
-  %2141 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
-  %2142 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2143 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2142, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2140, ptr %2143, align 8
-  %2144 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2142, i32 0, i32 1
-  store ptr %2141, ptr %2144, align 8
-  %2145 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2142, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ChanDir", ptr %2145, align 8
-  %2146 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2142, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ChanDir", ptr %2146, align 8
-  %2147 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2142, align 8
-  %2148 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2149 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2148, i32 0, i32 0
-  store ptr @27, ptr %2149, align 8
-  %2150 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2148, i32 0, i32 1
-  store i64 6, ptr %2150, align 4
-  %2151 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2148, align 8
-  %2152 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %2153 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %2154 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2155 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2154, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2151, ptr %2155, align 8
-  %2156 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2154, i32 0, i32 1
-  store ptr %2153, ptr %2156, align 8
-  %2157 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2154, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Common", ptr %2157, align 8
-  %2158 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2154, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Common", ptr %2158, align 8
-  %2159 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2154, align 8
-  %2160 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2161 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2160, i32 0, i32 0
-  store ptr @28, ptr %2161, align 8
-  %2162 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2160, i32 0, i32 1
-  store i64 15, ptr %2162, align 4
-  %2163 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2160, align 8
-  %2164 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %2165 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
-  %2166 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2167 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2166, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2163, ptr %2167, align 8
-  %2168 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2166, i32 0, i32 1
-  store ptr %2165, ptr %2168, align 8
-  %2169 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2166, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ExportedMethods", ptr %2169, align 8
-  %2170 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2166, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ExportedMethods", ptr %2170, align 8
-  %2171 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2166, align 8
-  %2172 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2173 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2172, i32 0, i32 0
-  store ptr @33, ptr %2173, align 8
-  %2174 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2172, i32 0, i32 1
-  store i64 10, ptr %2174, align 4
-  %2175 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2172, align 8
-  %2176 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %2177 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2178 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2177, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2175, ptr %2178, align 8
-  %2179 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2177, i32 0, i32 1
-  store ptr %2176, ptr %2179, align 8
-  %2180 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2177, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).FieldAlign", ptr %2180, align 8
-  %2181 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2177, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).FieldAlign", ptr %2181, align 8
-  %2182 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2177, align 8
-  %2183 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2184 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2183, i32 0, i32 0
-  store ptr @34, ptr %2184, align 8
-  %2185 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2183, i32 0, i32 1
-  store i64 8, ptr %2185, align 4
-  %2186 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2183, align 8
-  %2187 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %2188 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
-  %2189 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2190 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2189, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2186, ptr %2190, align 8
-  %2191 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2189, i32 0, i32 1
-  store ptr %2188, ptr %2191, align 8
-  %2192 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2189, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).FuncType", ptr %2192, align 8
-  %2193 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2189, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).FuncType", ptr %2193, align 8
-  %2194 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2189, align 8
-  %2195 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2196 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2195, i32 0, i32 0
-  store ptr @35, ptr %2196, align 8
-  %2197 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2195, i32 0, i32 1
-  store i64 7, ptr %2197, align 4
-  %2198 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2195, align 8
-  %2199 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2200 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2201 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2200, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2198, ptr %2201, align 8
-  %2202 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2200, i32 0, i32 1
-  store ptr %2199, ptr %2202, align 8
-  %2203 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2200, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).HasName", ptr %2203, align 8
-  %2204 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2200, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).HasName", ptr %2204, align 8
-  %2205 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2200, align 8
-  %2206 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2207 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2206, i32 0, i32 0
-  store ptr @62, ptr %2207, align 8
-  %2208 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2206, i32 0, i32 1
-  store i64 14, ptr %2208, align 4
-  %2209 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2206, align 8
-  %2210 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2211 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2212 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2211, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2209, ptr %2212, align 8
-  %2213 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2211, i32 0, i32 1
-  store ptr %2210, ptr %2213, align 8
-  %2214 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2211, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).HashMightPanic", ptr %2214, align 8
-  %2215 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2211, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).HashMightPanic", ptr %2215, align 8
-  %2216 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2211, align 8
-  %2217 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2218 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2217, i32 0, i32 0
-  store ptr @36, ptr %2218, align 8
-  %2219 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2217, i32 0, i32 1
-  store i64 10, ptr %2219, align 4
-  %2220 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2217, align 8
-  %2221 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2222 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2223 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2222, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2220, ptr %2223, align 8
-  %2224 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2222, i32 0, i32 1
-  store ptr %2221, ptr %2224, align 8
-  %2225 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2222, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IfaceIndir", ptr %2225, align 8
-  %2226 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2222, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IfaceIndir", ptr %2226, align 8
-  %2227 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2222, align 8
-  %2228 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2229 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2228, i32 0, i32 0
-  store ptr @63, ptr %2229, align 8
-  %2230 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2228, i32 0, i32 1
-  store i64 12, ptr %2230, align 4
-  %2231 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2228, align 8
-  %2232 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2233 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2234 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2233, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2231, ptr %2234, align 8
-  %2235 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2233, i32 0, i32 1
-  store ptr %2232, ptr %2235, align 8
-  %2236 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2233, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IndirectElem", ptr %2236, align 8
-  %2237 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2233, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IndirectElem", ptr %2237, align 8
-  %2238 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2233, align 8
-  %2239 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2240 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2239, i32 0, i32 0
-  store ptr @64, ptr %2240, align 8
-  %2241 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2239, i32 0, i32 1
-  store i64 11, ptr %2241, align 4
-  %2242 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2239, align 8
-  %2243 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2244 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2245 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2244, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2242, ptr %2245, align 8
-  %2246 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2244, i32 0, i32 1
-  store ptr %2243, ptr %2246, align 8
-  %2247 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2244, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IndirectKey", ptr %2247, align 8
-  %2248 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2244, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IndirectKey", ptr %2248, align 8
-  %2249 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2244, align 8
-  %2250 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2251 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2250, i32 0, i32 0
-  store ptr @37, ptr %2251, align 8
-  %2252 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2250, i32 0, i32 1
-  store i64 13, ptr %2252, align 4
-  %2253 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2250, align 8
-  %2254 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
-  %2255 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
-  %2256 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2257 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2256, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2253, ptr %2257, align 8
-  %2258 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2256, i32 0, i32 1
-  store ptr %2255, ptr %2258, align 8
-  %2259 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2256, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).InterfaceType", ptr %2259, align 8
-  %2260 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2256, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).InterfaceType", ptr %2260, align 8
-  %2261 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2256, align 8
-  %2262 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2263 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2262, i32 0, i32 0
-  store ptr @48, ptr %2263, align 8
-  %2264 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2262, i32 0, i32 1
-  store i64 9, ptr %2264, align 4
-  %2265 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2262, align 8
-  %2266 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2267 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2268 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2267, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2265, ptr %2268, align 8
-  %2269 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2267, i32 0, i32 1
-  store ptr %2266, ptr %2269, align 8
-  %2270 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2267, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IsClosure", ptr %2270, align 8
-  %2271 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2267, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IsClosure", ptr %2271, align 8
-  %2272 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2267, align 8
-  %2273 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2274 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2273, i32 0, i32 0
-  store ptr @49, ptr %2274, align 8
-  %2275 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2273, i32 0, i32 1
-  store i64 13, ptr %2275, align 4
-  %2276 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2273, align 8
-  %2277 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2278 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2279 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2278, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2276, ptr %2279, align 8
-  %2280 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2278, i32 0, i32 1
-  store ptr %2277, ptr %2280, align 8
-  %2281 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2278, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IsDirectIface", ptr %2281, align 8
-  %2282 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2278, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IsDirectIface", ptr %2282, align 8
-  %2283 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2278, align 8
-  %2284 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2285 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2284, i32 0, i32 0
-  store ptr @51, ptr %2285, align 8
-  %2286 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2284, i32 0, i32 1
-  store i64 4, ptr %2286, align 4
-  %2287 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2284, align 8
-  %2288 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
-  %2289 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2290 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2289, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2287, ptr %2290, align 8
-  %2291 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2289, i32 0, i32 1
-  store ptr %2288, ptr %2291, align 8
-  %2292 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2289, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Kind", ptr %2292, align 8
-  %2293 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2289, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Kind", ptr %2293, align 8
-  %2294 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2289, align 8
-  %2295 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2296 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2295, i32 0, i32 0
-  store ptr @24, ptr %2296, align 8
-  %2297 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2295, i32 0, i32 1
-  store i64 3, ptr %2297, align 4
-  %2298 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2295, align 8
-  %2299 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %2300 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2301 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2300, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2298, ptr %2301, align 8
-  %2302 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2300, i32 0, i32 1
-  store ptr %2299, ptr %2302, align 8
-  %2303 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2300, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Len", ptr %2303, align 8
-  %2304 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2300, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Len", ptr %2304, align 8
-  %2305 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2300, align 8
-  %2306 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2307 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2306, i32 0, i32 0
-  store ptr @54, ptr %2307, align 8
-  %2308 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2306, i32 0, i32 1
-  store i64 7, ptr %2308, align 4
-  %2309 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2306, align 8
-  %2310 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2311 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2310, i32 0, i32 0
-  store ptr @55, ptr %2311, align 8
-  %2312 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2310, i32 0, i32 1
-  store i64 43, ptr %2312, align 4
-  %2313 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2310, align 8
-  %2314 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2313, i64 25, i64 136, i64 0, i64 26)
-  %2315 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
-  %2316 = icmp eq ptr %2315, null
-  br i1 %2316, label %_llgo_111, label %_llgo_112
+  %960 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %961 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @18, i64 5 }, ptr undef, ptr undef, ptr undef }, ptr %960, 1
+  %962 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %961, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Align", 2
+  %963 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %962, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Align", 3
+  %964 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  %965 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
+  %966 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @19, i64 9 }, ptr undef, ptr undef, ptr undef }, ptr %965, 1
+  %967 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %966, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ArrayType", 2
+  %968 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %967, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ArrayType", 3
+  %969 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
+  %970 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @25, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %969, 1
+  %971 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %970, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ChanDir", 2
+  %972 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %971, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ChanDir", 3
+  %973 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %974 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %975 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @27, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %974, 1
+  %976 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %975, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Common", 2
+  %977 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %976, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Common", 3
+  %978 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %979 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
+  %980 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @28, i64 15 }, ptr undef, ptr undef, ptr undef }, ptr %979, 1
+  %981 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %980, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ExportedMethods", 2
+  %982 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %981, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ExportedMethods", 3
+  %983 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %984 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @33, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %983, 1
+  %985 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %984, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).FieldAlign", 2
+  %986 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %985, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).FieldAlign", 3
+  %987 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %988 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
+  %989 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @34, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %988, 1
+  %990 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %989, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).FuncType", 2
+  %991 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %990, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).FuncType", 3
+  %992 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %993 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @35, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %992, 1
+  %994 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %993, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).HasName", 2
+  %995 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %994, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).HasName", 3
+  %996 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %997 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @62, i64 14 }, ptr undef, ptr undef, ptr undef }, ptr %996, 1
+  %998 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %997, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).HashMightPanic", 2
+  %999 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %998, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).HashMightPanic", 3
+  %1000 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1001 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @36, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %1000, 1
+  %1002 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1001, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IfaceIndir", 2
+  %1003 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1002, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IfaceIndir", 3
+  %1004 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1005 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @63, i64 12 }, ptr undef, ptr undef, ptr undef }, ptr %1004, 1
+  %1006 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1005, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IndirectElem", 2
+  %1007 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1006, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IndirectElem", 3
+  %1008 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1009 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @64, i64 11 }, ptr undef, ptr undef, ptr undef }, ptr %1008, 1
+  %1010 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1009, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IndirectKey", 2
+  %1011 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1010, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IndirectKey", 3
+  %1012 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  %1013 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
+  %1014 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @37, i64 13 }, ptr undef, ptr undef, ptr undef }, ptr %1013, 1
+  %1015 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1014, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).InterfaceType", 2
+  %1016 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1015, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).InterfaceType", 3
+  %1017 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1018 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @48, i64 9 }, ptr undef, ptr undef, ptr undef }, ptr %1017, 1
+  %1019 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1018, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IsClosure", 2
+  %1020 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1019, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IsClosure", 3
+  %1021 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1022 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @49, i64 13 }, ptr undef, ptr undef, ptr undef }, ptr %1021, 1
+  %1023 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1022, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IsDirectIface", 2
+  %1024 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1023, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).IsDirectIface", 3
+  %1025 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
+  %1026 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @51, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %1025, 1
+  %1027 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1026, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Kind", 2
+  %1028 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1027, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Kind", 3
+  %1029 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %1030 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @24, i64 3 }, ptr undef, ptr undef, ptr undef }, ptr %1029, 1
+  %1031 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1030, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Len", 2
+  %1032 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1031, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Len", 3
+  %1033 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @55, i64 43 }, i64 25, i64 136, i64 0, i64 26)
+  %1034 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  %1035 = icmp eq ptr %1034, null
+  br i1 %1035, label %_llgo_111, label %_llgo_112
 
 _llgo_110:                                        ; preds = %_llgo_130, %_llgo_108
-  %2317 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
-  %2318 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
-  %2319 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
-  %2320 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2321 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2320, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %1839, ptr %2321, align 8
-  %2322 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2320, i32 0, i32 1
-  store ptr %2319, ptr %2322, align 8
-  %2323 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2320, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).MapType", ptr %2323, align 8
-  %2324 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2320, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).MapType", ptr %2324, align 8
-  %2325 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2320, align 8
-  %2326 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2327 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2326, i32 0, i32 0
-  store ptr @66, ptr %2327, align 8
-  %2328 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2326, i32 0, i32 1
-  store i64 9, ptr %2328, align 4
-  %2329 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2326, align 8
-  %2330 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %2331 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2332 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2331, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2329, ptr %2332, align 8
-  %2333 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2331, i32 0, i32 1
-  store ptr %2330, ptr %2333, align 8
-  %2334 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2331, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).NumMethod", ptr %2334, align 8
-  %2335 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2331, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).NumMethod", ptr %2335, align 8
-  %2336 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2331, align 8
-  %2337 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2338 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2337, i32 0, i32 0
-  store ptr @67, ptr %2338, align 8
-  %2339 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2337, i32 0, i32 1
-  store i64 8, ptr %2339, align 4
-  %2340 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2337, align 8
-  %2341 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2342 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2343 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2342, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2340, ptr %2343, align 8
-  %2344 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2342, i32 0, i32 1
-  store ptr %2341, ptr %2344, align 8
-  %2345 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2342, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Pointers", ptr %2345, align 8
-  %2346 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2342, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Pointers", ptr %2346, align 8
-  %2347 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2342, align 8
-  %2348 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2349 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2348, i32 0, i32 0
-  store ptr @69, ptr %2349, align 8
-  %2350 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2348, i32 0, i32 1
-  store i64 4, ptr %2350, align 4
-  %2351 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2348, align 8
-  %2352 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
-  %2353 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2354 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2353, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2351, ptr %2354, align 8
-  %2355 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2353, i32 0, i32 1
-  store ptr %2352, ptr %2355, align 8
-  %2356 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2353, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Size", ptr %2356, align 8
-  %2357 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2353, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Size", ptr %2357, align 8
-  %2358 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2353, align 8
-  %2359 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2360 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2359, i32 0, i32 0
-  store ptr @53, ptr %2360, align 8
-  %2361 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2359, i32 0, i32 1
-  store i64 6, ptr %2361, align 4
-  %2362 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2359, align 8
-  %2363 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %2364 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2365 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2364, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2362, ptr %2365, align 8
-  %2366 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2364, i32 0, i32 1
-  store ptr %2363, ptr %2366, align 8
-  %2367 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2364, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).String", ptr %2367, align 8
-  %2368 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2364, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).String", ptr %2368, align 8
-  %2369 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2364, align 8
-  %2370 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2371 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2370, i32 0, i32 0
-  store ptr @70, ptr %2371, align 8
-  %2372 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2370, i32 0, i32 1
-  store i64 10, ptr %2372, align 4
-  %2373 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2370, align 8
-  %2374 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
-  %2375 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
-  %2376 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2377 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2376, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2373, ptr %2377, align 8
-  %2378 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2376, i32 0, i32 1
-  store ptr %2375, ptr %2378, align 8
-  %2379 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2376, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).StructType", ptr %2379, align 8
-  %2380 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2376, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).StructType", ptr %2380, align 8
-  %2381 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2376, align 8
-  %2382 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2383 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2382, i32 0, i32 0
-  store ptr @80, ptr %2383, align 8
-  %2384 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2382, i32 0, i32 1
-  store i64 8, ptr %2384, align 4
-  %2385 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2382, align 8
-  %2386 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
-  %2387 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2388 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2387, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2385, ptr %2388, align 8
-  %2389 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2387, i32 0, i32 1
-  store ptr %2386, ptr %2389, align 8
-  %2390 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2387, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Uncommon", ptr %2390, align 8
-  %2391 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2387, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Uncommon", ptr %2391, align 8
-  %2392 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2387, align 8
-  %2393 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 920)
-  %2394 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2393, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %1377, ptr %2394, align 8
-  %2395 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2393, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %1389, ptr %2395, align 8
-  %2396 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2393, i64 2
-  store %"github.com/goplus/llgo/internal/abi.Method" %1400, ptr %2396, align 8
-  %2397 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2393, i64 3
-  store %"github.com/goplus/llgo/internal/abi.Method" %1412, ptr %2397, align 8
-  %2398 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2393, i64 4
-  store %"github.com/goplus/llgo/internal/abi.Method" %1424, ptr %2398, align 8
-  %2399 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2393, i64 5
-  store %"github.com/goplus/llgo/internal/abi.Method" %1436, ptr %2399, align 8
-  %2400 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2393, i64 6
-  store %"github.com/goplus/llgo/internal/abi.Method" %1447, ptr %2400, align 8
-  %2401 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2393, i64 7
-  store %"github.com/goplus/llgo/internal/abi.Method" %1459, ptr %2401, align 8
-  %2402 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2393, i64 8
-  store %"github.com/goplus/llgo/internal/abi.Method" %1470, ptr %2402, align 8
-  %2403 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2393, i64 9
-  store %"github.com/goplus/llgo/internal/abi.Method" %1481, ptr %2403, align 8
-  %2404 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2393, i64 10
-  store %"github.com/goplus/llgo/internal/abi.Method" %1711, ptr %2404, align 8
-  %2405 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2393, i64 11
-  store %"github.com/goplus/llgo/internal/abi.Method" %1722, ptr %2405, align 8
-  %2406 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2393, i64 12
-  store %"github.com/goplus/llgo/internal/abi.Method" %1733, ptr %2406, align 8
-  %2407 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2393, i64 13
-  store %"github.com/goplus/llgo/internal/abi.Method" %1745, ptr %2407, align 8
-  %2408 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2393, i64 14
-  store %"github.com/goplus/llgo/internal/abi.Method" %1824, ptr %2408, align 8
-  %2409 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2393, i64 15
-  store %"github.com/goplus/llgo/internal/abi.Method" %1835, ptr %2409, align 8
-  %2410 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2393, i64 16
-  store %"github.com/goplus/llgo/internal/abi.Method" %2325, ptr %2410, align 8
-  %2411 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2393, i64 17
-  store %"github.com/goplus/llgo/internal/abi.Method" %2336, ptr %2411, align 8
-  %2412 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2393, i64 18
-  store %"github.com/goplus/llgo/internal/abi.Method" %2347, ptr %2412, align 8
-  %2413 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2393, i64 19
-  store %"github.com/goplus/llgo/internal/abi.Method" %2358, ptr %2413, align 8
-  %2414 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2393, i64 20
-  store %"github.com/goplus/llgo/internal/abi.Method" %2369, ptr %2414, align 8
-  %2415 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2393, i64 21
-  store %"github.com/goplus/llgo/internal/abi.Method" %2381, ptr %2415, align 8
-  %2416 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2393, i64 22
-  store %"github.com/goplus/llgo/internal/abi.Method" %2392, ptr %2416, align 8
-  %2417 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2418 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2417, i32 0, i32 0
-  store ptr %2393, ptr %2418, align 8
-  %2419 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2417, i32 0, i32 1
-  store i64 23, ptr %2419, align 4
-  %2420 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2417, i32 0, i32 2
-  store i64 23, ptr %2420, align 4
-  %2421 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2417, align 8
-  %2422 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2423 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2422, i32 0, i32 0
-  store ptr @3, ptr %2423, align 8
-  %2424 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2422, i32 0, i32 1
-  store i64 35, ptr %2424, align 4
-  %2425 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2422, align 8
-  %2426 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2427 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2426, i32 0, i32 0
-  store ptr @37, ptr %2427, align 8
-  %2428 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2426, i32 0, i32 1
-  store i64 13, ptr %2428, align 4
-  %2429 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2426, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %1182, %"github.com/goplus/llgo/internal/runtime.String" %2425, %"github.com/goplus/llgo/internal/runtime.String" %2429, ptr %1366, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %2421)
+  %1036 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  %1037 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  %1038 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
+  %1039 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @54, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %1038, 1
+  %1040 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1039, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).MapType", 2
+  %1041 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1040, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).MapType", 3
+  %1042 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %1043 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @66, i64 9 }, ptr undef, ptr undef, ptr undef }, ptr %1042, 1
+  %1044 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1043, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).NumMethod", 2
+  %1045 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1044, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).NumMethod", 3
+  %1046 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1047 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @67, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %1046, 1
+  %1048 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1047, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Pointers", 2
+  %1049 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1048, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Pointers", 3
+  %1050 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
+  %1051 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @69, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %1050, 1
+  %1052 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1051, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Size", 2
+  %1053 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1052, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Size", 3
+  %1054 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %1055 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @53, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %1054, 1
+  %1056 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1055, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).String", 2
+  %1057 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1056, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).String", 3
+  %1058 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  %1059 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
+  %1060 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @70, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %1059, 1
+  %1061 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1060, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).StructType", 2
+  %1062 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1061, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).StructType", 3
+  %1063 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
+  %1064 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @80, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %1063, 1
+  %1065 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1064, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Uncommon", 2
+  %1066 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1065, ptr @"github.com/goplus/llgo/internal/abi.(*InterfaceType).Uncommon", 3
+  %1067 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 920)
+  %1068 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %628, ptr %1068, align 8
+  %1069 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %633, ptr %1069, align 8
+  %1070 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i64 2
+  store %"github.com/goplus/llgo/internal/abi.Method" %637, ptr %1070, align 8
+  %1071 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i64 3
+  store %"github.com/goplus/llgo/internal/abi.Method" %642, ptr %1071, align 8
+  %1072 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i64 4
+  store %"github.com/goplus/llgo/internal/abi.Method" %647, ptr %1072, align 8
+  %1073 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i64 5
+  store %"github.com/goplus/llgo/internal/abi.Method" %652, ptr %1073, align 8
+  %1074 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i64 6
+  store %"github.com/goplus/llgo/internal/abi.Method" %656, ptr %1074, align 8
+  %1075 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i64 7
+  store %"github.com/goplus/llgo/internal/abi.Method" %661, ptr %1075, align 8
+  %1076 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i64 8
+  store %"github.com/goplus/llgo/internal/abi.Method" %665, ptr %1076, align 8
+  %1077 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i64 9
+  store %"github.com/goplus/llgo/internal/abi.Method" %669, ptr %1077, align 8
+  %1078 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i64 10
+  store %"github.com/goplus/llgo/internal/abi.Method" %780, ptr %1078, align 8
+  %1079 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i64 11
+  store %"github.com/goplus/llgo/internal/abi.Method" %784, ptr %1079, align 8
+  %1080 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i64 12
+  store %"github.com/goplus/llgo/internal/abi.Method" %788, ptr %1080, align 8
+  %1081 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i64 13
+  store %"github.com/goplus/llgo/internal/abi.Method" %793, ptr %1081, align 8
+  %1082 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i64 14
+  store %"github.com/goplus/llgo/internal/abi.Method" %835, ptr %1082, align 8
+  %1083 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i64 15
+  store %"github.com/goplus/llgo/internal/abi.Method" %839, ptr %1083, align 8
+  %1084 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i64 16
+  store %"github.com/goplus/llgo/internal/abi.Method" %1041, ptr %1084, align 8
+  %1085 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i64 17
+  store %"github.com/goplus/llgo/internal/abi.Method" %1045, ptr %1085, align 8
+  %1086 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i64 18
+  store %"github.com/goplus/llgo/internal/abi.Method" %1049, ptr %1086, align 8
+  %1087 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i64 19
+  store %"github.com/goplus/llgo/internal/abi.Method" %1053, ptr %1087, align 8
+  %1088 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i64 20
+  store %"github.com/goplus/llgo/internal/abi.Method" %1057, ptr %1088, align 8
+  %1089 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i64 21
+  store %"github.com/goplus/llgo/internal/abi.Method" %1062, ptr %1089, align 8
+  %1090 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1067, i64 22
+  store %"github.com/goplus/llgo/internal/abi.Method" %1066, ptr %1090, align 8
+  %1091 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %1067, 0
+  %1092 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1091, i64 23, 1
+  %1093 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1092, i64 23, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %547, %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 35 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @37, i64 13 }, ptr %624, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %1093)
   br label %_llgo_90
 
 _llgo_111:                                        ; preds = %_llgo_109
-  %2430 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %2314)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %2430)
-  store ptr %2430, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  %1094 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1033)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1094)
+  store ptr %1094, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
   br label %_llgo_112
 
 _llgo_112:                                        ; preds = %_llgo_111, %_llgo_109
-  %2431 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
-  %2432 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
-  %2433 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
-  %2434 = icmp eq ptr %2433, null
-  br i1 %2434, label %_llgo_113, label %_llgo_114
+  %1095 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  %1096 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  %1097 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
+  %1098 = icmp eq ptr %1097, null
+  br i1 %1098, label %_llgo_113, label %_llgo_114
 
 _llgo_113:                                        ; preds = %_llgo_112
-  %2435 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %2436 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2437 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2436, i32 0, i32 0
-  store ptr %2435, ptr %2437, align 8
-  %2438 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2436, i32 0, i32 1
-  store i64 0, ptr %2438, align 4
-  %2439 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2436, i32 0, i32 2
-  store i64 0, ptr %2439, align 4
-  %2440 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2436, align 8
-  %2441 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %2442 = getelementptr ptr, ptr %2441, i64 0
-  store ptr %2432, ptr %2442, align 8
-  %2443 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2444 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2443, i32 0, i32 0
-  store ptr %2441, ptr %2444, align 8
-  %2445 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2443, i32 0, i32 1
-  store i64 1, ptr %2445, align 4
-  %2446 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2443, i32 0, i32 2
-  store i64 1, ptr %2446, align 4
-  %2447 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2443, align 8
-  %2448 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %2440, %"github.com/goplus/llgo/internal/runtime.Slice" %2447, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %2448)
-  store ptr %2448, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
+  %1099 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %1100 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %1099, 0
+  %1101 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1100, i64 0, 1
+  %1102 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1101, i64 0, 2
+  %1103 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %1104 = getelementptr ptr, ptr %1103, i64 0
+  store ptr %1096, ptr %1104, align 8
+  %1105 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %1103, 0
+  %1106 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1105, i64 1, 1
+  %1107 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1106, i64 1, 2
+  %1108 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1102, %"github.com/goplus/llgo/internal/runtime.Slice" %1107, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1108)
+  store ptr %1108, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
   br label %_llgo_114
 
 _llgo_114:                                        ; preds = %_llgo_113, %_llgo_112
-  %2449 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
-  %2450 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2451 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2450, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2309, ptr %2451, align 8
-  %2452 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2450, i32 0, i32 1
-  store ptr %2449, ptr %2452, align 8
-  %2453 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2450, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).MapType", ptr %2453, align 8
-  %2454 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2450, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).MapType", ptr %2454, align 8
-  %2455 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2450, align 8
-  %2456 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2457 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2456, i32 0, i32 0
-  store ptr @65, ptr %2457, align 8
-  %2458 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2456, i32 0, i32 1
-  store i64 13, ptr %2458, align 4
-  %2459 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2456, align 8
-  %2460 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2461 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2462 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2461, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2459, ptr %2462, align 8
-  %2463 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2461, i32 0, i32 1
-  store ptr %2460, ptr %2463, align 8
-  %2464 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2461, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).NeedKeyUpdate", ptr %2464, align 8
-  %2465 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2461, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).NeedKeyUpdate", ptr %2465, align 8
-  %2466 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2461, align 8
-  %2467 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2468 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2467, i32 0, i32 0
-  store ptr @66, ptr %2468, align 8
-  %2469 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2467, i32 0, i32 1
-  store i64 9, ptr %2469, align 4
-  %2470 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2467, align 8
-  %2471 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %2472 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2473 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2472, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2470, ptr %2473, align 8
-  %2474 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2472, i32 0, i32 1
-  store ptr %2471, ptr %2474, align 8
-  %2475 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2472, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).NumMethod", ptr %2475, align 8
-  %2476 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2472, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).NumMethod", ptr %2476, align 8
-  %2477 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2472, align 8
-  %2478 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2479 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2478, i32 0, i32 0
-  store ptr @67, ptr %2479, align 8
-  %2480 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2478, i32 0, i32 1
-  store i64 8, ptr %2480, align 4
-  %2481 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2478, align 8
-  %2482 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2483 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2484 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2483, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2481, ptr %2484, align 8
-  %2485 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2483, i32 0, i32 1
-  store ptr %2482, ptr %2485, align 8
-  %2486 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2483, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Pointers", ptr %2486, align 8
-  %2487 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2483, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Pointers", ptr %2487, align 8
-  %2488 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2483, align 8
-  %2489 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2490 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2489, i32 0, i32 0
-  store ptr @68, ptr %2490, align 8
-  %2491 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2489, i32 0, i32 1
-  store i64 12, ptr %2491, align 4
-  %2492 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2489, align 8
-  %2493 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2494 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2495 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2494, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2492, ptr %2495, align 8
-  %2496 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2494, i32 0, i32 1
-  store ptr %2493, ptr %2496, align 8
-  %2497 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2494, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ReflexiveKey", ptr %2497, align 8
-  %2498 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2494, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ReflexiveKey", ptr %2498, align 8
-  %2499 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2494, align 8
-  %2500 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2501 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2500, i32 0, i32 0
-  store ptr @69, ptr %2501, align 8
-  %2502 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2500, i32 0, i32 1
-  store i64 4, ptr %2502, align 4
-  %2503 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2500, align 8
-  %2504 = load ptr, ptr @_llgo_uintptr, align 8
-  %2505 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
-  %2506 = icmp eq ptr %2505, null
-  br i1 %2506, label %_llgo_115, label %_llgo_116
+  %1109 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
+  %1110 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @54, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %1109, 1
+  %1111 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1110, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).MapType", 2
+  %1112 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1111, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).MapType", 3
+  %1113 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1114 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @65, i64 13 }, ptr undef, ptr undef, ptr undef }, ptr %1113, 1
+  %1115 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1114, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).NeedKeyUpdate", 2
+  %1116 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1115, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).NeedKeyUpdate", 3
+  %1117 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %1118 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @66, i64 9 }, ptr undef, ptr undef, ptr undef }, ptr %1117, 1
+  %1119 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1118, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).NumMethod", 2
+  %1120 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1119, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).NumMethod", 3
+  %1121 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1122 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @67, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %1121, 1
+  %1123 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1122, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Pointers", 2
+  %1124 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1123, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Pointers", 3
+  %1125 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1126 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @68, i64 12 }, ptr undef, ptr undef, ptr undef }, ptr %1125, 1
+  %1127 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1126, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ReflexiveKey", 2
+  %1128 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1127, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).ReflexiveKey", 3
+  %1129 = load ptr, ptr @_llgo_uintptr, align 8
+  %1130 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
+  %1131 = icmp eq ptr %1130, null
+  br i1 %1131, label %_llgo_115, label %_llgo_116
 
 _llgo_115:                                        ; preds = %_llgo_114
-  %2507 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %2508 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2509 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2508, i32 0, i32 0
-  store ptr %2507, ptr %2509, align 8
-  %2510 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2508, i32 0, i32 1
-  store i64 0, ptr %2510, align 4
-  %2511 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2508, i32 0, i32 2
-  store i64 0, ptr %2511, align 4
-  %2512 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2508, align 8
-  %2513 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %2514 = getelementptr ptr, ptr %2513, i64 0
-  store ptr %2504, ptr %2514, align 8
-  %2515 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2516 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2515, i32 0, i32 0
-  store ptr %2513, ptr %2516, align 8
-  %2517 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2515, i32 0, i32 1
-  store i64 1, ptr %2517, align 4
-  %2518 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2515, i32 0, i32 2
-  store i64 1, ptr %2518, align 4
-  %2519 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2515, align 8
-  %2520 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %2512, %"github.com/goplus/llgo/internal/runtime.Slice" %2519, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %2520)
-  store ptr %2520, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
+  %1132 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %1133 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %1132, 0
+  %1134 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1133, i64 0, 1
+  %1135 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1134, i64 0, 2
+  %1136 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %1137 = getelementptr ptr, ptr %1136, i64 0
+  store ptr %1129, ptr %1137, align 8
+  %1138 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %1136, 0
+  %1139 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1138, i64 1, 1
+  %1140 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1139, i64 1, 2
+  %1141 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1135, %"github.com/goplus/llgo/internal/runtime.Slice" %1140, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1141)
+  store ptr %1141, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
   br label %_llgo_116
 
 _llgo_116:                                        ; preds = %_llgo_115, %_llgo_114
-  %2521 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
-  %2522 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2523 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2522, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2503, ptr %2523, align 8
-  %2524 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2522, i32 0, i32 1
-  store ptr %2521, ptr %2524, align 8
-  %2525 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2522, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Size", ptr %2525, align 8
-  %2526 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2522, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Size", ptr %2526, align 8
-  %2527 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2522, align 8
-  %2528 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2529 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2528, i32 0, i32 0
-  store ptr @53, ptr %2529, align 8
-  %2530 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2528, i32 0, i32 1
-  store i64 6, ptr %2530, align 4
-  %2531 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2528, align 8
-  %2532 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %2533 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2534 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2533, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2531, ptr %2534, align 8
-  %2535 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2533, i32 0, i32 1
-  store ptr %2532, ptr %2535, align 8
-  %2536 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2533, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).String", ptr %2536, align 8
-  %2537 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2533, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).String", ptr %2537, align 8
-  %2538 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2533, align 8
-  %2539 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2540 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2539, i32 0, i32 0
-  store ptr @70, ptr %2540, align 8
-  %2541 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2539, i32 0, i32 1
-  store i64 10, ptr %2541, align 4
-  %2542 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2539, align 8
-  %2543 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2544 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2543, i32 0, i32 0
-  store ptr @71, ptr %2544, align 8
-  %2545 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2543, i32 0, i32 1
-  store i64 46, ptr %2545, align 4
-  %2546 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2543, align 8
-  %2547 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2546, i64 25, i64 120, i64 0, i64 23)
-  %2548 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
-  %2549 = icmp eq ptr %2548, null
-  br i1 %2549, label %_llgo_117, label %_llgo_118
+  %1142 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
+  %1143 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @69, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %1142, 1
+  %1144 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1143, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Size", 2
+  %1145 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1144, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Size", 3
+  %1146 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %1147 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @53, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %1146, 1
+  %1148 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1147, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).String", 2
+  %1149 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1148, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).String", 3
+  %1150 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @71, i64 46 }, i64 25, i64 120, i64 0, i64 23)
+  %1151 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  %1152 = icmp eq ptr %1151, null
+  br i1 %1152, label %_llgo_117, label %_llgo_118
 
 _llgo_117:                                        ; preds = %_llgo_116
-  store ptr %2547, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  store ptr %1150, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
   br label %_llgo_118
 
 _llgo_118:                                        ; preds = %_llgo_117, %_llgo_116
-  %2550 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2551 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2550, i32 0, i32 0
-  store ptr @72, ptr %2551, align 8
-  %2552 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2550, i32 0, i32 1
-  store i64 47, ptr %2552, align 4
-  %2553 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2550, align 8
-  %2554 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2553, i64 25, i64 56, i64 0, i64 2)
-  %2555 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
-  %2556 = icmp eq ptr %2555, null
-  br i1 %2556, label %_llgo_119, label %_llgo_120
+  %1153 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @72, i64 47 }, i64 25, i64 56, i64 0, i64 2)
+  %1154 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
+  %1155 = icmp eq ptr %1154, null
+  br i1 %1155, label %_llgo_119, label %_llgo_120
 
 _llgo_119:                                        ; preds = %_llgo_118
-  store ptr %2554, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
+  store ptr %1153, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
   br label %_llgo_120
 
 _llgo_120:                                        ; preds = %_llgo_119, %_llgo_118
-  %2557 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %2558 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2559 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2558, i32 0, i32 0
-  store ptr @1, ptr %2559, align 8
-  %2560 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2558, i32 0, i32 1
-  store i64 40, ptr %2560, align 4
-  %2561 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2558, align 8
-  %2562 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2561, i64 25, i64 80, i64 0, i64 23)
-  %2563 = load ptr, ptr @"_llgo_struct$GYlWrg0B_axMyyq9xClGPKuTjurG0iQMRoz8Me1fQig", align 8
-  %2564 = icmp eq ptr %2563, null
-  br i1 %2564, label %_llgo_121, label %_llgo_122
+  %1156 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %1157 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 40 }, i64 25, i64 80, i64 0, i64 23)
+  %1158 = load ptr, ptr @"_llgo_struct$GYlWrg0B_axMyyq9xClGPKuTjurG0iQMRoz8Me1fQig", align 8
+  %1159 = icmp eq ptr %1158, null
+  br i1 %1159, label %_llgo_121, label %_llgo_122
 
 _llgo_121:                                        ; preds = %_llgo_120
-  %2565 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2566 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2565, i32 0, i32 0
-  store ptr @40, ptr %2566, align 8
-  %2567 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2565, i32 0, i32 1
-  store i64 5, ptr %2567, align 4
-  %2568 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2565, align 8
-  %2569 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2570 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2569, i32 0, i32 0
-  store ptr null, ptr %2570, align 8
-  %2571 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2569, i32 0, i32 1
-  store i64 0, ptr %2571, align 4
-  %2572 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2569, align 8
-  %2573 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %2574 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2568, ptr %2573, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %2572, i1 false)
-  %2575 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2576 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2575, i32 0, i32 0
-  store ptr @73, ptr %2576, align 8
-  %2577 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2575, i32 0, i32 1
-  store i64 3, ptr %2577, align 4
-  %2578 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2575, align 8
-  %2579 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2580 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2579, i32 0, i32 0
-  store ptr null, ptr %2580, align 8
-  %2581 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2579, i32 0, i32 1
-  store i64 0, ptr %2581, align 4
-  %2582 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2579, align 8
-  %2583 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %2562)
-  %2584 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2578, ptr %2583, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %2582, i1 false)
-  %2585 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2586 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2585, i32 0, i32 0
-  store ptr @74, ptr %2586, align 8
-  %2587 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2585, i32 0, i32 1
-  store i64 6, ptr %2587, align 4
-  %2588 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2585, align 8
-  %2589 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2590 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2589, i32 0, i32 0
-  store ptr null, ptr %2590, align 8
-  %2591 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2589, i32 0, i32 1
-  store i64 0, ptr %2591, align 4
-  %2592 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2589, align 8
-  %2593 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
-  %2594 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2588, ptr %2593, i64 24, %"github.com/goplus/llgo/internal/runtime.String" %2592, i1 false)
-  %2595 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2596 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2595, i32 0, i32 0
-  store ptr @75, ptr %2596, align 8
-  %2597 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2595, i32 0, i32 1
-  store i64 4, ptr %2597, align 4
-  %2598 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2595, align 8
-  %2599 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2600 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2599, i32 0, i32 0
-  store ptr null, ptr %2600, align 8
-  %2601 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2599, i32 0, i32 1
-  store i64 0, ptr %2601, align 4
-  %2602 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2599, align 8
-  %2603 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %2604 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2598, ptr %2603, i64 32, %"github.com/goplus/llgo/internal/runtime.String" %2602, i1 false)
-  %2605 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2606 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2605, i32 0, i32 0
-  store ptr @76, ptr %2606, align 8
-  %2607 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2605, i32 0, i32 1
-  store i64 9, ptr %2607, align 4
-  %2608 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2605, align 8
-  %2609 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2610 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2609, i32 0, i32 0
-  store ptr null, ptr %2610, align 8
-  %2611 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2609, i32 0, i32 1
-  store i64 0, ptr %2611, align 4
-  %2612 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2609, align 8
-  %2613 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 33)
-  %2614 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2608, ptr %2613, i64 48, %"github.com/goplus/llgo/internal/runtime.String" %2612, i1 false)
-  %2615 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2616 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2615, i32 0, i32 0
-  store ptr @7, ptr %2616, align 8
-  %2617 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2615, i32 0, i32 1
-  store i64 4, ptr %2617, align 4
-  %2618 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2615, align 8
-  %2619 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 280)
-  %2620 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2619, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2574, ptr %2620, align 8
-  %2621 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2619, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2584, ptr %2621, align 8
-  %2622 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2619, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2594, ptr %2622, align 8
-  %2623 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2619, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2604, ptr %2623, align 8
-  %2624 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2619, i64 4
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2614, ptr %2624, align 8
-  %2625 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2626 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2625, i32 0, i32 0
-  store ptr %2619, ptr %2626, align 8
-  %2627 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2625, i32 0, i32 1
-  store i64 5, ptr %2627, align 4
-  %2628 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2625, i32 0, i32 2
-  store i64 5, ptr %2628, align 4
-  %2629 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2625, align 8
-  %2630 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %2618, i64 56, %"github.com/goplus/llgo/internal/runtime.Slice" %2629)
-  store ptr %2630, ptr @"_llgo_struct$GYlWrg0B_axMyyq9xClGPKuTjurG0iQMRoz8Me1fQig", align 8
+  %1160 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %1161 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @40, i64 5 }, ptr %1160, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %1162 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1157)
+  %1163 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @73, i64 3 }, ptr %1162, i64 16, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %1164 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
+  %1165 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @74, i64 6 }, ptr %1164, i64 24, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %1166 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %1167 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @75, i64 4 }, ptr %1166, i64 32, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %1168 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 33)
+  %1169 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @76, i64 9 }, ptr %1168, i64 48, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %1170 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 280)
+  %1171 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1170, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1161, ptr %1171, align 8
+  %1172 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1170, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1163, ptr %1172, align 8
+  %1173 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1170, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1165, ptr %1173, align 8
+  %1174 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1170, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1167, ptr %1174, align 8
+  %1175 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1170, i64 4
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1169, ptr %1175, align 8
+  %1176 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %1170, 0
+  %1177 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1176, i64 5, 1
+  %1178 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1177, i64 5, 2
+  %1179 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 }, i64 56, %"github.com/goplus/llgo/internal/runtime.Slice" %1178)
+  store ptr %1179, ptr @"_llgo_struct$GYlWrg0B_axMyyq9xClGPKuTjurG0iQMRoz8Me1fQig", align 8
   br label %_llgo_122
 
 _llgo_122:                                        ; preds = %_llgo_121, %_llgo_120
-  %2631 = load ptr, ptr @"_llgo_struct$GYlWrg0B_axMyyq9xClGPKuTjurG0iQMRoz8Me1fQig", align 8
-  br i1 %2556, label %_llgo_123, label %_llgo_124
+  %1180 = load ptr, ptr @"_llgo_struct$GYlWrg0B_axMyyq9xClGPKuTjurG0iQMRoz8Me1fQig", align 8
+  br i1 %1155, label %_llgo_123, label %_llgo_124
 
 _llgo_123:                                        ; preds = %_llgo_122
-  %2632 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2633 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2632, i32 0, i32 0
-  store ptr @77, ptr %2633, align 8
-  %2634 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2632, i32 0, i32 1
-  store i64 8, ptr %2634, align 4
-  %2635 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2632, align 8
-  %2636 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2637 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2638 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2637, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2635, ptr %2638, align 8
-  %2639 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2637, i32 0, i32 1
-  store ptr %2636, ptr %2639, align 8
-  %2640 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2637, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructField).Embedded", ptr %2640, align 8
-  %2641 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2637, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructField).Embedded", ptr %2641, align 8
-  %2642 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2637, align 8
-  %2643 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2644 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2643, i32 0, i32 0
-  store ptr @42, ptr %2644, align 8
-  %2645 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2643, i32 0, i32 1
-  store i64 8, ptr %2645, align 4
-  %2646 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2643, align 8
-  %2647 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2648 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2649 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2648, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2646, ptr %2649, align 8
-  %2650 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2648, i32 0, i32 1
-  store ptr %2647, ptr %2650, align 8
-  %2651 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2648, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructField).Exported", ptr %2651, align 8
-  %2652 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2648, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructField).Exported", ptr %2652, align 8
-  %2653 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2648, align 8
-  %2654 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
-  %2655 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2654, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %2642, ptr %2655, align 8
-  %2656 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %2654, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %2653, ptr %2656, align 8
-  %2657 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2658 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2657, i32 0, i32 0
-  store ptr %2654, ptr %2658, align 8
-  %2659 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2657, i32 0, i32 1
-  store i64 2, ptr %2659, align 4
-  %2660 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2657, i32 0, i32 2
-  store i64 2, ptr %2660, align 4
-  %2661 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2657, align 8
-  %2662 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2663 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2662, i32 0, i32 0
-  store ptr @3, ptr %2663, align 8
-  %2664 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2662, i32 0, i32 1
-  store i64 35, ptr %2664, align 4
-  %2665 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2662, align 8
-  %2666 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2667 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2666, i32 0, i32 0
-  store ptr @78, ptr %2667, align 8
-  %2668 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2666, i32 0, i32 1
-  store i64 11, ptr %2668, align 4
-  %2669 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2666, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %2554, %"github.com/goplus/llgo/internal/runtime.String" %2665, %"github.com/goplus/llgo/internal/runtime.String" %2669, ptr %2631, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %2661)
+  %1181 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1182 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @77, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %1181, 1
+  %1183 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1182, ptr @"github.com/goplus/llgo/internal/abi.(*StructField).Embedded", 2
+  %1184 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1183, ptr @"github.com/goplus/llgo/internal/abi.(*StructField).Embedded", 3
+  %1185 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1186 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @42, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %1185, 1
+  %1187 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1186, ptr @"github.com/goplus/llgo/internal/abi.(*StructField).Exported", 2
+  %1188 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1187, ptr @"github.com/goplus/llgo/internal/abi.(*StructField).Exported", 3
+  %1189 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
+  %1190 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1189, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %1184, ptr %1190, align 8
+  %1191 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1189, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %1188, ptr %1191, align 8
+  %1192 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %1189, 0
+  %1193 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1192, i64 2, 1
+  %1194 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1193, i64 2, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %1153, %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 35 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @78, i64 11 }, ptr %1180, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %1194)
   br label %_llgo_124
 
 _llgo_124:                                        ; preds = %_llgo_123, %_llgo_122
-  %2670 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
-  %2671 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2672 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2671, i32 0, i32 0
-  store ptr @72, ptr %2672, align 8
-  %2673 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2671, i32 0, i32 1
-  store i64 47, ptr %2673, align 4
-  %2674 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2671, align 8
-  %2675 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2674, i64 25, i64 56, i64 0, i64 2)
-  %2676 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
-  %2677 = icmp eq ptr %2676, null
-  br i1 %2677, label %_llgo_125, label %_llgo_126
+  %1195 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
+  %1196 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @72, i64 47 }, i64 25, i64 56, i64 0, i64 2)
+  %1197 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
+  %1198 = icmp eq ptr %1197, null
+  br i1 %1198, label %_llgo_125, label %_llgo_126
 
 _llgo_125:                                        ; preds = %_llgo_124
-  %2678 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %2675)
-  store ptr %2678, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
+  %1199 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %1196)
+  store ptr %1199, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
   br label %_llgo_126
 
 _llgo_126:                                        ; preds = %_llgo_125, %_llgo_124
-  %2679 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
-  %2680 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2681 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2680, i32 0, i32 0
-  store ptr @1, ptr %2681, align 8
-  %2682 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2680, i32 0, i32 1
-  store i64 40, ptr %2682, align 4
-  %2683 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2680, align 8
-  %2684 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2683, i64 25, i64 80, i64 0, i64 23)
-  %2685 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2686 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2685, i32 0, i32 0
-  store ptr @72, ptr %2686, align 8
-  %2687 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2685, i32 0, i32 1
-  store i64 47, ptr %2687, align 4
-  %2688 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2685, align 8
-  %2689 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2688, i64 25, i64 56, i64 0, i64 2)
-  %2690 = load ptr, ptr @"_llgo_struct$K_cvuhBwc2_5r7UW089ibWfcfsGoDb4pZ7K19IcMTk0", align 8
-  %2691 = icmp eq ptr %2690, null
-  br i1 %2691, label %_llgo_127, label %_llgo_128
+  %1200 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.StructField", align 8
+  %1201 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 40 }, i64 25, i64 80, i64 0, i64 23)
+  %1202 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @72, i64 47 }, i64 25, i64 56, i64 0, i64 2)
+  %1203 = load ptr, ptr @"_llgo_struct$K_cvuhBwc2_5r7UW089ibWfcfsGoDb4pZ7K19IcMTk0", align 8
+  %1204 = icmp eq ptr %1203, null
+  br i1 %1204, label %_llgo_127, label %_llgo_128
 
 _llgo_127:                                        ; preds = %_llgo_126
-  %2692 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2693 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2692, i32 0, i32 0
-  store ptr @21, ptr %2693, align 8
-  %2694 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2692, i32 0, i32 1
-  store i64 4, ptr %2694, align 4
-  %2695 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2692, align 8
-  %2696 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2697 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2696, i32 0, i32 0
-  store ptr null, ptr %2697, align 8
-  %2698 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2696, i32 0, i32 1
-  store i64 0, ptr %2698, align 4
-  %2699 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2696, align 8
-  %2700 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2695, ptr %2684, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %2699, i1 true)
-  %2701 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2702 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2701, i32 0, i32 0
-  store ptr @46, ptr %2702, align 8
-  %2703 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2701, i32 0, i32 1
-  store i64 8, ptr %2703, align 4
-  %2704 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2701, align 8
-  %2705 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2706 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2705, i32 0, i32 0
-  store ptr null, ptr %2706, align 8
-  %2707 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2705, i32 0, i32 1
-  store i64 0, ptr %2707, align 4
-  %2708 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2705, align 8
-  %2709 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %2710 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2704, ptr %2709, i64 72, %"github.com/goplus/llgo/internal/runtime.String" %2708, i1 false)
-  %2711 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2712 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2711, i32 0, i32 0
-  store ptr @79, ptr %2712, align 8
-  %2713 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2711, i32 0, i32 1
-  store i64 6, ptr %2713, align 4
-  %2714 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2711, align 8
-  %2715 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2716 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2715, i32 0, i32 0
-  store ptr null, ptr %2716, align 8
-  %2717 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2715, i32 0, i32 1
-  store i64 0, ptr %2717, align 4
-  %2718 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2715, align 8
-  %2719 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %2689)
-  %2720 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %2714, ptr %2719, i64 88, %"github.com/goplus/llgo/internal/runtime.String" %2718, i1 false)
-  %2721 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2722 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2721, i32 0, i32 0
-  store ptr @7, ptr %2722, align 8
-  %2723 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2721, i32 0, i32 1
-  store i64 4, ptr %2723, align 4
-  %2724 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2721, align 8
-  %2725 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 168)
-  %2726 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2725, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2700, ptr %2726, align 8
-  %2727 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2725, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2710, ptr %2727, align 8
-  %2728 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %2725, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %2720, ptr %2728, align 8
-  %2729 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %2730 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2729, i32 0, i32 0
-  store ptr %2725, ptr %2730, align 8
-  %2731 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2729, i32 0, i32 1
-  store i64 3, ptr %2731, align 4
-  %2732 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2729, i32 0, i32 2
-  store i64 3, ptr %2732, align 4
-  %2733 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %2729, align 8
-  %2734 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %2724, i64 112, %"github.com/goplus/llgo/internal/runtime.Slice" %2733)
-  store ptr %2734, ptr @"_llgo_struct$K_cvuhBwc2_5r7UW089ibWfcfsGoDb4pZ7K19IcMTk0", align 8
+  %1205 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @21, i64 4 }, ptr %1201, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 true)
+  %1206 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %1207 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @46, i64 8 }, ptr %1206, i64 72, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %1208 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %1202)
+  %1209 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @79, i64 6 }, ptr %1208, i64 88, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %1210 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 168)
+  %1211 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1210, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1205, ptr %1211, align 8
+  %1212 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1210, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1207, ptr %1212, align 8
+  %1213 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1210, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1209, ptr %1213, align 8
+  %1214 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %1210, 0
+  %1215 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1214, i64 3, 1
+  %1216 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1215, i64 3, 2
+  %1217 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 }, i64 112, %"github.com/goplus/llgo/internal/runtime.Slice" %1216)
+  store ptr %1217, ptr @"_llgo_struct$K_cvuhBwc2_5r7UW089ibWfcfsGoDb4pZ7K19IcMTk0", align 8
   br label %_llgo_128
 
 _llgo_128:                                        ; preds = %_llgo_127, %_llgo_126
-  %2735 = load ptr, ptr @"_llgo_struct$K_cvuhBwc2_5r7UW089ibWfcfsGoDb4pZ7K19IcMTk0", align 8
-  br i1 %2549, label %_llgo_129, label %_llgo_130
+  %1218 = load ptr, ptr @"_llgo_struct$K_cvuhBwc2_5r7UW089ibWfcfsGoDb4pZ7K19IcMTk0", align 8
+  br i1 %1152, label %_llgo_129, label %_llgo_130
 
 _llgo_129:                                        ; preds = %_llgo_128
-  %2736 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2737 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2736, i32 0, i32 0
-  store ptr @18, ptr %2737, align 8
-  %2738 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2736, i32 0, i32 1
-  store i64 5, ptr %2738, align 4
-  %2739 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2736, align 8
-  %2740 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %2741 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2742 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2741, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2739, ptr %2742, align 8
-  %2743 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2741, i32 0, i32 1
-  store ptr %2740, ptr %2743, align 8
-  %2744 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2741, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Align", ptr %2744, align 8
-  %2745 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2741, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Align", ptr %2745, align 8
-  %2746 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2741, align 8
-  %2747 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2748 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2747, i32 0, i32 0
-  store ptr @19, ptr %2748, align 8
-  %2749 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2747, i32 0, i32 1
-  store i64 9, ptr %2749, align 4
-  %2750 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2747, align 8
-  %2751 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
-  %2752 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
-  %2753 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2754 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2753, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2750, ptr %2754, align 8
-  %2755 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2753, i32 0, i32 1
-  store ptr %2752, ptr %2755, align 8
-  %2756 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2753, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ArrayType", ptr %2756, align 8
-  %2757 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2753, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ArrayType", ptr %2757, align 8
-  %2758 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2753, align 8
-  %2759 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2760 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2759, i32 0, i32 0
-  store ptr @25, ptr %2760, align 8
-  %2761 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2759, i32 0, i32 1
-  store i64 7, ptr %2761, align 4
-  %2762 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2759, align 8
-  %2763 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
-  %2764 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2765 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2764, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2762, ptr %2765, align 8
-  %2766 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2764, i32 0, i32 1
-  store ptr %2763, ptr %2766, align 8
-  %2767 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2764, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ChanDir", ptr %2767, align 8
-  %2768 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2764, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ChanDir", ptr %2768, align 8
-  %2769 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2764, align 8
-  %2770 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2771 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2770, i32 0, i32 0
-  store ptr @27, ptr %2771, align 8
-  %2772 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2770, i32 0, i32 1
-  store i64 6, ptr %2772, align 4
-  %2773 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2770, align 8
-  %2774 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %2775 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %2776 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2777 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2776, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2773, ptr %2777, align 8
-  %2778 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2776, i32 0, i32 1
-  store ptr %2775, ptr %2778, align 8
-  %2779 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2776, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Common", ptr %2779, align 8
-  %2780 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2776, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Common", ptr %2780, align 8
-  %2781 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2776, align 8
-  %2782 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2783 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2782, i32 0, i32 0
-  store ptr @22, ptr %2783, align 8
-  %2784 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2782, i32 0, i32 1
-  store i64 4, ptr %2784, align 4
-  %2785 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2782, align 8
-  %2786 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %2787 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %2788 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2789 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2788, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2785, ptr %2789, align 8
-  %2790 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2788, i32 0, i32 1
-  store ptr %2787, ptr %2790, align 8
-  %2791 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2788, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Elem", ptr %2791, align 8
-  %2792 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2788, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Elem", ptr %2792, align 8
-  %2793 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2788, align 8
-  %2794 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2795 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2794, i32 0, i32 0
-  store ptr @28, ptr %2795, align 8
-  %2796 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2794, i32 0, i32 1
-  store i64 15, ptr %2796, align 4
-  %2797 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2794, align 8
-  %2798 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %2799 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
-  %2800 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2801 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2800, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2797, ptr %2801, align 8
-  %2802 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2800, i32 0, i32 1
-  store ptr %2799, ptr %2802, align 8
-  %2803 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2800, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ExportedMethods", ptr %2803, align 8
-  %2804 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2800, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ExportedMethods", ptr %2804, align 8
-  %2805 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2800, align 8
-  %2806 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2807 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2806, i32 0, i32 0
-  store ptr @33, ptr %2807, align 8
-  %2808 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2806, i32 0, i32 1
-  store i64 10, ptr %2808, align 4
-  %2809 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2806, align 8
-  %2810 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %2811 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2812 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2811, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2809, ptr %2812, align 8
-  %2813 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2811, i32 0, i32 1
-  store ptr %2810, ptr %2813, align 8
-  %2814 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2811, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).FieldAlign", ptr %2814, align 8
-  %2815 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2811, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).FieldAlign", ptr %2815, align 8
-  %2816 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2811, align 8
-  %2817 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2818 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2817, i32 0, i32 0
-  store ptr @34, ptr %2818, align 8
-  %2819 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2817, i32 0, i32 1
-  store i64 8, ptr %2819, align 4
-  %2820 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2817, align 8
-  %2821 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %2822 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
-  %2823 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2824 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2823, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2820, ptr %2824, align 8
-  %2825 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2823, i32 0, i32 1
-  store ptr %2822, ptr %2825, align 8
-  %2826 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2823, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).FuncType", ptr %2826, align 8
-  %2827 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2823, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).FuncType", ptr %2827, align 8
-  %2828 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2823, align 8
-  %2829 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2830 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2829, i32 0, i32 0
-  store ptr @35, ptr %2830, align 8
-  %2831 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2829, i32 0, i32 1
-  store i64 7, ptr %2831, align 4
-  %2832 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2829, align 8
-  %2833 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2834 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2835 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2834, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2832, ptr %2835, align 8
-  %2836 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2834, i32 0, i32 1
-  store ptr %2833, ptr %2836, align 8
-  %2837 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2834, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).HasName", ptr %2837, align 8
-  %2838 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2834, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).HasName", ptr %2838, align 8
-  %2839 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2834, align 8
-  %2840 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2841 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2840, i32 0, i32 0
-  store ptr @36, ptr %2841, align 8
-  %2842 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2840, i32 0, i32 1
-  store i64 10, ptr %2842, align 4
-  %2843 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2840, align 8
-  %2844 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2845 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2846 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2845, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2843, ptr %2846, align 8
-  %2847 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2845, i32 0, i32 1
-  store ptr %2844, ptr %2847, align 8
-  %2848 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2845, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).IfaceIndir", ptr %2848, align 8
-  %2849 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2845, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).IfaceIndir", ptr %2849, align 8
-  %2850 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2845, align 8
-  %2851 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2852 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2851, i32 0, i32 0
-  store ptr @37, ptr %2852, align 8
-  %2853 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2851, i32 0, i32 1
-  store i64 13, ptr %2853, align 4
-  %2854 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2851, align 8
-  %2855 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
-  %2856 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
-  %2857 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2858 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2857, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2854, ptr %2858, align 8
-  %2859 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2857, i32 0, i32 1
-  store ptr %2856, ptr %2859, align 8
-  %2860 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2857, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).InterfaceType", ptr %2860, align 8
-  %2861 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2857, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).InterfaceType", ptr %2861, align 8
-  %2862 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2857, align 8
-  %2863 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2864 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2863, i32 0, i32 0
-  store ptr @48, ptr %2864, align 8
-  %2865 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2863, i32 0, i32 1
-  store i64 9, ptr %2865, align 4
-  %2866 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2863, align 8
-  %2867 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2868 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2869 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2868, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2866, ptr %2869, align 8
-  %2870 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2868, i32 0, i32 1
-  store ptr %2867, ptr %2870, align 8
-  %2871 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2868, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).IsClosure", ptr %2871, align 8
-  %2872 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2868, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).IsClosure", ptr %2872, align 8
-  %2873 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2868, align 8
-  %2874 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2875 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2874, i32 0, i32 0
-  store ptr @49, ptr %2875, align 8
-  %2876 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2874, i32 0, i32 1
-  store i64 13, ptr %2876, align 4
-  %2877 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2874, align 8
-  %2878 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2879 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2880 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2879, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2877, ptr %2880, align 8
-  %2881 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2879, i32 0, i32 1
-  store ptr %2878, ptr %2881, align 8
-  %2882 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2879, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).IsDirectIface", ptr %2882, align 8
-  %2883 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2879, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).IsDirectIface", ptr %2883, align 8
-  %2884 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2879, align 8
-  %2885 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2886 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2885, i32 0, i32 0
-  store ptr @50, ptr %2886, align 8
-  %2887 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2885, i32 0, i32 1
-  store i64 3, ptr %2887, align 4
-  %2888 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2885, align 8
-  %2889 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %2890 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %2891 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2892 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2891, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2888, ptr %2892, align 8
-  %2893 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2891, i32 0, i32 1
-  store ptr %2890, ptr %2893, align 8
-  %2894 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2891, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Key", ptr %2894, align 8
-  %2895 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2891, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Key", ptr %2895, align 8
-  %2896 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2891, align 8
-  %2897 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2898 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2897, i32 0, i32 0
-  store ptr @51, ptr %2898, align 8
-  %2899 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2897, i32 0, i32 1
-  store i64 4, ptr %2899, align 4
-  %2900 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2897, align 8
-  %2901 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
-  %2902 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2903 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2902, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2900, ptr %2903, align 8
-  %2904 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2902, i32 0, i32 1
-  store ptr %2901, ptr %2904, align 8
-  %2905 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2902, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Kind", ptr %2905, align 8
-  %2906 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2902, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Kind", ptr %2906, align 8
-  %2907 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2902, align 8
-  %2908 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2909 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2908, i32 0, i32 0
-  store ptr @24, ptr %2909, align 8
-  %2910 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2908, i32 0, i32 1
-  store i64 3, ptr %2910, align 4
-  %2911 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2908, align 8
-  %2912 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %2913 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2914 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2913, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2911, ptr %2914, align 8
-  %2915 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2913, i32 0, i32 1
-  store ptr %2912, ptr %2915, align 8
-  %2916 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2913, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Len", ptr %2916, align 8
-  %2917 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2913, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Len", ptr %2917, align 8
-  %2918 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2913, align 8
-  %2919 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2920 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2919, i32 0, i32 0
-  store ptr @54, ptr %2920, align 8
-  %2921 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2919, i32 0, i32 1
-  store i64 7, ptr %2921, align 4
-  %2922 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2919, align 8
-  %2923 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
-  %2924 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
-  %2925 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2926 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2925, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2922, ptr %2926, align 8
-  %2927 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2925, i32 0, i32 1
-  store ptr %2924, ptr %2927, align 8
-  %2928 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2925, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).MapType", ptr %2928, align 8
-  %2929 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2925, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).MapType", ptr %2929, align 8
-  %2930 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2925, align 8
-  %2931 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2932 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2931, i32 0, i32 0
-  store ptr @66, ptr %2932, align 8
-  %2933 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2931, i32 0, i32 1
-  store i64 9, ptr %2933, align 4
-  %2934 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2931, align 8
-  %2935 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %2936 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2937 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2936, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2934, ptr %2937, align 8
-  %2938 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2936, i32 0, i32 1
-  store ptr %2935, ptr %2938, align 8
-  %2939 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2936, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).NumMethod", ptr %2939, align 8
-  %2940 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2936, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).NumMethod", ptr %2940, align 8
-  %2941 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2936, align 8
-  %2942 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2943 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2942, i32 0, i32 0
-  store ptr @67, ptr %2943, align 8
-  %2944 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2942, i32 0, i32 1
-  store i64 8, ptr %2944, align 4
-  %2945 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2942, align 8
-  %2946 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %2947 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2948 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2947, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2945, ptr %2948, align 8
-  %2949 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2947, i32 0, i32 1
-  store ptr %2946, ptr %2949, align 8
-  %2950 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2947, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Pointers", ptr %2950, align 8
-  %2951 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2947, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Pointers", ptr %2951, align 8
-  %2952 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2947, align 8
-  %2953 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2954 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2953, i32 0, i32 0
-  store ptr @69, ptr %2954, align 8
-  %2955 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2953, i32 0, i32 1
-  store i64 4, ptr %2955, align 4
-  %2956 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2953, align 8
-  %2957 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
-  %2958 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2959 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2958, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2956, ptr %2959, align 8
-  %2960 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2958, i32 0, i32 1
-  store ptr %2957, ptr %2960, align 8
-  %2961 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2958, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Size", ptr %2961, align 8
-  %2962 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2958, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Size", ptr %2962, align 8
-  %2963 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2958, align 8
-  %2964 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2965 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2964, i32 0, i32 0
-  store ptr @53, ptr %2965, align 8
-  %2966 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2964, i32 0, i32 1
-  store i64 6, ptr %2966, align 4
-  %2967 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2964, align 8
-  %2968 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %2969 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2970 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2969, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2967, ptr %2970, align 8
-  %2971 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2969, i32 0, i32 1
-  store ptr %2968, ptr %2971, align 8
-  %2972 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2969, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).String", ptr %2972, align 8
-  %2973 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2969, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).String", ptr %2973, align 8
-  %2974 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2969, align 8
-  %2975 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2976 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2975, i32 0, i32 0
-  store ptr @70, ptr %2976, align 8
-  %2977 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2975, i32 0, i32 1
-  store i64 10, ptr %2977, align 4
-  %2978 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2975, align 8
-  %2979 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2980 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2979, i32 0, i32 0
-  store ptr @71, ptr %2980, align 8
-  %2981 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2979, i32 0, i32 1
-  store i64 46, ptr %2981, align 4
-  %2982 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2979, align 8
-  %2983 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %2982, i64 25, i64 120, i64 0, i64 23)
-  %2984 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
-  %2985 = icmp eq ptr %2984, null
-  br i1 %2985, label %_llgo_131, label %_llgo_132
+  %1219 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %1220 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @18, i64 5 }, ptr undef, ptr undef, ptr undef }, ptr %1219, 1
+  %1221 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1220, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Align", 2
+  %1222 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1221, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Align", 3
+  %1223 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.ArrayType", align 8
+  %1224 = load ptr, ptr @"_llgo_func$CsVqlCxhoEcIvPD5BSBukfSiD9C7Ic5_Gf32MLbCWB4", align 8
+  %1225 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @19, i64 9 }, ptr undef, ptr undef, ptr undef }, ptr %1224, 1
+  %1226 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1225, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ArrayType", 2
+  %1227 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1226, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ArrayType", 3
+  %1228 = load ptr, ptr @"_llgo_func$TrNr0CVWj6qegOngzWbt2Jl7pr7IBJ5gOmgUf2ieIi4", align 8
+  %1229 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @25, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %1228, 1
+  %1230 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1229, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ChanDir", 2
+  %1231 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1230, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ChanDir", 3
+  %1232 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %1233 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %1234 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @27, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %1233, 1
+  %1235 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1234, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Common", 2
+  %1236 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1235, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Common", 3
+  %1237 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %1238 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %1239 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @22, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %1238, 1
+  %1240 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1239, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Elem", 2
+  %1241 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1240, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Elem", 3
+  %1242 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %1243 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
+  %1244 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @28, i64 15 }, ptr undef, ptr undef, ptr undef }, ptr %1243, 1
+  %1245 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1244, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ExportedMethods", 2
+  %1246 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1245, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).ExportedMethods", 3
+  %1247 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %1248 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @33, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %1247, 1
+  %1249 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1248, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).FieldAlign", 2
+  %1250 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1249, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).FieldAlign", 3
+  %1251 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %1252 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
+  %1253 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @34, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %1252, 1
+  %1254 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1253, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).FuncType", 2
+  %1255 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1254, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).FuncType", 3
+  %1256 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1257 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @35, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %1256, 1
+  %1258 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1257, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).HasName", 2
+  %1259 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1258, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).HasName", 3
+  %1260 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1261 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @36, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %1260, 1
+  %1262 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1261, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).IfaceIndir", 2
+  %1263 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1262, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).IfaceIndir", 3
+  %1264 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  %1265 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
+  %1266 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @37, i64 13 }, ptr undef, ptr undef, ptr undef }, ptr %1265, 1
+  %1267 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1266, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).InterfaceType", 2
+  %1268 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1267, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).InterfaceType", 3
+  %1269 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1270 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @48, i64 9 }, ptr undef, ptr undef, ptr undef }, ptr %1269, 1
+  %1271 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1270, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).IsClosure", 2
+  %1272 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1271, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).IsClosure", 3
+  %1273 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1274 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @49, i64 13 }, ptr undef, ptr undef, ptr undef }, ptr %1273, 1
+  %1275 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1274, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).IsDirectIface", 2
+  %1276 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1275, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).IsDirectIface", 3
+  %1277 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %1278 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %1279 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @50, i64 3 }, ptr undef, ptr undef, ptr undef }, ptr %1278, 1
+  %1280 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1279, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Key", 2
+  %1281 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1280, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Key", 3
+  %1282 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
+  %1283 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @51, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %1282, 1
+  %1284 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1283, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Kind", 2
+  %1285 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1284, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Kind", 3
+  %1286 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %1287 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @24, i64 3 }, ptr undef, ptr undef, ptr undef }, ptr %1286, 1
+  %1288 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1287, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Len", 2
+  %1289 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1288, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Len", 3
+  %1290 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  %1291 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
+  %1292 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @54, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %1291, 1
+  %1293 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1292, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).MapType", 2
+  %1294 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1293, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).MapType", 3
+  %1295 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %1296 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @66, i64 9 }, ptr undef, ptr undef, ptr undef }, ptr %1295, 1
+  %1297 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1296, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).NumMethod", 2
+  %1298 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1297, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).NumMethod", 3
+  %1299 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1300 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @67, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %1299, 1
+  %1301 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1300, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Pointers", 2
+  %1302 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1301, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Pointers", 3
+  %1303 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
+  %1304 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @69, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %1303, 1
+  %1305 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1304, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Size", 2
+  %1306 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1305, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Size", 3
+  %1307 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %1308 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @53, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %1307, 1
+  %1309 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1308, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).String", 2
+  %1310 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1309, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).String", 3
+  %1311 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @71, i64 46 }, i64 25, i64 120, i64 0, i64 23)
+  %1312 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  %1313 = icmp eq ptr %1312, null
+  br i1 %1313, label %_llgo_131, label %_llgo_132
 
 _llgo_130:                                        ; preds = %_llgo_144, %_llgo_128
-  %2986 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
-  %2987 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
-  %2988 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
-  %2989 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %2990 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2989, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2542, ptr %2990, align 8
-  %2991 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2989, i32 0, i32 1
-  store ptr %2988, ptr %2991, align 8
-  %2992 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2989, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).StructType", ptr %2992, align 8
-  %2993 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %2989, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).StructType", ptr %2993, align 8
-  %2994 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %2989, align 8
-  %2995 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2996 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2995, i32 0, i32 0
-  store ptr @80, ptr %2996, align 8
-  %2997 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2995, i32 0, i32 1
-  store i64 8, ptr %2997, align 4
-  %2998 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2995, align 8
-  %2999 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
-  %3000 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3001 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3000, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2998, ptr %3001, align 8
-  %3002 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3000, i32 0, i32 1
-  store ptr %2999, ptr %3002, align 8
-  %3003 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3000, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Uncommon", ptr %3003, align 8
-  %3004 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3000, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Uncommon", ptr %3004, align 8
-  %3005 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3000, align 8
-  %3006 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 1040)
-  %3007 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %2124, ptr %3007, align 8
-  %3008 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %2136, ptr %3008, align 8
-  %3009 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 2
-  store %"github.com/goplus/llgo/internal/abi.Method" %2147, ptr %3009, align 8
-  %3010 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 3
-  store %"github.com/goplus/llgo/internal/abi.Method" %2159, ptr %3010, align 8
-  %3011 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 4
-  store %"github.com/goplus/llgo/internal/abi.Method" %2171, ptr %3011, align 8
-  %3012 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 5
-  store %"github.com/goplus/llgo/internal/abi.Method" %2182, ptr %3012, align 8
-  %3013 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 6
-  store %"github.com/goplus/llgo/internal/abi.Method" %2194, ptr %3013, align 8
-  %3014 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 7
-  store %"github.com/goplus/llgo/internal/abi.Method" %2205, ptr %3014, align 8
-  %3015 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 8
-  store %"github.com/goplus/llgo/internal/abi.Method" %2216, ptr %3015, align 8
-  %3016 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 9
-  store %"github.com/goplus/llgo/internal/abi.Method" %2227, ptr %3016, align 8
-  %3017 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 10
-  store %"github.com/goplus/llgo/internal/abi.Method" %2238, ptr %3017, align 8
-  %3018 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 11
-  store %"github.com/goplus/llgo/internal/abi.Method" %2249, ptr %3018, align 8
-  %3019 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 12
-  store %"github.com/goplus/llgo/internal/abi.Method" %2261, ptr %3019, align 8
-  %3020 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 13
-  store %"github.com/goplus/llgo/internal/abi.Method" %2272, ptr %3020, align 8
-  %3021 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 14
-  store %"github.com/goplus/llgo/internal/abi.Method" %2283, ptr %3021, align 8
-  %3022 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 15
-  store %"github.com/goplus/llgo/internal/abi.Method" %2294, ptr %3022, align 8
-  %3023 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 16
-  store %"github.com/goplus/llgo/internal/abi.Method" %2305, ptr %3023, align 8
-  %3024 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 17
-  store %"github.com/goplus/llgo/internal/abi.Method" %2455, ptr %3024, align 8
-  %3025 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 18
-  store %"github.com/goplus/llgo/internal/abi.Method" %2466, ptr %3025, align 8
-  %3026 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 19
-  store %"github.com/goplus/llgo/internal/abi.Method" %2477, ptr %3026, align 8
-  %3027 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 20
-  store %"github.com/goplus/llgo/internal/abi.Method" %2488, ptr %3027, align 8
-  %3028 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 21
-  store %"github.com/goplus/llgo/internal/abi.Method" %2499, ptr %3028, align 8
-  %3029 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 22
-  store %"github.com/goplus/llgo/internal/abi.Method" %2527, ptr %3029, align 8
-  %3030 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 23
-  store %"github.com/goplus/llgo/internal/abi.Method" %2538, ptr %3030, align 8
-  %3031 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 24
-  store %"github.com/goplus/llgo/internal/abi.Method" %2994, ptr %3031, align 8
-  %3032 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3006, i64 25
-  store %"github.com/goplus/llgo/internal/abi.Method" %3005, ptr %3032, align 8
-  %3033 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %3034 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3033, i32 0, i32 0
-  store ptr %3006, ptr %3034, align 8
-  %3035 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3033, i32 0, i32 1
-  store i64 26, ptr %3035, align 4
-  %3036 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3033, i32 0, i32 2
-  store i64 26, ptr %3036, align 4
-  %3037 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3033, align 8
-  %3038 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3039 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3038, i32 0, i32 0
-  store ptr @3, ptr %3039, align 8
-  %3040 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3038, i32 0, i32 1
-  store i64 35, ptr %3040, align 4
-  %3041 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3038, align 8
-  %3042 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3043 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3042, i32 0, i32 0
-  store ptr @54, ptr %3043, align 8
-  %3044 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3042, i32 0, i32 1
-  store i64 7, ptr %3044, align 4
-  %3045 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3042, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %1844, %"github.com/goplus/llgo/internal/runtime.String" %3041, %"github.com/goplus/llgo/internal/runtime.String" %3045, ptr %2113, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %3037)
+  %1314 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  %1315 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  %1316 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
+  %1317 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @70, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %1316, 1
+  %1318 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1317, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).StructType", 2
+  %1319 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1318, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).StructType", 3
+  %1320 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
+  %1321 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @80, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %1320, 1
+  %1322 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1321, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Uncommon", 2
+  %1323 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1322, ptr @"github.com/goplus/llgo/internal/abi.(*MapType).Uncommon", 3
+  %1324 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 1040)
+  %1325 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %963, ptr %1325, align 8
+  %1326 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %968, ptr %1326, align 8
+  %1327 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 2
+  store %"github.com/goplus/llgo/internal/abi.Method" %972, ptr %1327, align 8
+  %1328 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 3
+  store %"github.com/goplus/llgo/internal/abi.Method" %977, ptr %1328, align 8
+  %1329 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 4
+  store %"github.com/goplus/llgo/internal/abi.Method" %982, ptr %1329, align 8
+  %1330 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 5
+  store %"github.com/goplus/llgo/internal/abi.Method" %986, ptr %1330, align 8
+  %1331 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 6
+  store %"github.com/goplus/llgo/internal/abi.Method" %991, ptr %1331, align 8
+  %1332 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 7
+  store %"github.com/goplus/llgo/internal/abi.Method" %995, ptr %1332, align 8
+  %1333 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 8
+  store %"github.com/goplus/llgo/internal/abi.Method" %999, ptr %1333, align 8
+  %1334 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 9
+  store %"github.com/goplus/llgo/internal/abi.Method" %1003, ptr %1334, align 8
+  %1335 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 10
+  store %"github.com/goplus/llgo/internal/abi.Method" %1007, ptr %1335, align 8
+  %1336 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 11
+  store %"github.com/goplus/llgo/internal/abi.Method" %1011, ptr %1336, align 8
+  %1337 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 12
+  store %"github.com/goplus/llgo/internal/abi.Method" %1016, ptr %1337, align 8
+  %1338 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 13
+  store %"github.com/goplus/llgo/internal/abi.Method" %1020, ptr %1338, align 8
+  %1339 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 14
+  store %"github.com/goplus/llgo/internal/abi.Method" %1024, ptr %1339, align 8
+  %1340 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 15
+  store %"github.com/goplus/llgo/internal/abi.Method" %1028, ptr %1340, align 8
+  %1341 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 16
+  store %"github.com/goplus/llgo/internal/abi.Method" %1032, ptr %1341, align 8
+  %1342 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 17
+  store %"github.com/goplus/llgo/internal/abi.Method" %1112, ptr %1342, align 8
+  %1343 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 18
+  store %"github.com/goplus/llgo/internal/abi.Method" %1116, ptr %1343, align 8
+  %1344 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 19
+  store %"github.com/goplus/llgo/internal/abi.Method" %1120, ptr %1344, align 8
+  %1345 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 20
+  store %"github.com/goplus/llgo/internal/abi.Method" %1124, ptr %1345, align 8
+  %1346 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 21
+  store %"github.com/goplus/llgo/internal/abi.Method" %1128, ptr %1346, align 8
+  %1347 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 22
+  store %"github.com/goplus/llgo/internal/abi.Method" %1145, ptr %1347, align 8
+  %1348 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 23
+  store %"github.com/goplus/llgo/internal/abi.Method" %1149, ptr %1348, align 8
+  %1349 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 24
+  store %"github.com/goplus/llgo/internal/abi.Method" %1319, ptr %1349, align 8
+  %1350 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1324, i64 25
+  store %"github.com/goplus/llgo/internal/abi.Method" %1323, ptr %1350, align 8
+  %1351 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %1324, 0
+  %1352 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1351, i64 26, 1
+  %1353 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1352, i64 26, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %840, %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 35 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @54, i64 7 }, ptr %959, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %1353)
   br label %_llgo_110
 
 _llgo_131:                                        ; preds = %_llgo_129
-  %3046 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %2983)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %3046)
-  store ptr %3046, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  %1354 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1311)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1354)
+  store ptr %1354, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
   br label %_llgo_132
 
 _llgo_132:                                        ; preds = %_llgo_131, %_llgo_129
-  %3047 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
-  %3048 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
-  %3049 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
-  %3050 = icmp eq ptr %3049, null
-  br i1 %3050, label %_llgo_133, label %_llgo_134
+  %1355 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  %1356 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  %1357 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
+  %1358 = icmp eq ptr %1357, null
+  br i1 %1358, label %_llgo_133, label %_llgo_134
 
 _llgo_133:                                        ; preds = %_llgo_132
-  %3051 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %3052 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %3053 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3052, i32 0, i32 0
-  store ptr %3051, ptr %3053, align 8
-  %3054 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3052, i32 0, i32 1
-  store i64 0, ptr %3054, align 4
-  %3055 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3052, i32 0, i32 2
-  store i64 0, ptr %3055, align 4
-  %3056 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3052, align 8
-  %3057 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %3058 = getelementptr ptr, ptr %3057, i64 0
-  store ptr %3048, ptr %3058, align 8
-  %3059 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %3060 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3059, i32 0, i32 0
-  store ptr %3057, ptr %3060, align 8
-  %3061 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3059, i32 0, i32 1
-  store i64 1, ptr %3061, align 4
-  %3062 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3059, i32 0, i32 2
-  store i64 1, ptr %3062, align 4
-  %3063 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3059, align 8
-  %3064 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %3056, %"github.com/goplus/llgo/internal/runtime.Slice" %3063, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %3064)
-  store ptr %3064, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
+  %1359 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %1360 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %1359, 0
+  %1361 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1360, i64 0, 1
+  %1362 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1361, i64 0, 2
+  %1363 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %1364 = getelementptr ptr, ptr %1363, i64 0
+  store ptr %1356, ptr %1364, align 8
+  %1365 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %1363, 0
+  %1366 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1365, i64 1, 1
+  %1367 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1366, i64 1, 2
+  %1368 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1362, %"github.com/goplus/llgo/internal/runtime.Slice" %1367, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1368)
+  store ptr %1368, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
   br label %_llgo_134
 
 _llgo_134:                                        ; preds = %_llgo_133, %_llgo_132
-  %3065 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
-  %3066 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3067 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3066, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %2978, ptr %3067, align 8
-  %3068 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3066, i32 0, i32 1
-  store ptr %3065, ptr %3068, align 8
-  %3069 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3066, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).StructType", ptr %3069, align 8
-  %3070 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3066, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).StructType", ptr %3070, align 8
-  %3071 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3066, align 8
-  %3072 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3073 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3072, i32 0, i32 0
-  store ptr @80, ptr %3073, align 8
-  %3074 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3072, i32 0, i32 1
-  store i64 8, ptr %3074, align 4
-  %3075 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3072, align 8
-  %3076 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3077 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3076, i32 0, i32 0
-  store ptr @81, ptr %3077, align 8
-  %3078 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3076, i32 0, i32 1
-  store i64 48, ptr %3078, align 4
-  %3079 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3076, align 8
-  %3080 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3079, i64 25, i64 24, i64 0, i64 2)
-  %3081 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
-  %3082 = icmp eq ptr %3081, null
-  br i1 %3082, label %_llgo_135, label %_llgo_136
+  %1369 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
+  %1370 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @70, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %1369, 1
+  %1371 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1370, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).StructType", 2
+  %1372 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1371, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).StructType", 3
+  %1373 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @81, i64 48 }, i64 25, i64 24, i64 0, i64 2)
+  %1374 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
+  %1375 = icmp eq ptr %1374, null
+  br i1 %1375, label %_llgo_135, label %_llgo_136
 
 _llgo_135:                                        ; preds = %_llgo_134
-  store ptr %3080, ptr @"_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
+  store ptr %1373, ptr @"_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
   br label %_llgo_136
 
 _llgo_136:                                        ; preds = %_llgo_135, %_llgo_134
-  %3083 = load ptr, ptr @"_llgo_struct$OKIlItfBJsawrEMnVSc2VQ7pxNxCHIgSoitcM9n4FVI", align 8
-  %3084 = icmp eq ptr %3083, null
-  br i1 %3084, label %_llgo_137, label %_llgo_138
+  %1376 = load ptr, ptr @"_llgo_struct$OKIlItfBJsawrEMnVSc2VQ7pxNxCHIgSoitcM9n4FVI", align 8
+  %1377 = icmp eq ptr %1376, null
+  br i1 %1377, label %_llgo_137, label %_llgo_138
 
 _llgo_137:                                        ; preds = %_llgo_136
-  %3085 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3086 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3085, i32 0, i32 0
-  store ptr @46, ptr %3086, align 8
-  %3087 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3085, i32 0, i32 1
-  store i64 8, ptr %3087, align 4
-  %3088 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3085, align 8
-  %3089 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3090 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3089, i32 0, i32 0
-  store ptr null, ptr %3090, align 8
-  %3091 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3089, i32 0, i32 1
-  store i64 0, ptr %3091, align 4
-  %3092 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3089, align 8
-  %3093 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %3094 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3088, ptr %3093, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %3092, i1 false)
-  %3095 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3096 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3095, i32 0, i32 0
-  store ptr @82, ptr %3096, align 8
-  %3097 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3095, i32 0, i32 1
-  store i64 6, ptr %3097, align 4
-  %3098 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3095, align 8
-  %3099 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3100 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3099, i32 0, i32 0
-  store ptr null, ptr %3100, align 8
-  %3101 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3099, i32 0, i32 1
-  store i64 0, ptr %3101, align 4
-  %3102 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3099, align 8
-  %3103 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 41)
-  %3104 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3098, ptr %3103, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %3102, i1 false)
-  %3105 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3106 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3105, i32 0, i32 0
-  store ptr @83, ptr %3106, align 8
-  %3107 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3105, i32 0, i32 1
-  store i64 6, ptr %3107, align 4
-  %3108 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3105, align 8
-  %3109 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3110 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3109, i32 0, i32 0
-  store ptr null, ptr %3110, align 8
-  %3111 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3109, i32 0, i32 1
-  store i64 0, ptr %3111, align 4
-  %3112 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3109, align 8
-  %3113 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 41)
-  %3114 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3108, ptr %3113, i64 18, %"github.com/goplus/llgo/internal/runtime.String" %3112, i1 false)
-  %3115 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3116 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3115, i32 0, i32 0
-  store ptr @84, ptr %3116, align 8
-  %3117 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3115, i32 0, i32 1
-  store i64 4, ptr %3117, align 4
-  %3118 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3115, align 8
-  %3119 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3120 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3119, i32 0, i32 0
-  store ptr null, ptr %3120, align 8
-  %3121 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3119, i32 0, i32 1
-  store i64 0, ptr %3121, align 4
-  %3122 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3119, align 8
-  %3123 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 42)
-  %3124 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3118, ptr %3123, i64 20, %"github.com/goplus/llgo/internal/runtime.String" %3122, i1 false)
-  %3125 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3126 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3125, i32 0, i32 0
-  store ptr @7, ptr %3126, align 8
-  %3127 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3125, i32 0, i32 1
-  store i64 4, ptr %3127, align 4
-  %3128 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3125, align 8
-  %3129 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
-  %3130 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3129, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3094, ptr %3130, align 8
-  %3131 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3129, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3104, ptr %3131, align 8
-  %3132 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3129, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3114, ptr %3132, align 8
-  %3133 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3129, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3124, ptr %3133, align 8
-  %3134 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %3135 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3134, i32 0, i32 0
-  store ptr %3129, ptr %3135, align 8
-  %3136 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3134, i32 0, i32 1
-  store i64 4, ptr %3136, align 4
-  %3137 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3134, i32 0, i32 2
-  store i64 4, ptr %3137, align 4
-  %3138 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3134, align 8
-  %3139 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %3128, i64 24, %"github.com/goplus/llgo/internal/runtime.Slice" %3138)
-  store ptr %3139, ptr @"_llgo_struct$OKIlItfBJsawrEMnVSc2VQ7pxNxCHIgSoitcM9n4FVI", align 8
+  %1378 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %1379 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @46, i64 8 }, ptr %1378, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %1380 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 41)
+  %1381 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @82, i64 6 }, ptr %1380, i64 16, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %1382 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 41)
+  %1383 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @83, i64 6 }, ptr %1382, i64 18, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %1384 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 42)
+  %1385 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @84, i64 4 }, ptr %1384, i64 20, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %1386 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
+  %1387 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1386, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1379, ptr %1387, align 8
+  %1388 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1386, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1381, ptr %1388, align 8
+  %1389 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1386, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1383, ptr %1389, align 8
+  %1390 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1386, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1385, ptr %1390, align 8
+  %1391 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %1386, 0
+  %1392 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1391, i64 4, 1
+  %1393 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1392, i64 4, 2
+  %1394 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 }, i64 24, %"github.com/goplus/llgo/internal/runtime.Slice" %1393)
+  store ptr %1394, ptr @"_llgo_struct$OKIlItfBJsawrEMnVSc2VQ7pxNxCHIgSoitcM9n4FVI", align 8
   br label %_llgo_138
 
 _llgo_138:                                        ; preds = %_llgo_137, %_llgo_136
-  %3140 = load ptr, ptr @"_llgo_struct$OKIlItfBJsawrEMnVSc2VQ7pxNxCHIgSoitcM9n4FVI", align 8
-  br i1 %3082, label %_llgo_139, label %_llgo_140
+  %1395 = load ptr, ptr @"_llgo_struct$OKIlItfBJsawrEMnVSc2VQ7pxNxCHIgSoitcM9n4FVI", align 8
+  br i1 %1375, label %_llgo_139, label %_llgo_140
 
 _llgo_139:                                        ; preds = %_llgo_138
-  %3141 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3142 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3141, i32 0, i32 0
-  store ptr @28, ptr %3142, align 8
-  %3143 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3141, i32 0, i32 1
-  store i64 15, ptr %3143, align 4
-  %3144 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3141, align 8
-  %3145 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %3146 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
-  %3147 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3148 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3147, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3144, ptr %3148, align 8
-  %3149 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3147, i32 0, i32 1
-  store ptr %3146, ptr %3149, align 8
-  %3150 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3147, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*UncommonType).ExportedMethods", ptr %3150, align 8
-  %3151 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3147, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*UncommonType).ExportedMethods", ptr %3151, align 8
-  %3152 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3147, align 8
-  %3153 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3154 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3153, i32 0, i32 0
-  store ptr @47, ptr %3154, align 8
-  %3155 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3153, i32 0, i32 1
-  store i64 7, ptr %3155, align 4
-  %3156 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3153, align 8
-  %3157 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %3158 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
-  %3159 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3160 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3159, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3156, ptr %3160, align 8
-  %3161 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3159, i32 0, i32 1
-  store ptr %3158, ptr %3161, align 8
-  %3162 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3159, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*UncommonType).Methods", ptr %3162, align 8
-  %3163 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3159, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*UncommonType).Methods", ptr %3163, align 8
-  %3164 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3159, align 8
-  %3165 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
-  %3166 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3165, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %3152, ptr %3166, align 8
-  %3167 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3165, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %3164, ptr %3167, align 8
-  %3168 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %3169 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3168, i32 0, i32 0
-  store ptr %3165, ptr %3169, align 8
-  %3170 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3168, i32 0, i32 1
-  store i64 2, ptr %3170, align 4
-  %3171 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3168, i32 0, i32 2
-  store i64 2, ptr %3171, align 4
-  %3172 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3168, align 8
-  %3173 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3174 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3173, i32 0, i32 0
-  store ptr @3, ptr %3174, align 8
-  %3175 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3173, i32 0, i32 1
-  store i64 35, ptr %3175, align 4
-  %3176 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3173, align 8
-  %3177 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3178 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3177, i32 0, i32 0
-  store ptr @85, ptr %3178, align 8
-  %3179 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3177, i32 0, i32 1
-  store i64 12, ptr %3179, align 4
-  %3180 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3177, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %3080, %"github.com/goplus/llgo/internal/runtime.String" %3176, %"github.com/goplus/llgo/internal/runtime.String" %3180, ptr %3140, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %3172)
+  %1396 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %1397 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
+  %1398 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @28, i64 15 }, ptr undef, ptr undef, ptr undef }, ptr %1397, 1
+  %1399 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1398, ptr @"github.com/goplus/llgo/internal/abi.(*UncommonType).ExportedMethods", 2
+  %1400 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1399, ptr @"github.com/goplus/llgo/internal/abi.(*UncommonType).ExportedMethods", 3
+  %1401 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %1402 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
+  %1403 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @47, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %1402, 1
+  %1404 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1403, ptr @"github.com/goplus/llgo/internal/abi.(*UncommonType).Methods", 2
+  %1405 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1404, ptr @"github.com/goplus/llgo/internal/abi.(*UncommonType).Methods", 3
+  %1406 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
+  %1407 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1406, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %1400, ptr %1407, align 8
+  %1408 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1406, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %1405, ptr %1408, align 8
+  %1409 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %1406, 0
+  %1410 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1409, i64 2, 1
+  %1411 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1410, i64 2, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %1373, %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 35 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @85, i64 12 }, ptr %1395, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %1411)
   br label %_llgo_140
 
 _llgo_140:                                        ; preds = %_llgo_139, %_llgo_138
-  %3181 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
-  %3182 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3183 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3182, i32 0, i32 0
-  store ptr @81, ptr %3183, align 8
-  %3184 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3182, i32 0, i32 1
-  store i64 48, ptr %3184, align 4
-  %3185 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3182, align 8
-  %3186 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3185, i64 25, i64 24, i64 0, i64 2)
-  %3187 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
-  %3188 = icmp eq ptr %3187, null
-  br i1 %3188, label %_llgo_141, label %_llgo_142
+  %1412 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
+  %1413 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @81, i64 48 }, i64 25, i64 24, i64 0, i64 2)
+  %1414 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
+  %1415 = icmp eq ptr %1414, null
+  br i1 %1415, label %_llgo_141, label %_llgo_142
 
 _llgo_141:                                        ; preds = %_llgo_140
-  %3189 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %3186)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %3189)
-  store ptr %3189, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
+  %1416 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1413)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1416)
+  store ptr %1416, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
   br label %_llgo_142
 
 _llgo_142:                                        ; preds = %_llgo_141, %_llgo_140
-  %3190 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
-  %3191 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
-  %3192 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
-  %3193 = icmp eq ptr %3192, null
-  br i1 %3193, label %_llgo_143, label %_llgo_144
+  %1417 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
+  %1418 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.UncommonType", align 8
+  %1419 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
+  %1420 = icmp eq ptr %1419, null
+  br i1 %1420, label %_llgo_143, label %_llgo_144
 
 _llgo_143:                                        ; preds = %_llgo_142
-  %3194 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %3195 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %3196 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3195, i32 0, i32 0
-  store ptr %3194, ptr %3196, align 8
-  %3197 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3195, i32 0, i32 1
-  store i64 0, ptr %3197, align 4
-  %3198 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3195, i32 0, i32 2
-  store i64 0, ptr %3198, align 4
-  %3199 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3195, align 8
-  %3200 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %3201 = getelementptr ptr, ptr %3200, i64 0
-  store ptr %3191, ptr %3201, align 8
-  %3202 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %3203 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3202, i32 0, i32 0
-  store ptr %3200, ptr %3203, align 8
-  %3204 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3202, i32 0, i32 1
-  store i64 1, ptr %3204, align 4
-  %3205 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3202, i32 0, i32 2
-  store i64 1, ptr %3205, align 4
-  %3206 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3202, align 8
-  %3207 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %3199, %"github.com/goplus/llgo/internal/runtime.Slice" %3206, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %3207)
-  store ptr %3207, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
+  %1421 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %1422 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %1421, 0
+  %1423 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1422, i64 0, 1
+  %1424 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1423, i64 0, 2
+  %1425 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %1426 = getelementptr ptr, ptr %1425, i64 0
+  store ptr %1418, ptr %1426, align 8
+  %1427 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %1425, 0
+  %1428 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1427, i64 1, 1
+  %1429 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1428, i64 1, 2
+  %1430 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %1424, %"github.com/goplus/llgo/internal/runtime.Slice" %1429, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %1430)
+  store ptr %1430, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
   br label %_llgo_144
 
 _llgo_144:                                        ; preds = %_llgo_143, %_llgo_142
-  %3208 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
-  %3209 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3210 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3209, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3075, ptr %3210, align 8
-  %3211 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3209, i32 0, i32 1
-  store ptr %3208, ptr %3211, align 8
-  %3212 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3209, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Uncommon", ptr %3212, align 8
-  %3213 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3209, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Uncommon", ptr %3213, align 8
-  %3214 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3209, align 8
-  %3215 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 920)
-  %3216 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3215, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %2746, ptr %3216, align 8
-  %3217 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3215, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %2758, ptr %3217, align 8
-  %3218 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3215, i64 2
-  store %"github.com/goplus/llgo/internal/abi.Method" %2769, ptr %3218, align 8
-  %3219 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3215, i64 3
-  store %"github.com/goplus/llgo/internal/abi.Method" %2781, ptr %3219, align 8
-  %3220 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3215, i64 4
-  store %"github.com/goplus/llgo/internal/abi.Method" %2793, ptr %3220, align 8
-  %3221 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3215, i64 5
-  store %"github.com/goplus/llgo/internal/abi.Method" %2805, ptr %3221, align 8
-  %3222 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3215, i64 6
-  store %"github.com/goplus/llgo/internal/abi.Method" %2816, ptr %3222, align 8
-  %3223 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3215, i64 7
-  store %"github.com/goplus/llgo/internal/abi.Method" %2828, ptr %3223, align 8
-  %3224 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3215, i64 8
-  store %"github.com/goplus/llgo/internal/abi.Method" %2839, ptr %3224, align 8
-  %3225 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3215, i64 9
-  store %"github.com/goplus/llgo/internal/abi.Method" %2850, ptr %3225, align 8
-  %3226 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3215, i64 10
-  store %"github.com/goplus/llgo/internal/abi.Method" %2862, ptr %3226, align 8
-  %3227 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3215, i64 11
-  store %"github.com/goplus/llgo/internal/abi.Method" %2873, ptr %3227, align 8
-  %3228 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3215, i64 12
-  store %"github.com/goplus/llgo/internal/abi.Method" %2884, ptr %3228, align 8
-  %3229 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3215, i64 13
-  store %"github.com/goplus/llgo/internal/abi.Method" %2896, ptr %3229, align 8
-  %3230 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3215, i64 14
-  store %"github.com/goplus/llgo/internal/abi.Method" %2907, ptr %3230, align 8
-  %3231 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3215, i64 15
-  store %"github.com/goplus/llgo/internal/abi.Method" %2918, ptr %3231, align 8
-  %3232 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3215, i64 16
-  store %"github.com/goplus/llgo/internal/abi.Method" %2930, ptr %3232, align 8
-  %3233 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3215, i64 17
-  store %"github.com/goplus/llgo/internal/abi.Method" %2941, ptr %3233, align 8
-  %3234 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3215, i64 18
-  store %"github.com/goplus/llgo/internal/abi.Method" %2952, ptr %3234, align 8
-  %3235 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3215, i64 19
-  store %"github.com/goplus/llgo/internal/abi.Method" %2963, ptr %3235, align 8
-  %3236 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3215, i64 20
-  store %"github.com/goplus/llgo/internal/abi.Method" %2974, ptr %3236, align 8
-  %3237 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3215, i64 21
-  store %"github.com/goplus/llgo/internal/abi.Method" %3071, ptr %3237, align 8
-  %3238 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3215, i64 22
-  store %"github.com/goplus/llgo/internal/abi.Method" %3214, ptr %3238, align 8
-  %3239 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %3240 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3239, i32 0, i32 0
-  store ptr %3215, ptr %3240, align 8
-  %3241 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3239, i32 0, i32 1
-  store i64 23, ptr %3241, align 4
-  %3242 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3239, i32 0, i32 2
-  store i64 23, ptr %3242, align 4
-  %3243 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3239, align 8
-  %3244 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3245 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3244, i32 0, i32 0
-  store ptr @3, ptr %3245, align 8
-  %3246 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3244, i32 0, i32 1
-  store i64 35, ptr %3246, align 4
-  %3247 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3244, align 8
-  %3248 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3249 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3248, i32 0, i32 0
-  store ptr @70, ptr %3249, align 8
-  %3250 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3248, i32 0, i32 1
-  store i64 10, ptr %3250, align 4
-  %3251 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3248, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %2547, %"github.com/goplus/llgo/internal/runtime.String" %3247, %"github.com/goplus/llgo/internal/runtime.String" %3251, ptr %2735, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %3243)
+  %1431 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
+  %1432 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @80, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %1431, 1
+  %1433 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1432, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Uncommon", 2
+  %1434 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1433, ptr @"github.com/goplus/llgo/internal/abi.(*StructType).Uncommon", 3
+  %1435 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 920)
+  %1436 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1435, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %1222, ptr %1436, align 8
+  %1437 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1435, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %1227, ptr %1437, align 8
+  %1438 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1435, i64 2
+  store %"github.com/goplus/llgo/internal/abi.Method" %1231, ptr %1438, align 8
+  %1439 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1435, i64 3
+  store %"github.com/goplus/llgo/internal/abi.Method" %1236, ptr %1439, align 8
+  %1440 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1435, i64 4
+  store %"github.com/goplus/llgo/internal/abi.Method" %1241, ptr %1440, align 8
+  %1441 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1435, i64 5
+  store %"github.com/goplus/llgo/internal/abi.Method" %1246, ptr %1441, align 8
+  %1442 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1435, i64 6
+  store %"github.com/goplus/llgo/internal/abi.Method" %1250, ptr %1442, align 8
+  %1443 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1435, i64 7
+  store %"github.com/goplus/llgo/internal/abi.Method" %1255, ptr %1443, align 8
+  %1444 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1435, i64 8
+  store %"github.com/goplus/llgo/internal/abi.Method" %1259, ptr %1444, align 8
+  %1445 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1435, i64 9
+  store %"github.com/goplus/llgo/internal/abi.Method" %1263, ptr %1445, align 8
+  %1446 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1435, i64 10
+  store %"github.com/goplus/llgo/internal/abi.Method" %1268, ptr %1446, align 8
+  %1447 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1435, i64 11
+  store %"github.com/goplus/llgo/internal/abi.Method" %1272, ptr %1447, align 8
+  %1448 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1435, i64 12
+  store %"github.com/goplus/llgo/internal/abi.Method" %1276, ptr %1448, align 8
+  %1449 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1435, i64 13
+  store %"github.com/goplus/llgo/internal/abi.Method" %1281, ptr %1449, align 8
+  %1450 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1435, i64 14
+  store %"github.com/goplus/llgo/internal/abi.Method" %1285, ptr %1450, align 8
+  %1451 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1435, i64 15
+  store %"github.com/goplus/llgo/internal/abi.Method" %1289, ptr %1451, align 8
+  %1452 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1435, i64 16
+  store %"github.com/goplus/llgo/internal/abi.Method" %1294, ptr %1452, align 8
+  %1453 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1435, i64 17
+  store %"github.com/goplus/llgo/internal/abi.Method" %1298, ptr %1453, align 8
+  %1454 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1435, i64 18
+  store %"github.com/goplus/llgo/internal/abi.Method" %1302, ptr %1454, align 8
+  %1455 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1435, i64 19
+  store %"github.com/goplus/llgo/internal/abi.Method" %1306, ptr %1455, align 8
+  %1456 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1435, i64 20
+  store %"github.com/goplus/llgo/internal/abi.Method" %1310, ptr %1456, align 8
+  %1457 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1435, i64 21
+  store %"github.com/goplus/llgo/internal/abi.Method" %1372, ptr %1457, align 8
+  %1458 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1435, i64 22
+  store %"github.com/goplus/llgo/internal/abi.Method" %1434, ptr %1458, align 8
+  %1459 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %1435, 0
+  %1460 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1459, i64 23, 1
+  %1461 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1460, i64 23, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %1150, %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 35 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @70, i64 10 }, ptr %1218, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %1461)
   br label %_llgo_130
 
 _llgo_145:                                        ; preds = %_llgo_64
-  %3252 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3253 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3252, i32 0, i32 0
-  store ptr @40, ptr %3253, align 8
-  %3254 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3252, i32 0, i32 1
-  store i64 5, ptr %3254, align 4
-  %3255 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3252, align 8
-  %3256 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3257 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3256, i32 0, i32 0
-  store ptr null, ptr %3257, align 8
-  %3258 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3256, i32 0, i32 1
-  store i64 0, ptr %3258, align 4
-  %3259 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3256, align 8
-  %3260 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %3261 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3255, ptr %3260, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %3259, i1 false)
-  %3262 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3263 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3262, i32 0, i32 0
-  store ptr @87, ptr %3263, align 8
-  %3264 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3262, i32 0, i32 1
-  store i64 5, ptr %3264, align 4
-  %3265 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3262, align 8
-  %3266 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3267 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3266, i32 0, i32 0
-  store ptr null, ptr %3267, align 8
-  %3268 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3266, i32 0, i32 1
-  store i64 0, ptr %3268, align 4
-  %3269 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3266, align 8
-  %3270 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1058)
-  %3271 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3265, ptr %3270, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %3269, i1 false)
-  %3272 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3273 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3272, i32 0, i32 0
-  store ptr @88, ptr %3273, align 8
-  %3274 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3272, i32 0, i32 1
-  store i64 4, ptr %3274, align 4
-  %3275 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3272, align 8
-  %3276 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3277 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3276, i32 0, i32 0
-  store ptr null, ptr %3277, align 8
-  %3278 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3276, i32 0, i32 1
-  store i64 0, ptr %3278, align 4
-  %3279 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3276, align 8
-  %3280 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %3281 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3275, ptr %3280, i64 24, %"github.com/goplus/llgo/internal/runtime.String" %3279, i1 false)
-  %3282 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3283 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3282, i32 0, i32 0
-  store ptr @89, ptr %3283, align 8
-  %3284 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3282, i32 0, i32 1
-  store i64 4, ptr %3284, align 4
-  %3285 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3282, align 8
-  %3286 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3287 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3286, i32 0, i32 0
-  store ptr null, ptr %3287, align 8
-  %3288 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3286, i32 0, i32 1
-  store i64 0, ptr %3288, align 4
-  %3289 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3286, align 8
-  %3290 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %3291 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3285, ptr %3290, i64 32, %"github.com/goplus/llgo/internal/runtime.String" %3289, i1 false)
-  %3292 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3293 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3292, i32 0, i32 0
-  store ptr @7, ptr %3293, align 8
-  %3294 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3292, i32 0, i32 1
-  store i64 4, ptr %3294, align 4
-  %3295 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3292, align 8
-  %3296 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
-  %3297 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3296, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3261, ptr %3297, align 8
-  %3298 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3296, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3271, ptr %3298, align 8
-  %3299 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3296, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3281, ptr %3299, align 8
-  %3300 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3296, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3291, ptr %3300, align 8
-  %3301 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %3302 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3301, i32 0, i32 0
-  store ptr %3296, ptr %3302, align 8
-  %3303 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3301, i32 0, i32 1
-  store i64 4, ptr %3303, align 4
-  %3304 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3301, i32 0, i32 2
-  store i64 4, ptr %3304, align 4
-  %3305 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3301, align 8
-  %3306 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %3295, i64 40, %"github.com/goplus/llgo/internal/runtime.Slice" %3305)
-  store ptr %3306, ptr @"_llgo_struct$SDp3TNnYnxb26MhB1v8VMbmY71BX77YOaY7lgS1cFx0", align 8
+  %1462 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %1463 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @40, i64 5 }, ptr %1462, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %1464 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %478)
+  %1465 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @87, i64 5 }, ptr %1464, i64 16, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %1466 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %1467 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @88, i64 4 }, ptr %1466, i64 24, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %1468 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %1469 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @89, i64 4 }, ptr %1468, i64 32, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %1470 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
+  %1471 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1470, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1463, ptr %1471, align 8
+  %1472 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1470, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1465, ptr %1472, align 8
+  %1473 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1470, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1467, ptr %1473, align 8
+  %1474 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1470, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1469, ptr %1474, align 8
+  %1475 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %1470, 0
+  %1476 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1475, i64 4, 1
+  %1477 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1476, i64 4, 2
+  %1478 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 }, i64 40, %"github.com/goplus/llgo/internal/runtime.Slice" %1477)
+  store ptr %1478, ptr @"_llgo_struct$SDp3TNnYnxb26MhB1v8VMbmY71BX77YOaY7lgS1cFx0", align 8
   br label %_llgo_146
 
 _llgo_146:                                        ; preds = %_llgo_145, %_llgo_64
-  %3307 = load ptr, ptr @"_llgo_struct$SDp3TNnYnxb26MhB1v8VMbmY71BX77YOaY7lgS1cFx0", align 8
-  br i1 %899, label %_llgo_147, label %_llgo_148
+  %1479 = load ptr, ptr @"_llgo_struct$SDp3TNnYnxb26MhB1v8VMbmY71BX77YOaY7lgS1cFx0", align 8
+  br i1 %416, label %_llgo_147, label %_llgo_148
 
 _llgo_147:                                        ; preds = %_llgo_146
-  %3308 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3309 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3308, i32 0, i32 0
-  store ptr @42, ptr %3309, align 8
-  %3310 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3308, i32 0, i32 1
-  store i64 8, ptr %3310, align 4
-  %3311 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3308, align 8
-  %3312 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %3313 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3314 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3313, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3311, ptr %3314, align 8
-  %3315 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3313, i32 0, i32 1
-  store ptr %3312, ptr %3315, align 8
-  %3316 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3313, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Method).Exported", ptr %3316, align 8
-  %3317 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3313, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Method).Exported", ptr %3317, align 8
-  %3318 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3313, align 8
-  %3319 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3320 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3319, i32 0, i32 0
-  store ptr @43, ptr %3320, align 8
-  %3321 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3319, i32 0, i32 1
-  store i64 4, ptr %3321, align 4
-  %3322 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3319, align 8
-  %3323 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %3324 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3325 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3324, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3322, ptr %3325, align 8
-  %3326 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3324, i32 0, i32 1
-  store ptr %3323, ptr %3326, align 8
-  %3327 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3324, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Method).Name", ptr %3327, align 8
-  %3328 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3324, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Method).Name", ptr %3328, align 8
-  %3329 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3324, align 8
-  %3330 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3331 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3330, i32 0, i32 0
-  store ptr @44, ptr %3331, align 8
-  %3332 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3330, i32 0, i32 1
-  store i64 7, ptr %3332, align 4
-  %3333 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3330, align 8
-  %3334 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %3335 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3336 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3335, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3333, ptr %3336, align 8
-  %3337 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3335, i32 0, i32 1
-  store ptr %3334, ptr %3337, align 8
-  %3338 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3335, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Method).PkgPath", ptr %3338, align 8
-  %3339 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3335, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*Method).PkgPath", ptr %3339, align 8
-  %3340 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3335, align 8
-  %3341 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 120)
-  %3342 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3341, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %3318, ptr %3342, align 8
-  %3343 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3341, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %3329, ptr %3343, align 8
-  %3344 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3341, i64 2
-  store %"github.com/goplus/llgo/internal/abi.Method" %3340, ptr %3344, align 8
-  %3345 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %3346 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3345, i32 0, i32 0
-  store ptr %3341, ptr %3346, align 8
-  %3347 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3345, i32 0, i32 1
-  store i64 3, ptr %3347, align 4
-  %3348 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3345, i32 0, i32 2
-  store i64 3, ptr %3348, align 4
-  %3349 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3345, align 8
-  %3350 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3351 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3350, i32 0, i32 0
-  store ptr @3, ptr %3351, align 8
-  %3352 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3350, i32 0, i32 1
-  store i64 35, ptr %3352, align 4
-  %3353 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3350, align 8
-  %3354 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3355 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3354, i32 0, i32 0
-  store ptr @90, ptr %3355, align 8
-  %3356 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3354, i32 0, i32 1
-  store i64 6, ptr %3356, align 4
-  %3357 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3354, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %897, %"github.com/goplus/llgo/internal/runtime.String" %3353, %"github.com/goplus/llgo/internal/runtime.String" %3357, ptr %3307, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %3349)
+  %1480 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1481 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @42, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %1480, 1
+  %1482 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1481, ptr @"github.com/goplus/llgo/internal/abi.(*Method).Exported", 2
+  %1483 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1482, ptr @"github.com/goplus/llgo/internal/abi.(*Method).Exported", 3
+  %1484 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %1485 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @43, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %1484, 1
+  %1486 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1485, ptr @"github.com/goplus/llgo/internal/abi.(*Method).Name", 2
+  %1487 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1486, ptr @"github.com/goplus/llgo/internal/abi.(*Method).Name", 3
+  %1488 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %1489 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @44, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %1488, 1
+  %1490 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1489, ptr @"github.com/goplus/llgo/internal/abi.(*Method).PkgPath", 2
+  %1491 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1490, ptr @"github.com/goplus/llgo/internal/abi.(*Method).PkgPath", 3
+  %1492 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 120)
+  %1493 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1492, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %1483, ptr %1493, align 8
+  %1494 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1492, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %1487, ptr %1494, align 8
+  %1495 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1492, i64 2
+  store %"github.com/goplus/llgo/internal/abi.Method" %1491, ptr %1495, align 8
+  %1496 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %1492, 0
+  %1497 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1496, i64 3, 1
+  %1498 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1497, i64 3, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %414, %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 35 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @90, i64 6 }, ptr %1479, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %1498)
   br label %_llgo_148
 
 _llgo_148:                                        ; preds = %_llgo_147, %_llgo_146
-  %3358 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %3359 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
-  %3360 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
-  %3361 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3362 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3361, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %892, ptr %3362, align 8
-  %3363 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3361, i32 0, i32 1
-  store ptr %3360, ptr %3363, align 8
-  %3364 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3361, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ExportedMethods", ptr %3364, align 8
-  %3365 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3361, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ExportedMethods", ptr %3365, align 8
-  %3366 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3361, align 8
-  %3367 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3368 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3367, i32 0, i32 0
-  store ptr @33, ptr %3368, align 8
-  %3369 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3367, i32 0, i32 1
-  store i64 10, ptr %3369, align 4
-  %3370 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3367, align 8
-  %3371 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %3372 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3373 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3372, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3370, ptr %3373, align 8
-  %3374 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3372, i32 0, i32 1
-  store ptr %3371, ptr %3374, align 8
-  %3375 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3372, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).FieldAlign", ptr %3375, align 8
-  %3376 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3372, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).FieldAlign", ptr %3376, align 8
-  %3377 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3372, align 8
-  %3378 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3379 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3378, i32 0, i32 0
-  store ptr @34, ptr %3379, align 8
-  %3380 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3378, i32 0, i32 1
-  store i64 8, ptr %3380, align 4
-  %3381 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3378, align 8
-  %3382 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
-  %3383 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
-  %3384 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3385 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3384, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3381, ptr %3385, align 8
-  %3386 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3384, i32 0, i32 1
-  store ptr %3383, ptr %3386, align 8
-  %3387 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3384, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).FuncType", ptr %3387, align 8
-  %3388 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3384, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).FuncType", ptr %3388, align 8
-  %3389 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3384, align 8
-  %3390 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3391 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3390, i32 0, i32 0
-  store ptr @35, ptr %3391, align 8
-  %3392 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3390, i32 0, i32 1
-  store i64 7, ptr %3392, align 4
-  %3393 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3390, align 8
-  %3394 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %3395 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3396 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3395, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3393, ptr %3396, align 8
-  %3397 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3395, i32 0, i32 1
-  store ptr %3394, ptr %3397, align 8
-  %3398 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3395, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).HasName", ptr %3398, align 8
-  %3399 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3395, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).HasName", ptr %3399, align 8
-  %3400 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3395, align 8
-  %3401 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3402 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3401, i32 0, i32 0
-  store ptr @36, ptr %3402, align 8
-  %3403 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3401, i32 0, i32 1
-  store i64 10, ptr %3403, align 4
-  %3404 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3401, align 8
-  %3405 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %3406 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3407 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3406, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3404, ptr %3407, align 8
-  %3408 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3406, i32 0, i32 1
-  store ptr %3405, ptr %3408, align 8
-  %3409 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3406, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).IfaceIndir", ptr %3409, align 8
-  %3410 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3406, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).IfaceIndir", ptr %3410, align 8
-  %3411 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3406, align 8
-  %3412 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3413 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3412, i32 0, i32 0
-  store ptr @37, ptr %3413, align 8
-  %3414 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3412, i32 0, i32 1
-  store i64 13, ptr %3414, align 4
-  %3415 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3412, align 8
-  %3416 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
-  %3417 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
-  %3418 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3419 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3418, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3415, ptr %3419, align 8
-  %3420 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3418, i32 0, i32 1
-  store ptr %3417, ptr %3420, align 8
-  %3421 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3418, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).InterfaceType", ptr %3421, align 8
-  %3422 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3418, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).InterfaceType", ptr %3422, align 8
-  %3423 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3418, align 8
-  %3424 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3425 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3424, i32 0, i32 0
-  store ptr @48, ptr %3425, align 8
-  %3426 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3424, i32 0, i32 1
-  store i64 9, ptr %3426, align 4
-  %3427 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3424, align 8
-  %3428 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %3429 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3430 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3429, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3427, ptr %3430, align 8
-  %3431 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3429, i32 0, i32 1
-  store ptr %3428, ptr %3431, align 8
-  %3432 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3429, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).IsClosure", ptr %3432, align 8
-  %3433 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3429, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).IsClosure", ptr %3433, align 8
-  %3434 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3429, align 8
-  %3435 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3436 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3435, i32 0, i32 0
-  store ptr @49, ptr %3436, align 8
-  %3437 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3435, i32 0, i32 1
-  store i64 13, ptr %3437, align 4
-  %3438 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3435, align 8
-  %3439 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %3440 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3441 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3440, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3438, ptr %3441, align 8
-  %3442 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3440, i32 0, i32 1
-  store ptr %3439, ptr %3442, align 8
-  %3443 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3440, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).IsDirectIface", ptr %3443, align 8
-  %3444 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3440, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).IsDirectIface", ptr %3444, align 8
-  %3445 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3440, align 8
-  %3446 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3447 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3446, i32 0, i32 0
-  store ptr @50, ptr %3447, align 8
-  %3448 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3446, i32 0, i32 1
-  store i64 3, ptr %3448, align 4
-  %3449 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3446, align 8
-  %3450 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
-  %3451 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
-  %3452 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3453 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3452, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3449, ptr %3453, align 8
-  %3454 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3452, i32 0, i32 1
-  store ptr %3451, ptr %3454, align 8
-  %3455 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3452, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Key", ptr %3455, align 8
-  %3456 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3452, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Key", ptr %3456, align 8
-  %3457 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3452, align 8
-  %3458 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3459 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3458, i32 0, i32 0
-  store ptr @51, ptr %3459, align 8
-  %3460 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3458, i32 0, i32 1
-  store i64 4, ptr %3460, align 4
-  %3461 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3458, align 8
-  %3462 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
-  %3463 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3464 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3463, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3461, ptr %3464, align 8
-  %3465 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3463, i32 0, i32 1
-  store ptr %3462, ptr %3465, align 8
-  %3466 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3463, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Kind", ptr %3466, align 8
-  %3467 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3463, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Kind", ptr %3467, align 8
-  %3468 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3463, align 8
-  %3469 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3470 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3469, i32 0, i32 0
-  store ptr @54, ptr %3470, align 8
-  %3471 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3469, i32 0, i32 1
-  store i64 7, ptr %3471, align 4
-  %3472 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3469, align 8
-  %3473 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
-  %3474 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
-  %3475 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3476 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3472, ptr %3476, align 8
-  %3477 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i32 0, i32 1
-  store ptr %3474, ptr %3477, align 8
-  %3478 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).MapType", ptr %3478, align 8
-  %3479 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).MapType", ptr %3479, align 8
-  %3480 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3475, align 8
-  %3481 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3482 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3481, i32 0, i32 0
-  store ptr @66, ptr %3482, align 8
-  %3483 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3481, i32 0, i32 1
-  store i64 9, ptr %3483, align 4
-  %3484 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3481, align 8
-  %3485 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %3486 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3487 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3486, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3484, ptr %3487, align 8
-  %3488 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3486, i32 0, i32 1
-  store ptr %3485, ptr %3488, align 8
-  %3489 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3486, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).NumMethod", ptr %3489, align 8
-  %3490 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3486, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).NumMethod", ptr %3490, align 8
-  %3491 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3486, align 8
-  %3492 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3493 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3492, i32 0, i32 0
-  store ptr @67, ptr %3493, align 8
-  %3494 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3492, i32 0, i32 1
-  store i64 8, ptr %3494, align 4
-  %3495 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3492, align 8
-  %3496 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
-  %3497 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3498 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3497, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3495, ptr %3498, align 8
-  %3499 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3497, i32 0, i32 1
-  store ptr %3496, ptr %3499, align 8
-  %3500 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3497, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Pointers", ptr %3500, align 8
-  %3501 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3497, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Pointers", ptr %3501, align 8
-  %3502 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3497, align 8
-  %3503 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3504 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3503, i32 0, i32 0
-  store ptr @69, ptr %3504, align 8
-  %3505 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3503, i32 0, i32 1
-  store i64 4, ptr %3505, align 4
-  %3506 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3503, align 8
-  %3507 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
-  %3508 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3509 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3508, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3506, ptr %3509, align 8
-  %3510 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3508, i32 0, i32 1
-  store ptr %3507, ptr %3510, align 8
-  %3511 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3508, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Size", ptr %3511, align 8
-  %3512 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3508, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Size", ptr %3512, align 8
-  %3513 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3508, align 8
-  %3514 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3515 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3514, i32 0, i32 0
-  store ptr @53, ptr %3515, align 8
-  %3516 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3514, i32 0, i32 1
-  store i64 6, ptr %3516, align 4
-  %3517 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3514, align 8
-  %3518 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %3519 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3520 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3519, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3517, ptr %3520, align 8
-  %3521 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3519, i32 0, i32 1
-  store ptr %3518, ptr %3521, align 8
-  %3522 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3519, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).String", ptr %3522, align 8
-  %3523 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3519, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).String", ptr %3523, align 8
-  %3524 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3519, align 8
-  %3525 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3526 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3525, i32 0, i32 0
-  store ptr @70, ptr %3526, align 8
-  %3527 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3525, i32 0, i32 1
-  store i64 10, ptr %3527, align 4
-  %3528 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3525, align 8
-  %3529 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
-  %3530 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
-  %3531 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3532 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3531, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3528, ptr %3532, align 8
-  %3533 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3531, i32 0, i32 1
-  store ptr %3530, ptr %3533, align 8
-  %3534 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3531, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).StructType", ptr %3534, align 8
-  %3535 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3531, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).StructType", ptr %3535, align 8
-  %3536 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3531, align 8
-  %3537 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3538 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3537, i32 0, i32 0
-  store ptr @80, ptr %3538, align 8
-  %3539 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3537, i32 0, i32 1
-  store i64 8, ptr %3539, align 4
-  %3540 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3537, align 8
-  %3541 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
-  %3542 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %3543 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3542, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %3540, ptr %3543, align 8
-  %3544 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3542, i32 0, i32 1
-  store ptr %3541, ptr %3544, align 8
-  %3545 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3542, i32 0, i32 2
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Uncommon", ptr %3545, align 8
-  %3546 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %3542, i32 0, i32 3
-  store ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Uncommon", ptr %3546, align 8
-  %3547 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %3542, align 8
-  %3548 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 840)
-  %3549 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3548, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %492, ptr %3549, align 8
-  %3550 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3548, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %814, ptr %3550, align 8
-  %3551 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3548, i64 2
-  store %"github.com/goplus/llgo/internal/abi.Method" %859, ptr %3551, align 8
-  %3552 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3548, i64 3
-  store %"github.com/goplus/llgo/internal/abi.Method" %888, ptr %3552, align 8
-  %3553 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3548, i64 4
-  store %"github.com/goplus/llgo/internal/abi.Method" %3366, ptr %3553, align 8
-  %3554 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3548, i64 5
-  store %"github.com/goplus/llgo/internal/abi.Method" %3377, ptr %3554, align 8
-  %3555 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3548, i64 6
-  store %"github.com/goplus/llgo/internal/abi.Method" %3389, ptr %3555, align 8
-  %3556 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3548, i64 7
-  store %"github.com/goplus/llgo/internal/abi.Method" %3400, ptr %3556, align 8
-  %3557 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3548, i64 8
-  store %"github.com/goplus/llgo/internal/abi.Method" %3411, ptr %3557, align 8
-  %3558 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3548, i64 9
-  store %"github.com/goplus/llgo/internal/abi.Method" %3423, ptr %3558, align 8
-  %3559 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3548, i64 10
-  store %"github.com/goplus/llgo/internal/abi.Method" %3434, ptr %3559, align 8
-  %3560 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3548, i64 11
-  store %"github.com/goplus/llgo/internal/abi.Method" %3445, ptr %3560, align 8
-  %3561 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3548, i64 12
-  store %"github.com/goplus/llgo/internal/abi.Method" %3457, ptr %3561, align 8
-  %3562 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3548, i64 13
-  store %"github.com/goplus/llgo/internal/abi.Method" %3468, ptr %3562, align 8
-  %3563 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3548, i64 14
-  store %"github.com/goplus/llgo/internal/abi.Method" %3480, ptr %3563, align 8
-  %3564 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3548, i64 15
-  store %"github.com/goplus/llgo/internal/abi.Method" %3491, ptr %3564, align 8
-  %3565 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3548, i64 16
-  store %"github.com/goplus/llgo/internal/abi.Method" %3502, ptr %3565, align 8
-  %3566 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3548, i64 17
-  store %"github.com/goplus/llgo/internal/abi.Method" %3513, ptr %3566, align 8
-  %3567 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3548, i64 18
-  store %"github.com/goplus/llgo/internal/abi.Method" %3524, ptr %3567, align 8
-  %3568 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3548, i64 19
-  store %"github.com/goplus/llgo/internal/abi.Method" %3536, ptr %3568, align 8
-  %3569 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %3548, i64 20
-  store %"github.com/goplus/llgo/internal/abi.Method" %3547, ptr %3569, align 8
-  %3570 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %3571 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3570, i32 0, i32 0
-  store ptr %3548, ptr %3571, align 8
-  %3572 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3570, i32 0, i32 1
-  store i64 21, ptr %3572, align 4
-  %3573 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3570, i32 0, i32 2
-  store i64 21, ptr %3573, align 4
-  %3574 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3570, align 8
-  %3575 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3576 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3575, i32 0, i32 0
-  store ptr @3, ptr %3576, align 8
-  %3577 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3575, i32 0, i32 1
-  store i64 35, ptr %3577, align 4
-  %3578 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3575, align 8
-  %3579 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3580 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3579, i32 0, i32 0
-  store ptr @19, ptr %3580, align 8
-  %3581 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3579, i32 0, i32 1
-  store i64 9, ptr %3581, align 4
-  %3582 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3579, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %405, %"github.com/goplus/llgo/internal/runtime.String" %3578, %"github.com/goplus/llgo/internal/runtime.String" %3582, ptr %481, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %3574)
+  %1499 = load ptr, ptr @"_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %1500 = load ptr, ptr @"[]_llgo_github.com/goplus/llgo/internal/abi.Method", align 8
+  %1501 = load ptr, ptr @"_llgo_func$r0w3aCNVheLGqjxncuxitGhNtWJagb9gZLqOSrNI7dg", align 8
+  %1502 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @28, i64 15 }, ptr undef, ptr undef, ptr undef }, ptr %1501, 1
+  %1503 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1502, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ExportedMethods", 2
+  %1504 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1503, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).ExportedMethods", 3
+  %1505 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %1506 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @33, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %1505, 1
+  %1507 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1506, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).FieldAlign", 2
+  %1508 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1507, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).FieldAlign", 3
+  %1509 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.FuncType", align 8
+  %1510 = load ptr, ptr @"_llgo_func$DsoxgOnxqV7tLvokF3AA14v1gtHsHaThoC8Q_XGcQww", align 8
+  %1511 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @34, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %1510, 1
+  %1512 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1511, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).FuncType", 2
+  %1513 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1512, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).FuncType", 3
+  %1514 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1515 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @35, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %1514, 1
+  %1516 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1515, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).HasName", 2
+  %1517 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1516, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).HasName", 3
+  %1518 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1519 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @36, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %1518, 1
+  %1520 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1519, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).IfaceIndir", 2
+  %1521 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1520, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).IfaceIndir", 3
+  %1522 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.InterfaceType", align 8
+  %1523 = load ptr, ptr @"_llgo_func$1QmforOaCy2fBAssC2y1FWCCT6fpq9RKwP2j2HIASY8", align 8
+  %1524 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @37, i64 13 }, ptr undef, ptr undef, ptr undef }, ptr %1523, 1
+  %1525 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1524, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).InterfaceType", 2
+  %1526 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1525, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).InterfaceType", 3
+  %1527 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1528 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @48, i64 9 }, ptr undef, ptr undef, ptr undef }, ptr %1527, 1
+  %1529 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1528, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).IsClosure", 2
+  %1530 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1529, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).IsClosure", 3
+  %1531 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1532 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @49, i64 13 }, ptr undef, ptr undef, ptr undef }, ptr %1531, 1
+  %1533 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1532, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).IsDirectIface", 2
+  %1534 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1533, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).IsDirectIface", 3
+  %1535 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.Type", align 8
+  %1536 = load ptr, ptr @"_llgo_func$4-mqItKfDlL0CgVKnUxoresYgh6zW1WSlZYZSsVzLRo", align 8
+  %1537 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @50, i64 3 }, ptr undef, ptr undef, ptr undef }, ptr %1536, 1
+  %1538 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1537, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Key", 2
+  %1539 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1538, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Key", 3
+  %1540 = load ptr, ptr @"_llgo_func$ntUE0UmVAWPS2O7GpCCGszSn-XnjHJntZZ2jYtwbFXI", align 8
+  %1541 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @51, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %1540, 1
+  %1542 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1541, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Kind", 2
+  %1543 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1542, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Kind", 3
+  %1544 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.MapType", align 8
+  %1545 = load ptr, ptr @"_llgo_func$d-NlqnjcQnaMjsBQY7qh2SWQmHb0XIigoceXdiJ8YT4", align 8
+  %1546 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @54, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %1545, 1
+  %1547 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1546, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).MapType", 2
+  %1548 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1547, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).MapType", 3
+  %1549 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %1550 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @66, i64 9 }, ptr undef, ptr undef, ptr undef }, ptr %1549, 1
+  %1551 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1550, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).NumMethod", 2
+  %1552 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1551, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).NumMethod", 3
+  %1553 = load ptr, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", align 8
+  %1554 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @67, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %1553, 1
+  %1555 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1554, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Pointers", 2
+  %1556 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1555, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Pointers", 3
+  %1557 = load ptr, ptr @"_llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s", align 8
+  %1558 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @69, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %1557, 1
+  %1559 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1558, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Size", 2
+  %1560 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1559, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Size", 3
+  %1561 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %1562 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @53, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %1561, 1
+  %1563 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1562, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).String", 2
+  %1564 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1563, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).String", 3
+  %1565 = load ptr, ptr @"*_llgo_github.com/goplus/llgo/internal/abi.StructType", align 8
+  %1566 = load ptr, ptr @"_llgo_func$qiNnn6Cbm3GtDp4gDI4U_DRV3h8zlz91s9jrfOXC--U", align 8
+  %1567 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @70, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %1566, 1
+  %1568 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1567, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).StructType", 2
+  %1569 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1568, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).StructType", 3
+  %1570 = load ptr, ptr @"_llgo_func$DbD4nZv_bjE4tH8hh-VfAjMXMpNfIsMlLJJJPKupp34", align 8
+  %1571 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @80, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %1570, 1
+  %1572 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1571, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Uncommon", 2
+  %1573 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %1572, ptr @"github.com/goplus/llgo/internal/abi.(*ArrayType).Uncommon", 3
+  %1574 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 840)
+  %1575 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %226, ptr %1575, align 8
+  %1576 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %373, ptr %1576, align 8
+  %1577 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i64 2
+  store %"github.com/goplus/llgo/internal/abi.Method" %395, ptr %1577, align 8
+  %1578 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i64 3
+  store %"github.com/goplus/llgo/internal/abi.Method" %413, ptr %1578, align 8
+  %1579 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i64 4
+  store %"github.com/goplus/llgo/internal/abi.Method" %1504, ptr %1579, align 8
+  %1580 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i64 5
+  store %"github.com/goplus/llgo/internal/abi.Method" %1508, ptr %1580, align 8
+  %1581 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i64 6
+  store %"github.com/goplus/llgo/internal/abi.Method" %1513, ptr %1581, align 8
+  %1582 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i64 7
+  store %"github.com/goplus/llgo/internal/abi.Method" %1517, ptr %1582, align 8
+  %1583 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i64 8
+  store %"github.com/goplus/llgo/internal/abi.Method" %1521, ptr %1583, align 8
+  %1584 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i64 9
+  store %"github.com/goplus/llgo/internal/abi.Method" %1526, ptr %1584, align 8
+  %1585 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i64 10
+  store %"github.com/goplus/llgo/internal/abi.Method" %1530, ptr %1585, align 8
+  %1586 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i64 11
+  store %"github.com/goplus/llgo/internal/abi.Method" %1534, ptr %1586, align 8
+  %1587 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i64 12
+  store %"github.com/goplus/llgo/internal/abi.Method" %1539, ptr %1587, align 8
+  %1588 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i64 13
+  store %"github.com/goplus/llgo/internal/abi.Method" %1543, ptr %1588, align 8
+  %1589 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i64 14
+  store %"github.com/goplus/llgo/internal/abi.Method" %1548, ptr %1589, align 8
+  %1590 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i64 15
+  store %"github.com/goplus/llgo/internal/abi.Method" %1552, ptr %1590, align 8
+  %1591 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i64 16
+  store %"github.com/goplus/llgo/internal/abi.Method" %1556, ptr %1591, align 8
+  %1592 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i64 17
+  store %"github.com/goplus/llgo/internal/abi.Method" %1560, ptr %1592, align 8
+  %1593 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i64 18
+  store %"github.com/goplus/llgo/internal/abi.Method" %1564, ptr %1593, align 8
+  %1594 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i64 19
+  store %"github.com/goplus/llgo/internal/abi.Method" %1569, ptr %1594, align 8
+  %1595 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %1574, i64 20
+  store %"github.com/goplus/llgo/internal/abi.Method" %1573, ptr %1595, align 8
+  %1596 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %1574, 0
+  %1597 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1596, i64 21, 1
+  %1598 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1597, i64 21, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %196, %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 35 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @19, i64 9 }, ptr %222, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %1598)
   br label %_llgo_42
 
 _llgo_149:                                        ; preds = %_llgo_32
-  %3583 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %368)
-  store ptr %3583, ptr @"[]_llgo_main.T", align 8
+  %1599 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %174)
+  store ptr %1599, ptr @"[]_llgo_main.T", align 8
   br label %_llgo_150
 
 _llgo_150:                                        ; preds = %_llgo_149, %_llgo_32
-  %3584 = load ptr, ptr @"[]_llgo_main.T", align 8
-  %3585 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3586 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3585, i32 0, i32 0
-  store ptr @0, ptr %3586, align 8
-  %3587 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3585, i32 0, i32 1
-  store i64 6, ptr %3587, align 4
-  %3588 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3585, align 8
-  %3589 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3588, i64 25, i64 48, i64 0, i64 0)
-  %3590 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3591 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3590, i32 0, i32 0
-  store ptr @1, ptr %3591, align 8
-  %3592 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3590, i32 0, i32 1
-  store i64 40, ptr %3592, align 4
-  %3593 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3590, align 8
-  %3594 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3593, i64 25, i64 80, i64 0, i64 23)
-  %3595 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3596 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3595, i32 0, i32 0
-  store ptr @0, ptr %3596, align 8
-  %3597 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3595, i32 0, i32 1
-  store i64 6, ptr %3597, align 4
-  %3598 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3595, align 8
-  %3599 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3598, i64 25, i64 48, i64 0, i64 0)
-  %3600 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3601 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3600, i32 0, i32 0
-  store ptr @91, ptr %3601, align 8
-  %3602 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3600, i32 0, i32 1
-  store i64 1, ptr %3602, align 4
-  %3603 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3600, align 8
-  %3604 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3605 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3604, i32 0, i32 0
-  store ptr null, ptr %3605, align 8
-  %3606 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3604, i32 0, i32 1
-  store i64 0, ptr %3606, align 4
-  %3607 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3604, align 8
-  %3608 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %3589)
-  %3609 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3603, ptr %3608, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %3607, i1 false)
-  %3610 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3611 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3610, i32 0, i32 0
-  store ptr @92, ptr %3611, align 8
-  %3612 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3610, i32 0, i32 1
-  store i64 1, ptr %3612, align 4
-  %3613 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3610, align 8
-  %3614 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3615 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3614, i32 0, i32 0
-  store ptr null, ptr %3615, align 8
-  %3616 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3614, i32 0, i32 1
-  store i64 0, ptr %3616, align 4
-  %3617 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3614, align 8
-  %3618 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %3594)
-  %3619 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3613, ptr %3618, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %3617, i1 false)
-  %3620 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3621 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3620, i32 0, i32 0
-  store ptr @93, ptr %3621, align 8
-  %3622 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3620, i32 0, i32 1
-  store i64 1, ptr %3622, align 4
-  %3623 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3620, align 8
-  %3624 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3625 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3624, i32 0, i32 0
-  store ptr null, ptr %3625, align 8
-  %3626 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3624, i32 0, i32 1
-  store i64 0, ptr %3626, align 4
-  %3627 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3624, align 8
-  %3628 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
-  %3629 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3623, ptr %3628, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %3627, i1 false)
-  %3630 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3631 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3630, i32 0, i32 0
-  store ptr @94, ptr %3631, align 8
-  %3632 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3630, i32 0, i32 1
-  store i64 1, ptr %3632, align 4
-  %3633 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3630, align 8
-  %3634 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3635 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3634, i32 0, i32 0
-  store ptr null, ptr %3635, align 8
-  %3636 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3634, i32 0, i32 1
-  store i64 0, ptr %3636, align 4
-  %3637 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3634, align 8
-  %3638 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %3599)
-  %3639 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %3633, ptr %3638, i64 24, %"github.com/goplus/llgo/internal/runtime.String" %3637, i1 false)
-  %3640 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3641 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3640, i32 0, i32 0
-  store ptr @7, ptr %3641, align 8
-  %3642 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3640, i32 0, i32 1
-  store i64 4, ptr %3642, align 4
-  %3643 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3640, align 8
-  %3644 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
-  %3645 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3644, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3609, ptr %3645, align 8
-  %3646 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3644, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3619, ptr %3646, align 8
-  %3647 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3644, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3629, ptr %3647, align 8
-  %3648 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %3644, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %3639, ptr %3648, align 8
-  %3649 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %3650 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3649, i32 0, i32 0
-  store ptr %3644, ptr %3650, align 8
-  %3651 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3649, i32 0, i32 1
-  store i64 4, ptr %3651, align 4
-  %3652 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3649, i32 0, i32 2
-  store i64 4, ptr %3652, align 4
-  %3653 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %3649, align 8
-  %3654 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %3643, i64 48, %"github.com/goplus/llgo/internal/runtime.Slice" %3653)
-  store ptr %3654, ptr @"main.struct$FYfyNCnlvkYOztpQWjt-y8D_WY3tpxyt5Qo62CJffTE", align 8
-  %3655 = load ptr, ptr @"main.struct$FYfyNCnlvkYOztpQWjt-y8D_WY3tpxyt5Qo62CJffTE", align 8
-  br i1 %6, label %_llgo_151, label %_llgo_152
+  %1600 = load ptr, ptr @"[]_llgo_main.T", align 8
+  %1601 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 6 }, i64 25, i64 48, i64 0, i64 0)
+  %1602 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 40 }, i64 25, i64 80, i64 0, i64 23)
+  %1603 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 6 }, i64 25, i64 48, i64 0, i64 0)
+  %1604 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1601)
+  %1605 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @91, i64 1 }, ptr %1604, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %1606 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %1602)
+  %1607 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @92, i64 1 }, ptr %1606, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %1608 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
+  %1609 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @93, i64 1 }, ptr %1608, i64 16, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %1610 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %1603)
+  %1611 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @94, i64 1 }, ptr %1610, i64 24, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %1612 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
+  %1613 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1612, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1605, ptr %1613, align 8
+  %1614 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1612, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1607, ptr %1614, align 8
+  %1615 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1612, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1609, ptr %1615, align 8
+  %1616 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %1612, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %1611, ptr %1616, align 8
+  %1617 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %1612, 0
+  %1618 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1617, i64 4, 1
+  %1619 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %1618, i64 4, 2
+  %1620 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 }, i64 48, %"github.com/goplus/llgo/internal/runtime.Slice" %1619)
+  store ptr %1620, ptr @"main.struct$FYfyNCnlvkYOztpQWjt-y8D_WY3tpxyt5Qo62CJffTE", align 8
+  %1621 = load ptr, ptr @"main.struct$FYfyNCnlvkYOztpQWjt-y8D_WY3tpxyt5Qo62CJffTE", align 8
+  br i1 %2, label %_llgo_151, label %_llgo_152
 
 _llgo_151:                                        ; preds = %_llgo_150
-  %3656 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3657 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3656, i32 0, i32 0
-  store ptr @7, ptr %3657, align 8
-  %3658 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3656, i32 0, i32 1
-  store i64 4, ptr %3658, align 4
-  %3659 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3656, align 8
-  %3660 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3661 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3660, i32 0, i32 0
-  store ptr @95, ptr %3661, align 8
-  %3662 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3660, i32 0, i32 1
-  store i64 1, ptr %3662, align 4
-  %3663 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3660, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %4, %"github.com/goplus/llgo/internal/runtime.String" %3659, %"github.com/goplus/llgo/internal/runtime.String" %3663, ptr %3655, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %0, %"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @95, i64 1 }, ptr %1621, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
   br label %_llgo_152
 
 _llgo_152:                                        ; preds = %_llgo_151, %_llgo_150

--- a/cl/_testrt/allocstr/out.ll
+++ b/cl/_testrt/allocstr/out.ll
@@ -10,13 +10,7 @@ source_filename = "main"
 
 define %"github.com/goplus/llgo/internal/runtime.String" @main.hello() {
 _llgo_0:
-  %0 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 0
-  store ptr @0, ptr %1, align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 1
-  store i64 12, ptr %2, align 4
-  %3 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %0, align 8
-  ret %"github.com/goplus/llgo/internal/runtime.String" %3
+  ret %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 12 }
 }
 
 define void @main.init() {

--- a/cl/_testrt/any/out.ll
+++ b/cl/_testrt/any/out.ll
@@ -28,22 +28,12 @@ _llgo_1:                                          ; preds = %_llgo_0
   ret ptr %5
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %6 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %6, i32 0, i32 0
-  store ptr @0, ptr %7, align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %6, i32 0, i32 1
-  store i64 21, ptr %8, align 4
-  %9 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %6, align 8
-  %10 = load ptr, ptr @_llgo_string, align 8
-  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %9, ptr %11, align 8
-  %12 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %12, i32 0, i32 0
-  store ptr %10, ptr %13, align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %12, i32 0, i32 1
-  store ptr %11, ptr %14, align 8
-  %15 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %12, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %15)
+  %6 = load ptr, ptr @_llgo_string, align 8
+  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 21 }, ptr %7, align 8
+  %8 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %6, 0
+  %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %8, ptr %7, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %9)
   unreachable
 }
 
@@ -61,22 +51,12 @@ _llgo_1:                                          ; preds = %_llgo_0
   ret i64 %6
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %7 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %7, i32 0, i32 0
-  store ptr @0, ptr %8, align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %7, i32 0, i32 1
-  store i64 21, ptr %9, align 4
-  %10 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %7, align 8
-  %11 = load ptr, ptr @_llgo_string, align 8
-  %12 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %10, ptr %12, align 8
-  %13 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %13, i32 0, i32 0
-  store ptr %11, ptr %14, align 8
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %13, i32 0, i32 1
-  store ptr %12, ptr %15, align 8
-  %16 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %13, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %16)
+  %7 = load ptr, ptr @_llgo_string, align 8
+  %8 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 21 }, ptr %8, align 8
+  %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %7, 0
+  %10 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %9, ptr %8, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %10)
   unreachable
 }
 
@@ -101,22 +81,14 @@ _llgo_0:
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
   %2 = load ptr, ptr @"*_llgo_int8", align 8
-  %3 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %3, i32 0, i32 0
-  store ptr %2, ptr %4, align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %3, i32 0, i32 1
-  store ptr @2, ptr %5, align 8
-  %6 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %3, align 8
-  %7 = call ptr @main.hi(%"github.com/goplus/llgo/internal/runtime.eface" %6)
-  %8 = load ptr, ptr @_llgo_int, align 8
-  %9 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %9, i32 0, i32 0
-  store ptr %8, ptr %10, align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %9, i32 0, i32 1
-  store ptr inttoptr (i64 100 to ptr), ptr %11, align 8
-  %12 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %9, align 8
-  %13 = call i64 @main.incVal(%"github.com/goplus/llgo/internal/runtime.eface" %12)
-  %14 = call i32 (ptr, ...) @printf(ptr @1, ptr %7, i64 %13)
+  %3 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %2, 0
+  %4 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %3, ptr @2, 1
+  %5 = call ptr @main.hi(%"github.com/goplus/llgo/internal/runtime.eface" %4)
+  %6 = load ptr, ptr @_llgo_int, align 8
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %6, 0
+  %8 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %7, ptr inttoptr (i64 100 to ptr), 1
+  %9 = call i64 @main.incVal(%"github.com/goplus/llgo/internal/runtime.eface" %8)
+  %10 = call i32 (ptr, ...) @printf(ptr @1, ptr %5, i64 %9)
   ret i32 0
 }
 

--- a/cl/_testrt/builtin/out.ll
+++ b/cl/_testrt/builtin/out.ll
@@ -94,41 +94,36 @@ _llgo_0:
   store i64 3, ptr %5, align 4
   %6 = getelementptr inbounds i64, ptr %2, i64 3
   store i64 4, ptr %6, align 4
-  %7 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %7, i32 0, i32 0
-  store ptr %2, ptr %8, align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %7, i32 0, i32 1
-  store i64 4, ptr %9, align 4
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %7, i32 0, i32 2
-  store i64 4, ptr %10, align 4
-  %11 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %7, align 8
-  %12 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
-  %13 = getelementptr inbounds i64, ptr %12, i64 0
-  %14 = getelementptr inbounds i64, ptr %12, i64 1
-  %15 = getelementptr inbounds i64, ptr %12, i64 2
-  %16 = getelementptr inbounds i64, ptr %12, i64 3
-  store i64 1, ptr %13, align 4
-  store i64 2, ptr %14, align 4
-  store i64 3, ptr %15, align 4
-  store i64 4, ptr %16, align 4
-  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 10)
-  %18 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %17, i64 1, i64 10, i64 0, i64 4, i64 10)
-  %19 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %11, 1
-  %20 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %11, 2
-  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %11)
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %2, 0
+  %8 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %7, i64 4, 1
+  %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %8, i64 4, 2
+  %10 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
+  %11 = getelementptr inbounds i64, ptr %10, i64 0
+  %12 = getelementptr inbounds i64, ptr %10, i64 1
+  %13 = getelementptr inbounds i64, ptr %10, i64 2
+  %14 = getelementptr inbounds i64, ptr %10, i64 3
+  store i64 1, ptr %11, align 4
+  store i64 2, ptr %12, align 4
+  store i64 3, ptr %13, align 4
+  store i64 4, ptr %14, align 4
+  %15 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 10)
+  %16 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %15, i64 1, i64 10, i64 0, i64 4, i64 10)
+  %17 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, 1
+  %18 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, 2
+  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %9)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %17)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %18)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
+  %19 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %16, 1
+  %20 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %16, 2
+  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %16)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %19)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %20)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %21 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %18, 1
-  %22 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %18, 2
-  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %18)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %21)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %22)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 4)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 4)
@@ -137,55 +132,52 @@ _llgo_0:
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 4)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %23 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
-  %24 = getelementptr inbounds i64, ptr %23, i64 0
-  store i64 1, ptr %24, align 4
-  %25 = getelementptr inbounds i64, ptr %23, i64 1
-  store i64 2, ptr %25, align 4
-  %26 = getelementptr inbounds i64, ptr %23, i64 2
-  store i64 3, ptr %26, align 4
-  %27 = getelementptr inbounds i64, ptr %23, i64 3
-  store i64 4, ptr %27, align 4
-  %28 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %29 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %28, i32 0, i32 0
-  store ptr %23, ptr %29, align 8
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %28, i32 0, i32 1
-  store i64 4, ptr %30, align 4
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %28, i32 0, i32 2
-  store i64 4, ptr %31, align 4
-  %32 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %28, align 8
-  %33 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %32, 1
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %33)
+  %21 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
+  %22 = getelementptr inbounds i64, ptr %21, i64 0
+  store i64 1, ptr %22, align 4
+  %23 = getelementptr inbounds i64, ptr %21, i64 1
+  store i64 2, ptr %23, align 4
+  %24 = getelementptr inbounds i64, ptr %21, i64 2
+  store i64 3, ptr %24, align 4
+  %25 = getelementptr inbounds i64, ptr %21, i64 3
+  store i64 4, ptr %25, align 4
+  %26 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %21, 0
+  %27 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %26, i64 4, 1
+  %28 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %27, i64 4, 2
+  %29 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %28, 1
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %29)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 4)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %34 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %11, 2
-  %35 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %11, 1
-  %36 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %11, 0
-  %37 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %36, i64 8, i64 %34, i64 1, i64 %35, i64 %34)
-  %38 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %37, 1
-  %39 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %11, 2
-  %40 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %11, 1
-  %41 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %11, 0
-  %42 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %41, i64 8, i64 %39, i64 1, i64 %40, i64 %39)
-  %43 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %42, 2
-  %44 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %11, 2
-  %45 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %11, 0
+  %30 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, 2
+  %31 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, 1
+  %32 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, 0
+  %33 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %32, i64 8, i64 %30, i64 1, i64 %31, i64 %30)
+  %34 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %33, 1
+  %35 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, 2
+  %36 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, 1
+  %37 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, 0
+  %38 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %37, i64 8, i64 %35, i64 1, i64 %36, i64 %35)
+  %39 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %38, 2
+  %40 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, 2
+  %41 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, 0
+  %42 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %41, i64 8, i64 %40, i64 1, i64 2, i64 %40)
+  %43 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %42, 1
+  %44 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, 2
+  %45 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, 0
   %46 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %45, i64 8, i64 %44, i64 1, i64 2, i64 %44)
-  %47 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %46, 1
-  %48 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %11, 2
-  %49 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %11, 0
-  %50 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %49, i64 8, i64 %48, i64 1, i64 2, i64 %48)
-  %51 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %50, 2
-  %52 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %11, 2
-  %53 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %11, 0
+  %47 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %46, 2
+  %48 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, 2
+  %49 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, 0
+  %50 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %49, i64 8, i64 %48, i64 1, i64 2, i64 2)
+  %51 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %50, 1
+  %52 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, 2
+  %53 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, 0
   %54 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %53, i64 8, i64 %52, i64 1, i64 2, i64 2)
-  %55 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %54, 1
-  %56 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %11, 2
-  %57 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %11, 0
-  %58 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %57, i64 8, i64 %56, i64 1, i64 2, i64 2)
-  %59 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %58, 2
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %38)
+  %55 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %54, 2
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %34)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %39)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %43)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
@@ -194,21 +186,23 @@ _llgo_0:
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %51)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %55)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
+  %56 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %10, i64 8, i64 4, i64 1, i64 4, i64 4)
+  %57 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %56, 1
+  %58 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %10, i64 8, i64 4, i64 1, i64 4, i64 4)
+  %59 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %58, 2
+  %60 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %10, i64 8, i64 4, i64 1, i64 2, i64 4)
+  %61 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %60, 1
+  %62 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %10, i64 8, i64 4, i64 1, i64 2, i64 4)
+  %63 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %62, 2
+  %64 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %10, i64 8, i64 4, i64 1, i64 2, i64 2)
+  %65 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %64, 1
+  %66 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %10, i64 8, i64 4, i64 1, i64 2, i64 2)
+  %67 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %66, 2
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %57)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %59)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %60 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %12, i64 8, i64 4, i64 1, i64 4, i64 4)
-  %61 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %60, 1
-  %62 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %12, i64 8, i64 4, i64 1, i64 4, i64 4)
-  %63 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %62, 2
-  %64 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %12, i64 8, i64 4, i64 1, i64 2, i64 4)
-  %65 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %64, 1
-  %66 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %12, i64 8, i64 4, i64 1, i64 2, i64 4)
-  %67 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %66, 2
-  %68 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %12, i64 8, i64 4, i64 1, i64 2, i64 2)
-  %69 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %68, 1
-  %70 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %12, i64 8, i64 4, i64 1, i64 2, i64 2)
-  %71 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %70, 2
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %61)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %63)
@@ -216,108 +210,56 @@ _llgo_0:
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %65)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %67)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
+  %68 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringSlice"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, i64 1, i64 5)
+  %69 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringSlice"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, i64 1, i64 2)
+  %70 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringSlice"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, i64 5, i64 5)
+  %71 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %70, 1
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %69)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %68)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %69)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %71)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %72 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %73 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %72, i32 0, i32 0
-  store ptr @0, ptr %73, align 8
-  %74 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %72, i32 0, i32 1
-  store i64 5, ptr %74, align 4
-  %75 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %72, align 8
-  %76 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %75, 1
-  %77 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringSlice"(%"github.com/goplus/llgo/internal/runtime.String" %75, i64 1, i64 %76)
-  %78 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %79 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %78, i32 0, i32 0
-  store ptr @0, ptr %79, align 8
-  %80 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %78, i32 0, i32 1
-  store i64 5, ptr %80, align 4
-  %81 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %78, align 8
-  %82 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringSlice"(%"github.com/goplus/llgo/internal/runtime.String" %81, i64 1, i64 2)
-  %83 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %84 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %83, i32 0, i32 0
-  store ptr @0, ptr %84, align 8
-  %85 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %83, i32 0, i32 1
-  store i64 5, ptr %85, align 4
-  %86 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %83, align 8
-  %87 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %86, 1
-  %88 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringSlice"(%"github.com/goplus/llgo/internal/runtime.String" %86, i64 5, i64 %87)
-  %89 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %88, 1
-  %90 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %91 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %90, i32 0, i32 0
-  store ptr @0, ptr %91, align 8
-  %92 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %90, i32 0, i32 1
-  store i64 5, ptr %92, align 4
-  %93 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %90, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %93)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %77)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %82)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %89)
+  %72 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
+  %73 = getelementptr inbounds i64, ptr %72, i64 0
+  store i64 5, ptr %73, align 4
+  %74 = getelementptr inbounds i64, ptr %72, i64 1
+  store i64 6, ptr %74, align 4
+  %75 = getelementptr inbounds i64, ptr %72, i64 2
+  store i64 7, ptr %75, align 4
+  %76 = getelementptr inbounds i64, ptr %72, i64 3
+  store i64 8, ptr %76, align 4
+  %77 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %72, 0
+  %78 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %77, i64 4, 1
+  %79 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %78, i64 4, 2
+  %80 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %79, 0
+  %81 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %79, 1
+  %82 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.SliceAppend"(%"github.com/goplus/llgo/internal/runtime.Slice" %9, ptr %80, i64 %81, i64 8)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %82)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %94 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
-  %95 = getelementptr inbounds i64, ptr %94, i64 0
-  store i64 5, ptr %95, align 4
-  %96 = getelementptr inbounds i64, ptr %94, i64 1
-  store i64 6, ptr %96, align 4
-  %97 = getelementptr inbounds i64, ptr %94, i64 2
-  store i64 7, ptr %97, align 4
-  %98 = getelementptr inbounds i64, ptr %94, i64 3
-  store i64 8, ptr %98, align 4
-  %99 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %100 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %99, i32 0, i32 0
-  store ptr %94, ptr %100, align 8
-  %101 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %99, i32 0, i32 1
-  store i64 4, ptr %101, align 4
-  %102 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %99, i32 0, i32 2
-  store i64 4, ptr %102, align 4
-  %103 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %99, align 8
-  %104 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %103, 0
-  %105 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %103, 1
-  %106 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.SliceAppend"(%"github.com/goplus/llgo/internal/runtime.Slice" %11, ptr %104, i64 %105, i64 8)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %106)
+  %83 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 3)
+  %84 = getelementptr inbounds i8, ptr %83, i64 0
+  store i8 97, ptr %84, align 1
+  %85 = getelementptr inbounds i8, ptr %83, i64 1
+  store i8 98, ptr %85, align 1
+  %86 = getelementptr inbounds i8, ptr %83, i64 2
+  store i8 99, ptr %86, align 1
+  %87 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %83, 0
+  %88 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %87, i64 3, 1
+  %89 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %88, i64 3, 2
+  %90 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.SliceAppend"(%"github.com/goplus/llgo/internal/runtime.Slice" %89, ptr @1, i64 3, i64 1)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %90)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %107 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 3)
-  %108 = getelementptr inbounds i8, ptr %107, i64 0
-  store i8 97, ptr %108, align 1
-  %109 = getelementptr inbounds i8, ptr %107, i64 1
-  store i8 98, ptr %109, align 1
-  %110 = getelementptr inbounds i8, ptr %107, i64 2
-  store i8 99, ptr %110, align 1
-  %111 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %112 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %111, i32 0, i32 0
-  store ptr %107, ptr %112, align 8
-  %113 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %111, i32 0, i32 1
-  store i64 3, ptr %113, align 4
-  %114 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %111, i32 0, i32 2
-  store i64 3, ptr %114, align 4
-  %115 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %111, align 8
-  %116 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %117 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %116, i32 0, i32 0
-  store ptr @1, ptr %117, align 8
-  %118 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %116, i32 0, i32 1
-  store i64 3, ptr %118, align 4
-  %119 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %116, align 8
-  %120 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %119, 0
-  %121 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %119, 1
-  %122 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.SliceAppend"(%"github.com/goplus/llgo/internal/runtime.Slice" %115, ptr %120, i64 %121, i64 1)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %122)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %123 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 16)
-  %124 = load ptr, ptr @_llgo_int, align 8
-  %125 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %126 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %125, i32 0, i32 0
-  store ptr %124, ptr %126, align 8
-  %127 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %125, i32 0, i32 1
-  store ptr inttoptr (i64 100 to ptr), ptr %127, align 8
-  %128 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %125, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %128, ptr %123, align 8
-  %129 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %123, align 8
-  %130 = ptrtoint ptr %123 to i64
+  %91 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 16)
+  %92 = load ptr, ptr @_llgo_int, align 8
+  %93 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %92, 0
+  %94 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %93, ptr inttoptr (i64 100 to ptr), 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %94, ptr %91, align 8
+  %95 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %91, align 8
+  %96 = ptrtoint ptr %91 to i64
   call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 true)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 0)
@@ -334,295 +276,169 @@ _llgo_0:
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double 1.005000e+02)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintEface"(%"github.com/goplus/llgo/internal/runtime.eface" %129)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintEface"(%"github.com/goplus/llgo/internal/runtime.eface" %95)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %123)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %91)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 %130)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 %96)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %131 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 3)
-  %132 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 8)
-  %133 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %134 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %133, i32 0, i32 0
-  store ptr %131, ptr %134, align 8
-  %135 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %133, i32 0, i32 1
-  store i64 3, ptr %135, align 4
-  %136 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %133, i32 0, i32 2
-  store i64 3, ptr %136, align 4
-  %137 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %133, align 8
-  %138 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %122, 0
-  %139 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %122, 1
-  %140 = call i64 @"github.com/goplus/llgo/internal/runtime.SliceCopy"(%"github.com/goplus/llgo/internal/runtime.Slice" %137, ptr %138, i64 %139, i64 1)
-  store i64 %140, ptr %132, align 4
-  %141 = load i64, ptr %132, align 4
-  %142 = getelementptr inbounds i8, ptr %131, i64 0
-  %143 = load i8, ptr %142, align 1
-  %144 = getelementptr inbounds i8, ptr %131, i64 1
-  %145 = load i8, ptr %144, align 1
-  %146 = getelementptr inbounds i8, ptr %131, i64 2
-  %147 = load i8, ptr %146, align 1
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %141)
+  %97 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 3)
+  %98 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 8)
+  %99 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %97, 0
+  %100 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %99, i64 3, 1
+  %101 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %100, i64 3, 2
+  %102 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %90, 0
+  %103 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %90, 1
+  %104 = call i64 @"github.com/goplus/llgo/internal/runtime.SliceCopy"(%"github.com/goplus/llgo/internal/runtime.Slice" %101, ptr %102, i64 %103, i64 1)
+  store i64 %104, ptr %98, align 4
+  %105 = load i64, ptr %98, align 4
+  %106 = getelementptr inbounds i8, ptr %97, i64 0
+  %107 = load i8, ptr %106, align 1
+  %108 = getelementptr inbounds i8, ptr %97, i64 1
+  %109 = load i8, ptr %108, align 1
+  %110 = getelementptr inbounds i8, ptr %97, i64 2
+  %111 = load i8, ptr %110, align 1
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %105)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  %148 = zext i8 %143 to i64
-  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 %148)
+  %112 = zext i8 %107 to i64
+  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 %112)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  %149 = zext i8 %145 to i64
-  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 %149)
+  %113 = zext i8 %109 to i64
+  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 %113)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  %150 = zext i8 %147 to i64
-  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 %150)
+  %114 = zext i8 %111 to i64
+  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 %114)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %151 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %131, i64 1, i64 3, i64 1, i64 3, i64 3)
-  %152 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %153 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %152, i32 0, i32 0
-  store ptr @2, ptr %153, align 8
-  %154 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %152, i32 0, i32 1
-  store i64 4, ptr %154, align 4
-  %155 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %152, align 8
-  %156 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %155, 0
-  %157 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %155, 1
-  %158 = call i64 @"github.com/goplus/llgo/internal/runtime.SliceCopy"(%"github.com/goplus/llgo/internal/runtime.Slice" %151, ptr %156, i64 %157, i64 1)
-  store i64 %158, ptr %132, align 4
-  %159 = load i64, ptr %132, align 4
-  %160 = getelementptr inbounds i8, ptr %131, i64 0
-  %161 = load i8, ptr %160, align 1
-  %162 = getelementptr inbounds i8, ptr %131, i64 1
-  %163 = load i8, ptr %162, align 1
-  %164 = getelementptr inbounds i8, ptr %131, i64 2
-  %165 = load i8, ptr %164, align 1
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %159)
+  %115 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.NewSlice3"(ptr %97, i64 1, i64 3, i64 1, i64 3, i64 3)
+  %116 = call i64 @"github.com/goplus/llgo/internal/runtime.SliceCopy"(%"github.com/goplus/llgo/internal/runtime.Slice" %115, ptr @2, i64 4, i64 1)
+  store i64 %116, ptr %98, align 4
+  %117 = load i64, ptr %98, align 4
+  %118 = getelementptr inbounds i8, ptr %97, i64 0
+  %119 = load i8, ptr %118, align 1
+  %120 = getelementptr inbounds i8, ptr %97, i64 1
+  %121 = load i8, ptr %120, align 1
+  %122 = getelementptr inbounds i8, ptr %97, i64 2
+  %123 = load i8, ptr %122, align 1
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %117)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  %166 = zext i8 %161 to i64
-  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 %166)
+  %124 = zext i8 %119 to i64
+  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 %124)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  %167 = zext i8 %163 to i64
-  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 %167)
+  %125 = zext i8 %121 to i64
+  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 %125)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  %168 = zext i8 %165 to i64
-  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 %168)
+  %126 = zext i8 %123 to i64
+  call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 %126)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %169 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %170 = getelementptr inbounds { ptr }, ptr %169, i32 0, i32 0
-  store ptr %132, ptr %170, align 8
-  %171 = alloca { ptr, ptr }, align 8
-  %172 = getelementptr inbounds { ptr, ptr }, ptr %171, i32 0, i32 0
-  store ptr @"main.main$2", ptr %172, align 8
-  %173 = getelementptr inbounds { ptr, ptr }, ptr %171, i32 0, i32 1
-  store ptr %169, ptr %173, align 8
-  %174 = load { ptr, ptr }, ptr %171, align 8
+  %127 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %128 = getelementptr inbounds { ptr }, ptr %127, i32 0, i32 0
+  store ptr %98, ptr %128, align 8
+  %129 = insertvalue { ptr, ptr } { ptr @"main.main$2", ptr undef }, ptr %127, 1
   call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr @main.demo)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr @main.demo)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr @"main.main$1")
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  %175 = extractvalue { ptr, ptr } %174, 0
-  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %175)
+  %130 = extractvalue { ptr, ptr } %129, 0
+  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %130)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %176 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %177 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %176, i32 0, i32 0
-  store ptr @3, ptr %177, align 8
-  %178 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %176, i32 0, i32 1
-  store i64 7, ptr %178, align 4
-  %179 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %176, align 8
-  %180 = call ptr @"github.com/goplus/llgo/internal/runtime.NewStringIter"(%"github.com/goplus/llgo/internal/runtime.String" %179)
+  %131 = call ptr @"github.com/goplus/llgo/internal/runtime.NewStringIter"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 7 })
   br label %_llgo_1
 
 _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-  %181 = call { i1, i64, i32 } @"github.com/goplus/llgo/internal/runtime.StringIterNext"(ptr %180)
-  %182 = extractvalue { i1, i64, i32 } %181, 0
-  br i1 %182, label %_llgo_2, label %_llgo_3
+  %132 = call { i1, i64, i32 } @"github.com/goplus/llgo/internal/runtime.StringIterNext"(ptr %131)
+  %133 = extractvalue { i1, i64, i32 } %132, 0
+  br i1 %133, label %_llgo_2, label %_llgo_3
 
 _llgo_2:                                          ; preds = %_llgo_1
-  %183 = extractvalue { i1, i64, i32 } %181, 1
-  %184 = extractvalue { i1, i64, i32 } %181, 2
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %183)
+  %134 = extractvalue { i1, i64, i32 } %132, 1
+  %135 = extractvalue { i1, i64, i32 } %132, 2
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %134)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  %185 = sext i32 %184 to i64
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %185)
+  %136 = sext i32 %135 to i64
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %136)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_1
 
 _llgo_3:                                          ; preds = %_llgo_1
-  %186 = call double @main.Inf(i64 1)
-  %187 = call double @main.Inf(i64 -1)
-  %188 = call double @main.NaN()
-  %189 = call double @main.NaN()
-  %190 = call i1 @main.IsNaN(double %189)
-  %191 = call i1 @main.IsNaN(double 1.000000e+00)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %186)
+  %137 = call double @main.Inf(i64 1)
+  %138 = call double @main.Inf(i64 -1)
+  %139 = call double @main.NaN()
+  %140 = call double @main.NaN()
+  %141 = call i1 @main.IsNaN(double %140)
+  %142 = call i1 @main.IsNaN(double 1.000000e+00)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %137)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %187)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %138)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %188)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double %139)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %190)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %141)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %191)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %142)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %192 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %193 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %192, i32 0, i32 0
-  store ptr @3, ptr %193, align 8
-  %194 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %192, i32 0, i32 1
-  store i64 7, ptr %194, align 4
-  %195 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %192, align 8
-  %196 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/internal/runtime.String" %195)
-  %197 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %198 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %197, i32 0, i32 0
-  store ptr @3, ptr %198, align 8
-  %199 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %197, i32 0, i32 1
-  store i64 7, ptr %199, align 4
-  %200 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %197, align 8
-  %201 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.StringToRunes"(%"github.com/goplus/llgo/internal/runtime.String" %200)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %196)
+  %143 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 7 })
+  %144 = call %"github.com/goplus/llgo/internal/runtime.Slice" @"github.com/goplus/llgo/internal/runtime.StringToRunes"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 7 })
+  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %143)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %201)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/internal/runtime.Slice" %144)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %202 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringFromBytes"(%"github.com/goplus/llgo/internal/runtime.Slice" %196)
-  %203 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringFromRunes"(%"github.com/goplus/llgo/internal/runtime.Slice" %201)
-  %204 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %196, 0
-  %205 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %196, 1
-  %206 = icmp sge i64 3, %205
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %206)
-  %207 = getelementptr inbounds i8, ptr %204, i64 3
-  %208 = load i8, ptr %207, align 1
-  %209 = sext i8 %208 to i32
-  %210 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringFromRune"(i32 %209)
-  %211 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %201, 0
-  %212 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %201, 1
-  %213 = icmp sge i64 0, %212
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %213)
-  %214 = getelementptr inbounds i32, ptr %211, i64 0
-  %215 = load i32, ptr %214, align 4
-  %216 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringFromRune"(i32 %215)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %202)
+  %145 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringFromBytes"(%"github.com/goplus/llgo/internal/runtime.Slice" %143)
+  %146 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringFromRunes"(%"github.com/goplus/llgo/internal/runtime.Slice" %144)
+  %147 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %143, 0
+  %148 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %143, 1
+  %149 = icmp sge i64 3, %148
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %149)
+  %150 = getelementptr inbounds i8, ptr %147, i64 3
+  %151 = load i8, ptr %150, align 1
+  %152 = sext i8 %151 to i32
+  %153 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringFromRune"(i32 %152)
+  %154 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %144, 0
+  %155 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %144, 1
+  %156 = icmp sge i64 0, %155
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %156)
+  %157 = getelementptr inbounds i32, ptr %154, i64 0
+  %158 = load i32, ptr %157, align 4
+  %159 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringFromRune"(i32 %158)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %145)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %203)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %146)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %210)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %153)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %216)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %159)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %217 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %218 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %217, i32 0, i32 0
-  store ptr @4, ptr %218, align 8
-  %219 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %217, i32 0, i32 1
-  store i64 3, ptr %219, align 4
-  %220 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %217, align 8
-  %221 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %222 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %221, i32 0, i32 0
-  store ptr @4, ptr %222, align 8
-  %223 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %221, i32 0, i32 1
-  store i64 3, ptr %223, align 4
-  %224 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %221, align 8
-  %225 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %220, %"github.com/goplus/llgo/internal/runtime.String" %224)
-  %226 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %227 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %226, i32 0, i32 0
-  store ptr @4, ptr %227, align 8
-  %228 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %226, i32 0, i32 1
-  store i64 3, ptr %228, align 4
-  %229 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %226, align 8
-  %230 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %231 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %230, i32 0, i32 0
-  store ptr @5, ptr %231, align 8
-  %232 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %230, i32 0, i32 1
-  store i64 3, ptr %232, align 4
-  %233 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %230, align 8
-  %234 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %229, %"github.com/goplus/llgo/internal/runtime.String" %233)
-  %235 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %236 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %235, i32 0, i32 0
-  store ptr @4, ptr %236, align 8
-  %237 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %235, i32 0, i32 1
-  store i64 3, ptr %237, align 4
-  %238 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %235, align 8
-  %239 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %240 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %239, i32 0, i32 0
-  store ptr @5, ptr %240, align 8
-  %241 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %239, i32 0, i32 1
-  store i64 3, ptr %241, align 4
-  %242 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %239, align 8
-  %243 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %238, %"github.com/goplus/llgo/internal/runtime.String" %242)
-  %244 = xor i1 %243, true
-  %245 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %246 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %245, i32 0, i32 0
-  store ptr @4, ptr %246, align 8
-  %247 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %245, i32 0, i32 1
-  store i64 3, ptr %247, align 4
-  %248 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %245, align 8
-  %249 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %250 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %249, i32 0, i32 0
-  store ptr @5, ptr %250, align 8
-  %251 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %249, i32 0, i32 1
-  store i64 3, ptr %251, align 4
-  %252 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %249, align 8
-  %253 = call i1 @"github.com/goplus/llgo/internal/runtime.StringLess"(%"github.com/goplus/llgo/internal/runtime.String" %248, %"github.com/goplus/llgo/internal/runtime.String" %252)
-  %254 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %255 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %254, i32 0, i32 0
-  store ptr @4, ptr %255, align 8
-  %256 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %254, i32 0, i32 1
-  store i64 3, ptr %256, align 4
-  %257 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %254, align 8
-  %258 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %259 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %258, i32 0, i32 0
-  store ptr @5, ptr %259, align 8
-  %260 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %258, i32 0, i32 1
-  store i64 3, ptr %260, align 4
-  %261 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %258, align 8
-  %262 = call i1 @"github.com/goplus/llgo/internal/runtime.StringLess"(%"github.com/goplus/llgo/internal/runtime.String" %261, %"github.com/goplus/llgo/internal/runtime.String" %257)
-  %263 = xor i1 %262, true
-  %264 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %265 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %264, i32 0, i32 0
-  store ptr @4, ptr %265, align 8
-  %266 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %264, i32 0, i32 1
-  store i64 3, ptr %266, align 4
-  %267 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %264, align 8
-  %268 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %269 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %268, i32 0, i32 0
-  store ptr @5, ptr %269, align 8
-  %270 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %268, i32 0, i32 1
-  store i64 3, ptr %270, align 4
-  %271 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %268, align 8
-  %272 = call i1 @"github.com/goplus/llgo/internal/runtime.StringLess"(%"github.com/goplus/llgo/internal/runtime.String" %271, %"github.com/goplus/llgo/internal/runtime.String" %267)
-  %273 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %274 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %273, i32 0, i32 0
-  store ptr @4, ptr %274, align 8
-  %275 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %273, i32 0, i32 1
-  store i64 3, ptr %275, align 4
-  %276 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %273, align 8
-  %277 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %278 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %277, i32 0, i32 0
-  store ptr @5, ptr %278, align 8
-  %279 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %277, i32 0, i32 1
-  store i64 3, ptr %279, align 4
-  %280 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %277, align 8
-  %281 = call i1 @"github.com/goplus/llgo/internal/runtime.StringLess"(%"github.com/goplus/llgo/internal/runtime.String" %276, %"github.com/goplus/llgo/internal/runtime.String" %280)
-  %282 = xor i1 %281, true
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %225)
+  %160 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 3 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 3 })
+  %161 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 3 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 3 })
+  %162 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 3 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 3 })
+  %163 = xor i1 %162, true
+  %164 = call i1 @"github.com/goplus/llgo/internal/runtime.StringLess"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 3 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 3 })
+  %165 = call i1 @"github.com/goplus/llgo/internal/runtime.StringLess"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 3 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 3 })
+  %166 = xor i1 %165, true
+  %167 = call i1 @"github.com/goplus/llgo/internal/runtime.StringLess"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 3 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 3 })
+  %168 = call i1 @"github.com/goplus/llgo/internal/runtime.StringLess"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 3 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 3 })
+  %169 = xor i1 %168, true
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %160)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %234)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %161)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %244)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %163)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %253)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %164)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %263)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %166)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %272)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %167)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %282)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %169)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 }
 
 define void @"main.main$1"() {
 _llgo_0:
-  %0 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 0
-  store ptr @6, ptr %1, align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 1
-  store i64 2, ptr %2, align 4
-  %3 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %0, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %3)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 2 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret void
 }

--- a/cl/_testrt/callback/out.ll
+++ b/cl/_testrt/callback/out.ll
@@ -34,20 +34,8 @@ _llgo_0:
   store ptr %1, ptr @__llgo_argv, align 8
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
-  %2 = alloca { ptr, ptr }, align 8
-  %3 = getelementptr inbounds { ptr, ptr }, ptr %2, i32 0, i32 0
-  store ptr @__llgo_stub.main.print, ptr %3, align 8
-  %4 = getelementptr inbounds { ptr, ptr }, ptr %2, i32 0, i32 1
-  store ptr null, ptr %4, align 8
-  %5 = load { ptr, ptr }, ptr %2, align 8
-  call void @main.callback(ptr @0, { ptr, ptr } %5)
-  %6 = alloca { ptr, ptr }, align 8
-  %7 = getelementptr inbounds { ptr, ptr }, ptr %6, i32 0, i32 0
-  store ptr @__llgo_stub.main.print, ptr %7, align 8
-  %8 = getelementptr inbounds { ptr, ptr }, ptr %6, i32 0, i32 1
-  store ptr null, ptr %8, align 8
-  %9 = load { ptr, ptr }, ptr %6, align 8
-  call void @main.callback(ptr @1, { ptr, ptr } %9)
+  call void @main.callback(ptr @0, { ptr, ptr } { ptr @__llgo_stub.main.print, ptr null })
+  call void @main.callback(ptr @1, { ptr, ptr } { ptr @__llgo_stub.main.print, ptr null })
   ret i32 0
 }
 

--- a/cl/_testrt/cast/out.ll
+++ b/cl/_testrt/cast/out.ll
@@ -17,22 +17,12 @@ _llgo_0:
   br i1 %3, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @0, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 5, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  %8 = load ptr, ptr @_llgo_string, align 8
-  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %7, ptr %9, align 8
-  %10 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 0
-  store ptr %8, ptr %11, align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 1
-  store ptr %9, ptr %12, align 8
-  %13 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %13)
+  %4 = load ptr, ptr @_llgo_string, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %5, align 8
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %4, 0
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %6, ptr %5, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %7)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_0
@@ -46,22 +36,12 @@ _llgo_0:
   br i1 %3, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @0, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 5, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  %8 = load ptr, ptr @_llgo_string, align 8
-  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %7, ptr %9, align 8
-  %10 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 0
-  store ptr %8, ptr %11, align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 1
-  store ptr %9, ptr %12, align 8
-  %13 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %13)
+  %4 = load ptr, ptr @_llgo_string, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %5, align 8
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %4, 0
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %6, ptr %5, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %7)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_0
@@ -75,22 +55,12 @@ _llgo_0:
   br i1 %3, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @0, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 5, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  %8 = load ptr, ptr @_llgo_string, align 8
-  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %7, ptr %9, align 8
-  %10 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 0
-  store ptr %8, ptr %11, align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 1
-  store ptr %9, ptr %12, align 8
-  %13 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %13)
+  %4 = load ptr, ptr @_llgo_string, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %5, align 8
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %4, 0
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %6, ptr %5, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %7)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_0
@@ -104,22 +74,12 @@ _llgo_0:
   br i1 %3, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @0, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 5, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  %8 = load ptr, ptr @_llgo_string, align 8
-  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %7, ptr %9, align 8
-  %10 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 0
-  store ptr %8, ptr %11, align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 1
-  store ptr %9, ptr %12, align 8
-  %13 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %13)
+  %4 = load ptr, ptr @_llgo_string, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %5, align 8
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %4, 0
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %6, ptr %5, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %7)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_0
@@ -133,22 +93,12 @@ _llgo_0:
   br i1 %3, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @0, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 5, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  %8 = load ptr, ptr @_llgo_string, align 8
-  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %7, ptr %9, align 8
-  %10 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 0
-  store ptr %8, ptr %11, align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 1
-  store ptr %9, ptr %12, align 8
-  %13 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %13)
+  %4 = load ptr, ptr @_llgo_string, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %5, align 8
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %4, 0
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %6, ptr %5, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %7)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_0
@@ -162,22 +112,12 @@ _llgo_0:
   br i1 %3, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @0, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 5, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  %8 = load ptr, ptr @_llgo_string, align 8
-  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %7, ptr %9, align 8
-  %10 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 0
-  store ptr %8, ptr %11, align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 1
-  store ptr %9, ptr %12, align 8
-  %13 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %13)
+  %4 = load ptr, ptr @_llgo_string, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %5, align 8
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %4, 0
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %6, ptr %5, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %7)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_0
@@ -191,22 +131,12 @@ _llgo_0:
   br i1 %3, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @0, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 5, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  %8 = load ptr, ptr @_llgo_string, align 8
-  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %7, ptr %9, align 8
-  %10 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 0
-  store ptr %8, ptr %11, align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 1
-  store ptr %9, ptr %12, align 8
-  %13 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %13)
+  %4 = load ptr, ptr @_llgo_string, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %5, align 8
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %4, 0
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %6, ptr %5, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %7)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_0
@@ -220,22 +150,12 @@ _llgo_0:
   br i1 %3, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @0, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 5, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  %8 = load ptr, ptr @_llgo_string, align 8
-  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %7, ptr %9, align 8
-  %10 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 0
-  store ptr %8, ptr %11, align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 1
-  store ptr %9, ptr %12, align 8
-  %13 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %13)
+  %4 = load ptr, ptr @_llgo_string, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %5, align 8
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %4, 0
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %6, ptr %5, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %7)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_0
@@ -249,22 +169,12 @@ _llgo_0:
   br i1 %3, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @0, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 5, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  %8 = load ptr, ptr @_llgo_string, align 8
-  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %7, ptr %9, align 8
-  %10 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 0
-  store ptr %8, ptr %11, align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 1
-  store ptr %9, ptr %12, align 8
-  %13 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %13)
+  %4 = load ptr, ptr @_llgo_string, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %5, align 8
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %4, 0
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %6, ptr %5, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %7)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_0
@@ -278,22 +188,12 @@ _llgo_0:
   br i1 %3, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @0, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 5, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  %8 = load ptr, ptr @_llgo_string, align 8
-  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %7, ptr %9, align 8
-  %10 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 0
-  store ptr %8, ptr %11, align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 1
-  store ptr %9, ptr %12, align 8
-  %13 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %13)
+  %4 = load ptr, ptr @_llgo_string, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %5, align 8
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %4, 0
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %6, ptr %5, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %7)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_0
@@ -307,22 +207,12 @@ _llgo_0:
   br i1 %3, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @0, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 5, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  %8 = load ptr, ptr @_llgo_string, align 8
-  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %7, ptr %9, align 8
-  %10 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 0
-  store ptr %8, ptr %11, align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 1
-  store ptr %9, ptr %12, align 8
-  %13 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %13)
+  %4 = load ptr, ptr @_llgo_string, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %5, align 8
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %4, 0
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %6, ptr %5, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %7)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_0
@@ -336,46 +226,26 @@ _llgo_0:
   br i1 %3, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @0, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 5, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  %8 = load ptr, ptr @_llgo_string, align 8
-  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %7, ptr %9, align 8
-  %10 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 0
-  store ptr %8, ptr %11, align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 1
-  store ptr %9, ptr %12, align 8
-  %13 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %13)
+  %4 = load ptr, ptr @_llgo_string, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %5, align 8
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %4, 0
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %6, ptr %5, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %7)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %14 = trunc i64 %1 to i32
-  %15 = icmp ne i32 %14, %0
-  br i1 %15, label %_llgo_3, label %_llgo_4
+  %8 = trunc i64 %1 to i32
+  %9 = icmp ne i32 %8, %0
+  br i1 %9, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %16 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %16, i32 0, i32 0
-  store ptr @0, ptr %17, align 8
-  %18 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %16, i32 0, i32 1
-  store i64 5, ptr %18, align 4
-  %19 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %16, align 8
-  %20 = load ptr, ptr @_llgo_string, align 8
-  %21 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %19, ptr %21, align 8
-  %22 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %22, i32 0, i32 0
-  store ptr %20, ptr %23, align 8
-  %24 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %22, i32 0, i32 1
-  store ptr %21, ptr %24, align 8
-  %25 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %22, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %25)
+  %10 = load ptr, ptr @_llgo_string, align 8
+  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %11, align 8
+  %12 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %10, 0
+  %13 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %12, ptr %11, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %13)
   unreachable
 
 _llgo_4:                                          ; preds = %_llgo_2

--- a/cl/_testrt/closure/out.ll
+++ b/cl/_testrt/closure/out.ll
@@ -28,25 +28,14 @@ _llgo_0:
   call void @main.init()
   call void @"main.main$1"(i64 100, i64 200)
   %2 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 16)
-  %3 = alloca { ptr, ptr }, align 8
-  %4 = getelementptr inbounds { ptr, ptr }, ptr %3, i32 0, i32 0
-  store ptr @"__llgo_stub.main.main$2", ptr %4, align 8
-  %5 = getelementptr inbounds { ptr, ptr }, ptr %3, i32 0, i32 1
-  store ptr null, ptr %5, align 8
-  %6 = load { ptr, ptr }, ptr %3, align 8
-  store { ptr, ptr } %6, ptr %2, align 8
-  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %8 = getelementptr inbounds { ptr }, ptr %7, i32 0, i32 0
-  store ptr %2, ptr %8, align 8
-  %9 = alloca { ptr, ptr }, align 8
-  %10 = getelementptr inbounds { ptr, ptr }, ptr %9, i32 0, i32 0
-  store ptr @"main.main$3", ptr %10, align 8
-  %11 = getelementptr inbounds { ptr, ptr }, ptr %9, i32 0, i32 1
-  store ptr %7, ptr %11, align 8
-  %12 = load { ptr, ptr }, ptr %9, align 8
-  %13 = extractvalue { ptr, ptr } %12, 1
-  %14 = extractvalue { ptr, ptr } %12, 0
-  call void %14(ptr %13)
+  store { ptr, ptr } { ptr @"__llgo_stub.main.main$2", ptr null }, ptr %2, align 8
+  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %4 = getelementptr inbounds { ptr }, ptr %3, i32 0, i32 0
+  store ptr %2, ptr %4, align 8
+  %5 = insertvalue { ptr, ptr } { ptr @"main.main$3", ptr undef }, ptr %3, 1
+  %6 = extractvalue { ptr, ptr } %5, 1
+  %7 = extractvalue { ptr, ptr } %5, 0
+  call void %7(ptr %6)
   ret i32 0
 }
 

--- a/cl/_testrt/closureconv/out.ll
+++ b/cl/_testrt/closureconv/out.ll
@@ -31,20 +31,15 @@ _llgo_0:
   %3 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
   %4 = getelementptr inbounds { ptr }, ptr %3, i32 0, i32 0
   store ptr %1, ptr %4, align 8
-  %5 = alloca { ptr, ptr }, align 8
-  %6 = getelementptr inbounds { ptr, ptr }, ptr %5, i32 0, i32 0
-  store ptr @"main.add$bound", ptr %6, align 8
-  %7 = getelementptr inbounds { ptr, ptr }, ptr %5, i32 0, i32 1
-  store ptr %3, ptr %7, align 8
-  %8 = load { ptr, ptr }, ptr %5, align 8
+  %5 = insertvalue { ptr, ptr } { ptr @"main.add$bound", ptr undef }, ptr %3, 1
+  %6 = getelementptr inbounds %main.Call, ptr %1, i32 0, i32 0
+  %7 = alloca %main.Func, align 8
+  store { ptr, ptr } %5, ptr %7, align 8
+  %8 = load %main.Func, ptr %7, align 8
+  store %main.Func %8, ptr %6, align 8
   %9 = getelementptr inbounds %main.Call, ptr %1, i32 0, i32 0
-  %10 = alloca %main.Func, align 8
-  store { ptr, ptr } %8, ptr %10, align 8
-  %11 = load %main.Func, ptr %10, align 8
-  store %main.Func %11, ptr %9, align 8
-  %12 = getelementptr inbounds %main.Call, ptr %1, i32 0, i32 0
-  %13 = load %main.Func, ptr %12, align 8
-  ret %main.Func %13
+  %10 = load %main.Func, ptr %9, align 8
+  ret %main.Func %10
 }
 
 define %main.Func @main.demo2() {
@@ -53,38 +48,21 @@ _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
   %2 = getelementptr inbounds { ptr }, ptr %1, i32 0, i32 0
   store ptr %0, ptr %2, align 8
-  %3 = alloca { ptr, ptr }, align 8
-  %4 = getelementptr inbounds { ptr, ptr }, ptr %3, i32 0, i32 0
-  store ptr @"main.add$bound", ptr %4, align 8
-  %5 = getelementptr inbounds { ptr, ptr }, ptr %3, i32 0, i32 1
-  store ptr %1, ptr %5, align 8
-  %6 = load { ptr, ptr }, ptr %3, align 8
-  %7 = alloca %main.Func, align 8
-  store { ptr, ptr } %6, ptr %7, align 8
-  %8 = load %main.Func, ptr %7, align 8
-  ret %main.Func %8
+  %3 = insertvalue { ptr, ptr } { ptr @"main.add$bound", ptr undef }, ptr %1, 1
+  %4 = alloca %main.Func, align 8
+  store { ptr, ptr } %3, ptr %4, align 8
+  %5 = load %main.Func, ptr %4, align 8
+  ret %main.Func %5
 }
 
 define %main.Func @main.demo3() {
 _llgo_0:
-  %0 = alloca %main.Func, align 8
-  %1 = getelementptr inbounds %main.Func, ptr %0, i32 0, i32 0
-  store ptr @__llgo_stub.main.add, ptr %1, align 8
-  %2 = getelementptr inbounds %main.Func, ptr %0, i32 0, i32 1
-  store ptr null, ptr %2, align 8
-  %3 = load %main.Func, ptr %0, align 8
-  ret %main.Func %3
+  ret %main.Func { ptr @__llgo_stub.main.add, ptr null }
 }
 
 define %main.Func @main.demo4() {
 _llgo_0:
-  %0 = alloca %main.Func, align 8
-  %1 = getelementptr inbounds %main.Func, ptr %0, i32 0, i32 0
-  store ptr @"__llgo_stub.main.demo4$1", ptr %1, align 8
-  %2 = getelementptr inbounds %main.Func, ptr %0, i32 0, i32 1
-  store ptr null, ptr %2, align 8
-  %3 = load %main.Func, ptr %0, align 8
-  ret %main.Func %3
+  ret %main.Func { ptr @"__llgo_stub.main.demo4$1", ptr null }
 }
 
 define i64 @"main.demo4$1"(i64 %0, i64 %1) {
@@ -100,16 +78,11 @@ _llgo_0:
   %2 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
   %3 = getelementptr inbounds { ptr }, ptr %2, i32 0, i32 0
   store ptr %1, ptr %3, align 8
-  %4 = alloca { ptr, ptr }, align 8
-  %5 = getelementptr inbounds { ptr, ptr }, ptr %4, i32 0, i32 0
-  store ptr @"main.demo5$1", ptr %5, align 8
-  %6 = getelementptr inbounds { ptr, ptr }, ptr %4, i32 0, i32 1
-  store ptr %2, ptr %6, align 8
-  %7 = load { ptr, ptr }, ptr %4, align 8
-  %8 = alloca %main.Func, align 8
-  store { ptr, ptr } %7, ptr %8, align 8
-  %9 = load %main.Func, ptr %8, align 8
-  ret %main.Func %9
+  %4 = insertvalue { ptr, ptr } { ptr @"main.demo5$1", ptr undef }, ptr %2, 1
+  %5 = alloca %main.Func, align 8
+  store { ptr, ptr } %4, ptr %5, align 8
+  %6 = load %main.Func, ptr %5, align 8
+  ret %main.Func %6
 }
 
 define i64 @"main.demo5$1"(ptr %0, i64 %1, i64 %2) {

--- a/cl/_testrt/closureiface/out.ll
+++ b/cl/_testrt/closureiface/out.ll
@@ -44,82 +44,53 @@ _llgo_0:
   %3 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
   %4 = getelementptr inbounds { ptr }, ptr %3, i32 0, i32 0
   store ptr %2, ptr %4, align 8
-  %5 = alloca { ptr, ptr }, align 8
-  %6 = getelementptr inbounds { ptr, ptr }, ptr %5, i32 0, i32 0
-  store ptr @"main.main$1", ptr %6, align 8
-  %7 = getelementptr inbounds { ptr, ptr }, ptr %5, i32 0, i32 1
-  store ptr %3, ptr %7, align 8
-  %8 = load { ptr, ptr }, ptr %5, align 8
-  %9 = load ptr, ptr @_llgo_Pointer, align 8
-  %10 = load ptr, ptr @_llgo_int, align 8
-  %11 = load ptr, ptr @"_llgo_func$LW7NaHY4krmx4VSCwrrjp23xg526aJ8NlR7kN98tIyE", align 8
-  %12 = load ptr, ptr @"main.struct$J4GOle3xvLePlAXZSFNKiHRJ-WQyyOMhvl8OQfxW2Q8", align 8
-  call void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr %12)
-  %13 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store { ptr, ptr } %8, ptr %13, align 8
-  %14 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %14, i32 0, i32 0
-  store ptr %12, ptr %15, align 8
-  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %14, i32 0, i32 1
-  store ptr %13, ptr %16, align 8
-  %17 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %14, align 8
-  %18 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %17, 0
-  %19 = load ptr, ptr @"main.struct$J4GOle3xvLePlAXZSFNKiHRJ-WQyyOMhvl8OQfxW2Q8", align 8
-  %20 = icmp eq ptr %18, %19
-  br i1 %20, label %_llgo_3, label %_llgo_4
+  %5 = insertvalue { ptr, ptr } { ptr @"main.main$1", ptr undef }, ptr %3, 1
+  %6 = load ptr, ptr @_llgo_Pointer, align 8
+  %7 = load ptr, ptr @_llgo_int, align 8
+  %8 = load ptr, ptr @"_llgo_func$LW7NaHY4krmx4VSCwrrjp23xg526aJ8NlR7kN98tIyE", align 8
+  %9 = load ptr, ptr @"main.struct$J4GOle3xvLePlAXZSFNKiHRJ-WQyyOMhvl8OQfxW2Q8", align 8
+  call void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr %9)
+  %10 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store { ptr, ptr } %5, ptr %10, align 8
+  %11 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %9, 0
+  %12 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %11, ptr %10, 1
+  %13 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %12, 0
+  %14 = load ptr, ptr @"main.struct$J4GOle3xvLePlAXZSFNKiHRJ-WQyyOMhvl8OQfxW2Q8", align 8
+  %15 = icmp eq ptr %13, %14
+  br i1 %15, label %_llgo_3, label %_llgo_4
 
 _llgo_1:                                          ; preds = %_llgo_5
-  %21 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %21, i32 0, i32 0
-  store ptr @3, ptr %22, align 8
-  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %21, i32 0, i32 1
-  store i64 5, ptr %23, align 4
-  %24 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %21, align 8
-  %25 = load ptr, ptr @_llgo_string, align 8
-  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %24, ptr %26, align 8
-  %27 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %28 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %27, i32 0, i32 0
-  store ptr %25, ptr %28, align 8
-  %29 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %27, i32 0, i32 1
-  store ptr %26, ptr %29, align 8
-  %30 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %27, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %30)
+  %16 = load ptr, ptr @_llgo_string, align 8
+  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 5 }, ptr %17, align 8
+  %18 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %16, 0
+  %19 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %18, ptr %17, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %19)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_5
-  %31 = extractvalue { ptr, ptr } %45, 1
-  %32 = extractvalue { ptr, ptr } %45, 0
-  %33 = call i64 %32(ptr %31, i64 100)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %33)
+  %20 = extractvalue { ptr, ptr } %28, 1
+  %21 = extractvalue { ptr, ptr } %28, 0
+  %22 = call i64 %21(ptr %20, i64 100)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %22)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 
 _llgo_3:                                          ; preds = %_llgo_0
-  %34 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %17, 1
-  %35 = load { ptr, ptr }, ptr %34, align 8
-  %36 = alloca { { ptr, ptr }, i1 }, align 8
-  %37 = getelementptr inbounds { { ptr, ptr }, i1 }, ptr %36, i32 0, i32 0
-  store { ptr, ptr } %35, ptr %37, align 8
-  %38 = getelementptr inbounds { { ptr, ptr }, i1 }, ptr %36, i32 0, i32 1
-  store i1 true, ptr %38, align 1
-  %39 = load { { ptr, ptr }, i1 }, ptr %36, align 8
+  %23 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %12, 1
+  %24 = load { ptr, ptr }, ptr %23, align 8
+  %25 = insertvalue { { ptr, ptr }, i1 } undef, { ptr, ptr } %24, 0
+  %26 = insertvalue { { ptr, ptr }, i1 } %25, i1 true, 1
   br label %_llgo_5
 
 _llgo_4:                                          ; preds = %_llgo_0
-  %40 = alloca { { ptr, ptr }, i1 }, align 8
-  %41 = getelementptr inbounds { { ptr, ptr }, i1 }, ptr %40, i32 0, i32 0
-  store { ptr, ptr } zeroinitializer, ptr %41, align 8
-  %42 = getelementptr inbounds { { ptr, ptr }, i1 }, ptr %40, i32 0, i32 1
-  store i1 false, ptr %42, align 1
-  %43 = load { { ptr, ptr }, i1 }, ptr %40, align 8
   br label %_llgo_5
 
 _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
-  %44 = phi { { ptr, ptr }, i1 } [ %39, %_llgo_3 ], [ %43, %_llgo_4 ]
-  %45 = extractvalue { { ptr, ptr }, i1 } %44, 0
-  %46 = extractvalue { { ptr, ptr }, i1 } %44, 1
-  br i1 %46, label %_llgo_2, label %_llgo_1
+  %27 = phi { { ptr, ptr }, i1 } [ %26, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
+  %28 = extractvalue { { ptr, ptr }, i1 } %27, 0
+  %29 = extractvalue { { ptr, ptr }, i1 } %27, 1
+  br i1 %29, label %_llgo_2, label %_llgo_1
 }
 
 define i64 @"main.main$1"(ptr %0, i64 %1) {
@@ -173,114 +144,59 @@ _llgo_5:                                          ; preds = %_llgo_4
   store ptr %6, ptr %12, align 8
   %13 = getelementptr ptr, ptr %11, i64 1
   store ptr %7, ptr %13, align 8
-  %14 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %14, i32 0, i32 0
-  store ptr %11, ptr %15, align 8
-  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %14, i32 0, i32 1
-  store i64 2, ptr %16, align 4
-  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %14, i32 0, i32 2
-  store i64 2, ptr %17, align 4
-  %18 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %14, align 8
-  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %20 = getelementptr ptr, ptr %19, i64 0
-  store ptr %8, ptr %20, align 8
-  %21 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, i32 0, i32 0
-  store ptr %19, ptr %22, align 8
-  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, i32 0, i32 1
-  store i64 1, ptr %23, align 4
-  %24 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, i32 0, i32 2
-  store i64 1, ptr %24, align 4
-  %25 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %21, align 8
-  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %18, %"github.com/goplus/llgo/internal/runtime.Slice" %25, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %26)
-  store ptr %26, ptr @"_llgo_func$LW7NaHY4krmx4VSCwrrjp23xg526aJ8NlR7kN98tIyE", align 8
+  %14 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %11, 0
+  %15 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %14, i64 2, 1
+  %16 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %15, i64 2, 2
+  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %18 = getelementptr ptr, ptr %17, i64 0
+  store ptr %8, ptr %18, align 8
+  %19 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %17, 0
+  %20 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %19, i64 1, 1
+  %21 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %20, i64 1, 2
+  %22 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %16, %"github.com/goplus/llgo/internal/runtime.Slice" %21, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %22)
+  store ptr %22, ptr @"_llgo_func$LW7NaHY4krmx4VSCwrrjp23xg526aJ8NlR7kN98tIyE", align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %27 = load ptr, ptr @_llgo_Pointer, align 8
-  %28 = load ptr, ptr @_llgo_int, align 8
-  %29 = load ptr, ptr @_llgo_int, align 8
-  %30 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %30, i32 0, i32 0
-  store ptr @0, ptr %31, align 8
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %30, i32 0, i32 1
-  store i64 1, ptr %32, align 4
-  %33 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %30, align 8
-  %34 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %34, i32 0, i32 0
-  store ptr null, ptr %35, align 8
-  %36 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %34, i32 0, i32 1
-  store i64 0, ptr %36, align 4
-  %37 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %34, align 8
-  %38 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %39 = getelementptr ptr, ptr %38, i64 0
-  store ptr %27, ptr %39, align 8
-  %40 = getelementptr ptr, ptr %38, i64 1
-  store ptr %28, ptr %40, align 8
-  %41 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %42 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %41, i32 0, i32 0
-  store ptr %38, ptr %42, align 8
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %41, i32 0, i32 1
-  store i64 2, ptr %43, align 4
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %41, i32 0, i32 2
-  store i64 2, ptr %44, align 4
-  %45 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %41, align 8
-  %46 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %47 = getelementptr ptr, ptr %46, i64 0
-  store ptr %29, ptr %47, align 8
-  %48 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %49 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, i32 0, i32 0
-  store ptr %46, ptr %49, align 8
-  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, i32 0, i32 1
-  store i64 1, ptr %50, align 4
-  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, i32 0, i32 2
-  store i64 1, ptr %51, align 4
-  %52 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, align 8
-  %53 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %45, %"github.com/goplus/llgo/internal/runtime.Slice" %52, i1 false)
-  %54 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %33, ptr %53, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %37, i1 false)
-  %55 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 0
-  store ptr @1, ptr %56, align 8
-  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 1
-  store i64 4, ptr %57, align 4
-  %58 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %55, align 8
-  %59 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %59, i32 0, i32 0
-  store ptr null, ptr %60, align 8
-  %61 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %59, i32 0, i32 1
-  store i64 0, ptr %61, align 4
-  %62 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %59, align 8
-  %63 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %64 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %58, ptr %63, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %62, i1 false)
-  %65 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %66 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %65, i32 0, i32 0
-  store ptr @2, ptr %66, align 8
-  %67 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %65, i32 0, i32 1
-  store i64 4, ptr %67, align 4
-  %68 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %65, align 8
-  %69 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %70 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %69, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %54, ptr %70, align 8
-  %71 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %69, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %64, ptr %71, align 8
-  %72 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %73 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %72, i32 0, i32 0
-  store ptr %69, ptr %73, align 8
-  %74 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %72, i32 0, i32 1
-  store i64 2, ptr %74, align 4
-  %75 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %72, i32 0, i32 2
-  store i64 2, ptr %75, align 4
-  %76 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %72, align 8
-  %77 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %68, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %76)
-  store ptr %77, ptr @"main.struct$J4GOle3xvLePlAXZSFNKiHRJ-WQyyOMhvl8OQfxW2Q8", align 8
-  %78 = load ptr, ptr @_llgo_string, align 8
-  %79 = icmp eq ptr %78, null
-  br i1 %79, label %_llgo_7, label %_llgo_8
+  %23 = load ptr, ptr @_llgo_Pointer, align 8
+  %24 = load ptr, ptr @_llgo_int, align 8
+  %25 = load ptr, ptr @_llgo_int, align 8
+  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %27 = getelementptr ptr, ptr %26, i64 0
+  store ptr %23, ptr %27, align 8
+  %28 = getelementptr ptr, ptr %26, i64 1
+  store ptr %24, ptr %28, align 8
+  %29 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %26, 0
+  %30 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %29, i64 2, 1
+  %31 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %30, i64 2, 2
+  %32 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %33 = getelementptr ptr, ptr %32, i64 0
+  store ptr %25, ptr %33, align 8
+  %34 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %32, 0
+  %35 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %34, i64 1, 1
+  %36 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %35, i64 1, 2
+  %37 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %31, %"github.com/goplus/llgo/internal/runtime.Slice" %36, i1 false)
+  %38 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 1 }, ptr %37, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %40 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, ptr %39, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %41 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %42 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %41, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %38, ptr %42, align 8
+  %43 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %41, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %40, ptr %43, align 8
+  %44 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %41, 0
+  %45 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %44, i64 2, 1
+  %46 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %45, i64 2, 2
+  %47 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %46)
+  store ptr %47, ptr @"main.struct$J4GOle3xvLePlAXZSFNKiHRJ-WQyyOMhvl8OQfxW2Q8", align 8
+  %48 = load ptr, ptr @_llgo_string, align 8
+  %49 = icmp eq ptr %48, null
+  br i1 %49, label %_llgo_7, label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_6
-  %80 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  store ptr %80, ptr @_llgo_string, align 8
+  %50 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  store ptr %50, ptr @_llgo_string, align 8
   br label %_llgo_8
 
 _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6

--- a/cl/_testrt/complex/out.ll
+++ b/cl/_testrt/complex/out.ll
@@ -28,61 +28,19 @@ _llgo_0:
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintFloat"(double 2.000000e+00)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %2 = alloca { double, double }, align 8
-  %3 = getelementptr inbounds { double, double }, ptr %2, i32 0, i32 0
-  store double -1.000000e+00, ptr %3, align 8
-  %4 = getelementptr inbounds { double, double }, ptr %2, i32 0, i32 1
-  store double -2.000000e+00, ptr %4, align 8
-  %5 = load { double, double }, ptr %2, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintComplex"({ double, double } %5)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintComplex"({ double, double } { double -1.000000e+00, double -2.000000e+00 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %6 = alloca { double, double }, align 8
-  %7 = getelementptr inbounds { double, double }, ptr %6, i32 0, i32 0
-  store double 4.000000e+00, ptr %7, align 8
-  %8 = getelementptr inbounds { double, double }, ptr %6, i32 0, i32 1
-  store double 6.000000e+00, ptr %8, align 8
-  %9 = load { double, double }, ptr %6, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintComplex"({ double, double } %9)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintComplex"({ double, double } { double 4.000000e+00, double 6.000000e+00 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %10 = alloca { double, double }, align 8
-  %11 = getelementptr inbounds { double, double }, ptr %10, i32 0, i32 0
-  store double -2.000000e+00, ptr %11, align 8
-  %12 = getelementptr inbounds { double, double }, ptr %10, i32 0, i32 1
-  store double -2.000000e+00, ptr %12, align 8
-  %13 = load { double, double }, ptr %10, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintComplex"({ double, double } %13)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintComplex"({ double, double } { double -2.000000e+00, double -2.000000e+00 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %14 = alloca { double, double }, align 8
-  %15 = getelementptr inbounds { double, double }, ptr %14, i32 0, i32 0
-  store double -5.000000e+00, ptr %15, align 8
-  %16 = getelementptr inbounds { double, double }, ptr %14, i32 0, i32 1
-  store double 1.000000e+01, ptr %16, align 8
-  %17 = load { double, double }, ptr %14, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintComplex"({ double, double } %17)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintComplex"({ double, double } { double -5.000000e+00, double 1.000000e+01 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %18 = alloca { double, double }, align 8
-  %19 = getelementptr inbounds { double, double }, ptr %18, i32 0, i32 0
-  store double 4.400000e-01, ptr %19, align 8
-  %20 = getelementptr inbounds { double, double }, ptr %18, i32 0, i32 1
-  store double -8.000000e-02, ptr %20, align 8
-  %21 = load { double, double }, ptr %18, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintComplex"({ double, double } %21)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintComplex"({ double, double } { double 4.400000e-01, double -8.000000e-02 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %22 = alloca { double, double }, align 8
-  %23 = getelementptr inbounds { double, double }, ptr %22, i32 0, i32 0
-  store double 0x7FF0000000000000, ptr %23, align 8
-  %24 = getelementptr inbounds { double, double }, ptr %22, i32 0, i32 1
-  store double 0x7FF0000000000000, ptr %24, align 8
-  %25 = load { double, double }, ptr %22, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintComplex"({ double, double } %25)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintComplex"({ double, double } { double 0x7FF0000000000000, double 0x7FF0000000000000 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %26 = alloca { double, double }, align 8
-  %27 = getelementptr inbounds { double, double }, ptr %26, i32 0, i32 0
-  store double 0x7FF8000000000000, ptr %27, align 8
-  %28 = getelementptr inbounds { double, double }, ptr %26, i32 0, i32 1
-  store double 0x7FF8000000000000, ptr %28, align 8
-  %29 = load { double, double }, ptr %26, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintComplex"({ double, double } %29)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintComplex"({ double, double } { double 0x7FF8000000000000, double 0x7FF8000000000000 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 true)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
@@ -92,28 +50,7 @@ _llgo_0:
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 true)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %30 = alloca { float, float }, align 8
-  %31 = getelementptr inbounds { float, float }, ptr %30, i32 0, i32 0
-  store float 1.000000e+00, ptr %31, align 4
-  %32 = getelementptr inbounds { float, float }, ptr %30, i32 0, i32 1
-  store float 2.000000e+00, ptr %32, align 4
-  %33 = load { float, float }, ptr %30, align 4
-  %34 = extractvalue { float, float } %33, 0
-  %35 = extractvalue { float, float } %33, 1
-  %36 = fpext float %34 to double
-  %37 = fpext float %35 to double
-  %38 = alloca { double, double }, align 8
-  %39 = getelementptr inbounds { double, double }, ptr %38, i32 0, i32 0
-  store double %36, ptr %39, align 8
-  %40 = getelementptr inbounds { double, double }, ptr %38, i32 0, i32 1
-  store double %37, ptr %40, align 8
-  %41 = load { double, double }, ptr %38, align 8
-  %42 = extractvalue { double, double } %41, 0
-  %43 = extractvalue { double, double } %41, 1
-  %44 = fcmp oeq double %42, 1.000000e+00
-  %45 = fcmp oeq double %43, 2.000000e+00
-  %46 = and i1 %44, %45
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %46)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 true)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 }

--- a/cl/_testrt/concat/out.ll
+++ b/cl/_testrt/concat/out.ll
@@ -15,54 +15,36 @@ source_filename = "main"
 define %"github.com/goplus/llgo/internal/runtime.String" @main.concat(%"github.com/goplus/llgo/internal/runtime.Slice" %0) {
 _llgo_0:
   %1 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %0, 1
-  %2 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 0
-  store ptr null, ptr %3, align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 1
-  store i64 0, ptr %4, align 4
-  %5 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
   br label %_llgo_1
 
 _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-  %6 = phi %"github.com/goplus/llgo/internal/runtime.String" [ %5, %_llgo_0 ], [ %17, %_llgo_2 ]
-  %7 = phi i64 [ -1, %_llgo_0 ], [ %8, %_llgo_2 ]
-  %8 = add i64 %7, 1
-  %9 = icmp slt i64 %8, %1
-  br i1 %9, label %_llgo_2, label %_llgo_3
+  %2 = phi %"github.com/goplus/llgo/internal/runtime.String" [ zeroinitializer, %_llgo_0 ], [ %13, %_llgo_2 ]
+  %3 = phi i64 [ -1, %_llgo_0 ], [ %4, %_llgo_2 ]
+  %4 = add i64 %3, 1
+  %5 = icmp slt i64 %4, %1
+  br i1 %5, label %_llgo_2, label %_llgo_3
 
 _llgo_2:                                          ; preds = %_llgo_1
-  %10 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %0, 0
-  %11 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %0, 1
-  %12 = icmp slt i64 %8, 0
-  %13 = icmp sge i64 %8, %11
-  %14 = or i1 %13, %12
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %14)
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %10, i64 %8
-  %16 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %15, align 8
-  %17 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringCat"(%"github.com/goplus/llgo/internal/runtime.String" %6, %"github.com/goplus/llgo/internal/runtime.String" %16)
+  %6 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %0, 0
+  %7 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %0, 1
+  %8 = icmp slt i64 %4, 0
+  %9 = icmp sge i64 %4, %7
+  %10 = or i1 %9, %8
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %10)
+  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %6, i64 %4
+  %12 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %11, align 8
+  %13 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringCat"(%"github.com/goplus/llgo/internal/runtime.String" %2, %"github.com/goplus/llgo/internal/runtime.String" %12)
   br label %_llgo_1
 
 _llgo_3:                                          ; preds = %_llgo_1
-  ret %"github.com/goplus/llgo/internal/runtime.String" %6
+  ret %"github.com/goplus/llgo/internal/runtime.String" %2
 }
 
 define %"github.com/goplus/llgo/internal/runtime.String" @main.info(%"github.com/goplus/llgo/internal/runtime.String" %0) {
 _llgo_0:
-  %1 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1, i32 0, i32 0
-  store ptr null, ptr %2, align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1, i32 0, i32 1
-  store i64 0, ptr %3, align 4
-  %4 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1, align 8
-  %5 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringCat"(%"github.com/goplus/llgo/internal/runtime.String" %4, %"github.com/goplus/llgo/internal/runtime.String" %0)
-  %6 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %6, i32 0, i32 0
-  store ptr @0, ptr %7, align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %6, i32 0, i32 1
-  store i64 3, ptr %8, align 4
-  %9 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %6, align 8
-  %10 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringCat"(%"github.com/goplus/llgo/internal/runtime.String" %5, %"github.com/goplus/llgo/internal/runtime.String" %9)
-  ret %"github.com/goplus/llgo/internal/runtime.String" %10
+  %1 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringCat"(%"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.String" %0)
+  %2 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringCat"(%"github.com/goplus/llgo/internal/runtime.String" %1, %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 3 })
+  ret %"github.com/goplus/llgo/internal/runtime.String" %2
 }
 
 define void @main.init() {
@@ -86,39 +68,16 @@ _llgo_0:
   call void @main.init()
   %2 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 48)
   %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i64 0
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @1, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 5, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %7, ptr %3, align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i64 1
-  %9 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %9, i32 0, i32 0
-  store ptr @2, ptr %10, align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %9, i32 0, i32 1
-  store i64 1, ptr %11, align 4
-  %12 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %9, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %12, ptr %8, align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i64 2
-  %14 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %14, i32 0, i32 0
-  store ptr @3, ptr %15, align 8
-  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %14, i32 0, i32 1
-  store i64 5, ptr %16, align 4
-  %17 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %14, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %17, ptr %13, align 8
-  %18 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %19 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %18, i32 0, i32 0
-  store ptr %2, ptr %19, align 8
-  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %18, i32 0, i32 1
-  store i64 3, ptr %20, align 4
-  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %18, i32 0, i32 2
-  store i64 3, ptr %21, align 4
-  %22 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %18, align 8
-  %23 = call %"github.com/goplus/llgo/internal/runtime.String" @main.concat(%"github.com/goplus/llgo/internal/runtime.Slice" %22)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %23)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 5 }, ptr %3, align 8
+  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i64 1
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 1 }, ptr %4, align 8
+  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i64 2
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 5 }, ptr %5, align 8
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %2, 0
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %6, i64 3, 1
+  %8 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %7, i64 3, 2
+  %9 = call %"github.com/goplus/llgo/internal/runtime.String" @main.concat(%"github.com/goplus/llgo/internal/runtime.Slice" %8)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %9)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 }

--- a/cl/_testrt/eface/out.ll
+++ b/cl/_testrt/eface/out.ll
@@ -8,7 +8,6 @@ source_filename = "main"
 %"github.com/goplus/llgo/internal/abi.UncommonType" = type { %"github.com/goplus/llgo/internal/runtime.String", i16, i16, i32 }
 %"github.com/goplus/llgo/internal/runtime.Slice" = type { ptr, i64, i64 }
 %"github.com/goplus/llgo/internal/abi.StructField" = type { %"github.com/goplus/llgo/internal/runtime.String", ptr, i64, %"github.com/goplus/llgo/internal/runtime.String", i1 }
-%"github.com/goplus/llgo/internal/abi.Method" = type { %"github.com/goplus/llgo/internal/runtime.String", ptr, ptr, ptr }
 
 @"main.init$guard" = global i1 false, align 1
 @0 = private unnamed_addr constant [6 x i8] c"invoke", align 1
@@ -45,21 +44,10 @@ source_filename = "main"
 @7 = private unnamed_addr constant [1 x i8] c"x", align 1
 @8 = private unnamed_addr constant [1 x i8] c"y", align 1
 @9 = private unnamed_addr constant [1 x i8] c"z", align 1
-@_llgo_main.T = linkonce global ptr null, align 8
-@10 = private unnamed_addr constant [6 x i8] c"main.T", align 1
-@11 = private unnamed_addr constant [6 x i8] c"Invoke", align 1
-@"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac" = linkonce global ptr null, align 8
-@12 = private unnamed_addr constant [1 x i8] c"T", align 1
 
 define void @"main.(*T).Invoke"(ptr %0) {
 _llgo_0:
-  %1 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1, i32 0, i32 0
-  store ptr @0, ptr %2, align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %1, i32 0, i32 1
-  store i64 6, ptr %3, align 4
-  %4 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %1, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %4)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 6 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret void
 }
@@ -70,13 +58,7 @@ _llgo_0:
   store %"github.com/goplus/llgo/internal/runtime.eface" %0, ptr %1, align 8
   %2 = getelementptr inbounds %main.eface, ptr %1, i32 0, i32 0
   %3 = load ptr, ptr %2, align 8
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr null, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 0, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  call void @main.dumpTyp(ptr %3, %"github.com/goplus/llgo/internal/runtime.String" %7)
+  call void @main.dumpTyp(ptr %3, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer)
   ret void
 }
 
@@ -122,51 +104,33 @@ _llgo_0:
 
 _llgo_1:                                          ; preds = %_llgo_0
   %21 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).Elem"(ptr %0)
-  %22 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %22, i32 0, i32 0
-  store ptr @1, ptr %23, align 8
-  %24 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %22, i32 0, i32 1
-  store i64 7, ptr %24, align 4
-  %25 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %22, align 8
-  %26 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringCat"(%"github.com/goplus/llgo/internal/runtime.String" %1, %"github.com/goplus/llgo/internal/runtime.String" %25)
-  call void @main.dumpTyp(ptr %21, %"github.com/goplus/llgo/internal/runtime.String" %26)
+  %22 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringCat"(%"github.com/goplus/llgo/internal/runtime.String" %1, %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 7 })
+  call void @main.dumpTyp(ptr %21, %"github.com/goplus/llgo/internal/runtime.String" %22)
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-  %27 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).Uncommon"(ptr %0)
-  %28 = icmp ne ptr %27, null
-  br i1 %28, label %_llgo_3, label %_llgo_4
+  %23 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).Uncommon"(ptr %0)
+  %24 = icmp ne ptr %23, null
+  br i1 %24, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %29 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).Uncommon"(ptr %0)
-  %30 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %30, i32 0, i32 0
-  store ptr @2, ptr %31, align 8
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %30, i32 0, i32 1
-  store i64 9, ptr %32, align 4
-  %33 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %30, align 8
-  %34 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringCat"(%"github.com/goplus/llgo/internal/runtime.String" %1, %"github.com/goplus/llgo/internal/runtime.String" %33)
-  call void @main.dumpUncommon(ptr %29, %"github.com/goplus/llgo/internal/runtime.String" %34)
-  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Type", ptr %0, i32 0, i32 10
-  %36 = load ptr, ptr %35, align 8
-  %37 = icmp ne ptr %36, null
-  br i1 %37, label %_llgo_5, label %_llgo_4
+  %25 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).Uncommon"(ptr %0)
+  %26 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringCat"(%"github.com/goplus/llgo/internal/runtime.String" %1, %"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 9 })
+  call void @main.dumpUncommon(ptr %25, %"github.com/goplus/llgo/internal/runtime.String" %26)
+  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Type", ptr %0, i32 0, i32 10
+  %28 = load ptr, ptr %27, align 8
+  %29 = icmp ne ptr %28, null
+  br i1 %29, label %_llgo_5, label %_llgo_4
 
 _llgo_4:                                          ; preds = %_llgo_5, %_llgo_3, %_llgo_2
   ret void
 
 _llgo_5:                                          ; preds = %_llgo_3
-  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Type", ptr %0, i32 0, i32 10
-  %39 = load ptr, ptr %38, align 8
-  %40 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).Uncommon"(ptr %39)
-  %41 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %42 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %41, i32 0, i32 0
-  store ptr @2, ptr %42, align 8
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %41, i32 0, i32 1
-  store i64 9, ptr %43, align 4
-  %44 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %41, align 8
-  %45 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringCat"(%"github.com/goplus/llgo/internal/runtime.String" %1, %"github.com/goplus/llgo/internal/runtime.String" %44)
-  call void @main.dumpUncommon(ptr %40, %"github.com/goplus/llgo/internal/runtime.String" %45)
+  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Type", ptr %0, i32 0, i32 10
+  %31 = load ptr, ptr %30, align 8
+  %32 = call ptr @"github.com/goplus/llgo/internal/abi.(*Type).Uncommon"(ptr %31)
+  %33 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringCat"(%"github.com/goplus/llgo/internal/runtime.String" %1, %"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 9 })
+  call void @main.dumpUncommon(ptr %32, %"github.com/goplus/llgo/internal/runtime.String" %33)
   br label %_llgo_4
 }
 
@@ -212,215 +176,108 @@ _llgo_0:
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
   %2 = load ptr, ptr @_llgo_bool, align 8
-  %3 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %3, i32 0, i32 0
-  store ptr %2, ptr %4, align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %3, i32 0, i32 1
-  store ptr inttoptr (i64 -1 to ptr), ptr %5, align 8
-  %6 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %3, align 8
-  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %6)
-  %7 = load ptr, ptr @_llgo_int, align 8
-  %8 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, i32 0, i32 0
-  store ptr %7, ptr %9, align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, i32 0, i32 1
-  store ptr null, ptr %10, align 8
-  %11 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, align 8
-  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %11)
-  %12 = load ptr, ptr @_llgo_int8, align 8
-  %13 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %13, i32 0, i32 0
-  store ptr %12, ptr %14, align 8
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %13, i32 0, i32 1
-  store ptr null, ptr %15, align 8
-  %16 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %13, align 8
+  %3 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %2, 0
+  %4 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %3, ptr inttoptr (i64 -1 to ptr), 1
+  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %4)
+  %5 = load ptr, ptr @_llgo_int, align 8
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %5, 0
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %6, ptr null, 1
+  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %7)
+  %8 = load ptr, ptr @_llgo_int8, align 8
+  %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %8, 0
+  %10 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %9, ptr null, 1
+  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %10)
+  %11 = load ptr, ptr @_llgo_int16, align 8
+  %12 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %11, 0
+  %13 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %12, ptr null, 1
+  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %13)
+  %14 = load ptr, ptr @_llgo_int32, align 8
+  %15 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %14, 0
+  %16 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %15, ptr null, 1
   call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %16)
-  %17 = load ptr, ptr @_llgo_int16, align 8
-  %18 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %19 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %18, i32 0, i32 0
-  store ptr %17, ptr %19, align 8
-  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %18, i32 0, i32 1
-  store ptr null, ptr %20, align 8
-  %21 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %18, align 8
-  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %21)
-  %22 = load ptr, ptr @_llgo_int32, align 8
-  %23 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %24 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %23, i32 0, i32 0
-  store ptr %22, ptr %24, align 8
-  %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %23, i32 0, i32 1
-  store ptr null, ptr %25, align 8
-  %26 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %23, align 8
-  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %26)
-  %27 = load ptr, ptr @_llgo_int64, align 8
-  %28 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %29 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %28, i32 0, i32 0
-  store ptr %27, ptr %29, align 8
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %28, i32 0, i32 1
-  store ptr null, ptr %30, align 8
-  %31 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %28, align 8
+  %17 = load ptr, ptr @_llgo_int64, align 8
+  %18 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %17, 0
+  %19 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %18, ptr null, 1
+  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %19)
+  %20 = load ptr, ptr @_llgo_uint, align 8
+  %21 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %20, 0
+  %22 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %21, ptr null, 1
+  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %22)
+  %23 = load ptr, ptr @_llgo_uint8, align 8
+  %24 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %23, 0
+  %25 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %24, ptr null, 1
+  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %25)
+  %26 = load ptr, ptr @_llgo_uint16, align 8
+  %27 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %26, 0
+  %28 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %27, ptr null, 1
+  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %28)
+  %29 = load ptr, ptr @_llgo_uint32, align 8
+  %30 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %29, 0
+  %31 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %30, ptr null, 1
   call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %31)
-  %32 = load ptr, ptr @_llgo_uint, align 8
-  %33 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %33, i32 0, i32 0
-  store ptr %32, ptr %34, align 8
-  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %33, i32 0, i32 1
-  store ptr null, ptr %35, align 8
-  %36 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %33, align 8
-  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %36)
-  %37 = load ptr, ptr @_llgo_uint8, align 8
-  %38 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i32 0, i32 0
-  store ptr %37, ptr %39, align 8
-  %40 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i32 0, i32 1
-  store ptr null, ptr %40, align 8
-  %41 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, align 8
-  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %41)
-  %42 = load ptr, ptr @_llgo_uint16, align 8
-  %43 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %43, i32 0, i32 0
-  store ptr %42, ptr %44, align 8
-  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %43, i32 0, i32 1
-  store ptr null, ptr %45, align 8
-  %46 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %43, align 8
-  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %46)
-  %47 = load ptr, ptr @_llgo_uint32, align 8
-  %48 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %49 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %48, i32 0, i32 0
-  store ptr %47, ptr %49, align 8
-  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %48, i32 0, i32 1
-  store ptr null, ptr %50, align 8
-  %51 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %48, align 8
-  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %51)
-  %52 = load ptr, ptr @_llgo_uint64, align 8
-  %53 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %54 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %53, i32 0, i32 0
-  store ptr %52, ptr %54, align 8
-  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %53, i32 0, i32 1
-  store ptr null, ptr %55, align 8
-  %56 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %53, align 8
+  %32 = load ptr, ptr @_llgo_uint64, align 8
+  %33 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %32, 0
+  %34 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %33, ptr null, 1
+  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %34)
+  %35 = load ptr, ptr @_llgo_uintptr, align 8
+  %36 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %35, 0
+  %37 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %36, ptr null, 1
+  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %37)
+  %38 = load ptr, ptr @_llgo_float32, align 8
+  %39 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %38, 0
+  %40 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %39, ptr null, 1
+  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %40)
+  %41 = load ptr, ptr @_llgo_float64, align 8
+  %42 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %41, 0
+  %43 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %42, ptr null, 1
+  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %43)
+  %44 = load ptr, ptr @"[10]_llgo_int", align 8
+  %45 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
+  store [10 x i64] zeroinitializer, ptr %45, align 4
+  %46 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %44, 0
+  %47 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %46, ptr %45, 1
+  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %47)
+  %48 = load ptr, ptr @_llgo_Pointer, align 8
+  %49 = load ptr, ptr @"_llgo_func$CqBkokmWG3Ia8PBDErMKLrnXwWQ3khfTBm7VXk_2y30", align 8
+  %50 = load ptr, ptr @"main.struct$hWvPvnlB9uIZSm1cMlcssbAfCpkLhNdpCzAk4conL0o", align 8
+  call void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr %50)
+  %51 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store { ptr, ptr } { ptr @"__llgo_stub.main.main$1", ptr null }, ptr %51, align 8
+  %52 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %50, 0
+  %53 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %52, ptr %51, 1
+  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %53)
+  %54 = load ptr, ptr @"*_llgo_int", align 8
+  %55 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %54, 0
+  %56 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %55, ptr null, 1
   call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %56)
-  %57 = load ptr, ptr @_llgo_uintptr, align 8
-  %58 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %59 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %58, i32 0, i32 0
-  store ptr %57, ptr %59, align 8
-  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %58, i32 0, i32 1
-  store ptr null, ptr %60, align 8
-  %61 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %58, align 8
-  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %61)
-  %62 = load ptr, ptr @_llgo_float32, align 8
-  %63 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %64 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %63, i32 0, i32 0
-  store ptr %62, ptr %64, align 8
-  %65 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %63, i32 0, i32 1
-  store ptr null, ptr %65, align 8
-  %66 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %63, align 8
-  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %66)
-  %67 = load ptr, ptr @_llgo_float64, align 8
-  %68 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %69 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i32 0, i32 0
-  store ptr %67, ptr %69, align 8
-  %70 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i32 0, i32 1
-  store ptr null, ptr %70, align 8
-  %71 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, align 8
-  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %71)
-  %72 = load ptr, ptr @"[10]_llgo_int", align 8
-  %73 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
-  store [10 x i64] zeroinitializer, ptr %73, align 4
-  %74 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %75 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %74, i32 0, i32 0
-  store ptr %72, ptr %75, align 8
-  %76 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %74, i32 0, i32 1
-  store ptr %73, ptr %76, align 8
-  %77 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %74, align 8
-  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %77)
-  %78 = alloca { ptr, ptr }, align 8
-  %79 = getelementptr inbounds { ptr, ptr }, ptr %78, i32 0, i32 0
-  store ptr @"__llgo_stub.main.main$1", ptr %79, align 8
-  %80 = getelementptr inbounds { ptr, ptr }, ptr %78, i32 0, i32 1
-  store ptr null, ptr %80, align 8
-  %81 = load { ptr, ptr }, ptr %78, align 8
-  %82 = load ptr, ptr @_llgo_Pointer, align 8
-  %83 = load ptr, ptr @"_llgo_func$CqBkokmWG3Ia8PBDErMKLrnXwWQ3khfTBm7VXk_2y30", align 8
-  %84 = load ptr, ptr @"main.struct$hWvPvnlB9uIZSm1cMlcssbAfCpkLhNdpCzAk4conL0o", align 8
-  call void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr %84)
-  %85 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store { ptr, ptr } %81, ptr %85, align 8
-  %86 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %87 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %86, i32 0, i32 0
-  store ptr %84, ptr %87, align 8
-  %88 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %86, i32 0, i32 1
-  store ptr %85, ptr %88, align 8
-  %89 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %86, align 8
-  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %89)
-  %90 = load ptr, ptr @"*_llgo_int", align 8
-  %91 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %92 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %91, i32 0, i32 0
-  store ptr %90, ptr %92, align 8
-  %93 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %91, i32 0, i32 1
-  store ptr null, ptr %93, align 8
-  %94 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %91, align 8
-  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %94)
-  %95 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 0)
-  %96 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %97 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %96, i32 0, i32 0
-  store ptr %95, ptr %97, align 8
-  %98 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %96, i32 0, i32 1
-  store i64 0, ptr %98, align 4
-  %99 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %96, i32 0, i32 2
-  store i64 0, ptr %99, align 4
-  %100 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %96, align 8
-  %101 = load ptr, ptr @"[]_llgo_int", align 8
-  %102 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  store %"github.com/goplus/llgo/internal/runtime.Slice" %100, ptr %102, align 8
-  %103 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %104 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %103, i32 0, i32 0
-  store ptr %101, ptr %104, align 8
-  %105 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %103, i32 0, i32 1
-  store ptr %102, ptr %105, align 8
-  %106 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %103, align 8
-  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %106)
-  %107 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %108 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %107, i32 0, i32 0
-  store ptr @6, ptr %108, align 8
-  %109 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %107, i32 0, i32 1
-  store i64 5, ptr %109, align 4
-  %110 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %107, align 8
-  %111 = load ptr, ptr @_llgo_string, align 8
-  %112 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %110, ptr %112, align 8
-  %113 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %114 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %113, i32 0, i32 0
-  store ptr %111, ptr %114, align 8
-  %115 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %113, i32 0, i32 1
-  store ptr %112, ptr %115, align 8
-  %116 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %113, align 8
-  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %116)
-  %117 = load ptr, ptr @"main.struct$RKbUG45GE4henGMAdmt0Rju0JptyR8NsX7IZLsOI0OM", align 8
-  %118 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  store { i8, i64, i64 } zeroinitializer, ptr %118, align 4
-  %119 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %120 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %119, i32 0, i32 0
-  store ptr %117, ptr %120, align 8
-  %121 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %119, i32 0, i32 1
-  store ptr %118, ptr %121, align 8
-  %122 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %119, align 8
-  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %122)
-  %123 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %124 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %123, i32 0, i32 0
-  store ptr null, ptr %124, align 8
-  %125 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %123, i32 0, i32 1
-  store i64 0, ptr %125, align 4
-  %126 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %123, align 8
-  %127 = load ptr, ptr @_llgo_main.T, align 8
-  %128 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %126, ptr %128, align 8
-  %129 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %130 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %129, i32 0, i32 0
-  store ptr %127, ptr %130, align 8
-  %131 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %129, i32 0, i32 1
-  store ptr %128, ptr %131, align 8
-  %132 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %129, align 8
-  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %132)
+  %57 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 0)
+  %58 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %57, 0
+  %59 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %58, i64 0, 1
+  %60 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %59, i64 0, 2
+  %61 = load ptr, ptr @"[]_llgo_int", align 8
+  %62 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  store %"github.com/goplus/llgo/internal/runtime.Slice" %60, ptr %62, align 8
+  %63 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %61, 0
+  %64 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %63, ptr %62, 1
+  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %64)
+  %65 = load ptr, ptr @_llgo_string, align 8
+  %66 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 5 }, ptr %66, align 8
+  %67 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %65, 0
+  %68 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %67, ptr %66, 1
+  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %68)
+  %69 = load ptr, ptr @"main.struct$RKbUG45GE4henGMAdmt0Rju0JptyR8NsX7IZLsOI0OM", align 8
+  %70 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  store { i8, i64, i64 } zeroinitializer, ptr %70, align 4
+  %71 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %69, 0
+  %72 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %71, ptr %70, 1
+  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %72)
+  %73 = load ptr, ptr @_llgo_string, align 8
+  %74 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, ptr %74, align 8
+  %75 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %73, 0
+  %76 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %75, ptr %74, 1
+  call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %76)
   ret i32 0
 }
 
@@ -624,291 +481,96 @@ _llgo_33:                                         ; preds = %_llgo_32
   %52 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
   %53 = getelementptr ptr, ptr %52, i64 0
   store ptr %49, ptr %53, align 8
-  %54 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %54, i32 0, i32 0
-  store ptr %52, ptr %55, align 8
-  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %54, i32 0, i32 1
-  store i64 1, ptr %56, align 4
-  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %54, i32 0, i32 2
-  store i64 1, ptr %57, align 4
-  %58 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %54, align 8
-  %59 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %60 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %61 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %60, i32 0, i32 0
-  store ptr %59, ptr %61, align 8
-  %62 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %60, i32 0, i32 1
-  store i64 0, ptr %62, align 4
-  %63 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %60, i32 0, i32 2
-  store i64 0, ptr %63, align 4
-  %64 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %60, align 8
-  %65 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %58, %"github.com/goplus/llgo/internal/runtime.Slice" %64, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %65)
-  store ptr %65, ptr @"_llgo_func$CqBkokmWG3Ia8PBDErMKLrnXwWQ3khfTBm7VXk_2y30", align 8
+  %54 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %52, 0
+  %55 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %54, i64 1, 1
+  %56 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %55, i64 1, 2
+  %57 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %58 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %57, 0
+  %59 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %58, i64 0, 1
+  %60 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %59, i64 0, 2
+  %61 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %56, %"github.com/goplus/llgo/internal/runtime.Slice" %60, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %61)
+  store ptr %61, ptr @"_llgo_func$CqBkokmWG3Ia8PBDErMKLrnXwWQ3khfTBm7VXk_2y30", align 8
   br label %_llgo_34
 
 _llgo_34:                                         ; preds = %_llgo_33, %_llgo_32
-  %66 = load ptr, ptr @_llgo_Pointer, align 8
-  %67 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %68 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %67, i32 0, i32 0
-  store ptr @3, ptr %68, align 8
-  %69 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %67, i32 0, i32 1
-  store i64 1, ptr %69, align 4
-  %70 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %67, align 8
-  %71 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %72 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %71, i32 0, i32 0
-  store ptr null, ptr %72, align 8
-  %73 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %71, i32 0, i32 1
-  store i64 0, ptr %73, align 4
-  %74 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %71, align 8
-  %75 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %76 = getelementptr ptr, ptr %75, i64 0
-  store ptr %66, ptr %76, align 8
-  %77 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %78 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %77, i32 0, i32 0
-  store ptr %75, ptr %78, align 8
-  %79 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %77, i32 0, i32 1
-  store i64 1, ptr %79, align 4
-  %80 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %77, i32 0, i32 2
-  store i64 1, ptr %80, align 4
-  %81 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %77, align 8
-  %82 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %83 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %84 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %83, i32 0, i32 0
-  store ptr %82, ptr %84, align 8
-  %85 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %83, i32 0, i32 1
-  store i64 0, ptr %85, align 4
-  %86 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %83, i32 0, i32 2
-  store i64 0, ptr %86, align 4
-  %87 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %83, align 8
-  %88 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %81, %"github.com/goplus/llgo/internal/runtime.Slice" %87, i1 false)
-  %89 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %70, ptr %88, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %74, i1 false)
-  %90 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %91 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %90, i32 0, i32 0
-  store ptr @4, ptr %91, align 8
-  %92 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %90, i32 0, i32 1
-  store i64 4, ptr %92, align 4
-  %93 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %90, align 8
-  %94 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %95 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %94, i32 0, i32 0
-  store ptr null, ptr %95, align 8
-  %96 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %94, i32 0, i32 1
-  store i64 0, ptr %96, align 4
-  %97 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %94, align 8
-  %98 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %99 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %93, ptr %98, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %97, i1 false)
-  %100 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %101 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %100, i32 0, i32 0
-  store ptr @5, ptr %101, align 8
-  %102 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %100, i32 0, i32 1
-  store i64 4, ptr %102, align 4
-  %103 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %100, align 8
-  %104 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %105 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %104, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %89, ptr %105, align 8
-  %106 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %104, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %99, ptr %106, align 8
-  %107 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %108 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %107, i32 0, i32 0
-  store ptr %104, ptr %108, align 8
-  %109 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %107, i32 0, i32 1
-  store i64 2, ptr %109, align 4
-  %110 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %107, i32 0, i32 2
-  store i64 2, ptr %110, align 4
-  %111 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %107, align 8
-  %112 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %103, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %111)
-  store ptr %112, ptr @"main.struct$hWvPvnlB9uIZSm1cMlcssbAfCpkLhNdpCzAk4conL0o", align 8
-  %113 = load ptr, ptr @"*_llgo_int", align 8
-  %114 = icmp eq ptr %113, null
-  br i1 %114, label %_llgo_35, label %_llgo_36
+  %62 = load ptr, ptr @_llgo_Pointer, align 8
+  %63 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %64 = getelementptr ptr, ptr %63, i64 0
+  store ptr %62, ptr %64, align 8
+  %65 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %63, 0
+  %66 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %65, i64 1, 1
+  %67 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %66, i64 1, 2
+  %68 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %69 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %68, 0
+  %70 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %69, i64 0, 1
+  %71 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %70, i64 0, 2
+  %72 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %67, %"github.com/goplus/llgo/internal/runtime.Slice" %71, i1 false)
+  %73 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 1 }, ptr %72, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %74 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %75 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, ptr %74, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %76 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %77 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %76, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %73, ptr %77, align 8
+  %78 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %76, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %75, ptr %78, align 8
+  %79 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %76, 0
+  %80 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %79, i64 2, 1
+  %81 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %80, i64 2, 2
+  %82 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %81)
+  store ptr %82, ptr @"main.struct$hWvPvnlB9uIZSm1cMlcssbAfCpkLhNdpCzAk4conL0o", align 8
+  %83 = load ptr, ptr @"*_llgo_int", align 8
+  %84 = icmp eq ptr %83, null
+  br i1 %84, label %_llgo_35, label %_llgo_36
 
 _llgo_35:                                         ; preds = %_llgo_34
-  %115 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %116 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %115)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %116)
-  store ptr %116, ptr @"*_llgo_int", align 8
+  %85 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %86 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %85)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %86)
+  store ptr %86, ptr @"*_llgo_int", align 8
   br label %_llgo_36
 
 _llgo_36:                                         ; preds = %_llgo_35, %_llgo_34
-  %117 = load ptr, ptr @"[]_llgo_int", align 8
-  %118 = icmp eq ptr %117, null
-  br i1 %118, label %_llgo_37, label %_llgo_38
+  %87 = load ptr, ptr @"[]_llgo_int", align 8
+  %88 = icmp eq ptr %87, null
+  br i1 %88, label %_llgo_37, label %_llgo_38
 
 _llgo_37:                                         ; preds = %_llgo_36
-  %119 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %120 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %119)
-  store ptr %120, ptr @"[]_llgo_int", align 8
+  %89 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %90 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %89)
+  store ptr %90, ptr @"[]_llgo_int", align 8
   br label %_llgo_38
 
 _llgo_38:                                         ; preds = %_llgo_37, %_llgo_36
-  %121 = load ptr, ptr @_llgo_string, align 8
-  %122 = icmp eq ptr %121, null
-  br i1 %122, label %_llgo_39, label %_llgo_40
+  %91 = load ptr, ptr @_llgo_string, align 8
+  %92 = icmp eq ptr %91, null
+  br i1 %92, label %_llgo_39, label %_llgo_40
 
 _llgo_39:                                         ; preds = %_llgo_38
-  %123 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  store ptr %123, ptr @_llgo_string, align 8
+  %93 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  store ptr %93, ptr @_llgo_string, align 8
   br label %_llgo_40
 
 _llgo_40:                                         ; preds = %_llgo_39, %_llgo_38
-  %124 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %125 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %124, i32 0, i32 0
-  store ptr @7, ptr %125, align 8
-  %126 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %124, i32 0, i32 1
-  store i64 1, ptr %126, align 4
-  %127 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %124, align 8
-  %128 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %129 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %128, i32 0, i32 0
-  store ptr null, ptr %129, align 8
-  %130 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %128, i32 0, i32 1
-  store i64 0, ptr %130, align 4
-  %131 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %128, align 8
-  %132 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 35)
-  %133 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %127, ptr %132, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %131, i1 false)
-  %134 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %135 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %134, i32 0, i32 0
-  store ptr @8, ptr %135, align 8
-  %136 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %134, i32 0, i32 1
-  store i64 1, ptr %136, align 4
-  %137 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %134, align 8
-  %138 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %139 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %138, i32 0, i32 0
-  store ptr null, ptr %139, align 8
-  %140 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %138, i32 0, i32 1
-  store i64 0, ptr %140, align 4
-  %141 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %138, align 8
-  %142 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %143 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %137, ptr %142, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %141, i1 false)
-  %144 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %145 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %144, i32 0, i32 0
-  store ptr @9, ptr %145, align 8
-  %146 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %144, i32 0, i32 1
-  store i64 1, ptr %146, align 4
-  %147 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %144, align 8
-  %148 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %149 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %148, i32 0, i32 0
-  store ptr null, ptr %149, align 8
-  %150 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %148, i32 0, i32 1
-  store i64 0, ptr %150, align 4
-  %151 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %148, align 8
-  %152 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %153 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %147, ptr %152, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %151, i1 false)
-  %154 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %155 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %154, i32 0, i32 0
-  store ptr @5, ptr %155, align 8
-  %156 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %154, i32 0, i32 1
-  store i64 4, ptr %156, align 4
-  %157 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %154, align 8
-  %158 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 168)
-  %159 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %158, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %133, ptr %159, align 8
-  %160 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %158, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %143, ptr %160, align 8
-  %161 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %158, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %153, ptr %161, align 8
-  %162 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %163 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %162, i32 0, i32 0
-  store ptr %158, ptr %163, align 8
-  %164 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %162, i32 0, i32 1
-  store i64 3, ptr %164, align 4
-  %165 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %162, i32 0, i32 2
-  store i64 3, ptr %165, align 4
-  %166 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %162, align 8
-  %167 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %157, i64 24, %"github.com/goplus/llgo/internal/runtime.Slice" %166)
-  store ptr %167, ptr @"main.struct$RKbUG45GE4henGMAdmt0Rju0JptyR8NsX7IZLsOI0OM", align 8
-  %168 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %169 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %168, i32 0, i32 0
-  store ptr @10, ptr %169, align 8
-  %170 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %168, i32 0, i32 1
-  store i64 6, ptr %170, align 4
-  %171 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %168, align 8
-  %172 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %171, i64 24, i64 16, i64 0, i64 1)
-  %173 = load ptr, ptr @_llgo_main.T, align 8
-  %174 = icmp eq ptr %173, null
-  br i1 %174, label %_llgo_41, label %_llgo_42
-
-_llgo_41:                                         ; preds = %_llgo_40
-  store ptr %172, ptr @_llgo_main.T, align 8
-  br label %_llgo_42
-
-_llgo_42:                                         ; preds = %_llgo_41, %_llgo_40
-  %175 = load ptr, ptr @_llgo_string, align 8
-  br i1 %174, label %_llgo_43, label %_llgo_44
-
-_llgo_43:                                         ; preds = %_llgo_42
-  %176 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %177 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %176, i32 0, i32 0
-  store ptr @11, ptr %177, align 8
-  %178 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %176, i32 0, i32 1
-  store i64 6, ptr %178, align 4
-  %179 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %176, align 8
-  %180 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %181 = icmp eq ptr %180, null
-  br i1 %181, label %_llgo_45, label %_llgo_46
-
-_llgo_44:                                         ; preds = %_llgo_46, %_llgo_42
+  %94 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 35)
+  %95 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 1 }, ptr %94, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %96 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %97 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 1 }, ptr %96, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %98 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %99 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 1 }, ptr %98, i64 16, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %100 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 168)
+  %101 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %100, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %95, ptr %101, align 8
+  %102 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %100, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %97, ptr %102, align 8
+  %103 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %100, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %99, ptr %103, align 8
+  %104 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %100, 0
+  %105 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %104, i64 3, 1
+  %106 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %105, i64 3, 2
+  %107 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 4 }, i64 24, %"github.com/goplus/llgo/internal/runtime.Slice" %106)
+  store ptr %107, ptr @"main.struct$RKbUG45GE4henGMAdmt0Rju0JptyR8NsX7IZLsOI0OM", align 8
   ret void
-
-_llgo_45:                                         ; preds = %_llgo_43
-  %182 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %183 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %184 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %183, i32 0, i32 0
-  store ptr %182, ptr %184, align 8
-  %185 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %183, i32 0, i32 1
-  store i64 0, ptr %185, align 4
-  %186 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %183, i32 0, i32 2
-  store i64 0, ptr %186, align 4
-  %187 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %183, align 8
-  %188 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %189 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %190 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %189, i32 0, i32 0
-  store ptr %188, ptr %190, align 8
-  %191 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %189, i32 0, i32 1
-  store i64 0, ptr %191, align 4
-  %192 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %189, i32 0, i32 2
-  store i64 0, ptr %192, align 4
-  %193 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %189, align 8
-  %194 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %187, %"github.com/goplus/llgo/internal/runtime.Slice" %193, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %194)
-  store ptr %194, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  br label %_llgo_46
-
-_llgo_46:                                         ; preds = %_llgo_45, %_llgo_43
-  %195 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %196 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %197 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %196, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %179, ptr %197, align 8
-  %198 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %196, i32 0, i32 1
-  store ptr %195, ptr %198, align 8
-  %199 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %196, i32 0, i32 2
-  store ptr @"main.(*T).Invoke", ptr %199, align 8
-  %200 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %196, i32 0, i32 3
-  store ptr @"main.(*T).Invoke", ptr %200, align 8
-  %201 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %196, align 8
-  %202 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %203 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %202, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %201, ptr %203, align 8
-  %204 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %205 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %204, i32 0, i32 0
-  store ptr %202, ptr %205, align 8
-  %206 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %204, i32 0, i32 1
-  store i64 1, ptr %206, align 4
-  %207 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %204, i32 0, i32 2
-  store i64 1, ptr %207, align 4
-  %208 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %204, align 8
-  %209 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %210 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %209, i32 0, i32 0
-  store ptr @5, ptr %210, align 8
-  %211 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %209, i32 0, i32 1
-  store i64 4, ptr %211, align 4
-  %212 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %209, align 8
-  %213 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %214 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %213, i32 0, i32 0
-  store ptr @12, ptr %214, align 8
-  %215 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %213, i32 0, i32 1
-  store i64 1, ptr %215, align 4
-  %216 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %213, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %172, %"github.com/goplus/llgo/internal/runtime.String" %212, %"github.com/goplus/llgo/internal/runtime.String" %216, ptr %175, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %208)
-  br label %_llgo_44
 }
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64)
@@ -936,7 +598,3 @@ declare void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr)
 declare ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr)
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr)
-
-declare ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String", i64, i64, i64, i64)
-
-declare void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr, %"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.String", ptr, %"github.com/goplus/llgo/internal/runtime.Slice", %"github.com/goplus/llgo/internal/runtime.Slice")

--- a/cl/_testrt/freevars/out.ll
+++ b/cl/_testrt/freevars/out.ll
@@ -27,13 +27,7 @@ _llgo_0:
   store ptr %1, ptr @__llgo_argv, align 8
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
-  %2 = alloca { ptr, ptr }, align 8
-  %3 = getelementptr inbounds { ptr, ptr }, ptr %2, i32 0, i32 0
-  store ptr @"__llgo_stub.main.main$2", ptr %3, align 8
-  %4 = getelementptr inbounds { ptr, ptr }, ptr %2, i32 0, i32 1
-  store ptr null, ptr %4, align 8
-  %5 = load { ptr, ptr }, ptr %2, align 8
-  call void @"main.main$1"({ ptr, ptr } %5)
+  call void @"main.main$1"({ ptr, ptr } { ptr @"__llgo_stub.main.main$2", ptr null })
   ret i32 0
 }
 
@@ -44,15 +38,10 @@ _llgo_0:
   %2 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
   %3 = getelementptr inbounds { ptr }, ptr %2, i32 0, i32 0
   store ptr %1, ptr %3, align 8
-  %4 = alloca { ptr, ptr }, align 8
-  %5 = getelementptr inbounds { ptr, ptr }, ptr %4, i32 0, i32 0
-  store ptr @"main.main$1$1", ptr %5, align 8
-  %6 = getelementptr inbounds { ptr, ptr }, ptr %4, i32 0, i32 1
-  store ptr %2, ptr %6, align 8
-  %7 = load { ptr, ptr }, ptr %4, align 8
-  %8 = extractvalue { ptr, ptr } %7, 1
-  %9 = extractvalue { ptr, ptr } %7, 0
-  call void %9(ptr %8, %"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
+  %4 = insertvalue { ptr, ptr } { ptr @"main.main$1$1", ptr undef }, ptr %2, 1
+  %5 = extractvalue { ptr, ptr } %4, 1
+  %6 = extractvalue { ptr, ptr } %4, 0
+  call void %6(ptr %5, %"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
   ret void
 }
 
@@ -61,37 +50,29 @@ _llgo_0:
   %2 = load { ptr }, ptr %0, align 8
   %3 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" %1)
   %4 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %1, 1
-  %5 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %5, i32 0, i32 0
-  store ptr %3, ptr %6, align 8
-  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %5, i32 0, i32 1
-  store ptr %4, ptr %7, align 8
-  %8 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %5, align 8
-  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
-  %10 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 0
-  store ptr %9, ptr %11, align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, i32 0, i32 1
-  store ptr null, ptr %12, align 8
-  %13 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %10, align 8
-  %14 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %8, %"github.com/goplus/llgo/internal/runtime.eface" %13)
-  %15 = xor i1 %14, true
-  br i1 %15, label %_llgo_1, label %_llgo_2
+  %5 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %3, 0
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %5, ptr %4, 1
+  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
+  %8 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %7, 0
+  %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %8, ptr null, 1
+  %10 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %6, %"github.com/goplus/llgo/internal/runtime.eface" %9)
+  %11 = xor i1 %10, true
+  br i1 %11, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
+  %12 = extractvalue { ptr } %2, 0
+  %13 = load { ptr, ptr }, ptr %12, align 8
+  %14 = extractvalue { ptr, ptr } %13, 1
+  %15 = extractvalue { ptr, ptr } %13, 0
+  call void %15(ptr %14, %"github.com/goplus/llgo/internal/runtime.iface" %1)
+  ret void
+
+_llgo_2:                                          ; preds = %_llgo_0
   %16 = extractvalue { ptr } %2, 0
   %17 = load { ptr, ptr }, ptr %16, align 8
   %18 = extractvalue { ptr, ptr } %17, 1
   %19 = extractvalue { ptr, ptr } %17, 0
-  call void %19(ptr %18, %"github.com/goplus/llgo/internal/runtime.iface" %1)
-  ret void
-
-_llgo_2:                                          ; preds = %_llgo_0
-  %20 = extractvalue { ptr } %2, 0
-  %21 = load { ptr, ptr }, ptr %20, align 8
-  %22 = extractvalue { ptr, ptr } %21, 1
-  %23 = extractvalue { ptr, ptr } %21, 0
-  call void %23(ptr %22, %"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
+  call void %19(ptr %18, %"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer)
   ret void
 }
 

--- a/cl/_testrt/funcdecl/out.ll
+++ b/cl/_testrt/funcdecl/out.ll
@@ -23,108 +23,74 @@ source_filename = "main"
 
 define void @main.check({ ptr, ptr } %0) {
 _llgo_0:
-  %1 = alloca { ptr, ptr }, align 8
-  %2 = getelementptr inbounds { ptr, ptr }, ptr %1, i32 0, i32 0
-  store ptr @__llgo_stub.main.demo, ptr %2, align 8
-  %3 = getelementptr inbounds { ptr, ptr }, ptr %1, i32 0, i32 1
-  store ptr null, ptr %3, align 8
-  %4 = load { ptr, ptr }, ptr %1, align 8
-  %5 = load ptr, ptr @_llgo_Pointer, align 8
-  %6 = load ptr, ptr @"_llgo_func$CqBkokmWG3Ia8PBDErMKLrnXwWQ3khfTBm7VXk_2y30", align 8
+  %1 = load ptr, ptr @_llgo_Pointer, align 8
+  %2 = load ptr, ptr @"_llgo_func$CqBkokmWG3Ia8PBDErMKLrnXwWQ3khfTBm7VXk_2y30", align 8
+  %3 = load ptr, ptr @"main.struct$hWvPvnlB9uIZSm1cMlcssbAfCpkLhNdpCzAk4conL0o", align 8
+  call void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr %3)
+  %4 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store { ptr, ptr } { ptr @__llgo_stub.main.demo, ptr null }, ptr %4, align 8
+  %5 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %3, 0
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %5, ptr %4, 1
   %7 = load ptr, ptr @"main.struct$hWvPvnlB9uIZSm1cMlcssbAfCpkLhNdpCzAk4conL0o", align 8
   call void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr %7)
   %8 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store { ptr, ptr } %4, ptr %8, align 8
-  %9 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %9, i32 0, i32 0
-  store ptr %7, ptr %10, align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %9, i32 0, i32 1
-  store ptr %8, ptr %11, align 8
-  %12 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %9, align 8
-  %13 = load ptr, ptr @"main.struct$hWvPvnlB9uIZSm1cMlcssbAfCpkLhNdpCzAk4conL0o", align 8
-  call void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr %13)
-  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store { ptr, ptr } %0, ptr %14, align 8
-  %15 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %15, i32 0, i32 0
-  store ptr %13, ptr %16, align 8
-  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %15, i32 0, i32 1
-  store ptr %14, ptr %17, align 8
-  %18 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %15, align 8
-  %19 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %12, 0
-  %20 = load ptr, ptr @"main.struct$hWvPvnlB9uIZSm1cMlcssbAfCpkLhNdpCzAk4conL0o", align 8
-  %21 = icmp eq ptr %19, %20
-  br i1 %21, label %_llgo_1, label %_llgo_2
+  store { ptr, ptr } %0, ptr %8, align 8
+  %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %7, 0
+  %10 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %9, ptr %8, 1
+  %11 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %6, 0
+  %12 = load ptr, ptr @"main.struct$hWvPvnlB9uIZSm1cMlcssbAfCpkLhNdpCzAk4conL0o", align 8
+  %13 = icmp eq ptr %11, %12
+  br i1 %13, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %22 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %12, 1
-  %23 = load { ptr, ptr }, ptr %22, align 8
-  %24 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %18, 0
-  %25 = load ptr, ptr @"main.struct$hWvPvnlB9uIZSm1cMlcssbAfCpkLhNdpCzAk4conL0o", align 8
-  %26 = icmp eq ptr %24, %25
-  br i1 %26, label %_llgo_3, label %_llgo_4
+  %14 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %6, 1
+  %15 = load { ptr, ptr }, ptr %14, align 8
+  %16 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %10, 0
+  %17 = load ptr, ptr @"main.struct$hWvPvnlB9uIZSm1cMlcssbAfCpkLhNdpCzAk4conL0o", align 8
+  %18 = icmp eq ptr %16, %17
+  br i1 %18, label %_llgo_3, label %_llgo_4
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %27 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %28 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %27, i32 0, i32 0
-  store ptr @3, ptr %28, align 8
-  %29 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %27, i32 0, i32 1
-  store i64 21, ptr %29, align 4
-  %30 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %27, align 8
-  %31 = load ptr, ptr @_llgo_string, align 8
-  %32 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %30, ptr %32, align 8
-  %33 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %33, i32 0, i32 0
-  store ptr %31, ptr %34, align 8
-  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %33, i32 0, i32 1
-  store ptr %32, ptr %35, align 8
-  %36 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %33, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %36)
+  %19 = load ptr, ptr @_llgo_string, align 8
+  %20 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 21 }, ptr %20, align 8
+  %21 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %19, 0
+  %22 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %21, ptr %20, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %22)
   unreachable
 
 _llgo_3:                                          ; preds = %_llgo_1
-  %37 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %18, 1
-  %38 = load { ptr, ptr }, ptr %37, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintEface"(%"github.com/goplus/llgo/internal/runtime.eface" %12)
+  %23 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %10, 1
+  %24 = load { ptr, ptr }, ptr %23, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintEface"(%"github.com/goplus/llgo/internal/runtime.eface" %6)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintEface"(%"github.com/goplus/llgo/internal/runtime.eface" %18)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintEface"(%"github.com/goplus/llgo/internal/runtime.eface" %10)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  %39 = extractvalue { ptr, ptr } %0, 0
-  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %39)
+  %25 = extractvalue { ptr, ptr } %0, 0
+  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %25)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  %40 = extractvalue { ptr, ptr } %23, 0
-  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %40)
+  %26 = extractvalue { ptr, ptr } %15, 0
+  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %26)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  %41 = extractvalue { ptr, ptr } %38, 0
-  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %41)
+  %27 = extractvalue { ptr, ptr } %24, 0
+  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %27)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr @main.demo)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %42 = call ptr @main.closurePtr(%"github.com/goplus/llgo/internal/runtime.eface" %12)
-  %43 = call ptr @main.closurePtr(%"github.com/goplus/llgo/internal/runtime.eface" %18)
-  %44 = icmp eq ptr %42, %43
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %44)
+  %28 = call ptr @main.closurePtr(%"github.com/goplus/llgo/internal/runtime.eface" %6)
+  %29 = call ptr @main.closurePtr(%"github.com/goplus/llgo/internal/runtime.eface" %10)
+  %30 = icmp eq ptr %28, %29
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %30)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret void
 
 _llgo_4:                                          ; preds = %_llgo_1
-  %45 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %46 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %45, i32 0, i32 0
-  store ptr @3, ptr %46, align 8
-  %47 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %45, i32 0, i32 1
-  store i64 21, ptr %47, align 4
-  %48 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %45, align 8
-  %49 = load ptr, ptr @_llgo_string, align 8
-  %50 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %48, ptr %50, align 8
-  %51 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %52 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %51, i32 0, i32 0
-  store ptr %49, ptr %52, align 8
-  %53 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %51, i32 0, i32 1
-  store ptr %50, ptr %53, align 8
-  %54 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %51, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %54)
+  %31 = load ptr, ptr @_llgo_string, align 8
+  %32 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 21 }, ptr %32, align 8
+  %33 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %31, 0
+  %34 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %33, ptr %32, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %34)
   unreachable
 }
 
@@ -141,13 +107,7 @@ _llgo_0:
 
 define void @main.demo() {
 _llgo_0:
-  %0 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 0
-  store ptr @4, ptr %1, align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 1
-  store i64 4, ptr %2, align 4
-  %3 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %0, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %3)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret void
 }
@@ -172,21 +132,9 @@ _llgo_0:
   store ptr %1, ptr @__llgo_argv, align 8
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
-  %2 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 0
-  store ptr @5, ptr %3, align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 1
-  store i64 5, ptr %4, align 4
-  %5 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %5)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 5 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %6 = alloca { ptr, ptr }, align 8
-  %7 = getelementptr inbounds { ptr, ptr }, ptr %6, i32 0, i32 0
-  store ptr @__llgo_stub.main.demo, ptr %7, align 8
-  %8 = getelementptr inbounds { ptr, ptr }, ptr %6, i32 0, i32 1
-  store ptr null, ptr %8, align 8
-  %9 = load { ptr, ptr }, ptr %6, align 8
-  call void @main.check({ ptr, ptr } %9)
+  call void @main.check({ ptr, ptr } { ptr @__llgo_stub.main.demo, ptr null })
   ret i32 0
 }
 
@@ -218,106 +166,51 @@ _llgo_3:                                          ; preds = %_llgo_2
   %6 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
   %7 = getelementptr ptr, ptr %6, i64 0
   store ptr %3, ptr %7, align 8
-  %8 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %8, i32 0, i32 0
-  store ptr %6, ptr %9, align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %8, i32 0, i32 1
-  store i64 1, ptr %10, align 4
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %8, i32 0, i32 2
-  store i64 1, ptr %11, align 4
-  %12 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %8, align 8
-  %13 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %14 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %14, i32 0, i32 0
-  store ptr %13, ptr %15, align 8
-  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %14, i32 0, i32 1
-  store i64 0, ptr %16, align 4
-  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %14, i32 0, i32 2
-  store i64 0, ptr %17, align 4
-  %18 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %14, align 8
-  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %12, %"github.com/goplus/llgo/internal/runtime.Slice" %18, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %19)
-  store ptr %19, ptr @"_llgo_func$CqBkokmWG3Ia8PBDErMKLrnXwWQ3khfTBm7VXk_2y30", align 8
+  %8 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %6, 0
+  %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %8, i64 1, 1
+  %10 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, i64 1, 2
+  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %12 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %11, 0
+  %13 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %12, i64 0, 1
+  %14 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %13, i64 0, 2
+  %15 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %10, %"github.com/goplus/llgo/internal/runtime.Slice" %14, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %15)
+  store ptr %15, ptr @"_llgo_func$CqBkokmWG3Ia8PBDErMKLrnXwWQ3khfTBm7VXk_2y30", align 8
   br label %_llgo_4
 
 _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
-  %20 = load ptr, ptr @_llgo_Pointer, align 8
-  %21 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %21, i32 0, i32 0
-  store ptr @0, ptr %22, align 8
-  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %21, i32 0, i32 1
-  store i64 1, ptr %23, align 4
-  %24 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %21, align 8
-  %25 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 0
-  store ptr null, ptr %26, align 8
-  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 1
-  store i64 0, ptr %27, align 4
-  %28 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %25, align 8
-  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %30 = getelementptr ptr, ptr %29, i64 0
-  store ptr %20, ptr %30, align 8
-  %31 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %31, i32 0, i32 0
-  store ptr %29, ptr %32, align 8
-  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %31, i32 0, i32 1
-  store i64 1, ptr %33, align 4
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %31, i32 0, i32 2
-  store i64 1, ptr %34, align 4
-  %35 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %31, align 8
-  %36 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %37 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %37, i32 0, i32 0
-  store ptr %36, ptr %38, align 8
-  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %37, i32 0, i32 1
-  store i64 0, ptr %39, align 4
-  %40 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %37, i32 0, i32 2
-  store i64 0, ptr %40, align 4
-  %41 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %37, align 8
-  %42 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %35, %"github.com/goplus/llgo/internal/runtime.Slice" %41, i1 false)
-  %43 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %24, ptr %42, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %28, i1 false)
-  %44 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %44, i32 0, i32 0
-  store ptr @1, ptr %45, align 8
-  %46 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %44, i32 0, i32 1
-  store i64 4, ptr %46, align 4
-  %47 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %44, align 8
-  %48 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %49 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %48, i32 0, i32 0
-  store ptr null, ptr %49, align 8
-  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %48, i32 0, i32 1
-  store i64 0, ptr %50, align 4
-  %51 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %48, align 8
-  %52 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %53 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %47, ptr %52, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %51, i1 false)
-  %54 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %54, i32 0, i32 0
-  store ptr @2, ptr %55, align 8
-  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %54, i32 0, i32 1
-  store i64 4, ptr %56, align 4
-  %57 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %54, align 8
-  %58 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %59 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %58, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %43, ptr %59, align 8
-  %60 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %58, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %53, ptr %60, align 8
-  %61 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %62 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %61, i32 0, i32 0
-  store ptr %58, ptr %62, align 8
-  %63 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %61, i32 0, i32 1
-  store i64 2, ptr %63, align 4
-  %64 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %61, i32 0, i32 2
-  store i64 2, ptr %64, align 4
-  %65 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %61, align 8
-  %66 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %57, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %65)
-  store ptr %66, ptr @"main.struct$hWvPvnlB9uIZSm1cMlcssbAfCpkLhNdpCzAk4conL0o", align 8
-  %67 = load ptr, ptr @_llgo_string, align 8
-  %68 = icmp eq ptr %67, null
-  br i1 %68, label %_llgo_5, label %_llgo_6
+  %16 = load ptr, ptr @_llgo_Pointer, align 8
+  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %18 = getelementptr ptr, ptr %17, i64 0
+  store ptr %16, ptr %18, align 8
+  %19 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %17, 0
+  %20 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %19, i64 1, 1
+  %21 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %20, i64 1, 2
+  %22 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %23 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %22, 0
+  %24 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %23, i64 0, 1
+  %25 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %24, i64 0, 2
+  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %21, %"github.com/goplus/llgo/internal/runtime.Slice" %25, i1 false)
+  %27 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 1 }, ptr %26, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %28 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %29 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, ptr %28, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %31 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %30, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %27, ptr %31, align 8
+  %32 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %30, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %29, ptr %32, align 8
+  %33 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %30, 0
+  %34 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %33, i64 2, 1
+  %35 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %34, i64 2, 2
+  %36 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %35)
+  store ptr %36, ptr @"main.struct$hWvPvnlB9uIZSm1cMlcssbAfCpkLhNdpCzAk4conL0o", align 8
+  %37 = load ptr, ptr @_llgo_string, align 8
+  %38 = icmp eq ptr %37, null
+  br i1 %38, label %_llgo_5, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_4
-  %69 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  store ptr %69, ptr @_llgo_string, align 8
+  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  store ptr %39, ptr @_llgo_string, align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4

--- a/cl/_testrt/index/out.ll
+++ b/cl/_testrt/index/out.ll
@@ -103,71 +103,44 @@ _llgo_0:
   %43 = load i64, ptr %42, align 4
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %43)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %44 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %44, i32 0, i32 0
-  store ptr @0, ptr %45, align 8
-  %46 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %44, i32 0, i32 1
-  store i64 6, ptr %46, align 4
-  %47 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %44, align 8
-  %48 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %47, 0
-  %49 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %47, 1
-  %50 = icmp sge i64 2, %49
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %50)
-  %51 = getelementptr inbounds i8, ptr %48, i64 2
-  %52 = load i8, ptr %51, align 1
-  %53 = sext i8 %52 to i32
-  %54 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringFromRune"(i32 %53)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %54)
+  %44 = load i8, ptr getelementptr inbounds (i8, ptr @0, i64 2), align 1
+  %45 = sext i8 %44 to i32
+  %46 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringFromRune"(i32 %45)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %46)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %55 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 0
-  store ptr @0, ptr %56, align 8
-  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 1
-  store i64 6, ptr %57, align 4
-  %58 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %55, align 8
-  %59 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %58, 0
-  %60 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %58, 1
-  %61 = icmp sge i64 1, %60
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %61)
-  %62 = getelementptr inbounds i8, ptr %59, i64 1
-  %63 = load i8, ptr %62, align 1
-  %64 = sext i8 %63 to i32
-  %65 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringFromRune"(i32 %64)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %65)
+  %47 = load i8, ptr getelementptr inbounds (i8, ptr @0, i64 1), align 1
+  %48 = sext i8 %47 to i32
+  %49 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringFromRune"(i32 %48)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %49)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %66 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 16)
-  %67 = getelementptr inbounds i64, ptr %66, i64 0
-  %68 = getelementptr inbounds i64, ptr %66, i64 1
-  store i64 1, ptr %67, align 4
-  store i64 2, ptr %68, align 4
-  %69 = getelementptr inbounds i64, ptr %66, i64 1
-  %70 = load i64, ptr %69, align 4
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %70)
+  %50 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 16)
+  %51 = getelementptr inbounds i64, ptr %50, i64 0
+  %52 = getelementptr inbounds i64, ptr %50, i64 1
+  store i64 1, ptr %51, align 4
+  store i64 2, ptr %52, align 4
+  %53 = getelementptr inbounds i64, ptr %50, i64 1
+  %54 = load i64, ptr %53, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %54)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %71 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
-  %72 = getelementptr inbounds i64, ptr %71, i64 0
-  store i64 1, ptr %72, align 4
-  %73 = getelementptr inbounds i64, ptr %71, i64 1
-  store i64 2, ptr %73, align 4
-  %74 = getelementptr inbounds i64, ptr %71, i64 2
-  store i64 3, ptr %74, align 4
-  %75 = getelementptr inbounds i64, ptr %71, i64 3
-  store i64 4, ptr %75, align 4
-  %76 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %77 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %76, i32 0, i32 0
-  store ptr %71, ptr %77, align 8
-  %78 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %76, i32 0, i32 1
-  store i64 4, ptr %78, align 4
-  %79 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %76, i32 0, i32 2
-  store i64 4, ptr %79, align 4
-  %80 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %76, align 8
-  %81 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %80, 0
-  %82 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %80, 1
-  %83 = icmp sge i64 1, %82
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %83)
-  %84 = getelementptr inbounds i64, ptr %81, i64 1
-  %85 = load i64, ptr %84, align 4
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %85)
+  %55 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
+  %56 = getelementptr inbounds i64, ptr %55, i64 0
+  store i64 1, ptr %56, align 4
+  %57 = getelementptr inbounds i64, ptr %55, i64 1
+  store i64 2, ptr %57, align 4
+  %58 = getelementptr inbounds i64, ptr %55, i64 2
+  store i64 3, ptr %58, align 4
+  %59 = getelementptr inbounds i64, ptr %55, i64 3
+  store i64 4, ptr %59, align 4
+  %60 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %55, 0
+  %61 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %60, i64 4, 1
+  %62 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %61, i64 4, 2
+  %63 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %62, 0
+  %64 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %62, 1
+  %65 = icmp sge i64 1, %64
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %65)
+  %66 = getelementptr inbounds i64, ptr %63, i64 1
+  %67 = load i64, ptr %66, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %67)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 0)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
@@ -183,12 +156,12 @@ declare void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64)
 
 declare void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8)
 
-declare void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1)
-
 declare %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/internal/runtime.StringFromRune"(i32)
 
 declare void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String")
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64)
+
+declare void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1)
 
 attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testrt/intgen/out.ll
+++ b/cl/_testrt/intgen/out.ll
@@ -72,101 +72,85 @@ _llgo_0:
   store ptr %1, ptr @__llgo_argv, align 8
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
-  %2 = alloca { ptr, ptr }, align 8
-  %3 = getelementptr inbounds { ptr, ptr }, ptr %2, i32 0, i32 0
-  store ptr @__llgo_stub.rand, ptr %3, align 8
-  %4 = getelementptr inbounds { ptr, ptr }, ptr %2, i32 0, i32 1
-  store ptr null, ptr %4, align 8
-  %5 = load { ptr, ptr }, ptr %2, align 8
-  %6 = call %"github.com/goplus/llgo/internal/runtime.Slice" @main.genInts(i64 5, { ptr, ptr } %5)
-  %7 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %6, 1
+  %2 = call %"github.com/goplus/llgo/internal/runtime.Slice" @main.genInts(i64 5, { ptr, ptr } { ptr @__llgo_stub.rand, ptr null })
+  %3 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %2, 1
   br label %_llgo_1
 
 _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-  %8 = phi i64 [ -1, %_llgo_0 ], [ %9, %_llgo_2 ]
-  %9 = add i64 %8, 1
-  %10 = icmp slt i64 %9, %7
-  br i1 %10, label %_llgo_2, label %_llgo_3
+  %4 = phi i64 [ -1, %_llgo_0 ], [ %5, %_llgo_2 ]
+  %5 = add i64 %4, 1
+  %6 = icmp slt i64 %5, %3
+  br i1 %6, label %_llgo_2, label %_llgo_3
 
 _llgo_2:                                          ; preds = %_llgo_1
-  %11 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %6, 0
-  %12 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %6, 1
-  %13 = icmp slt i64 %9, 0
-  %14 = icmp sge i64 %9, %12
-  %15 = or i1 %14, %13
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %15)
-  %16 = getelementptr inbounds i32, ptr %11, i64 %9
-  %17 = load i32, ptr %16, align 4
-  %18 = call i32 (ptr, ...) @printf(ptr @0, i32 %17)
+  %7 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %2, 0
+  %8 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %2, 1
+  %9 = icmp slt i64 %5, 0
+  %10 = icmp sge i64 %5, %8
+  %11 = or i1 %10, %9
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %11)
+  %12 = getelementptr inbounds i32, ptr %7, i64 %5
+  %13 = load i32, ptr %12, align 4
+  %14 = call i32 (ptr, ...) @printf(ptr @0, i32 %13)
   br label %_llgo_1
 
 _llgo_3:                                          ; preds = %_llgo_1
-  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 4)
-  store i32 1, ptr %19, align 4
-  %20 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %21 = getelementptr inbounds { ptr }, ptr %20, i32 0, i32 0
-  store ptr %19, ptr %21, align 8
-  %22 = alloca { ptr, ptr }, align 8
-  %23 = getelementptr inbounds { ptr, ptr }, ptr %22, i32 0, i32 0
-  store ptr @"main.main$1", ptr %23, align 8
-  %24 = getelementptr inbounds { ptr, ptr }, ptr %22, i32 0, i32 1
-  store ptr %20, ptr %24, align 8
-  %25 = load { ptr, ptr }, ptr %22, align 8
-  %26 = call %"github.com/goplus/llgo/internal/runtime.Slice" @main.genInts(i64 5, { ptr, ptr } %25)
-  %27 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %26, 1
+  %15 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 4)
+  store i32 1, ptr %15, align 4
+  %16 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %17 = getelementptr inbounds { ptr }, ptr %16, i32 0, i32 0
+  store ptr %15, ptr %17, align 8
+  %18 = insertvalue { ptr, ptr } { ptr @"main.main$1", ptr undef }, ptr %16, 1
+  %19 = call %"github.com/goplus/llgo/internal/runtime.Slice" @main.genInts(i64 5, { ptr, ptr } %18)
+  %20 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %19, 1
   br label %_llgo_4
 
 _llgo_4:                                          ; preds = %_llgo_5, %_llgo_3
-  %28 = phi i64 [ -1, %_llgo_3 ], [ %29, %_llgo_5 ]
-  %29 = add i64 %28, 1
-  %30 = icmp slt i64 %29, %27
-  br i1 %30, label %_llgo_5, label %_llgo_6
+  %21 = phi i64 [ -1, %_llgo_3 ], [ %22, %_llgo_5 ]
+  %22 = add i64 %21, 1
+  %23 = icmp slt i64 %22, %20
+  br i1 %23, label %_llgo_5, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_4
-  %31 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %26, 0
-  %32 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %26, 1
-  %33 = icmp slt i64 %29, 0
-  %34 = icmp sge i64 %29, %32
-  %35 = or i1 %34, %33
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %35)
-  %36 = getelementptr inbounds i32, ptr %31, i64 %29
-  %37 = load i32, ptr %36, align 4
-  %38 = call i32 (ptr, ...) @printf(ptr @1, i32 %37)
+  %24 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %19, 0
+  %25 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %19, 1
+  %26 = icmp slt i64 %22, 0
+  %27 = icmp sge i64 %22, %25
+  %28 = or i1 %27, %26
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %28)
+  %29 = getelementptr inbounds i32, ptr %24, i64 %22
+  %30 = load i32, ptr %29, align 4
+  %31 = call i32 (ptr, ...) @printf(ptr @1, i32 %30)
   br label %_llgo_4
 
 _llgo_6:                                          ; preds = %_llgo_4
-  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 4)
-  %40 = getelementptr inbounds %main.generator, ptr %39, i32 0, i32 0
-  store i32 1, ptr %40, align 4
-  %41 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %42 = getelementptr inbounds { ptr }, ptr %41, i32 0, i32 0
-  store ptr %39, ptr %42, align 8
-  %43 = alloca { ptr, ptr }, align 8
-  %44 = getelementptr inbounds { ptr, ptr }, ptr %43, i32 0, i32 0
-  store ptr @"main.next$bound", ptr %44, align 8
-  %45 = getelementptr inbounds { ptr, ptr }, ptr %43, i32 0, i32 1
-  store ptr %41, ptr %45, align 8
-  %46 = load { ptr, ptr }, ptr %43, align 8
-  %47 = call %"github.com/goplus/llgo/internal/runtime.Slice" @main.genInts(i64 5, { ptr, ptr } %46)
-  %48 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %47, 1
+  %32 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 4)
+  %33 = getelementptr inbounds %main.generator, ptr %32, i32 0, i32 0
+  store i32 1, ptr %33, align 4
+  %34 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %35 = getelementptr inbounds { ptr }, ptr %34, i32 0, i32 0
+  store ptr %32, ptr %35, align 8
+  %36 = insertvalue { ptr, ptr } { ptr @"main.next$bound", ptr undef }, ptr %34, 1
+  %37 = call %"github.com/goplus/llgo/internal/runtime.Slice" @main.genInts(i64 5, { ptr, ptr } %36)
+  %38 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %37, 1
   br label %_llgo_7
 
 _llgo_7:                                          ; preds = %_llgo_8, %_llgo_6
-  %49 = phi i64 [ -1, %_llgo_6 ], [ %50, %_llgo_8 ]
-  %50 = add i64 %49, 1
-  %51 = icmp slt i64 %50, %48
-  br i1 %51, label %_llgo_8, label %_llgo_9
+  %39 = phi i64 [ -1, %_llgo_6 ], [ %40, %_llgo_8 ]
+  %40 = add i64 %39, 1
+  %41 = icmp slt i64 %40, %38
+  br i1 %41, label %_llgo_8, label %_llgo_9
 
 _llgo_8:                                          ; preds = %_llgo_7
-  %52 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %47, 0
-  %53 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %47, 1
-  %54 = icmp slt i64 %50, 0
-  %55 = icmp sge i64 %50, %53
-  %56 = or i1 %55, %54
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %56)
-  %57 = getelementptr inbounds i32, ptr %52, i64 %50
-  %58 = load i32, ptr %57, align 4
-  %59 = call i32 (ptr, ...) @printf(ptr @2, i32 %58)
+  %42 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %37, 0
+  %43 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %37, 1
+  %44 = icmp slt i64 %40, 0
+  %45 = icmp sge i64 %40, %43
+  %46 = or i1 %45, %44
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %46)
+  %47 = getelementptr inbounds i32, ptr %42, i64 %40
+  %48 = load i32, ptr %47, align 4
+  %49 = call i32 (ptr, ...) @printf(ptr @2, i32 %48)
   br label %_llgo_7
 
 _llgo_9:                                          ; preds = %_llgo_7

--- a/cl/_testrt/len/out.ll
+++ b/cl/_testrt/len/out.ll
@@ -79,72 +79,55 @@ _llgo_0:
   %27 = load ptr, ptr @_llgo_string, align 8
   %28 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
   %29 = call ptr @"github.com/goplus/llgo/internal/runtime.MakeMap"(ptr %28, i64 1)
-  %30 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %30, i32 0, i32 0
-  store ptr @5, ptr %31, align 8
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %30, i32 0, i32 1
-  store i64 5, ptr %32, align 4
-  %33 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %30, align 8
-  %34 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
-  %35 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %30 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
+  %31 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  store i64 1, ptr %31, align 4
+  %32 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %30, ptr %29, ptr %31)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 5 }, ptr %32, align 8
+  %33 = getelementptr inbounds %main.data, ptr %21, i32 0, i32 3
+  %34 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
+  %35 = getelementptr inbounds i64, ptr %34, i64 0
   store i64 1, ptr %35, align 4
-  %36 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %34, ptr %29, ptr %35)
-  store %"github.com/goplus/llgo/internal/runtime.String" %33, ptr %36, align 8
-  %37 = getelementptr inbounds %main.data, ptr %21, i32 0, i32 3
-  %38 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
-  %39 = getelementptr inbounds i64, ptr %38, i64 0
-  store i64 1, ptr %39, align 4
-  %40 = getelementptr inbounds i64, ptr %38, i64 1
-  store i64 2, ptr %40, align 4
-  %41 = getelementptr inbounds i64, ptr %38, i64 2
-  store i64 3, ptr %41, align 4
-  %42 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, i32 0, i32 0
-  store ptr %38, ptr %43, align 8
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, i32 0, i32 1
-  store i64 3, ptr %44, align 4
-  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, i32 0, i32 2
-  store i64 3, ptr %45, align 4
-  %46 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, align 8
-  %47 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %48 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %47, i32 0, i32 0
-  store ptr @5, ptr %48, align 8
-  %49 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %47, i32 0, i32 1
-  store i64 5, ptr %49, align 4
-  %50 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %47, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %50, ptr %22, align 8
+  %36 = getelementptr inbounds i64, ptr %34, i64 1
+  store i64 2, ptr %36, align 4
+  %37 = getelementptr inbounds i64, ptr %34, i64 2
+  store i64 3, ptr %37, align 4
+  %38 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %34, 0
+  %39 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %38, i64 3, 1
+  %40 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %39, i64 3, 2
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 5 }, ptr %22, align 8
   store ptr %24, ptr %23, align 8
   store ptr %29, ptr %25, align 8
-  store %"github.com/goplus/llgo/internal/runtime.Slice" %46, ptr %37, align 8
-  %51 = getelementptr inbounds %main.data, ptr %21, i32 0, i32 0
-  %52 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %51, align 8
-  %53 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %52, 1
-  %54 = getelementptr inbounds %main.data, ptr %21, i32 0, i32 1
-  %55 = load ptr, ptr %54, align 8
-  %56 = call i64 @"github.com/goplus/llgo/internal/runtime.ChanLen"(ptr %55)
-  %57 = getelementptr inbounds %main.data, ptr %21, i32 0, i32 2
-  %58 = load ptr, ptr %57, align 8
-  %59 = call i64 @"github.com/goplus/llgo/internal/runtime.MapLen"(ptr %58)
-  %60 = getelementptr inbounds %main.data, ptr %21, i32 0, i32 3
-  %61 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %60, align 8
-  %62 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %61, 1
-  %63 = getelementptr inbounds %main.data, ptr %21, i32 0, i32 1
-  %64 = load ptr, ptr %63, align 8
-  %65 = call i64 @"github.com/goplus/llgo/internal/runtime.ChanCap"(ptr %64)
-  %66 = getelementptr inbounds %main.data, ptr %21, i32 0, i32 3
-  %67 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %66, align 8
-  %68 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %67, 2
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %53)
+  store %"github.com/goplus/llgo/internal/runtime.Slice" %40, ptr %33, align 8
+  %41 = getelementptr inbounds %main.data, ptr %21, i32 0, i32 0
+  %42 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %41, align 8
+  %43 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %42, 1
+  %44 = getelementptr inbounds %main.data, ptr %21, i32 0, i32 1
+  %45 = load ptr, ptr %44, align 8
+  %46 = call i64 @"github.com/goplus/llgo/internal/runtime.ChanLen"(ptr %45)
+  %47 = getelementptr inbounds %main.data, ptr %21, i32 0, i32 2
+  %48 = load ptr, ptr %47, align 8
+  %49 = call i64 @"github.com/goplus/llgo/internal/runtime.MapLen"(ptr %48)
+  %50 = getelementptr inbounds %main.data, ptr %21, i32 0, i32 3
+  %51 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %50, align 8
+  %52 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %51, 1
+  %53 = getelementptr inbounds %main.data, ptr %21, i32 0, i32 1
+  %54 = load ptr, ptr %53, align 8
+  %55 = call i64 @"github.com/goplus/llgo/internal/runtime.ChanCap"(ptr %54)
+  %56 = getelementptr inbounds %main.data, ptr %21, i32 0, i32 3
+  %57 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %56, align 8
+  %58 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %57, 2
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %43)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %56)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %46)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %59)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %49)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %62)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %52)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %65)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %55)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %68)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %58)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 }
@@ -194,92 +177,33 @@ _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
 _llgo_5:                                          ; preds = %_llgo_4
   %8 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
   %9 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %10 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %10, i32 0, i32 0
-  store ptr @0, ptr %11, align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %10, i32 0, i32 1
-  store i64 7, ptr %12, align 4
-  %13 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %10, align 8
-  %14 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %14, i32 0, i32 0
-  store ptr null, ptr %15, align 8
-  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %14, i32 0, i32 1
-  store i64 0, ptr %16, align 4
-  %17 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %14, align 8
-  %18 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %18)
-  %20 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %13, ptr %19, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %17, i1 false)
-  %21 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %21, i32 0, i32 0
-  store ptr @1, ptr %22, align 8
-  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %21, i32 0, i32 1
-  store i64 4, ptr %23, align 4
-  %24 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %21, align 8
-  %25 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 0
-  store ptr null, ptr %26, align 8
-  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 1
-  store i64 0, ptr %27, align 4
-  %28 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %25, align 8
-  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %29)
-  %31 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %24, ptr %30, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %28, i1 false)
-  %32 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %32, i32 0, i32 0
-  store ptr @2, ptr %33, align 8
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %32, i32 0, i32 1
-  store i64 5, ptr %34, align 4
-  %35 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %32, align 8
-  %36 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %36, i32 0, i32 0
-  store ptr null, ptr %37, align 8
-  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %36, i32 0, i32 1
-  store i64 0, ptr %38, align 4
-  %39 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %36, align 8
-  %40 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %41 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %40)
-  %42 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %35, ptr %41, i64 72, %"github.com/goplus/llgo/internal/runtime.String" %39, i1 false)
-  %43 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %43, i32 0, i32 0
-  store ptr @3, ptr %44, align 8
-  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %43, i32 0, i32 1
-  store i64 8, ptr %45, align 4
-  %46 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %43, align 8
-  %47 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %48 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %47, i32 0, i32 0
-  store ptr null, ptr %48, align 8
-  %49 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %47, i32 0, i32 1
-  store i64 0, ptr %49, align 4
-  %50 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %47, align 8
-  %51 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %52 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %46, ptr %51, i64 200, %"github.com/goplus/llgo/internal/runtime.String" %50, i1 false)
-  %53 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %54 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %53, i32 0, i32 0
-  store ptr @4, ptr %54, align 8
-  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %53, i32 0, i32 1
-  store i64 4, ptr %55, align 4
-  %56 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %53, align 8
-  %57 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
-  %58 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %57, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %20, ptr %58, align 8
-  %59 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %57, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %31, ptr %59, align 8
-  %60 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %57, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %42, ptr %60, align 8
-  %61 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %57, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %52, ptr %61, align 8
-  %62 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %63 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %62, i32 0, i32 0
-  store ptr %57, ptr %63, align 8
-  %64 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %62, i32 0, i32 1
-  store i64 4, ptr %64, align 4
-  %65 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %62, i32 0, i32 2
-  store i64 4, ptr %65, align 4
-  %66 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %62, align 8
-  %67 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %56, i64 208, %"github.com/goplus/llgo/internal/runtime.Slice" %66)
-  %68 = call ptr @"github.com/goplus/llgo/internal/runtime.MapOf"(ptr %8, ptr %9, ptr %67, i64 4)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %68)
-  store ptr %68, ptr @"map[_llgo_int]_llgo_string", align 8
+  %10 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %10)
+  %12 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 7 }, ptr %11, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %13 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %13)
+  %15 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, ptr %14, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %16 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %16)
+  %18 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 5 }, ptr %17, i64 72, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %20 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 8 }, ptr %19, i64 200, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %21 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
+  %22 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %21, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %12, ptr %22, align 8
+  %23 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %21, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %15, ptr %23, align 8
+  %24 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %21, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %18, ptr %24, align 8
+  %25 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %21, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %20, ptr %25, align 8
+  %26 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %21, 0
+  %27 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %26, i64 4, 1
+  %28 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %27, i64 4, 2
+  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, i64 208, %"github.com/goplus/llgo/internal/runtime.Slice" %28)
+  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.MapOf"(ptr %8, ptr %9, ptr %29, i64 4)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %30)
+  store ptr %30, ptr @"map[_llgo_int]_llgo_string", align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4

--- a/cl/_testrt/linkname/out.ll
+++ b/cl/_testrt/linkname/out.ll
@@ -42,16 +42,10 @@ _llgo_0:
   call void @"github.com/goplus/llgo/cl/internal/linktarget.F"(ptr @0, ptr @1, ptr @2, ptr @3)
   call void @"github.com/goplus/llgo/cl/internal/linktarget.F"(ptr @4, ptr @5, ptr @6, ptr @7)
   %2 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 16)
-  %3 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3, i32 0, i32 0
-  store ptr @8, ptr %4, align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3, i32 0, i32 1
-  store i64 5, ptr %5, align 4
-  %6 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3, align 8
-  call void @"github.com/goplus/llgo/cl/internal/linktarget.(*m).setInfo"(ptr %2, %"github.com/goplus/llgo/internal/runtime.String" %6)
-  %7 = load %main.m, ptr %2, align 8
-  %8 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/cl/internal/linktarget.m.info"(%main.m %7)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %8)
+  call void @"github.com/goplus/llgo/cl/internal/linktarget.(*m).setInfo"(ptr %2, %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 5 })
+  %3 = load %main.m, ptr %2, align 8
+  %4 = call %"github.com/goplus/llgo/internal/runtime.String" @"github.com/goplus/llgo/cl/internal/linktarget.m.info"(%main.m %3)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %4)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 }

--- a/cl/_testrt/makemap/out.ll
+++ b/cl/_testrt/makemap/out.ll
@@ -93,314 +93,194 @@ _llgo_0:
   %1 = load ptr, ptr @_llgo_string, align 8
   %2 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
   %3 = call ptr @"github.com/goplus/llgo/internal/runtime.MakeMap"(ptr %2, i64 0)
-  %4 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 0
-  store ptr @5, ptr %5, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %4, i32 0, i32 1
-  store i64 5, ptr %6, align 4
-  %7 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %4, align 8
-  %8 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
-  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  store i64 1, ptr %9, align 4
-  %10 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %8, ptr %3, ptr %9)
-  store %"github.com/goplus/llgo/internal/runtime.String" %7, ptr %10, align 8
-  %11 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %11, i32 0, i32 0
-  store ptr @6, ptr %12, align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %11, i32 0, i32 1
-  store i64 5, ptr %13, align 4
-  %14 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %11, align 8
-  %15 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
-  %16 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  store i64 2, ptr %16, align 4
-  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %15, ptr %3, ptr %16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %14, ptr %17, align 8
-  %18 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %19 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %18, i32 0, i32 0
-  store ptr @7, ptr %19, align 8
-  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %18, i32 0, i32 1
-  store i64 4, ptr %20, align 4
-  %21 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %18, align 8
-  %22 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
-  %23 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  store i64 3, ptr %23, align 4
-  %24 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %22, ptr %3, ptr %23)
-  store %"github.com/goplus/llgo/internal/runtime.String" %21, ptr %24, align 8
-  %25 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
-  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  store i64 1, ptr %26, align 4
-  %27 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAccess1"(ptr %25, ptr %3, ptr %26)
-  %28 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %27, align 8
-  %29 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
-  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  store i64 2, ptr %30, align 4
-  %31 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAccess1"(ptr %29, ptr %3, ptr %30)
-  %32 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %31, align 8
-  %33 = call i64 @"github.com/goplus/llgo/internal/runtime.MapLen"(ptr %3)
+  %4 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  store i64 1, ptr %5, align 4
+  %6 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %4, ptr %3, ptr %5)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 5 }, ptr %6, align 8
+  %7 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
+  %8 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  store i64 2, ptr %8, align 4
+  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %7, ptr %3, ptr %8)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 5 }, ptr %9, align 8
+  %10 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
+  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  store i64 3, ptr %11, align 4
+  %12 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %10, ptr %3, ptr %11)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 }, ptr %12, align 8
+  %13 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
+  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  store i64 1, ptr %14, align 4
+  %15 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAccess1"(ptr %13, ptr %3, ptr %14)
+  %16 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %15, align 8
+  %17 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
+  %18 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  store i64 2, ptr %18, align 4
+  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAccess1"(ptr %17, ptr %3, ptr %18)
+  %20 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %19, align 8
+  %21 = call i64 @"github.com/goplus/llgo/internal/runtime.MapLen"(ptr %3)
   call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %3)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %28)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %16)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %20)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %33)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %21)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %34 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
-  %35 = call ptr @"github.com/goplus/llgo/internal/runtime.NewMapIter"(ptr %34, ptr %3)
+  %22 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
+  %23 = call ptr @"github.com/goplus/llgo/internal/runtime.NewMapIter"(ptr %22, ptr %3)
   br label %_llgo_1
 
 _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-  %36 = call { i1, ptr, ptr } @"github.com/goplus/llgo/internal/runtime.MapIterNext"(ptr %35)
-  %37 = extractvalue { i1, ptr, ptr } %36, 0
-  br i1 %37, label %_llgo_11, label %_llgo_12
+  %24 = call { i1, ptr, ptr } @"github.com/goplus/llgo/internal/runtime.MapIterNext"(ptr %23)
+  %25 = extractvalue { i1, ptr, ptr } %24, 0
+  br i1 %25, label %_llgo_11, label %_llgo_12
 
 _llgo_2:                                          ; preds = %_llgo_13
-  %38 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %154, 1
-  %39 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %154, 2
-  %40 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %41 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %40, i32 0, i32 0
-  store ptr @8, ptr %41, align 8
-  %42 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %40, i32 0, i32 1
-  store i64 1, ptr %42, align 4
-  %43 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %40, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %38)
+  %26 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %88, 1
+  %27 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %88, 2
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %26)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %43)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 1 })
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %39)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %27)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_1
 
 _llgo_3:                                          ; preds = %_llgo_13
-  %44 = call i64 @"github.com/goplus/llgo/internal/runtime.MapLen"(ptr %3)
-  %45 = load ptr, ptr @"map[_llgo_string]_llgo_int", align 8
-  %46 = call ptr @"github.com/goplus/llgo/internal/runtime.MakeMap"(ptr %45, i64 %44)
-  %47 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
-  %48 = call ptr @"github.com/goplus/llgo/internal/runtime.NewMapIter"(ptr %47, ptr %3)
+  %28 = call i64 @"github.com/goplus/llgo/internal/runtime.MapLen"(ptr %3)
+  %29 = load ptr, ptr @"map[_llgo_string]_llgo_int", align 8
+  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.MakeMap"(ptr %29, i64 %28)
+  %31 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
+  %32 = call ptr @"github.com/goplus/llgo/internal/runtime.NewMapIter"(ptr %31, ptr %3)
   br label %_llgo_4
 
 _llgo_4:                                          ; preds = %_llgo_5, %_llgo_3
-  %49 = call { i1, ptr, ptr } @"github.com/goplus/llgo/internal/runtime.MapIterNext"(ptr %48)
-  %50 = extractvalue { i1, ptr, ptr } %49, 0
-  br i1 %50, label %_llgo_14, label %_llgo_15
+  %33 = call { i1, ptr, ptr } @"github.com/goplus/llgo/internal/runtime.MapIterNext"(ptr %32)
+  %34 = extractvalue { i1, ptr, ptr } %33, 0
+  br i1 %34, label %_llgo_14, label %_llgo_15
 
 _llgo_5:                                          ; preds = %_llgo_16
-  %51 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %170, 1
-  %52 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %170, 2
-  %53 = load ptr, ptr @"map[_llgo_string]_llgo_int", align 8
-  %54 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %52, ptr %54, align 8
-  %55 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %53, ptr %46, ptr %54)
-  store i64 %51, ptr %55, align 4
+  %35 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %96, 1
+  %36 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %96, 2
+  %37 = load ptr, ptr @"map[_llgo_string]_llgo_int", align 8
+  %38 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" %36, ptr %38, align 8
+  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %37, ptr %30, ptr %38)
+  store i64 %35, ptr %39, align 4
   br label %_llgo_4
 
 _llgo_6:                                          ; preds = %_llgo_16
-  %56 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %56, i32 0, i32 0
-  store ptr @7, ptr %57, align 8
-  %58 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %56, i32 0, i32 1
-  store i64 4, ptr %58, align 4
-  %59 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %56, align 8
+  %40 = load ptr, ptr @"map[_llgo_string]_llgo_int", align 8
+  %41 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 }, ptr %41, align 8
+  %42 = call { ptr, i1 } @"github.com/goplus/llgo/internal/runtime.MapAccess2"(ptr %40, ptr %30, ptr %41)
+  %43 = extractvalue { ptr, i1 } %42, 0
+  %44 = load i64, ptr %43, align 4
+  %45 = extractvalue { ptr, i1 } %42, 1
+  %46 = insertvalue { i64, i1 } undef, i64 %44, 0
+  %47 = insertvalue { i64, i1 } %46, i1 %45, 1
+  %48 = extractvalue { i64, i1 } %47, 0
+  %49 = extractvalue { i64, i1 } %47, 1
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 })
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %48)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %49)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
+  %50 = load ptr, ptr @"map[_llgo_string]_llgo_int", align 8
+  %51 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 2 }, ptr %51, align 8
+  %52 = call { ptr, i1 } @"github.com/goplus/llgo/internal/runtime.MapAccess2"(ptr %50, ptr %30, ptr %51)
+  %53 = extractvalue { ptr, i1 } %52, 0
+  %54 = load i64, ptr %53, align 4
+  %55 = extractvalue { ptr, i1 } %52, 1
+  %56 = insertvalue { i64, i1 } undef, i64 %54, 0
+  %57 = insertvalue { i64, i1 } %56, i1 %55, 1
+  %58 = extractvalue { i64, i1 } %57, 0
+  %59 = extractvalue { i64, i1 } %57, 1
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 2 })
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %58)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %59)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   %60 = load ptr, ptr @"map[_llgo_string]_llgo_int", align 8
   %61 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %59, ptr %61, align 8
-  %62 = call { ptr, i1 } @"github.com/goplus/llgo/internal/runtime.MapAccess2"(ptr %60, ptr %46, ptr %61)
-  %63 = extractvalue { ptr, i1 } %62, 0
-  %64 = load i64, ptr %63, align 4
-  %65 = extractvalue { ptr, i1 } %62, 1
-  %66 = alloca { i64, i1 }, align 8
-  %67 = getelementptr inbounds { i64, i1 }, ptr %66, i32 0, i32 0
-  store i64 %64, ptr %67, align 4
-  %68 = getelementptr inbounds { i64, i1 }, ptr %66, i32 0, i32 1
-  store i1 %65, ptr %68, align 1
-  %69 = load { i64, i1 }, ptr %66, align 4
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 }, ptr %61, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.MapDelete"(ptr %60, ptr %30, ptr %61)
+  %62 = load ptr, ptr @"map[_llgo_string]_llgo_int", align 8
+  %63 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 4 }, ptr %63, align 8
+  %64 = call { ptr, i1 } @"github.com/goplus/llgo/internal/runtime.MapAccess2"(ptr %62, ptr %30, ptr %63)
+  %65 = extractvalue { ptr, i1 } %64, 0
+  %66 = load i64, ptr %65, align 4
+  %67 = extractvalue { ptr, i1 } %64, 1
+  %68 = insertvalue { i64, i1 } undef, i64 %66, 0
+  %69 = insertvalue { i64, i1 } %68, i1 %67, 1
   %70 = extractvalue { i64, i1 } %69, 0
   %71 = extractvalue { i64, i1 } %69, 1
-  %72 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %73 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %72, i32 0, i32 0
-  store ptr @7, ptr %73, align 8
-  %74 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %72, i32 0, i32 1
-  store i64 4, ptr %74, align 4
-  %75 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %72, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %75)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %70)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %71)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %76 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %77 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %76, i32 0, i32 0
-  store ptr @9, ptr %77, align 8
-  %78 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %76, i32 0, i32 1
-  store i64 2, ptr %78, align 4
-  %79 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %76, align 8
-  %80 = load ptr, ptr @"map[_llgo_string]_llgo_int", align 8
-  %81 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %79, ptr %81, align 8
-  %82 = call { ptr, i1 } @"github.com/goplus/llgo/internal/runtime.MapAccess2"(ptr %80, ptr %46, ptr %81)
-  %83 = extractvalue { ptr, i1 } %82, 0
-  %84 = load i64, ptr %83, align 4
-  %85 = extractvalue { ptr, i1 } %82, 1
-  %86 = alloca { i64, i1 }, align 8
-  %87 = getelementptr inbounds { i64, i1 }, ptr %86, i32 0, i32 0
-  store i64 %84, ptr %87, align 4
-  %88 = getelementptr inbounds { i64, i1 }, ptr %86, i32 0, i32 1
-  store i1 %85, ptr %88, align 1
-  %89 = load { i64, i1 }, ptr %86, align 4
-  %90 = extractvalue { i64, i1 } %89, 0
-  %91 = extractvalue { i64, i1 } %89, 1
-  %92 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %93 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %92, i32 0, i32 0
-  store ptr @9, ptr %93, align 8
-  %94 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %92, i32 0, i32 1
-  store i64 2, ptr %94, align 4
-  %95 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %92, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %95)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %90)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %91)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %96 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %97 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %96, i32 0, i32 0
-  store ptr @7, ptr %97, align 8
-  %98 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %96, i32 0, i32 1
-  store i64 4, ptr %98, align 4
-  %99 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %96, align 8
-  %100 = load ptr, ptr @"map[_llgo_string]_llgo_int", align 8
-  %101 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %99, ptr %101, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.MapDelete"(ptr %100, ptr %46, ptr %101)
-  %102 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %103 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %102, i32 0, i32 0
-  store ptr @7, ptr %103, align 8
-  %104 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %102, i32 0, i32 1
-  store i64 4, ptr %104, align 4
-  %105 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %102, align 8
-  %106 = load ptr, ptr @"map[_llgo_string]_llgo_int", align 8
-  %107 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %105, ptr %107, align 8
-  %108 = call { ptr, i1 } @"github.com/goplus/llgo/internal/runtime.MapAccess2"(ptr %106, ptr %46, ptr %107)
-  %109 = extractvalue { ptr, i1 } %108, 0
-  %110 = load i64, ptr %109, align 4
-  %111 = extractvalue { ptr, i1 } %108, 1
-  %112 = alloca { i64, i1 }, align 8
-  %113 = getelementptr inbounds { i64, i1 }, ptr %112, i32 0, i32 0
-  store i64 %110, ptr %113, align 4
-  %114 = getelementptr inbounds { i64, i1 }, ptr %112, i32 0, i32 1
-  store i1 %111, ptr %114, align 1
-  %115 = load { i64, i1 }, ptr %112, align 4
-  %116 = extractvalue { i64, i1 } %115, 0
-  %117 = extractvalue { i64, i1 } %115, 1
-  br i1 %117, label %_llgo_7, label %_llgo_8
+  br i1 %71, label %_llgo_7, label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_6
-  %118 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %119 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %118, i32 0, i32 0
-  store ptr @10, ptr %119, align 8
-  %120 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %118, i32 0, i32 1
-  store i64 7, ptr %120, align 4
-  %121 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %118, align 8
-  %122 = load ptr, ptr @_llgo_string, align 8
-  %123 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %121, ptr %123, align 8
-  %124 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %125 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %124, i32 0, i32 0
-  store ptr %122, ptr %125, align 8
-  %126 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %124, i32 0, i32 1
-  store ptr %123, ptr %126, align 8
-  %127 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %124, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %127)
+  %72 = load ptr, ptr @_llgo_string, align 8
+  %73 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 7 }, ptr %73, align 8
+  %74 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %72, 0
+  %75 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %74, ptr %73, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %75)
   unreachable
 
 _llgo_8:                                          ; preds = %_llgo_6
-  %128 = call i64 @"github.com/goplus/llgo/internal/runtime.MapLen"(ptr %46)
-  %129 = icmp ne i64 %128, 2
-  br i1 %129, label %_llgo_9, label %_llgo_10
+  %76 = call i64 @"github.com/goplus/llgo/internal/runtime.MapLen"(ptr %30)
+  %77 = icmp ne i64 %76, 2
+  br i1 %77, label %_llgo_9, label %_llgo_10
 
 _llgo_9:                                          ; preds = %_llgo_8
-  %130 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %131 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %130, i32 0, i32 0
-  store ptr @11, ptr %131, align 8
-  %132 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %130, i32 0, i32 1
-  store i64 7, ptr %132, align 4
-  %133 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %130, align 8
-  %134 = load ptr, ptr @_llgo_string, align 8
-  %135 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %133, ptr %135, align 8
-  %136 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %137 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %136, i32 0, i32 0
-  store ptr %134, ptr %137, align 8
-  %138 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %136, i32 0, i32 1
-  store ptr %135, ptr %138, align 8
-  %139 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %136, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %139)
+  %78 = load ptr, ptr @_llgo_string, align 8
+  %79 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 7 }, ptr %79, align 8
+  %80 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %78, 0
+  %81 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %80, ptr %79, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %81)
   unreachable
 
 _llgo_10:                                         ; preds = %_llgo_8
   ret void
 
 _llgo_11:                                         ; preds = %_llgo_1
-  %140 = extractvalue { i1, ptr, ptr } %36, 1
-  %141 = extractvalue { i1, ptr, ptr } %36, 2
-  %142 = load i64, ptr %140, align 4
-  %143 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %141, align 8
-  %144 = alloca { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, align 8
-  %145 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %144, i32 0, i32 0
-  store i1 true, ptr %145, align 1
-  %146 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %144, i32 0, i32 1
-  store i64 %142, ptr %146, align 4
-  %147 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %144, i32 0, i32 2
-  store %"github.com/goplus/llgo/internal/runtime.String" %143, ptr %147, align 8
-  %148 = load { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %144, align 8
+  %82 = extractvalue { i1, ptr, ptr } %24, 1
+  %83 = extractvalue { i1, ptr, ptr } %24, 2
+  %84 = load i64, ptr %82, align 4
+  %85 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %83, align 8
+  %86 = insertvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } { i1 true, i64 undef, %"github.com/goplus/llgo/internal/runtime.String" undef }, i64 %84, 1
+  %87 = insertvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %86, %"github.com/goplus/llgo/internal/runtime.String" %85, 2
   br label %_llgo_13
 
 _llgo_12:                                         ; preds = %_llgo_1
-  %149 = alloca { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, align 8
-  %150 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %149, i32 0, i32 0
-  store i1 false, ptr %150, align 1
-  %151 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %149, i32 0, i32 1
-  store i64 0, ptr %151, align 4
-  %152 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %149, i32 0, i32 2
-  store %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, ptr %152, align 8
-  %153 = load { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %149, align 8
   br label %_llgo_13
 
 _llgo_13:                                         ; preds = %_llgo_12, %_llgo_11
-  %154 = phi { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } [ %148, %_llgo_11 ], [ %153, %_llgo_12 ]
-  %155 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %154, 0
-  br i1 %155, label %_llgo_2, label %_llgo_3
+  %88 = phi { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } [ %87, %_llgo_11 ], [ zeroinitializer, %_llgo_12 ]
+  %89 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %88, 0
+  br i1 %89, label %_llgo_2, label %_llgo_3
 
 _llgo_14:                                         ; preds = %_llgo_4
-  %156 = extractvalue { i1, ptr, ptr } %49, 1
-  %157 = extractvalue { i1, ptr, ptr } %49, 2
-  %158 = load i64, ptr %156, align 4
-  %159 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %157, align 8
-  %160 = alloca { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, align 8
-  %161 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %160, i32 0, i32 0
-  store i1 true, ptr %161, align 1
-  %162 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %160, i32 0, i32 1
-  store i64 %158, ptr %162, align 4
-  %163 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %160, i32 0, i32 2
-  store %"github.com/goplus/llgo/internal/runtime.String" %159, ptr %163, align 8
-  %164 = load { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %160, align 8
+  %90 = extractvalue { i1, ptr, ptr } %33, 1
+  %91 = extractvalue { i1, ptr, ptr } %33, 2
+  %92 = load i64, ptr %90, align 4
+  %93 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %91, align 8
+  %94 = insertvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } { i1 true, i64 undef, %"github.com/goplus/llgo/internal/runtime.String" undef }, i64 %92, 1
+  %95 = insertvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %94, %"github.com/goplus/llgo/internal/runtime.String" %93, 2
   br label %_llgo_16
 
 _llgo_15:                                         ; preds = %_llgo_4
-  %165 = alloca { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, align 8
-  %166 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %165, i32 0, i32 0
-  store i1 false, ptr %166, align 1
-  %167 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %165, i32 0, i32 1
-  store i64 0, ptr %167, align 4
-  %168 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %165, i32 0, i32 2
-  store %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, ptr %168, align 8
-  %169 = load { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %165, align 8
   br label %_llgo_16
 
 _llgo_16:                                         ; preds = %_llgo_15, %_llgo_14
-  %170 = phi { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } [ %164, %_llgo_14 ], [ %169, %_llgo_15 ]
-  %171 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %170, 0
-  br i1 %171, label %_llgo_5, label %_llgo_6
+  %96 = phi { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } [ %95, %_llgo_14 ], [ zeroinitializer, %_llgo_15 ]
+  %97 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %96, 0
+  br i1 %97, label %_llgo_5, label %_llgo_6
 }
 
 define void @main.make2() {
@@ -438,151 +318,111 @@ _llgo_0:
   %12 = load ptr, ptr @_llgo_main.N1, align 8
   %13 = extractvalue [1 x i64] %11, 0
   %14 = inttoptr i64 %13 to ptr
-  %15 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %15, i32 0, i32 0
-  store ptr %12, ptr %16, align 8
-  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %15, i32 0, i32 1
-  store ptr %14, ptr %17, align 8
-  %18 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %15, align 8
-  %19 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
-  %20 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.eface" %18, ptr %20, align 8
-  %21 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %19, ptr %8, ptr %20)
-  store i64 100, ptr %21, align 4
-  %22 = alloca [1 x i64], align 8
-  call void @llvm.memset(ptr %22, i8 0, i64 8, i1 false)
-  %23 = getelementptr inbounds i64, ptr %22, i64 0
-  store i64 2, ptr %23, align 4
-  %24 = load [1 x i64], ptr %22, align 4
-  %25 = load ptr, ptr @_llgo_main.N1, align 8
-  %26 = extractvalue [1 x i64] %24, 0
-  %27 = inttoptr i64 %26 to ptr
-  %28 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %29 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %28, i32 0, i32 0
-  store ptr %25, ptr %29, align 8
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %28, i32 0, i32 1
-  store ptr %27, ptr %30, align 8
-  %31 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %28, align 8
-  %32 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
-  %33 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.eface" %31, ptr %33, align 8
-  %34 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %32, ptr %8, ptr %33)
-  store i64 200, ptr %34, align 4
-  %35 = alloca [1 x i64], align 8
-  call void @llvm.memset(ptr %35, i8 0, i64 8, i1 false)
-  %36 = getelementptr inbounds i64, ptr %35, i64 0
-  store i64 3, ptr %36, align 4
-  %37 = load [1 x i64], ptr %35, align 4
-  %38 = load ptr, ptr @_llgo_main.N1, align 8
-  %39 = extractvalue [1 x i64] %37, 0
-  %40 = inttoptr i64 %39 to ptr
-  %41 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %42 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %41, i32 0, i32 0
-  store ptr %38, ptr %42, align 8
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %41, i32 0, i32 1
-  store ptr %40, ptr %43, align 8
-  %44 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %41, align 8
-  %45 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
-  %46 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.eface" %44, ptr %46, align 8
-  %47 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %45, ptr %8, ptr %46)
-  store i64 300, ptr %47, align 4
-  %48 = alloca [1 x i64], align 8
-  call void @llvm.memset(ptr %48, i8 0, i64 8, i1 false)
-  %49 = getelementptr inbounds i64, ptr %48, i64 0
-  store i64 2, ptr %49, align 4
-  %50 = load [1 x i64], ptr %48, align 4
-  %51 = load ptr, ptr @_llgo_main.N1, align 8
-  %52 = extractvalue [1 x i64] %50, 0
-  %53 = inttoptr i64 %52 to ptr
-  %54 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %54, i32 0, i32 0
-  store ptr %51, ptr %55, align 8
-  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %54, i32 0, i32 1
-  store ptr %53, ptr %56, align 8
-  %57 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %54, align 8
-  %58 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
-  %59 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.eface" %57, ptr %59, align 8
-  %60 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %58, ptr %8, ptr %59)
-  store i64 -200, ptr %60, align 4
-  %61 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
-  %62 = call ptr @"github.com/goplus/llgo/internal/runtime.NewMapIter"(ptr %61, ptr %8)
+  %15 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %12, 0
+  %16 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %15, ptr %14, 1
+  %17 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
+  %18 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.eface" %16, ptr %18, align 8
+  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %17, ptr %8, ptr %18)
+  store i64 100, ptr %19, align 4
+  %20 = alloca [1 x i64], align 8
+  call void @llvm.memset(ptr %20, i8 0, i64 8, i1 false)
+  %21 = getelementptr inbounds i64, ptr %20, i64 0
+  store i64 2, ptr %21, align 4
+  %22 = load [1 x i64], ptr %20, align 4
+  %23 = load ptr, ptr @_llgo_main.N1, align 8
+  %24 = extractvalue [1 x i64] %22, 0
+  %25 = inttoptr i64 %24 to ptr
+  %26 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %23, 0
+  %27 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %26, ptr %25, 1
+  %28 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
+  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.eface" %27, ptr %29, align 8
+  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %28, ptr %8, ptr %29)
+  store i64 200, ptr %30, align 4
+  %31 = alloca [1 x i64], align 8
+  call void @llvm.memset(ptr %31, i8 0, i64 8, i1 false)
+  %32 = getelementptr inbounds i64, ptr %31, i64 0
+  store i64 3, ptr %32, align 4
+  %33 = load [1 x i64], ptr %31, align 4
+  %34 = load ptr, ptr @_llgo_main.N1, align 8
+  %35 = extractvalue [1 x i64] %33, 0
+  %36 = inttoptr i64 %35 to ptr
+  %37 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %34, 0
+  %38 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %37, ptr %36, 1
+  %39 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
+  %40 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.eface" %38, ptr %40, align 8
+  %41 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %39, ptr %8, ptr %40)
+  store i64 300, ptr %41, align 4
+  %42 = alloca [1 x i64], align 8
+  call void @llvm.memset(ptr %42, i8 0, i64 8, i1 false)
+  %43 = getelementptr inbounds i64, ptr %42, i64 0
+  store i64 2, ptr %43, align 4
+  %44 = load [1 x i64], ptr %42, align 4
+  %45 = load ptr, ptr @_llgo_main.N1, align 8
+  %46 = extractvalue [1 x i64] %44, 0
+  %47 = inttoptr i64 %46 to ptr
+  %48 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %45, 0
+  %49 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %48, ptr %47, 1
+  %50 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
+  %51 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.eface" %49, ptr %51, align 8
+  %52 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %50, ptr %8, ptr %51)
+  store i64 -200, ptr %52, align 4
+  %53 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
+  %54 = call ptr @"github.com/goplus/llgo/internal/runtime.NewMapIter"(ptr %53, ptr %8)
   br label %_llgo_1
 
 _llgo_1:                                          ; preds = %_llgo_7, %_llgo_0
-  %63 = call { i1, ptr, ptr } @"github.com/goplus/llgo/internal/runtime.MapIterNext"(ptr %62)
-  %64 = extractvalue { i1, ptr, ptr } %63, 0
-  br i1 %64, label %_llgo_4, label %_llgo_5
+  %55 = call { i1, ptr, ptr } @"github.com/goplus/llgo/internal/runtime.MapIterNext"(ptr %54)
+  %56 = extractvalue { i1, ptr, ptr } %55, 0
+  br i1 %56, label %_llgo_4, label %_llgo_5
 
 _llgo_2:                                          ; preds = %_llgo_6
-  %65 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %84, 1
-  %66 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %84, 2
-  %67 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %65, 0
-  %68 = load ptr, ptr @_llgo_main.N1, align 8
-  %69 = icmp eq ptr %67, %68
-  br i1 %69, label %_llgo_7, label %_llgo_8
+  %57 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %68, 1
+  %58 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %68, 2
+  %59 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %57, 0
+  %60 = load ptr, ptr @_llgo_main.N1, align 8
+  %61 = icmp eq ptr %59, %60
+  br i1 %61, label %_llgo_7, label %_llgo_8
 
 _llgo_3:                                          ; preds = %_llgo_6
   ret void
 
 _llgo_4:                                          ; preds = %_llgo_1
-  %70 = extractvalue { i1, ptr, ptr } %63, 1
-  %71 = extractvalue { i1, ptr, ptr } %63, 2
-  %72 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %70, align 8
-  %73 = load i64, ptr %71, align 4
-  %74 = alloca { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, align 8
-  %75 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %74, i32 0, i32 0
-  store i1 true, ptr %75, align 1
-  %76 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %74, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.eface" %72, ptr %76, align 8
-  %77 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %74, i32 0, i32 2
-  store i64 %73, ptr %77, align 4
-  %78 = load { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %74, align 8
+  %62 = extractvalue { i1, ptr, ptr } %55, 1
+  %63 = extractvalue { i1, ptr, ptr } %55, 2
+  %64 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %62, align 8
+  %65 = load i64, ptr %63, align 4
+  %66 = insertvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } { i1 true, %"github.com/goplus/llgo/internal/runtime.eface" undef, i64 undef }, %"github.com/goplus/llgo/internal/runtime.eface" %64, 1
+  %67 = insertvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %66, i64 %65, 2
   br label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_1
-  %79 = alloca { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, align 8
-  %80 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %79, i32 0, i32 0
-  store i1 false, ptr %80, align 1
-  %81 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %79, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.eface" zeroinitializer, ptr %81, align 8
-  %82 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %79, i32 0, i32 2
-  store i64 0, ptr %82, align 4
-  %83 = load { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %79, align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %84 = phi { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } [ %78, %_llgo_4 ], [ %83, %_llgo_5 ]
-  %85 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %84, 0
-  br i1 %85, label %_llgo_2, label %_llgo_3
+  %68 = phi { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } [ %67, %_llgo_4 ], [ zeroinitializer, %_llgo_5 ]
+  %69 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %68, 0
+  br i1 %69, label %_llgo_2, label %_llgo_3
 
 _llgo_7:                                          ; preds = %_llgo_2
-  %86 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %65, 1
-  %87 = ptrtoint ptr %86 to i64
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %87)
+  %70 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %57, 1
+  %71 = ptrtoint ptr %70 to i64
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %71)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %66)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %58)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_1
 
 _llgo_8:                                          ; preds = %_llgo_2
-  %88 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %89 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %88, i32 0, i32 0
-  store ptr @14, ptr %89, align 8
-  %90 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %88, i32 0, i32 1
-  store i64 21, ptr %90, align 4
-  %91 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %88, align 8
-  %92 = load ptr, ptr @_llgo_string, align 8
-  %93 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %91, ptr %93, align 8
-  %94 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %95 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %94, i32 0, i32 0
-  store ptr %92, ptr %95, align 8
-  %96 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %94, i32 0, i32 1
-  store ptr %93, ptr %96, align 8
-  %97 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %94, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %97)
+  %72 = load ptr, ptr @_llgo_string, align 8
+  %73 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @14, i64 21 }, ptr %73, align 8
+  %74 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %72, 0
+  %75 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %74, ptr %73, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %75)
   unreachable
 }
 
@@ -599,162 +439,122 @@ _llgo_0:
   %5 = load ptr, ptr @_llgo_main.K, align 8
   %6 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 2)
   store [1 x %main.N] %4, ptr %6, align 1
-  %7 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, i32 0, i32 0
-  store ptr %5, ptr %8, align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, i32 0, i32 1
-  store ptr %6, ptr %9, align 8
-  %10 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, align 8
-  %11 = alloca [1 x %main.N], align 8
-  call void @llvm.memset(ptr %11, i8 0, i64 2, i1 false)
-  %12 = getelementptr inbounds %main.N, ptr %11, i64 0
-  %13 = getelementptr inbounds %main.N, ptr %12, i32 0, i32 0
-  %14 = getelementptr inbounds %main.N, ptr %12, i32 0, i32 1
-  store i8 1, ptr %13, align 1
-  store i8 2, ptr %14, align 1
-  %15 = load [1 x %main.N], ptr %11, align 1
-  %16 = load ptr, ptr @_llgo_main.K, align 8
-  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 2)
-  store [1 x %main.N] %15, ptr %17, align 1
-  %18 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %19 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %18, i32 0, i32 0
-  store ptr %16, ptr %19, align 8
-  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %18, i32 0, i32 1
-  store ptr %17, ptr %20, align 8
-  %21 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %18, align 8
-  %22 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %10, %"github.com/goplus/llgo/internal/runtime.eface" %21)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %22)
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %5, 0
+  %8 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %7, ptr %6, 1
+  %9 = alloca [1 x %main.N], align 8
+  call void @llvm.memset(ptr %9, i8 0, i64 2, i1 false)
+  %10 = getelementptr inbounds %main.N, ptr %9, i64 0
+  %11 = getelementptr inbounds %main.N, ptr %10, i32 0, i32 0
+  %12 = getelementptr inbounds %main.N, ptr %10, i32 0, i32 1
+  store i8 1, ptr %11, align 1
+  store i8 2, ptr %12, align 1
+  %13 = load [1 x %main.N], ptr %9, align 1
+  %14 = load ptr, ptr @_llgo_main.K, align 8
+  %15 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 2)
+  store [1 x %main.N] %13, ptr %15, align 1
+  %16 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %14, 0
+  %17 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %16, ptr %15, 1
+  %18 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %8, %"github.com/goplus/llgo/internal/runtime.eface" %17)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %18)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %23 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
-  %24 = call ptr @"github.com/goplus/llgo/internal/runtime.MakeMap"(ptr %23, i64 0)
-  %25 = alloca [1 x %main.N], align 8
-  call void @llvm.memset(ptr %25, i8 0, i64 2, i1 false)
-  %26 = getelementptr inbounds %main.N, ptr %25, i64 0
-  %27 = getelementptr inbounds %main.N, ptr %26, i32 0, i32 0
-  %28 = getelementptr inbounds %main.N, ptr %26, i32 0, i32 1
-  store i8 1, ptr %27, align 1
-  store i8 2, ptr %28, align 1
-  %29 = load [1 x %main.N], ptr %25, align 1
-  %30 = load ptr, ptr @_llgo_main.K, align 8
-  %31 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 2)
-  store [1 x %main.N] %29, ptr %31, align 1
-  %32 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %32, i32 0, i32 0
-  store ptr %30, ptr %33, align 8
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %32, i32 0, i32 1
-  store ptr %31, ptr %34, align 8
-  %35 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %32, align 8
-  %36 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
-  %37 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.eface" %35, ptr %37, align 8
-  %38 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %36, ptr %24, ptr %37)
-  store i64 100, ptr %38, align 4
-  %39 = alloca [1 x %main.N], align 8
-  call void @llvm.memset(ptr %39, i8 0, i64 2, i1 false)
-  %40 = getelementptr inbounds %main.N, ptr %39, i64 0
-  %41 = getelementptr inbounds %main.N, ptr %40, i32 0, i32 0
-  %42 = getelementptr inbounds %main.N, ptr %40, i32 0, i32 1
-  store i8 3, ptr %41, align 1
-  store i8 4, ptr %42, align 1
-  %43 = load [1 x %main.N], ptr %39, align 1
-  %44 = load ptr, ptr @_llgo_main.K, align 8
-  %45 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 2)
-  store [1 x %main.N] %43, ptr %45, align 1
-  %46 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %47 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %46, i32 0, i32 0
-  store ptr %44, ptr %47, align 8
-  %48 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %46, i32 0, i32 1
-  store ptr %45, ptr %48, align 8
-  %49 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %46, align 8
-  %50 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
-  %51 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.eface" %49, ptr %51, align 8
-  %52 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %50, ptr %24, ptr %51)
-  store i64 200, ptr %52, align 4
-  %53 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
-  %54 = call ptr @"github.com/goplus/llgo/internal/runtime.NewMapIter"(ptr %53, ptr %24)
+  %19 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
+  %20 = call ptr @"github.com/goplus/llgo/internal/runtime.MakeMap"(ptr %19, i64 0)
+  %21 = alloca [1 x %main.N], align 8
+  call void @llvm.memset(ptr %21, i8 0, i64 2, i1 false)
+  %22 = getelementptr inbounds %main.N, ptr %21, i64 0
+  %23 = getelementptr inbounds %main.N, ptr %22, i32 0, i32 0
+  %24 = getelementptr inbounds %main.N, ptr %22, i32 0, i32 1
+  store i8 1, ptr %23, align 1
+  store i8 2, ptr %24, align 1
+  %25 = load [1 x %main.N], ptr %21, align 1
+  %26 = load ptr, ptr @_llgo_main.K, align 8
+  %27 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 2)
+  store [1 x %main.N] %25, ptr %27, align 1
+  %28 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %26, 0
+  %29 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %28, ptr %27, 1
+  %30 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
+  %31 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.eface" %29, ptr %31, align 8
+  %32 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %30, ptr %20, ptr %31)
+  store i64 100, ptr %32, align 4
+  %33 = alloca [1 x %main.N], align 8
+  call void @llvm.memset(ptr %33, i8 0, i64 2, i1 false)
+  %34 = getelementptr inbounds %main.N, ptr %33, i64 0
+  %35 = getelementptr inbounds %main.N, ptr %34, i32 0, i32 0
+  %36 = getelementptr inbounds %main.N, ptr %34, i32 0, i32 1
+  store i8 3, ptr %35, align 1
+  store i8 4, ptr %36, align 1
+  %37 = load [1 x %main.N], ptr %33, align 1
+  %38 = load ptr, ptr @_llgo_main.K, align 8
+  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 2)
+  store [1 x %main.N] %37, ptr %39, align 1
+  %40 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %38, 0
+  %41 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %40, ptr %39, 1
+  %42 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
+  %43 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.eface" %41, ptr %43, align 8
+  %44 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %42, ptr %20, ptr %43)
+  store i64 200, ptr %44, align 4
+  %45 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
+  %46 = call ptr @"github.com/goplus/llgo/internal/runtime.NewMapIter"(ptr %45, ptr %20)
   br label %_llgo_1
 
 _llgo_1:                                          ; preds = %_llgo_7, %_llgo_0
-  %55 = call { i1, ptr, ptr } @"github.com/goplus/llgo/internal/runtime.MapIterNext"(ptr %54)
-  %56 = extractvalue { i1, ptr, ptr } %55, 0
-  br i1 %56, label %_llgo_4, label %_llgo_5
+  %47 = call { i1, ptr, ptr } @"github.com/goplus/llgo/internal/runtime.MapIterNext"(ptr %46)
+  %48 = extractvalue { i1, ptr, ptr } %47, 0
+  br i1 %48, label %_llgo_4, label %_llgo_5
 
 _llgo_2:                                          ; preds = %_llgo_6
-  %57 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %76, 1
-  %58 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %76, 2
-  %59 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %57, 0
-  %60 = load ptr, ptr @_llgo_main.K, align 8
-  %61 = icmp eq ptr %59, %60
-  br i1 %61, label %_llgo_7, label %_llgo_8
+  %49 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %60, 1
+  %50 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %60, 2
+  %51 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %49, 0
+  %52 = load ptr, ptr @_llgo_main.K, align 8
+  %53 = icmp eq ptr %51, %52
+  br i1 %53, label %_llgo_7, label %_llgo_8
 
 _llgo_3:                                          ; preds = %_llgo_6
   ret void
 
 _llgo_4:                                          ; preds = %_llgo_1
-  %62 = extractvalue { i1, ptr, ptr } %55, 1
-  %63 = extractvalue { i1, ptr, ptr } %55, 2
-  %64 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %62, align 8
-  %65 = load i64, ptr %63, align 4
-  %66 = alloca { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, align 8
-  %67 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %66, i32 0, i32 0
-  store i1 true, ptr %67, align 1
-  %68 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %66, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.eface" %64, ptr %68, align 8
-  %69 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %66, i32 0, i32 2
-  store i64 %65, ptr %69, align 4
-  %70 = load { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %66, align 8
+  %54 = extractvalue { i1, ptr, ptr } %47, 1
+  %55 = extractvalue { i1, ptr, ptr } %47, 2
+  %56 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %54, align 8
+  %57 = load i64, ptr %55, align 4
+  %58 = insertvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } { i1 true, %"github.com/goplus/llgo/internal/runtime.eface" undef, i64 undef }, %"github.com/goplus/llgo/internal/runtime.eface" %56, 1
+  %59 = insertvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %58, i64 %57, 2
   br label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_1
-  %71 = alloca { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, align 8
-  %72 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %71, i32 0, i32 0
-  store i1 false, ptr %72, align 1
-  %73 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %71, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.eface" zeroinitializer, ptr %73, align 8
-  %74 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %71, i32 0, i32 2
-  store i64 0, ptr %74, align 4
-  %75 = load { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %71, align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %76 = phi { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } [ %70, %_llgo_4 ], [ %75, %_llgo_5 ]
-  %77 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %76, 0
-  br i1 %77, label %_llgo_2, label %_llgo_3
+  %60 = phi { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } [ %59, %_llgo_4 ], [ zeroinitializer, %_llgo_5 ]
+  %61 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %60, 0
+  br i1 %61, label %_llgo_2, label %_llgo_3
 
 _llgo_7:                                          ; preds = %_llgo_2
-  %78 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %57, 1
-  %79 = load [1 x %main.N], ptr %78, align 1
-  %80 = alloca [1 x %main.N], align 8
-  call void @llvm.memset(ptr %80, i8 0, i64 2, i1 false)
-  store [1 x %main.N] %79, ptr %80, align 1
-  %81 = getelementptr inbounds %main.N, ptr %80, i64 0
-  %82 = load %main.N, ptr %81, align 1
-  %83 = extractvalue %main.N %82, 0
-  %84 = sext i8 %83 to i64
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %84)
+  %62 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %49, 1
+  %63 = load [1 x %main.N], ptr %62, align 1
+  %64 = alloca [1 x %main.N], align 8
+  call void @llvm.memset(ptr %64, i8 0, i64 2, i1 false)
+  store [1 x %main.N] %63, ptr %64, align 1
+  %65 = getelementptr inbounds %main.N, ptr %64, i64 0
+  %66 = load %main.N, ptr %65, align 1
+  %67 = extractvalue %main.N %66, 0
+  %68 = sext i8 %67 to i64
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %68)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %58)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %50)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_1
 
 _llgo_8:                                          ; preds = %_llgo_2
-  %85 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %86 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %85, i32 0, i32 0
-  store ptr @14, ptr %86, align 8
-  %87 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %85, i32 0, i32 1
-  store i64 21, ptr %87, align 4
-  %88 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %85, align 8
-  %89 = load ptr, ptr @_llgo_string, align 8
-  %90 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %88, ptr %90, align 8
-  %91 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %92 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %91, i32 0, i32 0
-  store ptr %89, ptr %92, align 8
-  %93 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %91, i32 0, i32 1
-  store ptr %90, ptr %93, align 8
-  %94 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %91, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %94)
+  %69 = load ptr, ptr @_llgo_string, align 8
+  %70 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @14, i64 21 }, ptr %70, align 8
+  %71 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %69, 0
+  %72 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %71, ptr %70, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %72)
   unreachable
 }
 
@@ -772,160 +572,120 @@ _llgo_0:
   %5 = load [1 x ptr], ptr %0, align 8
   %6 = load ptr, ptr @_llgo_main.K2, align 8
   %7 = extractvalue [1 x ptr] %5, 0
-  %8 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, i32 0, i32 0
-  store ptr %6, ptr %9, align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, i32 0, i32 1
-  store ptr %7, ptr %10, align 8
-  %11 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, align 8
-  %12 = alloca [1 x ptr], align 8
-  call void @llvm.memset(ptr %12, i8 0, i64 8, i1 false)
-  %13 = getelementptr inbounds ptr, ptr %12, i64 0
-  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 2)
-  %15 = getelementptr inbounds %main.N, ptr %14, i32 0, i32 0
-  %16 = getelementptr inbounds %main.N, ptr %14, i32 0, i32 1
-  store i8 1, ptr %15, align 1
-  store i8 2, ptr %16, align 1
-  store ptr %14, ptr %13, align 8
-  %17 = load [1 x ptr], ptr %12, align 8
-  %18 = load ptr, ptr @_llgo_main.K2, align 8
-  %19 = extractvalue [1 x ptr] %17, 0
-  %20 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %20, i32 0, i32 0
-  store ptr %18, ptr %21, align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %20, i32 0, i32 1
-  store ptr %19, ptr %22, align 8
-  %23 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %20, align 8
-  %24 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %11, %"github.com/goplus/llgo/internal/runtime.eface" %23)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %24)
+  %8 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %6, 0
+  %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %8, ptr %7, 1
+  %10 = alloca [1 x ptr], align 8
+  call void @llvm.memset(ptr %10, i8 0, i64 8, i1 false)
+  %11 = getelementptr inbounds ptr, ptr %10, i64 0
+  %12 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 2)
+  %13 = getelementptr inbounds %main.N, ptr %12, i32 0, i32 0
+  %14 = getelementptr inbounds %main.N, ptr %12, i32 0, i32 1
+  store i8 1, ptr %13, align 1
+  store i8 2, ptr %14, align 1
+  store ptr %12, ptr %11, align 8
+  %15 = load [1 x ptr], ptr %10, align 8
+  %16 = load ptr, ptr @_llgo_main.K2, align 8
+  %17 = extractvalue [1 x ptr] %15, 0
+  %18 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %16, 0
+  %19 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %18, ptr %17, 1
+  %20 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %9, %"github.com/goplus/llgo/internal/runtime.eface" %19)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %20)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %25 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
-  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.MakeMap"(ptr %25, i64 0)
-  %27 = alloca [1 x ptr], align 8
-  call void @llvm.memset(ptr %27, i8 0, i64 8, i1 false)
-  %28 = getelementptr inbounds ptr, ptr %27, i64 0
-  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 2)
-  %30 = getelementptr inbounds %main.N, ptr %29, i32 0, i32 0
-  %31 = getelementptr inbounds %main.N, ptr %29, i32 0, i32 1
-  store i8 1, ptr %30, align 1
-  store i8 2, ptr %31, align 1
-  store ptr %29, ptr %28, align 8
-  %32 = load [1 x ptr], ptr %27, align 8
-  %33 = load ptr, ptr @_llgo_main.K2, align 8
-  %34 = extractvalue [1 x ptr] %32, 0
-  %35 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %36 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %35, i32 0, i32 0
-  store ptr %33, ptr %36, align 8
-  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %35, i32 0, i32 1
-  store ptr %34, ptr %37, align 8
-  %38 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %35, align 8
-  %39 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
-  %40 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.eface" %38, ptr %40, align 8
-  %41 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %39, ptr %26, ptr %40)
-  store i64 100, ptr %41, align 4
-  %42 = alloca [1 x ptr], align 8
-  call void @llvm.memset(ptr %42, i8 0, i64 8, i1 false)
-  %43 = getelementptr inbounds ptr, ptr %42, i64 0
-  %44 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 2)
-  %45 = getelementptr inbounds %main.N, ptr %44, i32 0, i32 0
-  %46 = getelementptr inbounds %main.N, ptr %44, i32 0, i32 1
-  store i8 3, ptr %45, align 1
-  store i8 4, ptr %46, align 1
-  store ptr %44, ptr %43, align 8
-  %47 = load [1 x ptr], ptr %42, align 8
-  %48 = load ptr, ptr @_llgo_main.K2, align 8
-  %49 = extractvalue [1 x ptr] %47, 0
-  %50 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %50, i32 0, i32 0
-  store ptr %48, ptr %51, align 8
-  %52 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %50, i32 0, i32 1
-  store ptr %49, ptr %52, align 8
-  %53 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %50, align 8
-  %54 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
-  %55 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.eface" %53, ptr %55, align 8
-  %56 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %54, ptr %26, ptr %55)
-  store i64 200, ptr %56, align 4
-  %57 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
-  %58 = call ptr @"github.com/goplus/llgo/internal/runtime.NewMapIter"(ptr %57, ptr %26)
+  %21 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
+  %22 = call ptr @"github.com/goplus/llgo/internal/runtime.MakeMap"(ptr %21, i64 0)
+  %23 = alloca [1 x ptr], align 8
+  call void @llvm.memset(ptr %23, i8 0, i64 8, i1 false)
+  %24 = getelementptr inbounds ptr, ptr %23, i64 0
+  %25 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 2)
+  %26 = getelementptr inbounds %main.N, ptr %25, i32 0, i32 0
+  %27 = getelementptr inbounds %main.N, ptr %25, i32 0, i32 1
+  store i8 1, ptr %26, align 1
+  store i8 2, ptr %27, align 1
+  store ptr %25, ptr %24, align 8
+  %28 = load [1 x ptr], ptr %23, align 8
+  %29 = load ptr, ptr @_llgo_main.K2, align 8
+  %30 = extractvalue [1 x ptr] %28, 0
+  %31 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %29, 0
+  %32 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %31, ptr %30, 1
+  %33 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
+  %34 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.eface" %32, ptr %34, align 8
+  %35 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %33, ptr %22, ptr %34)
+  store i64 100, ptr %35, align 4
+  %36 = alloca [1 x ptr], align 8
+  call void @llvm.memset(ptr %36, i8 0, i64 8, i1 false)
+  %37 = getelementptr inbounds ptr, ptr %36, i64 0
+  %38 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 2)
+  %39 = getelementptr inbounds %main.N, ptr %38, i32 0, i32 0
+  %40 = getelementptr inbounds %main.N, ptr %38, i32 0, i32 1
+  store i8 3, ptr %39, align 1
+  store i8 4, ptr %40, align 1
+  store ptr %38, ptr %37, align 8
+  %41 = load [1 x ptr], ptr %36, align 8
+  %42 = load ptr, ptr @_llgo_main.K2, align 8
+  %43 = extractvalue [1 x ptr] %41, 0
+  %44 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %42, 0
+  %45 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %44, ptr %43, 1
+  %46 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
+  %47 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.eface" %45, ptr %47, align 8
+  %48 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %46, ptr %22, ptr %47)
+  store i64 200, ptr %48, align 4
+  %49 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
+  %50 = call ptr @"github.com/goplus/llgo/internal/runtime.NewMapIter"(ptr %49, ptr %22)
   br label %_llgo_1
 
 _llgo_1:                                          ; preds = %_llgo_7, %_llgo_0
-  %59 = call { i1, ptr, ptr } @"github.com/goplus/llgo/internal/runtime.MapIterNext"(ptr %58)
-  %60 = extractvalue { i1, ptr, ptr } %59, 0
-  br i1 %60, label %_llgo_4, label %_llgo_5
+  %51 = call { i1, ptr, ptr } @"github.com/goplus/llgo/internal/runtime.MapIterNext"(ptr %50)
+  %52 = extractvalue { i1, ptr, ptr } %51, 0
+  br i1 %52, label %_llgo_4, label %_llgo_5
 
 _llgo_2:                                          ; preds = %_llgo_6
-  %61 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %80, 1
-  %62 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %80, 2
-  %63 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %61, 0
-  %64 = load ptr, ptr @_llgo_main.K2, align 8
-  %65 = icmp eq ptr %63, %64
-  br i1 %65, label %_llgo_7, label %_llgo_8
+  %53 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %64, 1
+  %54 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %64, 2
+  %55 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %53, 0
+  %56 = load ptr, ptr @_llgo_main.K2, align 8
+  %57 = icmp eq ptr %55, %56
+  br i1 %57, label %_llgo_7, label %_llgo_8
 
 _llgo_3:                                          ; preds = %_llgo_6
   ret void
 
 _llgo_4:                                          ; preds = %_llgo_1
-  %66 = extractvalue { i1, ptr, ptr } %59, 1
-  %67 = extractvalue { i1, ptr, ptr } %59, 2
-  %68 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %66, align 8
-  %69 = load i64, ptr %67, align 4
-  %70 = alloca { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, align 8
-  %71 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %70, i32 0, i32 0
-  store i1 true, ptr %71, align 1
-  %72 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %70, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.eface" %68, ptr %72, align 8
-  %73 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %70, i32 0, i32 2
-  store i64 %69, ptr %73, align 4
-  %74 = load { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %70, align 8
+  %58 = extractvalue { i1, ptr, ptr } %51, 1
+  %59 = extractvalue { i1, ptr, ptr } %51, 2
+  %60 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %58, align 8
+  %61 = load i64, ptr %59, align 4
+  %62 = insertvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } { i1 true, %"github.com/goplus/llgo/internal/runtime.eface" undef, i64 undef }, %"github.com/goplus/llgo/internal/runtime.eface" %60, 1
+  %63 = insertvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %62, i64 %61, 2
   br label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_1
-  %75 = alloca { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, align 8
-  %76 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %75, i32 0, i32 0
-  store i1 false, ptr %76, align 1
-  %77 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %75, i32 0, i32 1
-  store %"github.com/goplus/llgo/internal/runtime.eface" zeroinitializer, ptr %77, align 8
-  %78 = getelementptr inbounds { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %75, i32 0, i32 2
-  store i64 0, ptr %78, align 4
-  %79 = load { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 }, ptr %75, align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %80 = phi { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } [ %74, %_llgo_4 ], [ %79, %_llgo_5 ]
-  %81 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %80, 0
-  br i1 %81, label %_llgo_2, label %_llgo_3
+  %64 = phi { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } [ %63, %_llgo_4 ], [ zeroinitializer, %_llgo_5 ]
+  %65 = extractvalue { i1, %"github.com/goplus/llgo/internal/runtime.eface", i64 } %64, 0
+  br i1 %65, label %_llgo_2, label %_llgo_3
 
 _llgo_7:                                          ; preds = %_llgo_2
-  %82 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %61, 1
-  %83 = getelementptr inbounds %main.N, ptr %82, i32 0, i32 0
-  %84 = load i8, ptr %83, align 1
-  %85 = sext i8 %84 to i64
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %85)
+  %66 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %53, 1
+  %67 = getelementptr inbounds %main.N, ptr %66, i32 0, i32 0
+  %68 = load i8, ptr %67, align 1
+  %69 = sext i8 %68 to i64
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %69)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %62)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %54)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_1
 
 _llgo_8:                                          ; preds = %_llgo_2
-  %86 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %87 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %86, i32 0, i32 0
-  store ptr @14, ptr %87, align 8
-  %88 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %86, i32 0, i32 1
-  store i64 21, ptr %88, align 4
-  %89 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %86, align 8
-  %90 = load ptr, ptr @_llgo_string, align 8
-  %91 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %89, ptr %91, align 8
-  %92 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %93 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %92, i32 0, i32 0
-  store ptr %90, ptr %93, align 8
-  %94 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %92, i32 0, i32 1
-  store ptr %91, ptr %94, align 8
-  %95 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %92, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %95)
+  %70 = load ptr, ptr @_llgo_string, align 8
+  %71 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @14, i64 21 }, ptr %71, align 8
+  %72 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %70, 0
+  %73 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %72, ptr %71, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %73)
   unreachable
 }
 
@@ -933,185 +693,29 @@ define void @main.make5() {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/internal/runtime.NewChan"(i64 8, i64 0)
   %1 = load ptr, ptr @"chan _llgo_int", align 8
-  %2 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %2, i32 0, i32 0
-  store ptr %1, ptr %3, align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %2, i32 0, i32 1
-  store ptr %0, ptr %4, align 8
-  %5 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %2, align 8
-  %6 = load ptr, ptr @"chan _llgo_int", align 8
-  %7 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, i32 0, i32 0
-  store ptr %6, ptr %8, align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, i32 0, i32 1
-  store ptr %0, ptr %9, align 8
-  %10 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %7, align 8
-  %11 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %5, %"github.com/goplus/llgo/internal/runtime.eface" %10)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %11)
+  %2 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %1, 0
+  %3 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %2, ptr %0, 1
+  %4 = load ptr, ptr @"chan _llgo_int", align 8
+  %5 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %4, 0
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %5, ptr %0, 1
+  %7 = call i1 @"github.com/goplus/llgo/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/internal/runtime.eface" %3, %"github.com/goplus/llgo/internal/runtime.eface" %6)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %7)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %12 = load ptr, ptr @"chan _llgo_int", align 8
-  %13 = load ptr, ptr @"map[chan _llgo_int]_llgo_int", align 8
-  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.MakeMap"(ptr %13, i64 0)
-  %15 = load ptr, ptr @"map[chan _llgo_int]_llgo_int", align 8
-  %16 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  store ptr %0, ptr %16, align 8
-  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %15, ptr %14, ptr %16)
-  store i64 100, ptr %17, align 4
-  %18 = load ptr, ptr @"map[chan _llgo_int]_llgo_int", align 8
-  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  store ptr %0, ptr %19, align 8
-  %20 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %18, ptr %14, ptr %19)
-  store i64 200, ptr %20, align 4
-  %21 = load ptr, ptr @"map[chan _llgo_int]_llgo_int", align 8
-  %22 = call ptr @"github.com/goplus/llgo/internal/runtime.NewMapIter"(ptr %21, ptr %14)
-  br label %_llgo_1
-
-_llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-  %23 = call { i1, ptr, ptr } @"github.com/goplus/llgo/internal/runtime.MapIterNext"(ptr %22)
-  %24 = extractvalue { i1, ptr, ptr } %23, 0
-  br i1 %24, label %_llgo_4, label %_llgo_5
-
-_llgo_2:                                          ; preds = %_llgo_6
-  %25 = extractvalue { i1, ptr, i64 } %41, 1
-  %26 = extractvalue { i1, ptr, i64 } %41, 2
-  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %25)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %26)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  br label %_llgo_1
-
-_llgo_3:                                          ; preds = %_llgo_6
-  ret void
-
-_llgo_4:                                          ; preds = %_llgo_1
-  %27 = extractvalue { i1, ptr, ptr } %23, 1
-  %28 = extractvalue { i1, ptr, ptr } %23, 2
-  %29 = load ptr, ptr %27, align 8
-  %30 = load i64, ptr %28, align 4
-  %31 = alloca { i1, ptr, i64 }, align 8
-  %32 = getelementptr inbounds { i1, ptr, i64 }, ptr %31, i32 0, i32 0
-  store i1 true, ptr %32, align 1
-  %33 = getelementptr inbounds { i1, ptr, i64 }, ptr %31, i32 0, i32 1
-  store ptr %29, ptr %33, align 8
-  %34 = getelementptr inbounds { i1, ptr, i64 }, ptr %31, i32 0, i32 2
-  store i64 %30, ptr %34, align 4
-  %35 = load { i1, ptr, i64 }, ptr %31, align 8
-  br label %_llgo_6
-
-_llgo_5:                                          ; preds = %_llgo_1
-  %36 = alloca { i1, ptr, i64 }, align 8
-  %37 = getelementptr inbounds { i1, ptr, i64 }, ptr %36, i32 0, i32 0
-  store i1 false, ptr %37, align 1
-  %38 = getelementptr inbounds { i1, ptr, i64 }, ptr %36, i32 0, i32 1
-  store ptr null, ptr %38, align 8
-  %39 = getelementptr inbounds { i1, ptr, i64 }, ptr %36, i32 0, i32 2
-  store i64 0, ptr %39, align 4
-  %40 = load { i1, ptr, i64 }, ptr %36, align 8
-  br label %_llgo_6
-
-_llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %41 = phi { i1, ptr, i64 } [ %35, %_llgo_4 ], [ %40, %_llgo_5 ]
-  %42 = extractvalue { i1, ptr, i64 } %41, 0
-  br i1 %42, label %_llgo_2, label %_llgo_3
-}
-
-define void @main.make6() {
-_llgo_0:
-  %0 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
-  %1 = call ptr @"github.com/goplus/llgo/internal/runtime.MakeMap"(ptr %0, i64 0)
-  %2 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 0
-  store ptr @5, ptr %3, align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 1
-  store i64 5, ptr %4, align 4
-  %5 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
-  %6 = load ptr, ptr @_llgo_main.M, align 8
-  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  store i64 1, ptr %7, align 4
-  %8 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %6, ptr %1, ptr %7)
-  store %"github.com/goplus/llgo/internal/runtime.String" %5, ptr %8, align 8
-  %9 = load ptr, ptr @_llgo_main.M, align 8
-  %10 = call ptr @"github.com/goplus/llgo/internal/runtime.NewMapIter"(ptr %9, ptr %1)
-  br label %_llgo_1
-
-_llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
-  %11 = call { i1, ptr, ptr } @"github.com/goplus/llgo/internal/runtime.MapIterNext"(ptr %10)
-  %12 = extractvalue { i1, ptr, ptr } %11, 0
-  br i1 %12, label %_llgo_4, label %_llgo_5
-
-_llgo_2:                                          ; preds = %_llgo_6
-  %13 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %29, 1
-  %14 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %29, 2
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %13)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %14)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  br label %_llgo_1
-
-_llgo_3:                                          ; preds = %_llgo_6
-  ret void
-
-_llgo_4:                                          ; preds = %_llgo_1
-  %15 = extractvalue { i1, ptr, ptr } %11, 1
-  %16 = extractvalue { i1, ptr, ptr } %11, 2
-  %17 = load i64, ptr %15, align 4
-  %18 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %16, align 8
-  %19 = alloca { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, align 8
-  %20 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %19, i32 0, i32 0
-  store i1 true, ptr %20, align 1
-  %21 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %19, i32 0, i32 1
-  store i64 %17, ptr %21, align 4
-  %22 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %19, i32 0, i32 2
-  store %"github.com/goplus/llgo/internal/runtime.String" %18, ptr %22, align 8
-  %23 = load { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %19, align 8
-  br label %_llgo_6
-
-_llgo_5:                                          ; preds = %_llgo_1
-  %24 = alloca { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, align 8
-  %25 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %24, i32 0, i32 0
-  store i1 false, ptr %25, align 1
-  %26 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %24, i32 0, i32 1
-  store i64 0, ptr %26, align 4
-  %27 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %24, i32 0, i32 2
-  store %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, ptr %27, align 8
-  %28 = load { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %24, align 8
-  br label %_llgo_6
-
-_llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %29 = phi { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } [ %23, %_llgo_4 ], [ %28, %_llgo_5 ]
-  %30 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %29, 0
-  br i1 %30, label %_llgo_2, label %_llgo_3
-}
-
-define void @main.make7() {
-_llgo_0:
-  %0 = load ptr, ptr @_llgo_main.N, align 8
-  %1 = load ptr, ptr @"map[_llgo_main.N]_llgo_string", align 8
-  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.MakeMap"(ptr %1, i64 2)
-  %3 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3, i32 0, i32 0
-  store ptr @5, ptr %4, align 8
-  %5 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %3, i32 0, i32 1
-  store i64 5, ptr %5, align 4
-  %6 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %3, align 8
-  %7 = load ptr, ptr @"map[_llgo_main.N]_llgo_string", align 8
-  %8 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  store i64 1, ptr %8, align 4
-  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %7, ptr %2, ptr %8)
-  store %"github.com/goplus/llgo/internal/runtime.String" %6, ptr %9, align 8
-  %10 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %10, i32 0, i32 0
-  store ptr @6, ptr %11, align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %10, i32 0, i32 1
-  store i64 5, ptr %12, align 4
-  %13 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %10, align 8
-  %14 = load ptr, ptr @"map[_llgo_main.N]_llgo_string", align 8
+  %8 = load ptr, ptr @"chan _llgo_int", align 8
+  %9 = load ptr, ptr @"map[chan _llgo_int]_llgo_int", align 8
+  %10 = call ptr @"github.com/goplus/llgo/internal/runtime.MakeMap"(ptr %9, i64 0)
+  %11 = load ptr, ptr @"map[chan _llgo_int]_llgo_int", align 8
+  %12 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  store ptr %0, ptr %12, align 8
+  %13 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %11, ptr %10, ptr %12)
+  store i64 100, ptr %13, align 4
+  %14 = load ptr, ptr @"map[chan _llgo_int]_llgo_int", align 8
   %15 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  store i64 2, ptr %15, align 4
-  %16 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %14, ptr %2, ptr %15)
-  store %"github.com/goplus/llgo/internal/runtime.String" %13, ptr %16, align 8
-  %17 = load ptr, ptr @"map[_llgo_main.N]_llgo_string", align 8
-  %18 = call ptr @"github.com/goplus/llgo/internal/runtime.NewMapIter"(ptr %17, ptr %2)
+  store ptr %0, ptr %15, align 8
+  %16 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %14, ptr %10, ptr %15)
+  store i64 200, ptr %16, align 4
+  %17 = load ptr, ptr @"map[chan _llgo_int]_llgo_int", align 8
+  %18 = call ptr @"github.com/goplus/llgo/internal/runtime.NewMapIter"(ptr %17, ptr %10)
   br label %_llgo_1
 
 _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
@@ -1120,54 +724,142 @@ _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
   br i1 %20, label %_llgo_4, label %_llgo_5
 
 _llgo_2:                                          ; preds = %_llgo_6
-  %21 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %41, 1
-  %22 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %41, 2
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %21)
+  %21 = extractvalue { i1, ptr, i64 } %29, 1
+  %22 = extractvalue { i1, ptr, i64 } %29, 2
+  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %21)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %22)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %22)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_1
 
 _llgo_3:                                          ; preds = %_llgo_6
-  %23 = load ptr, ptr @"map[_llgo_main.N]_llgo_string", align 8
-  %24 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  store i64 1, ptr %24, align 4
-  %25 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAccess1"(ptr %23, ptr %2, ptr %24)
-  %26 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %25, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %26)
+  ret void
+
+_llgo_4:                                          ; preds = %_llgo_1
+  %23 = extractvalue { i1, ptr, ptr } %19, 1
+  %24 = extractvalue { i1, ptr, ptr } %19, 2
+  %25 = load ptr, ptr %23, align 8
+  %26 = load i64, ptr %24, align 4
+  %27 = insertvalue { i1, ptr, i64 } { i1 true, ptr undef, i64 undef }, ptr %25, 1
+  %28 = insertvalue { i1, ptr, i64 } %27, i64 %26, 2
+  br label %_llgo_6
+
+_llgo_5:                                          ; preds = %_llgo_1
+  br label %_llgo_6
+
+_llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
+  %29 = phi { i1, ptr, i64 } [ %28, %_llgo_4 ], [ zeroinitializer, %_llgo_5 ]
+  %30 = extractvalue { i1, ptr, i64 } %29, 0
+  br i1 %30, label %_llgo_2, label %_llgo_3
+}
+
+define void @main.make6() {
+_llgo_0:
+  %0 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
+  %1 = call ptr @"github.com/goplus/llgo/internal/runtime.MakeMap"(ptr %0, i64 0)
+  %2 = load ptr, ptr @_llgo_main.M, align 8
+  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  store i64 1, ptr %3, align 4
+  %4 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %2, ptr %1, ptr %3)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 5 }, ptr %4, align 8
+  %5 = load ptr, ptr @_llgo_main.M, align 8
+  %6 = call ptr @"github.com/goplus/llgo/internal/runtime.NewMapIter"(ptr %5, ptr %1)
+  br label %_llgo_1
+
+_llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
+  %7 = call { i1, ptr, ptr } @"github.com/goplus/llgo/internal/runtime.MapIterNext"(ptr %6)
+  %8 = extractvalue { i1, ptr, ptr } %7, 0
+  br i1 %8, label %_llgo_4, label %_llgo_5
+
+_llgo_2:                                          ; preds = %_llgo_6
+  %9 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %17, 1
+  %10 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %17, 2
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %9)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %10)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
+  br label %_llgo_1
+
+_llgo_3:                                          ; preds = %_llgo_6
+  ret void
+
+_llgo_4:                                          ; preds = %_llgo_1
+  %11 = extractvalue { i1, ptr, ptr } %7, 1
+  %12 = extractvalue { i1, ptr, ptr } %7, 2
+  %13 = load i64, ptr %11, align 4
+  %14 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %12, align 8
+  %15 = insertvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } { i1 true, i64 undef, %"github.com/goplus/llgo/internal/runtime.String" undef }, i64 %13, 1
+  %16 = insertvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %15, %"github.com/goplus/llgo/internal/runtime.String" %14, 2
+  br label %_llgo_6
+
+_llgo_5:                                          ; preds = %_llgo_1
+  br label %_llgo_6
+
+_llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
+  %17 = phi { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } [ %16, %_llgo_4 ], [ zeroinitializer, %_llgo_5 ]
+  %18 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %17, 0
+  br i1 %18, label %_llgo_2, label %_llgo_3
+}
+
+define void @main.make7() {
+_llgo_0:
+  %0 = load ptr, ptr @_llgo_main.N, align 8
+  %1 = load ptr, ptr @"map[_llgo_main.N]_llgo_string", align 8
+  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.MakeMap"(ptr %1, i64 2)
+  %3 = load ptr, ptr @"map[_llgo_main.N]_llgo_string", align 8
+  %4 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  store i64 1, ptr %4, align 4
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %3, ptr %2, ptr %4)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 5 }, ptr %5, align 8
+  %6 = load ptr, ptr @"map[_llgo_main.N]_llgo_string", align 8
+  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  store i64 2, ptr %7, align 4
+  %8 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %6, ptr %2, ptr %7)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 5 }, ptr %8, align 8
+  %9 = load ptr, ptr @"map[_llgo_main.N]_llgo_string", align 8
+  %10 = call ptr @"github.com/goplus/llgo/internal/runtime.NewMapIter"(ptr %9, ptr %2)
+  br label %_llgo_1
+
+_llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
+  %11 = call { i1, ptr, ptr } @"github.com/goplus/llgo/internal/runtime.MapIterNext"(ptr %10)
+  %12 = extractvalue { i1, ptr, ptr } %11, 0
+  br i1 %12, label %_llgo_4, label %_llgo_5
+
+_llgo_2:                                          ; preds = %_llgo_6
+  %13 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %25, 1
+  %14 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %25, 2
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %13)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %14)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
+  br label %_llgo_1
+
+_llgo_3:                                          ; preds = %_llgo_6
+  %15 = load ptr, ptr @"map[_llgo_main.N]_llgo_string", align 8
+  %16 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  store i64 1, ptr %16, align 4
+  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAccess1"(ptr %15, ptr %2, ptr %16)
+  %18 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %17, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %18)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret void
 
 _llgo_4:                                          ; preds = %_llgo_1
-  %27 = extractvalue { i1, ptr, ptr } %19, 1
-  %28 = extractvalue { i1, ptr, ptr } %19, 2
-  %29 = load i64, ptr %27, align 4
-  %30 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %28, align 8
-  %31 = alloca { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, align 8
-  %32 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %31, i32 0, i32 0
-  store i1 true, ptr %32, align 1
-  %33 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %31, i32 0, i32 1
-  store i64 %29, ptr %33, align 4
-  %34 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %31, i32 0, i32 2
-  store %"github.com/goplus/llgo/internal/runtime.String" %30, ptr %34, align 8
-  %35 = load { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %31, align 8
+  %19 = extractvalue { i1, ptr, ptr } %11, 1
+  %20 = extractvalue { i1, ptr, ptr } %11, 2
+  %21 = load i64, ptr %19, align 4
+  %22 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %20, align 8
+  %23 = insertvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } { i1 true, i64 undef, %"github.com/goplus/llgo/internal/runtime.String" undef }, i64 %21, 1
+  %24 = insertvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %23, %"github.com/goplus/llgo/internal/runtime.String" %22, 2
   br label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_1
-  %36 = alloca { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, align 8
-  %37 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %36, i32 0, i32 0
-  store i1 false, ptr %37, align 1
-  %38 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %36, i32 0, i32 1
-  store i64 0, ptr %38, align 4
-  %39 = getelementptr inbounds { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %36, i32 0, i32 2
-  store %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, ptr %39, align 8
-  %40 = load { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" }, ptr %36, align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %41 = phi { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } [ %35, %_llgo_4 ], [ %40, %_llgo_5 ]
-  %42 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %41, 0
-  br i1 %42, label %_llgo_2, label %_llgo_3
+  %25 = phi { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } [ %24, %_llgo_4 ], [ zeroinitializer, %_llgo_5 ]
+  %26 = extractvalue { i1, i64, %"github.com/goplus/llgo/internal/runtime.String" } %25, 0
+  br i1 %26, label %_llgo_2, label %_llgo_3
 }
 
 declare void @"github.com/goplus/llgo/internal/runtime.init"()
@@ -1201,902 +893,383 @@ _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
 _llgo_5:                                          ; preds = %_llgo_4
   %8 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
   %9 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %10 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %10, i32 0, i32 0
-  store ptr @0, ptr %11, align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %10, i32 0, i32 1
-  store i64 7, ptr %12, align 4
-  %13 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %10, align 8
-  %14 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %15 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %14, i32 0, i32 0
-  store ptr null, ptr %15, align 8
-  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %14, i32 0, i32 1
-  store i64 0, ptr %16, align 4
-  %17 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %14, align 8
-  %18 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %18)
-  %20 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %13, ptr %19, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %17, i1 false)
-  %21 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %21, i32 0, i32 0
-  store ptr @1, ptr %22, align 8
-  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %21, i32 0, i32 1
-  store i64 4, ptr %23, align 4
-  %24 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %21, align 8
-  %25 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 0
-  store ptr null, ptr %26, align 8
-  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 1
-  store i64 0, ptr %27, align 4
-  %28 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %25, align 8
-  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %29)
-  %31 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %24, ptr %30, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %28, i1 false)
-  %32 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %32, i32 0, i32 0
-  store ptr @2, ptr %33, align 8
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %32, i32 0, i32 1
-  store i64 5, ptr %34, align 4
-  %35 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %32, align 8
-  %36 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %36, i32 0, i32 0
-  store ptr null, ptr %37, align 8
-  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %36, i32 0, i32 1
-  store i64 0, ptr %38, align 4
-  %39 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %36, align 8
-  %40 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %41 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %40)
-  %42 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %35, ptr %41, i64 72, %"github.com/goplus/llgo/internal/runtime.String" %39, i1 false)
-  %43 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %43, i32 0, i32 0
-  store ptr @3, ptr %44, align 8
-  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %43, i32 0, i32 1
-  store i64 8, ptr %45, align 4
-  %46 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %43, align 8
-  %47 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %48 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %47, i32 0, i32 0
-  store ptr null, ptr %48, align 8
-  %49 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %47, i32 0, i32 1
-  store i64 0, ptr %49, align 4
-  %50 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %47, align 8
-  %51 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %52 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %46, ptr %51, i64 200, %"github.com/goplus/llgo/internal/runtime.String" %50, i1 false)
-  %53 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %54 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %53, i32 0, i32 0
-  store ptr @4, ptr %54, align 8
-  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %53, i32 0, i32 1
-  store i64 4, ptr %55, align 4
-  %56 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %53, align 8
-  %57 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
-  %58 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %57, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %20, ptr %58, align 8
-  %59 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %57, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %31, ptr %59, align 8
-  %60 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %57, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %42, ptr %60, align 8
-  %61 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %57, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %52, ptr %61, align 8
-  %62 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %63 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %62, i32 0, i32 0
-  store ptr %57, ptr %63, align 8
-  %64 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %62, i32 0, i32 1
-  store i64 4, ptr %64, align 4
-  %65 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %62, i32 0, i32 2
-  store i64 4, ptr %65, align 4
-  %66 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %62, align 8
-  %67 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %56, i64 208, %"github.com/goplus/llgo/internal/runtime.Slice" %66)
-  %68 = call ptr @"github.com/goplus/llgo/internal/runtime.MapOf"(ptr %8, ptr %9, ptr %67, i64 4)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %68)
-  store ptr %68, ptr @"map[_llgo_int]_llgo_string", align 8
+  %10 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %10)
+  %12 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 7 }, ptr %11, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %13 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %13)
+  %15 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, ptr %14, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %16 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %16)
+  %18 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 5 }, ptr %17, i64 72, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %20 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 8 }, ptr %19, i64 200, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %21 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
+  %22 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %21, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %12, ptr %22, align 8
+  %23 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %21, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %15, ptr %23, align 8
+  %24 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %21, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %18, ptr %24, align 8
+  %25 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %21, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %20, ptr %25, align 8
+  %26 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %21, 0
+  %27 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %26, i64 4, 1
+  %28 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %27, i64 4, 2
+  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, i64 208, %"github.com/goplus/llgo/internal/runtime.Slice" %28)
+  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.MapOf"(ptr %8, ptr %9, ptr %29, i64 4)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %30)
+  store ptr %30, ptr @"map[_llgo_int]_llgo_string", align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %69 = load ptr, ptr @"map[_llgo_string]_llgo_int", align 8
-  %70 = icmp eq ptr %69, null
-  br i1 %70, label %_llgo_7, label %_llgo_8
+  %31 = load ptr, ptr @"map[_llgo_string]_llgo_int", align 8
+  %32 = icmp eq ptr %31, null
+  br i1 %32, label %_llgo_7, label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_6
-  %71 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %72 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %73 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %74 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %73, i32 0, i32 0
-  store ptr @0, ptr %74, align 8
-  %75 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %73, i32 0, i32 1
-  store i64 7, ptr %75, align 4
-  %76 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %73, align 8
-  %77 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %78 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %77, i32 0, i32 0
-  store ptr null, ptr %78, align 8
-  %79 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %77, i32 0, i32 1
-  store i64 0, ptr %79, align 4
-  %80 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %77, align 8
-  %81 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %82 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %81)
-  %83 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %76, ptr %82, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %80, i1 false)
-  %84 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %85 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %84, i32 0, i32 0
-  store ptr @1, ptr %85, align 8
-  %86 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %84, i32 0, i32 1
-  store i64 4, ptr %86, align 4
-  %87 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %84, align 8
-  %88 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %89 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %88, i32 0, i32 0
-  store ptr null, ptr %89, align 8
-  %90 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %88, i32 0, i32 1
-  store i64 0, ptr %90, align 4
-  %91 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %88, align 8
-  %92 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %93 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %92)
-  %94 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %87, ptr %93, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %91, i1 false)
-  %95 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %96 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %95, i32 0, i32 0
-  store ptr @2, ptr %96, align 8
-  %97 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %95, i32 0, i32 1
-  store i64 5, ptr %97, align 4
-  %98 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %95, align 8
-  %99 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %100 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %99, i32 0, i32 0
-  store ptr null, ptr %100, align 8
-  %101 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %99, i32 0, i32 1
-  store i64 0, ptr %101, align 4
-  %102 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %99, align 8
-  %103 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %104 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %103)
-  %105 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %98, ptr %104, i64 136, %"github.com/goplus/llgo/internal/runtime.String" %102, i1 false)
-  %106 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %107 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %106, i32 0, i32 0
-  store ptr @3, ptr %107, align 8
-  %108 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %106, i32 0, i32 1
-  store i64 8, ptr %108, align 4
-  %109 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %106, align 8
-  %110 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %111 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %110, i32 0, i32 0
-  store ptr null, ptr %111, align 8
-  %112 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %110, i32 0, i32 1
-  store i64 0, ptr %112, align 4
-  %113 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %110, align 8
-  %114 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %115 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %109, ptr %114, i64 200, %"github.com/goplus/llgo/internal/runtime.String" %113, i1 false)
-  %116 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %117 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %116, i32 0, i32 0
-  store ptr @4, ptr %117, align 8
-  %118 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %116, i32 0, i32 1
-  store i64 4, ptr %118, align 4
-  %119 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %116, align 8
-  %120 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
-  %121 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %120, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %83, ptr %121, align 8
-  %122 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %120, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %94, ptr %122, align 8
-  %123 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %120, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %105, ptr %123, align 8
-  %124 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %120, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %115, ptr %124, align 8
-  %125 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %126 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %125, i32 0, i32 0
-  store ptr %120, ptr %126, align 8
-  %127 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %125, i32 0, i32 1
-  store i64 4, ptr %127, align 4
-  %128 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %125, i32 0, i32 2
-  store i64 4, ptr %128, align 4
-  %129 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %125, align 8
-  %130 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %119, i64 208, %"github.com/goplus/llgo/internal/runtime.Slice" %129)
-  %131 = call ptr @"github.com/goplus/llgo/internal/runtime.MapOf"(ptr %71, ptr %72, ptr %130, i64 12)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %131)
-  store ptr %131, ptr @"map[_llgo_string]_llgo_int", align 8
+  %33 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %34 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %35 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %36 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %35)
+  %37 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 7 }, ptr %36, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %38 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %38)
+  %40 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, ptr %39, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %41 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %42 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %41)
+  %43 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 5 }, ptr %42, i64 136, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %44 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %45 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 8 }, ptr %44, i64 200, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %46 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
+  %47 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %46, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %37, ptr %47, align 8
+  %48 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %46, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %40, ptr %48, align 8
+  %49 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %46, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %43, ptr %49, align 8
+  %50 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %46, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %45, ptr %50, align 8
+  %51 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %46, 0
+  %52 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %51, i64 4, 1
+  %53 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %52, i64 4, 2
+  %54 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, i64 208, %"github.com/goplus/llgo/internal/runtime.Slice" %53)
+  %55 = call ptr @"github.com/goplus/llgo/internal/runtime.MapOf"(ptr %33, ptr %34, ptr %54, i64 12)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %55)
+  store ptr %55, ptr @"map[_llgo_string]_llgo_int", align 8
   br label %_llgo_8
 
 _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
-  %132 = load ptr, ptr @_llgo_any, align 8
-  %133 = icmp eq ptr %132, null
-  br i1 %133, label %_llgo_9, label %_llgo_10
+  %56 = load ptr, ptr @_llgo_any, align 8
+  %57 = icmp eq ptr %56, null
+  br i1 %57, label %_llgo_9, label %_llgo_10
 
 _llgo_9:                                          ; preds = %_llgo_8
-  %134 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %135 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %136 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %135, i32 0, i32 0
-  store ptr %134, ptr %136, align 8
-  %137 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %135, i32 0, i32 1
-  store i64 0, ptr %137, align 4
-  %138 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %135, i32 0, i32 2
-  store i64 0, ptr %138, align 4
-  %139 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %135, align 8
-  %140 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %141 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %140, i32 0, i32 0
-  store ptr @4, ptr %141, align 8
-  %142 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %140, i32 0, i32 1
-  store i64 4, ptr %142, align 4
-  %143 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %140, align 8
-  %144 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %145 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %144, i32 0, i32 0
-  store ptr null, ptr %145, align 8
-  %146 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %144, i32 0, i32 1
-  store i64 0, ptr %146, align 4
-  %147 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %144, align 8
-  %148 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %143, %"github.com/goplus/llgo/internal/runtime.String" %147, %"github.com/goplus/llgo/internal/runtime.Slice" %139)
-  store ptr %148, ptr @_llgo_any, align 8
+  %58 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %59 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %58, 0
+  %60 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %59, i64 0, 1
+  %61 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %60, i64 0, 2
+  %62 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %61)
+  store ptr %62, ptr @_llgo_any, align 8
   br label %_llgo_10
 
 _llgo_10:                                         ; preds = %_llgo_9, %_llgo_8
-  %149 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
-  %150 = icmp eq ptr %149, null
-  br i1 %150, label %_llgo_11, label %_llgo_12
+  %63 = load ptr, ptr @"map[_llgo_any]_llgo_int", align 8
+  %64 = icmp eq ptr %63, null
+  br i1 %64, label %_llgo_11, label %_llgo_12
 
 _llgo_11:                                         ; preds = %_llgo_10
-  %151 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %152 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %153 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %152, i32 0, i32 0
-  store ptr %151, ptr %153, align 8
-  %154 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %152, i32 0, i32 1
-  store i64 0, ptr %154, align 4
-  %155 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %152, i32 0, i32 2
-  store i64 0, ptr %155, align 4
-  %156 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %152, align 8
-  %157 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %158 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %157, i32 0, i32 0
-  store ptr @4, ptr %158, align 8
-  %159 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %157, i32 0, i32 1
-  store i64 4, ptr %159, align 4
-  %160 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %157, align 8
-  %161 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %162 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %161, i32 0, i32 0
-  store ptr null, ptr %162, align 8
-  %163 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %161, i32 0, i32 1
-  store i64 0, ptr %163, align 4
-  %164 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %161, align 8
-  %165 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %160, %"github.com/goplus/llgo/internal/runtime.String" %164, %"github.com/goplus/llgo/internal/runtime.Slice" %156)
-  %166 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %167 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %168 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %167, i32 0, i32 0
-  store ptr @0, ptr %168, align 8
-  %169 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %167, i32 0, i32 1
-  store i64 7, ptr %169, align 4
-  %170 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %167, align 8
-  %171 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %172 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %171, i32 0, i32 0
-  store ptr null, ptr %172, align 8
-  %173 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %171, i32 0, i32 1
-  store i64 0, ptr %173, align 4
-  %174 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %171, align 8
-  %175 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %176 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %175)
-  %177 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %170, ptr %176, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %174, i1 false)
-  %178 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %179 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %178, i32 0, i32 0
-  store ptr @1, ptr %179, align 8
-  %180 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %178, i32 0, i32 1
-  store i64 4, ptr %180, align 4
-  %181 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %178, align 8
-  %182 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %183 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %182, i32 0, i32 0
-  store ptr null, ptr %183, align 8
-  %184 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %182, i32 0, i32 1
-  store i64 0, ptr %184, align 4
-  %185 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %182, align 8
-  %186 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %187 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %188 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %187, i32 0, i32 0
-  store ptr %186, ptr %188, align 8
-  %189 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %187, i32 0, i32 1
-  store i64 0, ptr %189, align 4
-  %190 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %187, i32 0, i32 2
-  store i64 0, ptr %190, align 4
-  %191 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %187, align 8
-  %192 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %193 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %192, i32 0, i32 0
-  store ptr @4, ptr %193, align 8
-  %194 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %192, i32 0, i32 1
-  store i64 4, ptr %194, align 4
-  %195 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %192, align 8
-  %196 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %197 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %196, i32 0, i32 0
-  store ptr null, ptr %197, align 8
-  %198 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %196, i32 0, i32 1
-  store i64 0, ptr %198, align 4
-  %199 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %196, align 8
-  %200 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %195, %"github.com/goplus/llgo/internal/runtime.String" %199, %"github.com/goplus/llgo/internal/runtime.Slice" %191)
-  %201 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %200)
-  %202 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %181, ptr %201, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %185, i1 false)
-  %203 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %204 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %203, i32 0, i32 0
-  store ptr @2, ptr %204, align 8
-  %205 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %203, i32 0, i32 1
-  store i64 5, ptr %205, align 4
-  %206 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %203, align 8
-  %207 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %208 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %207, i32 0, i32 0
-  store ptr null, ptr %208, align 8
-  %209 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %207, i32 0, i32 1
-  store i64 0, ptr %209, align 4
-  %210 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %207, align 8
-  %211 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %212 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %211)
-  %213 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %206, ptr %212, i64 136, %"github.com/goplus/llgo/internal/runtime.String" %210, i1 false)
-  %214 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %215 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %214, i32 0, i32 0
-  store ptr @3, ptr %215, align 8
-  %216 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %214, i32 0, i32 1
-  store i64 8, ptr %216, align 4
-  %217 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %214, align 8
-  %218 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %219 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %218, i32 0, i32 0
-  store ptr null, ptr %219, align 8
-  %220 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %218, i32 0, i32 1
-  store i64 0, ptr %220, align 4
-  %221 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %218, align 8
-  %222 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %223 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %217, ptr %222, i64 200, %"github.com/goplus/llgo/internal/runtime.String" %221, i1 false)
-  %224 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %225 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %224, i32 0, i32 0
-  store ptr @4, ptr %225, align 8
-  %226 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %224, i32 0, i32 1
-  store i64 4, ptr %226, align 4
-  %227 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %224, align 8
-  %228 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
-  %229 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %228, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %177, ptr %229, align 8
-  %230 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %228, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %202, ptr %230, align 8
-  %231 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %228, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %213, ptr %231, align 8
-  %232 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %228, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %223, ptr %232, align 8
-  %233 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %234 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %233, i32 0, i32 0
-  store ptr %228, ptr %234, align 8
-  %235 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %233, i32 0, i32 1
-  store i64 4, ptr %235, align 4
-  %236 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %233, i32 0, i32 2
-  store i64 4, ptr %236, align 4
-  %237 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %233, align 8
-  %238 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %227, i64 208, %"github.com/goplus/llgo/internal/runtime.Slice" %237)
-  %239 = call ptr @"github.com/goplus/llgo/internal/runtime.MapOf"(ptr %165, ptr %166, ptr %238, i64 24)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %239)
-  store ptr %239, ptr @"map[_llgo_any]_llgo_int", align 8
+  %65 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %66 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %65, 0
+  %67 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %66, i64 0, 1
+  %68 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %67, i64 0, 2
+  %69 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %68)
+  %70 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %71 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %72 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %71)
+  %73 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 7 }, ptr %72, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %74 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %75 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %74, 0
+  %76 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %75, i64 0, 1
+  %77 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %76, i64 0, 2
+  %78 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %77)
+  %79 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %78)
+  %80 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, ptr %79, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %81 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %82 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %81)
+  %83 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 5 }, ptr %82, i64 136, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %84 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %85 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 8 }, ptr %84, i64 200, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %86 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
+  %87 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %86, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %73, ptr %87, align 8
+  %88 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %86, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %80, ptr %88, align 8
+  %89 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %86, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %83, ptr %89, align 8
+  %90 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %86, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %85, ptr %90, align 8
+  %91 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %86, 0
+  %92 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %91, i64 4, 1
+  %93 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %92, i64 4, 2
+  %94 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, i64 208, %"github.com/goplus/llgo/internal/runtime.Slice" %93)
+  %95 = call ptr @"github.com/goplus/llgo/internal/runtime.MapOf"(ptr %69, ptr %70, ptr %94, i64 24)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %95)
+  store ptr %95, ptr @"map[_llgo_any]_llgo_int", align 8
   br label %_llgo_12
 
 _llgo_12:                                         ; preds = %_llgo_11, %_llgo_10
-  %240 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %241 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %240, i32 0, i32 0
-  store ptr @12, ptr %241, align 8
-  %242 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %240, i32 0, i32 1
-  store i64 7, ptr %242, align 4
-  %243 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %240, align 8
-  %244 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %243, i64 17, i64 8, i64 0, i64 0)
-  %245 = load ptr, ptr @_llgo_main.N1, align 8
-  %246 = icmp eq ptr %245, null
-  br i1 %246, label %_llgo_13, label %_llgo_14
+  %96 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @12, i64 7 }, i64 17, i64 8, i64 0, i64 0)
+  %97 = load ptr, ptr @_llgo_main.N1, align 8
+  %98 = icmp eq ptr %97, null
+  br i1 %98, label %_llgo_13, label %_llgo_14
 
 _llgo_13:                                         ; preds = %_llgo_12
-  store ptr %244, ptr @_llgo_main.N1, align 8
+  store ptr %96, ptr @_llgo_main.N1, align 8
   br label %_llgo_14
 
 _llgo_14:                                         ; preds = %_llgo_13, %_llgo_12
-  %247 = load ptr, ptr @"[1]_llgo_int", align 8
-  %248 = icmp eq ptr %247, null
-  br i1 %248, label %_llgo_15, label %_llgo_16
+  %99 = load ptr, ptr @"[1]_llgo_int", align 8
+  %100 = icmp eq ptr %99, null
+  br i1 %100, label %_llgo_15, label %_llgo_16
 
 _llgo_15:                                         ; preds = %_llgo_14
-  %249 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %250 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 1, ptr %249)
-  store ptr %250, ptr @"[1]_llgo_int", align 8
+  %101 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %102 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 1, ptr %101)
+  store ptr %102, ptr @"[1]_llgo_int", align 8
   br label %_llgo_16
 
 _llgo_16:                                         ; preds = %_llgo_15, %_llgo_14
-  %251 = load ptr, ptr @"[1]_llgo_int", align 8
-  br i1 %246, label %_llgo_17, label %_llgo_18
+  %103 = load ptr, ptr @"[1]_llgo_int", align 8
+  br i1 %98, label %_llgo_17, label %_llgo_18
 
 _llgo_17:                                         ; preds = %_llgo_16
-  %252 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %253 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %252, i32 0, i32 0
-  store ptr @4, ptr %253, align 8
-  %254 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %252, i32 0, i32 1
-  store i64 4, ptr %254, align 4
-  %255 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %252, align 8
-  %256 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %257 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %256, i32 0, i32 0
-  store ptr @13, ptr %257, align 8
-  %258 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %256, i32 0, i32 1
-  store i64 2, ptr %258, align 4
-  %259 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %256, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %244, %"github.com/goplus/llgo/internal/runtime.String" %255, %"github.com/goplus/llgo/internal/runtime.String" %259, ptr %251, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %96, %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @13, i64 2 }, ptr %103, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
   br label %_llgo_18
 
 _llgo_18:                                         ; preds = %_llgo_17, %_llgo_16
-  %260 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %261 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %260, i32 0, i32 0
-  store ptr @15, ptr %261, align 8
-  %262 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %260, i32 0, i32 1
-  store i64 6, ptr %262, align 4
-  %263 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %260, align 8
-  %264 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %263, i64 17, i64 2, i64 0, i64 0)
-  %265 = load ptr, ptr @_llgo_main.K, align 8
-  %266 = icmp eq ptr %265, null
-  br i1 %266, label %_llgo_19, label %_llgo_20
+  %104 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @15, i64 6 }, i64 17, i64 2, i64 0, i64 0)
+  %105 = load ptr, ptr @_llgo_main.K, align 8
+  %106 = icmp eq ptr %105, null
+  br i1 %106, label %_llgo_19, label %_llgo_20
 
 _llgo_19:                                         ; preds = %_llgo_18
-  store ptr %264, ptr @_llgo_main.K, align 8
+  store ptr %104, ptr @_llgo_main.K, align 8
   br label %_llgo_20
 
 _llgo_20:                                         ; preds = %_llgo_19, %_llgo_18
-  %267 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %268 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %267, i32 0, i32 0
-  store ptr @16, ptr %268, align 8
-  %269 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %267, i32 0, i32 1
-  store i64 6, ptr %269, align 4
-  %270 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %267, align 8
-  %271 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %270, i64 25, i64 2, i64 0, i64 0)
-  %272 = load ptr, ptr @_llgo_main.N, align 8
-  %273 = icmp eq ptr %272, null
-  br i1 %273, label %_llgo_21, label %_llgo_22
+  %107 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @16, i64 6 }, i64 25, i64 2, i64 0, i64 0)
+  %108 = load ptr, ptr @_llgo_main.N, align 8
+  %109 = icmp eq ptr %108, null
+  br i1 %109, label %_llgo_21, label %_llgo_22
 
 _llgo_21:                                         ; preds = %_llgo_20
-  store ptr %271, ptr @_llgo_main.N, align 8
+  store ptr %107, ptr @_llgo_main.N, align 8
   br label %_llgo_22
 
 _llgo_22:                                         ; preds = %_llgo_21, %_llgo_20
-  %274 = load ptr, ptr @_llgo_int8, align 8
-  %275 = icmp eq ptr %274, null
-  br i1 %275, label %_llgo_23, label %_llgo_24
+  %110 = load ptr, ptr @_llgo_int8, align 8
+  %111 = icmp eq ptr %110, null
+  br i1 %111, label %_llgo_23, label %_llgo_24
 
 _llgo_23:                                         ; preds = %_llgo_22
-  %276 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 35)
-  store ptr %276, ptr @_llgo_int8, align 8
+  %112 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 35)
+  store ptr %112, ptr @_llgo_int8, align 8
   br label %_llgo_24
 
 _llgo_24:                                         ; preds = %_llgo_23, %_llgo_22
-  %277 = load ptr, ptr @_llgo_int8, align 8
-  %278 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %279 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %278, i32 0, i32 0
-  store ptr @17, ptr %279, align 8
-  %280 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %278, i32 0, i32 1
-  store i64 2, ptr %280, align 4
-  %281 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %278, align 8
-  %282 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %283 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %282, i32 0, i32 0
-  store ptr null, ptr %283, align 8
-  %284 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %282, i32 0, i32 1
-  store i64 0, ptr %284, align 4
-  %285 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %282, align 8
-  %286 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 35)
-  %287 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %281, ptr %286, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %285, i1 false)
-  %288 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %289 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %288, i32 0, i32 0
-  store ptr @18, ptr %289, align 8
-  %290 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %288, i32 0, i32 1
-  store i64 2, ptr %290, align 4
-  %291 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %288, align 8
-  %292 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %293 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %292, i32 0, i32 0
-  store ptr null, ptr %293, align 8
-  %294 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %292, i32 0, i32 1
-  store i64 0, ptr %294, align 4
-  %295 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %292, align 8
-  %296 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 35)
-  %297 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %291, ptr %296, i64 1, %"github.com/goplus/llgo/internal/runtime.String" %295, i1 false)
-  %298 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %299 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %298, i32 0, i32 0
-  store ptr @4, ptr %299, align 8
-  %300 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %298, i32 0, i32 1
-  store i64 4, ptr %300, align 4
-  %301 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %298, align 8
-  %302 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %303 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %302, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %287, ptr %303, align 8
-  %304 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %302, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %297, ptr %304, align 8
-  %305 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %306 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %305, i32 0, i32 0
-  store ptr %302, ptr %306, align 8
-  %307 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %305, i32 0, i32 1
-  store i64 2, ptr %307, align 4
-  %308 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %305, i32 0, i32 2
-  store i64 2, ptr %308, align 4
-  %309 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %305, align 8
-  %310 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %301, i64 2, %"github.com/goplus/llgo/internal/runtime.Slice" %309)
-  store ptr %310, ptr @"main.struct$e65EDK9vxC36Nz3YTgO1ulssLlNH03Bva_WWaCjH-4A", align 8
-  %311 = load ptr, ptr @"main.struct$e65EDK9vxC36Nz3YTgO1ulssLlNH03Bva_WWaCjH-4A", align 8
-  br i1 %273, label %_llgo_25, label %_llgo_26
+  %113 = load ptr, ptr @_llgo_int8, align 8
+  %114 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 35)
+  %115 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @17, i64 2 }, ptr %114, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %116 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 35)
+  %117 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @18, i64 2 }, ptr %116, i64 1, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %118 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %119 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %118, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %115, ptr %119, align 8
+  %120 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %118, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %117, ptr %120, align 8
+  %121 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %118, 0
+  %122 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %121, i64 2, 1
+  %123 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %122, i64 2, 2
+  %124 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, i64 2, %"github.com/goplus/llgo/internal/runtime.Slice" %123)
+  store ptr %124, ptr @"main.struct$e65EDK9vxC36Nz3YTgO1ulssLlNH03Bva_WWaCjH-4A", align 8
+  %125 = load ptr, ptr @"main.struct$e65EDK9vxC36Nz3YTgO1ulssLlNH03Bva_WWaCjH-4A", align 8
+  br i1 %109, label %_llgo_25, label %_llgo_26
 
 _llgo_25:                                         ; preds = %_llgo_24
-  %312 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %313 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %312, i32 0, i32 0
-  store ptr @4, ptr %313, align 8
-  %314 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %312, i32 0, i32 1
-  store i64 4, ptr %314, align 4
-  %315 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %312, align 8
-  %316 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %317 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %316, i32 0, i32 0
-  store ptr @19, ptr %317, align 8
-  %318 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %316, i32 0, i32 1
-  store i64 1, ptr %318, align 4
-  %319 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %316, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %271, %"github.com/goplus/llgo/internal/runtime.String" %315, %"github.com/goplus/llgo/internal/runtime.String" %319, ptr %311, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %107, %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @19, i64 1 }, ptr %125, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
   br label %_llgo_26
 
 _llgo_26:                                         ; preds = %_llgo_25, %_llgo_24
-  %320 = load ptr, ptr @_llgo_main.N, align 8
-  %321 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %322 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %321, i32 0, i32 0
-  store ptr @16, ptr %322, align 8
-  %323 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %321, i32 0, i32 1
-  store i64 6, ptr %323, align 4
-  %324 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %321, align 8
-  %325 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %324, i64 25, i64 2, i64 0, i64 0)
-  %326 = load ptr, ptr @"[1]_llgo_main.N", align 8
-  %327 = icmp eq ptr %326, null
-  br i1 %327, label %_llgo_27, label %_llgo_28
+  %126 = load ptr, ptr @_llgo_main.N, align 8
+  %127 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @16, i64 6 }, i64 25, i64 2, i64 0, i64 0)
+  %128 = load ptr, ptr @"[1]_llgo_main.N", align 8
+  %129 = icmp eq ptr %128, null
+  br i1 %129, label %_llgo_27, label %_llgo_28
 
 _llgo_27:                                         ; preds = %_llgo_26
-  %328 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 1, ptr %325)
-  store ptr %328, ptr @"[1]_llgo_main.N", align 8
+  %130 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 1, ptr %127)
+  store ptr %130, ptr @"[1]_llgo_main.N", align 8
   br label %_llgo_28
 
 _llgo_28:                                         ; preds = %_llgo_27, %_llgo_26
-  %329 = load ptr, ptr @"[1]_llgo_main.N", align 8
-  br i1 %266, label %_llgo_29, label %_llgo_30
+  %131 = load ptr, ptr @"[1]_llgo_main.N", align 8
+  br i1 %106, label %_llgo_29, label %_llgo_30
 
 _llgo_29:                                         ; preds = %_llgo_28
-  %330 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %331 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %330, i32 0, i32 0
-  store ptr @4, ptr %331, align 8
-  %332 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %330, i32 0, i32 1
-  store i64 4, ptr %332, align 4
-  %333 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %330, align 8
-  %334 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %335 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %334, i32 0, i32 0
-  store ptr @20, ptr %335, align 8
-  %336 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %334, i32 0, i32 1
-  store i64 1, ptr %336, align 4
-  %337 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %334, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %264, %"github.com/goplus/llgo/internal/runtime.String" %333, %"github.com/goplus/llgo/internal/runtime.String" %337, ptr %329, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %104, %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @20, i64 1 }, ptr %131, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
   br label %_llgo_30
 
 _llgo_30:                                         ; preds = %_llgo_29, %_llgo_28
-  %338 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %339 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %338, i32 0, i32 0
-  store ptr @21, ptr %339, align 8
-  %340 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %338, i32 0, i32 1
-  store i64 7, ptr %340, align 4
-  %341 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %338, align 8
-  %342 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %341, i64 17, i64 8, i64 0, i64 0)
-  %343 = load ptr, ptr @_llgo_main.K2, align 8
-  %344 = icmp eq ptr %343, null
-  br i1 %344, label %_llgo_31, label %_llgo_32
+  %132 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @21, i64 7 }, i64 17, i64 8, i64 0, i64 0)
+  %133 = load ptr, ptr @_llgo_main.K2, align 8
+  %134 = icmp eq ptr %133, null
+  br i1 %134, label %_llgo_31, label %_llgo_32
 
 _llgo_31:                                         ; preds = %_llgo_30
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %342)
-  store ptr %342, ptr @_llgo_main.K2, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %132)
+  store ptr %132, ptr @_llgo_main.K2, align 8
   br label %_llgo_32
 
 _llgo_32:                                         ; preds = %_llgo_31, %_llgo_30
-  %345 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %346 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %345, i32 0, i32 0
-  store ptr @16, ptr %346, align 8
-  %347 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %345, i32 0, i32 1
-  store i64 6, ptr %347, align 4
-  %348 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %345, align 8
-  %349 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %348, i64 25, i64 2, i64 0, i64 0)
-  %350 = load ptr, ptr @"*_llgo_main.N", align 8
-  %351 = icmp eq ptr %350, null
-  br i1 %351, label %_llgo_33, label %_llgo_34
+  %135 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @16, i64 6 }, i64 25, i64 2, i64 0, i64 0)
+  %136 = load ptr, ptr @"*_llgo_main.N", align 8
+  %137 = icmp eq ptr %136, null
+  br i1 %137, label %_llgo_33, label %_llgo_34
 
 _llgo_33:                                         ; preds = %_llgo_32
-  %352 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %349)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %352)
-  store ptr %352, ptr @"*_llgo_main.N", align 8
+  %138 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %135)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %138)
+  store ptr %138, ptr @"*_llgo_main.N", align 8
   br label %_llgo_34
 
 _llgo_34:                                         ; preds = %_llgo_33, %_llgo_32
-  %353 = load ptr, ptr @"*_llgo_main.N", align 8
-  %354 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %355 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %354, i32 0, i32 0
-  store ptr @16, ptr %355, align 8
-  %356 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %354, i32 0, i32 1
-  store i64 6, ptr %356, align 4
-  %357 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %354, align 8
-  %358 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %357, i64 25, i64 2, i64 0, i64 0)
-  %359 = load ptr, ptr @"[1]*_llgo_main.N", align 8
-  %360 = icmp eq ptr %359, null
-  br i1 %360, label %_llgo_35, label %_llgo_36
+  %139 = load ptr, ptr @"*_llgo_main.N", align 8
+  %140 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @16, i64 6 }, i64 25, i64 2, i64 0, i64 0)
+  %141 = load ptr, ptr @"[1]*_llgo_main.N", align 8
+  %142 = icmp eq ptr %141, null
+  br i1 %142, label %_llgo_35, label %_llgo_36
 
 _llgo_35:                                         ; preds = %_llgo_34
-  %361 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %358)
-  %362 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 1, ptr %361)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %362)
-  store ptr %362, ptr @"[1]*_llgo_main.N", align 8
+  %143 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %140)
+  %144 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 1, ptr %143)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %144)
+  store ptr %144, ptr @"[1]*_llgo_main.N", align 8
   br label %_llgo_36
 
 _llgo_36:                                         ; preds = %_llgo_35, %_llgo_34
-  %363 = load ptr, ptr @"[1]*_llgo_main.N", align 8
-  br i1 %344, label %_llgo_37, label %_llgo_38
+  %145 = load ptr, ptr @"[1]*_llgo_main.N", align 8
+  br i1 %134, label %_llgo_37, label %_llgo_38
 
 _llgo_37:                                         ; preds = %_llgo_36
-  %364 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %365 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %364, i32 0, i32 0
-  store ptr @4, ptr %365, align 8
-  %366 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %364, i32 0, i32 1
-  store i64 4, ptr %366, align 4
-  %367 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %364, align 8
-  %368 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %369 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %368, i32 0, i32 0
-  store ptr @22, ptr %369, align 8
-  %370 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %368, i32 0, i32 1
-  store i64 2, ptr %370, align 4
-  %371 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %368, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %342, %"github.com/goplus/llgo/internal/runtime.String" %367, %"github.com/goplus/llgo/internal/runtime.String" %371, ptr %363, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %132, %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @22, i64 2 }, ptr %145, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
   br label %_llgo_38
 
 _llgo_38:                                         ; preds = %_llgo_37, %_llgo_36
-  %372 = load ptr, ptr @"chan _llgo_int", align 8
-  %373 = icmp eq ptr %372, null
-  br i1 %373, label %_llgo_39, label %_llgo_40
+  %146 = load ptr, ptr @"chan _llgo_int", align 8
+  %147 = icmp eq ptr %146, null
+  br i1 %147, label %_llgo_39, label %_llgo_40
 
 _llgo_39:                                         ; preds = %_llgo_38
-  %374 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %375 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %374, i32 0, i32 0
-  store ptr @23, ptr %375, align 8
-  %376 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %374, i32 0, i32 1
-  store i64 4, ptr %376, align 4
-  %377 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %374, align 8
-  %378 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %379 = call ptr @"github.com/goplus/llgo/internal/runtime.ChanOf"(i64 3, %"github.com/goplus/llgo/internal/runtime.String" %377, ptr %378)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %379)
-  store ptr %379, ptr @"chan _llgo_int", align 8
+  %148 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %149 = call ptr @"github.com/goplus/llgo/internal/runtime.ChanOf"(i64 3, %"github.com/goplus/llgo/internal/runtime.String" { ptr @23, i64 4 }, ptr %148)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %149)
+  store ptr %149, ptr @"chan _llgo_int", align 8
   br label %_llgo_40
 
 _llgo_40:                                         ; preds = %_llgo_39, %_llgo_38
-  %380 = load ptr, ptr @"map[chan _llgo_int]_llgo_int", align 8
-  %381 = icmp eq ptr %380, null
-  br i1 %381, label %_llgo_41, label %_llgo_42
+  %150 = load ptr, ptr @"map[chan _llgo_int]_llgo_int", align 8
+  %151 = icmp eq ptr %150, null
+  br i1 %151, label %_llgo_41, label %_llgo_42
 
 _llgo_41:                                         ; preds = %_llgo_40
-  %382 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %383 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %382, i32 0, i32 0
-  store ptr @23, ptr %383, align 8
-  %384 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %382, i32 0, i32 1
-  store i64 4, ptr %384, align 4
-  %385 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %382, align 8
-  %386 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %387 = call ptr @"github.com/goplus/llgo/internal/runtime.ChanOf"(i64 3, %"github.com/goplus/llgo/internal/runtime.String" %385, ptr %386)
-  %388 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %389 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %390 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %389, i32 0, i32 0
-  store ptr @0, ptr %390, align 8
-  %391 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %389, i32 0, i32 1
-  store i64 7, ptr %391, align 4
-  %392 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %389, align 8
-  %393 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %394 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %393, i32 0, i32 0
-  store ptr null, ptr %394, align 8
-  %395 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %393, i32 0, i32 1
-  store i64 0, ptr %395, align 4
-  %396 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %393, align 8
-  %397 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %398 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %397)
-  %399 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %392, ptr %398, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %396, i1 false)
-  %400 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %401 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %400, i32 0, i32 0
-  store ptr @1, ptr %401, align 8
-  %402 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %400, i32 0, i32 1
-  store i64 4, ptr %402, align 4
-  %403 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %400, align 8
-  %404 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %405 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %404, i32 0, i32 0
-  store ptr null, ptr %405, align 8
-  %406 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %404, i32 0, i32 1
-  store i64 0, ptr %406, align 4
-  %407 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %404, align 8
-  %408 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %409 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %408, i32 0, i32 0
-  store ptr @23, ptr %409, align 8
-  %410 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %408, i32 0, i32 1
-  store i64 4, ptr %410, align 4
-  %411 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %408, align 8
-  %412 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %413 = call ptr @"github.com/goplus/llgo/internal/runtime.ChanOf"(i64 3, %"github.com/goplus/llgo/internal/runtime.String" %411, ptr %412)
-  %414 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %413)
-  %415 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %403, ptr %414, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %407, i1 false)
-  %416 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %417 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %416, i32 0, i32 0
-  store ptr @2, ptr %417, align 8
-  %418 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %416, i32 0, i32 1
-  store i64 5, ptr %418, align 4
-  %419 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %416, align 8
-  %420 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %421 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %420, i32 0, i32 0
-  store ptr null, ptr %421, align 8
-  %422 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %420, i32 0, i32 1
-  store i64 0, ptr %422, align 4
-  %423 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %420, align 8
-  %424 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %425 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %424)
-  %426 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %419, ptr %425, i64 72, %"github.com/goplus/llgo/internal/runtime.String" %423, i1 false)
-  %427 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %428 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %427, i32 0, i32 0
-  store ptr @3, ptr %428, align 8
-  %429 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %427, i32 0, i32 1
-  store i64 8, ptr %429, align 4
-  %430 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %427, align 8
-  %431 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %432 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %431, i32 0, i32 0
-  store ptr null, ptr %432, align 8
-  %433 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %431, i32 0, i32 1
-  store i64 0, ptr %433, align 4
-  %434 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %431, align 8
-  %435 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %436 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %430, ptr %435, i64 136, %"github.com/goplus/llgo/internal/runtime.String" %434, i1 false)
-  %437 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %438 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %437, i32 0, i32 0
-  store ptr @4, ptr %438, align 8
-  %439 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %437, i32 0, i32 1
-  store i64 4, ptr %439, align 4
-  %440 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %437, align 8
-  %441 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
-  %442 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %441, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %399, ptr %442, align 8
-  %443 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %441, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %415, ptr %443, align 8
-  %444 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %441, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %426, ptr %444, align 8
-  %445 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %441, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %436, ptr %445, align 8
-  %446 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %447 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %446, i32 0, i32 0
-  store ptr %441, ptr %447, align 8
-  %448 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %446, i32 0, i32 1
-  store i64 4, ptr %448, align 4
-  %449 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %446, i32 0, i32 2
-  store i64 4, ptr %449, align 4
-  %450 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %446, align 8
-  %451 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %440, i64 144, %"github.com/goplus/llgo/internal/runtime.Slice" %450)
-  %452 = call ptr @"github.com/goplus/llgo/internal/runtime.MapOf"(ptr %387, ptr %388, ptr %451, i64 4)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %452)
-  store ptr %452, ptr @"map[chan _llgo_int]_llgo_int", align 8
+  %152 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %153 = call ptr @"github.com/goplus/llgo/internal/runtime.ChanOf"(i64 3, %"github.com/goplus/llgo/internal/runtime.String" { ptr @23, i64 4 }, ptr %152)
+  %154 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %155 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %156 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %155)
+  %157 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 7 }, ptr %156, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %158 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %159 = call ptr @"github.com/goplus/llgo/internal/runtime.ChanOf"(i64 3, %"github.com/goplus/llgo/internal/runtime.String" { ptr @23, i64 4 }, ptr %158)
+  %160 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %159)
+  %161 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, ptr %160, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %162 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %163 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %162)
+  %164 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 5 }, ptr %163, i64 72, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %165 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %166 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 8 }, ptr %165, i64 136, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %167 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
+  %168 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %167, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %157, ptr %168, align 8
+  %169 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %167, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %161, ptr %169, align 8
+  %170 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %167, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %164, ptr %170, align 8
+  %171 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %167, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %166, ptr %171, align 8
+  %172 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %167, 0
+  %173 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %172, i64 4, 1
+  %174 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %173, i64 4, 2
+  %175 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, i64 144, %"github.com/goplus/llgo/internal/runtime.Slice" %174)
+  %176 = call ptr @"github.com/goplus/llgo/internal/runtime.MapOf"(ptr %153, ptr %154, ptr %175, i64 4)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %176)
+  store ptr %176, ptr @"map[chan _llgo_int]_llgo_int", align 8
   br label %_llgo_42
 
 _llgo_42:                                         ; preds = %_llgo_41, %_llgo_40
-  %453 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %454 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %453, i32 0, i32 0
-  store ptr @24, ptr %454, align 8
-  %455 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %453, i32 0, i32 1
-  store i64 6, ptr %455, align 4
-  %456 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %453, align 8
-  %457 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %456, i64 21, i64 8, i64 0, i64 0)
-  %458 = load ptr, ptr @_llgo_main.M, align 8
-  %459 = icmp eq ptr %458, null
-  br i1 %459, label %_llgo_43, label %_llgo_44
+  %177 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @24, i64 6 }, i64 21, i64 8, i64 0, i64 0)
+  %178 = load ptr, ptr @_llgo_main.M, align 8
+  %179 = icmp eq ptr %178, null
+  br i1 %179, label %_llgo_43, label %_llgo_44
 
 _llgo_43:                                         ; preds = %_llgo_42
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %457)
-  store ptr %457, ptr @_llgo_main.M, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %177)
+  store ptr %177, ptr @_llgo_main.M, align 8
   br label %_llgo_44
 
 _llgo_44:                                         ; preds = %_llgo_43, %_llgo_42
-  %460 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
-  br i1 %459, label %_llgo_45, label %_llgo_46
+  %180 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
+  br i1 %179, label %_llgo_45, label %_llgo_46
 
 _llgo_45:                                         ; preds = %_llgo_44
-  %461 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %462 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %461, i32 0, i32 0
-  store ptr @4, ptr %462, align 8
-  %463 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %461, i32 0, i32 1
-  store i64 4, ptr %463, align 4
-  %464 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %461, align 8
-  %465 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %466 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %465, i32 0, i32 0
-  store ptr @25, ptr %466, align 8
-  %467 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %465, i32 0, i32 1
-  store i64 1, ptr %467, align 4
-  %468 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %465, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %457, %"github.com/goplus/llgo/internal/runtime.String" %464, %"github.com/goplus/llgo/internal/runtime.String" %468, ptr %460, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %177, %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @25, i64 1 }, ptr %180, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
   br label %_llgo_46
 
 _llgo_46:                                         ; preds = %_llgo_45, %_llgo_44
-  %469 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %470 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %469, i32 0, i32 0
-  store ptr @16, ptr %470, align 8
-  %471 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %469, i32 0, i32 1
-  store i64 6, ptr %471, align 4
-  %472 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %469, align 8
-  %473 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %472, i64 2, i64 8, i64 0, i64 0)
-  %474 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %475 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %474, i32 0, i32 0
-  store ptr @16, ptr %475, align 8
-  %476 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %474, i32 0, i32 1
-  store i64 6, ptr %476, align 4
-  %477 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %474, align 8
-  %478 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %477, i64 2, i64 8, i64 0, i64 0)
-  %479 = load ptr, ptr @"map[_llgo_main.N]_llgo_string", align 8
-  %480 = icmp eq ptr %479, null
-  br i1 %480, label %_llgo_47, label %_llgo_48
+  %181 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @16, i64 6 }, i64 2, i64 8, i64 0, i64 0)
+  %182 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @16, i64 6 }, i64 2, i64 8, i64 0, i64 0)
+  %183 = load ptr, ptr @"map[_llgo_main.N]_llgo_string", align 8
+  %184 = icmp eq ptr %183, null
+  br i1 %184, label %_llgo_47, label %_llgo_48
 
 _llgo_47:                                         ; preds = %_llgo_46
-  %481 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %482 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %483 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %482, i32 0, i32 0
-  store ptr @0, ptr %483, align 8
-  %484 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %482, i32 0, i32 1
-  store i64 7, ptr %484, align 4
-  %485 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %482, align 8
-  %486 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %487 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %486, i32 0, i32 0
-  store ptr null, ptr %487, align 8
-  %488 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %486, i32 0, i32 1
-  store i64 0, ptr %488, align 4
-  %489 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %486, align 8
-  %490 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %491 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %490)
-  %492 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %485, ptr %491, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %489, i1 false)
-  %493 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %494 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %493, i32 0, i32 0
-  store ptr @1, ptr %494, align 8
-  %495 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %493, i32 0, i32 1
-  store i64 4, ptr %495, align 4
-  %496 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %493, align 8
-  %497 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %498 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %497, i32 0, i32 0
-  store ptr null, ptr %498, align 8
-  %499 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %497, i32 0, i32 1
-  store i64 0, ptr %499, align 4
-  %500 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %497, align 8
-  %501 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %478)
-  %502 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %496, ptr %501, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %500, i1 false)
-  %503 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %504 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %503, i32 0, i32 0
-  store ptr @2, ptr %504, align 8
-  %505 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %503, i32 0, i32 1
-  store i64 5, ptr %505, align 4
-  %506 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %503, align 8
-  %507 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %508 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %507, i32 0, i32 0
-  store ptr null, ptr %508, align 8
-  %509 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %507, i32 0, i32 1
-  store i64 0, ptr %509, align 4
-  %510 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %507, align 8
-  %511 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %512 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %511)
-  %513 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %506, ptr %512, i64 72, %"github.com/goplus/llgo/internal/runtime.String" %510, i1 false)
-  %514 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %515 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %514, i32 0, i32 0
-  store ptr @3, ptr %515, align 8
-  %516 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %514, i32 0, i32 1
-  store i64 8, ptr %516, align 4
-  %517 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %514, align 8
-  %518 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %519 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %518, i32 0, i32 0
-  store ptr null, ptr %519, align 8
-  %520 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %518, i32 0, i32 1
-  store i64 0, ptr %520, align 4
-  %521 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %518, align 8
-  %522 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %523 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %517, ptr %522, i64 200, %"github.com/goplus/llgo/internal/runtime.String" %521, i1 false)
-  %524 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %525 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %524, i32 0, i32 0
-  store ptr @4, ptr %525, align 8
-  %526 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %524, i32 0, i32 1
-  store i64 4, ptr %526, align 4
-  %527 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %524, align 8
-  %528 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
-  %529 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %528, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %492, ptr %529, align 8
-  %530 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %528, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %502, ptr %530, align 8
-  %531 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %528, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %513, ptr %531, align 8
-  %532 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %528, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %523, ptr %532, align 8
-  %533 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %534 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %533, i32 0, i32 0
-  store ptr %528, ptr %534, align 8
-  %535 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %533, i32 0, i32 1
-  store i64 4, ptr %535, align 4
-  %536 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %533, i32 0, i32 2
-  store i64 4, ptr %536, align 4
-  %537 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %533, align 8
-  %538 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %527, i64 208, %"github.com/goplus/llgo/internal/runtime.Slice" %537)
-  %539 = call ptr @"github.com/goplus/llgo/internal/runtime.MapOf"(ptr %473, ptr %481, ptr %538, i64 4)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %539)
-  store ptr %539, ptr @"map[_llgo_main.N]_llgo_string", align 8
+  %185 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %186 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %187 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %186)
+  %188 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 7 }, ptr %187, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %189 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %182)
+  %190 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, ptr %189, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %191 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %192 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %191)
+  %193 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 5 }, ptr %192, i64 72, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %194 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %195 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 8 }, ptr %194, i64 200, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %196 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
+  %197 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %196, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %188, ptr %197, align 8
+  %198 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %196, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %190, ptr %198, align 8
+  %199 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %196, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %193, ptr %199, align 8
+  %200 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %196, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %195, ptr %200, align 8
+  %201 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %196, 0
+  %202 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %201, i64 4, 1
+  %203 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %202, i64 4, 2
+  %204 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, i64 208, %"github.com/goplus/llgo/internal/runtime.Slice" %203)
+  %205 = call ptr @"github.com/goplus/llgo/internal/runtime.MapOf"(ptr %181, ptr %185, ptr %204, i64 4)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %205)
+  store ptr %205, ptr @"map[_llgo_main.N]_llgo_string", align 8
   br label %_llgo_48
 
 _llgo_48:                                         ; preds = %_llgo_47, %_llgo_46

--- a/cl/_testrt/map/out.ll
+++ b/cl/_testrt/map/out.ll
@@ -1,8 +1,8 @@
 ; ModuleID = 'main'
 source_filename = "main"
 
-%"github.com/goplus/llgo/internal/runtime.String" = type { ptr, i64 }
 %"github.com/goplus/llgo/internal/abi.StructField" = type { %"github.com/goplus/llgo/internal/runtime.String", ptr, i64, %"github.com/goplus/llgo/internal/runtime.String", i1 }
+%"github.com/goplus/llgo/internal/runtime.String" = type { ptr, i64 }
 %"github.com/goplus/llgo/internal/runtime.Slice" = type { ptr, i64, i64 }
 
 @"main.init$guard" = global i1 false, align 1
@@ -80,92 +80,33 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
 _llgo_3:                                          ; preds = %_llgo_2
   %5 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
   %6 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %7 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %7, i32 0, i32 0
-  store ptr @0, ptr %8, align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %7, i32 0, i32 1
-  store i64 7, ptr %9, align 4
-  %10 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %7, align 8
-  %11 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %11, i32 0, i32 0
-  store ptr null, ptr %12, align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %11, i32 0, i32 1
-  store i64 0, ptr %13, align 4
-  %14 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %11, align 8
-  %15 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %16 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %15)
-  %17 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %10, ptr %16, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %14, i1 false)
-  %18 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %19 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %18, i32 0, i32 0
-  store ptr @1, ptr %19, align 8
-  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %18, i32 0, i32 1
-  store i64 4, ptr %20, align 4
-  %21 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %18, align 8
-  %22 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %22, i32 0, i32 0
-  store ptr null, ptr %23, align 8
-  %24 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %22, i32 0, i32 1
-  store i64 0, ptr %24, align 4
-  %25 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %22, align 8
-  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %27 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %26)
-  %28 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %21, ptr %27, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %25, i1 false)
-  %29 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %29, i32 0, i32 0
-  store ptr @2, ptr %30, align 8
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %29, i32 0, i32 1
-  store i64 5, ptr %31, align 4
-  %32 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %29, align 8
-  %33 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %33, i32 0, i32 0
-  store ptr null, ptr %34, align 8
-  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %33, i32 0, i32 1
-  store i64 0, ptr %35, align 4
-  %36 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %33, align 8
-  %37 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %38 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %37)
-  %39 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %32, ptr %38, i64 72, %"github.com/goplus/llgo/internal/runtime.String" %36, i1 false)
-  %40 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %41 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %40, i32 0, i32 0
-  store ptr @3, ptr %41, align 8
-  %42 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %40, i32 0, i32 1
-  store i64 8, ptr %42, align 4
-  %43 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %40, align 8
-  %44 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %44, i32 0, i32 0
-  store ptr null, ptr %45, align 8
-  %46 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %44, i32 0, i32 1
-  store i64 0, ptr %46, align 4
-  %47 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %44, align 8
-  %48 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
-  %49 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %43, ptr %48, i64 136, %"github.com/goplus/llgo/internal/runtime.String" %47, i1 false)
-  %50 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %50, i32 0, i32 0
-  store ptr @4, ptr %51, align 8
-  %52 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %50, i32 0, i32 1
-  store i64 4, ptr %52, align 4
-  %53 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %50, align 8
-  %54 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
-  %55 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %54, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %17, ptr %55, align 8
-  %56 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %54, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %28, ptr %56, align 8
-  %57 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %54, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %39, ptr %57, align 8
-  %58 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %54, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %49, ptr %58, align 8
-  %59 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %59, i32 0, i32 0
-  store ptr %54, ptr %60, align 8
-  %61 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %59, i32 0, i32 1
-  store i64 4, ptr %61, align 4
-  %62 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %59, i32 0, i32 2
-  store i64 4, ptr %62, align 4
-  %63 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %59, align 8
-  %64 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %53, i64 144, %"github.com/goplus/llgo/internal/runtime.Slice" %63)
-  %65 = call ptr @"github.com/goplus/llgo/internal/runtime.MapOf"(ptr %5, ptr %6, ptr %64, i64 4)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %65)
-  store ptr %65, ptr @"map[_llgo_int]_llgo_int", align 8
+  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %8 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %7)
+  %9 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 7 }, ptr %8, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %10 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %10)
+  %12 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, ptr %11, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %13 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %13)
+  %15 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 5 }, ptr %14, i64 72, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %16 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
+  %17 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 8 }, ptr %16, i64 136, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %18 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
+  %19 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %18, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %9, ptr %19, align 8
+  %20 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %18, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %12, ptr %20, align 8
+  %21 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %18, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %15, ptr %21, align 8
+  %22 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %18, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %17, ptr %22, align 8
+  %23 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %18, 0
+  %24 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %23, i64 4, 1
+  %25 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %24, i64 4, 2
+  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, i64 144, %"github.com/goplus/llgo/internal/runtime.Slice" %25)
+  %27 = call ptr @"github.com/goplus/llgo/internal/runtime.MapOf"(ptr %5, ptr %6, ptr %26, i64 4)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %27)
+  store ptr %27, ptr @"map[_llgo_int]_llgo_int", align 8
   br label %_llgo_4
 
 _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2

--- a/cl/_testrt/named/out.ll
+++ b/cl/_testrt/named/out.ll
@@ -74,52 +74,47 @@ _llgo_0:
   %35 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
   %36 = getelementptr inbounds { ptr }, ptr %35, i32 0, i32 0
   store ptr %2, ptr %36, align 8
-  %37 = alloca { ptr, ptr }, align 8
-  %38 = getelementptr inbounds { ptr, ptr }, ptr %37, i32 0, i32 0
-  store ptr @"main.main$1", ptr %38, align 8
-  %39 = getelementptr inbounds { ptr, ptr }, ptr %37, i32 0, i32 1
-  store ptr %35, ptr %39, align 8
-  %40 = load { ptr, ptr }, ptr %37, align 8
-  %41 = getelementptr inbounds %main.mspan, ptr %34, i32 0, i32 5
-  store { ptr, ptr } %40, ptr %41, align 8
-  %42 = load ptr, ptr %2, align 8
-  %43 = getelementptr inbounds %main.mspan, ptr %42, i32 0, i32 0
-  %44 = load ptr, ptr %43, align 8
-  %45 = getelementptr inbounds %main.mspan, ptr %44, i32 0, i32 4
-  %46 = load i64, ptr %45, align 4
-  %47 = load ptr, ptr %2, align 8
-  %48 = getelementptr inbounds %main.mspan, ptr %47, i32 0, i32 2
-  %49 = load ptr, ptr %48, align 8
-  %50 = getelementptr inbounds %main.mSpanList, ptr %49, i32 0, i32 1
-  %51 = load ptr, ptr %50, align 8
-  %52 = getelementptr inbounds %main.mspan, ptr %51, i32 0, i32 4
-  %53 = load i64, ptr %52, align 4
-  %54 = load ptr, ptr %2, align 8
-  %55 = getelementptr inbounds %main.mspan, ptr %54, i32 0, i32 3
-  %56 = getelementptr inbounds %main.minfo, ptr %55, i32 0, i32 1
-  %57 = load i64, ptr %56, align 4
-  %58 = load ptr, ptr %2, align 8
-  %59 = getelementptr inbounds %main.mspan, ptr %58, i32 0, i32 3
-  %60 = getelementptr inbounds %main.minfo, ptr %59, i32 0, i32 0
-  %61 = load ptr, ptr %60, align 8
-  %62 = getelementptr inbounds %main.mspan, ptr %61, i32 0, i32 4
-  %63 = load i64, ptr %62, align 4
-  %64 = load ptr, ptr %2, align 8
-  %65 = getelementptr inbounds %main.mspan, ptr %64, i32 0, i32 5
-  %66 = load { ptr, ptr }, ptr %65, align 8
-  %67 = extractvalue { ptr, ptr } %66, 1
-  %68 = extractvalue { ptr, ptr } %66, 0
-  %69 = call i64 %68(ptr %67, i64 -2)
-  %70 = load ptr, ptr %2, align 8
-  %71 = getelementptr inbounds %main.mspan, ptr %70, i32 0, i32 3
-  %72 = getelementptr inbounds %main.minfo, ptr %71, i32 0, i32 0
-  %73 = load ptr, ptr %72, align 8
-  %74 = getelementptr inbounds %main.mspan, ptr %73, i32 0, i32 5
-  %75 = load { ptr, ptr }, ptr %74, align 8
-  %76 = extractvalue { ptr, ptr } %75, 1
-  %77 = extractvalue { ptr, ptr } %75, 0
-  %78 = call i64 %77(ptr %76, i64 -3)
-  %79 = call i32 (ptr, ...) @printf(ptr @0, i64 %46, i64 %53, i64 %57, i64 %63, i64 %69, i64 %78)
+  %37 = insertvalue { ptr, ptr } { ptr @"main.main$1", ptr undef }, ptr %35, 1
+  %38 = getelementptr inbounds %main.mspan, ptr %34, i32 0, i32 5
+  store { ptr, ptr } %37, ptr %38, align 8
+  %39 = load ptr, ptr %2, align 8
+  %40 = getelementptr inbounds %main.mspan, ptr %39, i32 0, i32 0
+  %41 = load ptr, ptr %40, align 8
+  %42 = getelementptr inbounds %main.mspan, ptr %41, i32 0, i32 4
+  %43 = load i64, ptr %42, align 4
+  %44 = load ptr, ptr %2, align 8
+  %45 = getelementptr inbounds %main.mspan, ptr %44, i32 0, i32 2
+  %46 = load ptr, ptr %45, align 8
+  %47 = getelementptr inbounds %main.mSpanList, ptr %46, i32 0, i32 1
+  %48 = load ptr, ptr %47, align 8
+  %49 = getelementptr inbounds %main.mspan, ptr %48, i32 0, i32 4
+  %50 = load i64, ptr %49, align 4
+  %51 = load ptr, ptr %2, align 8
+  %52 = getelementptr inbounds %main.mspan, ptr %51, i32 0, i32 3
+  %53 = getelementptr inbounds %main.minfo, ptr %52, i32 0, i32 1
+  %54 = load i64, ptr %53, align 4
+  %55 = load ptr, ptr %2, align 8
+  %56 = getelementptr inbounds %main.mspan, ptr %55, i32 0, i32 3
+  %57 = getelementptr inbounds %main.minfo, ptr %56, i32 0, i32 0
+  %58 = load ptr, ptr %57, align 8
+  %59 = getelementptr inbounds %main.mspan, ptr %58, i32 0, i32 4
+  %60 = load i64, ptr %59, align 4
+  %61 = load ptr, ptr %2, align 8
+  %62 = getelementptr inbounds %main.mspan, ptr %61, i32 0, i32 5
+  %63 = load { ptr, ptr }, ptr %62, align 8
+  %64 = extractvalue { ptr, ptr } %63, 1
+  %65 = extractvalue { ptr, ptr } %63, 0
+  %66 = call i64 %65(ptr %64, i64 -2)
+  %67 = load ptr, ptr %2, align 8
+  %68 = getelementptr inbounds %main.mspan, ptr %67, i32 0, i32 3
+  %69 = getelementptr inbounds %main.minfo, ptr %68, i32 0, i32 0
+  %70 = load ptr, ptr %69, align 8
+  %71 = getelementptr inbounds %main.mspan, ptr %70, i32 0, i32 5
+  %72 = load { ptr, ptr }, ptr %71, align 8
+  %73 = extractvalue { ptr, ptr } %72, 1
+  %74 = extractvalue { ptr, ptr } %72, 0
+  %75 = call i64 %74(ptr %73, i64 -3)
+  %76 = call i32 (ptr, ...) @printf(ptr @0, i64 %43, i64 %50, i64 %54, i64 %60, i64 %66, i64 %75)
   ret i32 0
 }
 

--- a/cl/_testrt/panic/out.ll
+++ b/cl/_testrt/panic/out.ll
@@ -30,22 +30,12 @@ _llgo_0:
   store ptr %1, ptr @__llgo_argv, align 8
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
-  %2 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 0
-  store ptr @0, ptr %3, align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 1
-  store i64 13, ptr %4, align 4
-  %5 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
-  %6 = load ptr, ptr @_llgo_string, align 8
-  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %5, ptr %7, align 8
-  %8 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, i32 0, i32 0
-  store ptr %6, ptr %9, align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, i32 0, i32 1
-  store ptr %7, ptr %10, align 8
-  %11 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %11)
+  %2 = load ptr, ptr @_llgo_string, align 8
+  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 13 }, ptr %3, align 8
+  %4 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %2, 0
+  %5 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %4, ptr %3, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %5)
   unreachable
 }
 

--- a/cl/_testrt/result/out.ll
+++ b/cl/_testrt/result/out.ll
@@ -10,13 +10,7 @@ source_filename = "main"
 
 define { ptr, ptr } @main.add() {
 _llgo_0:
-  %0 = alloca { ptr, ptr }, align 8
-  %1 = getelementptr inbounds { ptr, ptr }, ptr %0, i32 0, i32 0
-  store ptr @"__llgo_stub.main.add$1", ptr %1, align 8
-  %2 = getelementptr inbounds { ptr, ptr }, ptr %0, i32 0, i32 1
-  store ptr null, ptr %2, align 8
-  %3 = load { ptr, ptr }, ptr %0, align 8
-  ret { ptr, ptr } %3
+  ret { ptr, ptr } { ptr @"__llgo_stub.main.add$1", ptr null }
 }
 
 define i64 @"main.add$1"(i64 %0, i64 %1) {
@@ -27,19 +21,7 @@ _llgo_0:
 
 define { { ptr, ptr }, i64 } @main.add2() {
 _llgo_0:
-  %0 = alloca { ptr, ptr }, align 8
-  %1 = getelementptr inbounds { ptr, ptr }, ptr %0, i32 0, i32 0
-  store ptr @"__llgo_stub.main.add2$1", ptr %1, align 8
-  %2 = getelementptr inbounds { ptr, ptr }, ptr %0, i32 0, i32 1
-  store ptr null, ptr %2, align 8
-  %3 = load { ptr, ptr }, ptr %0, align 8
-  %4 = alloca { { ptr, ptr }, i64 }, align 8
-  %5 = getelementptr inbounds { { ptr, ptr }, i64 }, ptr %4, i32 0, i32 0
-  store { ptr, ptr } %3, ptr %5, align 8
-  %6 = getelementptr inbounds { { ptr, ptr }, i64 }, ptr %4, i32 0, i32 1
-  store i64 1, ptr %6, align 4
-  %7 = load { { ptr, ptr }, i64 }, ptr %4, align 8
-  ret { { ptr, ptr }, i64 } %7
+  ret { { ptr, ptr }, i64 } { { ptr, ptr } { ptr @"__llgo_stub.main.add2$1", ptr null }, i64 1 }
 }
 
 define i64 @"main.add2$1"(i64 %0, i64 %1) {
@@ -90,13 +72,7 @@ _llgo_0:
 
 define { ptr, ptr } @"main.main$1"() {
 _llgo_0:
-  %0 = alloca { ptr, ptr }, align 8
-  %1 = getelementptr inbounds { ptr, ptr }, ptr %0, i32 0, i32 0
-  store ptr @"__llgo_stub.main.main$1$1", ptr %1, align 8
-  %2 = getelementptr inbounds { ptr, ptr }, ptr %0, i32 0, i32 1
-  store ptr null, ptr %2, align 8
-  %3 = load { ptr, ptr }, ptr %0, align 8
-  ret { ptr, ptr } %3
+  ret { ptr, ptr } { ptr @"__llgo_stub.main.main$1$1", ptr null }
 }
 
 define i64 @"main.main$1$1"(i64 %0, i64 %1) {

--- a/cl/_testrt/slice2array/out.ll
+++ b/cl/_testrt/slice2array/out.ll
@@ -35,81 +35,71 @@ _llgo_0:
   store i8 2, ptr %4, align 1
   store i8 3, ptr %5, align 1
   store i8 4, ptr %6, align 1
-  %7 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %7, i32 0, i32 0
-  store ptr %2, ptr %8, align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %7, i32 0, i32 1
-  store i64 4, ptr %9, align 4
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %7, i32 0, i32 2
-  store i64 4, ptr %10, align 4
-  %11 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %7, align 8
-  %12 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %11, 1
-  %13 = icmp slt i64 %12, 4
-  br i1 %13, label %_llgo_1, label %_llgo_2
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %2, 0
+  %8 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %7, i64 4, 1
+  %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %8, i64 4, 2
+  %10 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, 1
+  %11 = icmp slt i64 %10, 4
+  br i1 %11, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %14 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %11, 1
-  call void @"github.com/goplus/llgo/internal/runtime.PanicSliceConvert"(i64 %14, i64 4)
+  %12 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, 1
+  call void @"github.com/goplus/llgo/internal/runtime.PanicSliceConvert"(i64 %12, i64 4)
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-  %15 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %11, 0
-  %16 = load [4 x i8], ptr %2, align 1
-  %17 = load [4 x i8], ptr %15, align 1
-  %18 = extractvalue [4 x i8] %16, 0
-  %19 = extractvalue [4 x i8] %17, 0
-  %20 = icmp eq i8 %18, %19
-  %21 = and i1 true, %20
-  %22 = extractvalue [4 x i8] %16, 1
-  %23 = extractvalue [4 x i8] %17, 1
-  %24 = icmp eq i8 %22, %23
-  %25 = and i1 %21, %24
-  %26 = extractvalue [4 x i8] %16, 2
-  %27 = extractvalue [4 x i8] %17, 2
-  %28 = icmp eq i8 %26, %27
-  %29 = and i1 %25, %28
-  %30 = extractvalue [4 x i8] %16, 3
-  %31 = extractvalue [4 x i8] %17, 3
-  %32 = icmp eq i8 %30, %31
-  %33 = and i1 %29, %32
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %33)
+  %13 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %9, 0
+  %14 = load [4 x i8], ptr %2, align 1
+  %15 = load [4 x i8], ptr %13, align 1
+  %16 = extractvalue [4 x i8] %14, 0
+  %17 = extractvalue [4 x i8] %15, 0
+  %18 = icmp eq i8 %16, %17
+  %19 = and i1 true, %18
+  %20 = extractvalue [4 x i8] %14, 1
+  %21 = extractvalue [4 x i8] %15, 1
+  %22 = icmp eq i8 %20, %21
+  %23 = and i1 %19, %22
+  %24 = extractvalue [4 x i8] %14, 2
+  %25 = extractvalue [4 x i8] %15, 2
+  %26 = icmp eq i8 %24, %25
+  %27 = and i1 %23, %26
+  %28 = extractvalue [4 x i8] %14, 3
+  %29 = extractvalue [4 x i8] %15, 3
+  %30 = icmp eq i8 %28, %29
+  %31 = and i1 %27, %30
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %31)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %34 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %34, i32 0, i32 0
-  store ptr %2, ptr %35, align 8
-  %36 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %34, i32 0, i32 1
-  store i64 4, ptr %36, align 4
-  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %34, i32 0, i32 2
-  store i64 4, ptr %37, align 4
-  %38 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %34, align 8
-  %39 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %38, 1
-  %40 = icmp slt i64 %39, 2
-  br i1 %40, label %_llgo_3, label %_llgo_4
+  %32 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %2, 0
+  %33 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %32, i64 4, 1
+  %34 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %33, i64 4, 2
+  %35 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %34, 1
+  %36 = icmp slt i64 %35, 2
+  br i1 %36, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %41 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %38, 1
-  call void @"github.com/goplus/llgo/internal/runtime.PanicSliceConvert"(i64 %41, i64 2)
+  %37 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %34, 1
+  call void @"github.com/goplus/llgo/internal/runtime.PanicSliceConvert"(i64 %37, i64 2)
   br label %_llgo_4
 
 _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
-  %42 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %38, 0
-  %43 = load [2 x i8], ptr %42, align 1
-  %44 = alloca [2 x i8], align 1
-  call void @llvm.memset(ptr %44, i8 0, i64 2, i1 false)
-  %45 = getelementptr inbounds i8, ptr %44, i64 0
-  %46 = getelementptr inbounds i8, ptr %44, i64 1
-  store i8 1, ptr %45, align 1
-  store i8 2, ptr %46, align 1
-  %47 = load [2 x i8], ptr %44, align 1
-  %48 = extractvalue [2 x i8] %43, 0
-  %49 = extractvalue [2 x i8] %47, 0
+  %38 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %34, 0
+  %39 = load [2 x i8], ptr %38, align 1
+  %40 = alloca [2 x i8], align 1
+  call void @llvm.memset(ptr %40, i8 0, i64 2, i1 false)
+  %41 = getelementptr inbounds i8, ptr %40, i64 0
+  %42 = getelementptr inbounds i8, ptr %40, i64 1
+  store i8 1, ptr %41, align 1
+  store i8 2, ptr %42, align 1
+  %43 = load [2 x i8], ptr %40, align 1
+  %44 = extractvalue [2 x i8] %39, 0
+  %45 = extractvalue [2 x i8] %43, 0
+  %46 = icmp eq i8 %44, %45
+  %47 = and i1 true, %46
+  %48 = extractvalue [2 x i8] %39, 1
+  %49 = extractvalue [2 x i8] %43, 1
   %50 = icmp eq i8 %48, %49
-  %51 = and i1 true, %50
-  %52 = extractvalue [2 x i8] %43, 1
-  %53 = extractvalue [2 x i8] %47, 1
-  %54 = icmp eq i8 %52, %53
-  %55 = and i1 %51, %54
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %55)
+  %51 = and i1 %47, %50
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %51)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 }

--- a/cl/_testrt/sum/out.ll
+++ b/cl/_testrt/sum/out.ll
@@ -36,16 +36,11 @@ _llgo_0:
   store i64 3, ptr %5, align 4
   %6 = getelementptr inbounds i64, ptr %2, i64 3
   store i64 4, ptr %6, align 4
-  %7 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %8 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %7, i32 0, i32 0
-  store ptr %2, ptr %8, align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %7, i32 0, i32 1
-  store i64 4, ptr %9, align 4
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %7, i32 0, i32 2
-  store i64 4, ptr %10, align 4
-  %11 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %7, align 8
-  %12 = call i64 @main.sum(%"github.com/goplus/llgo/internal/runtime.Slice" %11)
-  %13 = call i32 (ptr, ...) @printf(ptr @0, i64 %12)
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %2, 0
+  %8 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %7, i64 4, 1
+  %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %8, i64 4, 2
+  %10 = call i64 @main.sum(%"github.com/goplus/llgo/internal/runtime.Slice" %9)
+  %11 = call i32 (ptr, ...) @printf(ptr @0, i64 %10)
   ret i32 0
 }
 

--- a/cl/_testrt/tpabi/out.ll
+++ b/cl/_testrt/tpabi/out.ll
@@ -55,103 +55,69 @@ _llgo_0:
   call void @llvm.memset(ptr %2, i8 0, i64 24, i1 false)
   %3 = getelementptr inbounds %"main.T[string,int]", ptr %2, i32 0, i32 0
   %4 = getelementptr inbounds %"main.T[string,int]", ptr %2, i32 0, i32 1
-  %5 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %5, i32 0, i32 0
-  store ptr @0, ptr %6, align 8
-  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %5, i32 0, i32 1
-  store i64 1, ptr %7, align 4
-  %8 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %5, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %8, ptr %3, align 8
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 1 }, ptr %3, align 8
   store i64 1, ptr %4, align 4
-  %9 = load %"main.T[string,int]", ptr %2, align 8
-  %10 = load ptr, ptr @"_llgo_main.T[string,int]", align 8
-  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  store %"main.T[string,int]" %9, ptr %11, align 8
-  %12 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %12, i32 0, i32 0
-  store ptr %10, ptr %13, align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %12, i32 0, i32 1
-  store ptr %11, ptr %14, align 8
-  %15 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %12, align 8
-  %16 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %15, 0
-  %17 = load ptr, ptr @"_llgo_main.T[string,int]", align 8
-  %18 = icmp eq ptr %16, %17
-  br i1 %18, label %_llgo_1, label %_llgo_2
+  %5 = load %"main.T[string,int]", ptr %2, align 8
+  %6 = load ptr, ptr @"_llgo_main.T[string,int]", align 8
+  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  store %"main.T[string,int]" %5, ptr %7, align 8
+  %8 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %6, 0
+  %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %8, ptr %7, 1
+  %10 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %9, 0
+  %11 = load ptr, ptr @"_llgo_main.T[string,int]", align 8
+  %12 = icmp eq ptr %10, %11
+  br i1 %12, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %19 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %15, 1
-  %20 = load %"main.T[string,int]", ptr %19, align 8
-  %21 = extractvalue %"main.T[string,int]" %20, 0
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %21)
+  %13 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %9, 1
+  %14 = load %"main.T[string,int]", ptr %13, align 8
+  %15 = extractvalue %"main.T[string,int]" %14, 0
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %15)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %22 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
-  %23 = getelementptr inbounds %"main.T[string,int]", ptr %22, i32 0, i32 0
-  %24 = getelementptr inbounds %"main.T[string,int]", ptr %22, i32 0, i32 1
-  %25 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 0
-  store ptr @9, ptr %26, align 8
-  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 1
-  store i64 5, ptr %27, align 4
-  %28 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %25, align 8
-  store %"github.com/goplus/llgo/internal/runtime.String" %28, ptr %23, align 8
-  store i64 100, ptr %24, align 4
-  %29 = load ptr, ptr @"*_llgo_main.T[string,int]", align 8
-  %30 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %31 = load ptr, ptr @"_llgo_iface$BP0p_lUsEd-IbbtJVukGmgrdQkqzcoYzSiwgUvgFvUs", align 8
-  %32 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %31, ptr %29)
-  %33 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %33, i32 0, i32 0
-  store ptr %32, ptr %34, align 8
-  %35 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %33, i32 0, i32 1
-  store ptr %22, ptr %35, align 8
-  %36 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %33, align 8
-  %37 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %36)
-  %38 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %36, 0
-  %39 = getelementptr ptr, ptr %38, i64 3
-  %40 = load ptr, ptr %39, align 8
-  %41 = alloca { ptr, ptr }, align 8
-  %42 = getelementptr inbounds { ptr, ptr }, ptr %41, i32 0, i32 0
-  store ptr %40, ptr %42, align 8
-  %43 = getelementptr inbounds { ptr, ptr }, ptr %41, i32 0, i32 1
-  store ptr %37, ptr %43, align 8
-  %44 = load { ptr, ptr }, ptr %41, align 8
-  %45 = extractvalue { ptr, ptr } %44, 1
-  %46 = extractvalue { ptr, ptr } %44, 0
-  call void %46(ptr %45)
-  %47 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
-  %48 = getelementptr inbounds i64, ptr %47, i64 0
-  %49 = getelementptr inbounds i64, ptr %47, i64 1
-  %50 = getelementptr inbounds i64, ptr %47, i64 2
-  %51 = getelementptr inbounds i64, ptr %47, i64 3
-  store i64 1, ptr %48, align 4
-  store i64 2, ptr %49, align 4
-  store i64 3, ptr %50, align 4
-  store i64 4, ptr %51, align 4
-  %52 = getelementptr [4 x i64], ptr %47, i64 1
-  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %52)
+  %16 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
+  %17 = getelementptr inbounds %"main.T[string,int]", ptr %16, i32 0, i32 0
+  %18 = getelementptr inbounds %"main.T[string,int]", ptr %16, i32 0, i32 1
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 5 }, ptr %17, align 8
+  store i64 100, ptr %18, align 4
+  %19 = load ptr, ptr @"*_llgo_main.T[string,int]", align 8
+  %20 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %21 = load ptr, ptr @"_llgo_iface$BP0p_lUsEd-IbbtJVukGmgrdQkqzcoYzSiwgUvgFvUs", align 8
+  %22 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %21, ptr %19)
+  %23 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %22, 0
+  %24 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %23, ptr %16, 1
+  %25 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %24)
+  %26 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %24, 0
+  %27 = getelementptr ptr, ptr %26, i64 3
+  %28 = load ptr, ptr %27, align 8
+  %29 = insertvalue { ptr, ptr } undef, ptr %28, 0
+  %30 = insertvalue { ptr, ptr } %29, ptr %25, 1
+  %31 = extractvalue { ptr, ptr } %30, 1
+  %32 = extractvalue { ptr, ptr } %30, 0
+  call void %32(ptr %31)
+  %33 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 32)
+  %34 = getelementptr inbounds i64, ptr %33, i64 0
+  %35 = getelementptr inbounds i64, ptr %33, i64 1
+  %36 = getelementptr inbounds i64, ptr %33, i64 2
+  %37 = getelementptr inbounds i64, ptr %33, i64 3
+  store i64 1, ptr %34, align 4
+  store i64 2, ptr %35, align 4
+  store i64 3, ptr %36, align 4
+  store i64 4, ptr %37, align 4
+  %38 = getelementptr [4 x i64], ptr %33, i64 1
+  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %38)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %53 = getelementptr [4 x i64], ptr %47, i64 1
-  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %53)
+  %39 = getelementptr [4 x i64], ptr %33, i64 1
+  call void @"github.com/goplus/llgo/internal/runtime.PrintPointer"(ptr %39)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %54 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %55 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %54, i32 0, i32 0
-  store ptr @8, ptr %55, align 8
-  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %54, i32 0, i32 1
-  store i64 21, ptr %56, align 4
-  %57 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %54, align 8
-  %58 = load ptr, ptr @_llgo_string, align 8
-  %59 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %57, ptr %59, align 8
-  %60 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %61 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %60, i32 0, i32 0
-  store ptr %58, ptr %61, align 8
-  %62 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %60, i32 0, i32 1
-  store ptr %59, ptr %62, align 8
-  %63 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %60, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %63)
+  %40 = load ptr, ptr @_llgo_string, align 8
+  %41 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 21 }, ptr %41, align 8
+  %42 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %40, 0
+  %43 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %42, ptr %41, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %43)
   unreachable
 }
 
@@ -198,271 +164,131 @@ declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
 
 define void @"main.init$after"() {
 _llgo_0:
-  %0 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 0
-  store ptr @1, ptr %1, align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 1
-  store i64 19, ptr %2, align 4
-  %3 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %0, align 8
-  %4 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3, i64 25, i64 24, i64 1, i64 2)
-  %5 = load ptr, ptr @"_llgo_main.T[string,int]", align 8
-  %6 = icmp eq ptr %5, null
-  br i1 %6, label %_llgo_1, label %_llgo_2
+  %0 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 19 }, i64 25, i64 24, i64 1, i64 2)
+  %1 = load ptr, ptr @"_llgo_main.T[string,int]", align 8
+  %2 = icmp eq ptr %1, null
+  br i1 %2, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  store ptr %4, ptr @"_llgo_main.T[string,int]", align 8
+  store ptr %0, ptr @"_llgo_main.T[string,int]", align 8
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-  %7 = load ptr, ptr @_llgo_string, align 8
-  %8 = icmp eq ptr %7, null
-  br i1 %8, label %_llgo_3, label %_llgo_4
+  %3 = load ptr, ptr @_llgo_string, align 8
+  %4 = icmp eq ptr %3, null
+  br i1 %4, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  store ptr %9, ptr @_llgo_string, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  store ptr %5, ptr @_llgo_string, align 8
   br label %_llgo_4
 
 _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
-  %10 = load ptr, ptr @_llgo_string, align 8
-  %11 = load ptr, ptr @_llgo_int, align 8
-  %12 = icmp eq ptr %11, null
-  br i1 %12, label %_llgo_5, label %_llgo_6
+  %6 = load ptr, ptr @_llgo_string, align 8
+  %7 = load ptr, ptr @_llgo_int, align 8
+  %8 = icmp eq ptr %7, null
+  br i1 %8, label %_llgo_5, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_4
-  %13 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  store ptr %13, ptr @_llgo_int, align 8
+  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  store ptr %9, ptr @_llgo_int, align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %14 = load ptr, ptr @_llgo_int, align 8
-  %15 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %15, i32 0, i32 0
-  store ptr @2, ptr %16, align 8
-  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %15, i32 0, i32 1
-  store i64 1, ptr %17, align 4
-  %18 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %15, align 8
-  %19 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %19, i32 0, i32 0
-  store ptr null, ptr %20, align 8
-  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %19, i32 0, i32 1
-  store i64 0, ptr %21, align 4
-  %22 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %19, align 8
-  %23 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %24 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %18, ptr %23, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %22, i1 false)
-  %25 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 0
-  store ptr @3, ptr %26, align 8
-  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 1
-  store i64 1, ptr %27, align 4
-  %28 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %25, align 8
-  %29 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %29, i32 0, i32 0
-  store ptr null, ptr %30, align 8
-  %31 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %29, i32 0, i32 1
-  store i64 0, ptr %31, align 4
-  %32 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %29, align 8
-  %33 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %34 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %28, ptr %33, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %32, i1 false)
-  %35 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %36 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %35, i32 0, i32 0
-  store ptr @4, ptr %36, align 8
-  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %35, i32 0, i32 1
-  store i64 4, ptr %37, align 4
-  %38 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %35, align 8
-  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %40 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %39, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %24, ptr %40, align 8
-  %41 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %39, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %34, ptr %41, align 8
-  %42 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, i32 0, i32 0
-  store ptr %39, ptr %43, align 8
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, i32 0, i32 1
-  store i64 2, ptr %44, align 4
-  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, i32 0, i32 2
-  store i64 2, ptr %45, align 4
-  %46 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %42, align 8
-  %47 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %38, i64 24, %"github.com/goplus/llgo/internal/runtime.Slice" %46)
-  store ptr %47, ptr @"main.struct$A2OTYqQyUOqOQ-i_F5iXeAKWtxeWGEuyeN7HCfULCDk", align 8
-  %48 = load ptr, ptr @"main.struct$A2OTYqQyUOqOQ-i_F5iXeAKWtxeWGEuyeN7HCfULCDk", align 8
-  br i1 %6, label %_llgo_7, label %_llgo_8
+  %10 = load ptr, ptr @_llgo_int, align 8
+  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %12 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 1 }, ptr %11, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %13 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %14 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 1 }, ptr %13, i64 16, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %15 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %16 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %15, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %12, ptr %16, align 8
+  %17 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %15, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %14, ptr %17, align 8
+  %18 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %15, 0
+  %19 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %18, i64 2, 1
+  %20 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %19, i64 2, 2
+  %21 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, i64 24, %"github.com/goplus/llgo/internal/runtime.Slice" %20)
+  store ptr %21, ptr @"main.struct$A2OTYqQyUOqOQ-i_F5iXeAKWtxeWGEuyeN7HCfULCDk", align 8
+  %22 = load ptr, ptr @"main.struct$A2OTYqQyUOqOQ-i_F5iXeAKWtxeWGEuyeN7HCfULCDk", align 8
+  br i1 %2, label %_llgo_7, label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_6
-  %49 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %49, i32 0, i32 0
-  store ptr @5, ptr %50, align 8
-  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %49, i32 0, i32 1
-  store i64 4, ptr %51, align 4
-  %52 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %49, align 8
-  %53 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %54 = icmp eq ptr %53, null
-  br i1 %54, label %_llgo_9, label %_llgo_10
+  %23 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %24 = icmp eq ptr %23, null
+  br i1 %24, label %_llgo_9, label %_llgo_10
 
 _llgo_8:                                          ; preds = %_llgo_10, %_llgo_6
-  %55 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 0
-  store ptr @1, ptr %56, align 8
-  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 1
-  store i64 19, ptr %57, align 4
-  %58 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %55, align 8
-  %59 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %58, i64 25, i64 24, i64 1, i64 2)
-  %60 = load ptr, ptr @"*_llgo_main.T[string,int]", align 8
-  %61 = icmp eq ptr %60, null
-  br i1 %61, label %_llgo_11, label %_llgo_12
+  %25 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 19 }, i64 25, i64 24, i64 1, i64 2)
+  %26 = load ptr, ptr @"*_llgo_main.T[string,int]", align 8
+  %27 = icmp eq ptr %26, null
+  br i1 %27, label %_llgo_11, label %_llgo_12
 
 _llgo_9:                                          ; preds = %_llgo_7
-  %62 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %63 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %64 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %63, i32 0, i32 0
-  store ptr %62, ptr %64, align 8
-  %65 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %63, i32 0, i32 1
-  store i64 0, ptr %65, align 4
-  %66 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %63, i32 0, i32 2
-  store i64 0, ptr %66, align 4
-  %67 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %63, align 8
-  %68 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %69 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %70 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %69, i32 0, i32 0
-  store ptr %68, ptr %70, align 8
-  %71 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %69, i32 0, i32 1
-  store i64 0, ptr %71, align 4
-  %72 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %69, i32 0, i32 2
-  store i64 0, ptr %72, align 4
-  %73 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %69, align 8
-  %74 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %67, %"github.com/goplus/llgo/internal/runtime.Slice" %73, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %74)
-  store ptr %74, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %28 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %29 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %28, 0
+  %30 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %29, i64 0, 1
+  %31 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %30, i64 0, 2
+  %32 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %33 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %32, 0
+  %34 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %33, i64 0, 1
+  %35 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %34, i64 0, 2
+  %36 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %31, %"github.com/goplus/llgo/internal/runtime.Slice" %35, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %36)
+  store ptr %36, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
   br label %_llgo_10
 
 _llgo_10:                                         ; preds = %_llgo_9, %_llgo_7
-  %75 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %76 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %77 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %76, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %52, ptr %77, align 8
-  %78 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %76, i32 0, i32 1
-  store ptr %75, ptr %78, align 8
-  %79 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %76, i32 0, i32 2
-  store ptr @"main.(*T[string,int]).Demo", ptr %79, align 8
-  %80 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %76, i32 0, i32 3
-  store ptr @"main.(*T[string,int]).Demo", ptr %80, align 8
-  %81 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %76, align 8
-  %82 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %83 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %82, i32 0, i32 0
-  store ptr @6, ptr %83, align 8
-  %84 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %82, i32 0, i32 1
-  store i64 4, ptr %84, align 4
-  %85 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %82, align 8
-  %86 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %87 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %88 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %87, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %85, ptr %88, align 8
-  %89 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %87, i32 0, i32 1
-  store ptr %86, ptr %89, align 8
-  %90 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %87, i32 0, i32 2
-  store ptr @"main.(*T[string,int]).Info", ptr %90, align 8
-  %91 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %87, i32 0, i32 3
-  store ptr @"main.(*T[string,int]).Info", ptr %91, align 8
-  %92 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %87, align 8
-  %93 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %94 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %93, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %85, ptr %94, align 8
-  %95 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %93, i32 0, i32 1
-  store ptr %86, ptr %95, align 8
-  %96 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %93, i32 0, i32 2
-  store ptr @"main.(*T[string,int]).Info", ptr %96, align 8
-  %97 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %93, i32 0, i32 3
-  store ptr @"main.T[string,int].Info", ptr %97, align 8
-  %98 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %93, align 8
-  %99 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %100 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %99, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %98, ptr %100, align 8
-  %101 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %102 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %101, i32 0, i32 0
-  store ptr %99, ptr %102, align 8
-  %103 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %101, i32 0, i32 1
-  store i64 1, ptr %103, align 4
-  %104 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %101, i32 0, i32 2
-  store i64 1, ptr %104, align 4
-  %105 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %101, align 8
-  %106 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
-  %107 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %106, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %81, ptr %107, align 8
-  %108 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %106, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %92, ptr %108, align 8
-  %109 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %110 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %109, i32 0, i32 0
-  store ptr %106, ptr %110, align 8
-  %111 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %109, i32 0, i32 1
-  store i64 2, ptr %111, align 4
-  %112 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %109, i32 0, i32 2
-  store i64 2, ptr %112, align 4
-  %113 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %109, align 8
-  %114 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %115 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %114, i32 0, i32 0
-  store ptr @4, ptr %115, align 8
-  %116 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %114, i32 0, i32 1
-  store i64 4, ptr %116, align 4
-  %117 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %114, align 8
-  %118 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %119 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %118, i32 0, i32 0
-  store ptr @7, ptr %119, align 8
-  %120 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %118, i32 0, i32 1
-  store i64 13, ptr %120, align 4
-  %121 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %118, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %4, %"github.com/goplus/llgo/internal/runtime.String" %117, %"github.com/goplus/llgo/internal/runtime.String" %121, ptr %48, %"github.com/goplus/llgo/internal/runtime.Slice" %105, %"github.com/goplus/llgo/internal/runtime.Slice" %113)
+  %37 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %38 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %37, 1
+  %39 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %38, ptr @"main.(*T[string,int]).Demo", 2
+  %40 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %39, ptr @"main.(*T[string,int]).Demo", 3
+  %41 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %42 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %41, 1
+  %43 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %42, ptr @"main.(*T[string,int]).Info", 2
+  %44 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %43, ptr @"main.(*T[string,int]).Info", 3
+  %45 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %41, 1
+  %46 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %45, ptr @"main.(*T[string,int]).Info", 2
+  %47 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %46, ptr @"main.T[string,int].Info", 3
+  %48 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %49 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %48, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %47, ptr %49, align 8
+  %50 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %48, 0
+  %51 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %50, i64 1, 1
+  %52 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %51, i64 1, 2
+  %53 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
+  %54 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %53, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %40, ptr %54, align 8
+  %55 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %53, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %44, ptr %55, align 8
+  %56 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %53, 0
+  %57 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %56, i64 2, 1
+  %58 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %57, i64 2, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %0, %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 13 }, ptr %22, %"github.com/goplus/llgo/internal/runtime.Slice" %52, %"github.com/goplus/llgo/internal/runtime.Slice" %58)
   br label %_llgo_8
 
 _llgo_11:                                         ; preds = %_llgo_8
-  %122 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %59)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %122)
-  store ptr %122, ptr @"*_llgo_main.T[string,int]", align 8
+  %59 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %25)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %59)
+  store ptr %59, ptr @"*_llgo_main.T[string,int]", align 8
   br label %_llgo_12
 
 _llgo_12:                                         ; preds = %_llgo_11, %_llgo_8
-  %123 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %124 = load ptr, ptr @"_llgo_iface$BP0p_lUsEd-IbbtJVukGmgrdQkqzcoYzSiwgUvgFvUs", align 8
-  %125 = icmp eq ptr %124, null
-  br i1 %125, label %_llgo_13, label %_llgo_14
+  %60 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %61 = load ptr, ptr @"_llgo_iface$BP0p_lUsEd-IbbtJVukGmgrdQkqzcoYzSiwgUvgFvUs", align 8
+  %62 = icmp eq ptr %61, null
+  br i1 %62, label %_llgo_13, label %_llgo_14
 
 _llgo_13:                                         ; preds = %_llgo_12
-  %126 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %127 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %126, i32 0, i32 0
-  store ptr @5, ptr %127, align 8
-  %128 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %126, i32 0, i32 1
-  store i64 4, ptr %128, align 4
-  %129 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %126, align 8
-  %130 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %131 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %130, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %129, ptr %131, align 8
-  %132 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %130, i32 0, i32 1
-  store ptr %123, ptr %132, align 8
-  %133 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %130, align 8
-  %134 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %135 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %134, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %133, ptr %135, align 8
-  %136 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %137 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %136, i32 0, i32 0
-  store ptr %134, ptr %137, align 8
-  %138 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %136, i32 0, i32 1
-  store i64 1, ptr %138, align 4
-  %139 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %136, i32 0, i32 2
-  store i64 1, ptr %139, align 4
-  %140 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %136, align 8
-  %141 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %142 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %141, i32 0, i32 0
-  store ptr @4, ptr %142, align 8
-  %143 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %141, i32 0, i32 1
-  store i64 4, ptr %143, align 4
-  %144 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %141, align 8
-  %145 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %146 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %145, i32 0, i32 0
-  store ptr null, ptr %146, align 8
-  %147 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %145, i32 0, i32 1
-  store i64 0, ptr %147, align 4
-  %148 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %145, align 8
-  %149 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %144, %"github.com/goplus/llgo/internal/runtime.String" %148, %"github.com/goplus/llgo/internal/runtime.Slice" %140)
-  store ptr %149, ptr @"_llgo_iface$BP0p_lUsEd-IbbtJVukGmgrdQkqzcoYzSiwgUvgFvUs", align 8
+  %63 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 4 }, ptr undef }, ptr %60, 1
+  %64 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %65 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %64, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %63, ptr %65, align 8
+  %66 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %64, 0
+  %67 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %66, i64 1, 1
+  %68 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %67, i64 1, 2
+  %69 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %68)
+  store ptr %69, ptr @"_llgo_iface$BP0p_lUsEd-IbbtJVukGmgrdQkqzcoYzSiwgUvgFvUs", align 8
   br label %_llgo_14
 
 _llgo_14:                                         ; preds = %_llgo_13, %_llgo_12

--- a/cl/_testrt/tpfunc/out.ll
+++ b/cl/_testrt/tpfunc/out.ll
@@ -1,8 +1,6 @@
 ; ModuleID = 'main'
 source_filename = "main"
 
-%main.Func = type { ptr, ptr }
-
 @"main.init$guard" = global i1 false, align 1
 @__llgo_argc = global i32 0, align 4
 @__llgo_argv = global ptr null, align 8
@@ -26,12 +24,6 @@ _llgo_0:
   store ptr %1, ptr @__llgo_argv, align 8
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
-  %2 = alloca %main.Func, align 8
-  %3 = getelementptr inbounds %main.Func, ptr %2, i32 0, i32 0
-  store ptr @"__llgo_stub.main.main$1", ptr %3, align 8
-  %4 = getelementptr inbounds %main.Func, ptr %2, i32 0, i32 1
-  store ptr null, ptr %4, align 8
-  %5 = load %main.Func, ptr %2, align 8
   call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 16)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/internal/runtime.PrintUint"(i64 8)

--- a/cl/_testrt/tpmap/out.ll
+++ b/cl/_testrt/tpmap/out.ll
@@ -82,67 +82,49 @@ _llgo_0:
   store i64 0, ptr %7, align 4
   store i64 0, ptr %9, align 4
   %14 = load ptr, ptr @_llgo_int, align 8
-  %15 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %15, i32 0, i32 0
-  store ptr %14, ptr %16, align 8
-  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %15, i32 0, i32 1
-  store ptr null, ptr %17, align 8
-  %18 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %15, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %18, ptr %11, align 8
+  %15 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %14, 0
+  %16 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %15, ptr null, 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %16, ptr %11, align 8
   store ptr null, ptr %12, align 8
   store i64 0, ptr %13, align 4
-  %19 = load %main.cacheKey, ptr %6, align 8
-  %20 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %20, i32 0, i32 0
-  store ptr @19, ptr %21, align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %20, i32 0, i32 1
-  store i64 5, ptr %22, align 4
-  %23 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %20, align 8
-  %24 = load ptr, ptr @"map[_llgo_main.cacheKey]_llgo_string", align 8
-  %25 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  store %main.cacheKey %19, ptr %25, align 8
-  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %24, ptr %5, ptr %25)
-  store %"github.com/goplus/llgo/internal/runtime.String" %23, ptr %26, align 8
-  %27 = alloca %main.cacheKey, align 8
-  call void @llvm.memset(ptr %27, i8 0, i64 48, i1 false)
-  %28 = getelementptr inbounds %main.cacheKey, ptr %27, i32 0, i32 0
-  %29 = getelementptr inbounds %main.cacheKey, ptr %27, i32 0, i32 1
-  %30 = getelementptr inbounds %main.T2, ptr %29, i32 0, i32 0
-  %31 = getelementptr inbounds %main.cacheKey, ptr %27, i32 0, i32 2
-  %32 = getelementptr inbounds %"main.T3[any]", ptr %31, i32 0, i32 0
-  %33 = getelementptr inbounds %main.cacheKey, ptr %27, i32 0, i32 3
-  %34 = getelementptr inbounds %main.cacheKey, ptr %27, i32 0, i32 4
+  %17 = load %main.cacheKey, ptr %6, align 8
+  %18 = load ptr, ptr @"map[_llgo_main.cacheKey]_llgo_string", align 8
+  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  store %main.cacheKey %17, ptr %19, align 8
+  %20 = call ptr @"github.com/goplus/llgo/internal/runtime.MapAssign"(ptr %18, ptr %5, ptr %19)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @19, i64 5 }, ptr %20, align 8
+  %21 = alloca %main.cacheKey, align 8
+  call void @llvm.memset(ptr %21, i8 0, i64 48, i1 false)
+  %22 = getelementptr inbounds %main.cacheKey, ptr %21, i32 0, i32 0
+  %23 = getelementptr inbounds %main.cacheKey, ptr %21, i32 0, i32 1
+  %24 = getelementptr inbounds %main.T2, ptr %23, i32 0, i32 0
+  %25 = getelementptr inbounds %main.cacheKey, ptr %21, i32 0, i32 2
+  %26 = getelementptr inbounds %"main.T3[any]", ptr %25, i32 0, i32 0
+  %27 = getelementptr inbounds %main.cacheKey, ptr %21, i32 0, i32 3
+  %28 = getelementptr inbounds %main.cacheKey, ptr %21, i32 0, i32 4
+  store i64 0, ptr %22, align 4
+  store i64 0, ptr %24, align 4
+  %29 = load ptr, ptr @_llgo_int, align 8
+  %30 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %29, 0
+  %31 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %30, ptr null, 1
+  store %"github.com/goplus/llgo/internal/runtime.eface" %31, ptr %26, align 8
+  store ptr null, ptr %27, align 8
   store i64 0, ptr %28, align 4
-  store i64 0, ptr %30, align 4
-  %35 = load ptr, ptr @_llgo_int, align 8
-  %36 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %36, i32 0, i32 0
-  store ptr %35, ptr %37, align 8
-  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %36, i32 0, i32 1
-  store ptr null, ptr %38, align 8
-  %39 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %36, align 8
-  store %"github.com/goplus/llgo/internal/runtime.eface" %39, ptr %32, align 8
-  store ptr null, ptr %33, align 8
-  store i64 0, ptr %34, align 4
-  %40 = load %main.cacheKey, ptr %27, align 8
-  %41 = load ptr, ptr @"map[_llgo_main.cacheKey]_llgo_string", align 8
-  %42 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  store %main.cacheKey %40, ptr %42, align 8
-  %43 = call { ptr, i1 } @"github.com/goplus/llgo/internal/runtime.MapAccess2"(ptr %41, ptr %5, ptr %42)
-  %44 = extractvalue { ptr, i1 } %43, 0
-  %45 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %44, align 8
-  %46 = extractvalue { ptr, i1 } %43, 1
-  %47 = alloca { %"github.com/goplus/llgo/internal/runtime.String", i1 }, align 8
-  %48 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.String", i1 }, ptr %47, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %45, ptr %48, align 8
-  %49 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.String", i1 }, ptr %47, i32 0, i32 1
-  store i1 %46, ptr %49, align 1
-  %50 = load { %"github.com/goplus/llgo/internal/runtime.String", i1 }, ptr %47, align 8
-  %51 = extractvalue { %"github.com/goplus/llgo/internal/runtime.String", i1 } %50, 0
-  %52 = extractvalue { %"github.com/goplus/llgo/internal/runtime.String", i1 } %50, 1
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %51)
+  %32 = load %main.cacheKey, ptr %21, align 8
+  %33 = load ptr, ptr @"map[_llgo_main.cacheKey]_llgo_string", align 8
+  %34 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  store %main.cacheKey %32, ptr %34, align 8
+  %35 = call { ptr, i1 } @"github.com/goplus/llgo/internal/runtime.MapAccess2"(ptr %33, ptr %5, ptr %34)
+  %36 = extractvalue { ptr, i1 } %35, 0
+  %37 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %36, align 8
+  %38 = extractvalue { ptr, i1 } %35, 1
+  %39 = insertvalue { %"github.com/goplus/llgo/internal/runtime.String", i1 } undef, %"github.com/goplus/llgo/internal/runtime.String" %37, 0
+  %40 = insertvalue { %"github.com/goplus/llgo/internal/runtime.String", i1 } %39, i1 %38, 1
+  %41 = extractvalue { %"github.com/goplus/llgo/internal/runtime.String", i1 } %40, 0
+  %42 = extractvalue { %"github.com/goplus/llgo/internal/runtime.String", i1 } %40, 1
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %41)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %52)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %42)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 }
@@ -151,518 +133,206 @@ declare void @"github.com/goplus/llgo/internal/runtime.init"()
 
 define void @"main.init$after"() {
 _llgo_0:
-  %0 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 0
-  store ptr @0, ptr %1, align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 1
-  store i64 13, ptr %2, align 4
-  %3 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %0, align 8
-  %4 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3, i64 25, i64 48, i64 0, i64 0)
-  store ptr %4, ptr @_llgo_main.cacheKey, align 8
-  %5 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %5, i32 0, i32 0
-  store ptr @1, ptr %6, align 8
-  %7 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %5, i32 0, i32 1
-  store i64 7, ptr %7, align 4
-  %8 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %5, align 8
-  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %8, i64 2, i64 8, i64 0, i64 0)
-  %10 = load ptr, ptr @_llgo_main.T1, align 8
-  %11 = icmp eq ptr %10, null
-  br i1 %11, label %_llgo_1, label %_llgo_2
+  %0 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 13 }, i64 25, i64 48, i64 0, i64 0)
+  store ptr %0, ptr @_llgo_main.cacheKey, align 8
+  %1 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 7 }, i64 2, i64 8, i64 0, i64 0)
+  %2 = load ptr, ptr @_llgo_main.T1, align 8
+  %3 = icmp eq ptr %2, null
+  br i1 %3, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  store ptr %9, ptr @_llgo_main.T1, align 8
+  store ptr %1, ptr @_llgo_main.T1, align 8
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-  %12 = load ptr, ptr @_llgo_int, align 8
-  %13 = icmp eq ptr %12, null
-  br i1 %13, label %_llgo_3, label %_llgo_4
+  %4 = load ptr, ptr @_llgo_int, align 8
+  %5 = icmp eq ptr %4, null
+  br i1 %5, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  store ptr %14, ptr @_llgo_int, align 8
+  %6 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  store ptr %6, ptr @_llgo_int, align 8
   br label %_llgo_4
 
 _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
-  %15 = load ptr, ptr @_llgo_int, align 8
-  br i1 %11, label %_llgo_5, label %_llgo_6
+  %7 = load ptr, ptr @_llgo_int, align 8
+  br i1 %3, label %_llgo_5, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_4
-  %16 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %16, i32 0, i32 0
-  store ptr @2, ptr %17, align 8
-  %18 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %16, i32 0, i32 1
-  store i64 4, ptr %18, align 4
-  %19 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %16, align 8
-  %20 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %20, i32 0, i32 0
-  store ptr @3, ptr %21, align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %20, i32 0, i32 1
-  store i64 2, ptr %22, align 4
-  %23 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %20, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %9, %"github.com/goplus/llgo/internal/runtime.String" %19, %"github.com/goplus/llgo/internal/runtime.String" %23, ptr %15, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %1, %"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 2 }, ptr %7, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %24 = load ptr, ptr @_llgo_main.T1, align 8
-  %25 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 0
-  store ptr @4, ptr %26, align 8
-  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %25, i32 0, i32 1
-  store i64 7, ptr %27, align 4
-  %28 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %25, align 8
-  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %28, i64 25, i64 8, i64 0, i64 0)
-  %30 = load ptr, ptr @_llgo_main.T2, align 8
-  %31 = icmp eq ptr %30, null
-  br i1 %31, label %_llgo_7, label %_llgo_8
+  %8 = load ptr, ptr @_llgo_main.T1, align 8
+  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 7 }, i64 25, i64 8, i64 0, i64 0)
+  %10 = load ptr, ptr @_llgo_main.T2, align 8
+  %11 = icmp eq ptr %10, null
+  br i1 %11, label %_llgo_7, label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_6
-  store ptr %29, ptr @_llgo_main.T2, align 8
+  store ptr %9, ptr @_llgo_main.T2, align 8
   br label %_llgo_8
 
 _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
-  %32 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %32, i32 0, i32 0
-  store ptr @5, ptr %33, align 8
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %32, i32 0, i32 1
-  store i64 1, ptr %34, align 4
-  %35 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %32, align 8
-  %36 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %36, i32 0, i32 0
-  store ptr null, ptr %37, align 8
-  %38 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %36, i32 0, i32 1
-  store i64 0, ptr %38, align 4
-  %39 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %36, align 8
-  %40 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %41 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %35, ptr %40, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %39, i1 false)
-  %42 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %42, i32 0, i32 0
-  store ptr @2, ptr %43, align 8
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %42, i32 0, i32 1
-  store i64 4, ptr %44, align 4
-  %45 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %42, align 8
-  %46 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
-  %47 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %46, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %41, ptr %47, align 8
-  %48 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %49 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, i32 0, i32 0
-  store ptr %46, ptr %49, align 8
-  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, i32 0, i32 1
-  store i64 1, ptr %50, align 4
-  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, i32 0, i32 2
-  store i64 1, ptr %51, align 4
-  %52 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %48, align 8
-  %53 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %45, i64 8, %"github.com/goplus/llgo/internal/runtime.Slice" %52)
-  store ptr %53, ptr @"main.struct$MYpsoM99ZwFY087IpUOkIw1zjBA_sgFXVodmn1m-G88", align 8
-  %54 = load ptr, ptr @"main.struct$MYpsoM99ZwFY087IpUOkIw1zjBA_sgFXVodmn1m-G88", align 8
-  br i1 %31, label %_llgo_9, label %_llgo_10
+  %12 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %13 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 1 }, ptr %12, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
+  %15 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %14, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %13, ptr %15, align 8
+  %16 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %14, 0
+  %17 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %16, i64 1, 1
+  %18 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %17, i64 1, 2
+  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, i64 8, %"github.com/goplus/llgo/internal/runtime.Slice" %18)
+  store ptr %19, ptr @"main.struct$MYpsoM99ZwFY087IpUOkIw1zjBA_sgFXVodmn1m-G88", align 8
+  %20 = load ptr, ptr @"main.struct$MYpsoM99ZwFY087IpUOkIw1zjBA_sgFXVodmn1m-G88", align 8
+  br i1 %11, label %_llgo_9, label %_llgo_10
 
 _llgo_9:                                          ; preds = %_llgo_8
-  %55 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 0
-  store ptr @2, ptr %56, align 8
-  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 1
-  store i64 4, ptr %57, align 4
-  %58 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %55, align 8
-  %59 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %59, i32 0, i32 0
-  store ptr @6, ptr %60, align 8
-  %61 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %59, i32 0, i32 1
-  store i64 2, ptr %61, align 4
-  %62 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %59, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %29, %"github.com/goplus/llgo/internal/runtime.String" %58, %"github.com/goplus/llgo/internal/runtime.String" %62, ptr %54, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %9, %"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 2 }, ptr %20, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
   br label %_llgo_10
 
 _llgo_10:                                         ; preds = %_llgo_9, %_llgo_8
-  %63 = load ptr, ptr @_llgo_main.T2, align 8
-  %64 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %65 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %64, i32 0, i32 0
-  store ptr @7, ptr %65, align 8
-  %66 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %64, i32 0, i32 1
-  store i64 12, ptr %66, align 4
-  %67 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %64, align 8
-  %68 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %67, i64 25, i64 16, i64 0, i64 0)
-  %69 = load ptr, ptr @"_llgo_main.T3[any]", align 8
-  %70 = icmp eq ptr %69, null
-  br i1 %70, label %_llgo_11, label %_llgo_12
+  %21 = load ptr, ptr @_llgo_main.T2, align 8
+  %22 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 12 }, i64 25, i64 16, i64 0, i64 0)
+  %23 = load ptr, ptr @"_llgo_main.T3[any]", align 8
+  %24 = icmp eq ptr %23, null
+  br i1 %24, label %_llgo_11, label %_llgo_12
 
 _llgo_11:                                         ; preds = %_llgo_10
-  store ptr %68, ptr @"_llgo_main.T3[any]", align 8
+  store ptr %22, ptr @"_llgo_main.T3[any]", align 8
   br label %_llgo_12
 
 _llgo_12:                                         ; preds = %_llgo_11, %_llgo_10
-  %71 = load ptr, ptr @_llgo_any, align 8
-  %72 = icmp eq ptr %71, null
-  br i1 %72, label %_llgo_13, label %_llgo_14
+  %25 = load ptr, ptr @_llgo_any, align 8
+  %26 = icmp eq ptr %25, null
+  br i1 %26, label %_llgo_13, label %_llgo_14
 
 _llgo_13:                                         ; preds = %_llgo_12
-  %73 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %74 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %75 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %74, i32 0, i32 0
-  store ptr %73, ptr %75, align 8
-  %76 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %74, i32 0, i32 1
-  store i64 0, ptr %76, align 4
-  %77 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %74, i32 0, i32 2
-  store i64 0, ptr %77, align 4
-  %78 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %74, align 8
-  %79 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %80 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %79, i32 0, i32 0
-  store ptr @2, ptr %80, align 8
-  %81 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %79, i32 0, i32 1
-  store i64 4, ptr %81, align 4
-  %82 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %79, align 8
-  %83 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %84 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %83, i32 0, i32 0
-  store ptr null, ptr %84, align 8
-  %85 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %83, i32 0, i32 1
-  store i64 0, ptr %85, align 4
-  %86 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %83, align 8
-  %87 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %82, %"github.com/goplus/llgo/internal/runtime.String" %86, %"github.com/goplus/llgo/internal/runtime.Slice" %78)
-  store ptr %87, ptr @_llgo_any, align 8
+  %27 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %28 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %27, 0
+  %29 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %28, i64 0, 1
+  %30 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %29, i64 0, 2
+  %31 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %30)
+  store ptr %31, ptr @_llgo_any, align 8
   br label %_llgo_14
 
 _llgo_14:                                         ; preds = %_llgo_13, %_llgo_12
-  %88 = load ptr, ptr @_llgo_any, align 8
-  %89 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %90 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %89, i32 0, i32 0
-  store ptr @5, ptr %90, align 8
-  %91 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %89, i32 0, i32 1
-  store i64 1, ptr %91, align 4
-  %92 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %89, align 8
-  %93 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %94 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %93, i32 0, i32 0
-  store ptr null, ptr %94, align 8
-  %95 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %93, i32 0, i32 1
-  store i64 0, ptr %95, align 4
-  %96 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %93, align 8
-  %97 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %98 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %99 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %98, i32 0, i32 0
-  store ptr %97, ptr %99, align 8
-  %100 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %98, i32 0, i32 1
-  store i64 0, ptr %100, align 4
-  %101 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %98, i32 0, i32 2
-  store i64 0, ptr %101, align 4
-  %102 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %98, align 8
-  %103 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %104 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %103, i32 0, i32 0
-  store ptr @2, ptr %104, align 8
-  %105 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %103, i32 0, i32 1
-  store i64 4, ptr %105, align 4
-  %106 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %103, align 8
-  %107 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %108 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %107, i32 0, i32 0
-  store ptr null, ptr %108, align 8
-  %109 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %107, i32 0, i32 1
-  store i64 0, ptr %109, align 4
-  %110 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %107, align 8
-  %111 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %106, %"github.com/goplus/llgo/internal/runtime.String" %110, %"github.com/goplus/llgo/internal/runtime.Slice" %102)
-  %112 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %92, ptr %111, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %96, i1 false)
-  %113 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %114 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %113, i32 0, i32 0
-  store ptr @2, ptr %114, align 8
-  %115 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %113, i32 0, i32 1
-  store i64 4, ptr %115, align 4
-  %116 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %113, align 8
-  %117 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
-  %118 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %117, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %112, ptr %118, align 8
-  %119 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %120 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %119, i32 0, i32 0
-  store ptr %117, ptr %120, align 8
-  %121 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %119, i32 0, i32 1
-  store i64 1, ptr %121, align 4
-  %122 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %119, i32 0, i32 2
-  store i64 1, ptr %122, align 4
-  %123 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %119, align 8
-  %124 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %116, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %123)
-  store ptr %124, ptr @"main.struct$op7q0963ur0ih9ul6OteH-C75UVydPxwKOVpX1hUjzo", align 8
-  %125 = load ptr, ptr @"main.struct$op7q0963ur0ih9ul6OteH-C75UVydPxwKOVpX1hUjzo", align 8
-  br i1 %70, label %_llgo_15, label %_llgo_16
+  %32 = load ptr, ptr @_llgo_any, align 8
+  %33 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %34 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %33, 0
+  %35 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %34, i64 0, 1
+  %36 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %35, i64 0, 2
+  %37 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %36)
+  %38 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 1 }, ptr %37, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
+  %40 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %39, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %38, ptr %40, align 8
+  %41 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %39, 0
+  %42 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %41, i64 1, 1
+  %43 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %42, i64 1, 2
+  %44 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %43)
+  store ptr %44, ptr @"main.struct$op7q0963ur0ih9ul6OteH-C75UVydPxwKOVpX1hUjzo", align 8
+  %45 = load ptr, ptr @"main.struct$op7q0963ur0ih9ul6OteH-C75UVydPxwKOVpX1hUjzo", align 8
+  br i1 %24, label %_llgo_15, label %_llgo_16
 
 _llgo_15:                                         ; preds = %_llgo_14
-  %126 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %127 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %126, i32 0, i32 0
-  store ptr @2, ptr %127, align 8
-  %128 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %126, i32 0, i32 1
-  store i64 4, ptr %128, align 4
-  %129 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %126, align 8
-  %130 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %131 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %130, i32 0, i32 0
-  store ptr @8, ptr %131, align 8
-  %132 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %130, i32 0, i32 1
-  store i64 7, ptr %132, align 4
-  %133 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %130, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %68, %"github.com/goplus/llgo/internal/runtime.String" %129, %"github.com/goplus/llgo/internal/runtime.String" %133, ptr %125, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %22, %"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 7 }, ptr %45, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
   br label %_llgo_16
 
 _llgo_16:                                         ; preds = %_llgo_15, %_llgo_14
-  %134 = load ptr, ptr @"_llgo_main.T3[any]", align 8
-  %135 = load ptr, ptr @"*_llgo_int", align 8
-  %136 = icmp eq ptr %135, null
-  br i1 %136, label %_llgo_17, label %_llgo_18
+  %46 = load ptr, ptr @"_llgo_main.T3[any]", align 8
+  %47 = load ptr, ptr @"*_llgo_int", align 8
+  %48 = icmp eq ptr %47, null
+  br i1 %48, label %_llgo_17, label %_llgo_18
 
 _llgo_17:                                         ; preds = %_llgo_16
-  %137 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %138 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %137)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %138)
-  store ptr %138, ptr @"*_llgo_int", align 8
+  %49 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %50 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %49)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %50)
+  store ptr %50, ptr @"*_llgo_int", align 8
   br label %_llgo_18
 
 _llgo_18:                                         ; preds = %_llgo_17, %_llgo_16
-  %139 = load ptr, ptr @"*_llgo_int", align 8
-  %140 = load ptr, ptr @_llgo_uintptr, align 8
-  %141 = icmp eq ptr %140, null
-  br i1 %141, label %_llgo_19, label %_llgo_20
+  %51 = load ptr, ptr @"*_llgo_int", align 8
+  %52 = load ptr, ptr @_llgo_uintptr, align 8
+  %53 = icmp eq ptr %52, null
+  br i1 %53, label %_llgo_19, label %_llgo_20
 
 _llgo_19:                                         ; preds = %_llgo_18
-  %142 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
-  store ptr %142, ptr @_llgo_uintptr, align 8
+  %54 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
+  store ptr %54, ptr @_llgo_uintptr, align 8
   br label %_llgo_20
 
 _llgo_20:                                         ; preds = %_llgo_19, %_llgo_18
-  %143 = load ptr, ptr @_llgo_uintptr, align 8
-  %144 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %145 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %144, i32 0, i32 0
-  store ptr @1, ptr %145, align 8
-  %146 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %144, i32 0, i32 1
-  store i64 7, ptr %146, align 4
-  %147 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %144, align 8
-  %148 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %147, i64 2, i64 8, i64 0, i64 0)
-  %149 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %150 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %149, i32 0, i32 0
-  store ptr @4, ptr %150, align 8
-  %151 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %149, i32 0, i32 1
-  store i64 7, ptr %151, align 4
-  %152 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %149, align 8
-  %153 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %152, i64 25, i64 8, i64 0, i64 0)
-  %154 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %155 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %154, i32 0, i32 0
-  store ptr @7, ptr %155, align 8
-  %156 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %154, i32 0, i32 1
-  store i64 12, ptr %156, align 4
-  %157 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %154, align 8
-  %158 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %157, i64 25, i64 16, i64 0, i64 0)
-  %159 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %160 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %159, i32 0, i32 0
-  store ptr @9, ptr %160, align 8
-  %161 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %159, i32 0, i32 1
-  store i64 2, ptr %161, align 4
-  %162 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %159, align 8
-  %163 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %164 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %163, i32 0, i32 0
-  store ptr null, ptr %164, align 8
-  %165 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %163, i32 0, i32 1
-  store i64 0, ptr %165, align 4
-  %166 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %163, align 8
-  %167 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %162, ptr %148, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %166, i1 false)
-  %168 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %169 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %168, i32 0, i32 0
-  store ptr @10, ptr %169, align 8
-  %170 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %168, i32 0, i32 1
-  store i64 2, ptr %170, align 4
-  %171 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %168, align 8
-  %172 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %173 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %172, i32 0, i32 0
-  store ptr null, ptr %173, align 8
-  %174 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %172, i32 0, i32 1
-  store i64 0, ptr %174, align 4
-  %175 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %172, align 8
-  %176 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %171, ptr %153, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %175, i1 false)
-  %177 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %178 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %177, i32 0, i32 0
-  store ptr @11, ptr %178, align 8
-  %179 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %177, i32 0, i32 1
-  store i64 2, ptr %179, align 4
-  %180 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %177, align 8
-  %181 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %182 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %181, i32 0, i32 0
-  store ptr null, ptr %182, align 8
-  %183 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %181, i32 0, i32 1
-  store i64 0, ptr %183, align 4
-  %184 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %181, align 8
-  %185 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %180, ptr %158, i64 16, %"github.com/goplus/llgo/internal/runtime.String" %184, i1 false)
-  %186 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %187 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %186, i32 0, i32 0
-  store ptr @12, ptr %187, align 8
-  %188 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %186, i32 0, i32 1
-  store i64 2, ptr %188, align 4
-  %189 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %186, align 8
-  %190 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %191 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %190, i32 0, i32 0
-  store ptr null, ptr %191, align 8
-  %192 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %190, i32 0, i32 1
-  store i64 0, ptr %192, align 4
-  %193 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %190, align 8
-  %194 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %195 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %194)
-  %196 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %189, ptr %195, i64 32, %"github.com/goplus/llgo/internal/runtime.String" %193, i1 false)
-  %197 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %198 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %197, i32 0, i32 0
-  store ptr @13, ptr %198, align 8
-  %199 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %197, i32 0, i32 1
-  store i64 2, ptr %199, align 4
-  %200 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %197, align 8
-  %201 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %202 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %201, i32 0, i32 0
-  store ptr null, ptr %202, align 8
-  %203 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %201, i32 0, i32 1
-  store i64 0, ptr %203, align 4
-  %204 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %201, align 8
-  %205 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
-  %206 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %200, ptr %205, i64 40, %"github.com/goplus/llgo/internal/runtime.String" %204, i1 false)
-  %207 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %208 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %207, i32 0, i32 0
-  store ptr @2, ptr %208, align 8
-  %209 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %207, i32 0, i32 1
-  store i64 4, ptr %209, align 4
-  %210 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %207, align 8
-  %211 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 280)
-  %212 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %211, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %167, ptr %212, align 8
-  %213 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %211, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %176, ptr %213, align 8
-  %214 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %211, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %185, ptr %214, align 8
-  %215 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %211, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %196, ptr %215, align 8
-  %216 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %211, i64 4
-  store %"github.com/goplus/llgo/internal/abi.StructField" %206, ptr %216, align 8
-  %217 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %218 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %217, i32 0, i32 0
-  store ptr %211, ptr %218, align 8
-  %219 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %217, i32 0, i32 1
-  store i64 5, ptr %219, align 4
-  %220 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %217, i32 0, i32 2
-  store i64 5, ptr %220, align 4
-  %221 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %217, align 8
-  %222 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %210, i64 48, %"github.com/goplus/llgo/internal/runtime.Slice" %221)
-  store ptr %222, ptr @"main.struct$ZLgMjv1XBA1L4yXCpdouRvQF2okeuHQ-YWVTE34gq4I", align 8
-  %223 = load ptr, ptr @"main.struct$ZLgMjv1XBA1L4yXCpdouRvQF2okeuHQ-YWVTE34gq4I", align 8
-  %224 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %225 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %224, i32 0, i32 0
-  store ptr @2, ptr %225, align 8
-  %226 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %224, i32 0, i32 1
-  store i64 4, ptr %226, align 4
-  %227 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %224, align 8
-  %228 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %229 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %228, i32 0, i32 0
-  store ptr @14, ptr %229, align 8
-  %230 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %228, i32 0, i32 1
-  store i64 8, ptr %230, align 4
-  %231 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %228, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %4, %"github.com/goplus/llgo/internal/runtime.String" %227, %"github.com/goplus/llgo/internal/runtime.String" %231, ptr %223, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
-  %232 = load ptr, ptr @_llgo_string, align 8
-  %233 = icmp eq ptr %232, null
-  br i1 %233, label %_llgo_21, label %_llgo_22
+  %55 = load ptr, ptr @_llgo_uintptr, align 8
+  %56 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 7 }, i64 2, i64 8, i64 0, i64 0)
+  %57 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 7 }, i64 25, i64 8, i64 0, i64 0)
+  %58 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 12 }, i64 25, i64 16, i64 0, i64 0)
+  %59 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 2 }, ptr %56, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %60 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 2 }, ptr %57, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %61 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 2 }, ptr %58, i64 16, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %62 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %63 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %62)
+  %64 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @12, i64 2 }, ptr %63, i64 32, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %65 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 44)
+  %66 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @13, i64 2 }, ptr %65, i64 40, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %67 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 280)
+  %68 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %67, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %59, ptr %68, align 8
+  %69 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %67, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %60, ptr %69, align 8
+  %70 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %67, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %61, ptr %70, align 8
+  %71 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %67, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %64, ptr %71, align 8
+  %72 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %67, i64 4
+  store %"github.com/goplus/llgo/internal/abi.StructField" %66, ptr %72, align 8
+  %73 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %67, 0
+  %74 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %73, i64 5, 1
+  %75 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %74, i64 5, 2
+  %76 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, i64 48, %"github.com/goplus/llgo/internal/runtime.Slice" %75)
+  store ptr %76, ptr @"main.struct$ZLgMjv1XBA1L4yXCpdouRvQF2okeuHQ-YWVTE34gq4I", align 8
+  %77 = load ptr, ptr @"main.struct$ZLgMjv1XBA1L4yXCpdouRvQF2okeuHQ-YWVTE34gq4I", align 8
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %0, %"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @14, i64 8 }, ptr %77, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  %78 = load ptr, ptr @_llgo_string, align 8
+  %79 = icmp eq ptr %78, null
+  br i1 %79, label %_llgo_21, label %_llgo_22
 
 _llgo_21:                                         ; preds = %_llgo_20
-  %234 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  store ptr %234, ptr @_llgo_string, align 8
+  %80 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  store ptr %80, ptr @_llgo_string, align 8
   br label %_llgo_22
 
 _llgo_22:                                         ; preds = %_llgo_21, %_llgo_20
-  %235 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %236 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %235, i32 0, i32 0
-  store ptr @0, ptr %236, align 8
-  %237 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %235, i32 0, i32 1
-  store i64 13, ptr %237, align 4
-  %238 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %235, align 8
-  %239 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %238, i64 25, i64 48, i64 0, i64 0)
-  %240 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %241 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %240, i32 0, i32 0
-  store ptr @0, ptr %241, align 8
-  %242 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %240, i32 0, i32 1
-  store i64 13, ptr %242, align 4
-  %243 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %240, align 8
-  %244 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %243, i64 25, i64 48, i64 0, i64 0)
-  %245 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %246 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %247 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %246, i32 0, i32 0
-  store ptr @15, ptr %247, align 8
-  %248 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %246, i32 0, i32 1
-  store i64 7, ptr %248, align 4
-  %249 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %246, align 8
-  %250 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %251 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %250, i32 0, i32 0
-  store ptr null, ptr %251, align 8
-  %252 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %250, i32 0, i32 1
-  store i64 0, ptr %252, align 4
-  %253 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %250, align 8
-  %254 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %255 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %254)
-  %256 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %249, ptr %255, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %253, i1 false)
-  %257 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %258 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %257, i32 0, i32 0
-  store ptr @16, ptr %258, align 8
-  %259 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %257, i32 0, i32 1
-  store i64 4, ptr %259, align 4
-  %260 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %257, align 8
-  %261 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %262 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %261, i32 0, i32 0
-  store ptr null, ptr %262, align 8
-  %263 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %261, i32 0, i32 1
-  store i64 0, ptr %263, align 4
-  %264 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %261, align 8
-  %265 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %244)
-  %266 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %260, ptr %265, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %264, i1 false)
-  %267 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %268 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %267, i32 0, i32 0
-  store ptr @17, ptr %268, align 8
-  %269 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %267, i32 0, i32 1
-  store i64 5, ptr %269, align 4
-  %270 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %267, align 8
-  %271 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %272 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %271, i32 0, i32 0
-  store ptr null, ptr %272, align 8
-  %273 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %271, i32 0, i32 1
-  store i64 0, ptr %273, align 4
-  %274 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %271, align 8
-  %275 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %276 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %275)
-  %277 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %270, ptr %276, i64 392, %"github.com/goplus/llgo/internal/runtime.String" %274, i1 false)
-  %278 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %279 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %278, i32 0, i32 0
-  store ptr @18, ptr %279, align 8
-  %280 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %278, i32 0, i32 1
-  store i64 8, ptr %280, align 4
-  %281 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %278, align 8
-  %282 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %283 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %282, i32 0, i32 0
-  store ptr null, ptr %283, align 8
-  %284 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %282, i32 0, i32 1
-  store i64 0, ptr %284, align 4
-  %285 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %282, align 8
-  %286 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %287 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %281, ptr %286, i64 520, %"github.com/goplus/llgo/internal/runtime.String" %285, i1 false)
-  %288 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %289 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %288, i32 0, i32 0
-  store ptr @2, ptr %289, align 8
-  %290 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %288, i32 0, i32 1
-  store i64 4, ptr %290, align 4
-  %291 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %288, align 8
-  %292 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
-  %293 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %292, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %256, ptr %293, align 8
-  %294 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %292, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %266, ptr %294, align 8
-  %295 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %292, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %277, ptr %295, align 8
-  %296 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %292, i64 3
-  store %"github.com/goplus/llgo/internal/abi.StructField" %287, ptr %296, align 8
-  %297 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %298 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %297, i32 0, i32 0
-  store ptr %292, ptr %298, align 8
-  %299 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %297, i32 0, i32 1
-  store i64 4, ptr %299, align 4
-  %300 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %297, i32 0, i32 2
-  store i64 4, ptr %300, align 4
-  %301 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %297, align 8
-  %302 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %291, i64 528, %"github.com/goplus/llgo/internal/runtime.Slice" %301)
-  %303 = call ptr @"github.com/goplus/llgo/internal/runtime.MapOf"(ptr %239, ptr %245, ptr %302, i64 24)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %303)
-  store ptr %303, ptr @"map[_llgo_main.cacheKey]_llgo_string", align 8
+  %81 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 13 }, i64 25, i64 48, i64 0, i64 0)
+  %82 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 13 }, i64 25, i64 48, i64 0, i64 0)
+  %83 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %84 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %85 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %84)
+  %86 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @15, i64 7 }, ptr %85, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %87 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %82)
+  %88 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @16, i64 4 }, ptr %87, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %89 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %90 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 8, ptr %89)
+  %91 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @17, i64 5 }, ptr %90, i64 392, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %92 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %93 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @18, i64 8 }, ptr %92, i64 520, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %94 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 224)
+  %95 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %94, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %86, ptr %95, align 8
+  %96 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %94, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %88, ptr %96, align 8
+  %97 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %94, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %91, ptr %97, align 8
+  %98 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %94, i64 3
+  store %"github.com/goplus/llgo/internal/abi.StructField" %93, ptr %98, align 8
+  %99 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %94, 0
+  %100 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %99, i64 4, 1
+  %101 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %100, i64 4, 2
+  %102 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, i64 528, %"github.com/goplus/llgo/internal/runtime.Slice" %101)
+  %103 = call ptr @"github.com/goplus/llgo/internal/runtime.MapOf"(ptr %81, ptr %83, ptr %102, i64 24)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %103)
+  store ptr %103, ptr @"map[_llgo_main.cacheKey]_llgo_string", align 8
   ret void
 }
 

--- a/cl/_testrt/tpmethod/out.ll
+++ b/cl/_testrt/tpmethod/out.ll
@@ -46,14 +46,8 @@ source_filename = "main"
 
 define %"github.com/goplus/llgo/internal/runtime.iface" @main.ReadFile(%"github.com/goplus/llgo/internal/runtime.String" %0) {
 _llgo_0:
-  %1 = alloca { ptr, ptr }, align 8
-  %2 = getelementptr inbounds { ptr, ptr }, ptr %1, i32 0, i32 0
-  store ptr @"__llgo_stub.main.ReadFile$1", ptr %2, align 8
-  %3 = getelementptr inbounds { ptr, ptr }, ptr %1, i32 0, i32 1
-  store ptr null, ptr %3, align 8
-  %4 = load { ptr, ptr }, ptr %1, align 8
-  %5 = call %"github.com/goplus/llgo/internal/runtime.iface" @"main.Async[main.Tuple[error]]"({ ptr, ptr } %4)
-  ret %"github.com/goplus/llgo/internal/runtime.iface" %5
+  %1 = call %"github.com/goplus/llgo/internal/runtime.iface" @"main.Async[main.Tuple[error]]"({ ptr, ptr } { ptr @"__llgo_stub.main.ReadFile$1", ptr null })
+  ret %"github.com/goplus/llgo/internal/runtime.iface" %1
 }
 
 define void @"main.ReadFile$1"({ ptr, ptr } %0) {
@@ -89,32 +83,16 @@ _llgo_0:
   store ptr %1, ptr @__llgo_argv, align 8
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
-  %2 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 0
-  store ptr @0, ptr %3, align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 1
-  store i64 7, ptr %4, align 4
-  %5 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
-  %6 = call %"github.com/goplus/llgo/internal/runtime.iface" @main.ReadFile(%"github.com/goplus/llgo/internal/runtime.String" %5)
-  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %6)
-  %8 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %6, 0
-  %9 = getelementptr ptr, ptr %8, i64 3
-  %10 = load ptr, ptr %9, align 8
-  %11 = alloca { ptr, ptr }, align 8
-  %12 = getelementptr inbounds { ptr, ptr }, ptr %11, i32 0, i32 0
-  store ptr %10, ptr %12, align 8
-  %13 = getelementptr inbounds { ptr, ptr }, ptr %11, i32 0, i32 1
-  store ptr %7, ptr %13, align 8
-  %14 = load { ptr, ptr }, ptr %11, align 8
-  %15 = extractvalue { ptr, ptr } %14, 1
-  %16 = extractvalue { ptr, ptr } %14, 0
-  %17 = alloca { ptr, ptr }, align 8
-  %18 = getelementptr inbounds { ptr, ptr }, ptr %17, i32 0, i32 0
-  store ptr @"__llgo_stub.main.main$1", ptr %18, align 8
-  %19 = getelementptr inbounds { ptr, ptr }, ptr %17, i32 0, i32 1
-  store ptr null, ptr %19, align 8
-  %20 = load { ptr, ptr }, ptr %17, align 8
-  call void %16(ptr %15, { ptr, ptr } %20)
+  %2 = call %"github.com/goplus/llgo/internal/runtime.iface" @main.ReadFile(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 7 })
+  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/internal/runtime.iface" %2)
+  %4 = extractvalue %"github.com/goplus/llgo/internal/runtime.iface" %2, 0
+  %5 = getelementptr ptr, ptr %4, i64 3
+  %6 = load ptr, ptr %5, align 8
+  %7 = insertvalue { ptr, ptr } undef, ptr %6, 0
+  %8 = insertvalue { ptr, ptr } %7, ptr %3, 1
+  %9 = extractvalue { ptr, ptr } %8, 1
+  %10 = extractvalue { ptr, ptr } %8, 0
+  call void %10(ptr %9, { ptr, ptr } { ptr @"__llgo_stub.main.main$1", ptr null })
   ret i32 0
 }
 
@@ -165,13 +143,9 @@ _llgo_0:
   %7 = load ptr, ptr @"_llgo_func$C0YAnS54eM5TTOK79-PISU_oLySCvOtTKOpIh9jI2pM", align 8
   %8 = load ptr, ptr @"_llgo_iface$Nwf494fPwMWb08Ae8NF-s-Tau0AFb_mdl0sjJX-pbHw", align 8
   %9 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %8, ptr %4)
-  %10 = alloca %"github.com/goplus/llgo/internal/runtime.iface", align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %10, i32 0, i32 0
-  store ptr %9, ptr %11, align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.iface", ptr %10, i32 0, i32 1
-  store ptr %1, ptr %12, align 8
-  %13 = load %"github.com/goplus/llgo/internal/runtime.iface", ptr %10, align 8
-  ret %"github.com/goplus/llgo/internal/runtime.iface" %13
+  %10 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %9, 0
+  %11 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %10, ptr %1, 1
+  ret %"github.com/goplus/llgo/internal/runtime.iface" %11
 }
 
 define linkonce void @"__llgo_stub.main.ReadFile$1"(ptr %0, { ptr, ptr } %1) {
@@ -201,756 +175,351 @@ declare ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64)
 
 define void @"main.init$after"() {
 _llgo_0:
-  %0 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 0
-  store ptr @1, ptr %1, align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 1
-  store i64 30, ptr %2, align 4
-  %3 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %0, align 8
-  %4 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3, i64 25, i64 24, i64 0, i64 1)
-  store ptr %4, ptr @"_llgo_main.future[main.Tuple[error]]", align 8
-  %5 = load ptr, ptr @_llgo_Pointer, align 8
-  %6 = icmp eq ptr %5, null
-  br i1 %6, label %_llgo_1, label %_llgo_2
+  %0 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 30 }, i64 25, i64 24, i64 0, i64 1)
+  store ptr %0, ptr @"_llgo_main.future[main.Tuple[error]]", align 8
+  %1 = load ptr, ptr @_llgo_Pointer, align 8
+  %2 = icmp eq ptr %1, null
+  br i1 %2, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %7)
-  store ptr %7, ptr @_llgo_Pointer, align 8
+  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %3)
+  store ptr %3, ptr @_llgo_Pointer, align 8
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-  %8 = load ptr, ptr @_llgo_Pointer, align 8
-  %9 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %9, i32 0, i32 0
-  store ptr @2, ptr %10, align 8
-  %11 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %9, i32 0, i32 1
-  store i64 17, ptr %11, align 4
-  %12 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %9, align 8
-  %13 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %12, i64 25, i64 16, i64 1, i64 1)
-  %14 = load ptr, ptr @"_llgo_main.Tuple[error]", align 8
-  %15 = icmp eq ptr %14, null
-  br i1 %15, label %_llgo_3, label %_llgo_4
+  %4 = load ptr, ptr @_llgo_Pointer, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 17 }, i64 25, i64 16, i64 1, i64 1)
+  %6 = load ptr, ptr @"_llgo_main.Tuple[error]", align 8
+  %7 = icmp eq ptr %6, null
+  br i1 %7, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  store ptr %13, ptr @"_llgo_main.Tuple[error]", align 8
+  store ptr %5, ptr @"_llgo_main.Tuple[error]", align 8
   br label %_llgo_4
 
 _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
-  %16 = load ptr, ptr @_llgo_string, align 8
-  %17 = icmp eq ptr %16, null
-  br i1 %17, label %_llgo_5, label %_llgo_6
+  %8 = load ptr, ptr @_llgo_string, align 8
+  %9 = icmp eq ptr %8, null
+  br i1 %9, label %_llgo_5, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_4
-  %18 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  store ptr %18, ptr @_llgo_string, align 8
+  %10 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  store ptr %10, ptr @_llgo_string, align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %19 = load ptr, ptr @_llgo_string, align 8
-  %20 = load ptr, ptr @_llgo_string, align 8
-  %21 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %22 = icmp eq ptr %21, null
-  br i1 %22, label %_llgo_7, label %_llgo_8
+  %11 = load ptr, ptr @_llgo_string, align 8
+  %12 = load ptr, ptr @_llgo_string, align 8
+  %13 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %14 = icmp eq ptr %13, null
+  br i1 %14, label %_llgo_7, label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_6
-  %23 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %24 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %25 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %24, i32 0, i32 0
-  store ptr %23, ptr %25, align 8
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %24, i32 0, i32 1
-  store i64 0, ptr %26, align 4
-  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %24, i32 0, i32 2
-  store i64 0, ptr %27, align 4
-  %28 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %24, align 8
-  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %30 = getelementptr ptr, ptr %29, i64 0
-  store ptr %20, ptr %30, align 8
-  %31 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %31, i32 0, i32 0
-  store ptr %29, ptr %32, align 8
-  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %31, i32 0, i32 1
-  store i64 1, ptr %33, align 4
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %31, i32 0, i32 2
-  store i64 1, ptr %34, align 4
-  %35 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %31, align 8
-  %36 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %28, %"github.com/goplus/llgo/internal/runtime.Slice" %35, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %36)
-  store ptr %36, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %15 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %16 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %15, 0
+  %17 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %16, i64 0, 1
+  %18 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %17, i64 0, 2
+  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %20 = getelementptr ptr, ptr %19, i64 0
+  store ptr %12, ptr %20, align 8
+  %21 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %19, 0
+  %22 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %21, i64 1, 1
+  %23 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %22, i64 1, 2
+  %24 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %18, %"github.com/goplus/llgo/internal/runtime.Slice" %23, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %24)
+  store ptr %24, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
   br label %_llgo_8
 
 _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
-  %37 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %38 = load ptr, ptr @_llgo_error, align 8
-  %39 = icmp eq ptr %38, null
-  br i1 %39, label %_llgo_9, label %_llgo_10
+  %25 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %26 = load ptr, ptr @_llgo_error, align 8
+  %27 = icmp eq ptr %26, null
+  br i1 %27, label %_llgo_9, label %_llgo_10
 
 _llgo_9:                                          ; preds = %_llgo_8
-  %40 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %41 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %40, i32 0, i32 0
-  store ptr @3, ptr %41, align 8
-  %42 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %40, i32 0, i32 1
-  store i64 5, ptr %42, align 4
-  %43 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %40, align 8
-  %44 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %45 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %44, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %43, ptr %45, align 8
-  %46 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %44, i32 0, i32 1
-  store ptr %37, ptr %46, align 8
-  %47 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %44, align 8
-  %48 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %49 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %48, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %47, ptr %49, align 8
-  %50 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %50, i32 0, i32 0
-  store ptr %48, ptr %51, align 8
-  %52 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %50, i32 0, i32 1
-  store i64 1, ptr %52, align 4
-  %53 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %50, i32 0, i32 2
-  store i64 1, ptr %53, align 4
-  %54 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %50, align 8
-  %55 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %56 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 0
-  store ptr @4, ptr %56, align 8
-  %57 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %55, i32 0, i32 1
-  store i64 4, ptr %57, align 4
-  %58 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %55, align 8
-  %59 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %59, i32 0, i32 0
-  store ptr @5, ptr %60, align 8
-  %61 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %59, i32 0, i32 1
-  store i64 5, ptr %61, align 4
-  %62 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %59, align 8
-  %63 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %58, %"github.com/goplus/llgo/internal/runtime.String" %62, %"github.com/goplus/llgo/internal/runtime.Slice" %54)
-  store ptr %63, ptr @_llgo_error, align 8
+  %28 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 5 }, ptr undef }, ptr %25, 1
+  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %30 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %29, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %28, ptr %30, align 8
+  %31 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %29, 0
+  %32 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %31, i64 1, 1
+  %33 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %32, i64 1, 2
+  %34 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 5 }, %"github.com/goplus/llgo/internal/runtime.Slice" %33)
+  store ptr %34, ptr @_llgo_error, align 8
   br label %_llgo_10
 
 _llgo_10:                                         ; preds = %_llgo_9, %_llgo_8
-  %64 = load ptr, ptr @_llgo_error, align 8
-  %65 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %66 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %67 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %66, i32 0, i32 0
-  store ptr @6, ptr %67, align 8
-  %68 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %66, i32 0, i32 1
-  store i64 1, ptr %68, align 4
-  %69 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %66, align 8
-  %70 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %71 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %70, i32 0, i32 0
-  store ptr null, ptr %71, align 8
-  %72 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %70, i32 0, i32 1
-  store i64 0, ptr %72, align 4
-  %73 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %70, align 8
-  %74 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %75 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %74, i32 0, i32 0
-  store ptr @3, ptr %75, align 8
-  %76 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %74, i32 0, i32 1
-  store i64 5, ptr %76, align 4
-  %77 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %74, align 8
-  %78 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %79 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %78, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %77, ptr %79, align 8
-  %80 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %78, i32 0, i32 1
-  store ptr %65, ptr %80, align 8
-  %81 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %78, align 8
-  %82 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %83 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %82, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %81, ptr %83, align 8
-  %84 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %85 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %84, i32 0, i32 0
-  store ptr %82, ptr %85, align 8
-  %86 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %84, i32 0, i32 1
-  store i64 1, ptr %86, align 4
-  %87 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %84, i32 0, i32 2
-  store i64 1, ptr %87, align 4
-  %88 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %84, align 8
-  %89 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %90 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %89, i32 0, i32 0
-  store ptr @4, ptr %90, align 8
-  %91 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %89, i32 0, i32 1
-  store i64 4, ptr %91, align 4
-  %92 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %89, align 8
-  %93 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %94 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %93, i32 0, i32 0
-  store ptr @5, ptr %94, align 8
-  %95 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %93, i32 0, i32 1
-  store i64 5, ptr %95, align 4
-  %96 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %93, align 8
-  %97 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %92, %"github.com/goplus/llgo/internal/runtime.String" %96, %"github.com/goplus/llgo/internal/runtime.Slice" %88)
-  %98 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %69, ptr %97, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %73, i1 false)
-  %99 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %100 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %99, i32 0, i32 0
-  store ptr @4, ptr %100, align 8
-  %101 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %99, i32 0, i32 1
-  store i64 4, ptr %101, align 4
-  %102 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %99, align 8
-  %103 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
-  %104 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %103, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %98, ptr %104, align 8
-  %105 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %106 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %105, i32 0, i32 0
-  store ptr %103, ptr %106, align 8
-  %107 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %105, i32 0, i32 1
-  store i64 1, ptr %107, align 4
-  %108 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %105, i32 0, i32 2
-  store i64 1, ptr %108, align 4
-  %109 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %105, align 8
-  %110 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %102, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %109)
-  store ptr %110, ptr @"main.struct$ddtj0teo4LtYcagzh1w6BsSZ7226uefXlqreeHsfVRo", align 8
-  %111 = load ptr, ptr @"main.struct$ddtj0teo4LtYcagzh1w6BsSZ7226uefXlqreeHsfVRo", align 8
-  br i1 %15, label %_llgo_11, label %_llgo_12
+  %35 = load ptr, ptr @_llgo_error, align 8
+  %36 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %37 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 5 }, ptr undef }, ptr %36, 1
+  %38 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %39 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %38, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %37, ptr %39, align 8
+  %40 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %38, 0
+  %41 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %40, i64 1, 1
+  %42 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %41, i64 1, 2
+  %43 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 5 }, %"github.com/goplus/llgo/internal/runtime.Slice" %42)
+  %44 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 1 }, ptr %43, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %45 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
+  %46 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %45, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %44, ptr %46, align 8
+  %47 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %45, 0
+  %48 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %47, i64 1, 1
+  %49 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %48, i64 1, 2
+  %50 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %49)
+  store ptr %50, ptr @"main.struct$ddtj0teo4LtYcagzh1w6BsSZ7226uefXlqreeHsfVRo", align 8
+  %51 = load ptr, ptr @"main.struct$ddtj0teo4LtYcagzh1w6BsSZ7226uefXlqreeHsfVRo", align 8
+  br i1 %7, label %_llgo_11, label %_llgo_12
 
 _llgo_11:                                         ; preds = %_llgo_10
-  %112 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %113 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %112, i32 0, i32 0
-  store ptr @7, ptr %113, align 8
-  %114 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %112, i32 0, i32 1
-  store i64 3, ptr %114, align 4
-  %115 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %112, align 8
-  %116 = load ptr, ptr @_llgo_error, align 8
-  %117 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
-  %118 = icmp eq ptr %117, null
-  br i1 %118, label %_llgo_13, label %_llgo_14
+  %52 = load ptr, ptr @_llgo_error, align 8
+  %53 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
+  %54 = icmp eq ptr %53, null
+  br i1 %54, label %_llgo_13, label %_llgo_14
 
 _llgo_12:                                         ; preds = %_llgo_14, %_llgo_10
-  %119 = load ptr, ptr @"_llgo_main.Tuple[error]", align 8
-  %120 = load ptr, ptr @_llgo_Pointer, align 8
-  %121 = load ptr, ptr @"_llgo_main.Tuple[error]", align 8
-  %122 = load ptr, ptr @"_llgo_func$-0z_KAFZTayiATHsoRweDLyk3Y_08iRGccLVoNDb2Q4", align 8
-  %123 = icmp eq ptr %122, null
-  br i1 %123, label %_llgo_15, label %_llgo_16
+  %55 = load ptr, ptr @"_llgo_main.Tuple[error]", align 8
+  %56 = load ptr, ptr @_llgo_Pointer, align 8
+  %57 = load ptr, ptr @"_llgo_main.Tuple[error]", align 8
+  %58 = load ptr, ptr @"_llgo_func$-0z_KAFZTayiATHsoRweDLyk3Y_08iRGccLVoNDb2Q4", align 8
+  %59 = icmp eq ptr %58, null
+  br i1 %59, label %_llgo_15, label %_llgo_16
 
 _llgo_13:                                         ; preds = %_llgo_11
-  %124 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %125 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %126 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %125, i32 0, i32 0
-  store ptr %124, ptr %126, align 8
-  %127 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %125, i32 0, i32 1
-  store i64 0, ptr %127, align 4
-  %128 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %125, i32 0, i32 2
-  store i64 0, ptr %128, align 4
-  %129 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %125, align 8
-  %130 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %131 = getelementptr ptr, ptr %130, i64 0
-  store ptr %116, ptr %131, align 8
-  %132 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %133 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %132, i32 0, i32 0
-  store ptr %130, ptr %133, align 8
-  %134 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %132, i32 0, i32 1
-  store i64 1, ptr %134, align 4
-  %135 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %132, i32 0, i32 2
-  store i64 1, ptr %135, align 4
-  %136 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %132, align 8
-  %137 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %129, %"github.com/goplus/llgo/internal/runtime.Slice" %136, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %137)
-  store ptr %137, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
+  %60 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %61 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %60, 0
+  %62 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %61, i64 0, 1
+  %63 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %62, i64 0, 2
+  %64 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %65 = getelementptr ptr, ptr %64, i64 0
+  store ptr %52, ptr %65, align 8
+  %66 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %64, 0
+  %67 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %66, i64 1, 1
+  %68 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %67, i64 1, 2
+  %69 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %63, %"github.com/goplus/llgo/internal/runtime.Slice" %68, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %69)
+  store ptr %69, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
   br label %_llgo_14
 
 _llgo_14:                                         ; preds = %_llgo_13, %_llgo_11
-  %138 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
-  %139 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %140 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %139, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %115, ptr %140, align 8
-  %141 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %139, i32 0, i32 1
-  store ptr %138, ptr %141, align 8
-  %142 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %139, i32 0, i32 2
-  store ptr @"main.(*Tuple[error]).Get", ptr %142, align 8
-  %143 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %139, i32 0, i32 3
-  store ptr @"main.(*Tuple[error]).Get", ptr %143, align 8
-  %144 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %139, align 8
-  %145 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %146 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %145, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %115, ptr %146, align 8
-  %147 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %145, i32 0, i32 1
-  store ptr %138, ptr %147, align 8
-  %148 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %145, i32 0, i32 2
-  store ptr @"main.(*Tuple[error]).Get", ptr %148, align 8
-  %149 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %145, i32 0, i32 3
-  store ptr @"main.Tuple[error].Get", ptr %149, align 8
-  %150 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %145, align 8
-  %151 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %152 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %151, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %150, ptr %152, align 8
-  %153 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %154 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %153, i32 0, i32 0
-  store ptr %151, ptr %154, align 8
-  %155 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %153, i32 0, i32 1
-  store i64 1, ptr %155, align 4
-  %156 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %153, i32 0, i32 2
-  store i64 1, ptr %156, align 4
-  %157 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %153, align 8
-  %158 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %159 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %158, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %144, ptr %159, align 8
-  %160 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %161 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %160, i32 0, i32 0
-  store ptr %158, ptr %161, align 8
-  %162 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %160, i32 0, i32 1
-  store i64 1, ptr %162, align 4
-  %163 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %160, i32 0, i32 2
-  store i64 1, ptr %163, align 4
-  %164 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %160, align 8
-  %165 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %166 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %165, i32 0, i32 0
-  store ptr @4, ptr %166, align 8
-  %167 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %165, i32 0, i32 1
-  store i64 4, ptr %167, align 4
-  %168 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %165, align 8
-  %169 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %170 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %169, i32 0, i32 0
-  store ptr @8, ptr %170, align 8
-  %171 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %169, i32 0, i32 1
-  store i64 12, ptr %171, align 4
-  %172 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %169, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %13, %"github.com/goplus/llgo/internal/runtime.String" %168, %"github.com/goplus/llgo/internal/runtime.String" %172, ptr %111, %"github.com/goplus/llgo/internal/runtime.Slice" %157, %"github.com/goplus/llgo/internal/runtime.Slice" %164)
+  %70 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
+  %71 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 3 }, ptr undef, ptr undef, ptr undef }, ptr %70, 1
+  %72 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %71, ptr @"main.(*Tuple[error]).Get", 2
+  %73 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %72, ptr @"main.(*Tuple[error]).Get", 3
+  %74 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 3 }, ptr undef, ptr undef, ptr undef }, ptr %70, 1
+  %75 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %74, ptr @"main.(*Tuple[error]).Get", 2
+  %76 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %75, ptr @"main.Tuple[error].Get", 3
+  %77 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %78 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %77, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %76, ptr %78, align 8
+  %79 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %77, 0
+  %80 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %79, i64 1, 1
+  %81 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %80, i64 1, 2
+  %82 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %83 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %82, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %73, ptr %83, align 8
+  %84 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %82, 0
+  %85 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %84, i64 1, 1
+  %86 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %85, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %5, %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 12 }, ptr %51, %"github.com/goplus/llgo/internal/runtime.Slice" %81, %"github.com/goplus/llgo/internal/runtime.Slice" %86)
   br label %_llgo_12
 
 _llgo_15:                                         ; preds = %_llgo_12
-  %173 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %174 = getelementptr ptr, ptr %173, i64 0
-  store ptr %120, ptr %174, align 8
-  %175 = getelementptr ptr, ptr %173, i64 1
-  store ptr %121, ptr %175, align 8
-  %176 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %177 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %176, i32 0, i32 0
-  store ptr %173, ptr %177, align 8
-  %178 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %176, i32 0, i32 1
-  store i64 2, ptr %178, align 4
-  %179 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %176, i32 0, i32 2
-  store i64 2, ptr %179, align 4
-  %180 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %176, align 8
-  %181 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %182 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %183 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %182, i32 0, i32 0
-  store ptr %181, ptr %183, align 8
-  %184 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %182, i32 0, i32 1
-  store i64 0, ptr %184, align 4
-  %185 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %182, i32 0, i32 2
-  store i64 0, ptr %185, align 4
-  %186 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %182, align 8
-  %187 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %180, %"github.com/goplus/llgo/internal/runtime.Slice" %186, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %187)
-  store ptr %187, ptr @"_llgo_func$-0z_KAFZTayiATHsoRweDLyk3Y_08iRGccLVoNDb2Q4", align 8
+  %87 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %88 = getelementptr ptr, ptr %87, i64 0
+  store ptr %56, ptr %88, align 8
+  %89 = getelementptr ptr, ptr %87, i64 1
+  store ptr %57, ptr %89, align 8
+  %90 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %87, 0
+  %91 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %90, i64 2, 1
+  %92 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %91, i64 2, 2
+  %93 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %94 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %93, 0
+  %95 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %94, i64 0, 1
+  %96 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %95, i64 0, 2
+  %97 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %92, %"github.com/goplus/llgo/internal/runtime.Slice" %96, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %97)
+  store ptr %97, ptr @"_llgo_func$-0z_KAFZTayiATHsoRweDLyk3Y_08iRGccLVoNDb2Q4", align 8
   br label %_llgo_16
 
 _llgo_16:                                         ; preds = %_llgo_15, %_llgo_12
-  %188 = load ptr, ptr @"_llgo_func$-0z_KAFZTayiATHsoRweDLyk3Y_08iRGccLVoNDb2Q4", align 8
-  %189 = load ptr, ptr @_llgo_Pointer, align 8
-  %190 = load ptr, ptr @"_llgo_main.Tuple[error]", align 8
-  %191 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %192 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %191, i32 0, i32 0
-  store ptr @9, ptr %192, align 8
-  %193 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %191, i32 0, i32 1
-  store i64 1, ptr %193, align 4
-  %194 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %191, align 8
-  %195 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %196 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %195, i32 0, i32 0
-  store ptr null, ptr %196, align 8
-  %197 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %195, i32 0, i32 1
-  store i64 0, ptr %197, align 4
-  %198 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %195, align 8
-  %199 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %200 = getelementptr ptr, ptr %199, i64 0
-  store ptr %189, ptr %200, align 8
-  %201 = getelementptr ptr, ptr %199, i64 1
-  store ptr %190, ptr %201, align 8
-  %202 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %203 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %202, i32 0, i32 0
-  store ptr %199, ptr %203, align 8
-  %204 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %202, i32 0, i32 1
-  store i64 2, ptr %204, align 4
-  %205 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %202, i32 0, i32 2
-  store i64 2, ptr %205, align 4
-  %206 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %202, align 8
-  %207 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %208 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %209 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %208, i32 0, i32 0
-  store ptr %207, ptr %209, align 8
-  %210 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %208, i32 0, i32 1
-  store i64 0, ptr %210, align 4
-  %211 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %208, i32 0, i32 2
-  store i64 0, ptr %211, align 4
-  %212 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %208, align 8
-  %213 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %206, %"github.com/goplus/llgo/internal/runtime.Slice" %212, i1 false)
-  %214 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %194, ptr %213, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %198, i1 false)
-  %215 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %216 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %215, i32 0, i32 0
-  store ptr @10, ptr %216, align 8
-  %217 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %215, i32 0, i32 1
-  store i64 4, ptr %217, align 4
-  %218 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %215, align 8
-  %219 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %220 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %219, i32 0, i32 0
-  store ptr null, ptr %220, align 8
-  %221 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %219, i32 0, i32 1
-  store i64 0, ptr %221, align 4
-  %222 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %219, align 8
-  %223 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %224 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %218, ptr %223, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %222, i1 false)
-  %225 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %226 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %225, i32 0, i32 0
-  store ptr @4, ptr %226, align 8
-  %227 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %225, i32 0, i32 1
-  store i64 4, ptr %227, align 4
-  %228 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %225, align 8
-  %229 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %230 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %229, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %214, ptr %230, align 8
-  %231 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %229, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %224, ptr %231, align 8
-  %232 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %233 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %232, i32 0, i32 0
-  store ptr %229, ptr %233, align 8
-  %234 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %232, i32 0, i32 1
-  store i64 2, ptr %234, align 4
-  %235 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %232, i32 0, i32 2
-  store i64 2, ptr %235, align 4
-  %236 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %232, align 8
-  %237 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %228, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %236)
-  store ptr %237, ptr @"main.struct$NucqrsSdwvefK8Neq8AbgvHqpAoTlQ4Z7-24dNSPHoY", align 8
-  %238 = load ptr, ptr @"main.struct$NucqrsSdwvefK8Neq8AbgvHqpAoTlQ4Z7-24dNSPHoY", align 8
-  %239 = load ptr, ptr @_llgo_Pointer, align 8
-  %240 = load ptr, ptr @"main.struct$NucqrsSdwvefK8Neq8AbgvHqpAoTlQ4Z7-24dNSPHoY", align 8
-  %241 = load ptr, ptr @"_llgo_func$8wjokNeb8lp2A2m-DoWHb8GZbqJJXaBuxj8bfRgBwsw", align 8
-  %242 = icmp eq ptr %241, null
-  br i1 %242, label %_llgo_17, label %_llgo_18
+  %98 = load ptr, ptr @"_llgo_func$-0z_KAFZTayiATHsoRweDLyk3Y_08iRGccLVoNDb2Q4", align 8
+  %99 = load ptr, ptr @_llgo_Pointer, align 8
+  %100 = load ptr, ptr @"_llgo_main.Tuple[error]", align 8
+  %101 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %102 = getelementptr ptr, ptr %101, i64 0
+  store ptr %99, ptr %102, align 8
+  %103 = getelementptr ptr, ptr %101, i64 1
+  store ptr %100, ptr %103, align 8
+  %104 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %101, 0
+  %105 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %104, i64 2, 1
+  %106 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %105, i64 2, 2
+  %107 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %108 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %107, 0
+  %109 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %108, i64 0, 1
+  %110 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %109, i64 0, 2
+  %111 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %106, %"github.com/goplus/llgo/internal/runtime.Slice" %110, i1 false)
+  %112 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 1 }, ptr %111, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %113 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %114 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, ptr %113, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %115 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %116 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %115, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %112, ptr %116, align 8
+  %117 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %115, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %114, ptr %117, align 8
+  %118 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %115, 0
+  %119 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %118, i64 2, 1
+  %120 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %119, i64 2, 2
+  %121 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %120)
+  store ptr %121, ptr @"main.struct$NucqrsSdwvefK8Neq8AbgvHqpAoTlQ4Z7-24dNSPHoY", align 8
+  %122 = load ptr, ptr @"main.struct$NucqrsSdwvefK8Neq8AbgvHqpAoTlQ4Z7-24dNSPHoY", align 8
+  %123 = load ptr, ptr @_llgo_Pointer, align 8
+  %124 = load ptr, ptr @"main.struct$NucqrsSdwvefK8Neq8AbgvHqpAoTlQ4Z7-24dNSPHoY", align 8
+  %125 = load ptr, ptr @"_llgo_func$8wjokNeb8lp2A2m-DoWHb8GZbqJJXaBuxj8bfRgBwsw", align 8
+  %126 = icmp eq ptr %125, null
+  br i1 %126, label %_llgo_17, label %_llgo_18
 
 _llgo_17:                                         ; preds = %_llgo_16
-  %243 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %244 = getelementptr ptr, ptr %243, i64 0
-  store ptr %239, ptr %244, align 8
-  %245 = getelementptr ptr, ptr %243, i64 1
-  store ptr %240, ptr %245, align 8
-  %246 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %247 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %246, i32 0, i32 0
-  store ptr %243, ptr %247, align 8
-  %248 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %246, i32 0, i32 1
-  store i64 2, ptr %248, align 4
-  %249 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %246, i32 0, i32 2
-  store i64 2, ptr %249, align 4
-  %250 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %246, align 8
-  %251 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %252 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %253 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %252, i32 0, i32 0
-  store ptr %251, ptr %253, align 8
-  %254 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %252, i32 0, i32 1
-  store i64 0, ptr %254, align 4
-  %255 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %252, i32 0, i32 2
-  store i64 0, ptr %255, align 4
-  %256 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %252, align 8
-  %257 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %250, %"github.com/goplus/llgo/internal/runtime.Slice" %256, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %257)
-  store ptr %257, ptr @"_llgo_func$8wjokNeb8lp2A2m-DoWHb8GZbqJJXaBuxj8bfRgBwsw", align 8
+  %127 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %128 = getelementptr ptr, ptr %127, i64 0
+  store ptr %123, ptr %128, align 8
+  %129 = getelementptr ptr, ptr %127, i64 1
+  store ptr %124, ptr %129, align 8
+  %130 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %127, 0
+  %131 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %130, i64 2, 1
+  %132 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %131, i64 2, 2
+  %133 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %134 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %133, 0
+  %135 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %134, i64 0, 1
+  %136 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %135, i64 0, 2
+  %137 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %132, %"github.com/goplus/llgo/internal/runtime.Slice" %136, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %137)
+  store ptr %137, ptr @"_llgo_func$8wjokNeb8lp2A2m-DoWHb8GZbqJJXaBuxj8bfRgBwsw", align 8
   br label %_llgo_18
 
 _llgo_18:                                         ; preds = %_llgo_17, %_llgo_16
-  %258 = load ptr, ptr @"_llgo_func$8wjokNeb8lp2A2m-DoWHb8GZbqJJXaBuxj8bfRgBwsw", align 8
-  %259 = load ptr, ptr @_llgo_Pointer, align 8
-  %260 = load ptr, ptr @"main.struct$NucqrsSdwvefK8Neq8AbgvHqpAoTlQ4Z7-24dNSPHoY", align 8
-  %261 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %262 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %261, i32 0, i32 0
-  store ptr @9, ptr %262, align 8
-  %263 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %261, i32 0, i32 1
-  store i64 1, ptr %263, align 4
-  %264 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %261, align 8
-  %265 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %266 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %265, i32 0, i32 0
-  store ptr null, ptr %266, align 8
-  %267 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %265, i32 0, i32 1
-  store i64 0, ptr %267, align 4
-  %268 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %265, align 8
-  %269 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %270 = getelementptr ptr, ptr %269, i64 0
-  store ptr %259, ptr %270, align 8
-  %271 = getelementptr ptr, ptr %269, i64 1
-  store ptr %260, ptr %271, align 8
-  %272 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %273 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %272, i32 0, i32 0
-  store ptr %269, ptr %273, align 8
-  %274 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %272, i32 0, i32 1
-  store i64 2, ptr %274, align 4
-  %275 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %272, i32 0, i32 2
-  store i64 2, ptr %275, align 4
-  %276 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %272, align 8
-  %277 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %278 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %279 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %278, i32 0, i32 0
-  store ptr %277, ptr %279, align 8
-  %280 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %278, i32 0, i32 1
-  store i64 0, ptr %280, align 4
-  %281 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %278, i32 0, i32 2
-  store i64 0, ptr %281, align 4
-  %282 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %278, align 8
-  %283 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %276, %"github.com/goplus/llgo/internal/runtime.Slice" %282, i1 false)
-  %284 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %264, ptr %283, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %268, i1 false)
-  %285 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %286 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %285, i32 0, i32 0
-  store ptr @10, ptr %286, align 8
-  %287 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %285, i32 0, i32 1
-  store i64 4, ptr %287, align 4
-  %288 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %285, align 8
-  %289 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %290 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %289, i32 0, i32 0
-  store ptr null, ptr %290, align 8
-  %291 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %289, i32 0, i32 1
-  store i64 0, ptr %291, align 4
-  %292 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %289, align 8
-  %293 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %294 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %288, ptr %293, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %292, i1 false)
-  %295 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %296 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %295, i32 0, i32 0
-  store ptr @4, ptr %296, align 8
-  %297 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %295, i32 0, i32 1
-  store i64 4, ptr %297, align 4
-  %298 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %295, align 8
-  %299 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %300 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %299, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %284, ptr %300, align 8
-  %301 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %299, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %294, ptr %301, align 8
-  %302 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %303 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %302, i32 0, i32 0
-  store ptr %299, ptr %303, align 8
-  %304 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %302, i32 0, i32 1
-  store i64 2, ptr %304, align 4
-  %305 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %302, i32 0, i32 2
-  store i64 2, ptr %305, align 4
-  %306 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %302, align 8
-  %307 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %298, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %306)
-  store ptr %307, ptr @"main.struct$ti_L8YygAzqrdADYjADo-CrIBPIrzAe7WUDQrPhGsLk", align 8
-  %308 = load ptr, ptr @"main.struct$ti_L8YygAzqrdADYjADo-CrIBPIrzAe7WUDQrPhGsLk", align 8
-  %309 = load ptr, ptr @_llgo_Pointer, align 8
-  %310 = load ptr, ptr @"main.struct$NucqrsSdwvefK8Neq8AbgvHqpAoTlQ4Z7-24dNSPHoY", align 8
-  %311 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %312 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %311, i32 0, i32 0
-  store ptr @11, ptr %312, align 8
-  %313 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %311, i32 0, i32 1
-  store i64 2, ptr %313, align 4
-  %314 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %311, align 8
-  %315 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %316 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %315, i32 0, i32 0
-  store ptr null, ptr %316, align 8
-  %317 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %315, i32 0, i32 1
-  store i64 0, ptr %317, align 4
-  %318 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %315, align 8
-  %319 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %320 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %319, i32 0, i32 0
-  store ptr @9, ptr %320, align 8
-  %321 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %319, i32 0, i32 1
-  store i64 1, ptr %321, align 4
-  %322 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %319, align 8
-  %323 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %324 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %323, i32 0, i32 0
-  store ptr null, ptr %324, align 8
-  %325 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %323, i32 0, i32 1
-  store i64 0, ptr %325, align 4
-  %326 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %323, align 8
-  %327 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %328 = getelementptr ptr, ptr %327, i64 0
-  store ptr %309, ptr %328, align 8
-  %329 = getelementptr ptr, ptr %327, i64 1
-  store ptr %310, ptr %329, align 8
-  %330 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %331 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %330, i32 0, i32 0
-  store ptr %327, ptr %331, align 8
-  %332 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %330, i32 0, i32 1
-  store i64 2, ptr %332, align 4
-  %333 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %330, i32 0, i32 2
-  store i64 2, ptr %333, align 4
-  %334 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %330, align 8
-  %335 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %336 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %337 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %336, i32 0, i32 0
-  store ptr %335, ptr %337, align 8
-  %338 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %336, i32 0, i32 1
-  store i64 0, ptr %338, align 4
-  %339 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %336, i32 0, i32 2
-  store i64 0, ptr %339, align 4
-  %340 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %336, align 8
-  %341 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %334, %"github.com/goplus/llgo/internal/runtime.Slice" %340, i1 false)
-  %342 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %322, ptr %341, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %326, i1 false)
-  %343 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %344 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %343, i32 0, i32 0
-  store ptr @10, ptr %344, align 8
-  %345 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %343, i32 0, i32 1
-  store i64 4, ptr %345, align 4
-  %346 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %343, align 8
-  %347 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %348 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %347, i32 0, i32 0
-  store ptr null, ptr %348, align 8
-  %349 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %347, i32 0, i32 1
-  store i64 0, ptr %349, align 4
-  %350 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %347, align 8
-  %351 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %352 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %346, ptr %351, i64 8, %"github.com/goplus/llgo/internal/runtime.String" %350, i1 false)
-  %353 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %354 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %353, i32 0, i32 0
-  store ptr @4, ptr %354, align 8
-  %355 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %353, i32 0, i32 1
-  store i64 4, ptr %355, align 4
-  %356 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %353, align 8
-  %357 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %358 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %357, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %342, ptr %358, align 8
-  %359 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %357, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %352, ptr %359, align 8
-  %360 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %361 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %360, i32 0, i32 0
-  store ptr %357, ptr %361, align 8
-  %362 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %360, i32 0, i32 1
-  store i64 2, ptr %362, align 4
-  %363 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %360, i32 0, i32 2
-  store i64 2, ptr %363, align 4
-  %364 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %360, align 8
-  %365 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %356, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %364)
-  %366 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" %314, ptr %365, i64 0, %"github.com/goplus/llgo/internal/runtime.String" %318, i1 false)
-  %367 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %368 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %367, i32 0, i32 0
-  store ptr @4, ptr %368, align 8
-  %369 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %367, i32 0, i32 1
-  store i64 4, ptr %369, align 4
-  %370 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %367, align 8
-  %371 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
-  %372 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %371, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %366, ptr %372, align 8
-  %373 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %374 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %373, i32 0, i32 0
-  store ptr %371, ptr %374, align 8
-  %375 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %373, i32 0, i32 1
-  store i64 1, ptr %375, align 4
-  %376 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %373, i32 0, i32 2
-  store i64 1, ptr %376, align 4
-  %377 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %373, align 8
-  %378 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" %370, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %377)
-  store ptr %378, ptr @"main.struct$ovoVIslEZIUrMi_-W6orVCU5A_Y8gqTBvvvJEMlWdJY", align 8
-  %379 = load ptr, ptr @"main.struct$ovoVIslEZIUrMi_-W6orVCU5A_Y8gqTBvvvJEMlWdJY", align 8
-  %380 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %381 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %380, i32 0, i32 0
-  store ptr @12, ptr %381, align 8
-  %382 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %380, i32 0, i32 1
-  store i64 4, ptr %382, align 4
-  %383 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %380, align 8
-  %384 = load ptr, ptr @"_llgo_func$-0z_KAFZTayiATHsoRweDLyk3Y_08iRGccLVoNDb2Q4", align 8
-  %385 = load ptr, ptr @"main.struct$NucqrsSdwvefK8Neq8AbgvHqpAoTlQ4Z7-24dNSPHoY", align 8
-  %386 = load ptr, ptr @"main.struct$NucqrsSdwvefK8Neq8AbgvHqpAoTlQ4Z7-24dNSPHoY", align 8
-  %387 = load ptr, ptr @"_llgo_func$C0YAnS54eM5TTOK79-PISU_oLySCvOtTKOpIh9jI2pM", align 8
-  %388 = icmp eq ptr %387, null
-  br i1 %388, label %_llgo_19, label %_llgo_20
+  %138 = load ptr, ptr @"_llgo_func$8wjokNeb8lp2A2m-DoWHb8GZbqJJXaBuxj8bfRgBwsw", align 8
+  %139 = load ptr, ptr @_llgo_Pointer, align 8
+  %140 = load ptr, ptr @"main.struct$NucqrsSdwvefK8Neq8AbgvHqpAoTlQ4Z7-24dNSPHoY", align 8
+  %141 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %142 = getelementptr ptr, ptr %141, i64 0
+  store ptr %139, ptr %142, align 8
+  %143 = getelementptr ptr, ptr %141, i64 1
+  store ptr %140, ptr %143, align 8
+  %144 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %141, 0
+  %145 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %144, i64 2, 1
+  %146 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %145, i64 2, 2
+  %147 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %148 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %147, 0
+  %149 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %148, i64 0, 1
+  %150 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %149, i64 0, 2
+  %151 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %146, %"github.com/goplus/llgo/internal/runtime.Slice" %150, i1 false)
+  %152 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 1 }, ptr %151, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %153 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %154 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, ptr %153, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %155 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %156 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %155, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %152, ptr %156, align 8
+  %157 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %155, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %154, ptr %157, align 8
+  %158 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %155, 0
+  %159 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %158, i64 2, 1
+  %160 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %159, i64 2, 2
+  %161 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %160)
+  store ptr %161, ptr @"main.struct$ti_L8YygAzqrdADYjADo-CrIBPIrzAe7WUDQrPhGsLk", align 8
+  %162 = load ptr, ptr @"main.struct$ti_L8YygAzqrdADYjADo-CrIBPIrzAe7WUDQrPhGsLk", align 8
+  %163 = load ptr, ptr @_llgo_Pointer, align 8
+  %164 = load ptr, ptr @"main.struct$NucqrsSdwvefK8Neq8AbgvHqpAoTlQ4Z7-24dNSPHoY", align 8
+  %165 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %166 = getelementptr ptr, ptr %165, i64 0
+  store ptr %163, ptr %166, align 8
+  %167 = getelementptr ptr, ptr %165, i64 1
+  store ptr %164, ptr %167, align 8
+  %168 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %165, 0
+  %169 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %168, i64 2, 1
+  %170 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %169, i64 2, 2
+  %171 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %172 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %171, 0
+  %173 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %172, i64 0, 1
+  %174 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %173, i64 0, 2
+  %175 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %170, %"github.com/goplus/llgo/internal/runtime.Slice" %174, i1 false)
+  %176 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 1 }, ptr %175, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %177 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %178 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, ptr %177, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %179 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %180 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %179, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %176, ptr %180, align 8
+  %181 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %179, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %178, ptr %181, align 8
+  %182 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %179, 0
+  %183 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %182, i64 2, 1
+  %184 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %183, i64 2, 2
+  %185 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %184)
+  %186 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 2 }, ptr %185, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %187 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
+  %188 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %187, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %186, ptr %188, align 8
+  %189 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %187, 0
+  %190 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %189, i64 1, 1
+  %191 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %190, i64 1, 2
+  %192 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %191)
+  store ptr %192, ptr @"main.struct$ovoVIslEZIUrMi_-W6orVCU5A_Y8gqTBvvvJEMlWdJY", align 8
+  %193 = load ptr, ptr @"main.struct$ovoVIslEZIUrMi_-W6orVCU5A_Y8gqTBvvvJEMlWdJY", align 8
+  %194 = load ptr, ptr @"_llgo_func$-0z_KAFZTayiATHsoRweDLyk3Y_08iRGccLVoNDb2Q4", align 8
+  %195 = load ptr, ptr @"main.struct$NucqrsSdwvefK8Neq8AbgvHqpAoTlQ4Z7-24dNSPHoY", align 8
+  %196 = load ptr, ptr @"main.struct$NucqrsSdwvefK8Neq8AbgvHqpAoTlQ4Z7-24dNSPHoY", align 8
+  %197 = load ptr, ptr @"_llgo_func$C0YAnS54eM5TTOK79-PISU_oLySCvOtTKOpIh9jI2pM", align 8
+  %198 = icmp eq ptr %197, null
+  br i1 %198, label %_llgo_19, label %_llgo_20
 
 _llgo_19:                                         ; preds = %_llgo_18
-  %389 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %390 = getelementptr ptr, ptr %389, i64 0
-  store ptr %386, ptr %390, align 8
-  %391 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %392 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %391, i32 0, i32 0
-  store ptr %389, ptr %392, align 8
-  %393 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %391, i32 0, i32 1
-  store i64 1, ptr %393, align 4
-  %394 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %391, i32 0, i32 2
-  store i64 1, ptr %394, align 4
-  %395 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %391, align 8
-  %396 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %397 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %398 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %397, i32 0, i32 0
-  store ptr %396, ptr %398, align 8
-  %399 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %397, i32 0, i32 1
-  store i64 0, ptr %399, align 4
-  %400 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %397, i32 0, i32 2
-  store i64 0, ptr %400, align 4
-  %401 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %397, align 8
-  %402 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %395, %"github.com/goplus/llgo/internal/runtime.Slice" %401, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %402)
-  store ptr %402, ptr @"_llgo_func$C0YAnS54eM5TTOK79-PISU_oLySCvOtTKOpIh9jI2pM", align 8
+  %199 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %200 = getelementptr ptr, ptr %199, i64 0
+  store ptr %196, ptr %200, align 8
+  %201 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %199, 0
+  %202 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %201, i64 1, 1
+  %203 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %202, i64 1, 2
+  %204 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %205 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %204, 0
+  %206 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %205, i64 0, 1
+  %207 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %206, i64 0, 2
+  %208 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %203, %"github.com/goplus/llgo/internal/runtime.Slice" %207, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %208)
+  store ptr %208, ptr @"_llgo_func$C0YAnS54eM5TTOK79-PISU_oLySCvOtTKOpIh9jI2pM", align 8
   br label %_llgo_20
 
 _llgo_20:                                         ; preds = %_llgo_19, %_llgo_18
-  %403 = load ptr, ptr @"_llgo_func$C0YAnS54eM5TTOK79-PISU_oLySCvOtTKOpIh9jI2pM", align 8
-  %404 = alloca %"github.com/goplus/llgo/internal/abi.Method", align 8
-  %405 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %404, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %383, ptr %405, align 8
-  %406 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %404, i32 0, i32 1
-  store ptr %403, ptr %406, align 8
-  %407 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %404, i32 0, i32 2
-  store ptr @"main.(*future[main.Tuple[error]]).Then", ptr %407, align 8
-  %408 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Method", ptr %404, i32 0, i32 3
-  store ptr @"main.(*future[main.Tuple[error]]).Then", ptr %408, align 8
-  %409 = load %"github.com/goplus/llgo/internal/abi.Method", ptr %404, align 8
-  %410 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %411 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %410, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %409, ptr %411, align 8
-  %412 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %413 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %412, i32 0, i32 0
-  store ptr %410, ptr %413, align 8
-  %414 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %412, i32 0, i32 1
-  store i64 1, ptr %414, align 4
-  %415 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %412, i32 0, i32 2
-  store i64 1, ptr %415, align 4
-  %416 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %412, align 8
-  %417 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %418 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %417, i32 0, i32 0
-  store ptr @4, ptr %418, align 8
-  %419 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %417, i32 0, i32 1
-  store i64 4, ptr %419, align 4
-  %420 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %417, align 8
-  %421 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %422 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %421, i32 0, i32 0
-  store ptr @13, ptr %422, align 8
-  %423 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %421, i32 0, i32 1
-  store i64 25, ptr %423, align 4
-  %424 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %421, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %4, %"github.com/goplus/llgo/internal/runtime.String" %420, %"github.com/goplus/llgo/internal/runtime.String" %424, ptr %379, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %416)
-  %425 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %426 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %425, i32 0, i32 0
-  store ptr @1, ptr %426, align 8
-  %427 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %425, i32 0, i32 1
-  store i64 30, ptr %427, align 4
-  %428 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %425, align 8
-  %429 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %428, i64 25, i64 24, i64 0, i64 1)
-  %430 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %429)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %430)
-  store ptr %430, ptr @"*_llgo_main.future[main.Tuple[error]]", align 8
-  %431 = load ptr, ptr @"_llgo_func$C0YAnS54eM5TTOK79-PISU_oLySCvOtTKOpIh9jI2pM", align 8
-  %432 = load ptr, ptr @"_llgo_iface$Nwf494fPwMWb08Ae8NF-s-Tau0AFb_mdl0sjJX-pbHw", align 8
-  %433 = icmp eq ptr %432, null
-  br i1 %433, label %_llgo_21, label %_llgo_22
+  %209 = load ptr, ptr @"_llgo_func$C0YAnS54eM5TTOK79-PISU_oLySCvOtTKOpIh9jI2pM", align 8
+  %210 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @12, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %209, 1
+  %211 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %210, ptr @"main.(*future[main.Tuple[error]]).Then", 2
+  %212 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %211, ptr @"main.(*future[main.Tuple[error]]).Then", 3
+  %213 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %214 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %213, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %212, ptr %214, align 8
+  %215 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %213, 0
+  %216 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %215, i64 1, 1
+  %217 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %216, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %0, %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @13, i64 25 }, ptr %193, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %217)
+  %218 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 30 }, i64 25, i64 24, i64 0, i64 1)
+  %219 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %218)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %219)
+  store ptr %219, ptr @"*_llgo_main.future[main.Tuple[error]]", align 8
+  %220 = load ptr, ptr @"_llgo_func$C0YAnS54eM5TTOK79-PISU_oLySCvOtTKOpIh9jI2pM", align 8
+  %221 = load ptr, ptr @"_llgo_iface$Nwf494fPwMWb08Ae8NF-s-Tau0AFb_mdl0sjJX-pbHw", align 8
+  %222 = icmp eq ptr %221, null
+  br i1 %222, label %_llgo_21, label %_llgo_22
 
 _llgo_21:                                         ; preds = %_llgo_20
-  %434 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %435 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %434, i32 0, i32 0
-  store ptr @12, ptr %435, align 8
-  %436 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %434, i32 0, i32 1
-  store i64 4, ptr %436, align 4
-  %437 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %434, align 8
-  %438 = alloca %"github.com/goplus/llgo/internal/abi.Imethod", align 8
-  %439 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %438, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %437, ptr %439, align 8
-  %440 = getelementptr inbounds %"github.com/goplus/llgo/internal/abi.Imethod", ptr %438, i32 0, i32 1
-  store ptr %431, ptr %440, align 8
-  %441 = load %"github.com/goplus/llgo/internal/abi.Imethod", ptr %438, align 8
-  %442 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %443 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %442, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %441, ptr %443, align 8
-  %444 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %445 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %444, i32 0, i32 0
-  store ptr %442, ptr %445, align 8
-  %446 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %444, i32 0, i32 1
-  store i64 1, ptr %446, align 4
-  %447 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %444, i32 0, i32 2
-  store i64 1, ptr %447, align 4
-  %448 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %444, align 8
-  %449 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %450 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %449, i32 0, i32 0
-  store ptr @4, ptr %450, align 8
-  %451 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %449, i32 0, i32 1
-  store i64 4, ptr %451, align 4
-  %452 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %449, align 8
-  %453 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %454 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %453, i32 0, i32 0
-  store ptr null, ptr %454, align 8
-  %455 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %453, i32 0, i32 1
-  store i64 0, ptr %455, align 4
-  %456 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %453, align 8
-  %457 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" %452, %"github.com/goplus/llgo/internal/runtime.String" %456, %"github.com/goplus/llgo/internal/runtime.Slice" %448)
-  store ptr %457, ptr @"_llgo_iface$Nwf494fPwMWb08Ae8NF-s-Tau0AFb_mdl0sjJX-pbHw", align 8
+  %223 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @12, i64 4 }, ptr undef }, ptr %220, 1
+  %224 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %225 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %224, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %223, ptr %225, align 8
+  %226 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %224, 0
+  %227 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %226, i64 1, 1
+  %228 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %227, i64 1, 2
+  %229 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %228)
+  store ptr %229, ptr @"_llgo_iface$Nwf494fPwMWb08Ae8NF-s-Tau0AFb_mdl0sjJX-pbHw", align 8
   br label %_llgo_22
 
 _llgo_22:                                         ; preds = %_llgo_21, %_llgo_20

--- a/cl/_testrt/typed/out.ll
+++ b/cl/_testrt/typed/out.ll
@@ -9,9 +9,9 @@ source_filename = "main"
 @__llgo_argc = global i32 0, align 4
 @__llgo_argv = global ptr null, align 8
 @0 = private unnamed_addr constant [5 x i8] c"hello", align 1
+@_llgo_string = linkonce global ptr null, align 8
 @_llgo_main.T = linkonce global ptr null, align 8
 @1 = private unnamed_addr constant [6 x i8] c"main.T", align 1
-@_llgo_string = linkonce global ptr null, align 8
 @2 = private unnamed_addr constant [4 x i8] c"main", align 1
 @3 = private unnamed_addr constant [1 x i8] c"T", align 1
 @4 = private unnamed_addr constant [21 x i8] c"type assertion failed", align 1
@@ -41,140 +41,96 @@ _llgo_0:
   store ptr %1, ptr @__llgo_argv, align 8
   call void @"github.com/goplus/llgo/internal/runtime.init"()
   call void @main.init()
-  %2 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 0
-  store ptr @0, ptr %3, align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 1
-  store i64 5, ptr %4, align 4
-  %5 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
-  %6 = load ptr, ptr @_llgo_main.T, align 8
-  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %5, ptr %7, align 8
-  %8 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, i32 0, i32 0
-  store ptr %6, ptr %9, align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, i32 0, i32 1
-  store ptr %7, ptr %10, align 8
-  %11 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, align 8
-  %12 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %11, 0
-  %13 = load ptr, ptr @_llgo_main.T, align 8
-  %14 = icmp eq ptr %12, %13
-  br i1 %14, label %_llgo_1, label %_llgo_2
+  %2 = load ptr, ptr @_llgo_string, align 8
+  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %3, align 8
+  %4 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %2, 0
+  %5 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %4, ptr %3, 1
+  %6 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %5, 0
+  %7 = load ptr, ptr @_llgo_main.T, align 8
+  %8 = icmp eq ptr %6, %7
+  br i1 %8, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %15 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %11, 1
-  %16 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %15, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %16)
+  %9 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %5, 1
+  %10 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %9, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %10)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %17 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %11, 0
-  %18 = load ptr, ptr @_llgo_string, align 8
-  %19 = icmp eq ptr %17, %18
-  br i1 %19, label %_llgo_3, label %_llgo_4
+  %11 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %5, 0
+  %12 = load ptr, ptr @_llgo_string, align 8
+  %13 = icmp eq ptr %11, %12
+  br i1 %13, label %_llgo_3, label %_llgo_4
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %20 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %20, i32 0, i32 0
-  store ptr @4, ptr %21, align 8
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %20, i32 0, i32 1
-  store i64 21, ptr %22, align 4
-  %23 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %20, align 8
-  %24 = load ptr, ptr @_llgo_string, align 8
-  %25 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %23, ptr %25, align 8
-  %26 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %27 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %26, i32 0, i32 0
-  store ptr %24, ptr %27, align 8
-  %28 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %26, i32 0, i32 1
-  store ptr %25, ptr %28, align 8
-  %29 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %26, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %29)
+  %14 = load ptr, ptr @_llgo_string, align 8
+  %15 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 21 }, ptr %15, align 8
+  %16 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %14, 0
+  %17 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %16, ptr %15, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %17)
   unreachable
 
 _llgo_3:                                          ; preds = %_llgo_1
-  %30 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %11, 1
-  %31 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %30, align 8
-  %32 = alloca { %"github.com/goplus/llgo/internal/runtime.String", i1 }, align 8
-  %33 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.String", i1 }, ptr %32, i32 0, i32 0
-  store %"github.com/goplus/llgo/internal/runtime.String" %31, ptr %33, align 8
-  %34 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.String", i1 }, ptr %32, i32 0, i32 1
-  store i1 true, ptr %34, align 1
-  %35 = load { %"github.com/goplus/llgo/internal/runtime.String", i1 }, ptr %32, align 8
+  %18 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %5, 1
+  %19 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %18, align 8
+  %20 = insertvalue { %"github.com/goplus/llgo/internal/runtime.String", i1 } undef, %"github.com/goplus/llgo/internal/runtime.String" %19, 0
+  %21 = insertvalue { %"github.com/goplus/llgo/internal/runtime.String", i1 } %20, i1 true, 1
   br label %_llgo_5
 
 _llgo_4:                                          ; preds = %_llgo_1
-  %36 = alloca { %"github.com/goplus/llgo/internal/runtime.String", i1 }, align 8
-  %37 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.String", i1 }, ptr %36, i32 0, i32 0
-  store { ptr, i64 } zeroinitializer, ptr %37, align 8
-  %38 = getelementptr inbounds { %"github.com/goplus/llgo/internal/runtime.String", i1 }, ptr %36, i32 0, i32 1
-  store i1 false, ptr %38, align 1
-  %39 = load { %"github.com/goplus/llgo/internal/runtime.String", i1 }, ptr %36, align 8
   br label %_llgo_5
 
 _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
-  %40 = phi { %"github.com/goplus/llgo/internal/runtime.String", i1 } [ %35, %_llgo_3 ], [ %39, %_llgo_4 ]
-  %41 = extractvalue { %"github.com/goplus/llgo/internal/runtime.String", i1 } %40, 0
-  %42 = extractvalue { %"github.com/goplus/llgo/internal/runtime.String", i1 } %40, 1
-  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %41)
+  %22 = phi { %"github.com/goplus/llgo/internal/runtime.String", i1 } [ %21, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
+  %23 = extractvalue { %"github.com/goplus/llgo/internal/runtime.String", i1 } %22, 0
+  %24 = extractvalue { %"github.com/goplus/llgo/internal/runtime.String", i1 } %22, 1
+  call void @"github.com/goplus/llgo/internal/runtime.PrintString"(%"github.com/goplus/llgo/internal/runtime.String" %23)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %42)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %24)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
-  %43 = alloca [2 x i64], align 8
-  call void @llvm.memset(ptr %43, i8 0, i64 16, i1 false)
-  %44 = getelementptr inbounds i64, ptr %43, i64 0
-  %45 = getelementptr inbounds i64, ptr %43, i64 1
-  store i64 1, ptr %44, align 4
-  store i64 2, ptr %45, align 4
-  %46 = load [2 x i64], ptr %43, align 4
-  %47 = load ptr, ptr @_llgo_main.A, align 8
-  %48 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store [2 x i64] %46, ptr %48, align 4
-  %49 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %49, i32 0, i32 0
-  store ptr %47, ptr %50, align 8
-  %51 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %49, i32 0, i32 1
-  store ptr %48, ptr %51, align 8
-  %52 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %49, align 8
-  %53 = alloca [2 x i64], align 8
-  call void @llvm.memset(ptr %53, i8 0, i64 16, i1 false)
-  %54 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %52, 0
-  %55 = load ptr, ptr @_llgo_main.A, align 8
-  %56 = icmp eq ptr %54, %55
-  br i1 %56, label %_llgo_6, label %_llgo_7
+  %25 = alloca [2 x i64], align 8
+  call void @llvm.memset(ptr %25, i8 0, i64 16, i1 false)
+  %26 = getelementptr inbounds i64, ptr %25, i64 0
+  %27 = getelementptr inbounds i64, ptr %25, i64 1
+  store i64 1, ptr %26, align 4
+  store i64 2, ptr %27, align 4
+  %28 = load [2 x i64], ptr %25, align 4
+  %29 = load ptr, ptr @_llgo_main.A, align 8
+  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store [2 x i64] %28, ptr %30, align 4
+  %31 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %29, 0
+  %32 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %31, ptr %30, 1
+  %33 = alloca [2 x i64], align 8
+  call void @llvm.memset(ptr %33, i8 0, i64 16, i1 false)
+  %34 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %32, 0
+  %35 = load ptr, ptr @_llgo_main.A, align 8
+  %36 = icmp eq ptr %34, %35
+  br i1 %36, label %_llgo_6, label %_llgo_7
 
 _llgo_6:                                          ; preds = %_llgo_5
-  %57 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %52, 1
-  %58 = load [2 x i64], ptr %57, align 4
-  %59 = alloca { [2 x i64], i1 }, align 8
-  %60 = getelementptr inbounds { [2 x i64], i1 }, ptr %59, i32 0, i32 0
-  store [2 x i64] %58, ptr %60, align 4
-  %61 = getelementptr inbounds { [2 x i64], i1 }, ptr %59, i32 0, i32 1
-  store i1 true, ptr %61, align 1
-  %62 = load { [2 x i64], i1 }, ptr %59, align 4
+  %37 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %32, 1
+  %38 = load [2 x i64], ptr %37, align 4
+  %39 = insertvalue { [2 x i64], i1 } undef, [2 x i64] %38, 0
+  %40 = insertvalue { [2 x i64], i1 } %39, i1 true, 1
   br label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_5
-  %63 = alloca { [2 x i64], i1 }, align 8
-  %64 = getelementptr inbounds { [2 x i64], i1 }, ptr %63, i32 0, i32 0
-  store [2 x i64] zeroinitializer, ptr %64, align 4
-  %65 = getelementptr inbounds { [2 x i64], i1 }, ptr %63, i32 0, i32 1
-  store i1 false, ptr %65, align 1
-  %66 = load { [2 x i64], i1 }, ptr %63, align 4
   br label %_llgo_8
 
 _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
-  %67 = phi { [2 x i64], i1 } [ %62, %_llgo_6 ], [ %66, %_llgo_7 ]
-  %68 = extractvalue { [2 x i64], i1 } %67, 0
-  store [2 x i64] %68, ptr %53, align 4
-  %69 = extractvalue { [2 x i64], i1 } %67, 1
-  %70 = getelementptr inbounds i64, ptr %53, i64 0
-  %71 = load i64, ptr %70, align 4
-  %72 = getelementptr inbounds i64, ptr %53, i64 1
-  %73 = load i64, ptr %72, align 4
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %71)
+  %41 = phi { [2 x i64], i1 } [ %40, %_llgo_6 ], [ zeroinitializer, %_llgo_7 ]
+  %42 = extractvalue { [2 x i64], i1 } %41, 0
+  store [2 x i64] %42, ptr %33, align 4
+  %43 = extractvalue { [2 x i64], i1 } %41, 1
+  %44 = getelementptr inbounds i64, ptr %33, i64 0
+  %45 = load i64, ptr %44, align 4
+  %46 = getelementptr inbounds i64, ptr %33, i64 1
+  %47 = load i64, ptr %46, align 4
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %45)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %73)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %47)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %69)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintBool"(i1 %43)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret i32 0
 }
@@ -183,120 +139,84 @@ declare void @"github.com/goplus/llgo/internal/runtime.init"()
 
 define void @"main.init$after"() {
 _llgo_0:
-  %0 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %1 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 0
-  store ptr @1, ptr %1, align 8
-  %2 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %0, i32 0, i32 1
-  store i64 6, ptr %2, align 4
-  %3 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %0, align 8
-  %4 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %3, i64 24, i64 16, i64 0, i64 0)
-  %5 = load ptr, ptr @_llgo_main.T, align 8
-  %6 = icmp eq ptr %5, null
-  br i1 %6, label %_llgo_1, label %_llgo_2
+  %0 = load ptr, ptr @_llgo_string, align 8
+  %1 = icmp eq ptr %0, null
+  br i1 %1, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  store ptr %4, ptr @_llgo_main.T, align 8
+  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  store ptr %2, ptr @_llgo_string, align 8
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-  %7 = load ptr, ptr @_llgo_string, align 8
-  %8 = icmp eq ptr %7, null
-  br i1 %8, label %_llgo_3, label %_llgo_4
+  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 6 }, i64 24, i64 16, i64 0, i64 0)
+  %4 = load ptr, ptr @_llgo_main.T, align 8
+  %5 = icmp eq ptr %4, null
+  br i1 %5, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  store ptr %9, ptr @_llgo_string, align 8
+  store ptr %3, ptr @_llgo_main.T, align 8
   br label %_llgo_4
 
 _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
-  %10 = load ptr, ptr @_llgo_string, align 8
-  br i1 %6, label %_llgo_5, label %_llgo_6
+  %6 = load ptr, ptr @_llgo_string, align 8
+  br i1 %5, label %_llgo_5, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_4
-  %11 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %12 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %11, i32 0, i32 0
-  store ptr @2, ptr %12, align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %11, i32 0, i32 1
-  store i64 4, ptr %13, align 4
-  %14 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %11, align 8
-  %15 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %16 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %15, i32 0, i32 0
-  store ptr @3, ptr %16, align 8
-  %17 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %15, i32 0, i32 1
-  store i64 1, ptr %17, align 4
-  %18 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %15, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %4, %"github.com/goplus/llgo/internal/runtime.String" %14, %"github.com/goplus/llgo/internal/runtime.String" %18, ptr %10, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %3, %"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 1 }, ptr %6, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %19 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %19, i32 0, i32 0
-  store ptr @5, ptr %20, align 8
-  %21 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %19, i32 0, i32 1
-  store i64 6, ptr %21, align 4
-  %22 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %19, align 8
-  %23 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" %22, i64 17, i64 16, i64 0, i64 0)
-  %24 = load ptr, ptr @_llgo_main.A, align 8
-  %25 = icmp eq ptr %24, null
-  br i1 %25, label %_llgo_7, label %_llgo_8
+  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 6 }, i64 17, i64 16, i64 0, i64 0)
+  %8 = load ptr, ptr @_llgo_main.A, align 8
+  %9 = icmp eq ptr %8, null
+  br i1 %9, label %_llgo_7, label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_6
-  store ptr %23, ptr @_llgo_main.A, align 8
+  store ptr %7, ptr @_llgo_main.A, align 8
   br label %_llgo_8
 
 _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
-  %26 = load ptr, ptr @_llgo_int, align 8
-  %27 = icmp eq ptr %26, null
-  br i1 %27, label %_llgo_9, label %_llgo_10
+  %10 = load ptr, ptr @_llgo_int, align 8
+  %11 = icmp eq ptr %10, null
+  br i1 %11, label %_llgo_9, label %_llgo_10
 
 _llgo_9:                                          ; preds = %_llgo_8
-  %28 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  store ptr %28, ptr @_llgo_int, align 8
+  %12 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  store ptr %12, ptr @_llgo_int, align 8
   br label %_llgo_10
 
 _llgo_10:                                         ; preds = %_llgo_9, %_llgo_8
-  %29 = load ptr, ptr @_llgo_int, align 8
-  %30 = load ptr, ptr @"[2]_llgo_int", align 8
-  %31 = icmp eq ptr %30, null
-  br i1 %31, label %_llgo_11, label %_llgo_12
+  %13 = load ptr, ptr @_llgo_int, align 8
+  %14 = load ptr, ptr @"[2]_llgo_int", align 8
+  %15 = icmp eq ptr %14, null
+  br i1 %15, label %_llgo_11, label %_llgo_12
 
 _llgo_11:                                         ; preds = %_llgo_10
-  %32 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %33 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 2, ptr %32)
-  store ptr %33, ptr @"[2]_llgo_int", align 8
+  %16 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64 2, ptr %16)
+  store ptr %17, ptr @"[2]_llgo_int", align 8
   br label %_llgo_12
 
 _llgo_12:                                         ; preds = %_llgo_11, %_llgo_10
-  %34 = load ptr, ptr @"[2]_llgo_int", align 8
-  br i1 %25, label %_llgo_13, label %_llgo_14
+  %18 = load ptr, ptr @"[2]_llgo_int", align 8
+  br i1 %9, label %_llgo_13, label %_llgo_14
 
 _llgo_13:                                         ; preds = %_llgo_12
-  %35 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %36 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %35, i32 0, i32 0
-  store ptr @2, ptr %36, align 8
-  %37 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %35, i32 0, i32 1
-  store i64 4, ptr %37, align 4
-  %38 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %35, align 8
-  %39 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %40 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %39, i32 0, i32 0
-  store ptr @6, ptr %40, align 8
-  %41 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %39, i32 0, i32 1
-  store i64 1, ptr %41, align 4
-  %42 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %39, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %23, %"github.com/goplus/llgo/internal/runtime.String" %38, %"github.com/goplus/llgo/internal/runtime.String" %42, ptr %34, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %7, %"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 1 }, ptr %18, { ptr, i64, i64 } zeroinitializer, { ptr, i64, i64 } zeroinitializer)
   br label %_llgo_14
 
 _llgo_14:                                         ; preds = %_llgo_13, %_llgo_12
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String", i64, i64, i64, i64)
-
 declare ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64)
 
-declare void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr, %"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.String", ptr, %"github.com/goplus/llgo/internal/runtime.Slice", %"github.com/goplus/llgo/internal/runtime.Slice")
-
 declare ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64)
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String", i64, i64, i64, i64)
+
+declare void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr, %"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.String", ptr, %"github.com/goplus/llgo/internal/runtime.Slice", %"github.com/goplus/llgo/internal/runtime.Slice")
 
 declare void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface")
 

--- a/cl/_testrt/unsafe/out.ll
+++ b/cl/_testrt/unsafe/out.ll
@@ -36,394 +36,223 @@ _llgo_0:
   br i1 false, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %2 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %3 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 0
-  store ptr @0, ptr %3, align 8
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %2, i32 0, i32 1
-  store i64 5, ptr %4, align 4
-  %5 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %2, align 8
-  %6 = load ptr, ptr @_llgo_string, align 8
-  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %5, ptr %7, align 8
-  %8 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, i32 0, i32 0
-  store ptr %6, ptr %9, align 8
-  %10 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, i32 0, i32 1
-  store ptr %7, ptr %10, align 8
-  %11 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %8, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %11)
+  %2 = load ptr, ptr @_llgo_string, align 8
+  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %3, align 8
+  %4 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %2, 0
+  %5 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %4, ptr %3, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %5)
   unreachable
 
 _llgo_2:                                          ; preds = %_llgo_0
   br i1 false, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %12 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %13 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %12, i32 0, i32 0
-  store ptr @0, ptr %13, align 8
-  %14 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %12, i32 0, i32 1
-  store i64 5, ptr %14, align 4
-  %15 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %12, align 8
-  %16 = load ptr, ptr @_llgo_string, align 8
-  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %15, ptr %17, align 8
-  %18 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %19 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %18, i32 0, i32 0
-  store ptr %16, ptr %19, align 8
-  %20 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %18, i32 0, i32 1
-  store ptr %17, ptr %20, align 8
-  %21 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %18, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %21)
+  %6 = load ptr, ptr @_llgo_string, align 8
+  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %7, align 8
+  %8 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %6, 0
+  %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %8, ptr %7, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %9)
   unreachable
 
 _llgo_4:                                          ; preds = %_llgo_2
   br i1 false, label %_llgo_5, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_4
-  %22 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %23 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %22, i32 0, i32 0
-  store ptr @0, ptr %23, align 8
-  %24 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %22, i32 0, i32 1
-  store i64 5, ptr %24, align 4
-  %25 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %22, align 8
-  %26 = load ptr, ptr @_llgo_string, align 8
-  %27 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %25, ptr %27, align 8
-  %28 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %29 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %28, i32 0, i32 0
-  store ptr %26, ptr %29, align 8
-  %30 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %28, i32 0, i32 1
-  store ptr %27, ptr %30, align 8
-  %31 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %28, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %31)
+  %10 = load ptr, ptr @_llgo_string, align 8
+  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %11, align 8
+  %12 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %10, 0
+  %13 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %12, ptr %11, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %13)
   unreachable
 
 _llgo_6:                                          ; preds = %_llgo_4
   br i1 false, label %_llgo_7, label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_6
-  %32 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %33 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %32, i32 0, i32 0
-  store ptr @0, ptr %33, align 8
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %32, i32 0, i32 1
-  store i64 5, ptr %34, align 4
-  %35 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %32, align 8
-  %36 = load ptr, ptr @_llgo_string, align 8
-  %37 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %35, ptr %37, align 8
-  %38 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %39 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i32 0, i32 0
-  store ptr %36, ptr %39, align 8
-  %40 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, i32 0, i32 1
-  store ptr %37, ptr %40, align 8
-  %41 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %38, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %41)
+  %14 = load ptr, ptr @_llgo_string, align 8
+  %15 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %15, align 8
+  %16 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %14, 0
+  %17 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %16, ptr %15, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %17)
   unreachable
 
 _llgo_8:                                          ; preds = %_llgo_6
   br i1 false, label %_llgo_9, label %_llgo_10
 
 _llgo_9:                                          ; preds = %_llgo_8
-  %42 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %42, i32 0, i32 0
-  store ptr @0, ptr %43, align 8
-  %44 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %42, i32 0, i32 1
-  store i64 5, ptr %44, align 4
-  %45 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %42, align 8
-  %46 = load ptr, ptr @_llgo_string, align 8
-  %47 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %45, ptr %47, align 8
-  %48 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %49 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %48, i32 0, i32 0
-  store ptr %46, ptr %49, align 8
-  %50 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %48, i32 0, i32 1
-  store ptr %47, ptr %50, align 8
-  %51 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %48, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %51)
+  %18 = load ptr, ptr @_llgo_string, align 8
+  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %19, align 8
+  %20 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %18, 0
+  %21 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %20, ptr %19, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %21)
   unreachable
 
 _llgo_10:                                         ; preds = %_llgo_8
   br i1 false, label %_llgo_11, label %_llgo_12
 
 _llgo_11:                                         ; preds = %_llgo_10
-  %52 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %53 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %52, i32 0, i32 0
-  store ptr @0, ptr %53, align 8
-  %54 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %52, i32 0, i32 1
-  store i64 5, ptr %54, align 4
-  %55 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %52, align 8
-  %56 = load ptr, ptr @_llgo_string, align 8
-  %57 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %55, ptr %57, align 8
-  %58 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %59 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %58, i32 0, i32 0
-  store ptr %56, ptr %59, align 8
-  %60 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %58, i32 0, i32 1
-  store ptr %57, ptr %60, align 8
-  %61 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %58, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %61)
+  %22 = load ptr, ptr @_llgo_string, align 8
+  %23 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %23, align 8
+  %24 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %22, 0
+  %25 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %24, ptr %23, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %25)
   unreachable
 
 _llgo_12:                                         ; preds = %_llgo_10
   br i1 false, label %_llgo_13, label %_llgo_14
 
 _llgo_13:                                         ; preds = %_llgo_12
-  %62 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %63 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %62, i32 0, i32 0
-  store ptr @0, ptr %63, align 8
-  %64 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %62, i32 0, i32 1
-  store i64 5, ptr %64, align 4
-  %65 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %62, align 8
-  %66 = load ptr, ptr @_llgo_string, align 8
-  %67 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %65, ptr %67, align 8
-  %68 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %69 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i32 0, i32 0
-  store ptr %66, ptr %69, align 8
-  %70 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, i32 0, i32 1
-  store ptr %67, ptr %70, align 8
-  %71 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %68, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %71)
+  %26 = load ptr, ptr @_llgo_string, align 8
+  %27 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %27, align 8
+  %28 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %26, 0
+  %29 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %28, ptr %27, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %29)
   unreachable
 
 _llgo_14:                                         ; preds = %_llgo_12
   br i1 false, label %_llgo_15, label %_llgo_16
 
 _llgo_15:                                         ; preds = %_llgo_14
-  %72 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %73 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %72, i32 0, i32 0
-  store ptr @0, ptr %73, align 8
-  %74 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %72, i32 0, i32 1
-  store i64 5, ptr %74, align 4
-  %75 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %72, align 8
-  %76 = load ptr, ptr @_llgo_string, align 8
-  %77 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %75, ptr %77, align 8
-  %78 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %79 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %78, i32 0, i32 0
-  store ptr %76, ptr %79, align 8
-  %80 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %78, i32 0, i32 1
-  store ptr %77, ptr %80, align 8
-  %81 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %78, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %81)
+  %30 = load ptr, ptr @_llgo_string, align 8
+  %31 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %31, align 8
+  %32 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %30, 0
+  %33 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %32, ptr %31, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %33)
   unreachable
 
 _llgo_16:                                         ; preds = %_llgo_14
   br i1 false, label %_llgo_17, label %_llgo_18
 
 _llgo_17:                                         ; preds = %_llgo_16
-  %82 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %83 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %82, i32 0, i32 0
-  store ptr @0, ptr %83, align 8
-  %84 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %82, i32 0, i32 1
-  store i64 5, ptr %84, align 4
-  %85 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %82, align 8
-  %86 = load ptr, ptr @_llgo_string, align 8
-  %87 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %85, ptr %87, align 8
-  %88 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %89 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %88, i32 0, i32 0
-  store ptr %86, ptr %89, align 8
-  %90 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %88, i32 0, i32 1
-  store ptr %87, ptr %90, align 8
-  %91 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %88, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %91)
+  %34 = load ptr, ptr @_llgo_string, align 8
+  %35 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %35, align 8
+  %36 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %34, 0
+  %37 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %36, ptr %35, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %37)
   unreachable
 
 _llgo_18:                                         ; preds = %_llgo_16
   br i1 false, label %_llgo_19, label %_llgo_20
 
 _llgo_19:                                         ; preds = %_llgo_18
-  %92 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %93 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %92, i32 0, i32 0
-  store ptr @0, ptr %93, align 8
-  %94 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %92, i32 0, i32 1
-  store i64 5, ptr %94, align 4
-  %95 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %92, align 8
-  %96 = load ptr, ptr @_llgo_string, align 8
-  %97 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %95, ptr %97, align 8
-  %98 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %99 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %98, i32 0, i32 0
-  store ptr %96, ptr %99, align 8
-  %100 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %98, i32 0, i32 1
-  store ptr %97, ptr %100, align 8
-  %101 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %98, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %101)
+  %38 = load ptr, ptr @_llgo_string, align 8
+  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %39, align 8
+  %40 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %38, 0
+  %41 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %40, ptr %39, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %41)
   unreachable
 
 _llgo_20:                                         ; preds = %_llgo_18
-  %102 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %103 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %102, i32 0, i32 0
-  store ptr @1, ptr %103, align 8
-  %104 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %102, i32 0, i32 1
-  store i64 3, ptr %104, align 4
-  %105 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %102, align 8
-  %106 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %107 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %106, i32 0, i32 0
-  store ptr @2, ptr %107, align 8
-  %108 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %106, i32 0, i32 1
-  store i64 3, ptr %108, align 4
-  %109 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %106, align 8
-  %110 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" %105, %"github.com/goplus/llgo/internal/runtime.String" %109)
-  %111 = xor i1 %110, true
-  br i1 %111, label %_llgo_21, label %_llgo_22
+  %42 = call i1 @"github.com/goplus/llgo/internal/runtime.StringEqual"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 3 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 3 })
+  %43 = xor i1 %42, true
+  br i1 %43, label %_llgo_21, label %_llgo_22
 
 _llgo_21:                                         ; preds = %_llgo_20
-  %112 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %113 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %112, i32 0, i32 0
-  store ptr @0, ptr %113, align 8
-  %114 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %112, i32 0, i32 1
-  store i64 5, ptr %114, align 4
-  %115 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %112, align 8
-  %116 = load ptr, ptr @_llgo_string, align 8
-  %117 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %115, ptr %117, align 8
-  %118 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %119 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %118, i32 0, i32 0
-  store ptr %116, ptr %119, align 8
-  %120 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %118, i32 0, i32 1
-  store ptr %117, ptr %120, align 8
-  %121 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %118, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %121)
+  %44 = load ptr, ptr @_llgo_string, align 8
+  %45 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %45, align 8
+  %46 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %44, 0
+  %47 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %46, ptr %45, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %47)
   unreachable
 
 _llgo_22:                                         ; preds = %_llgo_20
-  %122 = extractvalue %"github.com/goplus/llgo/internal/runtime.String" %105, 0
-  %123 = getelementptr inbounds i8, ptr %122, i64 0
-  %124 = load i8, ptr %123, align 1
-  %125 = icmp ne i8 %124, 97
-  br i1 %125, label %_llgo_23, label %_llgo_26
+  %48 = load i8, ptr @1, align 1
+  %49 = icmp ne i8 %48, 97
+  br i1 %49, label %_llgo_23, label %_llgo_26
 
 _llgo_23:                                         ; preds = %_llgo_25, %_llgo_26, %_llgo_22
-  %126 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %127 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %126, i32 0, i32 0
-  store ptr @0, ptr %127, align 8
-  %128 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %126, i32 0, i32 1
-  store i64 5, ptr %128, align 4
-  %129 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %126, align 8
-  %130 = load ptr, ptr @_llgo_string, align 8
-  %131 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %129, ptr %131, align 8
-  %132 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %133 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %132, i32 0, i32 0
-  store ptr %130, ptr %133, align 8
-  %134 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %132, i32 0, i32 1
-  store ptr %131, ptr %134, align 8
-  %135 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %132, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %135)
+  %50 = load ptr, ptr @_llgo_string, align 8
+  %51 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %51, align 8
+  %52 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %50, 0
+  %53 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %52, ptr %51, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %53)
   unreachable
 
 _llgo_24:                                         ; preds = %_llgo_25
-  %136 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 16)
-  %137 = getelementptr inbounds i64, ptr %136, i64 0
-  %138 = getelementptr inbounds i64, ptr %136, i64 1
-  store i64 1, ptr %137, align 4
-  store i64 2, ptr %138, align 4
-  %139 = getelementptr inbounds i64, ptr %136, i64 0
-  %140 = alloca %"github.com/goplus/llgo/internal/runtime.Slice", align 8
-  %141 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %140, i32 0, i32 0
-  store ptr %139, ptr %141, align 8
-  %142 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %140, i32 0, i32 1
-  store i64 2, ptr %142, align 4
-  %143 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.Slice", ptr %140, i32 0, i32 2
-  store i64 2, ptr %143, align 4
-  %144 = load %"github.com/goplus/llgo/internal/runtime.Slice", ptr %140, align 8
-  %145 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %144, 0
-  %146 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %144, 1
-  %147 = icmp sge i64 0, %146
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %147)
-  %148 = getelementptr inbounds i64, ptr %145, i64 0
-  %149 = load i64, ptr %148, align 4
-  %150 = icmp ne i64 %149, 1
-  br i1 %150, label %_llgo_27, label %_llgo_29
+  %54 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 16)
+  %55 = getelementptr inbounds i64, ptr %54, i64 0
+  %56 = getelementptr inbounds i64, ptr %54, i64 1
+  store i64 1, ptr %55, align 4
+  store i64 2, ptr %56, align 4
+  %57 = getelementptr inbounds i64, ptr %54, i64 0
+  %58 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %57, 0
+  %59 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %58, i64 2, 1
+  %60 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %59, i64 2, 2
+  %61 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %60, 0
+  %62 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %60, 1
+  %63 = icmp sge i64 0, %62
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %63)
+  %64 = getelementptr inbounds i64, ptr %61, i64 0
+  %65 = load i64, ptr %64, align 4
+  %66 = icmp ne i64 %65, 1
+  br i1 %66, label %_llgo_27, label %_llgo_29
 
 _llgo_25:                                         ; preds = %_llgo_26
-  %151 = getelementptr inbounds i8, ptr %122, i64 2
-  %152 = load i8, ptr %151, align 1
-  %153 = icmp ne i8 %152, 99
-  br i1 %153, label %_llgo_23, label %_llgo_24
+  %67 = load i8, ptr getelementptr inbounds (i8, ptr @1, i64 2), align 1
+  %68 = icmp ne i8 %67, 99
+  br i1 %68, label %_llgo_23, label %_llgo_24
 
 _llgo_26:                                         ; preds = %_llgo_22
-  %154 = getelementptr inbounds i8, ptr %122, i64 1
-  %155 = load i8, ptr %154, align 1
-  %156 = icmp ne i8 %155, 98
-  br i1 %156, label %_llgo_23, label %_llgo_25
+  %69 = load i8, ptr getelementptr inbounds (i8, ptr @1, i64 1), align 1
+  %70 = icmp ne i8 %69, 98
+  br i1 %70, label %_llgo_23, label %_llgo_25
 
 _llgo_27:                                         ; preds = %_llgo_29, %_llgo_24
-  %157 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %158 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %157, i32 0, i32 0
-  store ptr @0, ptr %158, align 8
-  %159 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %157, i32 0, i32 1
-  store i64 5, ptr %159, align 4
-  %160 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %157, align 8
-  %161 = load ptr, ptr @_llgo_string, align 8
-  %162 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %160, ptr %162, align 8
-  %163 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %164 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %163, i32 0, i32 0
-  store ptr %161, ptr %164, align 8
-  %165 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %163, i32 0, i32 1
-  store ptr %162, ptr %165, align 8
-  %166 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %163, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %166)
+  %71 = load ptr, ptr @_llgo_string, align 8
+  %72 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %72, align 8
+  %73 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %71, 0
+  %74 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %73, ptr %72, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %74)
   unreachable
 
 _llgo_28:                                         ; preds = %_llgo_29
-  %167 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %144, 0
-  %168 = load i64, ptr %167, align 4
-  %169 = icmp ne i64 %168, 1
-  br i1 %169, label %_llgo_30, label %_llgo_31
+  %75 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %60, 0
+  %76 = load i64, ptr %75, align 4
+  %77 = icmp ne i64 %76, 1
+  br i1 %77, label %_llgo_30, label %_llgo_31
 
 _llgo_29:                                         ; preds = %_llgo_24
-  %170 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %144, 0
-  %171 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %144, 1
-  %172 = icmp sge i64 1, %171
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %172)
-  %173 = getelementptr inbounds i64, ptr %170, i64 1
-  %174 = load i64, ptr %173, align 4
-  %175 = icmp ne i64 %174, 2
-  br i1 %175, label %_llgo_27, label %_llgo_28
+  %78 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %60, 0
+  %79 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %60, 1
+  %80 = icmp sge i64 1, %79
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %80)
+  %81 = getelementptr inbounds i64, ptr %78, i64 1
+  %82 = load i64, ptr %81, align 4
+  %83 = icmp ne i64 %82, 2
+  br i1 %83, label %_llgo_27, label %_llgo_28
 
 _llgo_30:                                         ; preds = %_llgo_28
-  %176 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %177 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %176, i32 0, i32 0
-  store ptr @0, ptr %177, align 8
-  %178 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %176, i32 0, i32 1
-  store i64 5, ptr %178, align 4
-  %179 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %176, align 8
-  %180 = load ptr, ptr @_llgo_string, align 8
-  %181 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %179, ptr %181, align 8
-  %182 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %183 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %182, i32 0, i32 0
-  store ptr %180, ptr %183, align 8
-  %184 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %182, i32 0, i32 1
-  store ptr %181, ptr %184, align 8
-  %185 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %182, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %185)
+  %84 = load ptr, ptr @_llgo_string, align 8
+  %85 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %85, align 8
+  %86 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %84, 0
+  %87 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %86, ptr %85, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %87)
   unreachable
 
 _llgo_31:                                         ; preds = %_llgo_28
   br i1 icmp ne (i64 ptrtoint (ptr getelementptr (i8, ptr null, i64 1) to i64), i64 1), label %_llgo_32, label %_llgo_33
 
 _llgo_32:                                         ; preds = %_llgo_31
-  %186 = alloca %"github.com/goplus/llgo/internal/runtime.String", align 8
-  %187 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %186, i32 0, i32 0
-  store ptr @0, ptr %187, align 8
-  %188 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.String", ptr %186, i32 0, i32 1
-  store i64 5, ptr %188, align 4
-  %189 = load %"github.com/goplus/llgo/internal/runtime.String", ptr %186, align 8
-  %190 = load ptr, ptr @_llgo_string, align 8
-  %191 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/internal/runtime.String" %189, ptr %191, align 8
-  %192 = alloca %"github.com/goplus/llgo/internal/runtime.eface", align 8
-  %193 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %192, i32 0, i32 0
-  store ptr %190, ptr %193, align 8
-  %194 = getelementptr inbounds %"github.com/goplus/llgo/internal/runtime.eface", ptr %192, i32 0, i32 1
-  store ptr %191, ptr %194, align 8
-  %195 = load %"github.com/goplus/llgo/internal/runtime.eface", ptr %192, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %195)
+  %88 = load ptr, ptr @_llgo_string, align 8
+  %89 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr %89, align 8
+  %90 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %88, 0
+  %91 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %90, ptr %89, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %91)
   unreachable
 
 _llgo_33:                                         ; preds = %_llgo_31

--- a/ssa/datastruct.go
+++ b/ssa/datastruct.go
@@ -757,7 +757,7 @@ func (b Builder) chanOp(s *SelectState) Expr {
 	} else {
 		etyp := prog.Elem(s.Chan.Type)
 		val = b.Alloc(etyp, false)
-		size = prog.IntVal(prog.SizeOf(etyp), prog.Int())
+		size = prog.IntVal(prog.SizeOf(etyp), prog.Int32())
 	}
 	send := prog.BoolVal(s.Send)
 	typ := b.Prog.rtType("ChanOp")

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -234,7 +234,7 @@ func (b Builder) Const(v constant.Value, typ Type) Expr {
 			v, _ := constant.Float64Val(constant.ToFloat(v))
 			return prog.FloatVal(v, typ)
 		case kind == types.String:
-			return Expr{b.Str(constant.StringVal(v)).impl, typ}
+			return b.Str(constant.StringVal(v))
 		case kind == types.Complex128 || kind == types.Complex64:
 			v = constant.ToComplex(v)
 			re, _ := constant.Float64Val(constant.Real(v))

--- a/ssa/memory.go
+++ b/ssa/memory.go
@@ -56,9 +56,11 @@ func (b Builder) aggregateValue(t Type, flds ...llvm.Value) Expr {
 }
 
 func aggregateValue(b llvm.Builder, tll llvm.Type, flds ...llvm.Value) llvm.Value {
-	ptr := llvm.CreateAlloca(b, tll)
-	aggregateInit(b, ptr, tll, flds...)
-	return llvm.CreateLoad(b, tll, ptr)
+	agg := llvm.Undef(tll)
+	for i, fld := range flds {
+		agg = b.CreateInsertValue(agg, fld, i, "")
+	}
+	return agg
 }
 
 func aggregateInit(b llvm.Builder, ptr llvm.Value, tll llvm.Type, flds ...llvm.Value) {

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -346,6 +346,7 @@ func (p Program) NewPackage(name, pkgPath string) Package {
 	pyobjs := make(map[string]PyObjRef)
 	pymods := make(map[string]Global)
 	strs := make(map[string]llvm.Value)
+	goStrs := make(map[string]llvm.Value)
 	chkabi := make(map[types.Type]bool)
 	glbDbgVars := make(map[Expr]bool)
 	p.NeedRuntime = false
@@ -353,7 +354,8 @@ func (p Program) NewPackage(name, pkgPath string) Package {
 	// p.needPyInit = false
 	ret := &aPackage{
 		mod: mod, vars: gbls, fns: fns, stubs: stubs,
-		pyobjs: pyobjs, pymods: pymods, strs: strs, chkabi: chkabi, Prog: p,
+		pyobjs: pyobjs, pymods: pymods, strs: strs, goStrs: goStrs,
+		chkabi: chkabi, Prog: p,
 		di: nil, cu: nil, glbDbgVars: glbDbgVars,
 	}
 	ret.abi.Init(pkgPath)
@@ -603,6 +605,7 @@ type aPackage struct {
 	pyobjs map[string]PyObjRef
 	pymods map[string]Global
 	strs   map[string]llvm.Value
+	goStrs map[string]llvm.Value
 	chkabi map[types.Type]bool
 	afterb unsafe.Pointer
 	patch  func(types.Type) types.Type

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -370,13 +370,8 @@ source_filename = "foo/bar"
 
 define { i64, double } @fn(double %0) {
 _llgo_0:
-  %1 = alloca { i64, double }, align 8
-  %2 = getelementptr inbounds { i64, double }, ptr %1, i32 0, i32 0
-  store ptr @a, ptr %2, align 8
-  %3 = getelementptr inbounds { i64, double }, ptr %1, i32 0, i32 1
-  store double %0, ptr %3, align 8
-  %4 = load { i64, double }, ptr %1, align 8
-  ret { i64, double } %4
+  %1 = insertvalue { i64, double } { ptr @a, double undef }, double %0, 1
+  ret { i64, double } %1
 }
 `)
 }


### PR DESCRIPTION
Fix https://github.com/goplus/llgo/issues/819

Also fixed `ChanOp.Size`, found by `insertvalue` instruction.