### PR TITLE
Enable demo test

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -128,7 +128,6 @@ jobs:
           bash _lldb/runtest.sh -v
 
       - name: Test demos
-        continue-on-error: true
         run: |
           # TODO(lijie): force python3-embed to be linked with python-3.12-embed
           # Currently, python3-embed is python-3.13-embed, doesn't work with pytorch

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -115,12 +115,12 @@ jobs:
         run: |
           echo "Test result on ${{matrix.os}} with LLVM ${{matrix.llvm}}" > result.md
           bash .github/workflows/test_llgo.sh
-      
+
       - name: chore/_xtool build tests
         run: |
           cd chore/_xtool
           llgo build -v ./...
-      
+
       - name: LLDB tests
         if: ${{startsWith(matrix.os, 'macos')}}
         run: |
@@ -129,7 +129,17 @@ jobs:
 
       - name: Test demos
         continue-on-error: true
-        run: bash .github/workflows/test_demo.sh
+        run: |
+          # TODO(lijie): force python3-embed to be linked with python-3.12-embed
+          # Currently, python3-embed is python-3.13-embed, doesn't work with pytorch
+          # Will remove this after pytorch is fixed.
+          pcdir=$HOME/pc
+          mkdir -p $pcdir
+          libdir=$(pkg-config --variable=libdir python-3.12-embed)
+          echo "libdir: $libdir"
+          ln -s $libdir/pkgconfig/python-3.12-embed.pc $pcdir/python3-embed.pc
+          export PKG_CONFIG_PATH=$pcdir
+          bash .github/workflows/test_demo.sh
 
       - name: Show test result
         run: cat result.md

--- a/internal/build/cgo.go
+++ b/internal/build/cgo.go
@@ -188,11 +188,18 @@ func parseCgo_(pkg *aPackage, files []*ast.File) (cfiles []string, preambles []c
 		dirs[dir] = none{}
 	}
 	for dir := range dirs {
-		files, err := filepath.Glob(filepath.Join(dir, "*.c"))
+		matches, err := filepath.Glob(filepath.Join(dir, "*.c"))
 		if err != nil {
 			continue
 		}
-		cfiles = append(cfiles, files...)
+		for _, match := range matches {
+			if strings.HasSuffix(match, "_test.c") {
+				continue
+			}
+			if fi, err := os.Stat(match); err == nil && !fi.IsDir() {
+				cfiles = append(cfiles, match)
+			}
+		}
 	}
 
 	for _, file := range files {

--- a/internal/lib/syscall/syscall_linux.go
+++ b/internal/lib/syscall/syscall_linux.go
@@ -15,6 +15,7 @@ import (
 	_ "unsafe"
 
 	"github.com/goplus/llgo/c"
+	"github.com/goplus/llgo/c/os"
 	"github.com/goplus/llgo/c/syscall"
 )
 
@@ -114,7 +115,14 @@ func Pipe2(p []int, flags int) error {
 // -----------------------------------------------------------------------------
 
 func Faccessat(dirfd int, path string, mode uint32, flags int) (err error) {
-	panic("todo: syscall.Faccessat")
+	ret := faccessat(c.Int(dirfd), c.AllocaCStr(path), c.Int(mode), c.Int(flags))
+	if ret != 0 {
+		return Errno(os.Errno())
+	}
+	return nil
 }
+
+//go:linkname faccessat C.faccessat
+func faccessat(dirfd c.Int, path *c.Char, mode c.Int, flags c.Int) c.Int
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
- [x] Skip test c files likes `go/src/crypto/internal/boring/div_test.c` to avoid duplicated `main`
- [x] Force run demo with python 3.12
- [x] Enable demo result checking
  - [x] Fix `_demo/logdemo`, blocked by https://github.com/goplus/llgo/issues/877
  - [x] Fix `_demo/{oslookpath,sysexec}`