### PR TITLE
Fix type patching

### DIFF
--- a/_demo/syncdebug/syncdebug.go
+++ b/_demo/syncdebug/syncdebug.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"io"
+	"os"
+	"sync"
+	"unsafe"
+
+	llsync "github.com/goplus/llgo/c/pthread/sync"
+)
+
+type L struct {
+	mu sync.Mutex
+	s  string
+	i  int
+	w  io.Writer
+}
+
+func main() {
+	l := &L{s: "hello", i: 123, w: os.Stdout}
+	println("sizeof(L):", unsafe.Sizeof(L{}))
+	println("sizeof(sync.Mutex):", unsafe.Sizeof(sync.Mutex{}))
+	println("sizeof(llsync.Mutex):", unsafe.Sizeof(llsync.Mutex{}))
+	println("l:", l, "l.s:", l.s, "l.i:", l.i, "l.w:", l.w)
+	l.mu.Lock()
+	println("locked")
+	println("l:", l, "l.s:", l.s, "l.i:", l.i, "l.w:", l.w)
+	l.w.Write([]byte(l.s))
+	l.w.Write([]byte("\n"))
+	l.mu.Unlock()
+}

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -105,6 +105,8 @@ type aProgram struct {
 	sizes types.Sizes  // provided by Go compiler
 	gocvt goTypes
 
+	patchType func(types.Type) types.Type
+
 	rt    *types.Package
 	rtget func() *types.Package
 
@@ -231,6 +233,17 @@ func NewProgram(target *Target) Program {
 		ptrSize: td.PointerSize(), named: make(map[string]llvm.Type), fnnamed: make(map[string]int),
 		linkname: make(map[string]string),
 	}
+}
+
+func (p Program) SetPatch(patchType func(types.Type) types.Type) {
+	p.patchType = patchType
+}
+
+func (p Program) patch(typ types.Type) types.Type {
+	if p.patchType != nil {
+		return p.patchType(typ)
+	}
+	return typ
 }
 
 // SetRuntime sets the runtime.

--- a/ssa/type.go
+++ b/ssa/type.go
@@ -429,7 +429,7 @@ func (p Program) toLLVMFields(raw *types.Struct) (fields []llvm.Type) {
 	if n > 0 {
 		fields = make([]llvm.Type, n)
 		for i := 0; i < n; i++ {
-			fields[i] = p.rawType(raw.Field(i).Type()).ll
+			fields[i] = p.rawType(p.patch(raw.Field(i).Type())).ll
 		}
 	}
 	return
@@ -443,7 +443,7 @@ func (p Program) toLLVMTypes(t *types.Tuple, n int) (ret []llvm.Type) {
 	if n > 0 {
 		ret = make([]llvm.Type, n)
 		for i := 0; i < n; i++ {
-			ret[i] = p.rawType(t.At(i).Type()).ll
+			ret[i] = p.rawType(p.patch(t.At(i).Type())).ll
 		}
 	}
 	return


### PR DESCRIPTION
Fix https://github.com/goplus/llgo/issues/877

```go
package main

import (
	"io"
	"os"
	"sync"
	"unsafe"

	llsync "github.com/goplus/llgo/c/pthread/sync"
)

type L struct {
	mu sync.Mutex
	s  string
	i  int
	w  io.Writer
}

func main() {
	l := &L{s: "hello", i: 123, w: os.Stdout}
	println("sizeof(L):", unsafe.Sizeof(L{}))
	println("sizeof(sync.Mutex):", unsafe.Sizeof(sync.Mutex{}))
	println("sizeof(llsync.Mutex):", unsafe.Sizeof(llsync.Mutex{}))
	println("l:", l, "l.s:", l.s, "l.i:", l.i, "l.w:", l.w)
	l.mu.Lock()
	println("locked")
	println("l:", l, "l.s:", l.s, "l.i:", l.i, "l.w:", l.w)
	l.w.Write([]byte(l.s))
	l.w.Write([]byte("\n"))
	l.mu.Unlock()
}
```

Outputs on macOS arm64:

```shelll
sizeof(L): 48
sizeof(sync.Mutex): 8
sizeof(llsync.Mutex): 64
l: 0x102649a10 l.s: hello l.i: 123 l.w: (0x10264e8d0,0x10264e990)
locked
l: 0x102649a10 l.s: hello l.i: 123 l.w: (0x10264e8d0,0x10264e990)
hello
```

Outputs on Ubuntu arm64:

```shell
l: 0x4000163360 l.out: (0x84de58,0x4000120010)
sizeof(L): 48
sizeof(sync.Mutex): 8
sizeof(llsync.Mutex): 48
l: 0xe6b592ab7f60 l.s: hello l.i: 123 l.w: (0xe6b592aa17b0,0xe6b592aa1870)
locked
l: 0xe6b592ab7f60 l.s: hello l.i: 123 l.w: (0xe6b592aa17b0,0xe6b592aa1870)
hello
```