### PR TITLE
ci: lock release build to llvm@18

### DIFF
--- a/.github/workflows/populate_darwin_sysroot.sh
+++ b/.github/workflows/populate_darwin_sysroot.sh
@@ -11,7 +11,7 @@ DARWIN_ARM64_LLVM_PREFIX=.sysroot/darwin/arm64/opt/homebrew/opt/llvm@18
 mkdir -p "${DARWIN_AMD64_LLVM_PREFIX}" "${DARWIN_ARM64_LLVM_PREFIX}"
 
 BREW_LLVM_FORMULA_JSON="$(mktemp)"
-curl -fsSL https://formulae.brew.sh/api/formula/llvm.json > "${BREW_LLVM_FORMULA_JSON}"
+curl -fsSL https://formulae.brew.sh/api/formula/llvm@18.json > "${BREW_LLVM_FORMULA_JSON}"
 BREW_LLVM_AMD64_BOTTLE_URL=$(jq -r '.bottle.stable.files.sonoma.url' "${BREW_LLVM_FORMULA_JSON}")
 BREW_LLVM_ARM64_BOTTLE_URL=$(jq -r '.bottle.stable.files.arm64_sonoma.url' "${BREW_LLVM_FORMULA_JSON}")
 curl -fsSL -H "Authorization: Bearer QQ==" "${BREW_LLVM_AMD64_BOTTLE_URL}" | tar -xzf - --strip-components=2 -C "${DARWIN_AMD64_LLVM_PREFIX}"


### PR DESCRIPTION
Test build: https://github.com/cpunion/llgo/actions/runs/12077809222
Test release: https://github.com/cpunion/llgo/releases/tag/v0.9.27