### PR TITLE
abi: fix named interface init

### DIFF
--- a/cl/_testgo/ifaceconv/out.ll
+++ b/cl/_testgo/ifaceconv/out.ll
@@ -20,14 +20,14 @@ source_filename = "main"
 @2 = private unnamed_addr constant [21 x i8] c"nil i0.(I0) succeeded", align 1
 @_llgo_string = linkonce global ptr null, align 8
 @_llgo_main.I1 = linkonce global ptr null, align 8
+@3 = private unnamed_addr constant [7 x i8] c"main.I1", align 1
 @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac" = linkonce global ptr null, align 8
-@3 = private unnamed_addr constant [6 x i8] c"main.f", align 1
-@4 = private unnamed_addr constant [7 x i8] c"main.I1", align 1
+@4 = private unnamed_addr constant [6 x i8] c"main.f", align 1
 @"main.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4" = linkonce global ptr null, align 8
 @5 = private unnamed_addr constant [21 x i8] c"nil i1.(I1) succeeded", align 1
 @_llgo_main.I2 = linkonce global ptr null, align 8
-@6 = private unnamed_addr constant [6 x i8] c"main.g", align 1
-@7 = private unnamed_addr constant [7 x i8] c"main.I2", align 1
+@6 = private unnamed_addr constant [7 x i8] c"main.I2", align 1
+@7 = private unnamed_addr constant [6 x i8] c"main.g", align 1
 @"main.iface$gZBF8fFlqIMZ9M6lT2VWPyc3eu5Co6j0WoKGIEgDPAw" = linkonce global ptr null, align 8
 @8 = private unnamed_addr constant [21 x i8] c"nil i2.(I2) succeeded", align 1
 @_llgo_main.C1 = linkonce global ptr null, align 8
@@ -475,69 +475,83 @@ declare void @"github.com/goplus/llgo/internal/runtime.init"()
 
 define void @"main.init$after"() {
 _llgo_0:
-  %0 = load ptr, ptr @_llgo_main.I0, align 8
-  %1 = icmp eq ptr %0, null
-  br i1 %1, label %_llgo_1, label %_llgo_2
+  %0 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamedInterface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 7 })
+  %1 = load ptr, ptr @_llgo_main.I0, align 8
+  %2 = icmp eq ptr %1, null
+  br i1 %2, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %3 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %2, 0
-  %4 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %3, i64 0, 1
-  %5 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %4, i64 0, 2
-  %6 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 7 }, %"github.com/goplus/llgo/internal/runtime.Slice" %5)
-  store ptr %6, ptr @_llgo_main.I0, align 8
+  store ptr %0, ptr @_llgo_main.I0, align 8
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-  %7 = load ptr, ptr @_llgo_string, align 8
-  %8 = icmp eq ptr %7, null
-  br i1 %8, label %_llgo_3, label %_llgo_4
+  br i1 %2, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  store ptr %9, ptr @_llgo_string, align 8
+  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %4 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %3, 0
+  %5 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %4, i64 0, 1
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %5, i64 0, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamedInterface"(ptr %0, %"github.com/goplus/llgo/internal/runtime.Slice" %6)
   br label %_llgo_4
 
 _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
-  %10 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %11 = icmp eq ptr %10, null
-  br i1 %11, label %_llgo_5, label %_llgo_6
+  %7 = load ptr, ptr @_llgo_string, align 8
+  %8 = icmp eq ptr %7, null
+  br i1 %8, label %_llgo_5, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_4
-  %12 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %13 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %12, 0
-  %14 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %13, i64 0, 1
-  %15 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %14, i64 0, 2
-  %16 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %17 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %16, 0
-  %18 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %17, i64 0, 1
-  %19 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %18, i64 0, 2
-  %20 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %15, %"github.com/goplus/llgo/internal/runtime.Slice" %19, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %20)
-  store ptr %20, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  store ptr %9, ptr @_llgo_string, align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %21 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %22 = load ptr, ptr @_llgo_main.I1, align 8
-  %23 = icmp eq ptr %22, null
-  br i1 %23, label %_llgo_7, label %_llgo_8
+  %10 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamedInterface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 7 })
+  %11 = load ptr, ptr @_llgo_main.I1, align 8
+  %12 = icmp eq ptr %11, null
+  br i1 %12, label %_llgo_7, label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_6
-  %24 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 6 }, ptr undef }, ptr %21, 1
-  %25 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %26 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %25, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %24, ptr %26, align 8
-  %27 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %25, 0
-  %28 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %27, i64 1, 1
-  %29 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %28, i64 1, 2
-  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 7 }, %"github.com/goplus/llgo/internal/runtime.Slice" %29)
-  store ptr %30, ptr @_llgo_main.I1, align 8
+  store ptr %10, ptr @_llgo_main.I1, align 8
   br label %_llgo_8
 
 _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
+  %13 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %14 = icmp eq ptr %13, null
+  br i1 %14, label %_llgo_9, label %_llgo_10
+
+_llgo_9:                                          ; preds = %_llgo_8
+  %15 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %16 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %15, 0
+  %17 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %16, i64 0, 1
+  %18 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %17, i64 0, 2
+  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %20 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %19, 0
+  %21 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %20, i64 0, 1
+  %22 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %21, i64 0, 2
+  %23 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %18, %"github.com/goplus/llgo/internal/runtime.Slice" %22, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %23)
+  store ptr %23, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  br label %_llgo_10
+
+_llgo_10:                                         ; preds = %_llgo_9, %_llgo_8
+  %24 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  br i1 %12, label %_llgo_11, label %_llgo_12
+
+_llgo_11:                                         ; preds = %_llgo_10
+  %25 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 6 }, ptr undef }, ptr %24, 1
+  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %27 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %26, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %25, ptr %27, align 8
+  %28 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %26, 0
+  %29 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %28, i64 1, 1
+  %30 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %29, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamedInterface"(ptr %10, %"github.com/goplus/llgo/internal/runtime.Slice" %30)
+  br label %_llgo_12
+
+_llgo_12:                                         ; preds = %_llgo_11, %_llgo_10
   %31 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %32 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 6 }, ptr undef }, ptr %31, 1
+  %32 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 6 }, ptr undef }, ptr %31, 1
   %33 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
   %34 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %33, i64 0
   store %"github.com/goplus/llgo/internal/abi.Imethod" %32, ptr %34, align 8
@@ -546,32 +560,39 @@ _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
   %37 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %36, i64 1, 2
   %38 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %37)
   store ptr %38, ptr @"main.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", align 8
-  %39 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %40 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %41 = load ptr, ptr @_llgo_main.I2, align 8
-  %42 = icmp eq ptr %41, null
-  br i1 %42, label %_llgo_9, label %_llgo_10
+  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamedInterface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 7 })
+  %40 = load ptr, ptr @_llgo_main.I2, align 8
+  %41 = icmp eq ptr %40, null
+  br i1 %41, label %_llgo_13, label %_llgo_14
 
-_llgo_9:                                          ; preds = %_llgo_8
-  %43 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 6 }, ptr undef }, ptr %39, 1
-  %44 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 6 }, ptr undef }, ptr %40, 1
-  %45 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  %46 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %45, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %43, ptr %46, align 8
-  %47 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %45, i64 1
+_llgo_13:                                         ; preds = %_llgo_12
+  store ptr %39, ptr @_llgo_main.I2, align 8
+  br label %_llgo_14
+
+_llgo_14:                                         ; preds = %_llgo_13, %_llgo_12
+  %42 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %43 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  br i1 %41, label %_llgo_15, label %_llgo_16
+
+_llgo_15:                                         ; preds = %_llgo_14
+  %44 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 6 }, ptr undef }, ptr %42, 1
+  %45 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 6 }, ptr undef }, ptr %43, 1
+  %46 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  %47 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %46, i64 0
   store %"github.com/goplus/llgo/internal/abi.Imethod" %44, ptr %47, align 8
-  %48 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %45, 0
-  %49 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %48, i64 2, 1
-  %50 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %49, i64 2, 2
-  %51 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 7 }, %"github.com/goplus/llgo/internal/runtime.Slice" %50)
-  store ptr %51, ptr @_llgo_main.I2, align 8
-  br label %_llgo_10
+  %48 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %46, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %45, ptr %48, align 8
+  %49 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %46, 0
+  %50 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %49, i64 2, 1
+  %51 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %50, i64 2, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamedInterface"(ptr %39, %"github.com/goplus/llgo/internal/runtime.Slice" %51)
+  br label %_llgo_16
 
-_llgo_10:                                         ; preds = %_llgo_9, %_llgo_8
+_llgo_16:                                         ; preds = %_llgo_15, %_llgo_14
   %52 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
   %53 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %54 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 6 }, ptr undef }, ptr %52, 1
-  %55 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 6 }, ptr undef }, ptr %53, 1
+  %54 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 6 }, ptr undef }, ptr %52, 1
+  %55 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 6 }, ptr undef }, ptr %53, 1
   %56 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
   %57 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %56, i64 0
   store %"github.com/goplus/llgo/internal/abi.Imethod" %54, ptr %57, align 8
@@ -585,36 +606,36 @@ _llgo_10:                                         ; preds = %_llgo_9, %_llgo_8
   %63 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 7 }, i64 25, i64 0, i64 1, i64 1)
   %64 = load ptr, ptr @_llgo_main.C1, align 8
   %65 = icmp eq ptr %64, null
-  br i1 %65, label %_llgo_11, label %_llgo_12
+  br i1 %65, label %_llgo_17, label %_llgo_18
 
-_llgo_11:                                         ; preds = %_llgo_10
+_llgo_17:                                         ; preds = %_llgo_16
   store ptr %63, ptr @_llgo_main.C1, align 8
-  br label %_llgo_12
+  br label %_llgo_18
 
-_llgo_12:                                         ; preds = %_llgo_11, %_llgo_10
+_llgo_18:                                         ; preds = %_llgo_17, %_llgo_16
   %66 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
   %67 = icmp eq ptr %66, null
-  br i1 %67, label %_llgo_13, label %_llgo_14
+  br i1 %67, label %_llgo_19, label %_llgo_20
 
-_llgo_13:                                         ; preds = %_llgo_12
+_llgo_19:                                         ; preds = %_llgo_18
   %68 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
   %69 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %68, 0
   %70 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %69, i64 0, 1
   %71 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %70, i64 0, 2
   %72 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, i64 0, %"github.com/goplus/llgo/internal/runtime.Slice" %71)
   store ptr %72, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
-  br label %_llgo_14
+  br label %_llgo_20
 
-_llgo_14:                                         ; preds = %_llgo_13, %_llgo_12
+_llgo_20:                                         ; preds = %_llgo_19, %_llgo_18
   %73 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
-  br i1 %65, label %_llgo_15, label %_llgo_16
+  br i1 %65, label %_llgo_21, label %_llgo_22
 
-_llgo_15:                                         ; preds = %_llgo_14
+_llgo_21:                                         ; preds = %_llgo_20
   %74 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %75 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %74, 1
+  %75 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %74, 1
   %76 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %75, ptr @"main.(*C1).f", 2
   %77 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %76, ptr @"main.(*C1).f", 3
-  %78 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %74, 1
+  %78 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %74, 1
   %79 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %78, ptr @"main.(*C1).f", 2
   %80 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %79, ptr @main.C1.f, 3
   %81 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
@@ -630,35 +651,35 @@ _llgo_15:                                         ; preds = %_llgo_14
   %89 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %88, i64 1, 1
   %90 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %89, i64 1, 2
   call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %63, %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 2 }, ptr %73, %"github.com/goplus/llgo/internal/runtime.Slice" %85, %"github.com/goplus/llgo/internal/runtime.Slice" %90)
-  br label %_llgo_16
+  br label %_llgo_22
 
-_llgo_16:                                         ; preds = %_llgo_15, %_llgo_14
+_llgo_22:                                         ; preds = %_llgo_21, %_llgo_20
   %91 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @15, i64 7 }, i64 25, i64 0, i64 2, i64 2)
   %92 = load ptr, ptr @_llgo_main.C2, align 8
   %93 = icmp eq ptr %92, null
-  br i1 %93, label %_llgo_17, label %_llgo_18
+  br i1 %93, label %_llgo_23, label %_llgo_24
 
-_llgo_17:                                         ; preds = %_llgo_16
+_llgo_23:                                         ; preds = %_llgo_22
   store ptr %91, ptr @_llgo_main.C2, align 8
-  br label %_llgo_18
+  br label %_llgo_24
 
-_llgo_18:                                         ; preds = %_llgo_17, %_llgo_16
+_llgo_24:                                         ; preds = %_llgo_23, %_llgo_22
   %94 = load ptr, ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", align 8
-  br i1 %93, label %_llgo_19, label %_llgo_20
+  br i1 %93, label %_llgo_25, label %_llgo_26
 
-_llgo_19:                                         ; preds = %_llgo_18
+_llgo_25:                                         ; preds = %_llgo_24
   %95 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %96 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %95, 1
+  %96 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %95, 1
   %97 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %96, ptr @"main.(*C2).f", 2
   %98 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %97, ptr @"main.(*C2).f", 3
-  %99 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %95, 1
+  %99 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %95, 1
   %100 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %99, ptr @"main.(*C2).f", 2
   %101 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %100, ptr @main.C2.f, 3
   %102 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %103 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %102, 1
+  %103 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %102, 1
   %104 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %103, ptr @"main.(*C2).g", 2
   %105 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %104, ptr @"main.(*C2).g", 3
-  %106 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %102, 1
+  %106 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %102, 1
   %107 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %106, ptr @"main.(*C2).g", 2
   %108 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %107, ptr @main.C2.g, 3
   %109 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
@@ -678,13 +699,15 @@ _llgo_19:                                         ; preds = %_llgo_18
   %119 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %118, i64 2, 1
   %120 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %119, i64 2, 2
   call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %91, %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @17, i64 2 }, ptr %94, %"github.com/goplus/llgo/internal/runtime.Slice" %114, %"github.com/goplus/llgo/internal/runtime.Slice" %120)
-  br label %_llgo_20
+  br label %_llgo_26
 
-_llgo_20:                                         ; preds = %_llgo_19, %_llgo_18
+_llgo_26:                                         ; preds = %_llgo_25, %_llgo_24
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.Slice")
+declare ptr @"github.com/goplus/llgo/internal/runtime.NewNamedInterface"(%"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.String")
+
+declare void @"github.com/goplus/llgo/internal/runtime.InitNamedInterface"(ptr, %"github.com/goplus/llgo/internal/runtime.Slice")
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64)
 
@@ -699,6 +722,8 @@ declare ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/go
 declare ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice", %"github.com/goplus/llgo/internal/runtime.Slice", i1)
 
 declare void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr)
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.Slice")
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr, ptr)
 

--- a/cl/_testgo/ifaceprom/out.ll
+++ b/cl/_testgo/ifaceprom/out.ll
@@ -566,28 +566,35 @@ _llgo_10:                                         ; preds = %_llgo_9, %_llgo_8
   %78 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %77, i64 2, 2
   %79 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %78)
   store ptr %79, ptr @"main.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", align 8
-  %80 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %81 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %82 = load ptr, ptr @_llgo_main.I, align 8
-  %83 = icmp eq ptr %82, null
-  br i1 %83, label %_llgo_11, label %_llgo_12
+  %80 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamedInterface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 6 })
+  %81 = load ptr, ptr @_llgo_main.I, align 8
+  %82 = icmp eq ptr %81, null
+  br i1 %82, label %_llgo_11, label %_llgo_12
 
 _llgo_11:                                         ; preds = %_llgo_10
-  %84 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 8 }, ptr undef }, ptr %80, 1
-  %85 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 8 }, ptr undef }, ptr %81, 1
-  %86 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  %87 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %86, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %84, ptr %87, align 8
-  %88 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %86, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %85, ptr %88, align 8
-  %89 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %86, 0
-  %90 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %89, i64 2, 1
-  %91 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %90, i64 2, 2
-  %92 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 6 }, %"github.com/goplus/llgo/internal/runtime.Slice" %91)
-  store ptr %92, ptr @_llgo_main.I, align 8
+  store ptr %80, ptr @_llgo_main.I, align 8
   br label %_llgo_12
 
 _llgo_12:                                         ; preds = %_llgo_11, %_llgo_10
+  %83 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %84 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  br i1 %82, label %_llgo_13, label %_llgo_14
+
+_llgo_13:                                         ; preds = %_llgo_12
+  %85 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 8 }, ptr undef }, ptr %83, 1
+  %86 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 8 }, ptr undef }, ptr %84, 1
+  %87 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  %88 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %87, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %85, ptr %88, align 8
+  %89 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %87, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %86, ptr %89, align 8
+  %90 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %87, 0
+  %91 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %90, i64 2, 1
+  %92 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %91, i64 2, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamedInterface"(ptr %80, %"github.com/goplus/llgo/internal/runtime.Slice" %92)
+  br label %_llgo_14
+
+_llgo_14:                                         ; preds = %_llgo_13, %_llgo_12
   ret void
 }
 
@@ -614,6 +621,10 @@ declare ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr, ptr)
 declare void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface")
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface")
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.NewNamedInterface"(%"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.String")
+
+declare void @"github.com/goplus/llgo/internal/runtime.InitNamedInterface"(ptr, %"github.com/goplus/llgo/internal/runtime.Slice")
 
 declare i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr, ptr)
 

--- a/cl/_testgo/interface/out.ll
+++ b/cl/_testgo/interface/out.ll
@@ -403,28 +403,35 @@ _llgo_23:                                         ; preds = %_llgo_22
   br label %_llgo_24
 
 _llgo_24:                                         ; preds = %_llgo_23, %_llgo_22
-  %100 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %101 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
-  %102 = load ptr, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Gamer", align 8
-  %103 = icmp eq ptr %102, null
-  br i1 %103, label %_llgo_25, label %_llgo_26
+  %100 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamedInterface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 38 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @12, i64 44 })
+  %101 = load ptr, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Gamer", align 8
+  %102 = icmp eq ptr %101, null
+  br i1 %102, label %_llgo_25, label %_llgo_26
 
 _llgo_25:                                         ; preds = %_llgo_24
-  %104 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, ptr undef }, ptr %100, 1
-  %105 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 47 }, ptr undef }, ptr %101, 1
-  %106 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  %107 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %106, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %104, ptr %107, align 8
-  %108 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %106, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %105, ptr %108, align 8
-  %109 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %106, 0
-  %110 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %109, i64 2, 1
-  %111 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %110, i64 2, 2
-  %112 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 38 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @12, i64 44 }, %"github.com/goplus/llgo/internal/runtime.Slice" %111)
-  store ptr %112, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Gamer", align 8
+  store ptr %100, ptr @"_llgo_github.com/goplus/llgo/cl/internal/foo.Gamer", align 8
   br label %_llgo_26
 
 _llgo_26:                                         ; preds = %_llgo_25, %_llgo_24
+  %103 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  %104 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
+  br i1 %102, label %_llgo_27, label %_llgo_28
+
+_llgo_27:                                         ; preds = %_llgo_26
+  %105 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, ptr undef }, ptr %103, 1
+  %106 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 47 }, ptr undef }, ptr %104, 1
+  %107 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  %108 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %107, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %105, ptr %108, align 8
+  %109 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %107, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %106, ptr %109, align 8
+  %110 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %107, 0
+  %111 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %110, i64 2, 1
+  %112 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %111, i64 2, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamedInterface"(ptr %100, %"github.com/goplus/llgo/internal/runtime.Slice" %112)
+  br label %_llgo_28
+
+_llgo_28:                                         ; preds = %_llgo_27, %_llgo_26
   %113 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
   %114 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
   %115 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, ptr undef }, ptr %113, 1
@@ -458,9 +465,13 @@ declare ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr)
 
-declare ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.Slice")
+declare ptr @"github.com/goplus/llgo/internal/runtime.NewNamedInterface"(%"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.String")
+
+declare void @"github.com/goplus/llgo/internal/runtime.InitNamedInterface"(ptr, %"github.com/goplus/llgo/internal/runtime.Slice")
 
 declare i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr, ptr)
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.Slice")
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr, ptr)
 

--- a/cl/_testgo/invoke/out.ll
+++ b/cl/_testgo/invoke/out.ll
@@ -1016,38 +1016,45 @@ _llgo_61:                                         ; preds = %_llgo_60
   br label %_llgo_62
 
 _llgo_62:                                         ; preds = %_llgo_61, %_llgo_60
-  %279 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %279 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamedInterface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @30, i64 6 })
   %280 = load ptr, ptr @_llgo_main.I, align 8
   %281 = icmp eq ptr %280, null
   br i1 %281, label %_llgo_63, label %_llgo_64
 
 _llgo_63:                                         ; preds = %_llgo_62
-  %282 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 6 }, ptr undef }, ptr %279, 1
-  %283 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %284 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %283, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %282, ptr %284, align 8
-  %285 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %283, 0
-  %286 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %285, i64 1, 1
-  %287 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %286, i64 1, 2
-  %288 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @30, i64 6 }, %"github.com/goplus/llgo/internal/runtime.Slice" %287)
-  store ptr %288, ptr @_llgo_main.I, align 8
+  store ptr %279, ptr @_llgo_main.I, align 8
   br label %_llgo_64
 
 _llgo_64:                                         ; preds = %_llgo_63, %_llgo_62
-  %289 = load ptr, ptr @_llgo_any, align 8
-  %290 = icmp eq ptr %289, null
-  br i1 %290, label %_llgo_65, label %_llgo_66
+  %282 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  br i1 %281, label %_llgo_65, label %_llgo_66
 
 _llgo_65:                                         ; preds = %_llgo_64
+  %283 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 6 }, ptr undef }, ptr %282, 1
+  %284 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %285 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %284, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %283, ptr %285, align 8
+  %286 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %284, 0
+  %287 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %286, i64 1, 1
+  %288 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %287, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamedInterface"(ptr %279, %"github.com/goplus/llgo/internal/runtime.Slice" %288)
+  br label %_llgo_66
+
+_llgo_66:                                         ; preds = %_llgo_65, %_llgo_64
+  %289 = load ptr, ptr @_llgo_any, align 8
+  %290 = icmp eq ptr %289, null
+  br i1 %290, label %_llgo_67, label %_llgo_68
+
+_llgo_67:                                         ; preds = %_llgo_66
   %291 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
   %292 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %291, 0
   %293 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %292, i64 0, 1
   %294 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %293, i64 0, 2
   %295 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %294)
   store ptr %295, ptr @_llgo_any, align 8
-  br label %_llgo_66
+  br label %_llgo_68
 
-_llgo_66:                                         ; preds = %_llgo_65, %_llgo_64
+_llgo_68:                                         ; preds = %_llgo_67, %_llgo_66
   ret void
 }
 
@@ -1080,6 +1087,10 @@ declare void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr)
 declare ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface")
 
 declare void @"github.com/goplus/llgo/internal/runtime.PrintIface"(%"github.com/goplus/llgo/internal/runtime.iface")
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.NewNamedInterface"(%"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.String")
+
+declare void @"github.com/goplus/llgo/internal/runtime.InitNamedInterface"(ptr, %"github.com/goplus/llgo/internal/runtime.Slice")
 
 declare i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr, ptr)
 

--- a/cl/_testgo/reader/out.ll
+++ b/cl/_testgo/reader/out.ll
@@ -17,29 +17,29 @@ source_filename = "main"
 @main.ErrShortWrite = global %"github.com/goplus/llgo/internal/runtime.iface" zeroinitializer, align 8
 @"main.init$guard" = global i1 false, align 1
 @_llgo_main.WriterTo = linkonce global ptr null, align 8
+@0 = private unnamed_addr constant [4 x i8] c"main", align 1
+@1 = private unnamed_addr constant [13 x i8] c"main.WriterTo", align 1
 @_llgo_main.Writer = linkonce global ptr null, align 8
+@2 = private unnamed_addr constant [11 x i8] c"main.Writer", align 1
 @_llgo_byte = linkonce global ptr null, align 8
 @"[]_llgo_byte" = linkonce global ptr null, align 8
 @_llgo_int = linkonce global ptr null, align 8
 @_llgo_error = linkonce global ptr null, align 8
+@3 = private unnamed_addr constant [5 x i8] c"error", align 1
 @_llgo_string = linkonce global ptr null, align 8
 @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" = linkonce global ptr null, align 8
-@0 = private unnamed_addr constant [5 x i8] c"Error", align 1
-@1 = private unnamed_addr constant [4 x i8] c"main", align 1
-@2 = private unnamed_addr constant [5 x i8] c"error", align 1
+@4 = private unnamed_addr constant [5 x i8] c"Error", align 1
 @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY" = linkonce global ptr null, align 8
-@3 = private unnamed_addr constant [5 x i8] c"Write", align 1
-@4 = private unnamed_addr constant [11 x i8] c"main.Writer", align 1
+@5 = private unnamed_addr constant [5 x i8] c"Write", align 1
 @_llgo_int64 = linkonce global ptr null, align 8
 @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk" = linkonce global ptr null, align 8
-@5 = private unnamed_addr constant [7 x i8] c"WriteTo", align 1
-@6 = private unnamed_addr constant [13 x i8] c"main.WriterTo", align 1
+@6 = private unnamed_addr constant [7 x i8] c"WriteTo", align 1
 @"_llgo_iface$eN81k1zqixGTyagHw_4nqH4mGfwwehTOCTXUlbT9kzk" = linkonce global ptr null, align 8
 @_llgo_main.nopCloserWriterTo = linkonce global ptr null, align 8
 @7 = private unnamed_addr constant [22 x i8] c"main.nopCloserWriterTo", align 1
 @_llgo_main.Reader = linkonce global ptr null, align 8
-@8 = private unnamed_addr constant [4 x i8] c"Read", align 1
-@9 = private unnamed_addr constant [11 x i8] c"main.Reader", align 1
+@8 = private unnamed_addr constant [11 x i8] c"main.Reader", align 1
+@9 = private unnamed_addr constant [4 x i8] c"Read", align 1
 @"_llgo_struct$_3ow4zXXILqvC0WDqDRNq5DPhjE1DInJgN924VHWc2Y" = linkonce global ptr null, align 8
 @10 = private unnamed_addr constant [6 x i8] c"Reader", align 1
 @11 = private unnamed_addr constant [5 x i8] c"Close", align 1
@@ -50,9 +50,9 @@ source_filename = "main"
 @13 = private unnamed_addr constant [14 x i8] c"main.nopCloser", align 1
 @14 = private unnamed_addr constant [9 x i8] c"nopCloser", align 1
 @_llgo_main.StringWriter = linkonce global ptr null, align 8
+@15 = private unnamed_addr constant [17 x i8] c"main.StringWriter", align 1
 @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw" = linkonce global ptr null, align 8
-@15 = private unnamed_addr constant [11 x i8] c"WriteString", align 1
-@16 = private unnamed_addr constant [17 x i8] c"main.StringWriter", align 1
+@16 = private unnamed_addr constant [11 x i8] c"WriteString", align 1
 @"_llgo_iface$Ly4zXiUMEac-hYAMw6b6miJ1JEhGfLyBWyBOhpsRZcU" = linkonce global ptr null, align 8
 @17 = private unnamed_addr constant [3 x i8] c"EOF", align 1
 @18 = private unnamed_addr constant [11 x i8] c"short write", align 1
@@ -935,775 +935,804 @@ declare ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/go
 
 define void @"main.init$after"() {
 _llgo_0:
-  %0 = load ptr, ptr @_llgo_byte, align 8
-  %1 = icmp eq ptr %0, null
-  br i1 %1, label %_llgo_1, label %_llgo_2
+  %0 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamedInterface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 13 })
+  %1 = load ptr, ptr @_llgo_main.WriterTo, align 8
+  %2 = icmp eq ptr %1, null
+  br i1 %2, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  store ptr %2, ptr @_llgo_byte, align 8
+  store ptr %0, ptr @_llgo_main.WriterTo, align 8
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-  %3 = load ptr, ptr @_llgo_byte, align 8
-  %4 = load ptr, ptr @"[]_llgo_byte", align 8
+  %3 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamedInterface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 11 })
+  %4 = load ptr, ptr @_llgo_main.Writer, align 8
   %5 = icmp eq ptr %4, null
   br i1 %5, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %6 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
-  %7 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %6)
-  store ptr %7, ptr @"[]_llgo_byte", align 8
+  store ptr %3, ptr @_llgo_main.Writer, align 8
   br label %_llgo_4
 
 _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
-  %8 = load ptr, ptr @"[]_llgo_byte", align 8
-  %9 = load ptr, ptr @_llgo_int, align 8
-  %10 = icmp eq ptr %9, null
-  br i1 %10, label %_llgo_5, label %_llgo_6
+  %6 = load ptr, ptr @_llgo_byte, align 8
+  %7 = icmp eq ptr %6, null
+  br i1 %7, label %_llgo_5, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_4
-  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  store ptr %11, ptr @_llgo_int, align 8
+  %8 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  store ptr %8, ptr @_llgo_byte, align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %12 = load ptr, ptr @_llgo_int, align 8
-  %13 = load ptr, ptr @_llgo_string, align 8
-  %14 = icmp eq ptr %13, null
-  br i1 %14, label %_llgo_7, label %_llgo_8
+  %9 = load ptr, ptr @_llgo_byte, align 8
+  %10 = load ptr, ptr @"[]_llgo_byte", align 8
+  %11 = icmp eq ptr %10, null
+  br i1 %11, label %_llgo_7, label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_6
-  %15 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  store ptr %15, ptr @_llgo_string, align 8
+  %12 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 40)
+  %13 = call ptr @"github.com/goplus/llgo/internal/runtime.SliceOf"(ptr %12)
+  store ptr %13, ptr @"[]_llgo_byte", align 8
   br label %_llgo_8
 
 _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
-  %16 = load ptr, ptr @_llgo_string, align 8
-  %17 = load ptr, ptr @_llgo_string, align 8
-  %18 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %19 = icmp eq ptr %18, null
-  br i1 %19, label %_llgo_9, label %_llgo_10
+  %14 = load ptr, ptr @"[]_llgo_byte", align 8
+  %15 = load ptr, ptr @_llgo_int, align 8
+  %16 = icmp eq ptr %15, null
+  br i1 %16, label %_llgo_9, label %_llgo_10
 
 _llgo_9:                                          ; preds = %_llgo_8
-  %20 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %21 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %20, 0
-  %22 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %21, i64 0, 1
-  %23 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %22, i64 0, 2
-  %24 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %25 = getelementptr ptr, ptr %24, i64 0
-  store ptr %17, ptr %25, align 8
-  %26 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %24, 0
-  %27 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %26, i64 1, 1
-  %28 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %27, i64 1, 2
-  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %23, %"github.com/goplus/llgo/internal/runtime.Slice" %28, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %29)
-  store ptr %29, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %17 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  store ptr %17, ptr @_llgo_int, align 8
   br label %_llgo_10
 
 _llgo_10:                                         ; preds = %_llgo_9, %_llgo_8
-  %30 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %31 = load ptr, ptr @_llgo_error, align 8
-  %32 = icmp eq ptr %31, null
-  br i1 %32, label %_llgo_11, label %_llgo_12
+  %18 = load ptr, ptr @_llgo_int, align 8
+  %19 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamedInterface"(%"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 5 })
+  %20 = load ptr, ptr @_llgo_error, align 8
+  %21 = icmp eq ptr %20, null
+  br i1 %21, label %_llgo_11, label %_llgo_12
 
 _llgo_11:                                         ; preds = %_llgo_10
-  %33 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr undef }, ptr %30, 1
-  %34 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %35 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %34, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %33, ptr %35, align 8
-  %36 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %34, 0
-  %37 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %36, i64 1, 1
-  %38 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %37, i64 1, 2
-  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 5 }, %"github.com/goplus/llgo/internal/runtime.Slice" %38)
-  store ptr %39, ptr @_llgo_error, align 8
+  store ptr %19, ptr @_llgo_error, align 8
   br label %_llgo_12
 
 _llgo_12:                                         ; preds = %_llgo_11, %_llgo_10
-  %40 = load ptr, ptr @_llgo_error, align 8
-  %41 = load ptr, ptr @"[]_llgo_byte", align 8
-  %42 = load ptr, ptr @_llgo_int, align 8
-  %43 = load ptr, ptr @_llgo_error, align 8
-  %44 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
-  %45 = icmp eq ptr %44, null
-  br i1 %45, label %_llgo_13, label %_llgo_14
+  %22 = load ptr, ptr @_llgo_string, align 8
+  %23 = icmp eq ptr %22, null
+  br i1 %23, label %_llgo_13, label %_llgo_14
 
 _llgo_13:                                         ; preds = %_llgo_12
-  %46 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %47 = getelementptr ptr, ptr %46, i64 0
-  store ptr %41, ptr %47, align 8
-  %48 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %46, 0
-  %49 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %48, i64 1, 1
-  %50 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %49, i64 1, 2
-  %51 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %52 = getelementptr ptr, ptr %51, i64 0
-  store ptr %42, ptr %52, align 8
-  %53 = getelementptr ptr, ptr %51, i64 1
-  store ptr %43, ptr %53, align 8
-  %54 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %51, 0
-  %55 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %54, i64 2, 1
-  %56 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %55, i64 2, 2
-  %57 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %50, %"github.com/goplus/llgo/internal/runtime.Slice" %56, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %57)
-  store ptr %57, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
+  %24 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  store ptr %24, ptr @_llgo_string, align 8
   br label %_llgo_14
 
 _llgo_14:                                         ; preds = %_llgo_13, %_llgo_12
-  %58 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
-  %59 = load ptr, ptr @_llgo_main.Writer, align 8
-  %60 = icmp eq ptr %59, null
-  br i1 %60, label %_llgo_15, label %_llgo_16
+  %25 = load ptr, ptr @_llgo_string, align 8
+  %26 = load ptr, ptr @_llgo_string, align 8
+  %27 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %28 = icmp eq ptr %27, null
+  br i1 %28, label %_llgo_15, label %_llgo_16
 
 _llgo_15:                                         ; preds = %_llgo_14
-  %61 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 5 }, ptr undef }, ptr %58, 1
-  %62 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %63 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %62, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %61, ptr %63, align 8
-  %64 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %62, 0
-  %65 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %64, i64 1, 1
-  %66 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %65, i64 1, 2
-  %67 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 11 }, %"github.com/goplus/llgo/internal/runtime.Slice" %66)
-  store ptr %67, ptr @_llgo_main.Writer, align 8
+  %29 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %30 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %29, 0
+  %31 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %30, i64 0, 1
+  %32 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %31, i64 0, 2
+  %33 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %34 = getelementptr ptr, ptr %33, i64 0
+  store ptr %26, ptr %34, align 8
+  %35 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %33, 0
+  %36 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %35, i64 1, 1
+  %37 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %36, i64 1, 2
+  %38 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %32, %"github.com/goplus/llgo/internal/runtime.Slice" %37, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %38)
+  store ptr %38, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
   br label %_llgo_16
 
 _llgo_16:                                         ; preds = %_llgo_15, %_llgo_14
-  %68 = load ptr, ptr @_llgo_main.Writer, align 8
-  %69 = load ptr, ptr @_llgo_int64, align 8
-  %70 = icmp eq ptr %69, null
-  br i1 %70, label %_llgo_17, label %_llgo_18
+  %39 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  br i1 %21, label %_llgo_17, label %_llgo_18
 
 _llgo_17:                                         ; preds = %_llgo_16
-  %71 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 38)
-  store ptr %71, ptr @_llgo_int64, align 8
+  %40 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 5 }, ptr undef }, ptr %39, 1
+  %41 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %42 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %41, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %40, ptr %42, align 8
+  %43 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %41, 0
+  %44 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %43, i64 1, 1
+  %45 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %44, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamedInterface"(ptr %19, %"github.com/goplus/llgo/internal/runtime.Slice" %45)
   br label %_llgo_18
 
 _llgo_18:                                         ; preds = %_llgo_17, %_llgo_16
-  %72 = load ptr, ptr @_llgo_int64, align 8
-  %73 = load ptr, ptr @_llgo_main.Writer, align 8
-  %74 = load ptr, ptr @_llgo_int64, align 8
-  %75 = load ptr, ptr @_llgo_error, align 8
-  %76 = load ptr, ptr @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk", align 8
-  %77 = icmp eq ptr %76, null
-  br i1 %77, label %_llgo_19, label %_llgo_20
+  %46 = load ptr, ptr @_llgo_error, align 8
+  %47 = load ptr, ptr @"[]_llgo_byte", align 8
+  %48 = load ptr, ptr @_llgo_int, align 8
+  %49 = load ptr, ptr @_llgo_error, align 8
+  %50 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
+  %51 = icmp eq ptr %50, null
+  br i1 %51, label %_llgo_19, label %_llgo_20
 
 _llgo_19:                                         ; preds = %_llgo_18
-  %78 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %79 = getelementptr ptr, ptr %78, i64 0
-  store ptr %73, ptr %79, align 8
-  %80 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %78, 0
-  %81 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %80, i64 1, 1
-  %82 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %81, i64 1, 2
-  %83 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %84 = getelementptr ptr, ptr %83, i64 0
-  store ptr %74, ptr %84, align 8
-  %85 = getelementptr ptr, ptr %83, i64 1
-  store ptr %75, ptr %85, align 8
-  %86 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %83, 0
-  %87 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %86, i64 2, 1
-  %88 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %87, i64 2, 2
-  %89 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %82, %"github.com/goplus/llgo/internal/runtime.Slice" %88, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %89)
-  store ptr %89, ptr @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk", align 8
+  %52 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %53 = getelementptr ptr, ptr %52, i64 0
+  store ptr %47, ptr %53, align 8
+  %54 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %52, 0
+  %55 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %54, i64 1, 1
+  %56 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %55, i64 1, 2
+  %57 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %58 = getelementptr ptr, ptr %57, i64 0
+  store ptr %48, ptr %58, align 8
+  %59 = getelementptr ptr, ptr %57, i64 1
+  store ptr %49, ptr %59, align 8
+  %60 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %57, 0
+  %61 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %60, i64 2, 1
+  %62 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %61, i64 2, 2
+  %63 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %56, %"github.com/goplus/llgo/internal/runtime.Slice" %62, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %63)
+  store ptr %63, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
   br label %_llgo_20
 
 _llgo_20:                                         ; preds = %_llgo_19, %_llgo_18
-  %90 = load ptr, ptr @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk", align 8
-  %91 = load ptr, ptr @_llgo_main.WriterTo, align 8
-  %92 = icmp eq ptr %91, null
-  br i1 %92, label %_llgo_21, label %_llgo_22
+  %64 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
+  br i1 %5, label %_llgo_21, label %_llgo_22
 
 _llgo_21:                                         ; preds = %_llgo_20
-  %93 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 7 }, ptr undef }, ptr %90, 1
-  %94 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %95 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %94, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %93, ptr %95, align 8
-  %96 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %94, 0
-  %97 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %96, i64 1, 1
-  %98 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %97, i64 1, 2
-  %99 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 13 }, %"github.com/goplus/llgo/internal/runtime.Slice" %98)
-  store ptr %99, ptr @_llgo_main.WriterTo, align 8
+  %65 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 5 }, ptr undef }, ptr %64, 1
+  %66 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %67 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %66, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %65, ptr %67, align 8
+  %68 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %66, 0
+  %69 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %68, i64 1, 1
+  %70 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %69, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamedInterface"(ptr %3, %"github.com/goplus/llgo/internal/runtime.Slice" %70)
   br label %_llgo_22
 
 _llgo_22:                                         ; preds = %_llgo_21, %_llgo_20
+  %71 = load ptr, ptr @_llgo_main.Writer, align 8
+  %72 = load ptr, ptr @_llgo_int64, align 8
+  %73 = icmp eq ptr %72, null
+  br i1 %73, label %_llgo_23, label %_llgo_24
+
+_llgo_23:                                         ; preds = %_llgo_22
+  %74 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 38)
+  store ptr %74, ptr @_llgo_int64, align 8
+  br label %_llgo_24
+
+_llgo_24:                                         ; preds = %_llgo_23, %_llgo_22
+  %75 = load ptr, ptr @_llgo_int64, align 8
+  %76 = load ptr, ptr @_llgo_main.Writer, align 8
+  %77 = load ptr, ptr @_llgo_int64, align 8
+  %78 = load ptr, ptr @_llgo_error, align 8
+  %79 = load ptr, ptr @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk", align 8
+  %80 = icmp eq ptr %79, null
+  br i1 %80, label %_llgo_25, label %_llgo_26
+
+_llgo_25:                                         ; preds = %_llgo_24
+  %81 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %82 = getelementptr ptr, ptr %81, i64 0
+  store ptr %76, ptr %82, align 8
+  %83 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %81, 0
+  %84 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %83, i64 1, 1
+  %85 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %84, i64 1, 2
+  %86 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %87 = getelementptr ptr, ptr %86, i64 0
+  store ptr %77, ptr %87, align 8
+  %88 = getelementptr ptr, ptr %86, i64 1
+  store ptr %78, ptr %88, align 8
+  %89 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %86, 0
+  %90 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %89, i64 2, 1
+  %91 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %90, i64 2, 2
+  %92 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %85, %"github.com/goplus/llgo/internal/runtime.Slice" %91, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %92)
+  store ptr %92, ptr @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk", align 8
+  br label %_llgo_26
+
+_llgo_26:                                         ; preds = %_llgo_25, %_llgo_24
+  %93 = load ptr, ptr @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk", align 8
+  br i1 %2, label %_llgo_27, label %_llgo_28
+
+_llgo_27:                                         ; preds = %_llgo_26
+  %94 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 7 }, ptr undef }, ptr %93, 1
+  %95 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %96 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %95, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %94, ptr %96, align 8
+  %97 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %95, 0
+  %98 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %97, i64 1, 1
+  %99 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %98, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamedInterface"(ptr %0, %"github.com/goplus/llgo/internal/runtime.Slice" %99)
+  br label %_llgo_28
+
+_llgo_28:                                         ; preds = %_llgo_27, %_llgo_26
   %100 = load ptr, ptr @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk", align 8
   %101 = load ptr, ptr @"_llgo_iface$eN81k1zqixGTyagHw_4nqH4mGfwwehTOCTXUlbT9kzk", align 8
   %102 = icmp eq ptr %101, null
-  br i1 %102, label %_llgo_23, label %_llgo_24
+  br i1 %102, label %_llgo_29, label %_llgo_30
 
-_llgo_23:                                         ; preds = %_llgo_22
-  %103 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 7 }, ptr undef }, ptr %100, 1
+_llgo_29:                                         ; preds = %_llgo_28
+  %103 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 7 }, ptr undef }, ptr %100, 1
   %104 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
   %105 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %104, i64 0
   store %"github.com/goplus/llgo/internal/abi.Imethod" %103, ptr %105, align 8
   %106 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %104, 0
   %107 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %106, i64 1, 1
   %108 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %107, i64 1, 2
-  %109 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %108)
+  %109 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %108)
   store ptr %109, ptr @"_llgo_iface$eN81k1zqixGTyagHw_4nqH4mGfwwehTOCTXUlbT9kzk", align 8
-  br label %_llgo_24
-
-_llgo_24:                                         ; preds = %_llgo_23, %_llgo_22
-  %110 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 22 }, i64 25, i64 16, i64 3, i64 3)
-  store ptr %110, ptr @_llgo_main.nopCloserWriterTo, align 8
-  %111 = load ptr, ptr @"[]_llgo_byte", align 8
-  %112 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
-  %113 = load ptr, ptr @_llgo_main.Reader, align 8
-  %114 = icmp eq ptr %113, null
-  br i1 %114, label %_llgo_25, label %_llgo_26
-
-_llgo_25:                                         ; preds = %_llgo_24
-  %115 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 4 }, ptr undef }, ptr %112, 1
-  %116 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %117 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %116, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %115, ptr %117, align 8
-  %118 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %116, 0
-  %119 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %118, i64 1, 1
-  %120 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %119, i64 1, 2
-  %121 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 11 }, %"github.com/goplus/llgo/internal/runtime.Slice" %120)
-  store ptr %121, ptr @_llgo_main.Reader, align 8
-  br label %_llgo_26
-
-_llgo_26:                                         ; preds = %_llgo_25, %_llgo_24
-  %122 = load ptr, ptr @_llgo_main.Reader, align 8
-  %123 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
-  %124 = load ptr, ptr @"_llgo_struct$_3ow4zXXILqvC0WDqDRNq5DPhjE1DInJgN924VHWc2Y", align 8
-  %125 = icmp eq ptr %124, null
-  br i1 %125, label %_llgo_27, label %_llgo_28
-
-_llgo_27:                                         ; preds = %_llgo_26
-  %126 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 4 }, ptr undef }, ptr %123, 1
-  %127 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %128 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %127, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %126, ptr %128, align 8
-  %129 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %127, 0
-  %130 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %129, i64 1, 1
-  %131 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %130, i64 1, 2
-  %132 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 11 }, %"github.com/goplus/llgo/internal/runtime.Slice" %131)
-  %133 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 6 }, ptr %132, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 true)
-  %134 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
-  %135 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %134, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %133, ptr %135, align 8
-  %136 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %134, 0
-  %137 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %136, i64 1, 1
-  %138 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %137, i64 1, 2
-  %139 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %138)
-  store ptr %139, ptr @"_llgo_struct$_3ow4zXXILqvC0WDqDRNq5DPhjE1DInJgN924VHWc2Y", align 8
-  br label %_llgo_28
-
-_llgo_28:                                         ; preds = %_llgo_27, %_llgo_26
-  %140 = load ptr, ptr @"_llgo_struct$_3ow4zXXILqvC0WDqDRNq5DPhjE1DInJgN924VHWc2Y", align 8
-  %141 = load ptr, ptr @_llgo_error, align 8
-  %142 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
-  %143 = icmp eq ptr %142, null
-  br i1 %143, label %_llgo_29, label %_llgo_30
-
-_llgo_29:                                         ; preds = %_llgo_28
-  %144 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %145 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %144, 0
-  %146 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %145, i64 0, 1
-  %147 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %146, i64 0, 2
-  %148 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %149 = getelementptr ptr, ptr %148, i64 0
-  store ptr %141, ptr %149, align 8
-  %150 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %148, 0
-  %151 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %150, i64 1, 1
-  %152 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %151, i64 1, 2
-  %153 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %147, %"github.com/goplus/llgo/internal/runtime.Slice" %152, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %153)
-  store ptr %153, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
   br label %_llgo_30
 
 _llgo_30:                                         ; preds = %_llgo_29, %_llgo_28
-  %154 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
-  %155 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 5 }, ptr undef, ptr undef, ptr undef }, ptr %154, 1
-  %156 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %155, ptr @"main.(*nopCloserWriterTo).Close", 2
-  %157 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %156, ptr @"main.(*nopCloserWriterTo).Close", 3
-  %158 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 5 }, ptr undef, ptr undef, ptr undef }, ptr %154, 1
-  %159 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %158, ptr @"main.(*nopCloserWriterTo).Close", 2
-  %160 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %159, ptr @main.nopCloserWriterTo.Close, 3
-  %161 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
-  %162 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %161, 1
-  %163 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %162, ptr @"main.(*nopCloserWriterTo).Read", 2
-  %164 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %163, ptr @"main.(*nopCloserWriterTo).Read", 3
-  %165 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %161, 1
-  %166 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %165, ptr @"main.(*nopCloserWriterTo).Read", 2
-  %167 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %166, ptr @main.nopCloserWriterTo.Read, 3
-  %168 = load ptr, ptr @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk", align 8
-  %169 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %168, 1
-  %170 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %169, ptr @"main.(*nopCloserWriterTo).WriteTo", 2
-  %171 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %170, ptr @"main.(*nopCloserWriterTo).WriteTo", 3
-  %172 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %168, 1
-  %173 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %172, ptr @"main.(*nopCloserWriterTo).WriteTo", 2
-  %174 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %173, ptr @main.nopCloserWriterTo.WriteTo, 3
-  %175 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 120)
-  %176 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %175, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %160, ptr %176, align 8
-  %177 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %175, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %167, ptr %177, align 8
-  %178 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %175, i64 2
-  store %"github.com/goplus/llgo/internal/abi.Method" %174, ptr %178, align 8
-  %179 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %175, 0
-  %180 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %179, i64 3, 1
-  %181 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %180, i64 3, 2
-  %182 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 120)
-  %183 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %182, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %157, ptr %183, align 8
-  %184 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %182, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %164, ptr %184, align 8
-  %185 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %182, i64 2
-  store %"github.com/goplus/llgo/internal/abi.Method" %171, ptr %185, align 8
-  %186 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %182, 0
-  %187 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %186, i64 3, 1
-  %188 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %187, i64 3, 2
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %110, %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @12, i64 17 }, ptr %140, %"github.com/goplus/llgo/internal/runtime.Slice" %181, %"github.com/goplus/llgo/internal/runtime.Slice" %188)
-  %189 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
-  %190 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
-  %191 = load ptr, ptr @"_llgo_iface$L2Ik-AJcd0jsoBw5fQ07pQpfUM-kh78Wn2bOeak6M3I", align 8
-  %192 = icmp eq ptr %191, null
-  br i1 %192, label %_llgo_31, label %_llgo_32
+  %110 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 22 }, i64 25, i64 16, i64 3, i64 3)
+  store ptr %110, ptr @_llgo_main.nopCloserWriterTo, align 8
+  %111 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamedInterface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 11 })
+  %112 = load ptr, ptr @_llgo_main.Reader, align 8
+  %113 = icmp eq ptr %112, null
+  br i1 %113, label %_llgo_31, label %_llgo_32
 
 _llgo_31:                                         ; preds = %_llgo_30
-  %193 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 5 }, ptr undef }, ptr %189, 1
-  %194 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 4 }, ptr undef }, ptr %190, 1
-  %195 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
-  %196 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %195, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %193, ptr %196, align 8
-  %197 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %195, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %194, ptr %197, align 8
-  %198 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %195, 0
-  %199 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %198, i64 2, 1
-  %200 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %199, i64 2, 2
-  %201 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %200)
-  store ptr %201, ptr @"_llgo_iface$L2Ik-AJcd0jsoBw5fQ07pQpfUM-kh78Wn2bOeak6M3I", align 8
+  store ptr %111, ptr @_llgo_main.Reader, align 8
   br label %_llgo_32
 
 _llgo_32:                                         ; preds = %_llgo_31, %_llgo_30
-  %202 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @13, i64 14 }, i64 25, i64 16, i64 2, i64 2)
-  store ptr %202, ptr @_llgo_main.nopCloser, align 8
-  %203 = load ptr, ptr @"_llgo_struct$_3ow4zXXILqvC0WDqDRNq5DPhjE1DInJgN924VHWc2Y", align 8
-  %204 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
-  %205 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 5 }, ptr undef, ptr undef, ptr undef }, ptr %204, 1
-  %206 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %205, ptr @"main.(*nopCloser).Close", 2
-  %207 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %206, ptr @"main.(*nopCloser).Close", 3
-  %208 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 5 }, ptr undef, ptr undef, ptr undef }, ptr %204, 1
-  %209 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %208, ptr @"main.(*nopCloser).Close", 2
-  %210 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %209, ptr @main.nopCloser.Close, 3
-  %211 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
-  %212 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %211, 1
-  %213 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %212, ptr @"main.(*nopCloser).Read", 2
-  %214 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %213, ptr @"main.(*nopCloser).Read", 3
-  %215 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %211, 1
-  %216 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %215, ptr @"main.(*nopCloser).Read", 2
-  %217 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %216, ptr @main.nopCloser.Read, 3
-  %218 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
-  %219 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %218, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %210, ptr %219, align 8
-  %220 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %218, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %217, ptr %220, align 8
-  %221 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %218, 0
-  %222 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %221, i64 2, 1
-  %223 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %222, i64 2, 2
-  %224 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
-  %225 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %224, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %207, ptr %225, align 8
-  %226 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %224, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %214, ptr %226, align 8
-  %227 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %224, 0
-  %228 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %227, i64 2, 1
-  %229 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %228, i64 2, 2
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %202, %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @14, i64 9 }, ptr %203, %"github.com/goplus/llgo/internal/runtime.Slice" %223, %"github.com/goplus/llgo/internal/runtime.Slice" %229)
-  %230 = load ptr, ptr @_llgo_string, align 8
-  %231 = load ptr, ptr @_llgo_int, align 8
-  %232 = load ptr, ptr @_llgo_error, align 8
-  %233 = load ptr, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw", align 8
-  %234 = icmp eq ptr %233, null
-  br i1 %234, label %_llgo_33, label %_llgo_34
+  %114 = load ptr, ptr @"[]_llgo_byte", align 8
+  %115 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
+  br i1 %113, label %_llgo_33, label %_llgo_34
 
 _llgo_33:                                         ; preds = %_llgo_32
-  %235 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %236 = getelementptr ptr, ptr %235, i64 0
-  store ptr %230, ptr %236, align 8
-  %237 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %235, 0
-  %238 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %237, i64 1, 1
-  %239 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %238, i64 1, 2
-  %240 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %241 = getelementptr ptr, ptr %240, i64 0
-  store ptr %231, ptr %241, align 8
-  %242 = getelementptr ptr, ptr %240, i64 1
-  store ptr %232, ptr %242, align 8
-  %243 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %240, 0
-  %244 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %243, i64 2, 1
-  %245 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %244, i64 2, 2
-  %246 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %239, %"github.com/goplus/llgo/internal/runtime.Slice" %245, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %246)
-  store ptr %246, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw", align 8
+  %116 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 4 }, ptr undef }, ptr %115, 1
+  %117 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %118 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %117, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %116, ptr %118, align 8
+  %119 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %117, 0
+  %120 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %119, i64 1, 1
+  %121 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %120, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamedInterface"(ptr %111, %"github.com/goplus/llgo/internal/runtime.Slice" %121)
   br label %_llgo_34
 
 _llgo_34:                                         ; preds = %_llgo_33, %_llgo_32
-  %247 = load ptr, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw", align 8
-  %248 = load ptr, ptr @_llgo_main.StringWriter, align 8
-  %249 = icmp eq ptr %248, null
-  br i1 %249, label %_llgo_35, label %_llgo_36
+  %122 = load ptr, ptr @_llgo_main.Reader, align 8
+  %123 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamedInterface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 11 })
+  %124 = load ptr, ptr @"_llgo_struct$_3ow4zXXILqvC0WDqDRNq5DPhjE1DInJgN924VHWc2Y", align 8
+  %125 = icmp eq ptr %124, null
+  br i1 %125, label %_llgo_35, label %_llgo_36
 
 _llgo_35:                                         ; preds = %_llgo_34
-  %250 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @15, i64 11 }, ptr undef }, ptr %247, 1
-  %251 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %252 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %251, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %250, ptr %252, align 8
-  %253 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %251, 0
-  %254 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %253, i64 1, 1
-  %255 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %254, i64 1, 2
-  %256 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @16, i64 17 }, %"github.com/goplus/llgo/internal/runtime.Slice" %255)
-  store ptr %256, ptr @_llgo_main.StringWriter, align 8
+  %126 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 6 }, ptr %123, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 true)
+  %127 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
+  %128 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %127, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %126, ptr %128, align 8
+  %129 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %127, 0
+  %130 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %129, i64 1, 1
+  %131 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %130, i64 1, 2
+  %132 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %131)
+  store ptr %132, ptr @"_llgo_struct$_3ow4zXXILqvC0WDqDRNq5DPhjE1DInJgN924VHWc2Y", align 8
   br label %_llgo_36
 
 _llgo_36:                                         ; preds = %_llgo_35, %_llgo_34
-  %257 = load ptr, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw", align 8
-  %258 = load ptr, ptr @"_llgo_iface$Ly4zXiUMEac-hYAMw6b6miJ1JEhGfLyBWyBOhpsRZcU", align 8
-  %259 = icmp eq ptr %258, null
-  br i1 %259, label %_llgo_37, label %_llgo_38
+  %133 = load ptr, ptr @"_llgo_struct$_3ow4zXXILqvC0WDqDRNq5DPhjE1DInJgN924VHWc2Y", align 8
+  %134 = load ptr, ptr @_llgo_error, align 8
+  %135 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
+  %136 = icmp eq ptr %135, null
+  br i1 %136, label %_llgo_37, label %_llgo_38
 
 _llgo_37:                                         ; preds = %_llgo_36
-  %260 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @15, i64 11 }, ptr undef }, ptr %257, 1
-  %261 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %262 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %261, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %260, ptr %262, align 8
-  %263 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %261, 0
-  %264 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %263, i64 1, 1
-  %265 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %264, i64 1, 2
-  %266 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %265)
-  store ptr %266, ptr @"_llgo_iface$Ly4zXiUMEac-hYAMw6b6miJ1JEhGfLyBWyBOhpsRZcU", align 8
+  %137 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %138 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %137, 0
+  %139 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %138, i64 0, 1
+  %140 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %139, i64 0, 2
+  %141 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %142 = getelementptr ptr, ptr %141, i64 0
+  store ptr %134, ptr %142, align 8
+  %143 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %141, 0
+  %144 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %143, i64 1, 1
+  %145 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %144, i64 1, 2
+  %146 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %140, %"github.com/goplus/llgo/internal/runtime.Slice" %145, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %146)
+  store ptr %146, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
   br label %_llgo_38
 
 _llgo_38:                                         ; preds = %_llgo_37, %_llgo_36
-  %267 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @20, i64 17 }, i64 25, i64 32, i64 0, i64 10)
-  store ptr %267, ptr @_llgo_main.stringReader, align 8
-  %268 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %269 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @21, i64 1 }, ptr %268, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
-  %270 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 38)
-  %271 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @22, i64 1 }, ptr %270, i64 16, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
-  %272 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
-  %273 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @23, i64 8 }, ptr %272, i64 24, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
-  %274 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 168)
-  %275 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %274, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %269, ptr %275, align 8
-  %276 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %274, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %271, ptr %276, align 8
-  %277 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %274, i64 2
-  store %"github.com/goplus/llgo/internal/abi.StructField" %273, ptr %277, align 8
-  %278 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %274, 0
-  %279 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %278, i64 3, 1
-  %280 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %279, i64 3, 2
-  %281 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, i64 32, %"github.com/goplus/llgo/internal/runtime.Slice" %280)
-  store ptr %281, ptr @"main.struct$Mdt84yjYYwxF9D2i4cRmpEPiWaO6tsjtrbGUjyESypk", align 8
-  %282 = load ptr, ptr @"main.struct$Mdt84yjYYwxF9D2i4cRmpEPiWaO6tsjtrbGUjyESypk", align 8
-  %283 = load ptr, ptr @_llgo_int, align 8
-  %284 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %285 = icmp eq ptr %284, null
-  br i1 %285, label %_llgo_39, label %_llgo_40
+  %147 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
+  %148 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 5 }, ptr undef, ptr undef, ptr undef }, ptr %147, 1
+  %149 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %148, ptr @"main.(*nopCloserWriterTo).Close", 2
+  %150 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %149, ptr @"main.(*nopCloserWriterTo).Close", 3
+  %151 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 5 }, ptr undef, ptr undef, ptr undef }, ptr %147, 1
+  %152 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %151, ptr @"main.(*nopCloserWriterTo).Close", 2
+  %153 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %152, ptr @main.nopCloserWriterTo.Close, 3
+  %154 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
+  %155 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %154, 1
+  %156 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %155, ptr @"main.(*nopCloserWriterTo).Read", 2
+  %157 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %156, ptr @"main.(*nopCloserWriterTo).Read", 3
+  %158 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %154, 1
+  %159 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %158, ptr @"main.(*nopCloserWriterTo).Read", 2
+  %160 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %159, ptr @main.nopCloserWriterTo.Read, 3
+  %161 = load ptr, ptr @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk", align 8
+  %162 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %161, 1
+  %163 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %162, ptr @"main.(*nopCloserWriterTo).WriteTo", 2
+  %164 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %163, ptr @"main.(*nopCloserWriterTo).WriteTo", 3
+  %165 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %161, 1
+  %166 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %165, ptr @"main.(*nopCloserWriterTo).WriteTo", 2
+  %167 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %166, ptr @main.nopCloserWriterTo.WriteTo, 3
+  %168 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 120)
+  %169 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %168, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %153, ptr %169, align 8
+  %170 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %168, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %160, ptr %170, align 8
+  %171 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %168, i64 2
+  store %"github.com/goplus/llgo/internal/abi.Method" %167, ptr %171, align 8
+  %172 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %168, 0
+  %173 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %172, i64 3, 1
+  %174 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %173, i64 3, 2
+  %175 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 120)
+  %176 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %175, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %150, ptr %176, align 8
+  %177 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %175, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %157, ptr %177, align 8
+  %178 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %175, i64 2
+  store %"github.com/goplus/llgo/internal/abi.Method" %164, ptr %178, align 8
+  %179 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %175, 0
+  %180 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %179, i64 3, 1
+  %181 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %180, i64 3, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %110, %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @12, i64 17 }, ptr %133, %"github.com/goplus/llgo/internal/runtime.Slice" %174, %"github.com/goplus/llgo/internal/runtime.Slice" %181)
+  %182 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
+  %183 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
+  %184 = load ptr, ptr @"_llgo_iface$L2Ik-AJcd0jsoBw5fQ07pQpfUM-kh78Wn2bOeak6M3I", align 8
+  %185 = icmp eq ptr %184, null
+  br i1 %185, label %_llgo_39, label %_llgo_40
 
 _llgo_39:                                         ; preds = %_llgo_38
-  %286 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %287 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %286, 0
-  %288 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %287, i64 0, 1
-  %289 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %288, i64 0, 2
-  %290 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %291 = getelementptr ptr, ptr %290, i64 0
-  store ptr %283, ptr %291, align 8
-  %292 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %290, 0
-  %293 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %292, i64 1, 1
-  %294 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %293, i64 1, 2
-  %295 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %289, %"github.com/goplus/llgo/internal/runtime.Slice" %294, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %295)
-  store ptr %295, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %186 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 5 }, ptr undef }, ptr %182, 1
+  %187 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 4 }, ptr undef }, ptr %183, 1
+  %188 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 48)
+  %189 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %188, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %186, ptr %189, align 8
+  %190 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %188, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %187, ptr %190, align 8
+  %191 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %188, 0
+  %192 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %191, i64 2, 1
+  %193 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %192, i64 2, 2
+  %194 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %193)
+  store ptr %194, ptr @"_llgo_iface$L2Ik-AJcd0jsoBw5fQ07pQpfUM-kh78Wn2bOeak6M3I", align 8
   br label %_llgo_40
 
 _llgo_40:                                         ; preds = %_llgo_39, %_llgo_38
-  %296 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
-  %297 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @24, i64 3 }, ptr undef, ptr undef, ptr undef }, ptr %296, 1
-  %298 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %297, ptr @"main.(*stringReader).Len", 2
-  %299 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %298, ptr @"main.(*stringReader).Len", 3
-  %300 = load ptr, ptr @"[]_llgo_byte", align 8
-  %301 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
-  %302 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %301, 1
-  %303 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %302, ptr @"main.(*stringReader).Read", 2
-  %304 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %303, ptr @"main.(*stringReader).Read", 3
-  %305 = load ptr, ptr @"[]_llgo_byte", align 8
-  %306 = load ptr, ptr @"[]_llgo_byte", align 8
-  %307 = load ptr, ptr @_llgo_int64, align 8
-  %308 = load ptr, ptr @_llgo_int, align 8
-  %309 = load ptr, ptr @_llgo_error, align 8
-  %310 = load ptr, ptr @"_llgo_func$TY5Etv7VBKM_-2um1BDEeQEE2lP06Pt6G54EuKiNC3c", align 8
-  %311 = icmp eq ptr %310, null
-  br i1 %311, label %_llgo_41, label %_llgo_42
+  %195 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @13, i64 14 }, i64 25, i64 16, i64 2, i64 2)
+  store ptr %195, ptr @_llgo_main.nopCloser, align 8
+  %196 = load ptr, ptr @"_llgo_struct$_3ow4zXXILqvC0WDqDRNq5DPhjE1DInJgN924VHWc2Y", align 8
+  %197 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
+  %198 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 5 }, ptr undef, ptr undef, ptr undef }, ptr %197, 1
+  %199 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %198, ptr @"main.(*nopCloser).Close", 2
+  %200 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %199, ptr @"main.(*nopCloser).Close", 3
+  %201 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 5 }, ptr undef, ptr undef, ptr undef }, ptr %197, 1
+  %202 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %201, ptr @"main.(*nopCloser).Close", 2
+  %203 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %202, ptr @main.nopCloser.Close, 3
+  %204 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
+  %205 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %204, 1
+  %206 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %205, ptr @"main.(*nopCloser).Read", 2
+  %207 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %206, ptr @"main.(*nopCloser).Read", 3
+  %208 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %204, 1
+  %209 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %208, ptr @"main.(*nopCloser).Read", 2
+  %210 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %209, ptr @main.nopCloser.Read, 3
+  %211 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
+  %212 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %211, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %203, ptr %212, align 8
+  %213 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %211, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %210, ptr %213, align 8
+  %214 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %211, 0
+  %215 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %214, i64 2, 1
+  %216 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %215, i64 2, 2
+  %217 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 80)
+  %218 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %217, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %200, ptr %218, align 8
+  %219 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %217, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %207, ptr %219, align 8
+  %220 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %217, 0
+  %221 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %220, i64 2, 1
+  %222 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %221, i64 2, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %195, %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @14, i64 9 }, ptr %196, %"github.com/goplus/llgo/internal/runtime.Slice" %216, %"github.com/goplus/llgo/internal/runtime.Slice" %222)
+  %223 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamedInterface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @15, i64 17 })
+  %224 = load ptr, ptr @_llgo_main.StringWriter, align 8
+  %225 = icmp eq ptr %224, null
+  br i1 %225, label %_llgo_41, label %_llgo_42
 
 _llgo_41:                                         ; preds = %_llgo_40
-  %312 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %313 = getelementptr ptr, ptr %312, i64 0
-  store ptr %306, ptr %313, align 8
-  %314 = getelementptr ptr, ptr %312, i64 1
-  store ptr %307, ptr %314, align 8
-  %315 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %312, 0
-  %316 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %315, i64 2, 1
-  %317 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %316, i64 2, 2
-  %318 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %319 = getelementptr ptr, ptr %318, i64 0
-  store ptr %308, ptr %319, align 8
-  %320 = getelementptr ptr, ptr %318, i64 1
-  store ptr %309, ptr %320, align 8
-  %321 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %318, 0
-  %322 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %321, i64 2, 1
-  %323 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %322, i64 2, 2
-  %324 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %317, %"github.com/goplus/llgo/internal/runtime.Slice" %323, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %324)
-  store ptr %324, ptr @"_llgo_func$TY5Etv7VBKM_-2um1BDEeQEE2lP06Pt6G54EuKiNC3c", align 8
+  store ptr %223, ptr @_llgo_main.StringWriter, align 8
   br label %_llgo_42
 
 _llgo_42:                                         ; preds = %_llgo_41, %_llgo_40
-  %325 = load ptr, ptr @"_llgo_func$TY5Etv7VBKM_-2um1BDEeQEE2lP06Pt6G54EuKiNC3c", align 8
-  %326 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @25, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %325, 1
-  %327 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %326, ptr @"main.(*stringReader).ReadAt", 2
-  %328 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %327, ptr @"main.(*stringReader).ReadAt", 3
-  %329 = load ptr, ptr @_llgo_byte, align 8
-  %330 = load ptr, ptr @_llgo_error, align 8
-  %331 = load ptr, ptr @"_llgo_func$6bvVpCcGPUc3z_EmsQTHB0AVT1hP5-NNLVRgm43teCM", align 8
-  %332 = icmp eq ptr %331, null
-  br i1 %332, label %_llgo_43, label %_llgo_44
+  %226 = load ptr, ptr @_llgo_string, align 8
+  %227 = load ptr, ptr @_llgo_int, align 8
+  %228 = load ptr, ptr @_llgo_error, align 8
+  %229 = load ptr, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw", align 8
+  %230 = icmp eq ptr %229, null
+  br i1 %230, label %_llgo_43, label %_llgo_44
 
 _llgo_43:                                         ; preds = %_llgo_42
-  %333 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %334 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %333, 0
-  %335 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %334, i64 0, 1
-  %336 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %335, i64 0, 2
-  %337 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %338 = getelementptr ptr, ptr %337, i64 0
-  store ptr %329, ptr %338, align 8
-  %339 = getelementptr ptr, ptr %337, i64 1
-  store ptr %330, ptr %339, align 8
-  %340 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %337, 0
-  %341 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %340, i64 2, 1
-  %342 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %341, i64 2, 2
-  %343 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %336, %"github.com/goplus/llgo/internal/runtime.Slice" %342, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %343)
-  store ptr %343, ptr @"_llgo_func$6bvVpCcGPUc3z_EmsQTHB0AVT1hP5-NNLVRgm43teCM", align 8
+  %231 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %232 = getelementptr ptr, ptr %231, i64 0
+  store ptr %226, ptr %232, align 8
+  %233 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %231, 0
+  %234 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %233, i64 1, 1
+  %235 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %234, i64 1, 2
+  %236 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %237 = getelementptr ptr, ptr %236, i64 0
+  store ptr %227, ptr %237, align 8
+  %238 = getelementptr ptr, ptr %236, i64 1
+  store ptr %228, ptr %238, align 8
+  %239 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %236, 0
+  %240 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %239, i64 2, 1
+  %241 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %240, i64 2, 2
+  %242 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %235, %"github.com/goplus/llgo/internal/runtime.Slice" %241, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %242)
+  store ptr %242, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw", align 8
   br label %_llgo_44
 
 _llgo_44:                                         ; preds = %_llgo_43, %_llgo_42
-  %344 = load ptr, ptr @"_llgo_func$6bvVpCcGPUc3z_EmsQTHB0AVT1hP5-NNLVRgm43teCM", align 8
-  %345 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @26, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %344, 1
-  %346 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %345, ptr @"main.(*stringReader).ReadByte", 2
-  %347 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %346, ptr @"main.(*stringReader).ReadByte", 3
-  %348 = load ptr, ptr @_llgo_rune, align 8
-  %349 = icmp eq ptr %348, null
-  br i1 %349, label %_llgo_45, label %_llgo_46
+  %243 = load ptr, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw", align 8
+  br i1 %225, label %_llgo_45, label %_llgo_46
 
 _llgo_45:                                         ; preds = %_llgo_44
-  %350 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 37)
-  store ptr %350, ptr @_llgo_rune, align 8
+  %244 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @16, i64 11 }, ptr undef }, ptr %243, 1
+  %245 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %246 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %245, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %244, ptr %246, align 8
+  %247 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %245, 0
+  %248 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %247, i64 1, 1
+  %249 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %248, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamedInterface"(ptr %223, %"github.com/goplus/llgo/internal/runtime.Slice" %249)
   br label %_llgo_46
 
 _llgo_46:                                         ; preds = %_llgo_45, %_llgo_44
-  %351 = load ptr, ptr @_llgo_rune, align 8
-  %352 = load ptr, ptr @_llgo_rune, align 8
-  %353 = load ptr, ptr @_llgo_int, align 8
-  %354 = load ptr, ptr @_llgo_error, align 8
-  %355 = load ptr, ptr @"_llgo_func$CB0CO6hV_feSzhi4pz1P4omza2fKNK930wvOR1T33fU", align 8
-  %356 = icmp eq ptr %355, null
-  br i1 %356, label %_llgo_47, label %_llgo_48
+  %250 = load ptr, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw", align 8
+  %251 = load ptr, ptr @"_llgo_iface$Ly4zXiUMEac-hYAMw6b6miJ1JEhGfLyBWyBOhpsRZcU", align 8
+  %252 = icmp eq ptr %251, null
+  br i1 %252, label %_llgo_47, label %_llgo_48
 
 _llgo_47:                                         ; preds = %_llgo_46
-  %357 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %358 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %357, 0
-  %359 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %358, i64 0, 1
-  %360 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %359, i64 0, 2
-  %361 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %362 = getelementptr ptr, ptr %361, i64 0
-  store ptr %352, ptr %362, align 8
-  %363 = getelementptr ptr, ptr %361, i64 1
-  store ptr %353, ptr %363, align 8
-  %364 = getelementptr ptr, ptr %361, i64 2
-  store ptr %354, ptr %364, align 8
-  %365 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %361, 0
-  %366 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %365, i64 3, 1
-  %367 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %366, i64 3, 2
-  %368 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %360, %"github.com/goplus/llgo/internal/runtime.Slice" %367, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %368)
-  store ptr %368, ptr @"_llgo_func$CB0CO6hV_feSzhi4pz1P4omza2fKNK930wvOR1T33fU", align 8
+  %253 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @16, i64 11 }, ptr undef }, ptr %250, 1
+  %254 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %255 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %254, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %253, ptr %255, align 8
+  %256 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %254, 0
+  %257 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %256, i64 1, 1
+  %258 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %257, i64 1, 2
+  %259 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %258)
+  store ptr %259, ptr @"_llgo_iface$Ly4zXiUMEac-hYAMw6b6miJ1JEhGfLyBWyBOhpsRZcU", align 8
   br label %_llgo_48
 
 _llgo_48:                                         ; preds = %_llgo_47, %_llgo_46
-  %369 = load ptr, ptr @"_llgo_func$CB0CO6hV_feSzhi4pz1P4omza2fKNK930wvOR1T33fU", align 8
-  %370 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @27, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %369, 1
-  %371 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %370, ptr @"main.(*stringReader).ReadRune", 2
-  %372 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %371, ptr @"main.(*stringReader).ReadRune", 3
-  %373 = load ptr, ptr @_llgo_int64, align 8
-  %374 = load ptr, ptr @_llgo_int, align 8
-  %375 = load ptr, ptr @_llgo_int64, align 8
-  %376 = load ptr, ptr @_llgo_error, align 8
-  %377 = load ptr, ptr @"_llgo_func$HE7H49xPa1uXmrkMDpqB3RCRGf3qzhLGrxKCEXOYjms", align 8
-  %378 = icmp eq ptr %377, null
-  br i1 %378, label %_llgo_49, label %_llgo_50
+  %260 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @20, i64 17 }, i64 25, i64 32, i64 0, i64 10)
+  store ptr %260, ptr @_llgo_main.stringReader, align 8
+  %261 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %262 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @21, i64 1 }, ptr %261, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %263 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 38)
+  %264 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @22, i64 1 }, ptr %263, i64 16, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %265 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 34)
+  %266 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @23, i64 8 }, ptr %265, i64 24, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %267 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 168)
+  %268 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %267, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %262, ptr %268, align 8
+  %269 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %267, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %264, ptr %269, align 8
+  %270 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %267, i64 2
+  store %"github.com/goplus/llgo/internal/abi.StructField" %266, ptr %270, align 8
+  %271 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %267, 0
+  %272 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %271, i64 3, 1
+  %273 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %272, i64 3, 2
+  %274 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, i64 32, %"github.com/goplus/llgo/internal/runtime.Slice" %273)
+  store ptr %274, ptr @"main.struct$Mdt84yjYYwxF9D2i4cRmpEPiWaO6tsjtrbGUjyESypk", align 8
+  %275 = load ptr, ptr @"main.struct$Mdt84yjYYwxF9D2i4cRmpEPiWaO6tsjtrbGUjyESypk", align 8
+  %276 = load ptr, ptr @_llgo_int, align 8
+  %277 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %278 = icmp eq ptr %277, null
+  br i1 %278, label %_llgo_49, label %_llgo_50
 
 _llgo_49:                                         ; preds = %_llgo_48
-  %379 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %380 = getelementptr ptr, ptr %379, i64 0
-  store ptr %373, ptr %380, align 8
-  %381 = getelementptr ptr, ptr %379, i64 1
-  store ptr %374, ptr %381, align 8
-  %382 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %379, 0
-  %383 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %382, i64 2, 1
-  %384 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %383, i64 2, 2
-  %385 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
-  %386 = getelementptr ptr, ptr %385, i64 0
-  store ptr %375, ptr %386, align 8
-  %387 = getelementptr ptr, ptr %385, i64 1
-  store ptr %376, ptr %387, align 8
-  %388 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %385, 0
-  %389 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %388, i64 2, 1
-  %390 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %389, i64 2, 2
-  %391 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %384, %"github.com/goplus/llgo/internal/runtime.Slice" %390, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %391)
-  store ptr %391, ptr @"_llgo_func$HE7H49xPa1uXmrkMDpqB3RCRGf3qzhLGrxKCEXOYjms", align 8
+  %279 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %280 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %279, 0
+  %281 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %280, i64 0, 1
+  %282 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %281, i64 0, 2
+  %283 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %284 = getelementptr ptr, ptr %283, i64 0
+  store ptr %276, ptr %284, align 8
+  %285 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %283, 0
+  %286 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %285, i64 1, 1
+  %287 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %286, i64 1, 2
+  %288 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %282, %"github.com/goplus/llgo/internal/runtime.Slice" %287, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %288)
+  store ptr %288, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
   br label %_llgo_50
 
 _llgo_50:                                         ; preds = %_llgo_49, %_llgo_48
-  %392 = load ptr, ptr @"_llgo_func$HE7H49xPa1uXmrkMDpqB3RCRGf3qzhLGrxKCEXOYjms", align 8
-  %393 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @28, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %392, 1
-  %394 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %393, ptr @"main.(*stringReader).Seek", 2
-  %395 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %394, ptr @"main.(*stringReader).Seek", 3
-  %396 = load ptr, ptr @_llgo_int64, align 8
-  %397 = load ptr, ptr @"_llgo_func$Eoig9xhJM5GShHH5aNPxTZZXp1IZxprRl4zPuv2hkug", align 8
-  %398 = icmp eq ptr %397, null
-  br i1 %398, label %_llgo_51, label %_llgo_52
+  %289 = load ptr, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", align 8
+  %290 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @24, i64 3 }, ptr undef, ptr undef, ptr undef }, ptr %289, 1
+  %291 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %290, ptr @"main.(*stringReader).Len", 2
+  %292 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %291, ptr @"main.(*stringReader).Len", 3
+  %293 = load ptr, ptr @"[]_llgo_byte", align 8
+  %294 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
+  %295 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %294, 1
+  %296 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %295, ptr @"main.(*stringReader).Read", 2
+  %297 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %296, ptr @"main.(*stringReader).Read", 3
+  %298 = load ptr, ptr @"[]_llgo_byte", align 8
+  %299 = load ptr, ptr @"[]_llgo_byte", align 8
+  %300 = load ptr, ptr @_llgo_int64, align 8
+  %301 = load ptr, ptr @_llgo_int, align 8
+  %302 = load ptr, ptr @_llgo_error, align 8
+  %303 = load ptr, ptr @"_llgo_func$TY5Etv7VBKM_-2um1BDEeQEE2lP06Pt6G54EuKiNC3c", align 8
+  %304 = icmp eq ptr %303, null
+  br i1 %304, label %_llgo_51, label %_llgo_52
 
 _llgo_51:                                         ; preds = %_llgo_50
-  %399 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %400 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %399, 0
-  %401 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %400, i64 0, 1
-  %402 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %401, i64 0, 2
-  %403 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %404 = getelementptr ptr, ptr %403, i64 0
-  store ptr %396, ptr %404, align 8
-  %405 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %403, 0
-  %406 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %405, i64 1, 1
-  %407 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %406, i64 1, 2
-  %408 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %402, %"github.com/goplus/llgo/internal/runtime.Slice" %407, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %408)
-  store ptr %408, ptr @"_llgo_func$Eoig9xhJM5GShHH5aNPxTZZXp1IZxprRl4zPuv2hkug", align 8
+  %305 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %306 = getelementptr ptr, ptr %305, i64 0
+  store ptr %299, ptr %306, align 8
+  %307 = getelementptr ptr, ptr %305, i64 1
+  store ptr %300, ptr %307, align 8
+  %308 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %305, 0
+  %309 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %308, i64 2, 1
+  %310 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %309, i64 2, 2
+  %311 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %312 = getelementptr ptr, ptr %311, i64 0
+  store ptr %301, ptr %312, align 8
+  %313 = getelementptr ptr, ptr %311, i64 1
+  store ptr %302, ptr %313, align 8
+  %314 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %311, 0
+  %315 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %314, i64 2, 1
+  %316 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %315, i64 2, 2
+  %317 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %310, %"github.com/goplus/llgo/internal/runtime.Slice" %316, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %317)
+  store ptr %317, ptr @"_llgo_func$TY5Etv7VBKM_-2um1BDEeQEE2lP06Pt6G54EuKiNC3c", align 8
   br label %_llgo_52
 
 _llgo_52:                                         ; preds = %_llgo_51, %_llgo_50
-  %409 = load ptr, ptr @"_llgo_func$Eoig9xhJM5GShHH5aNPxTZZXp1IZxprRl4zPuv2hkug", align 8
-  %410 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @29, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %409, 1
-  %411 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %410, ptr @"main.(*stringReader).Size", 2
-  %412 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %411, ptr @"main.(*stringReader).Size", 3
-  %413 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
-  %414 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @30, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %413, 1
-  %415 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %414, ptr @"main.(*stringReader).UnreadByte", 2
-  %416 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %415, ptr @"main.(*stringReader).UnreadByte", 3
-  %417 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
-  %418 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @31, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %417, 1
-  %419 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %418, ptr @"main.(*stringReader).UnreadRune", 2
-  %420 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %419, ptr @"main.(*stringReader).UnreadRune", 3
-  %421 = load ptr, ptr @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk", align 8
-  %422 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %421, 1
-  %423 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %422, ptr @"main.(*stringReader).WriteTo", 2
-  %424 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %423, ptr @"main.(*stringReader).WriteTo", 3
-  %425 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 400)
-  %426 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %425, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %299, ptr %426, align 8
-  %427 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %425, i64 1
-  store %"github.com/goplus/llgo/internal/abi.Method" %304, ptr %427, align 8
-  %428 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %425, i64 2
-  store %"github.com/goplus/llgo/internal/abi.Method" %328, ptr %428, align 8
-  %429 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %425, i64 3
-  store %"github.com/goplus/llgo/internal/abi.Method" %347, ptr %429, align 8
-  %430 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %425, i64 4
-  store %"github.com/goplus/llgo/internal/abi.Method" %372, ptr %430, align 8
-  %431 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %425, i64 5
-  store %"github.com/goplus/llgo/internal/abi.Method" %395, ptr %431, align 8
-  %432 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %425, i64 6
-  store %"github.com/goplus/llgo/internal/abi.Method" %412, ptr %432, align 8
-  %433 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %425, i64 7
-  store %"github.com/goplus/llgo/internal/abi.Method" %416, ptr %433, align 8
-  %434 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %425, i64 8
-  store %"github.com/goplus/llgo/internal/abi.Method" %420, ptr %434, align 8
-  %435 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %425, i64 9
-  store %"github.com/goplus/llgo/internal/abi.Method" %424, ptr %435, align 8
-  %436 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %425, 0
-  %437 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %436, i64 10, 1
-  %438 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %437, i64 10, 2
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %267, %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @32, i64 12 }, ptr %282, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %438)
-  %439 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @20, i64 17 }, i64 25, i64 32, i64 0, i64 10)
-  %440 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %439)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %440)
-  store ptr %440, ptr @"*_llgo_main.stringReader", align 8
-  %441 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
-  %442 = load ptr, ptr @"_llgo_iface$OFO8Us9n8ajWCabGedeuoJ-Za2zAMk4Jh0FunAcUCFE", align 8
-  %443 = icmp eq ptr %442, null
-  br i1 %443, label %_llgo_53, label %_llgo_54
+  %318 = load ptr, ptr @"_llgo_func$TY5Etv7VBKM_-2um1BDEeQEE2lP06Pt6G54EuKiNC3c", align 8
+  %319 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @25, i64 6 }, ptr undef, ptr undef, ptr undef }, ptr %318, 1
+  %320 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %319, ptr @"main.(*stringReader).ReadAt", 2
+  %321 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %320, ptr @"main.(*stringReader).ReadAt", 3
+  %322 = load ptr, ptr @_llgo_byte, align 8
+  %323 = load ptr, ptr @_llgo_error, align 8
+  %324 = load ptr, ptr @"_llgo_func$6bvVpCcGPUc3z_EmsQTHB0AVT1hP5-NNLVRgm43teCM", align 8
+  %325 = icmp eq ptr %324, null
+  br i1 %325, label %_llgo_53, label %_llgo_54
 
 _llgo_53:                                         ; preds = %_llgo_52
-  %444 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 4 }, ptr undef }, ptr %441, 1
-  %445 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %446 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %445, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %444, ptr %446, align 8
-  %447 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %445, 0
-  %448 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %447, i64 1, 1
-  %449 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %448, i64 1, 2
-  %450 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %449)
-  store ptr %450, ptr @"_llgo_iface$OFO8Us9n8ajWCabGedeuoJ-Za2zAMk4Jh0FunAcUCFE", align 8
+  %326 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %327 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %326, 0
+  %328 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %327, i64 0, 1
+  %329 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %328, i64 0, 2
+  %330 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %331 = getelementptr ptr, ptr %330, i64 0
+  store ptr %322, ptr %331, align 8
+  %332 = getelementptr ptr, ptr %330, i64 1
+  store ptr %323, ptr %332, align 8
+  %333 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %330, 0
+  %334 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %333, i64 2, 1
+  %335 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %334, i64 2, 2
+  %336 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %329, %"github.com/goplus/llgo/internal/runtime.Slice" %335, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %336)
+  store ptr %336, ptr @"_llgo_func$6bvVpCcGPUc3z_EmsQTHB0AVT1hP5-NNLVRgm43teCM", align 8
   br label %_llgo_54
 
 _llgo_54:                                         ; preds = %_llgo_53, %_llgo_52
-  %451 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @33, i64 16 }, i64 25, i64 16, i64 0, i64 1)
-  store ptr %451, ptr @_llgo_main.errorString, align 8
-  %452 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  %453 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @21, i64 1 }, ptr %452, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
-  %454 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
-  %455 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %454, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %453, ptr %455, align 8
-  %456 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %454, 0
-  %457 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %456, i64 1, 1
-  %458 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %457, i64 1, 2
-  %459 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %458)
-  store ptr %459, ptr @"main.struct$QTufDJA9wEDzuzgkA-ZSrLqW-B6lWN8O25mTSglAoLQ", align 8
-  %460 = load ptr, ptr @"main.struct$QTufDJA9wEDzuzgkA-ZSrLqW-B6lWN8O25mTSglAoLQ", align 8
-  %461 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %462 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr undef, ptr undef, ptr undef }, ptr %461, 1
-  %463 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %462, ptr @"main.(*errorString).Error", 2
-  %464 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %463, ptr @"main.(*errorString).Error", 3
-  %465 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %466 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %465, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %464, ptr %466, align 8
-  %467 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %465, 0
-  %468 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %467, i64 1, 1
-  %469 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %468, i64 1, 2
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %451, %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @34, i64 11 }, ptr %460, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %469)
-  %470 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @33, i64 16 }, i64 25, i64 16, i64 0, i64 1)
-  %471 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %470)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %471)
-  store ptr %471, ptr @"*_llgo_main.errorString", align 8
-  %472 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %473 = load ptr, ptr @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU", align 8
-  %474 = icmp eq ptr %473, null
-  br i1 %474, label %_llgo_55, label %_llgo_56
+  %337 = load ptr, ptr @"_llgo_func$6bvVpCcGPUc3z_EmsQTHB0AVT1hP5-NNLVRgm43teCM", align 8
+  %338 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @26, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %337, 1
+  %339 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %338, ptr @"main.(*stringReader).ReadByte", 2
+  %340 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %339, ptr @"main.(*stringReader).ReadByte", 3
+  %341 = load ptr, ptr @_llgo_rune, align 8
+  %342 = icmp eq ptr %341, null
+  br i1 %342, label %_llgo_55, label %_llgo_56
 
 _llgo_55:                                         ; preds = %_llgo_54
-  %475 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 5 }, ptr undef }, ptr %472, 1
-  %476 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %477 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %476, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %475, ptr %477, align 8
-  %478 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %476, 0
-  %479 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %478, i64 1, 1
-  %480 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %479, i64 1, 2
-  %481 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %480)
-  store ptr %481, ptr @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU", align 8
+  %343 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 37)
+  store ptr %343, ptr @_llgo_rune, align 8
   br label %_llgo_56
 
 _llgo_56:                                         ; preds = %_llgo_55, %_llgo_54
+  %344 = load ptr, ptr @_llgo_rune, align 8
+  %345 = load ptr, ptr @_llgo_rune, align 8
+  %346 = load ptr, ptr @_llgo_int, align 8
+  %347 = load ptr, ptr @_llgo_error, align 8
+  %348 = load ptr, ptr @"_llgo_func$CB0CO6hV_feSzhi4pz1P4omza2fKNK930wvOR1T33fU", align 8
+  %349 = icmp eq ptr %348, null
+  br i1 %349, label %_llgo_57, label %_llgo_58
+
+_llgo_57:                                         ; preds = %_llgo_56
+  %350 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %351 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %350, 0
+  %352 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %351, i64 0, 1
+  %353 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %352, i64 0, 2
+  %354 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %355 = getelementptr ptr, ptr %354, i64 0
+  store ptr %345, ptr %355, align 8
+  %356 = getelementptr ptr, ptr %354, i64 1
+  store ptr %346, ptr %356, align 8
+  %357 = getelementptr ptr, ptr %354, i64 2
+  store ptr %347, ptr %357, align 8
+  %358 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %354, 0
+  %359 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %358, i64 3, 1
+  %360 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %359, i64 3, 2
+  %361 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %353, %"github.com/goplus/llgo/internal/runtime.Slice" %360, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %361)
+  store ptr %361, ptr @"_llgo_func$CB0CO6hV_feSzhi4pz1P4omza2fKNK930wvOR1T33fU", align 8
+  br label %_llgo_58
+
+_llgo_58:                                         ; preds = %_llgo_57, %_llgo_56
+  %362 = load ptr, ptr @"_llgo_func$CB0CO6hV_feSzhi4pz1P4omza2fKNK930wvOR1T33fU", align 8
+  %363 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @27, i64 8 }, ptr undef, ptr undef, ptr undef }, ptr %362, 1
+  %364 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %363, ptr @"main.(*stringReader).ReadRune", 2
+  %365 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %364, ptr @"main.(*stringReader).ReadRune", 3
+  %366 = load ptr, ptr @_llgo_int64, align 8
+  %367 = load ptr, ptr @_llgo_int, align 8
+  %368 = load ptr, ptr @_llgo_int64, align 8
+  %369 = load ptr, ptr @_llgo_error, align 8
+  %370 = load ptr, ptr @"_llgo_func$HE7H49xPa1uXmrkMDpqB3RCRGf3qzhLGrxKCEXOYjms", align 8
+  %371 = icmp eq ptr %370, null
+  br i1 %371, label %_llgo_59, label %_llgo_60
+
+_llgo_59:                                         ; preds = %_llgo_58
+  %372 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %373 = getelementptr ptr, ptr %372, i64 0
+  store ptr %366, ptr %373, align 8
+  %374 = getelementptr ptr, ptr %372, i64 1
+  store ptr %367, ptr %374, align 8
+  %375 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %372, 0
+  %376 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %375, i64 2, 1
+  %377 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %376, i64 2, 2
+  %378 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  %379 = getelementptr ptr, ptr %378, i64 0
+  store ptr %368, ptr %379, align 8
+  %380 = getelementptr ptr, ptr %378, i64 1
+  store ptr %369, ptr %380, align 8
+  %381 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %378, 0
+  %382 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %381, i64 2, 1
+  %383 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %382, i64 2, 2
+  %384 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %377, %"github.com/goplus/llgo/internal/runtime.Slice" %383, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %384)
+  store ptr %384, ptr @"_llgo_func$HE7H49xPa1uXmrkMDpqB3RCRGf3qzhLGrxKCEXOYjms", align 8
+  br label %_llgo_60
+
+_llgo_60:                                         ; preds = %_llgo_59, %_llgo_58
+  %385 = load ptr, ptr @"_llgo_func$HE7H49xPa1uXmrkMDpqB3RCRGf3qzhLGrxKCEXOYjms", align 8
+  %386 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @28, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %385, 1
+  %387 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %386, ptr @"main.(*stringReader).Seek", 2
+  %388 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %387, ptr @"main.(*stringReader).Seek", 3
+  %389 = load ptr, ptr @_llgo_int64, align 8
+  %390 = load ptr, ptr @"_llgo_func$Eoig9xhJM5GShHH5aNPxTZZXp1IZxprRl4zPuv2hkug", align 8
+  %391 = icmp eq ptr %390, null
+  br i1 %391, label %_llgo_61, label %_llgo_62
+
+_llgo_61:                                         ; preds = %_llgo_60
+  %392 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %393 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %392, 0
+  %394 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %393, i64 0, 1
+  %395 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %394, i64 0, 2
+  %396 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %397 = getelementptr ptr, ptr %396, i64 0
+  store ptr %389, ptr %397, align 8
+  %398 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %396, 0
+  %399 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %398, i64 1, 1
+  %400 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %399, i64 1, 2
+  %401 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %395, %"github.com/goplus/llgo/internal/runtime.Slice" %400, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %401)
+  store ptr %401, ptr @"_llgo_func$Eoig9xhJM5GShHH5aNPxTZZXp1IZxprRl4zPuv2hkug", align 8
+  br label %_llgo_62
+
+_llgo_62:                                         ; preds = %_llgo_61, %_llgo_60
+  %402 = load ptr, ptr @"_llgo_func$Eoig9xhJM5GShHH5aNPxTZZXp1IZxprRl4zPuv2hkug", align 8
+  %403 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @29, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %402, 1
+  %404 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %403, ptr @"main.(*stringReader).Size", 2
+  %405 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %404, ptr @"main.(*stringReader).Size", 3
+  %406 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
+  %407 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @30, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %406, 1
+  %408 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %407, ptr @"main.(*stringReader).UnreadByte", 2
+  %409 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %408, ptr @"main.(*stringReader).UnreadByte", 3
+  %410 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
+  %411 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @31, i64 10 }, ptr undef, ptr undef, ptr undef }, ptr %410, 1
+  %412 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %411, ptr @"main.(*stringReader).UnreadRune", 2
+  %413 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %412, ptr @"main.(*stringReader).UnreadRune", 3
+  %414 = load ptr, ptr @"_llgo_func$MrYxYl10p_I07B55pBsGw9la9zbzU2vGDPLWrT714Uk", align 8
+  %415 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 7 }, ptr undef, ptr undef, ptr undef }, ptr %414, 1
+  %416 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %415, ptr @"main.(*stringReader).WriteTo", 2
+  %417 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %416, ptr @"main.(*stringReader).WriteTo", 3
+  %418 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 400)
+  %419 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %418, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %292, ptr %419, align 8
+  %420 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %418, i64 1
+  store %"github.com/goplus/llgo/internal/abi.Method" %297, ptr %420, align 8
+  %421 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %418, i64 2
+  store %"github.com/goplus/llgo/internal/abi.Method" %321, ptr %421, align 8
+  %422 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %418, i64 3
+  store %"github.com/goplus/llgo/internal/abi.Method" %340, ptr %422, align 8
+  %423 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %418, i64 4
+  store %"github.com/goplus/llgo/internal/abi.Method" %365, ptr %423, align 8
+  %424 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %418, i64 5
+  store %"github.com/goplus/llgo/internal/abi.Method" %388, ptr %424, align 8
+  %425 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %418, i64 6
+  store %"github.com/goplus/llgo/internal/abi.Method" %405, ptr %425, align 8
+  %426 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %418, i64 7
+  store %"github.com/goplus/llgo/internal/abi.Method" %409, ptr %426, align 8
+  %427 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %418, i64 8
+  store %"github.com/goplus/llgo/internal/abi.Method" %413, ptr %427, align 8
+  %428 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %418, i64 9
+  store %"github.com/goplus/llgo/internal/abi.Method" %417, ptr %428, align 8
+  %429 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %418, 0
+  %430 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %429, i64 10, 1
+  %431 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %430, i64 10, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %260, %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @32, i64 12 }, ptr %275, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %431)
+  %432 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @20, i64 17 }, i64 25, i64 32, i64 0, i64 10)
+  %433 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %432)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %433)
+  store ptr %433, ptr @"*_llgo_main.stringReader", align 8
+  %434 = load ptr, ptr @"_llgo_func$06yPPin-fnDnxFKkLLcJ1GEUhIobjPimde7T_Id_hmY", align 8
+  %435 = load ptr, ptr @"_llgo_iface$OFO8Us9n8ajWCabGedeuoJ-Za2zAMk4Jh0FunAcUCFE", align 8
+  %436 = icmp eq ptr %435, null
+  br i1 %436, label %_llgo_63, label %_llgo_64
+
+_llgo_63:                                         ; preds = %_llgo_62
+  %437 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 4 }, ptr undef }, ptr %434, 1
+  %438 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %439 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %438, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %437, ptr %439, align 8
+  %440 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %438, 0
+  %441 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %440, i64 1, 1
+  %442 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %441, i64 1, 2
+  %443 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %442)
+  store ptr %443, ptr @"_llgo_iface$OFO8Us9n8ajWCabGedeuoJ-Za2zAMk4Jh0FunAcUCFE", align 8
+  br label %_llgo_64
+
+_llgo_64:                                         ; preds = %_llgo_63, %_llgo_62
+  %444 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @33, i64 16 }, i64 25, i64 16, i64 0, i64 1)
+  store ptr %444, ptr @_llgo_main.errorString, align 8
+  %445 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  %446 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @21, i64 1 }, ptr %445, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %447 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
+  %448 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %447, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %446, ptr %448, align 8
+  %449 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %447, 0
+  %450 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %449, i64 1, 1
+  %451 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %450, i64 1, 2
+  %452 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %451)
+  store ptr %452, ptr @"main.struct$QTufDJA9wEDzuzgkA-ZSrLqW-B6lWN8O25mTSglAoLQ", align 8
+  %453 = load ptr, ptr @"main.struct$QTufDJA9wEDzuzgkA-ZSrLqW-B6lWN8O25mTSglAoLQ", align 8
+  %454 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %455 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 5 }, ptr undef, ptr undef, ptr undef }, ptr %454, 1
+  %456 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %455, ptr @"main.(*errorString).Error", 2
+  %457 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %456, ptr @"main.(*errorString).Error", 3
+  %458 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %459 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %458, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %457, ptr %459, align 8
+  %460 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %458, 0
+  %461 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %460, i64 1, 1
+  %462 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %461, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %444, %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @34, i64 11 }, ptr %453, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %462)
+  %463 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @33, i64 16 }, i64 25, i64 16, i64 0, i64 1)
+  %464 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %463)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %464)
+  store ptr %464, ptr @"*_llgo_main.errorString", align 8
+  %465 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %466 = load ptr, ptr @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU", align 8
+  %467 = icmp eq ptr %466, null
+  br i1 %467, label %_llgo_65, label %_llgo_66
+
+_llgo_65:                                         ; preds = %_llgo_64
+  %468 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 5 }, ptr undef }, ptr %465, 1
+  %469 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %470 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %469, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %468, ptr %470, align 8
+  %471 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %469, 0
+  %472 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %471, i64 1, 1
+  %473 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %472, i64 1, 2
+  %474 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %473)
+  store ptr %474, ptr @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU", align 8
+  br label %_llgo_66
+
+_llgo_66:                                         ; preds = %_llgo_65, %_llgo_64
   ret void
 }
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.NewNamedInterface"(%"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.String")
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64)
 
@@ -1715,9 +1744,11 @@ declare ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64)
 
 declare void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr)
 
-declare ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.Slice")
+declare void @"github.com/goplus/llgo/internal/runtime.InitNamedInterface"(ptr, %"github.com/goplus/llgo/internal/runtime.Slice")
 
 declare i1 @"github.com/goplus/llgo/internal/runtime.Implements"(ptr, ptr)
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.Slice")
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr, ptr)
 

--- a/cl/_testrt/tpmethod/out.ll
+++ b/cl/_testrt/tpmethod/out.ll
@@ -19,13 +19,13 @@ source_filename = "main"
 @"_llgo_main.Tuple[error]" = linkonce global ptr null, align 8
 @2 = private unnamed_addr constant [17 x i8] c"main.Tuple[error]", align 1
 @_llgo_error = linkonce global ptr null, align 8
+@3 = private unnamed_addr constant [5 x i8] c"error", align 1
 @_llgo_string = linkonce global ptr null, align 8
 @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" = linkonce global ptr null, align 8
-@3 = private unnamed_addr constant [5 x i8] c"Error", align 1
-@4 = private unnamed_addr constant [4 x i8] c"main", align 1
-@5 = private unnamed_addr constant [5 x i8] c"error", align 1
+@4 = private unnamed_addr constant [5 x i8] c"Error", align 1
 @"main.struct$ddtj0teo4LtYcagzh1w6BsSZ7226uefXlqreeHsfVRo" = linkonce global ptr null, align 8
-@6 = private unnamed_addr constant [1 x i8] c"v", align 1
+@5 = private unnamed_addr constant [1 x i8] c"v", align 1
+@6 = private unnamed_addr constant [4 x i8] c"main", align 1
 @7 = private unnamed_addr constant [3 x i8] c"Get", align 1
 @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w" = linkonce global ptr null, align 8
 @8 = private unnamed_addr constant [12 x i8] c"Tuple[error]", align 1
@@ -186,309 +186,310 @@ _llgo_1:                                          ; preds = %_llgo_0
   br label %_llgo_2
 
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-  %4 = load ptr, ptr @_llgo_string, align 8
-  %5 = icmp eq ptr %4, null
-  br i1 %5, label %_llgo_3, label %_llgo_4
+  %4 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamedInterface"(%"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 5 })
+  %5 = load ptr, ptr @_llgo_error, align 8
+  %6 = icmp eq ptr %5, null
+  br i1 %6, label %_llgo_3, label %_llgo_4
 
 _llgo_3:                                          ; preds = %_llgo_2
-  %6 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
-  store ptr %6, ptr @_llgo_string, align 8
+  store ptr %4, ptr @_llgo_error, align 8
   br label %_llgo_4
 
 _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
   %7 = load ptr, ptr @_llgo_string, align 8
-  %8 = load ptr, ptr @_llgo_string, align 8
-  %9 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %10 = icmp eq ptr %9, null
-  br i1 %10, label %_llgo_5, label %_llgo_6
+  %8 = icmp eq ptr %7, null
+  br i1 %8, label %_llgo_5, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_4
-  %11 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %12 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %11, 0
-  %13 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %12, i64 0, 1
-  %14 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %13, i64 0, 2
-  %15 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %16 = getelementptr ptr, ptr %15, i64 0
-  store ptr %8, ptr %16, align 8
-  %17 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %15, 0
-  %18 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %17, i64 1, 1
-  %19 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %18, i64 1, 2
-  %20 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %14, %"github.com/goplus/llgo/internal/runtime.Slice" %19, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %20)
-  store ptr %20, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %9 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  store ptr %9, ptr @_llgo_string, align 8
   br label %_llgo_6
 
 _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-  %21 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %22 = load ptr, ptr @_llgo_error, align 8
-  %23 = icmp eq ptr %22, null
-  br i1 %23, label %_llgo_7, label %_llgo_8
+  %10 = load ptr, ptr @_llgo_string, align 8
+  %11 = load ptr, ptr @_llgo_string, align 8
+  %12 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  %13 = icmp eq ptr %12, null
+  br i1 %13, label %_llgo_7, label %_llgo_8
 
 _llgo_7:                                          ; preds = %_llgo_6
-  %24 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 5 }, ptr undef }, ptr %21, 1
-  %25 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %26 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %25, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %24, ptr %26, align 8
-  %27 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %25, 0
-  %28 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %27, i64 1, 1
-  %29 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %28, i64 1, 2
-  %30 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 5 }, %"github.com/goplus/llgo/internal/runtime.Slice" %29)
-  store ptr %30, ptr @_llgo_error, align 8
+  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %15 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %14, 0
+  %16 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %15, i64 0, 1
+  %17 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %16, i64 0, 2
+  %18 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %19 = getelementptr ptr, ptr %18, i64 0
+  store ptr %11, ptr %19, align 8
+  %20 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %18, 0
+  %21 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %20, i64 1, 1
+  %22 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %21, i64 1, 2
+  %23 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %17, %"github.com/goplus/llgo/internal/runtime.Slice" %22, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %23)
+  store ptr %23, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
   br label %_llgo_8
 
 _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
+  %24 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
+  br i1 %6, label %_llgo_9, label %_llgo_10
+
+_llgo_9:                                          ; preds = %_llgo_8
+  %25 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 5 }, ptr undef }, ptr %24, 1
+  %26 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %27 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %26, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %25, ptr %27, align 8
+  %28 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %26, 0
+  %29 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %28, i64 1, 1
+  %30 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %29, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamedInterface"(ptr %4, %"github.com/goplus/llgo/internal/runtime.Slice" %30)
+  br label %_llgo_10
+
+_llgo_10:                                         ; preds = %_llgo_9, %_llgo_8
   %31 = load ptr, ptr @_llgo_error, align 8
-  %32 = load ptr, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", align 8
-  %33 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 5 }, ptr undef }, ptr %32, 1
-  %34 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %35 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %34, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %33, ptr %35, align 8
+  %32 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamedInterface"(%"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 5 })
+  %33 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 1 }, ptr %32, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %34 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
+  %35 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %34, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %33, ptr %35, align 8
   %36 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %34, 0
   %37 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %36, i64 1, 1
   %38 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %37, i64 1, 2
-  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 5 }, %"github.com/goplus/llgo/internal/runtime.Slice" %38)
-  %40 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 1 }, ptr %39, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
-  %41 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
-  %42 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %41, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %40, ptr %42, align 8
-  %43 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %41, 0
-  %44 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %43, i64 1, 1
-  %45 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %44, i64 1, 2
-  %46 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %45)
-  store ptr %46, ptr @"main.struct$ddtj0teo4LtYcagzh1w6BsSZ7226uefXlqreeHsfVRo", align 8
-  %47 = load ptr, ptr @"main.struct$ddtj0teo4LtYcagzh1w6BsSZ7226uefXlqreeHsfVRo", align 8
-  br i1 %3, label %_llgo_9, label %_llgo_10
+  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %38)
+  store ptr %39, ptr @"main.struct$ddtj0teo4LtYcagzh1w6BsSZ7226uefXlqreeHsfVRo", align 8
+  %40 = load ptr, ptr @"main.struct$ddtj0teo4LtYcagzh1w6BsSZ7226uefXlqreeHsfVRo", align 8
+  br i1 %3, label %_llgo_11, label %_llgo_12
 
-_llgo_9:                                          ; preds = %_llgo_8
-  %48 = load ptr, ptr @_llgo_error, align 8
-  %49 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
-  %50 = icmp eq ptr %49, null
-  br i1 %50, label %_llgo_11, label %_llgo_12
+_llgo_11:                                         ; preds = %_llgo_10
+  %41 = load ptr, ptr @_llgo_error, align 8
+  %42 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
+  %43 = icmp eq ptr %42, null
+  br i1 %43, label %_llgo_13, label %_llgo_14
 
-_llgo_10:                                         ; preds = %_llgo_12, %_llgo_8
-  %51 = load ptr, ptr @"_llgo_main.Tuple[error]", align 8
-  %52 = load ptr, ptr @"_llgo_main.Tuple[error]", align 8
-  %53 = load ptr, ptr @"_llgo_func$1BeCdGdxwWG-Dtl1HbNuSy2_sb8rBMTmu7zhcPPofmU", align 8
-  %54 = icmp eq ptr %53, null
-  br i1 %54, label %_llgo_13, label %_llgo_14
+_llgo_12:                                         ; preds = %_llgo_14, %_llgo_10
+  %44 = load ptr, ptr @"_llgo_main.Tuple[error]", align 8
+  %45 = load ptr, ptr @"_llgo_main.Tuple[error]", align 8
+  %46 = load ptr, ptr @"_llgo_func$1BeCdGdxwWG-Dtl1HbNuSy2_sb8rBMTmu7zhcPPofmU", align 8
+  %47 = icmp eq ptr %46, null
+  br i1 %47, label %_llgo_15, label %_llgo_16
 
-_llgo_11:                                         ; preds = %_llgo_9
-  %55 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %56 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %55, 0
-  %57 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %56, i64 0, 1
-  %58 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %57, i64 0, 2
-  %59 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %60 = getelementptr ptr, ptr %59, i64 0
-  store ptr %48, ptr %60, align 8
-  %61 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %59, 0
-  %62 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %61, i64 1, 1
-  %63 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %62, i64 1, 2
-  %64 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %58, %"github.com/goplus/llgo/internal/runtime.Slice" %63, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %64)
-  store ptr %64, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
-  br label %_llgo_12
-
-_llgo_12:                                         ; preds = %_llgo_11, %_llgo_9
-  %65 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
-  %66 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 3 }, ptr undef, ptr undef, ptr undef }, ptr %65, 1
-  %67 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %66, ptr @"main.(*Tuple[error]).Get", 2
-  %68 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %67, ptr @"main.(*Tuple[error]).Get", 3
-  %69 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 3 }, ptr undef, ptr undef, ptr undef }, ptr %65, 1
-  %70 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %69, ptr @"main.(*Tuple[error]).Get", 2
-  %71 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %70, ptr @"main.Tuple[error].Get", 3
-  %72 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %73 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %72, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %71, ptr %73, align 8
-  %74 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %72, 0
-  %75 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %74, i64 1, 1
-  %76 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %75, i64 1, 2
-  %77 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %78 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %77, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %68, ptr %78, align 8
-  %79 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %77, 0
-  %80 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %79, i64 1, 1
-  %81 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %80, i64 1, 2
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %1, %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 12 }, ptr %47, %"github.com/goplus/llgo/internal/runtime.Slice" %76, %"github.com/goplus/llgo/internal/runtime.Slice" %81)
-  br label %_llgo_10
-
-_llgo_13:                                         ; preds = %_llgo_10
-  %82 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %83 = getelementptr ptr, ptr %82, i64 0
-  store ptr %52, ptr %83, align 8
-  %84 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %82, 0
-  %85 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %84, i64 1, 1
-  %86 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %85, i64 1, 2
-  %87 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %88 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %87, 0
-  %89 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %88, i64 0, 1
-  %90 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %89, i64 0, 2
-  %91 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %86, %"github.com/goplus/llgo/internal/runtime.Slice" %90, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %91)
-  store ptr %91, ptr @"_llgo_func$1BeCdGdxwWG-Dtl1HbNuSy2_sb8rBMTmu7zhcPPofmU", align 8
+_llgo_13:                                         ; preds = %_llgo_11
+  %48 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %49 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %48, 0
+  %50 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %49, i64 0, 1
+  %51 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %50, i64 0, 2
+  %52 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %53 = getelementptr ptr, ptr %52, i64 0
+  store ptr %41, ptr %53, align 8
+  %54 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %52, 0
+  %55 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %54, i64 1, 1
+  %56 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %55, i64 1, 2
+  %57 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %51, %"github.com/goplus/llgo/internal/runtime.Slice" %56, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %57)
+  store ptr %57, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
   br label %_llgo_14
 
-_llgo_14:                                         ; preds = %_llgo_13, %_llgo_10
-  %92 = load ptr, ptr @"_llgo_func$1BeCdGdxwWG-Dtl1HbNuSy2_sb8rBMTmu7zhcPPofmU", align 8
-  %93 = load ptr, ptr @_llgo_Pointer, align 8
-  %94 = icmp eq ptr %93, null
-  br i1 %94, label %_llgo_15, label %_llgo_16
+_llgo_14:                                         ; preds = %_llgo_13, %_llgo_11
+  %58 = load ptr, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", align 8
+  %59 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 3 }, ptr undef, ptr undef, ptr undef }, ptr %58, 1
+  %60 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %59, ptr @"main.(*Tuple[error]).Get", 2
+  %61 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %60, ptr @"main.(*Tuple[error]).Get", 3
+  %62 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @7, i64 3 }, ptr undef, ptr undef, ptr undef }, ptr %58, 1
+  %63 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %62, ptr @"main.(*Tuple[error]).Get", 2
+  %64 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %63, ptr @"main.Tuple[error].Get", 3
+  %65 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %66 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %65, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %64, ptr %66, align 8
+  %67 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %65, 0
+  %68 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %67, i64 1, 1
+  %69 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %68, i64 1, 2
+  %70 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %71 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %70, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %61, ptr %71, align 8
+  %72 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %70, 0
+  %73 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %72, i64 1, 1
+  %74 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %73, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %1, %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 12 }, ptr %40, %"github.com/goplus/llgo/internal/runtime.Slice" %69, %"github.com/goplus/llgo/internal/runtime.Slice" %74)
+  br label %_llgo_12
 
-_llgo_15:                                         ; preds = %_llgo_14
-  %95 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %95)
-  store ptr %95, ptr @_llgo_Pointer, align 8
+_llgo_15:                                         ; preds = %_llgo_12
+  %75 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %76 = getelementptr ptr, ptr %75, i64 0
+  store ptr %45, ptr %76, align 8
+  %77 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %75, 0
+  %78 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %77, i64 1, 1
+  %79 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %78, i64 1, 2
+  %80 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %81 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %80, 0
+  %82 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %81, i64 0, 1
+  %83 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %82, i64 0, 2
+  %84 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %79, %"github.com/goplus/llgo/internal/runtime.Slice" %83, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %84)
+  store ptr %84, ptr @"_llgo_func$1BeCdGdxwWG-Dtl1HbNuSy2_sb8rBMTmu7zhcPPofmU", align 8
   br label %_llgo_16
 
-_llgo_16:                                         ; preds = %_llgo_15, %_llgo_14
-  %96 = load ptr, ptr @_llgo_Pointer, align 8
-  %97 = load ptr, ptr @"_llgo_main.Tuple[error]", align 8
-  %98 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %99 = getelementptr ptr, ptr %98, i64 0
-  store ptr %97, ptr %99, align 8
-  %100 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %98, 0
-  %101 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %100, i64 1, 1
-  %102 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %101, i64 1, 2
-  %103 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %104 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %103, 0
-  %105 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %104, i64 0, 1
-  %106 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %105, i64 0, 2
-  %107 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %102, %"github.com/goplus/llgo/internal/runtime.Slice" %106, i1 false)
-  %108 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 1 }, ptr %107, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
-  %109 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %110 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, ptr %109, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
-  %111 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %112 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %111, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %108, ptr %112, align 8
-  %113 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %111, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %110, ptr %113, align 8
-  %114 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %111, 0
-  %115 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %114, i64 2, 1
-  %116 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %115, i64 2, 2
-  %117 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %116)
-  store ptr %117, ptr @"main.struct$rDvDk5u0SueGnrMxDz_wBrplEFUjtXshBCEyKeM6edc", align 8
-  %118 = load ptr, ptr @"main.struct$rDvDk5u0SueGnrMxDz_wBrplEFUjtXshBCEyKeM6edc", align 8
-  %119 = load ptr, ptr @"main.struct$rDvDk5u0SueGnrMxDz_wBrplEFUjtXshBCEyKeM6edc", align 8
-  %120 = load ptr, ptr @"_llgo_func$80MkNg5FlG-QIrR0qzHGiPc77AqvdbJflSWOeG5LcUY", align 8
-  %121 = icmp eq ptr %120, null
-  br i1 %121, label %_llgo_17, label %_llgo_18
+_llgo_16:                                         ; preds = %_llgo_15, %_llgo_12
+  %85 = load ptr, ptr @"_llgo_func$1BeCdGdxwWG-Dtl1HbNuSy2_sb8rBMTmu7zhcPPofmU", align 8
+  %86 = load ptr, ptr @_llgo_Pointer, align 8
+  %87 = icmp eq ptr %86, null
+  br i1 %87, label %_llgo_17, label %_llgo_18
 
 _llgo_17:                                         ; preds = %_llgo_16
-  %122 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %123 = getelementptr ptr, ptr %122, i64 0
-  store ptr %119, ptr %123, align 8
-  %124 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %122, 0
-  %125 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %124, i64 1, 1
-  %126 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %125, i64 1, 2
-  %127 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %128 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %127, 0
-  %129 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %128, i64 0, 1
-  %130 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %129, i64 0, 2
-  %131 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %126, %"github.com/goplus/llgo/internal/runtime.Slice" %130, i1 false)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %131)
-  store ptr %131, ptr @"_llgo_func$80MkNg5FlG-QIrR0qzHGiPc77AqvdbJflSWOeG5LcUY", align 8
+  %88 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %88)
+  store ptr %88, ptr @_llgo_Pointer, align 8
   br label %_llgo_18
 
 _llgo_18:                                         ; preds = %_llgo_17, %_llgo_16
-  %132 = load ptr, ptr @"_llgo_func$80MkNg5FlG-QIrR0qzHGiPc77AqvdbJflSWOeG5LcUY", align 8
-  %133 = load ptr, ptr @"main.struct$rDvDk5u0SueGnrMxDz_wBrplEFUjtXshBCEyKeM6edc", align 8
-  %134 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %135 = getelementptr ptr, ptr %134, i64 0
-  store ptr %133, ptr %135, align 8
-  %136 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %134, 0
-  %137 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %136, i64 1, 1
-  %138 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %137, i64 1, 2
-  %139 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %140 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %139, 0
-  %141 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %140, i64 0, 1
-  %142 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %141, i64 0, 2
-  %143 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %138, %"github.com/goplus/llgo/internal/runtime.Slice" %142, i1 false)
-  %144 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 1 }, ptr %143, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
-  %145 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %146 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, ptr %145, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
-  %147 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %148 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %147, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %144, ptr %148, align 8
-  %149 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %147, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %146, ptr %149, align 8
-  %150 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %147, 0
-  %151 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %150, i64 2, 1
-  %152 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %151, i64 2, 2
-  %153 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %152)
-  store ptr %153, ptr @"main.struct$mxZtxt4nClm7R35-Ksu7sUaZcPWf2mnqwCsrqo4qOB8", align 8
-  %154 = load ptr, ptr @"main.struct$mxZtxt4nClm7R35-Ksu7sUaZcPWf2mnqwCsrqo4qOB8", align 8
-  %155 = load ptr, ptr @"main.struct$rDvDk5u0SueGnrMxDz_wBrplEFUjtXshBCEyKeM6edc", align 8
-  %156 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
-  %157 = getelementptr ptr, ptr %156, i64 0
-  store ptr %155, ptr %157, align 8
-  %158 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %156, 0
-  %159 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %158, i64 1, 1
-  %160 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %159, i64 1, 2
-  %161 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
-  %162 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %161, 0
-  %163 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %162, i64 0, 1
-  %164 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %163, i64 0, 2
-  %165 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %160, %"github.com/goplus/llgo/internal/runtime.Slice" %164, i1 false)
-  %166 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 1 }, ptr %165, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
-  %167 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %168 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, ptr %167, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
-  %169 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
-  %170 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %169, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %166, ptr %170, align 8
-  %171 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %169, i64 1
-  store %"github.com/goplus/llgo/internal/abi.StructField" %168, ptr %171, align 8
-  %172 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %169, 0
-  %173 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %172, i64 2, 1
-  %174 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %173, i64 2, 2
-  %175 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %174)
-  %176 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 2 }, ptr %175, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
-  %177 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
-  %178 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %177, i64 0
-  store %"github.com/goplus/llgo/internal/abi.StructField" %176, ptr %178, align 8
-  %179 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %177, 0
-  %180 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %179, i64 1, 1
-  %181 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %180, i64 1, 2
-  %182 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %181)
-  store ptr %182, ptr @"main.struct$LaXSfCbp9zvBYWtLq2i0GtWrY5UrmS8NmXCVxsyY920", align 8
-  %183 = load ptr, ptr @"main.struct$LaXSfCbp9zvBYWtLq2i0GtWrY5UrmS8NmXCVxsyY920", align 8
-  %184 = load ptr, ptr @"_llgo_func$1BeCdGdxwWG-Dtl1HbNuSy2_sb8rBMTmu7zhcPPofmU", align 8
-  %185 = load ptr, ptr @"main.struct$rDvDk5u0SueGnrMxDz_wBrplEFUjtXshBCEyKeM6edc", align 8
-  %186 = load ptr, ptr @"_llgo_func$80MkNg5FlG-QIrR0qzHGiPc77AqvdbJflSWOeG5LcUY", align 8
-  %187 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @12, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %186, 1
-  %188 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %187, ptr @"main.(*future[main.Tuple[error]]).Then", 2
-  %189 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %188, ptr @"main.(*future[main.Tuple[error]]).Then", 3
-  %190 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
-  %191 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %190, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Method" %189, ptr %191, align 8
-  %192 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %190, 0
-  %193 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %192, i64 1, 1
-  %194 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %193, i64 1, 2
-  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %0, %"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @13, i64 25 }, ptr %183, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %194)
-  %195 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 30 }, i64 25, i64 24, i64 0, i64 1)
-  %196 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %195)
-  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %196)
-  store ptr %196, ptr @"*_llgo_main.future[main.Tuple[error]]", align 8
-  %197 = load ptr, ptr @"_llgo_func$80MkNg5FlG-QIrR0qzHGiPc77AqvdbJflSWOeG5LcUY", align 8
-  %198 = load ptr, ptr @"_llgo_iface$siNiE0pGpvdoyzPUhSP4dREmGht9v7Axb0C9hezIyDM", align 8
-  %199 = icmp eq ptr %198, null
-  br i1 %199, label %_llgo_19, label %_llgo_20
+  %89 = load ptr, ptr @_llgo_Pointer, align 8
+  %90 = load ptr, ptr @"_llgo_main.Tuple[error]", align 8
+  %91 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %92 = getelementptr ptr, ptr %91, i64 0
+  store ptr %90, ptr %92, align 8
+  %93 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %91, 0
+  %94 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %93, i64 1, 1
+  %95 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %94, i64 1, 2
+  %96 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %97 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %96, 0
+  %98 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %97, i64 0, 1
+  %99 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %98, i64 0, 2
+  %100 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %95, %"github.com/goplus/llgo/internal/runtime.Slice" %99, i1 false)
+  %101 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 1 }, ptr %100, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %102 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %103 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, ptr %102, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %104 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %105 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %104, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %101, ptr %105, align 8
+  %106 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %104, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %103, ptr %106, align 8
+  %107 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %104, 0
+  %108 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %107, i64 2, 1
+  %109 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %108, i64 2, 2
+  %110 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %109)
+  store ptr %110, ptr @"main.struct$rDvDk5u0SueGnrMxDz_wBrplEFUjtXshBCEyKeM6edc", align 8
+  %111 = load ptr, ptr @"main.struct$rDvDk5u0SueGnrMxDz_wBrplEFUjtXshBCEyKeM6edc", align 8
+  %112 = load ptr, ptr @"main.struct$rDvDk5u0SueGnrMxDz_wBrplEFUjtXshBCEyKeM6edc", align 8
+  %113 = load ptr, ptr @"_llgo_func$80MkNg5FlG-QIrR0qzHGiPc77AqvdbJflSWOeG5LcUY", align 8
+  %114 = icmp eq ptr %113, null
+  br i1 %114, label %_llgo_19, label %_llgo_20
 
 _llgo_19:                                         ; preds = %_llgo_18
-  %200 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @12, i64 4 }, ptr undef }, ptr %197, 1
-  %201 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
-  %202 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %201, i64 0
-  store %"github.com/goplus/llgo/internal/abi.Imethod" %200, ptr %202, align 8
-  %203 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %201, 0
-  %204 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %203, i64 1, 1
-  %205 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %204, i64 1, 2
-  %206 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %205)
-  store ptr %206, ptr @"_llgo_iface$siNiE0pGpvdoyzPUhSP4dREmGht9v7Axb0C9hezIyDM", align 8
+  %115 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %116 = getelementptr ptr, ptr %115, i64 0
+  store ptr %112, ptr %116, align 8
+  %117 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %115, 0
+  %118 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %117, i64 1, 1
+  %119 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %118, i64 1, 2
+  %120 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %121 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %120, 0
+  %122 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %121, i64 0, 1
+  %123 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %122, i64 0, 2
+  %124 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %119, %"github.com/goplus/llgo/internal/runtime.Slice" %123, i1 false)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %124)
+  store ptr %124, ptr @"_llgo_func$80MkNg5FlG-QIrR0qzHGiPc77AqvdbJflSWOeG5LcUY", align 8
   br label %_llgo_20
 
 _llgo_20:                                         ; preds = %_llgo_19, %_llgo_18
+  %125 = load ptr, ptr @"_llgo_func$80MkNg5FlG-QIrR0qzHGiPc77AqvdbJflSWOeG5LcUY", align 8
+  %126 = load ptr, ptr @"main.struct$rDvDk5u0SueGnrMxDz_wBrplEFUjtXshBCEyKeM6edc", align 8
+  %127 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %128 = getelementptr ptr, ptr %127, i64 0
+  store ptr %126, ptr %128, align 8
+  %129 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %127, 0
+  %130 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %129, i64 1, 1
+  %131 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %130, i64 1, 2
+  %132 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %133 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %132, 0
+  %134 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %133, i64 0, 1
+  %135 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %134, i64 0, 2
+  %136 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %131, %"github.com/goplus/llgo/internal/runtime.Slice" %135, i1 false)
+  %137 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 1 }, ptr %136, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %138 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %139 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, ptr %138, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %140 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %141 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %140, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %137, ptr %141, align 8
+  %142 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %140, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %139, ptr %142, align 8
+  %143 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %140, 0
+  %144 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %143, i64 2, 1
+  %145 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %144, i64 2, 2
+  %146 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %145)
+  store ptr %146, ptr @"main.struct$mxZtxt4nClm7R35-Ksu7sUaZcPWf2mnqwCsrqo4qOB8", align 8
+  %147 = load ptr, ptr @"main.struct$mxZtxt4nClm7R35-Ksu7sUaZcPWf2mnqwCsrqo4qOB8", align 8
+  %148 = load ptr, ptr @"main.struct$rDvDk5u0SueGnrMxDz_wBrplEFUjtXshBCEyKeM6edc", align 8
+  %149 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
+  %150 = getelementptr ptr, ptr %149, i64 0
+  store ptr %148, ptr %150, align 8
+  %151 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %149, 0
+  %152 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %151, i64 1, 1
+  %153 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %152, i64 1, 2
+  %154 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 0)
+  %155 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %154, 0
+  %156 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %155, i64 0, 1
+  %157 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %156, i64 0, 2
+  %158 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %153, %"github.com/goplus/llgo/internal/runtime.Slice" %157, i1 false)
+  %159 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 1 }, ptr %158, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %160 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
+  %161 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @10, i64 4 }, ptr %160, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %162 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
+  %163 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %162, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %159, ptr %163, align 8
+  %164 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %162, i64 1
+  store %"github.com/goplus/llgo/internal/abi.StructField" %161, ptr %164, align 8
+  %165 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %162, 0
+  %166 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %165, i64 2, 1
+  %167 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %166, i64 2, 2
+  %168 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %167)
+  %169 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 2 }, ptr %168, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %170 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 56)
+  %171 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %170, i64 0
+  store %"github.com/goplus/llgo/internal/abi.StructField" %169, ptr %171, align 8
+  %172 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %170, 0
+  %173 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %172, i64 1, 1
+  %174 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %173, i64 1, 2
+  %175 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %174)
+  store ptr %175, ptr @"main.struct$LaXSfCbp9zvBYWtLq2i0GtWrY5UrmS8NmXCVxsyY920", align 8
+  %176 = load ptr, ptr @"main.struct$LaXSfCbp9zvBYWtLq2i0GtWrY5UrmS8NmXCVxsyY920", align 8
+  %177 = load ptr, ptr @"_llgo_func$1BeCdGdxwWG-Dtl1HbNuSy2_sb8rBMTmu7zhcPPofmU", align 8
+  %178 = load ptr, ptr @"main.struct$rDvDk5u0SueGnrMxDz_wBrplEFUjtXshBCEyKeM6edc", align 8
+  %179 = load ptr, ptr @"_llgo_func$80MkNg5FlG-QIrR0qzHGiPc77AqvdbJflSWOeG5LcUY", align 8
+  %180 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @12, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %179, 1
+  %181 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %180, ptr @"main.(*future[main.Tuple[error]]).Then", 2
+  %182 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %181, ptr @"main.(*future[main.Tuple[error]]).Then", 3
+  %183 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 40)
+  %184 = getelementptr %"github.com/goplus/llgo/internal/abi.Method", ptr %183, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Method" %182, ptr %184, align 8
+  %185 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %183, 0
+  %186 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %185, i64 1, 1
+  %187 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %186, i64 1, 2
+  call void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr %0, %"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" { ptr @13, i64 25 }, ptr %176, { ptr, i64, i64 } zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %187)
+  %188 = call ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 30 }, i64 25, i64 24, i64 0, i64 1)
+  %189 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %188)
+  call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %189)
+  store ptr %189, ptr @"*_llgo_main.future[main.Tuple[error]]", align 8
+  %190 = load ptr, ptr @"_llgo_func$80MkNg5FlG-QIrR0qzHGiPc77AqvdbJflSWOeG5LcUY", align 8
+  %191 = load ptr, ptr @"_llgo_iface$siNiE0pGpvdoyzPUhSP4dREmGht9v7Axb0C9hezIyDM", align 8
+  %192 = icmp eq ptr %191, null
+  br i1 %192, label %_llgo_21, label %_llgo_22
+
+_llgo_21:                                         ; preds = %_llgo_20
+  %193 = insertvalue %"github.com/goplus/llgo/internal/abi.Imethod" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @12, i64 4 }, ptr undef }, ptr %190, 1
+  %194 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 24)
+  %195 = getelementptr %"github.com/goplus/llgo/internal/abi.Imethod", ptr %194, i64 0
+  store %"github.com/goplus/llgo/internal/abi.Imethod" %193, ptr %195, align 8
+  %196 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %194, 0
+  %197 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %196, i64 1, 1
+  %198 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %197, i64 1, 2
+  %199 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 4 }, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/internal/runtime.Slice" %198)
+  store ptr %199, ptr @"_llgo_iface$siNiE0pGpvdoyzPUhSP4dREmGht9v7Axb0C9hezIyDM", align 8
+  br label %_llgo_22
+
+_llgo_22:                                         ; preds = %_llgo_21, %_llgo_20
   ret void
 }
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.NewNamed"(%"github.com/goplus/llgo/internal/runtime.String", i64, i64, i64, i64)
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.NewNamedInterface"(%"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.String")
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64)
 
@@ -498,7 +499,7 @@ declare ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64)
 
 declare void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr)
 
-declare ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.Slice")
+declare void @"github.com/goplus/llgo/internal/runtime.InitNamedInterface"(ptr, %"github.com/goplus/llgo/internal/runtime.Slice")
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String", i64, %"github.com/goplus/llgo/internal/runtime.Slice")
 
@@ -507,6 +508,8 @@ declare %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/l
 declare void @"github.com/goplus/llgo/internal/runtime.InitNamed"(ptr, %"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.String", ptr, %"github.com/goplus/llgo/internal/runtime.Slice", %"github.com/goplus/llgo/internal/runtime.Slice")
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr)
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.String", %"github.com/goplus/llgo/internal/runtime.Slice")
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr, ptr)
 

--- a/internal/runtime/z_face.go
+++ b/internal/runtime/z_face.go
@@ -224,6 +224,40 @@ func Func(in, out []*Type, variadic bool) *FuncType {
 	return ret
 }
 
+func NewNamedInterface(pkgPath, name string) *InterfaceType {
+	ret := &struct {
+		abi.InterfaceType
+		u abi.UncommonType
+	}{
+		abi.InterfaceType{
+			Type: Type{
+				Size_:       unsafe.Sizeof(eface{}),
+				PtrBytes:    2 * pointerSize,
+				Hash:        uint32(abi.Interface), // TODO(xsw): hash
+				Align_:      uint8(pointerAlign),
+				FieldAlign_: uint8(pointerAlign),
+				Kind_:       uint8(abi.Interface),
+				Str_:        name,
+				TFlag:       abi.TFlagNamed | abi.TFlagUncommon,
+			},
+			PkgPath_: pkgPath,
+		},
+		abi.UncommonType{
+			PkgPath_: pkgPath,
+		},
+	}
+	return &ret.InterfaceType
+}
+
+func InitNamedInterface(ret *InterfaceType, methods []Imethod) {
+	ret.Methods = methods
+	if len(methods) == 0 {
+		ret.Equal = nilinterequal
+	} else {
+		ret.Equal = interequal
+	}
+}
+
 // Interface returns an interface type.
 // Don't call NewNamed for named interface type.
 func Interface(pkgPath, name string, methods []Imethod) *InterfaceType {


### PR DESCRIPTION
fix named interface init.
```
fix internal/reflectlite.Type imethod incorrect if recursion ( eg. Implements(u Type) bool )
fix named interface with abi.TFlagNamed | abi.TFlagUncommon
```