### PR TITLE
ssa: closure use specific struct field name

### DIFF
--- a/cl/_testgo/invoke/out.ll
+++ b/cl/_testgo/invoke/out.ll
@@ -59,9 +59,9 @@ source_filename = "main"
 @_llgo_main.T6 = linkonce global ptr null, align 8
 @19 = private unnamed_addr constant [2 x i8] c"T6", align 1
 @_llgo_Pointer = linkonce global ptr null, align 8
-@"main.struct$ShRx0rnZQIkym8zpNxljLHWZbDzaCdzDkVBTe78YZMw" = linkonce global ptr null, align 8
-@20 = private unnamed_addr constant [1 x i8] c"f", align 1
-@21 = private unnamed_addr constant [4 x i8] c"data", align 1
+@"main.struct$TWlEC03isGYe2Nyy2HYnOBsOYR1lIx43oIUpIyqvm4s" = linkonce global ptr null, align 8
+@20 = private unnamed_addr constant [2 x i8] c"$f", align 1
+@21 = private unnamed_addr constant [5 x i8] c"$data", align 1
 @"*_llgo_main.T6" = linkonce global ptr null, align 8
 @"_llgo_iface$jwmSdgh1zvY_TDIgLzCkvkbiyrdwl9N806DH0JGcyMI" = linkonce global ptr null, align 8
 @22 = private unnamed_addr constant [5 x i8] c"world", align 1
@@ -337,7 +337,6 @@ _llgo_0:
   call void @main.invoke(%"github.com/goplus/llgo/internal/runtime.iface" %81)
   %82 = load %main.T6, ptr %11, align 8
   %83 = load ptr, ptr @_llgo_main.T6, align 8
-  call void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr %83)
   %84 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
   store %main.T6 %82, ptr %84, align 8
   %85 = load ptr, ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", align 8
@@ -935,9 +934,9 @@ _llgo_56:                                         ; preds = %_llgo_55, %_llgo_54
   %231 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %230, i64 1, 1
   %232 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %231, i64 1, 2
   %233 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %227, %"github.com/goplus/llgo/internal/runtime.Slice" %232, i1 false)
-  %234 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @20, i64 1 }, ptr %233, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %234 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @20, i64 2 }, ptr %233, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %235 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %236 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @21, i64 4 }, ptr %235, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %236 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @21, i64 5 }, ptr %235, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %237 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
   %238 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %237, i64 0
   store %"github.com/goplus/llgo/internal/abi.StructField" %234, ptr %238, align 8
@@ -947,8 +946,8 @@ _llgo_56:                                         ; preds = %_llgo_55, %_llgo_54
   %241 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %240, i64 2, 1
   %242 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %241, i64 2, 2
   %243 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %242)
-  store ptr %243, ptr @"main.struct$ShRx0rnZQIkym8zpNxljLHWZbDzaCdzDkVBTe78YZMw", align 8
-  %244 = load ptr, ptr @"main.struct$ShRx0rnZQIkym8zpNxljLHWZbDzaCdzDkVBTe78YZMw", align 8
+  store ptr %243, ptr @"main.struct$TWlEC03isGYe2Nyy2HYnOBsOYR1lIx43oIUpIyqvm4s", align 8
+  %244 = load ptr, ptr @"main.struct$TWlEC03isGYe2Nyy2HYnOBsOYR1lIx43oIUpIyqvm4s", align 8
   br i1 %217, label %_llgo_57, label %_llgo_58
 
 _llgo_57:                                         ; preds = %_llgo_56
@@ -1074,8 +1073,6 @@ declare ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr, ptr)
 declare ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr)
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.ArrayOf"(i64, ptr)
-
-declare void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr)
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.IfaceType"(%"github.com/goplus/llgo/internal/runtime.iface")
 

--- a/cl/_testgo/reflect/in.go
+++ b/cl/_testgo/reflect/in.go
@@ -93,12 +93,11 @@ func callMethod() {
 	println("method", fn.Kind(), fn.Type().String())
 	r := fn.Call([]reflect.Value{reflect.ValueOf(100)})
 	println(r[0].Int())
-	//TODO type assert
-	// ifn, ok := fn.Interface().(func(int) int)
-	// if !ok {
-	// 	panic("error")
-	// }
-	// ifn(1)
+	ifn, ok := fn.Interface().(func(int) int)
+	if !ok {
+		panic("error")
+	}
+	ifn(1)
 	v2 := reflect.ValueOf(fn.Interface())
 	r2 := v2.Call([]reflect.Value{reflect.ValueOf(100)})
 	println(r2[0].Int())
@@ -111,12 +110,11 @@ func callIMethod() {
 	println("imethod", fn.Kind(), fn.Type().String())
 	r := fn.Call([]reflect.Value{reflect.ValueOf(100)})
 	println(r[0].Int())
-	//TODO type assert
-	// ifn, ok := fn.Interface().(func(int) int)
-	// if !ok {
-	// 	panic("error")
-	// }
-	// ifn(1)
+	ifn, ok := fn.Interface().(func(int) int)
+	if !ok {
+		panic("error")
+	}
+	ifn(1)
 	v2 := reflect.ValueOf(fn.Interface())
 	r2 := v2.Call([]reflect.Value{reflect.ValueOf(100)})
 	println(r2[0].Int())

--- a/cl/_testgo/reflect/out.ll
+++ b/cl/_testgo/reflect/out.ll
@@ -16,9 +16,9 @@ source_filename = "main"
 @_llgo_int = linkonce global ptr null, align 8
 @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" = linkonce global ptr null, align 8
 @_llgo_Pointer = linkonce global ptr null, align 8
-@"main.struct$0F5MIVpixVnQ6IoIDrJI9hTk70oCWg1odzb2q0E2rJ0" = linkonce global ptr null, align 8
-@1 = private unnamed_addr constant [1 x i8] c"f", align 1
-@2 = private unnamed_addr constant [4 x i8] c"data", align 1
+@"main.struct$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk" = linkonce global ptr null, align 8
+@1 = private unnamed_addr constant [2 x i8] c"$f", align 1
+@2 = private unnamed_addr constant [5 x i8] c"$data", align 1
 @3 = private unnamed_addr constant [4 x i8] c"main", align 1
 @4 = private unnamed_addr constant [7 x i8] c"closure", align 1
 @5 = private unnamed_addr constant [5 x i8] c"error", align 1
@@ -38,7 +38,7 @@ source_filename = "main"
 @_llgo_any = linkonce global ptr null, align 8
 @"[]_llgo_any" = linkonce global ptr null, align 8
 @"_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU" = linkonce global ptr null, align 8
-@"main.struct$zCLFE3aa581X7nuJztqlq4JjJDbHkfoMY0CexWOzH8A" = linkonce global ptr null, align 8
+@"main.struct$FjMjjQr3-2iTiWyZP1IIQFOz0hUCa0OS6pEm5uVV6Pk" = linkonce global ptr null, align 8
 @14 = private unnamed_addr constant [10 x i8] c"call.slice", align 1
 @15 = private unnamed_addr constant [21 x i8] c"type assertion failed", align 1
 @__llgo_argc = global i32 0, align 4
@@ -80,8 +80,7 @@ _llgo_0:
   %4 = load ptr, ptr @_llgo_int, align 8
   %5 = load ptr, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU", align 8
   %6 = load ptr, ptr @_llgo_Pointer, align 8
-  %7 = load ptr, ptr @"main.struct$0F5MIVpixVnQ6IoIDrJI9hTk70oCWg1odzb2q0E2rJ0", align 8
-  call void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr %7)
+  %7 = load ptr, ptr @"main.struct$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", align 8
   %8 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
   store { ptr, ptr } %3, ptr %8, align 8
   %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %7, 0
@@ -126,7 +125,7 @@ _llgo_0:
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   %39 = call %"github.com/goplus/llgo/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %11)
   %40 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %39, 0
-  %41 = load ptr, ptr @"main.struct$0F5MIVpixVnQ6IoIDrJI9hTk70oCWg1odzb2q0E2rJ0", align 8
+  %41 = load ptr, ptr @"main.struct$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", align 8
   %42 = icmp eq ptr %40, %41
   br i1 %42, label %_llgo_3, label %_llgo_4
 
@@ -176,8 +175,7 @@ _llgo_0:
 
 define void @main.callFunc() {
 _llgo_0:
-  %0 = load ptr, ptr @"main.struct$0F5MIVpixVnQ6IoIDrJI9hTk70oCWg1odzb2q0E2rJ0", align 8
-  call void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr %0)
+  %0 = load ptr, ptr @"main.struct$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", align 8
   %1 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
   store { ptr, ptr } { ptr @"__llgo_stub.main.callFunc$1", ptr null }, ptr %1, align 8
   %2 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %0, 0
@@ -222,7 +220,7 @@ _llgo_0:
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   %32 = call %"github.com/goplus/llgo/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %4)
   %33 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %32, 0
-  %34 = load ptr, ptr @"main.struct$0F5MIVpixVnQ6IoIDrJI9hTk70oCWg1odzb2q0E2rJ0", align 8
+  %34 = load ptr, ptr @"main.struct$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", align 8
   %35 = icmp eq ptr %33, %34
   br i1 %35, label %_llgo_3, label %_llgo_4
 
@@ -322,28 +320,63 @@ _llgo_0:
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %41)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   %42 = call %"github.com/goplus/llgo/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %14)
-  %43 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %42)
-  %44 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
-  %45 = getelementptr inbounds %reflect.Value, ptr %44, i64 0
-  %46 = load ptr, ptr @_llgo_int, align 8
-  %47 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %46, 0
-  %48 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %47, ptr inttoptr (i64 100 to ptr), 1
-  %49 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %48)
-  store %reflect.Value %49, ptr %45, align 8
-  %50 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %44, 0
-  %51 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %50, i64 1, 1
-  %52 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %51, i64 1, 2
-  %53 = call %"github.com/goplus/llgo/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %43, %"github.com/goplus/llgo/internal/runtime.Slice" %52)
-  %54 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %53, 0
-  %55 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %53, 1
-  %56 = icmp sge i64 0, %55
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %56)
-  %57 = getelementptr inbounds %reflect.Value, ptr %54, i64 0
-  %58 = load %reflect.Value, ptr %57, align 8
-  %59 = call i64 @reflect.Value.Int(%reflect.Value %58)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %59)
+  %43 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %42, 0
+  %44 = load ptr, ptr @"main.struct$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", align 8
+  %45 = icmp eq ptr %43, %44
+  br i1 %45, label %_llgo_3, label %_llgo_4
+
+_llgo_1:                                          ; preds = %_llgo_5
+  %46 = load ptr, ptr @_llgo_string, align 8
+  %47 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 5 }, ptr %47, align 8
+  %48 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %46, 0
+  %49 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %48, ptr %47, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %49)
+  unreachable
+
+_llgo_2:                                          ; preds = %_llgo_5
+  %50 = extractvalue { ptr, ptr } %76, 1
+  %51 = extractvalue { ptr, ptr } %76, 0
+  %52 = call i64 %51(ptr %50, i64 1)
+  %53 = call %"github.com/goplus/llgo/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %14)
+  %54 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %53)
+  %55 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
+  %56 = getelementptr inbounds %reflect.Value, ptr %55, i64 0
+  %57 = load ptr, ptr @_llgo_int, align 8
+  %58 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %57, 0
+  %59 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %58, ptr inttoptr (i64 100 to ptr), 1
+  %60 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %59)
+  store %reflect.Value %60, ptr %56, align 8
+  %61 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %55, 0
+  %62 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %61, i64 1, 1
+  %63 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %62, i64 1, 2
+  %64 = call %"github.com/goplus/llgo/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %54, %"github.com/goplus/llgo/internal/runtime.Slice" %63)
+  %65 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %64, 0
+  %66 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %64, 1
+  %67 = icmp sge i64 0, %66
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %67)
+  %68 = getelementptr inbounds %reflect.Value, ptr %65, i64 0
+  %69 = load %reflect.Value, ptr %68, align 8
+  %70 = call i64 @reflect.Value.Int(%reflect.Value %69)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %70)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret void
+
+_llgo_3:                                          ; preds = %_llgo_0
+  %71 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %42, 1
+  %72 = load { ptr, ptr }, ptr %71, align 8
+  %73 = insertvalue { { ptr, ptr }, i1 } undef, { ptr, ptr } %72, 0
+  %74 = insertvalue { { ptr, ptr }, i1 } %73, i1 true, 1
+  br label %_llgo_5
+
+_llgo_4:                                          ; preds = %_llgo_0
+  br label %_llgo_5
+
+_llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
+  %75 = phi { { ptr, ptr }, i1 } [ %74, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
+  %76 = extractvalue { { ptr, ptr }, i1 } %75, 0
+  %77 = extractvalue { { ptr, ptr }, i1 } %75, 1
+  br i1 %77, label %_llgo_2, label %_llgo_1
 }
 
 define void @main.callMethod() {
@@ -394,28 +427,63 @@ _llgo_0:
   call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %33)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   %34 = call %"github.com/goplus/llgo/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %6)
-  %35 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %34)
-  %36 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
-  %37 = getelementptr inbounds %reflect.Value, ptr %36, i64 0
-  %38 = load ptr, ptr @_llgo_int, align 8
-  %39 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %38, 0
-  %40 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %39, ptr inttoptr (i64 100 to ptr), 1
-  %41 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %40)
-  store %reflect.Value %41, ptr %37, align 8
-  %42 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %36, 0
-  %43 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %42, i64 1, 1
-  %44 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %43, i64 1, 2
-  %45 = call %"github.com/goplus/llgo/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %35, %"github.com/goplus/llgo/internal/runtime.Slice" %44)
-  %46 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %45, 0
-  %47 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %45, 1
-  %48 = icmp sge i64 0, %47
-  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %48)
-  %49 = getelementptr inbounds %reflect.Value, ptr %46, i64 0
-  %50 = load %reflect.Value, ptr %49, align 8
-  %51 = call i64 @reflect.Value.Int(%reflect.Value %50)
-  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %51)
+  %35 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %34, 0
+  %36 = load ptr, ptr @"main.struct$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", align 8
+  %37 = icmp eq ptr %35, %36
+  br i1 %37, label %_llgo_3, label %_llgo_4
+
+_llgo_1:                                          ; preds = %_llgo_5
+  %38 = load ptr, ptr @_llgo_string, align 8
+  %39 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 5 }, ptr %39, align 8
+  %40 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %38, 0
+  %41 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %40, ptr %39, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %41)
+  unreachable
+
+_llgo_2:                                          ; preds = %_llgo_5
+  %42 = extractvalue { ptr, ptr } %68, 1
+  %43 = extractvalue { ptr, ptr } %68, 0
+  %44 = call i64 %43(ptr %42, i64 1)
+  %45 = call %"github.com/goplus/llgo/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %6)
+  %46 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %45)
+  %47 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocZ"(i64 24)
+  %48 = getelementptr inbounds %reflect.Value, ptr %47, i64 0
+  %49 = load ptr, ptr @_llgo_int, align 8
+  %50 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %49, 0
+  %51 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %50, ptr inttoptr (i64 100 to ptr), 1
+  %52 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/internal/runtime.eface" %51)
+  store %reflect.Value %52, ptr %48, align 8
+  %53 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" undef, ptr %47, 0
+  %54 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %53, i64 1, 1
+  %55 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %54, i64 1, 2
+  %56 = call %"github.com/goplus/llgo/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %46, %"github.com/goplus/llgo/internal/runtime.Slice" %55)
+  %57 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %56, 0
+  %58 = extractvalue %"github.com/goplus/llgo/internal/runtime.Slice" %56, 1
+  %59 = icmp sge i64 0, %58
+  call void @"github.com/goplus/llgo/internal/runtime.AssertIndexRange"(i1 %59)
+  %60 = getelementptr inbounds %reflect.Value, ptr %57, i64 0
+  %61 = load %reflect.Value, ptr %60, align 8
+  %62 = call i64 @reflect.Value.Int(%reflect.Value %61)
+  call void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64 %62)
   call void @"github.com/goplus/llgo/internal/runtime.PrintByte"(i8 10)
   ret void
+
+_llgo_3:                                          ; preds = %_llgo_0
+  %63 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %34, 1
+  %64 = load { ptr, ptr }, ptr %63, align 8
+  %65 = insertvalue { { ptr, ptr }, i1 } undef, { ptr, ptr } %64, 0
+  %66 = insertvalue { { ptr, ptr }, i1 } %65, i1 true, 1
+  br label %_llgo_5
+
+_llgo_4:                                          ; preds = %_llgo_0
+  br label %_llgo_5
+
+_llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
+  %67 = phi { { ptr, ptr }, i1 } [ %66, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
+  %68 = extractvalue { { ptr, ptr }, i1 } %67, 0
+  %69 = extractvalue { { ptr, ptr }, i1 } %67, 1
+  br i1 %69, label %_llgo_2, label %_llgo_1
 }
 
 define void @main.callSlice() {
@@ -423,8 +491,7 @@ _llgo_0:
   %0 = load ptr, ptr @_llgo_any, align 8
   %1 = load ptr, ptr @"[]_llgo_any", align 8
   %2 = load ptr, ptr @"_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU", align 8
-  %3 = load ptr, ptr @"main.struct$zCLFE3aa581X7nuJztqlq4JjJDbHkfoMY0CexWOzH8A", align 8
-  call void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr %3)
+  %3 = load ptr, ptr @"main.struct$FjMjjQr3-2iTiWyZP1IIQFOz0hUCa0OS6pEm5uVV6Pk", align 8
   %4 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
   store { ptr, ptr } { ptr @__llgo_stub.main.demo, ptr null }, ptr %4, align 8
   %5 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %3, 0
@@ -1073,9 +1140,9 @@ _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
   %31 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %30, i64 1, 1
   %32 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %31, i64 1, 2
   %33 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %27, %"github.com/goplus/llgo/internal/runtime.Slice" %32, i1 false)
-  %34 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 1 }, ptr %33, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %34 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 2 }, ptr %33, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %35 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %36 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, ptr %35, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %36 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 5 }, ptr %35, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %37 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
   %38 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %37, i64 0
   store %"github.com/goplus/llgo/internal/abi.StructField" %34, ptr %38, align 8
@@ -1085,7 +1152,7 @@ _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
   %41 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %40, i64 2, 1
   %42 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %41, i64 2, 2
   %43 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %42)
-  store ptr %43, ptr @"main.struct$0F5MIVpixVnQ6IoIDrJI9hTk70oCWg1odzb2q0E2rJ0", align 8
+  store ptr %43, ptr @"main.struct$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", align 8
   %44 = load ptr, ptr @_llgo_string, align 8
   %45 = icmp eq ptr %44, null
   br i1 %45, label %_llgo_7, label %_llgo_8
@@ -1293,9 +1360,9 @@ _llgo_22:                                         ; preds = %_llgo_21, %_llgo_20
   %162 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %161, i64 2, 1
   %163 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %162, i64 2, 2
   %164 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %157, %"github.com/goplus/llgo/internal/runtime.Slice" %163, i1 true)
-  %165 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 1 }, ptr %164, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %165 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 2 }, ptr %164, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %166 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %167 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, ptr %166, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %167 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 5 }, ptr %166, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %168 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
   %169 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %168, i64 0
   store %"github.com/goplus/llgo/internal/abi.StructField" %165, ptr %169, align 8
@@ -1305,7 +1372,7 @@ _llgo_22:                                         ; preds = %_llgo_21, %_llgo_20
   %172 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %171, i64 2, 1
   %173 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %172, i64 2, 2
   %174 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %173)
-  store ptr %174, ptr @"main.struct$zCLFE3aa581X7nuJztqlq4JjJDbHkfoMY0CexWOzH8A", align 8
+  store ptr %174, ptr @"main.struct$FjMjjQr3-2iTiWyZP1IIQFOz0hUCa0OS6pEm5uVV6Pk", align 8
   %175 = load ptr, ptr @"map[_llgo_int]_llgo_string", align 8
   %176 = icmp eq ptr %175, null
   br i1 %176, label %_llgo_23, label %_llgo_24
@@ -1355,8 +1422,6 @@ declare void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr)
 declare ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String", i64, %"github.com/goplus/llgo/internal/runtime.Slice")
 
 declare %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String", ptr, i64, %"github.com/goplus/llgo/internal/runtime.String", i1)
-
-declare void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr)
 
 declare i64 @reflect.Value.Kind(%reflect.Value)
 

--- a/cl/_testrt/abinamed/out.ll
+++ b/cl/_testrt/abinamed/out.ll
@@ -29,14 +29,14 @@ source_filename = "main"
 @_llgo_Pointer = linkonce global ptr null, align 8
 @_llgo_bool = linkonce global ptr null, align 8
 @"_llgo_func$fC75jGwF1nV5TF91gEeTF_JCtbG9Z7_yOawHBxqBh6E" = linkonce global ptr null, align 8
-@"main.struct$LkOyXt2ZOfLj0dN8XuScd4CdSpCRJ9cWp1KI05fr0Ls" = linkonce global ptr null, align 8
-@5 = private unnamed_addr constant [1 x i8] c"f", align 1
-@6 = private unnamed_addr constant [4 x i8] c"data", align 1
+@"main.struct$6Ehc6TOqEXOG056rtIWcVOuWzJK8QENYOqW7yQ1sEPU" = linkonce global ptr null, align 8
+@5 = private unnamed_addr constant [2 x i8] c"$f", align 1
+@6 = private unnamed_addr constant [5 x i8] c"$data", align 1
 @_llgo_byte = linkonce global ptr null, align 8
 @"*_llgo_byte" = linkonce global ptr null, align 8
 @_llgo_string = linkonce global ptr null, align 8
 @"*_llgo_github.com/goplus/llgo/internal/abi.Type" = linkonce global ptr null, align 8
-@"main.struct$kUO272Qk09C5NvUyOEWKmjUAoxxi3RhHpgqoeM6e1Tk" = linkonce global ptr null, align 8
+@"main.struct$s_4wS-L0c3X6acFEdGgOe80u4rOxTCyvHVAjIByYQqY" = linkonce global ptr null, align 8
 @7 = private unnamed_addr constant [5 x i8] c"Size_", align 1
 @8 = private unnamed_addr constant [8 x i8] c"PtrBytes", align 1
 @9 = private unnamed_addr constant [4 x i8] c"Hash", align 1
@@ -108,9 +108,9 @@ source_filename = "main"
 @46 = private unnamed_addr constant [7 x i8] c"MapType", align 1
 @"_llgo_github.com/goplus/llgo/internal/abi.MapType" = linkonce global ptr null, align 8
 @"_llgo_func$ahHMZCcDhfW-lrs446sPkiW0NoVa2vpmK_wKarVa_20" = linkonce global ptr null, align 8
-@"main.struct$2gmPOZCguOeDHn3rO8wA0kSBY0yVjg54EviMsNeV45o" = linkonce global ptr null, align 8
+@"main.struct$Oy3XhjARgY_pH1HU6oBj0nSC2Qs1A6CU4bRajpBttZc" = linkonce global ptr null, align 8
 @_llgo_uint16 = linkonce global ptr null, align 8
-@"main.struct$jgHT3zlvUCWdGAH-l4Nn1MOOw31LQoSt74SxHNLR50Q" = linkonce global ptr null, align 8
+@"main.struct$NNQFCWl7PM2tdO3Cxl4doIs1_JQl2vsUbnXLc46j14k" = linkonce global ptr null, align 8
 @47 = private unnamed_addr constant [6 x i8] c"Bucket", align 1
 @48 = private unnamed_addr constant [6 x i8] c"Hasher", align 1
 @49 = private unnamed_addr constant [7 x i8] c"KeySize", align 1
@@ -569,9 +569,9 @@ _llgo_22:                                         ; preds = %_llgo_21, %_llgo_20
   %66 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %65, i64 1, 1
   %67 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %66, i64 1, 2
   %68 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %62, %"github.com/goplus/llgo/internal/runtime.Slice" %67, i1 false)
-  %69 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 1 }, ptr %68, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %69 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 2 }, ptr %68, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %70 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %71 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 4 }, ptr %70, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %71 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 5 }, ptr %70, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %72 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
   %73 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %72, i64 0
   store %"github.com/goplus/llgo/internal/abi.StructField" %69, ptr %73, align 8
@@ -581,8 +581,8 @@ _llgo_22:                                         ; preds = %_llgo_21, %_llgo_20
   %76 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %75, i64 2, 1
   %77 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %76, i64 2, 2
   %78 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %77)
-  store ptr %78, ptr @"main.struct$LkOyXt2ZOfLj0dN8XuScd4CdSpCRJ9cWp1KI05fr0Ls", align 8
-  %79 = load ptr, ptr @"main.struct$LkOyXt2ZOfLj0dN8XuScd4CdSpCRJ9cWp1KI05fr0Ls", align 8
+  store ptr %78, ptr @"main.struct$6Ehc6TOqEXOG056rtIWcVOuWzJK8QENYOqW7yQ1sEPU", align 8
+  %79 = load ptr, ptr @"main.struct$6Ehc6TOqEXOG056rtIWcVOuWzJK8QENYOqW7yQ1sEPU", align 8
   %80 = load ptr, ptr @_llgo_byte, align 8
   %81 = icmp eq ptr %80, null
   br i1 %81, label %_llgo_23, label %_llgo_24
@@ -665,9 +665,9 @@ _llgo_30:                                         ; preds = %_llgo_29, %_llgo_28
   %126 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %125, i64 1, 1
   %127 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %126, i64 1, 2
   %128 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %122, %"github.com/goplus/llgo/internal/runtime.Slice" %127, i1 false)
-  %129 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 1 }, ptr %128, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %129 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 2 }, ptr %128, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %130 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %131 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 4 }, ptr %130, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %131 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 5 }, ptr %130, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %132 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
   %133 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %132, i64 0
   store %"github.com/goplus/llgo/internal/abi.StructField" %129, ptr %133, align 8
@@ -712,8 +712,8 @@ _llgo_30:                                         ; preds = %_llgo_29, %_llgo_28
   %160 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %159, i64 11, 1
   %161 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %160, i64 11, 2
   %162 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, i64 72, %"github.com/goplus/llgo/internal/runtime.Slice" %161)
-  store ptr %162, ptr @"main.struct$kUO272Qk09C5NvUyOEWKmjUAoxxi3RhHpgqoeM6e1Tk", align 8
-  %163 = load ptr, ptr @"main.struct$kUO272Qk09C5NvUyOEWKmjUAoxxi3RhHpgqoeM6e1Tk", align 8
+  store ptr %162, ptr @"main.struct$s_4wS-L0c3X6acFEdGgOe80u4rOxTCyvHVAjIByYQqY", align 8
+  %163 = load ptr, ptr @"main.struct$s_4wS-L0c3X6acFEdGgOe80u4rOxTCyvHVAjIByYQqY", align 8
   br i1 %11, label %_llgo_31, label %_llgo_32
 
 _llgo_31:                                         ; preds = %_llgo_30
@@ -1781,9 +1781,9 @@ _llgo_106:                                        ; preds = %_llgo_105, %_llgo_1
   %870 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %869, i64 1, 1
   %871 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %870, i64 1, 2
   %872 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %866, %"github.com/goplus/llgo/internal/runtime.Slice" %871, i1 false)
-  %873 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 1 }, ptr %872, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %873 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 2 }, ptr %872, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %874 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %875 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 4 }, ptr %874, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %875 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 5 }, ptr %874, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %876 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
   %877 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %876, i64 0
   store %"github.com/goplus/llgo/internal/abi.StructField" %873, ptr %877, align 8
@@ -1793,8 +1793,8 @@ _llgo_106:                                        ; preds = %_llgo_105, %_llgo_1
   %880 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %879, i64 2, 1
   %881 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %880, i64 2, 2
   %882 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %881)
-  store ptr %882, ptr @"main.struct$2gmPOZCguOeDHn3rO8wA0kSBY0yVjg54EviMsNeV45o", align 8
-  %883 = load ptr, ptr @"main.struct$2gmPOZCguOeDHn3rO8wA0kSBY0yVjg54EviMsNeV45o", align 8
+  store ptr %882, ptr @"main.struct$Oy3XhjARgY_pH1HU6oBj0nSC2Qs1A6CU4bRajpBttZc", align 8
+  %883 = load ptr, ptr @"main.struct$Oy3XhjARgY_pH1HU6oBj0nSC2Qs1A6CU4bRajpBttZc", align 8
   %884 = load ptr, ptr @_llgo_uint16, align 8
   %885 = icmp eq ptr %884, null
   br i1 %885, label %_llgo_107, label %_llgo_108
@@ -1835,9 +1835,9 @@ _llgo_108:                                        ; preds = %_llgo_107, %_llgo_1
   %911 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %910, i64 1, 1
   %912 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %911, i64 1, 2
   %913 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %907, %"github.com/goplus/llgo/internal/runtime.Slice" %912, i1 false)
-  %914 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 1 }, ptr %913, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %914 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 2 }, ptr %913, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %915 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %916 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 4 }, ptr %915, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %916 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @6, i64 5 }, ptr %915, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %917 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
   %918 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %917, i64 0
   store %"github.com/goplus/llgo/internal/abi.StructField" %914, ptr %918, align 8
@@ -1879,8 +1879,8 @@ _llgo_108:                                        ; preds = %_llgo_107, %_llgo_1
   %944 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %943, i64 9, 1
   %945 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %944, i64 9, 2
   %946 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 4 }, i64 120, %"github.com/goplus/llgo/internal/runtime.Slice" %945)
-  store ptr %946, ptr @"main.struct$jgHT3zlvUCWdGAH-l4Nn1MOOw31LQoSt74SxHNLR50Q", align 8
-  %947 = load ptr, ptr @"main.struct$jgHT3zlvUCWdGAH-l4Nn1MOOw31LQoSt74SxHNLR50Q", align 8
+  store ptr %946, ptr @"main.struct$NNQFCWl7PM2tdO3Cxl4doIs1_JQl2vsUbnXLc46j14k", align 8
+  %947 = load ptr, ptr @"main.struct$NNQFCWl7PM2tdO3Cxl4doIs1_JQl2vsUbnXLc46j14k", align 8
   br i1 %836, label %_llgo_109, label %_llgo_110
 
 _llgo_109:                                        ; preds = %_llgo_108

--- a/cl/_testrt/closureiface/out.ll
+++ b/cl/_testrt/closureiface/out.ll
@@ -12,9 +12,9 @@ source_filename = "main"
 @_llgo_int = linkonce global ptr null, align 8
 @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" = linkonce global ptr null, align 8
 @_llgo_Pointer = linkonce global ptr null, align 8
-@"main.struct$0F5MIVpixVnQ6IoIDrJI9hTk70oCWg1odzb2q0E2rJ0" = linkonce global ptr null, align 8
-@0 = private unnamed_addr constant [1 x i8] c"f", align 1
-@1 = private unnamed_addr constant [4 x i8] c"data", align 1
+@"main.struct$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk" = linkonce global ptr null, align 8
+@0 = private unnamed_addr constant [2 x i8] c"$f", align 1
+@1 = private unnamed_addr constant [5 x i8] c"$data", align 1
 @2 = private unnamed_addr constant [4 x i8] c"main", align 1
 @3 = private unnamed_addr constant [5 x i8] c"error", align 1
 @_llgo_string = linkonce global ptr null, align 8
@@ -48,14 +48,13 @@ _llgo_0:
   %6 = load ptr, ptr @_llgo_int, align 8
   %7 = load ptr, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU", align 8
   %8 = load ptr, ptr @_llgo_Pointer, align 8
-  %9 = load ptr, ptr @"main.struct$0F5MIVpixVnQ6IoIDrJI9hTk70oCWg1odzb2q0E2rJ0", align 8
-  call void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr %9)
+  %9 = load ptr, ptr @"main.struct$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", align 8
   %10 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
   store { ptr, ptr } %5, ptr %10, align 8
   %11 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %9, 0
   %12 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %11, ptr %10, 1
   %13 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %12, 0
-  %14 = load ptr, ptr @"main.struct$0F5MIVpixVnQ6IoIDrJI9hTk70oCWg1odzb2q0E2rJ0", align 8
+  %14 = load ptr, ptr @"main.struct$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", align 8
   %15 = icmp eq ptr %13, %14
   br i1 %15, label %_llgo_3, label %_llgo_4
 
@@ -171,9 +170,9 @@ _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
   %31 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %30, i64 1, 1
   %32 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %31, i64 1, 2
   %33 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %27, %"github.com/goplus/llgo/internal/runtime.Slice" %32, i1 false)
-  %34 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 1 }, ptr %33, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %34 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 2 }, ptr %33, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %35 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %36 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, ptr %35, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %36 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 5 }, ptr %35, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %37 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
   %38 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %37, i64 0
   store %"github.com/goplus/llgo/internal/abi.StructField" %34, ptr %38, align 8
@@ -183,7 +182,7 @@ _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
   %41 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %40, i64 2, 1
   %42 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %41, i64 2, 2
   %43 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %42)
-  store ptr %43, ptr @"main.struct$0F5MIVpixVnQ6IoIDrJI9hTk70oCWg1odzb2q0E2rJ0", align 8
+  store ptr %43, ptr @"main.struct$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", align 8
   %44 = load ptr, ptr @_llgo_string, align 8
   %45 = icmp eq ptr %44, null
   br i1 %45, label %_llgo_7, label %_llgo_8
@@ -206,8 +205,6 @@ declare void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr)
 declare ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String", i64, %"github.com/goplus/llgo/internal/runtime.Slice")
 
 declare %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String", ptr, i64, %"github.com/goplus/llgo/internal/runtime.String", i1)
-
-declare void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr)
 
 declare void @"github.com/goplus/llgo/internal/runtime.PrintInt"(i64)
 

--- a/cl/_testrt/eface/out.ll
+++ b/cl/_testrt/eface/out.ll
@@ -33,9 +33,9 @@ source_filename = "main"
 @"[10]_llgo_int" = linkonce global ptr null, align 8
 @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac" = linkonce global ptr null, align 8
 @_llgo_Pointer = linkonce global ptr null, align 8
-@"main.struct$MYJJzV_XnHHne2yABOrxrKaJAnHA7CUbHXWeamxO-48" = linkonce global ptr null, align 8
-@3 = private unnamed_addr constant [1 x i8] c"f", align 1
-@4 = private unnamed_addr constant [4 x i8] c"data", align 1
+@"main.struct$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8" = linkonce global ptr null, align 8
+@3 = private unnamed_addr constant [2 x i8] c"$f", align 1
+@4 = private unnamed_addr constant [5 x i8] c"$data", align 1
 @5 = private unnamed_addr constant [4 x i8] c"main", align 1
 @"*_llgo_int" = linkonce global ptr null, align 8
 @"[]_llgo_int" = linkonce global ptr null, align 8
@@ -246,8 +246,7 @@ _llgo_0:
   call void @main.dump(%"github.com/goplus/llgo/internal/runtime.eface" %47)
   %48 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
   %49 = load ptr, ptr @_llgo_Pointer, align 8
-  %50 = load ptr, ptr @"main.struct$MYJJzV_XnHHne2yABOrxrKaJAnHA7CUbHXWeamxO-48", align 8
-  call void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr %50)
+  %50 = load ptr, ptr @"main.struct$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", align 8
   %51 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
   store { ptr, ptr } { ptr @"__llgo_stub.main.main$1", ptr null }, ptr %51, align 8
   %52 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %50, 0
@@ -509,9 +508,9 @@ _llgo_34:                                         ; preds = %_llgo_33, %_llgo_32
   %66 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %65, i64 0, 1
   %67 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %66, i64 0, 2
   %68 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %63, %"github.com/goplus/llgo/internal/runtime.Slice" %67, i1 false)
-  %69 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 1 }, ptr %68, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %69 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @3, i64 2 }, ptr %68, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %70 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %71 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 4 }, ptr %70, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %71 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @4, i64 5 }, ptr %70, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %72 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
   %73 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %72, i64 0
   store %"github.com/goplus/llgo/internal/abi.StructField" %69, ptr %73, align 8
@@ -521,7 +520,7 @@ _llgo_34:                                         ; preds = %_llgo_33, %_llgo_32
   %76 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %75, i64 2, 1
   %77 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %76, i64 2, 2
   %78 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @5, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %77)
-  store ptr %78, ptr @"main.struct$MYJJzV_XnHHne2yABOrxrKaJAnHA7CUbHXWeamxO-48", align 8
+  store ptr %78, ptr @"main.struct$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", align 8
   %79 = load ptr, ptr @"*_llgo_int", align 8
   %80 = icmp eq ptr %79, null
   br i1 %80, label %_llgo_35, label %_llgo_36
@@ -623,8 +622,6 @@ declare void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr)
 declare ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String", i64, %"github.com/goplus/llgo/internal/runtime.Slice")
 
 declare %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String", ptr, i64, %"github.com/goplus/llgo/internal/runtime.String", i1)
-
-declare void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr)
 
 declare ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr)
 

--- a/cl/_testrt/funcdecl/out.ll
+++ b/cl/_testrt/funcdecl/out.ll
@@ -10,9 +10,9 @@ source_filename = "main"
 @"main.init$guard" = global i1 false, align 1
 @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac" = linkonce global ptr null, align 8
 @_llgo_Pointer = linkonce global ptr null, align 8
-@"main.struct$MYJJzV_XnHHne2yABOrxrKaJAnHA7CUbHXWeamxO-48" = linkonce global ptr null, align 8
-@0 = private unnamed_addr constant [1 x i8] c"f", align 1
-@1 = private unnamed_addr constant [4 x i8] c"data", align 1
+@"main.struct$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8" = linkonce global ptr null, align 8
+@0 = private unnamed_addr constant [2 x i8] c"$f", align 1
+@1 = private unnamed_addr constant [5 x i8] c"$data", align 1
 @2 = private unnamed_addr constant [4 x i8] c"main", align 1
 @3 = private unnamed_addr constant [21 x i8] c"type assertion failed", align 1
 @_llgo_string = linkonce global ptr null, align 8
@@ -25,20 +25,18 @@ define void @main.check({ ptr, ptr } %0) {
 _llgo_0:
   %1 = load ptr, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", align 8
   %2 = load ptr, ptr @_llgo_Pointer, align 8
-  %3 = load ptr, ptr @"main.struct$MYJJzV_XnHHne2yABOrxrKaJAnHA7CUbHXWeamxO-48", align 8
-  call void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr %3)
+  %3 = load ptr, ptr @"main.struct$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", align 8
   %4 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
   store { ptr, ptr } { ptr @__llgo_stub.main.demo, ptr null }, ptr %4, align 8
   %5 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %3, 0
   %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %5, ptr %4, 1
-  %7 = load ptr, ptr @"main.struct$MYJJzV_XnHHne2yABOrxrKaJAnHA7CUbHXWeamxO-48", align 8
-  call void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr %7)
+  %7 = load ptr, ptr @"main.struct$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", align 8
   %8 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
   store { ptr, ptr } %0, ptr %8, align 8
   %9 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %7, 0
   %10 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %9, ptr %8, 1
   %11 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %6, 0
-  %12 = load ptr, ptr @"main.struct$MYJJzV_XnHHne2yABOrxrKaJAnHA7CUbHXWeamxO-48", align 8
+  %12 = load ptr, ptr @"main.struct$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", align 8
   %13 = icmp eq ptr %11, %12
   br i1 %13, label %_llgo_1, label %_llgo_2
 
@@ -46,7 +44,7 @@ _llgo_1:                                          ; preds = %_llgo_0
   %14 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %6, 1
   %15 = load { ptr, ptr }, ptr %14, align 8
   %16 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %10, 0
-  %17 = load ptr, ptr @"main.struct$MYJJzV_XnHHne2yABOrxrKaJAnHA7CUbHXWeamxO-48", align 8
+  %17 = load ptr, ptr @"main.struct$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", align 8
   %18 = icmp eq ptr %16, %17
   br i1 %18, label %_llgo_3, label %_llgo_4
 
@@ -185,9 +183,9 @@ _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
   %20 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %19, i64 0, 1
   %21 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %20, i64 0, 2
   %22 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %17, %"github.com/goplus/llgo/internal/runtime.Slice" %21, i1 false)
-  %23 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 1 }, ptr %22, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %23 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 2 }, ptr %22, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %24 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %25 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, ptr %24, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %25 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 5 }, ptr %24, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %26 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
   %27 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %26, i64 0
   store %"github.com/goplus/llgo/internal/abi.StructField" %23, ptr %27, align 8
@@ -197,7 +195,7 @@ _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
   %30 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %29, i64 2, 1
   %31 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %30, i64 2, 2
   %32 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %31)
-  store ptr %32, ptr @"main.struct$MYJJzV_XnHHne2yABOrxrKaJAnHA7CUbHXWeamxO-48", align 8
+  store ptr %32, ptr @"main.struct$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", align 8
   %33 = load ptr, ptr @_llgo_string, align 8
   %34 = icmp eq ptr %33, null
   br i1 %34, label %_llgo_5, label %_llgo_6
@@ -222,8 +220,6 @@ declare ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64)
 declare ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String", i64, %"github.com/goplus/llgo/internal/runtime.Slice")
 
 declare %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String", ptr, i64, %"github.com/goplus/llgo/internal/runtime.String", i1)
-
-declare void @"github.com/goplus/llgo/internal/runtime.SetClosure"(ptr)
 
 declare void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface")
 

--- a/cl/_testrt/tpmethod/out.ll
+++ b/cl/_testrt/tpmethod/out.ll
@@ -30,16 +30,16 @@ source_filename = "main"
 @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w" = linkonce global ptr null, align 8
 @"_llgo_func$1BeCdGdxwWG-Dtl1HbNuSy2_sb8rBMTmu7zhcPPofmU" = linkonce global ptr null, align 8
 @_llgo_Pointer = linkonce global ptr null, align 8
-@"main.struct$rDvDk5u0SueGnrMxDz_wBrplEFUjtXshBCEyKeM6edc" = linkonce global ptr null, align 8
-@8 = private unnamed_addr constant [1 x i8] c"f", align 1
-@9 = private unnamed_addr constant [4 x i8] c"data", align 1
-@"_llgo_func$80MkNg5FlG-QIrR0qzHGiPc77AqvdbJflSWOeG5LcUY" = linkonce global ptr null, align 8
-@"main.struct$mxZtxt4nClm7R35-Ksu7sUaZcPWf2mnqwCsrqo4qOB8" = linkonce global ptr null, align 8
-@"main.struct$LaXSfCbp9zvBYWtLq2i0GtWrY5UrmS8NmXCVxsyY920" = linkonce global ptr null, align 8
+@"main.struct$vwhCZhgsid50r1SsT8OmKpRI0Cpljg78h5JlpD1CTR4" = linkonce global ptr null, align 8
+@8 = private unnamed_addr constant [2 x i8] c"$f", align 1
+@9 = private unnamed_addr constant [5 x i8] c"$data", align 1
+@"_llgo_func$_so3zZGPIhTQghxFcf7CCCVzSOk2lxOt7xgGKcTzc0s" = linkonce global ptr null, align 8
+@"main.struct$awGH2Wh33bS1v_s7SNAwKW27E20HcwiiPPzh9UA7QDs" = linkonce global ptr null, align 8
+@"main.struct$N1awC7qGapVTS_NFj1Q0jk6nCjATrIK-60oOEyDjabo" = linkonce global ptr null, align 8
 @10 = private unnamed_addr constant [2 x i8] c"fn", align 1
 @11 = private unnamed_addr constant [4 x i8] c"Then", align 1
 @"*_llgo_main.future[main.Tuple[error]]" = linkonce global ptr null, align 8
-@"_llgo_iface$siNiE0pGpvdoyzPUhSP4dREmGht9v7Axb0C9hezIyDM" = linkonce global ptr null, align 8
+@"_llgo_iface$pTofAxYfPZHsCMD5T70nrOx1gjHf9m2QCLNvEOl1py0" = linkonce global ptr null, align 8
 
 define %"github.com/goplus/llgo/internal/runtime.iface" @main.ReadFile(%"github.com/goplus/llgo/internal/runtime.String" %0) {
 _llgo_0:
@@ -136,9 +136,9 @@ _llgo_0:
   %3 = load ptr, ptr @"_llgo_main.future[main.Tuple[error]]", align 8
   %4 = load ptr, ptr @"*_llgo_main.future[main.Tuple[error]]", align 8
   %5 = load ptr, ptr @"_llgo_func$1BeCdGdxwWG-Dtl1HbNuSy2_sb8rBMTmu7zhcPPofmU", align 8
-  %6 = load ptr, ptr @"main.struct$rDvDk5u0SueGnrMxDz_wBrplEFUjtXshBCEyKeM6edc", align 8
-  %7 = load ptr, ptr @"_llgo_func$80MkNg5FlG-QIrR0qzHGiPc77AqvdbJflSWOeG5LcUY", align 8
-  %8 = load ptr, ptr @"_llgo_iface$siNiE0pGpvdoyzPUhSP4dREmGht9v7Axb0C9hezIyDM", align 8
+  %6 = load ptr, ptr @"main.struct$vwhCZhgsid50r1SsT8OmKpRI0Cpljg78h5JlpD1CTR4", align 8
+  %7 = load ptr, ptr @"_llgo_func$_so3zZGPIhTQghxFcf7CCCVzSOk2lxOt7xgGKcTzc0s", align 8
+  %8 = load ptr, ptr @"_llgo_iface$pTofAxYfPZHsCMD5T70nrOx1gjHf9m2QCLNvEOl1py0", align 8
   %9 = call ptr @"github.com/goplus/llgo/internal/runtime.NewItab"(ptr %8, ptr %4)
   %10 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" undef, ptr %9, 0
   %11 = insertvalue %"github.com/goplus/llgo/internal/runtime.iface" %10, ptr %1, 1
@@ -350,9 +350,9 @@ _llgo_18:                                         ; preds = %_llgo_17, %_llgo_16
   %98 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %97, i64 0, 1
   %99 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %98, i64 0, 2
   %100 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %95, %"github.com/goplus/llgo/internal/runtime.Slice" %99, i1 false)
-  %101 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 1 }, ptr %100, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %101 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 2 }, ptr %100, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %102 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %103 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 4 }, ptr %102, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %103 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 5 }, ptr %102, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %104 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
   %105 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %104, i64 0
   store %"github.com/goplus/llgo/internal/abi.StructField" %101, ptr %105, align 8
@@ -362,10 +362,10 @@ _llgo_18:                                         ; preds = %_llgo_17, %_llgo_16
   %108 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %107, i64 2, 1
   %109 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %108, i64 2, 2
   %110 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %109)
-  store ptr %110, ptr @"main.struct$rDvDk5u0SueGnrMxDz_wBrplEFUjtXshBCEyKeM6edc", align 8
-  %111 = load ptr, ptr @"main.struct$rDvDk5u0SueGnrMxDz_wBrplEFUjtXshBCEyKeM6edc", align 8
-  %112 = load ptr, ptr @"main.struct$rDvDk5u0SueGnrMxDz_wBrplEFUjtXshBCEyKeM6edc", align 8
-  %113 = load ptr, ptr @"_llgo_func$80MkNg5FlG-QIrR0qzHGiPc77AqvdbJflSWOeG5LcUY", align 8
+  store ptr %110, ptr @"main.struct$vwhCZhgsid50r1SsT8OmKpRI0Cpljg78h5JlpD1CTR4", align 8
+  %111 = load ptr, ptr @"main.struct$vwhCZhgsid50r1SsT8OmKpRI0Cpljg78h5JlpD1CTR4", align 8
+  %112 = load ptr, ptr @"main.struct$vwhCZhgsid50r1SsT8OmKpRI0Cpljg78h5JlpD1CTR4", align 8
+  %113 = load ptr, ptr @"_llgo_func$_so3zZGPIhTQghxFcf7CCCVzSOk2lxOt7xgGKcTzc0s", align 8
   %114 = icmp eq ptr %113, null
   br i1 %114, label %_llgo_19, label %_llgo_20
 
@@ -382,12 +382,12 @@ _llgo_19:                                         ; preds = %_llgo_18
   %123 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %122, i64 0, 2
   %124 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %119, %"github.com/goplus/llgo/internal/runtime.Slice" %123, i1 false)
   call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %124)
-  store ptr %124, ptr @"_llgo_func$80MkNg5FlG-QIrR0qzHGiPc77AqvdbJflSWOeG5LcUY", align 8
+  store ptr %124, ptr @"_llgo_func$_so3zZGPIhTQghxFcf7CCCVzSOk2lxOt7xgGKcTzc0s", align 8
   br label %_llgo_20
 
 _llgo_20:                                         ; preds = %_llgo_19, %_llgo_18
-  %125 = load ptr, ptr @"_llgo_func$80MkNg5FlG-QIrR0qzHGiPc77AqvdbJflSWOeG5LcUY", align 8
-  %126 = load ptr, ptr @"main.struct$rDvDk5u0SueGnrMxDz_wBrplEFUjtXshBCEyKeM6edc", align 8
+  %125 = load ptr, ptr @"_llgo_func$_so3zZGPIhTQghxFcf7CCCVzSOk2lxOt7xgGKcTzc0s", align 8
+  %126 = load ptr, ptr @"main.struct$vwhCZhgsid50r1SsT8OmKpRI0Cpljg78h5JlpD1CTR4", align 8
   %127 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
   %128 = getelementptr ptr, ptr %127, i64 0
   store ptr %126, ptr %128, align 8
@@ -399,9 +399,9 @@ _llgo_20:                                         ; preds = %_llgo_19, %_llgo_18
   %134 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %133, i64 0, 1
   %135 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %134, i64 0, 2
   %136 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %131, %"github.com/goplus/llgo/internal/runtime.Slice" %135, i1 false)
-  %137 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 1 }, ptr %136, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %137 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 2 }, ptr %136, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %138 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %139 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 4 }, ptr %138, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %139 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 5 }, ptr %138, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %140 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
   %141 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %140, i64 0
   store %"github.com/goplus/llgo/internal/abi.StructField" %137, ptr %141, align 8
@@ -411,9 +411,9 @@ _llgo_20:                                         ; preds = %_llgo_19, %_llgo_18
   %144 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %143, i64 2, 1
   %145 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %144, i64 2, 2
   %146 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %145)
-  store ptr %146, ptr @"main.struct$mxZtxt4nClm7R35-Ksu7sUaZcPWf2mnqwCsrqo4qOB8", align 8
-  %147 = load ptr, ptr @"main.struct$mxZtxt4nClm7R35-Ksu7sUaZcPWf2mnqwCsrqo4qOB8", align 8
-  %148 = load ptr, ptr @"main.struct$rDvDk5u0SueGnrMxDz_wBrplEFUjtXshBCEyKeM6edc", align 8
+  store ptr %146, ptr @"main.struct$awGH2Wh33bS1v_s7SNAwKW27E20HcwiiPPzh9UA7QDs", align 8
+  %147 = load ptr, ptr @"main.struct$awGH2Wh33bS1v_s7SNAwKW27E20HcwiiPPzh9UA7QDs", align 8
+  %148 = load ptr, ptr @"main.struct$vwhCZhgsid50r1SsT8OmKpRI0Cpljg78h5JlpD1CTR4", align 8
   %149 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 8)
   %150 = getelementptr ptr, ptr %149, i64 0
   store ptr %148, ptr %150, align 8
@@ -425,9 +425,9 @@ _llgo_20:                                         ; preds = %_llgo_19, %_llgo_18
   %156 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %155, i64 0, 1
   %157 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %156, i64 0, 2
   %158 = call ptr @"github.com/goplus/llgo/internal/runtime.Func"(%"github.com/goplus/llgo/internal/runtime.Slice" %153, %"github.com/goplus/llgo/internal/runtime.Slice" %157, i1 false)
-  %159 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 1 }, ptr %158, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %159 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @8, i64 2 }, ptr %158, i64 0, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %160 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 58)
-  %161 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 4 }, ptr %160, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
+  %161 = call %"github.com/goplus/llgo/internal/abi.StructField" @"github.com/goplus/llgo/internal/runtime.StructField"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @9, i64 5 }, ptr %160, i64 8, %"github.com/goplus/llgo/internal/runtime.String" zeroinitializer, i1 false)
   %162 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 112)
   %163 = getelementptr %"github.com/goplus/llgo/internal/abi.StructField", ptr %162, i64 0
   store %"github.com/goplus/llgo/internal/abi.StructField" %159, ptr %163, align 8
@@ -445,11 +445,11 @@ _llgo_20:                                         ; preds = %_llgo_19, %_llgo_18
   %173 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %172, i64 1, 1
   %174 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %173, i64 1, 2
   %175 = call ptr @"github.com/goplus/llgo/internal/runtime.Struct"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, i64 16, %"github.com/goplus/llgo/internal/runtime.Slice" %174)
-  store ptr %175, ptr @"main.struct$LaXSfCbp9zvBYWtLq2i0GtWrY5UrmS8NmXCVxsyY920", align 8
-  %176 = load ptr, ptr @"main.struct$LaXSfCbp9zvBYWtLq2i0GtWrY5UrmS8NmXCVxsyY920", align 8
+  store ptr %175, ptr @"main.struct$N1awC7qGapVTS_NFj1Q0jk6nCjATrIK-60oOEyDjabo", align 8
+  %176 = load ptr, ptr @"main.struct$N1awC7qGapVTS_NFj1Q0jk6nCjATrIK-60oOEyDjabo", align 8
   %177 = load ptr, ptr @"_llgo_func$1BeCdGdxwWG-Dtl1HbNuSy2_sb8rBMTmu7zhcPPofmU", align 8
-  %178 = load ptr, ptr @"main.struct$rDvDk5u0SueGnrMxDz_wBrplEFUjtXshBCEyKeM6edc", align 8
-  %179 = load ptr, ptr @"_llgo_func$80MkNg5FlG-QIrR0qzHGiPc77AqvdbJflSWOeG5LcUY", align 8
+  %178 = load ptr, ptr @"main.struct$vwhCZhgsid50r1SsT8OmKpRI0Cpljg78h5JlpD1CTR4", align 8
+  %179 = load ptr, ptr @"_llgo_func$_so3zZGPIhTQghxFcf7CCCVzSOk2lxOt7xgGKcTzc0s", align 8
   %180 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" { %"github.com/goplus/llgo/internal/runtime.String" { ptr @11, i64 4 }, ptr undef, ptr undef, ptr undef }, ptr %179, 1
   %181 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %180, ptr @"main.(*future[main.Tuple[error]]).Then", 2
   %182 = insertvalue %"github.com/goplus/llgo/internal/abi.Method" %181, ptr @"main.(*future[main.Tuple[error]]).Then", 3
@@ -464,8 +464,8 @@ _llgo_20:                                         ; preds = %_llgo_19, %_llgo_18
   %189 = call ptr @"github.com/goplus/llgo/internal/runtime.PointerTo"(ptr %188)
   call void @"github.com/goplus/llgo/internal/runtime.SetDirectIface"(ptr %189)
   store ptr %189, ptr @"*_llgo_main.future[main.Tuple[error]]", align 8
-  %190 = load ptr, ptr @"_llgo_func$80MkNg5FlG-QIrR0qzHGiPc77AqvdbJflSWOeG5LcUY", align 8
-  %191 = load ptr, ptr @"_llgo_iface$siNiE0pGpvdoyzPUhSP4dREmGht9v7Axb0C9hezIyDM", align 8
+  %190 = load ptr, ptr @"_llgo_func$_so3zZGPIhTQghxFcf7CCCVzSOk2lxOt7xgGKcTzc0s", align 8
+  %191 = load ptr, ptr @"_llgo_iface$pTofAxYfPZHsCMD5T70nrOx1gjHf9m2QCLNvEOl1py0", align 8
   %192 = icmp eq ptr %191, null
   br i1 %192, label %_llgo_21, label %_llgo_22
 
@@ -478,7 +478,7 @@ _llgo_21:                                         ; preds = %_llgo_20
   %197 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %196, i64 1, 1
   %198 = insertvalue %"github.com/goplus/llgo/internal/runtime.Slice" %197, i64 1, 2
   %199 = call ptr @"github.com/goplus/llgo/internal/runtime.Interface"(%"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 4 }, %"github.com/goplus/llgo/internal/runtime.Slice" %198)
-  store ptr %199, ptr @"_llgo_iface$siNiE0pGpvdoyzPUhSP4dREmGht9v7Axb0C9hezIyDM", align 8
+  store ptr %199, ptr @"_llgo_iface$pTofAxYfPZHsCMD5T70nrOx1gjHf9m2QCLNvEOl1py0", align 8
   br label %_llgo_22
 
 _llgo_22:                                         ; preds = %_llgo_21, %_llgo_20

--- a/internal/lib/reflect/makefunc.go
+++ b/internal/lib/reflect/makefunc.go
@@ -129,14 +129,12 @@ func makeMethodValue(op string, v Value) Value {
 
 	// v.Type returns the actual type of the method value.
 	ftyp := (*funcType)(unsafe.Pointer(v.Type().(*rtype)))
-	ptyp := rtypeOf(unsafe.Pointer(uintptr(0)))
-	typ := runtime.Struct(v.typ().Uncommon().PkgPath_, 2*unsafe.Sizeof(0), abi.StructField{
-		Name_: "f",
+	typ := runtime.Struct("", 2*unsafe.Sizeof(0), abi.StructField{
+		Name_: "$f",
 		Typ:   &ftyp.Type,
 	}, abi.StructField{
-		Name_:  "data",
-		Typ:    ptyp,
-		Offset: unsafe.Sizeof(0),
+		Name_: "$data",
+		Typ:   unsafePointerType,
 	})
 	typ.TFlag |= abi.TFlagClosure
 	_, _, fn := methodReceiver(op, rcvr, int(v.flag)>>flagMethodShift)
@@ -149,6 +147,8 @@ func makeMethodValue(op string, v Value) Value {
 	// but we want Interface() and other operations to fail early.
 	return Value{typ, unsafe.Pointer(fv), v.flag&flagRO | flagIndir | flag(Func)}
 }
+
+var unsafePointerType = rtypeOf(unsafe.Pointer(nil))
 
 /*
 func methodValueCallCodePtr() uintptr {

--- a/internal/runtime/z_face.go
+++ b/internal/runtime/z_face.go
@@ -486,10 +486,6 @@ func isDirectIface(t *_type) bool {
 	return t.Kind_&abi.KindDirectIface != 0
 }
 
-func SetClosure(t *abi.Type) {
-	t.TFlag |= abi.TFlagClosure
-}
-
 func interfaceStr(ft *abi.InterfaceType) string {
 	repr := make([]byte, 0, 64)
 	repr = append(repr, "interface {"...)

--- a/internal/runtime/z_type.go
+++ b/internal/runtime/z_type.go
@@ -197,6 +197,10 @@ func Struct(pkgPath string, size uintptr, fields ...abi.StructField) *Type {
 	if len(fields) == 1 && isDirectIface(fields[0].Typ) {
 		ret.Kind_ |= abi.KindDirectIface
 	}
+	if len(fields) == 2 && fields[0].Name_ == "$f" && fields[0].Typ.Kind() == abi.Func &&
+		fields[1].Name_ == "$data" && fields[1].Typ.Kind() == abi.UnsafePointer {
+		ret.TFlag |= abi.TFlagClosure
+	}
 	rtypeList.addType(&ret.Type)
 	return &ret.Type
 }
@@ -504,7 +508,7 @@ func eqFields(s1, s2 []abi.StructField) bool {
 func (r *rtypes) findStruct(pkgPath string, size uintptr, fields []abi.StructField) *Type {
 	for _, typ := range r.types {
 		if typ.Kind() == abi.Struct && typ.Size() == size {
-			if st := typ.StructType(); st.PkgPath_ == pkgPath && eqFields(st.Fields, fields) {
+			if st := typ.StructType(); (st.IsClosure() || st.PkgPath_ == pkgPath) && eqFields(st.Fields, fields) {
 				return typ
 			}
 		}

--- a/ssa/interface.go
+++ b/ssa/interface.go
@@ -106,9 +106,6 @@ func (b Builder) MakeInterface(tinter Type, x Expr) (ret Expr) {
 	prog := b.Prog
 	typ := x.Type
 	tabi := b.abiType(typ.raw.Type)
-	if x.kind == vkClosure {
-		b.InlineCall(b.Pkg.rtFunc("SetClosure"), tabi)
-	}
 	kind, _, lvl := abi.DataKindOf(typ.raw.Type, 0, prog.is32Bits)
 	switch kind {
 	case abi.Indirect:

--- a/ssa/type.go
+++ b/ssa/type.go
@@ -417,8 +417,9 @@ func (p Program) toLLVMStruct(raw *types.Struct) (ret llvm.Type, kind valueKind)
 func isClosure(raw *types.Struct) bool {
 	n := raw.NumFields()
 	if n == 2 {
-		if _, ok := raw.Field(0).Type().(*types.Signature); ok {
-			return raw.Field(1).Type() == types.Typ[types.UnsafePointer]
+		f1, f2 := raw.Field(0), raw.Field(1)
+		if _, ok := f1.Type().(*types.Signature); ok && f1.Name() == "$f" {
+			return f2.Type() == types.Typ[types.UnsafePointer] && f2.Name() == "$data"
 		}
 	}
 	return false

--- a/ssa/type_cvt.go
+++ b/ssa/type_cvt.go
@@ -176,8 +176,8 @@ func Instantiate(orig types.Type, t *types.Named) (types.Type, bool) {
 func (p goTypes) cvtClosure(sig *types.Signature) *types.Struct {
 	raw := p.cvtFunc(sig, nil)
 	flds := []*types.Var{
-		types.NewField(token.NoPos, nil, "f", raw, false),
-		types.NewField(token.NoPos, nil, "data", types.Typ[types.UnsafePointer], false),
+		types.NewField(token.NoPos, nil, "$f", raw, false),
+		types.NewField(token.NoPos, nil, "$data", types.Typ[types.UnsafePointer], false),
 	}
 	return types.NewStruct(flds, nil)
 }


### PR DESCRIPTION
closure struct `{ f ftype, data unsafe.Pointer}` => `{ $f ftype, $data unsafe.pointer }`

abi.StructType check closure  ( abi.TFlagClosure ) ignore .PkgPath_