### PR TITLE
ssa: fix bitcast for float32

### DIFF
--- a/cl/_testrt/float2any/in.go
+++ b/cl/_testrt/float2any/in.go
@@ -1,0 +1,28 @@
+package main
+
+const pi = 3.14159265
+
+func check32(v any) {
+	if v.(float32) != pi {
+		panic("error f32")
+	}
+}
+
+func check64(v any) {
+	if v.(float64) != pi {
+		panic("error f64")
+	}
+}
+
+func f32() float32 {
+	return pi
+}
+
+func f64() float64 {
+	return pi
+}
+
+func main() {
+	check32(f32())
+	check64(f64())
+}

--- a/cl/_testrt/float2any/out.ll
+++ b/cl/_testrt/float2any/out.ll
@@ -1,0 +1,178 @@
+; ModuleID = 'main'
+source_filename = "main"
+
+%"github.com/goplus/llgo/internal/runtime.eface" = type { ptr, ptr }
+%"github.com/goplus/llgo/internal/runtime.String" = type { ptr, i64 }
+
+@"main.init$guard" = global i1 false, align 1
+@_llgo_float32 = linkonce global ptr null, align 8
+@0 = private unnamed_addr constant [21 x i8] c"type assertion failed", align 1
+@_llgo_string = linkonce global ptr null, align 8
+@1 = private unnamed_addr constant [9 x i8] c"error f32", align 1
+@_llgo_float64 = linkonce global ptr null, align 8
+@2 = private unnamed_addr constant [9 x i8] c"error f64", align 1
+@__llgo_argc = global i32 0, align 4
+@__llgo_argv = global ptr null, align 8
+
+define void @main.check32(%"github.com/goplus/llgo/internal/runtime.eface" %0) {
+_llgo_0:
+  %1 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 0
+  %2 = load ptr, ptr @_llgo_float32, align 8
+  %3 = icmp eq ptr %1, %2
+  br i1 %3, label %_llgo_3, label %_llgo_4
+
+_llgo_1:                                          ; preds = %_llgo_3
+  %4 = load ptr, ptr @_llgo_string, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @1, i64 9 }, ptr %5, align 8
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %4, 0
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %6, ptr %5, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %7)
+  unreachable
+
+_llgo_2:                                          ; preds = %_llgo_3
+  ret void
+
+_llgo_3:                                          ; preds = %_llgo_0
+  %8 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
+  %9 = ptrtoint ptr %8 to i64
+  %10 = trunc i64 %9 to i32
+  %11 = bitcast i32 %10 to float
+  %12 = fcmp une float %11, 0x400921FB60000000
+  br i1 %12, label %_llgo_1, label %_llgo_2
+
+_llgo_4:                                          ; preds = %_llgo_0
+  %13 = load ptr, ptr @_llgo_string, align 8
+  %14 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 21 }, ptr %14, align 8
+  %15 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %13, 0
+  %16 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %15, ptr %14, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %16)
+  unreachable
+}
+
+define void @main.check64(%"github.com/goplus/llgo/internal/runtime.eface" %0) {
+_llgo_0:
+  %1 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 0
+  %2 = load ptr, ptr @_llgo_float64, align 8
+  %3 = icmp eq ptr %1, %2
+  br i1 %3, label %_llgo_3, label %_llgo_4
+
+_llgo_1:                                          ; preds = %_llgo_3
+  %4 = load ptr, ptr @_llgo_string, align 8
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @2, i64 9 }, ptr %5, align 8
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %4, 0
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %6, ptr %5, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %7)
+  unreachable
+
+_llgo_2:                                          ; preds = %_llgo_3
+  ret void
+
+_llgo_3:                                          ; preds = %_llgo_0
+  %8 = extractvalue %"github.com/goplus/llgo/internal/runtime.eface" %0, 1
+  %9 = ptrtoint ptr %8 to i64
+  %10 = bitcast i64 %9 to double
+  %11 = fcmp une double %10, 0x400921FB53C8D4F1
+  br i1 %11, label %_llgo_1, label %_llgo_2
+
+_llgo_4:                                          ; preds = %_llgo_0
+  %12 = load ptr, ptr @_llgo_string, align 8
+  %13 = call ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/internal/runtime.String" { ptr @0, i64 21 }, ptr %13, align 8
+  %14 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %12, 0
+  %15 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %14, ptr %13, 1
+  call void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface" %15)
+  unreachable
+}
+
+define float @main.f32() {
+_llgo_0:
+  ret float 0x400921FB60000000
+}
+
+define double @main.f64() {
+_llgo_0:
+  ret double 0x400921FB53C8D4F1
+}
+
+define void @main.init() {
+_llgo_0:
+  %0 = load i1, ptr @"main.init$guard", align 1
+  br i1 %0, label %_llgo_2, label %_llgo_1
+
+_llgo_1:                                          ; preds = %_llgo_0
+  store i1 true, ptr @"main.init$guard", align 1
+  call void @"main.init$after"()
+  br label %_llgo_2
+
+_llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+  ret void
+}
+
+define i32 @main(i32 %0, ptr %1) {
+_llgo_0:
+  store i32 %0, ptr @__llgo_argc, align 4
+  store ptr %1, ptr @__llgo_argv, align 8
+  call void @"github.com/goplus/llgo/internal/runtime.init"()
+  call void @main.init()
+  %2 = call float @main.f32()
+  %3 = load ptr, ptr @_llgo_float32, align 8
+  %4 = bitcast float %2 to i32
+  %5 = inttoptr i32 %4 to ptr
+  %6 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %3, 0
+  %7 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %6, ptr %5, 1
+  call void @main.check32(%"github.com/goplus/llgo/internal/runtime.eface" %7)
+  %8 = call double @main.f64()
+  %9 = load ptr, ptr @_llgo_float64, align 8
+  %10 = bitcast double %8 to i64
+  %11 = inttoptr i64 %10 to ptr
+  %12 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" undef, ptr %9, 0
+  %13 = insertvalue %"github.com/goplus/llgo/internal/runtime.eface" %12, ptr %11, 1
+  call void @main.check64(%"github.com/goplus/llgo/internal/runtime.eface" %13)
+  ret i32 0
+}
+
+define void @"main.init$after"() {
+_llgo_0:
+  %0 = load ptr, ptr @_llgo_float32, align 8
+  %1 = icmp eq ptr %0, null
+  br i1 %1, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  %2 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 45)
+  store ptr %2, ptr @_llgo_float32, align 8
+  br label %_llgo_2
+
+_llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+  %3 = load ptr, ptr @_llgo_string, align 8
+  %4 = icmp eq ptr %3, null
+  br i1 %4, label %_llgo_3, label %_llgo_4
+
+_llgo_3:                                          ; preds = %_llgo_2
+  %5 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 24)
+  store ptr %5, ptr @_llgo_string, align 8
+  br label %_llgo_4
+
+_llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
+  %6 = load ptr, ptr @_llgo_float64, align 8
+  %7 = icmp eq ptr %6, null
+  br i1 %7, label %_llgo_5, label %_llgo_6
+
+_llgo_5:                                          ; preds = %_llgo_4
+  %8 = call ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64 46)
+  store ptr %8, ptr @_llgo_float64, align 8
+  br label %_llgo_6
+
+_llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
+  ret void
+}
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.Basic"(i64)
+
+declare ptr @"github.com/goplus/llgo/internal/runtime.AllocU"(i64)
+
+declare void @"github.com/goplus/llgo/internal/runtime.Panic"(%"github.com/goplus/llgo/internal/runtime.eface")
+
+declare void @"github.com/goplus/llgo/internal/runtime.init"()

--- a/ssa/interface.go
+++ b/ssa/interface.go
@@ -126,7 +126,11 @@ func (b Builder) MakeInterface(tinter Type, x Expr) (ret Expr) {
 		u = llvm.CreateIntCast(b.impl, ximpl, tu.ll)
 	case abi.BitCast:
 		tu := prog.Uintptr()
-		u = llvm.CreateBitCast(b.impl, ximpl, tu.ll)
+		if b.Prog.td.TypeAllocSize(typ.ll) < b.Prog.td.TypeAllocSize(tu.ll) {
+			u = llvm.CreateBitCast(b.impl, ximpl, prog.Uint32().ll)
+		} else {
+			u = llvm.CreateBitCast(b.impl, ximpl, tu.ll)
+		}
 	default:
 		panic("todo")
 	}


### PR DESCRIPTION
fix float32 to any bitcast
```
package main
const pi = 3.14159265
func check32(v any) {
	if v.(float32) != pi {
		panic("error f32")
	}
}
func f32() float32 {
	return pi
}
func main() {
	check32(f32())
}
```
```
invalid cast opcode for cast from 'float' to 'i64'
  122 |   %4 = bitcast float %2 to i64
```