### PR TITLE
x/ffi: add WrapFunc for go callback compatible c abi

### DIFF
--- a/x/ffi/_demo/_wrap/wrap.c
+++ b/x/ffi/_demo/_wrap/wrap.c
@@ -23,3 +23,15 @@ int demo2( int (*fn)(struct array)) {
     a.k = 4;
     return (*fn)(a);
 }
+
+int demo3(void (*fn)(struct array, int *n)) {
+    printf("c.demo3: %p\n",fn);
+    struct array a;
+    a.x = 1;
+    a.y = 2;
+    a.z = 3;
+    a.k = 4;
+    int n = 0;
+    (*fn)(a,&n);
+    return n;
+}

--- a/x/ffi/_demo/_wrap/wrap.c
+++ b/x/ffi/_demo/_wrap/wrap.c
@@ -35,3 +35,13 @@ int demo3(void (*fn)(struct array, int *n)) {
     (*fn)(a,&n);
     return n;
 }
+
+int demo4( int (*fn)(struct array*)) {
+    printf("c.demo4: %p\n",fn);
+    struct array a;
+    a.x = 1;
+    a.y = 2;
+    a.z = 3;
+    a.k = 4;
+    return (*fn)(&a);
+}

--- a/x/ffi/_demo/wrap/main.go
+++ b/x/ffi/_demo/wrap/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"unsafe"
+
+	"github.com/goplus/llgo/c"
+	"github.com/goplus/llgo/x/ffi"
+)
+
+const (
+	LLGoPackage = "link"
+	LLGoFiles   = "../_wrap/wrap.c"
+)
+
+//go:linkname demo2wrap C.demo2
+func demo2wrap(fn unsafe.Pointer) c.Int
+
+//go:linkname demo3wrap C.demo3
+func demo3wrap(fn unsafe.Pointer) c.Int
+
+//llgo:type C
+type array struct {
+	x c.Int
+	y c.Int
+	z c.Int
+	k c.Int
+}
+
+func callback2(a array) c.Int {
+	c.Printf(c.Str("go.callback2 %d %d %d %d\n"), a.x, a.y, a.z, a.k)
+	return a.x + a.y + a.z + a.k
+}
+
+func callback3(a array, r *c.Int) {
+	c.Printf(c.Str("go.callback3 %d %d %d %d\n"), a.x, a.y, a.z, a.k)
+	*r = a.x + a.y + a.z + a.k
+}
+
+func main() {
+	wrap()
+	c.Printf(c.Str("\n"))
+	wrapNoRet()
+}
+
+func wrap() {
+	fn := ffi.WrapFunc(callback2, func(a *array, r *c.Int) {
+		*r = callback2(*a)
+	})
+	ret := demo2wrap(fn)
+	c.Printf(c.Str("ret: %d\n"), ret)
+}
+
+func wrapNoRet() {
+	fn := ffi.WrapFunc(callback3, func(a *array, r **c.Int) {
+		callback3(*a, *r)
+	})
+	ret := demo3wrap(fn)
+	c.Printf(c.Str("ret: %d\n"), ret)
+}

--- a/x/ffi/ffi.go
+++ b/x/ffi/ffi.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ffi
 
 import (

--- a/x/ffi/type.go
+++ b/x/ffi/type.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ffi
 
 import (

--- a/x/ffi/wrap.go
+++ b/x/ffi/wrap.go
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ffi
+
+import (
+	"unsafe"
+
+	"github.com/goplus/llgo/internal/abi"
+)
+
+var (
+	ffiTypeClosure = StructOf(TypePointer, TypePointer)
+)
+
+type eface struct {
+	typ  *abi.Type
+	data unsafe.Pointer
+}
+
+func rtypeOf(i any) *abi.Type {
+	e := *(*eface)(unsafe.Pointer(&i))
+	return e.typ
+}
+
+func WrapFunc(fn interface{}, wrap interface{}) unsafe.Pointer {
+	e := (*eface)(unsafe.Pointer(&fn))
+	if !e.typ.IsClosure() {
+		panic("invalid func")
+	}
+	ftyp := e.typ.StructType().Fields[0].Typ.FuncType()
+	sig, err := toFFISig(ftyp.In, ftyp.Out)
+	if err != nil {
+		panic(err)
+	}
+	wf := newWrapFunc(wrap)
+	c := NewClosure()
+	if len(ftyp.Out) == 0 {
+		c.Bind(sig, func(cif *Signature, ret unsafe.Pointer, args *unsafe.Pointer, userdata unsafe.Pointer) {
+			wf := (*wrapFunc)(userdata)
+			wf.CallNoRet(args)
+		}, unsafe.Pointer(wf))
+	} else {
+		c.Bind(sig, func(cif *Signature, ret unsafe.Pointer, args *unsafe.Pointer, userdata unsafe.Pointer) {
+			wf := (*wrapFunc)(userdata)
+			wf.Call(ret, args)
+		}, unsafe.Pointer(wf))
+	}
+	return c.Fn
+}
+
+type wrapFunc struct {
+	sig  *Signature
+	ftyp *abi.FuncType
+	fn   unsafe.Pointer
+	args []unsafe.Pointer
+	n    int
+}
+
+func (p *wrapFunc) Call(ret unsafe.Pointer, pargs *unsafe.Pointer) {
+	args := unsafe.Slice(pargs, p.n-2)
+	for i := 0; i < p.n-2; i++ {
+		p.args[i+1] = unsafe.Pointer(&args[i])
+	}
+	p.args[p.n-1] = unsafe.Pointer(&ret)
+	Call(p.sig, p.fn, nil, p.args...)
+}
+
+func (p *wrapFunc) CallNoRet(pargs *unsafe.Pointer) {
+	args := unsafe.Slice(pargs, p.n-1)
+	for i := 0; i < p.n-1; i++ {
+		p.args[i+1] = unsafe.Pointer(&args[i])
+	}
+	Call(p.sig, p.fn, nil, p.args...)
+}
+
+func newWrapFunc(fn interface{}) *wrapFunc {
+	e := (*eface)(unsafe.Pointer(&fn))
+	if !e.typ.IsClosure() {
+		panic("invalid wrap func")
+	}
+	ftyp := e.typ.StructType().Fields[0].Typ.FuncType()
+	sig, err := toFFISig(append([]*abi.Type{unsafePointerType}, ftyp.In...), ftyp.Out)
+	if err != nil {
+		panic(err)
+	}
+	c := (*struct {
+		fn  unsafe.Pointer
+		env unsafe.Pointer
+	})(e.data)
+	n := len(ftyp.In) + 1
+	args := make([]unsafe.Pointer, n)
+	args[0] = unsafe.Pointer(&c.env)
+	return &wrapFunc{sig, ftyp, c.fn, args, n}
+}
+
+var (
+	unsafePointerType = rtypeOf(unsafe.Pointer(nil))
+)
+
+func toFFIType(typ *abi.Type) *Type {
+	kind := typ.Kind()
+	switch kind {
+	case abi.Bool, abi.Int, abi.Int8, abi.Int16, abi.Int32, abi.Int64,
+		abi.Uint, abi.Uint8, abi.Uint16, abi.Uint32, abi.Uint64, abi.Uintptr,
+		abi.Float32, abi.Float64, abi.Complex64, abi.Complex128:
+		return Typ[kind]
+	case abi.Array:
+		st := typ.ArrayType()
+		return ArrayOf(toFFIType(st.Elem), int(st.Len))
+	case abi.Chan:
+		return TypePointer
+	case abi.Func:
+		return ffiTypeClosure
+	case abi.Interface:
+		return TypeInterface
+	case abi.Map:
+		return TypePointer
+	case abi.Pointer:
+		return TypePointer
+	case abi.Slice:
+		return TypeSlice
+	case abi.String:
+		return TypeString
+	case abi.Struct:
+		st := typ.StructType()
+		fields := make([]*Type, len(st.Fields))
+		for i, fs := range st.Fields {
+			fields[i] = toFFIType(fs.Typ)
+		}
+		return StructOf(fields...)
+	case abi.UnsafePointer:
+		return TypePointer
+	}
+	panic("ffi.toFFIType unsupport type " + typ.String())
+}
+
+func toFFISig(tin, tout []*abi.Type) (*Signature, error) {
+	args := make([]*Type, len(tin))
+	for i, in := range tin {
+		args[i] = toFFIType(in)
+	}
+	var ret *Type
+	switch n := len(tout); n {
+	case 0:
+		ret = TypeVoid
+	case 1:
+		ret = toFFIType(tout[0])
+	default:
+		fields := make([]*Type, n)
+		for i, out := range tout {
+			fields[i] = toFFIType(out)
+		}
+		ret = StructOf(fields...)
+	}
+	return NewSignature(ret, args...)
+}


### PR DESCRIPTION
```
// llgo:type C
type WrapperFunc func(ret unsafe.Pointer, args []unsafe.Pointer)

 // MakeFunc make go func/closure to c func ptr
func MakeFunc(fn interface{}) unsafe.Pointer

// WrapFunc wrap go func to c func ptr by fn type
func WrapFunc(fn interface{}, wrap WrapperFunc) unsafe.Pointer

// WrapFuncType wrap go func to c func ptr by ftyp
func WrapFuncType(ftyp *abi.FuncType, WrapperFunc) unsafe.Pointer
```