### PR TITLE
runtime: show stacktrace when panic

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -62,7 +62,7 @@ jobs:
           echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${{matrix.llvm}} main" | sudo tee /etc/apt/sources.list.d/llvm.list
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo apt-get update
-          sudo apt-get install -y llvm-${{matrix.llvm}}-dev clang-${{matrix.llvm}} libclang-${{matrix.llvm}}-dev lld-${{matrix.llvm}} pkg-config libgc-dev libssl-dev zlib1g-dev libffi-dev libcjson-dev
+          sudo apt-get install -y llvm-${{matrix.llvm}}-dev clang-${{matrix.llvm}} libclang-${{matrix.llvm}}-dev lld-${{matrix.llvm}} pkg-config libgc-dev libssl-dev zlib1g-dev libffi-dev libcjson-dev libunwind-dev
           echo "/usr/lib/llvm-${{matrix.llvm}}/bin" >> $GITHUB_PATH
 
           # Install optional deps for demos.

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ go install -v github.com/goplus/llgo/cmd/llgo@latest
 echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-18 main" | sudo tee /etc/apt/sources.list.d/llvm.list
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
 sudo apt-get update
-sudo apt-get install -y llvm-18-dev clang-18 libclang-18-dev lld-18 pkg-config libgc-dev libssl-dev zlib1g-dev libcjson-dev libsqlite3-dev
+sudo apt-get install -y llvm-18-dev clang-18 libclang-18-dev lld-18 pkg-config libgc-dev libssl-dev zlib1g-dev libcjson-dev libsqlite3-dev libunwind-dev
 sudo apt-get install -y python3.12-dev # optional
 go install -v github.com/goplus/llgo/cmd/llgo@latest
 ```

--- a/_demo/failed/stacktrace/main.go
+++ b/_demo/failed/stacktrace/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+)
+
+type MyStruct[T any] struct {
+	value T
+}
+
+func (m *MyStruct[T]) Method() {
+	fmt.Println("In generic method")
+	genericFunc[T](m.value)
+}
+
+func genericFunc[T any](v T) {
+	fmt.Println("In generic function")
+	normalFunc()
+}
+
+func normalFunc() {
+	fmt.Println("In normal function")
+	panic("panic occurs here")
+}
+
+func main() {
+	m := &MyStruct[string]{value: "hello"}
+	m.Method()
+}
+
+//Expected:
+// In generic method
+// In generic function
+// In normal function
+// panic: panic occurs here
+
+// [0x00C6D310 github.com/goplus/llgo/internal/runtime.Rethrow+0x2f, SP = 0x60]
+// [0x00C6CF44 github.com/goplus/llgo/internal/runtime.Panic+0x2d, SP = 0x50]
+// [0x00C69420 main.normalFunc+0xf, SP = 0xa8]
+// [0x00C69564 main.genericFunc[string]+0x18, SP = 0x74]
+// [0x00C694A8 main.(*MyStruct[string]).Method+0x1f, SP = 0x84]
+// [0x00C6936C main+0x4, SP = 0x40]

--- a/c/debug/_wrap/debug.c
+++ b/c/debug/_wrap/debug.c
@@ -1,4 +1,5 @@
 #if defined(__linux__)
+#define UNW_LOCAL_ONLY
 #define _GNU_SOURCE
 #include <features.h>
 #endif

--- a/c/debug/debug.go
+++ b/c/debug/debug.go
@@ -1,5 +1,9 @@
 package debug
 
+/*
+#cgo linux LDFLAGS: -lunwind
+*/
+import "C"
 import (
 	"unsafe"
 

--- a/doc/_readme/scripts/install_ubuntu.sh
+++ b/doc/_readme/scripts/install_ubuntu.sh
@@ -2,6 +2,6 @@
 echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-18 main" | sudo tee /etc/apt/sources.list.d/llvm.list
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
 sudo apt-get update
-sudo apt-get install -y llvm-18-dev clang-18 libclang-18-dev lld-18 pkg-config libgc-dev libssl-dev zlib1g-dev libcjson-dev libsqlite3-dev
+sudo apt-get install -y llvm-18-dev clang-18 libclang-18-dev lld-18 pkg-config libgc-dev libssl-dev zlib1g-dev libcjson-dev libsqlite3-dev libunwind-dev
 sudo apt-get install -y python3.12-dev # optional
 go install -v github.com/goplus/llgo/cmd/llgo@latest

--- a/internal/runtime/z_rt.go
+++ b/internal/runtime/z_rt.go
@@ -20,6 +20,7 @@ import (
 	"unsafe"
 
 	"github.com/goplus/llgo/c"
+	"github.com/goplus/llgo/c/debug"
 	"github.com/goplus/llgo/c/pthread"
 	"github.com/goplus/llgo/c/signal"
 	"github.com/goplus/llgo/c/syscall"
@@ -61,6 +62,13 @@ func Rethrow(link *Defer) {
 	if ptr := excepKey.Get(); ptr != nil {
 		if link == nil {
 			TracePanic(*(*any)(ptr))
+			debug.StackTrace(0, func(fr *debug.Frame) bool {
+				var info debug.Info
+				debug.Addrinfo(unsafe.Pointer(fr.PC), &info)
+				c.Fprintf(c.Stderr, c.Str("[0x%08X %s+0x%x, SP = 0x%x]\n"), fr.PC, fr.Name, fr.Offset, fr.SP)
+				return true
+			})
+
 			c.Free(ptr)
 			c.Exit(2)
 		} else {


### PR DESCRIPTION
```
go run ./cmd/llgo run ./_demo/failed/stacktrace
# github.com/goplus/llgo/cmd/llgo
ld: warning: -ld_classic is deprecated and will be removed in a future release
In generic method
In generic function
In normal function
panic: panic occurs here

[0x0271D310 github.com/goplus/llgo/internal/runtime.Rethrow+0x2f, SP = 0x60]
[0x0271CF44 github.com/goplus/llgo/internal/runtime.Panic+0x2d, SP = 0x50]
[0x02719420 main.normalFunc+0xf, SP = 0xa8]
[0x02719564 main.genericFunc[string]+0x18, SP = 0x74]
[0x027194A8 main.(*MyStruct[string]).Method+0x1f, SP = 0x84]
[0x0271936C main+0x4, SP = 0x40]
exit status 2
```