### PR TITLE
build.ParseArgs returns new slices to fix wrong patterns with flags appending

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -688,8 +688,8 @@ func ParseArgs(args []string, swflags map[string]bool) (flags, patterns []string
 		if strings.HasPrefix(arg, "-") {
 			checkFlag(arg, &i, &verbose, swflags)
 		} else {
-			patterns = args[i:]
-			flags = args[:i]
+			patterns = append([]string{}, args[i:]...)
+			flags = append([]string{}, args[:i]...)
 			return
 		}
 	}


### PR DESCRIPTION
Before:

```shell
➜  _demo git:(main) ✗ go run ../cmd/llgo build ./async ./hello
# github.com/goplus/llgo/cmd/llgo
ld: warning: -ld_classic is deprecated and will be removed in a future release
build flags: [-tags llgo]
patterns: [-tags llgo]
-: malformed import path "-tags": leading dash
cannot build SSA for package -tags
-: package llgo is not in GOROOT (/opt/homebrew/Cellar/go@1.20/1.20.14/libexec/src/llgo)
cannot build SSA for package llgo
exit status 1
```

After:

```shell
➜  _demo git:(fix-build) ✗ go run ../cmd/llgo build ./async ./hello
# github.com/goplus/llgo/cmd/llgo
ld: warning: -ld_classic is deprecated and will be removed in a future release
build flags: [-tags llgo]
patterns: [./async ./hello]
```