### PR TITLE
README: fix dependences requirement for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Follow these steps to generate the `llgo` command (its usage is the same as the 
 
 ```sh
 brew update
-brew install llvm@18 bdw-gc openssl cjson libffi
+brew install llvm@18 bdw-gc openssl cjson libffi pkg-config
 brew install python@3.12 # optional
 brew link --force libffi
 go install -v github.com/goplus/llgo/cmd/llgo@latest


### PR DESCRIPTION
User may not install pkg-config when initalization.

When lacking of pkg-config tool, it will panic like that 

```
panic: test link args ' $(pkg-config --libs bdw-gc); -lgc' failed
	expanded to: [-lgc]
	resolved to: [-lgc]
	error: ld: library 'gc' not found
clang: error: linker command failed with exit code 1 (use -v to see invocation)

```