### PR TITLE
ssa: fix cvtType check types.Alias

### DIFF
--- a/compiler/ssa/abitype.go
+++ b/compiler/ssa/abitype.go
@@ -19,6 +19,7 @@ package ssa
 import (
 	"go/token"
 	"go/types"
+	"unsafe"
 
 	"github.com/goplus/llgo/compiler/ssa/abi"
 	"github.com/goplus/llvm"
@@ -248,7 +249,7 @@ func (b Builder) abiNamedInterfaceOf(t *types.Named) func() Expr {
 }
 
 func (b Builder) sizeof(t types.Type) int64 {
-	sizes := (*goProgram)(b.Prog)
+	sizes := (*goProgram)(unsafe.Pointer(b.Prog))
 	return sizes.Sizeof(t)
 }
 
@@ -332,7 +333,7 @@ func (b Builder) abiChanOf(t *types.Chan) func() Expr {
 func (b Builder) abiMapOf(t *types.Map) func() Expr {
 	key := b.abiTypeOf(t.Key())
 	elem := b.abiTypeOf(t.Elem())
-	sizes := (*goProgram)(b.Prog)
+	sizes := (*goProgram)(unsafe.Pointer(b.Prog))
 	bucket := b.abiTypeOf(abi.MapBucketType(t, sizes))
 	flags := abi.MapTypeFlags(t, sizes)
 	return func() Expr {

--- a/compiler/ssa/type.go
+++ b/compiler/ssa/type.go
@@ -19,6 +19,7 @@ package ssa
 import (
 	"fmt"
 	"go/types"
+	"unsafe"
 
 	"github.com/goplus/llgo/compiler/ssa/abi"
 	"github.com/goplus/llvm"
@@ -96,7 +97,7 @@ func (p *goProgram) Alignof(T types.Type) int64 {
 // Offsetsof must implement the offset guarantees required by the spec.
 // A negative entry in the result indicates that the struct is too large.
 func (p *goProgram) Offsetsof(fields []*types.Var) (ret []int64) {
-	prog := Program(p)
+	prog := Program(unsafe.Pointer(p))
 	ptrSize := int64(prog.PointerSize())
 	extra := int64(0)
 	ret = p.sizes.Offsetsof(fields)
@@ -111,7 +112,7 @@ func (p *goProgram) Offsetsof(fields []*types.Var) (ret []int64) {
 // Sizeof must implement the size guarantees required by the spec.
 // A negative result indicates that T is too large.
 func (p *goProgram) Sizeof(T types.Type) int64 {
-	prog := Program(p)
+	prog := Program(unsafe.Pointer(p))
 	ptrSize := int64(prog.PointerSize())
 	baseSize := prog.sizes.Sizeof(T) + p.extraSize(T, ptrSize)
 	switch T.Underlying().(type) {
@@ -171,7 +172,7 @@ func (t Type) RawType() types.Type {
 // TypeSizes returns the sizes of the types.
 func (p Program) TypeSizes(sizes types.Sizes) types.Sizes {
 	p.sizes = sizes
-	return (*goProgram)(p)
+	return (*goProgram)(unsafe.Pointer(p))
 }
 
 // TODO(xsw):

--- a/compiler/ssa/type_cvt.go
+++ b/compiler/ssa/type_cvt.go
@@ -116,7 +116,7 @@ func (p goTypes) cvtType(typ types.Type) (raw types.Type, cvt bool) {
 	case *types.TypeParam:
 		return typ.Underlying(), false
 	case *types.Alias:
-		return types.Unalias(t), true
+		return p.cvtType(types.Unalias(t))
 	default:
 		panic(fmt.Sprintf("cvtType: unexpected type - %T", typ))
 	}


### PR DESCRIPTION
- fix cvtType for go1.22/1.23 `GODEBUG=gotypesalias=1`
- fix compiler build for go1.22 `GODEBUG=gotypesalias=1`