### PR TITLE
Fix abi for uninstantiated generic methods

### DIFF
--- a/compiler/ssa/abitype.go
+++ b/compiler/ssa/abitype.go
@@ -130,10 +130,16 @@ func (b Builder) abiMethods(t *types.Named) (ret, pret int) {
 
 // Method{name string, typ *FuncType, ifn, tfn abi.Text}
 func (b Builder) abiMethodOf(mPkg *types.Package, mName string, mSig *types.Signature /*, bg Background = InGo */) (mthd, ptrMthd Expr) {
+	fullName := abi.FullName(mPkg, mName)
+	if mSig.TypeParams().Len() > 0 {
+		if fn := b.Pkg.FuncOf(fullName); fn != nil {
+			return
+		}
+	}
 	prog := b.Prog
 	name := b.Str(mName).impl
 	if !token.IsExported(mName) {
-		name = b.Str(abi.FullName(mPkg, mName)).impl
+		name = b.Str(fullName).impl
 	}
 	abiSigGo := types.NewSignatureType(nil, nil, nil, mSig.Params(), mSig.Results(), mSig.Variadic())
 	abiSig := prog.FuncDecl(abiSigGo, InGo).raw.Type
@@ -286,7 +292,9 @@ func (b Builder) abiInitNamed(ret Expr, t *types.Named) func() Expr {
 				if !mthd.IsNil() {
 					mthds = append(mthds, mthd)
 				}
-				ptrMthds = append(ptrMthds, ptrMthd)
+				if !ptrMthd.IsNil() {
+					ptrMthds = append(ptrMthds, ptrMthd)
+				}
 			}
 			if len(mthds) > 0 {
 				methods = b.SliceLit(tSlice, mthds...)


### PR DESCRIPTION
Fix https://github.com/goplus/llgo/issues/947

- Don't generate ABI for uninstantiated generic methods