### PR TITLE
fix(ssa): fix incorrectly ABI for uninstantiated generic methods

### DIFF
--- a/compiler/cl/compile.go
+++ b/compiler/cl/compile.go
@@ -260,6 +260,8 @@ func (p *context) compileFuncDecl(pkg llssa.Package, f *ssa.Function) (llssa.Fun
 			fn.Inline(llssa.NoInline)
 		}
 	}
+	// set compiled to check generic function global instantiation
+	pkg.Prog.SetFuncCompiled(name)
 	isCgo := isCgoExternSymbol(f)
 	if nblk := len(f.Blocks); nblk > 0 {
 		p.cgoCalled = false


### PR DESCRIPTION
Fix https://github.com/goplus/llgo/issues/947

- Skip ABI generation for uninstantiated generic methods

Maybe a better way is refactoring ABI generation based on type/func compilation.