### PR TITLE
ci: go test remove -v

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,11 +44,11 @@ jobs:
 
       - name: Test
         if: ${{!startsWith(matrix.os, 'macos')}}
-        run: go test -v ./...
+        run: go test ./...
 
       - name: Test with coverage
         if: startsWith(matrix.os, 'macos')
-        run: go test -v -coverprofile="coverage.txt" -covermode=atomic ./...
+        run: go test -coverprofile="coverage.txt" -covermode=atomic ./...
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/compiler/cl/compile_test.go
+++ b/compiler/cl/compile_test.go
@@ -17,22 +17,12 @@
 package cl_test
 
 import (
-	"io"
-	"log"
-	"os"
 	"testing"
 
 	"github.com/goplus/llgo/compiler/cl"
 	"github.com/goplus/llgo/compiler/cl/cltest"
 	"github.com/goplus/llgo/compiler/internal/build"
 )
-
-func init() {
-	devNull, _ := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
-	os.Stderr = devNull
-	os.Stdout = devNull
-	log.SetOutput(io.Discard)
-}
 
 func testCompile(t *testing.T, src, expected string) {
 	t.Helper()

--- a/compiler/ssa/cl_test.go
+++ b/compiler/ssa/cl_test.go
@@ -18,9 +18,6 @@ package ssa_test
 
 import (
 	"go/types"
-	"io"
-	"log"
-	"os"
 	"testing"
 
 	"github.com/goplus/llgo/compiler/cl/cltest"
@@ -29,10 +26,6 @@ import (
 )
 
 func init() {
-	devNull, _ := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
-	os.Stderr = devNull
-	os.Stdout = devNull
-	log.SetOutput(io.Discard)
 	ssa.SetDebug(ssa.DbgFlagAll)
 }
 


### PR DESCRIPTION
- reset test default actions for ci/ssa
- ci go test remove -v