### PR TITLE
c/clang:presume location

### DIFF
--- a/c/clang/_wrap/cursor.cpp
+++ b/c/clang/_wrap/cursor.cpp
@@ -213,6 +213,10 @@ void wrap_clang_getSpellingLocation(CXSourceLocation *loc, CXFile *file, unsigne
     clang_getSpellingLocation(*loc, file, line, column, offset);
 }
 
+void wrap_clang_getPresumedLocation(CXSourceLocation *loc, CXString *filename, unsigned *line, unsigned *column) {
+    clang_getPresumedLocation(*loc, filename, line, column);
+}
+
 void wrap_clang_getRangeStart(CXSourceRange *range, CXSourceLocation *loc) { *loc = clang_getRangeStart(*range); }
 
 void wrap_clang_getRangeEnd(CXSourceRange *range, CXSourceLocation *loc) { *loc = clang_getRangeEnd(*range); }

--- a/c/clang/clang.go
+++ b/c/clang/clang.go
@@ -2879,6 +2879,53 @@ func (l SourceLocation) Offset() (ret c.Uint) {
 }
 
 /**
+ * Retrieve the file, line and column represented by the given source
+ * location, as specified in a # line directive.
+ *
+ * Example: given the following source code in a file somefile.c
+ *
+ * \code
+ * #123 "dummy.c" 1
+ *
+ * static int func(void)
+ * {
+ *     return 0;
+ * }
+ * \endcode
+ *
+ * the location information returned by this function would be
+ *
+ * File: dummy.c Line: 124 Column: 12
+ *
+ * whereas clang_getExpansionLocation would have returned
+ *
+ * File: somefile.c Line: 3 Column: 12
+ *
+ * \param location the location within a source file that will be decomposed
+ * into its parts.
+ *
+ * \param filename [out] if non-NULL, will be set to the filename of the
+ * source location. Note that filenames returned will be for "virtual" files,
+ * which don't necessarily exist on the machine running clang - e.g. when
+ * parsing preprocessed output obtained from a different environment. If
+ * a non-NULL value is passed in, remember to dispose of the returned value
+ * using \c clang_disposeString() once you've finished with it. For an invalid
+ * source location, an empty string is returned.
+ *
+ * \param line [out] if non-NULL, will be set to the line number of the
+ * source location. For an invalid source location, zero is returned.
+ *
+ * \param column [out] if non-NULL, will be set to the column number of the
+ * source location. For an invalid source location, zero is returned.
+ */
+// llgo:link (*SourceLocation).wrapPresumedLocation C.wrap_clang_getPresumedLocation
+func (l *SourceLocation) wrapPresumedLocation(filename *String, line, column *c.Uint) {}
+
+func (l SourceLocation) PresumedLocation(filename *String, line, column *c.Uint) {
+	l.wrapPresumedLocation(filename, line, column)
+}
+
+/**
  * Retrieve a source location representing the first character within a
  * source range.
  */


### PR DESCRIPTION
`main.h`
```c
#define foo 1
typedef struct A {
    long a;
    char d[foo];
} A;
#include "compat.h"
typedef B C;
```
compat.h
```c
typedef A B;
```
`clang -dD -E -C -x c-header main.h > temp.i`
got `temp.i`
```c
..............
# 1 "main.h" 2
#define dsdadadassd 1
typedef struct A {
    long a;
    char d[1];
} A;
# 1 "./compat.h" 1
typedef A B;
# 7 "main.h" 2
typedef B C;
```
`symboldump temp.i` can get the origin location from line command of clang -E 's result
```bash
Location: temp.i:452:9
Presumed Location: main.h:1:9
Marco Name: foo
Content: foo 1 
--------------------------------
Location: temp.i:453:16
Presumed Location: main.h:2:16
Name: A
--------------------------------
Location: temp.i:456:3
Presumed Location: main.h:5:3
Name: A
--------------------------------
Location: temp.i:458:11
Presumed Location: ./compat.h:1:11
Name: B
--------------------------------
Location: temp.i:460:11
Presumed Location: main.h:7:11
Name: C
--------------------------------
```