### PR TITLE
Fix release build

### DIFF
--- a/.github/workflows/populate_linux_sysroot.sh
+++ b/.github/workflows/populate_linux_sysroot.sh
@@ -139,5 +139,8 @@ populate_linux_sysroot() {
 		debian:bullseye \
 		/populate_linux_sysroot.sh
 }
-populate_linux_sysroot amd64 "${LINUX_AMD64_PREFIX}"
-populate_linux_sysroot arm64 "${LINUX_ARM64_PREFIX}"
+populate_linux_sysroot amd64 "${LINUX_AMD64_PREFIX}" &
+populate_linux_sysroot arm64 "${LINUX_ARM64_PREFIX}" &
+
+# Wait for both background processes to complete
+wait

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -35,6 +35,8 @@ jobs:
           go-version: 1.23.x
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
       - name: Download Darwin sysroot tarball
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -11,18 +11,9 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Cache Darwin sysroot
-        id: cache-sysroot
-        uses: actions/cache@v4
-        with:
-          path: |
-            .sysroot/darwin.tar.gz
-          key: darwin-sysroot-${{ runner.os }}-${{ hashFiles('.github/workflows/populate_darwin_sysroot.sh') }}
       - name: Populate Darwin sysroot
-        if: steps.cache-sysroot.outputs.cache-hit != 'true'
         run: bash .github/workflows/populate_darwin_sysroot.sh
       - name: Create Darwin sysroot tarball
-        if: steps.cache-sysroot.outputs.cache-hit != 'true'
         run: tar -czvf .sysroot/darwin.tar.gz -C .sysroot darwin
       - name: Upload Darwin sysroot tarball
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Lock to `tonistiigi/binfmt:qemu-v7.0.0-28` to avoid `binfmt` crash, see https://github.com/docker/setup-qemu-action/issues/198

See build result: https://github.com/cpunion/llgo/releases/tag/v0.9.51