### PR TITLE
cl: fix wrong global variable type patching

### DIFF
--- a/compiler/cl/import.go
+++ b/compiler/cl/import.go
@@ -568,7 +568,7 @@ func (p *context) varOf(b llssa.Builder, v *ssa.Global) llssa.Expr {
 	}
 	ret := pkg.VarOf(name)
 	if ret == nil {
-		ret = pkg.NewVar(name, globalType(v), llssa.Background(vtype))
+		ret = pkg.NewVar(name, p.patchType(v.Type()), llssa.Background(vtype))
 	}
 	return ret.Expr
 }


### PR DESCRIPTION
Fix wrong `sync.Mutex` size that cause crashes on linux.

Fix https://github.com/goplus/llgo/issues/1001

Before:

```llvm
; linux
%sync.Mutex = type { i32, i32 }
@testing.matchMutex = global %sync.Mutex zeroinitializer, align 4

; macos
%sync.Mutex = type { i64, [56 x i8] }
@testing.matchMutex = global %sync.Mutex zeroinitializer, align 8
```

After:

```llvm
; linux
@testing.matchMutex = global [48 x i8]

; macos (no changes)
%sync.Mutex = type { i64, [56 x i8] }
@testing.matchMutex = global %sync.Mutex zeroinitializer, align 8
```