### PR TITLE
runtime:rm log of StartProcess

### DIFF
--- a/runtime/internal/lib/os/exec_posix.go
+++ b/runtime/internal/lib/os/exec_posix.go
@@ -64,7 +64,6 @@ func startProcess(name string, argv []string, attr *ProcAttr) (p *Process, err e
 			return nil, &PathError{Op: "fork/exec", Path: name, Err: e}
 		}
 	}
-	println("StartProcess", pid, h, e)
 
 	return newProcess(pid, h), nil
 }


### PR DESCRIPTION
Log outputs a different Pid each time, which causes undesirable errors during comparative testing

`llgo.expect`
```bash
=> Result of llgo.expect
#stdout
.....
#stderr
StartProcess 8041 0 ((nil),(nil))
StartProcess 8042 0 ((nil),(nil))
StartProcess 8045 0 ((nil),(nil))
StartProcess 8046 0 ((nil),(nil))
#exit 0
=> Expected llgo.expect
#stdout
......
#stderr

#exit 0
2025/02/27 03:40:57 checkEqual: unexpected llgo.expect
panic: checkEqual: unexpected llgo.expect
```