### PR TITLE
ci: run llgo test

### DIFF
--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -165,6 +165,7 @@ jobs:
 
       - name: run llgo test
         run: |
+          llgo test ./...
           cd _demo
           llgo test -v ./runtest
 

--- a/compiler/chore/llgen/llgen_test.go
+++ b/compiler/chore/llgen/llgen_test.go
@@ -1,3 +1,6 @@
+//go:build !llgo
+// +build !llgo
+
 package main
 
 import (

--- a/compiler/chore/llpyg/pysig/parse_test.go
+++ b/compiler/chore/llpyg/pysig/parse_test.go
@@ -1,3 +1,6 @@
+//go:build !llgo
+// +build !llgo
+
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
  *

--- a/compiler/cl/blocks/block_test.go
+++ b/compiler/cl/blocks/block_test.go
@@ -1,3 +1,6 @@
+//go:build !llgo
+// +build !llgo
+
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
  *

--- a/compiler/cl/builtin_test.go
+++ b/compiler/cl/builtin_test.go
@@ -1,3 +1,6 @@
+//go:build !llgo
+// +build !llgo
+
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
  *

--- a/compiler/cl/compile_test.go
+++ b/compiler/cl/compile_test.go
@@ -1,3 +1,6 @@
+//go:build !llgo
+// +build !llgo
+
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
  *

--- a/compiler/cmd/llgo/llgo_test.go
+++ b/compiler/cmd/llgo/llgo_test.go
@@ -1,3 +1,6 @@
+//go:build !llgo
+// +build !llgo
+
 package main
 
 import (

--- a/compiler/internal/build/build.go
+++ b/compiler/internal/build/build.go
@@ -175,6 +175,14 @@ func Do(args []string, conf *Config) ([]Package, error) {
 			}
 		case ModeRun:
 			return nil, fmt.Errorf("cannot run multiple packages")
+		case ModeTest:
+			newInitial := make([]*packages.Package, 0, len(initial))
+			for _, pkg := range initial {
+				if needLink(pkg, mode) {
+					newInitial = append(newInitial, pkg)
+				}
+			}
+			initial = newInitial
 		}
 	}
 

--- a/compiler/internal/build/build_test.go
+++ b/compiler/internal/build/build_test.go
@@ -1,3 +1,6 @@
+//go:build !llgo
+// +build !llgo
+
 package build
 
 import (

--- a/compiler/internal/buildtags/buildtags_test.go
+++ b/compiler/internal/buildtags/buildtags_test.go
@@ -1,3 +1,6 @@
+//go:build !llgo
+// +build !llgo
+
 package buildtags
 
 import (

--- a/compiler/internal/env/env_test.go
+++ b/compiler/internal/env/env_test.go
@@ -1,3 +1,6 @@
+//go:build !llgo
+// +build !llgo
+
 package env
 
 import (

--- a/compiler/ssa/cl_test.go
+++ b/compiler/ssa/cl_test.go
@@ -1,3 +1,6 @@
+//go:build !llgo
+// +build !llgo
+
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
  *

--- a/compiler/ssa/package.go
+++ b/compiler/ssa/package.go
@@ -387,14 +387,13 @@ func (p Program) NewPackage(name, pkgPath string) Package {
 	pyobjs := make(map[string]PyObjRef)
 	pymods := make(map[string]Global)
 	strs := make(map[string]llvm.Value)
-	goStrs := make(map[string]llvm.Value)
 	chkabi := make(map[types.Type]bool)
 	glbDbgVars := make(map[Expr]bool)
 	// Don't need reset p.needPyInit here
 	// p.needPyInit = false
 	ret := &aPackage{
 		mod: mod, vars: gbls, fns: fns, stubs: stubs,
-		pyobjs: pyobjs, pymods: pymods, strs: strs, goStrs: goStrs,
+		pyobjs: pyobjs, pymods: pymods, strs: strs,
 		chkabi: chkabi, Prog: p,
 		di: nil, cu: nil, glbDbgVars: glbDbgVars,
 	}

--- a/compiler/ssa/ssa_test.go
+++ b/compiler/ssa/ssa_test.go
@@ -1,3 +1,6 @@
+//go:build !llgo
+// +build !llgo
+
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
  *

--- a/compiler/ssa/ssatest/ssautil_test.go
+++ b/compiler/ssa/ssatest/ssautil_test.go
@@ -1,3 +1,6 @@
+//go:build !llgo
+// +build !llgo
+
 package ssatest
 
 import (

--- a/runtime/abi/map_test.go
+++ b/runtime/abi/map_test.go
@@ -1,3 +1,6 @@
+//go:build !llgo
+// +build !llgo
+
 package abi
 
 import (

--- a/test/c_test.go
+++ b/test/c_test.go
@@ -1,0 +1,21 @@
+//go:build llgo
+// +build llgo
+
+package test
+
+import (
+	"testing"
+
+	"github.com/goplus/llgo/c"
+)
+
+// Can't put it in c/ package because it is marked as 'decl'
+func TestCstr(t *testing.T) {
+	cstr := c.Str("foo")
+	if cstr == nil {
+		t.Fatal("cstr() returned nil")
+	}
+	if c.Strlen(cstr) != 3 {
+		t.Fatal("cstr() returned invalid length")
+	}
+}

--- a/xtool/clang/_types/parser/_parser_test.go
+++ b/xtool/clang/_types/parser/_parser_test.go
@@ -1,3 +1,6 @@
+//go:build !llgo
+// +build !llgo
+
 /*
  * Copyright (c) 2022 The GoPlus Authors (goplus.org). All rights reserved.
  *


### PR DESCRIPTION
- [x] Reduce unnecessary pkgs compilation for `llgo test` https://github.com/goplus/llgo/issues/1026
- [x] Split go tests and llgo tests by `llgo` build tag, and run `go test ./...` and `llgo test ./...` in CI workflow