### PR TITLE
Remove LLVM runtime depencendy, better c toolchain integration

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -27,7 +27,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: README.md
+          args: --max-concurrency 3 --retry-wait-time 15 README.md
 
   remote_install:
     strategy:

--- a/c/debug/debug.go
+++ b/c/debug/debug.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	LLGoPackage = "link: $(llvm-config --ldflags --libs); -lunwind"
-	LLGoFiles   = "$(llvm-config --cflags): _wrap/debug.c"
+	LLGoPackage = "link"
+	LLGoFiles   = "_wrap/debug.c"
 )
 
 type Info struct {

--- a/compiler/internal/build/build.go
+++ b/compiler/internal/build/build.go
@@ -488,7 +488,7 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, linkArgs
 	if verbose {
 		fmt.Fprintln(os.Stderr, "clang", args)
 	}
-	err = ctx.env.Clang().Exec(args...)
+	err = ctx.env.Clang().Link(args...)
 	check(err)
 
 	if IsRpathChangeEnabled() && runtime.GOOS == "darwin" {
@@ -870,7 +870,7 @@ func clFile(ctx *context, args []string, cFile, expFile string, procFile func(li
 	if verbose {
 		fmt.Fprintln(os.Stderr, "clang", args)
 	}
-	err := ctx.env.Clang().Exec(args...)
+	err := ctx.env.Clang().Compile(args...)
 	check(err)
 	procFile(llFile)
 }

--- a/runtime/internal/clite/debug/debug.go
+++ b/runtime/internal/clite/debug/debug.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	LLGoPackage = "link: $(llvm-config --ldflags --libs); -lunwind"
-	LLGoFiles   = "$(llvm-config --cflags): _wrap/debug.c"
+	LLGoPackage = "link"
+	LLGoFiles   = "_wrap/debug.c"
 )
 
 type Info struct {

--- a/xtool/clang/clang.go
+++ b/xtool/clang/clang.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 // -----------------------------------------------------------------------------
@@ -38,6 +39,32 @@ func New(app string) *Cmd {
 		app = "clang"
 	}
 	return &Cmd{app, os.Stdout, os.Stderr}
+}
+
+func (p *Cmd) Compile(args ...string) error {
+	// Parse CFLAGS environment variable into separate arguments
+	cflags := strings.Fields(os.Getenv("CFLAGS"))
+	if len(cflags) > 0 {
+		// Create a new slice with capacity for all arguments
+		newArgs := make([]string, 0, len(cflags)+len(args))
+		newArgs = append(newArgs, cflags...)
+		newArgs = append(newArgs, args...)
+		args = newArgs
+	}
+	return p.Exec(args...)
+}
+
+func (p *Cmd) Link(args ...string) error {
+	// Parse LDFLAGS environment variable into separate arguments
+	ldflags := strings.Fields(os.Getenv("LDFLAGS"))
+	if len(ldflags) > 0 {
+		// Create a new slice with capacity for all arguments
+		newArgs := make([]string, 0, len(ldflags)+len(args))
+		newArgs = append(newArgs, ldflags...)
+		newArgs = append(newArgs, args...)
+		args = newArgs
+	}
+	return p.Exec(args...)
 }
 
 // Exec executes a clang command.


### PR DESCRIPTION
- [x] Remove LLVM runtime dependency
  - Can use `libunwind` instead of `llvm/libunwind` (better for WASM support)
  - Can use libunwind formula on Homebrew Linux
- [x] Process CFLAGS/LDFLAGS for clang compilation and linking
  - Better integration with Homebrew Linux (test passed on https://github.com/Homebrew/homebrew-core/pull/210790) 
  - And better integration with other c toolchain