### PR TITLE
Remove cgo from llgo/c and llgo/runtime

### DIFF
--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -166,8 +166,10 @@ jobs:
       - name: run llgo test
         run: |
           llgo test ./...
-          cd _demo
-          llgo test -v ./runtest
+          cd runtime
+          llgo test ./...
+          cd ../_demo
+          llgo test ./runtest
 
   hello:
     continue-on-error: true

--- a/c/c.go
+++ b/c/c.go
@@ -16,11 +16,6 @@
 
 package c
 
-// typedef unsigned int uint;
-// typedef unsigned long ulong;
-// typedef unsigned long long ulonglong;
-// typedef long long longlong;
-import "C"
 import "unsafe"
 
 const (
@@ -41,14 +36,16 @@ type FILE struct {
 }
 
 type (
-	Int  C.int
-	Uint C.uint
+	Int  = int32
+	Uint = uint32
 
-	Long  C.long
-	Ulong C.ulong
+	// Long and Ulong are defined in platform-specific files
+	// Windows (both 32-bit and 64-bit): int32/uint32
+	// Unix/Linux/macOS 32-bit: int32/uint32
+	// Unix/Linux/macOS 64-bit: int64/uint64
 
-	LongLong  C.longlong
-	UlongLong C.ulonglong
+	LongLong  = int64
+	UlongLong = uint64
 )
 
 type integer interface {
@@ -308,6 +305,3 @@ func GetoptLong(argc Int, argv **Char, optstring *Char, longopts *Option, longin
 func GetoptLongOnly(argc Int, argv **Char, optstring *Char, longopts *Option, longindex *Int) Int
 
 // -----------------------------------------------------------------------------
-
-//go:linkname Sysconf C.sysconf
-func Sysconf(name Int) Long

--- a/c/ctypes_32bit.go
+++ b/c/ctypes_32bit.go
@@ -1,4 +1,6 @@
-//go:build linux
+//go:build (linux || darwin || freebsd || netbsd || openbsd || solaris) && (386 || arm || mips || mipsle)
+// +build linux darwin freebsd netbsd openbsd solaris
+// +build 386 arm mips mipsle
 
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
@@ -16,14 +18,10 @@
  * limitations under the License.
  */
 
-package os
+package c
 
-import _ "unsafe"
-
-const (
-	LLGoFiles   = "_os/os.c"
-	LLGoPackage = "link"
+// For 32-bit Unix/Linux/macOS, Long is 32-bit
+type (
+	Long  = int32
+	Ulong = uint32
 )
-
-//go:linkname Clearenv C.clearenv
-func Clearenv()

--- a/c/ctypes_unix64.go
+++ b/c/ctypes_unix64.go
@@ -1,4 +1,6 @@
-//go:build linux
+//go:build (linux || darwin || freebsd || netbsd || openbsd || solaris) && (amd64 || arm64 || ppc64 || ppc64le || mips64 || mips64le || s390x || riscv64)
+// +build linux darwin freebsd netbsd openbsd solaris
+// +build amd64 arm64 ppc64 ppc64le mips64 mips64le s390x riscv64
 
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
@@ -16,14 +18,10 @@
  * limitations under the License.
  */
 
-package os
+package c
 
-import _ "unsafe"
-
-const (
-	LLGoFiles   = "_os/os.c"
-	LLGoPackage = "link"
+// For 64-bit Unix/Linux/macOS, Long is 64-bit
+type (
+	Long  = int64
+	Ulong = uint64
 )
-
-//go:linkname Clearenv C.clearenv
-func Clearenv()

--- a/c/ctypes_wasm.go
+++ b/c/ctypes_wasm.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build wasip1 || js
+// +build wasip1 js
 
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
@@ -19,13 +19,8 @@
 
 package c
 
-import _ "unsafe"
-
-//go:linkname Stdin stdin
-var Stdin FilePtr
-
-//go:linkname Stdout stdout
-var Stdout FilePtr
-
-//go:linkname Stderr stderr
-var Stderr FilePtr
+// For WebAssembly targets, Long is 32-bit per the spec
+type (
+	Long  = int32
+	Ulong = uint32
+)

--- a/c/ctypes_windows.go
+++ b/c/ctypes_windows.go
@@ -1,5 +1,5 @@
-//go:build !linux
-// +build !linux
+//go:build windows
+// +build windows
 
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
@@ -19,13 +19,8 @@
 
 package c
 
-import _ "unsafe"
-
-//go:linkname Stdin __stdinp
-var Stdin FilePtr
-
-//go:linkname Stdout __stdoutp
-var Stdout FilePtr
-
-//go:linkname Stderr __stderrp
-var Stderr FilePtr
+// For Windows (LLP64 model), Long is 32-bit, regardless of architecture
+type (
+	Long  = int32
+	Ulong = uint32
+)

--- a/c/debug/debug.go
+++ b/c/debug/debug.go
@@ -1,9 +1,5 @@
 package debug
 
-/*
-#cgo linux LDFLAGS: -lunwind
-*/
-import "C"
 import (
 	"unsafe"
 
@@ -11,8 +7,7 @@ import (
 )
 
 const (
-	LLGoPackage = "link"
-	LLGoFiles   = "_wrap/debug.c"
+	LLGoFiles = "_wrap/debug.c"
 )
 
 type Info struct {

--- a/c/debug/libunwind.go
+++ b/c/debug/libunwind.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package debug
+
+const (
+	LLGoPackage = "link"
+)

--- a/c/debug/libunwind_linux.go
+++ b/c/debug/libunwind_linux.go
@@ -1,0 +1,7 @@
+//go:build linux
+
+package debug
+
+const (
+	LLGoPackage = "link: -lunwind"
+)

--- a/c/os/os.go
+++ b/c/os/os.go
@@ -16,19 +16,11 @@
 
 package os
 
-// #include <sys/stat.h>
-// #include <limits.h>
-import "C"
-
 import (
 	_ "unsafe"
 
 	"github.com/goplus/llgo/c"
 	"github.com/goplus/llgo/c/syscall"
-)
-
-const (
-	PATH_MAX = C.PATH_MAX
 )
 
 const (
@@ -59,14 +51,6 @@ const (
 )
 
 type (
-	ModeT C.mode_t
-	UidT  C.uid_t
-	GidT  C.gid_t
-	OffT  C.off_t
-	DevT  C.dev_t
-)
-
-type (
 	StatT = syscall.Stat_t
 )
 
@@ -93,6 +77,9 @@ func Readlink(path *c.Char, buf c.Pointer, bufsize uintptr) int
 
 //go:linkname Unlink C.unlink
 func Unlink(path *c.Char) c.Int
+
+//go:linkname Unlinkat C.unlinkat
+func Unlinkat(dirfd c.Int, path *c.Char, flags c.Int) c.Int
 
 //go:linkname Remove C.remove
 func Remove(path *c.Char) c.Int
@@ -183,6 +170,9 @@ func Dup(fd c.Int) c.Int
 //go:linkname Dup2 C.dup2
 func Dup2(oldfd c.Int, newfd c.Int) c.Int
 
+//go:linkname Dup3 C.dup3
+func Dup3(oldfd c.Int, newfd c.Int, flags c.Int) c.Int
+
 /* TODO(xsw):
 On Alpha, IA-64, MIPS, SuperH, and SPARC/SPARC64, pipe() has the following prototype:
 struct fd_pair {
@@ -272,6 +262,20 @@ func Getpid() PidT
 
 //go:linkname Getppid C.getppid
 func Getppid() PidT
+
+// Invoke `system call' number SYSNO, passing it the remaining arguments.
+// This is completely system-dependent, and not often useful.
+
+// In Unix, `syscall' sets `errno' for all errors and most calls return -1
+// for errors; in many systems you cannot pass arguments or get return
+// values for all system calls (`pipe', `fork', and `getppid' typically
+// among them).
+
+// In Mach, all system calls take normal arguments and always return an
+// error code (zero for success).
+//
+//go:linkname Syscall C.syscall
+func Syscall(sysno c.Long, __llgo_va_list ...any) c.Long
 
 //go:linkname Kill C.kill
 func Kill(pid PidT, sig c.Int) c.Int

--- a/c/os/os_darwin.go
+++ b/c/os/os_darwin.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
  *
@@ -25,5 +23,17 @@ const (
 	LLGoPackage = "link"
 )
 
-//go:linkname Clearenv C.clearenv
+const (
+	PATH_MAX = 1024
+)
+
+type (
+	ModeT uint16
+	UidT  uint32
+	GidT  uint32
+	OffT  int64
+	DevT  int32
+)
+
+//go:linkname Clearenv C.llgoClearenv
 func Clearenv()

--- a/c/os/os_other.go
+++ b/c/os/os_other.go
@@ -18,7 +18,7 @@
 
 package os
 
-import "C"
+import _ "unsafe"
 
 const (
 	LLGoFiles   = "_os/os.c"

--- a/c/os/os_other.go
+++ b/c/os/os_other.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build !darwin
 
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
@@ -25,5 +25,17 @@ const (
 	LLGoPackage = "link"
 )
 
-//go:linkname Clearenv C.llgoClearenv
+const (
+	PATH_MAX = 4096
+)
+
+type (
+	ModeT uint32
+	UidT  uint32
+	GidT  uint32
+	OffT  int64
+	DevT  uint64
+)
+
+//go:linkname Clearenv C.clearenv
 func Clearenv()

--- a/c/pthread/sync/_sema.go
+++ b/c/pthread/sync/_sema.go
@@ -16,9 +16,6 @@
 
 package sync
 
-// #include <semaphore.h>
-import "C"
-
 import (
 	_ "unsafe"
 

--- a/c/pthread/sync/sync.go
+++ b/c/pthread/sync/sync.go
@@ -16,9 +16,6 @@
 
 package sync
 
-// #include <pthread.h>
-import "C"
-
 import (
 	_ "unsafe"
 
@@ -31,12 +28,32 @@ const (
 	LLGoPackage = "link"
 )
 
+const (
+	PthreadOnceSize       = 16
+	PthreadMutexSize      = 64
+	PthreadMutexAttrSize  = 16
+	PthreadCondSize       = 48
+	PthreadCondAttrSize   = 16
+	PthreadRWLockSize     = 200
+	PthreadRWLockAttrSize = 24
+)
+
+const (
+	PTHREAD_MUTEX_NORMAL     = 0
+	PTHREAD_MUTEX_ERRORCHECK = 1
+	PTHREAD_MUTEX_RECURSIVE  = 2
+	PTHREAD_MUTEX_DEFAULT    = PTHREAD_MUTEX_NORMAL
+)
+
 // -----------------------------------------------------------------------------
 
 // Once is an object that will perform exactly one action.
-type Once C.pthread_once_t
+// pthread_once_t
+type Once struct {
+	Unused [PthreadOnceSize]c.Char
+}
 
-//go:linkname OnceInit llgoSyncOnceInitVal
+//go:linkname OnceInit once_control
 var OnceInit Once
 
 // llgo:link (*Once).Do C.pthread_once
@@ -47,14 +64,17 @@ func (o *Once) Do(f func()) c.Int { return 0 }
 type MutexType c.Int
 
 const (
-	MUTEX_NORMAL     MutexType = C.PTHREAD_MUTEX_NORMAL
-	MUTEX_ERRORCHECK MutexType = C.PTHREAD_MUTEX_ERRORCHECK
-	MUTEX_RECURSIVE  MutexType = C.PTHREAD_MUTEX_RECURSIVE
-	MUTEX_DEFAULT    MutexType = C.PTHREAD_MUTEX_DEFAULT
+	MUTEX_NORMAL     MutexType = PTHREAD_MUTEX_NORMAL
+	MUTEX_ERRORCHECK MutexType = PTHREAD_MUTEX_ERRORCHECK
+	MUTEX_RECURSIVE  MutexType = PTHREAD_MUTEX_RECURSIVE
+	MUTEX_DEFAULT    MutexType = PTHREAD_MUTEX_DEFAULT
 )
 
 // MutexAttr is a mutex attribute object.
-type MutexAttr C.pthread_mutexattr_t
+// pthread_mutexattr_t
+type MutexAttr struct {
+	Unused [PthreadMutexAttrSize]c.Char
+}
 
 // llgo:link (*MutexAttr).Init C.pthread_mutexattr_init
 func (a *MutexAttr) Init(attr *MutexAttr) c.Int { return 0 }
@@ -68,7 +88,10 @@ func (a *MutexAttr) SetType(typ MutexType) c.Int { return 0 }
 // -----------------------------------------------------------------------------
 
 // Mutex is a mutual exclusion lock.
-type Mutex C.pthread_mutex_t
+// pthread_mutex_t
+type Mutex struct {
+	Unused [PthreadMutexSize]c.Char
+}
 
 // llgo:link (*Mutex).Init C.pthread_mutex_init
 func (m *Mutex) Init(attr *MutexAttr) c.Int { return 0 }
@@ -88,7 +111,10 @@ func (m *Mutex) Unlock() {}
 // -----------------------------------------------------------------------------
 
 // RWLockAttr is a read-write lock attribute object.
-type RWLockAttr C.pthread_rwlockattr_t
+// pthread_rwlockattr_t
+type RWLockAttr struct {
+	Unused [PthreadRWLockAttrSize]c.Char
+}
 
 // llgo:link (*RWLockAttr).Init C.pthread_rwlockattr_init
 func (a *RWLockAttr) Init(attr *RWLockAttr) c.Int { return 0 }
@@ -105,7 +131,10 @@ func (a *RWLockAttr) GetPShared(pshared *c.Int) c.Int { return 0 }
 // -----------------------------------------------------------------------------
 
 // RWLock is a read-write lock.
-type RWLock C.pthread_rwlock_t
+// pthread_rwlock_t
+type RWLock struct {
+	Unused [PthreadRWLockSize]c.Char
+}
 
 // llgo:link (*RWLock).Init C.pthread_rwlock_init
 func (rw *RWLock) Init(attr *RWLockAttr) c.Int { return 0 }
@@ -134,7 +163,10 @@ func (rw *RWLock) Unlock() {}
 // -----------------------------------------------------------------------------
 
 // CondAttr is a condition variable attribute object.
-type CondAttr C.pthread_condattr_t
+// pthread_condattr_t
+type CondAttr struct {
+	Unused [PthreadCondAttrSize]c.Char
+}
 
 // llgo:link (*CondAttr).Init C.pthread_condattr_init
 func (a *CondAttr) Init(attr *CondAttr) c.Int { return 0 }
@@ -142,16 +174,19 @@ func (a *CondAttr) Init(attr *CondAttr) c.Int { return 0 }
 // llgo:link (*CondAttr).Destroy C.pthread_condattr_destroy
 func (a *CondAttr) Destroy() {}
 
-// llgo:link (*CondAttr).SetClock C.pthread_condattr_setclock
-func (a *CondAttr) SetClock(clock time.ClockidT) c.Int { return 0 }
+// // llgo:link (*CondAttr).SetClock C.pthread_condattr_setclock
+// func (a *CondAttr) SetClock(clock time.ClockidT) c.Int { return 0 }
 
-// llgo:link (*CondAttr).GetClock C.pthread_condattr_getclock
-func (a *CondAttr) GetClock(clock *time.ClockidT) c.Int { return 0 }
+// // llgo:link (*CondAttr).GetClock C.pthread_condattr_getclock
+// func (a *CondAttr) GetClock(clock *time.ClockidT) c.Int { return 0 }
 
 // -----------------------------------------------------------------------------
 
 // Cond is a condition variable.
-type Cond C.pthread_cond_t
+// pthread_cond_t
+type Cond struct {
+	Unused [PthreadCondSize]c.Char
+}
 
 // llgo:link (*Cond).Init C.pthread_cond_init
 func (c *Cond) Init(attr *CondAttr) c.Int { return 0 }

--- a/c/pthread/sync/sync.go
+++ b/c/pthread/sync/sync.go
@@ -29,16 +29,6 @@ const (
 )
 
 const (
-	PthreadOnceSize       = 16
-	PthreadMutexSize      = 64
-	PthreadMutexAttrSize  = 16
-	PthreadCondSize       = 48
-	PthreadCondAttrSize   = 16
-	PthreadRWLockSize     = 200
-	PthreadRWLockAttrSize = 24
-)
-
-const (
 	PTHREAD_MUTEX_NORMAL     = 0
 	PTHREAD_MUTEX_ERRORCHECK = 1
 	PTHREAD_MUTEX_RECURSIVE  = 2

--- a/c/pthread/sync/sync_darwin_amd64.go
+++ b/c/pthread/sync/sync_darwin_amd64.go
@@ -1,0 +1,11 @@
+package sync
+
+const (
+	PthreadOnceSize       = 16
+	PthreadMutexSize      = 56
+	PthreadMutexAttrSize  = 8
+	PthreadCondSize       = 40
+	PthreadCondAttrSize   = 8
+	PthreadRWLockSize     = 192
+	PthreadRWLockAttrSize = 16
+)

--- a/c/pthread/sync/sync_darwin_arm64.go
+++ b/c/pthread/sync/sync_darwin_arm64.go
@@ -1,0 +1,11 @@
+package sync
+
+const (
+	PthreadOnceSize       = 16
+	PthreadMutexSize      = 64
+	PthreadMutexAttrSize  = 16
+	PthreadCondSize       = 48
+	PthreadCondAttrSize   = 16
+	PthreadRWLockSize     = 200
+	PthreadRWLockAttrSize = 24
+)

--- a/c/pthread/sync/sync_linux_amd64.go
+++ b/c/pthread/sync/sync_linux_amd64.go
@@ -1,0 +1,11 @@
+package sync
+
+const (
+	PthreadOnceSize       = 4
+	PthreadMutexSize      = 40
+	PthreadMutexAttrSize  = 4
+	PthreadCondSize       = 48
+	PthreadCondAttrSize   = 4
+	PthreadRWLockSize     = 56
+	PthreadRWLockAttrSize = 8
+)

--- a/c/pthread/sync/sync_linux_arm64.go
+++ b/c/pthread/sync/sync_linux_arm64.go
@@ -1,0 +1,11 @@
+package sync
+
+const (
+	PthreadOnceSize       = 4
+	PthreadMutexSize      = 48
+	PthreadMutexAttrSize  = 8
+	PthreadCondSize       = 48
+	PthreadCondAttrSize   = 8
+	PthreadRWLockSize     = 56
+	PthreadRWLockAttrSize = 8
+)

--- a/c/setjmp/jmpbuf_darwin_amd64.go
+++ b/c/setjmp/jmpbuf_darwin_amd64.go
@@ -1,0 +1,6 @@
+package setjmp
+
+const (
+	SigjmpBufSize = 196
+	JmpBufSize    = 192
+)

--- a/c/setjmp/jmpbuf_darwin_arm64.go
+++ b/c/setjmp/jmpbuf_darwin_arm64.go
@@ -1,0 +1,6 @@
+package setjmp
+
+const (
+	SigjmpBufSize = 196
+	JmpBufSize    = 192
+)

--- a/c/setjmp/jmpbuf_linux_amd64.go
+++ b/c/setjmp/jmpbuf_linux_amd64.go
@@ -1,0 +1,12 @@
+//go:build !darwin
+
+package setjmp
+
+import (
+	_ "unsafe"
+)
+
+const (
+	SigjmpBufSize = 200
+	JmpBufSize    = 200
+)

--- a/c/setjmp/jmpbuf_linux_arm64.go
+++ b/c/setjmp/jmpbuf_linux_arm64.go
@@ -1,0 +1,6 @@
+package setjmp
+
+const (
+	SigjmpBufSize = 312
+	JmpBufSize    = 312
+)

--- a/c/signal/signal.go
+++ b/c/signal/signal.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/goplus/llgo/c"
 )
-import "C"
 
 const (
 	LLGoPackage = "link"

--- a/c/stdio_darwin.go
+++ b/c/stdio_darwin.go
@@ -1,4 +1,5 @@
-//go:build linux
+//go:build darwin
+// +build darwin
 
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
@@ -16,14 +17,15 @@
  * limitations under the License.
  */
 
-package os
+package c
 
 import _ "unsafe"
 
-const (
-	LLGoFiles   = "_os/os.c"
-	LLGoPackage = "link"
-)
+//go:linkname Stdin __stdinp
+var Stdin FilePtr
 
-//go:linkname Clearenv C.clearenv
-func Clearenv()
+//go:linkname Stdout __stdoutp
+var Stdout FilePtr
+
+//go:linkname Stderr __stderrp
+var Stderr FilePtr

--- a/c/stdio_default.go
+++ b/c/stdio_default.go
@@ -1,4 +1,5 @@
-//go:build linux
+//go:build !darwin
+// +build !darwin
 
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
@@ -16,14 +17,15 @@
  * limitations under the License.
  */
 
-package os
+package c
 
 import _ "unsafe"
 
-const (
-	LLGoFiles   = "_os/os.c"
-	LLGoPackage = "link"
-)
+//go:linkname Stdin stdin
+var Stdin FilePtr
 
-//go:linkname Clearenv C.clearenv
-func Clearenv()
+//go:linkname Stdout stdout
+var Stdout FilePtr
+
+//go:linkname Stderr stderr
+var Stderr FilePtr

--- a/c/time/time.go
+++ b/c/time/time.go
@@ -16,9 +16,6 @@
 
 package time
 
-// #include <time.h>
-import "C"
-
 import (
 	_ "unsafe"
 
@@ -31,7 +28,12 @@ const (
 
 // -----------------------------------------------------------------------------
 
-type TimeT C.time_t
+const (
+	ClockTSize = 8
+)
+
+// time_t
+type TimeT c.IntptrT
 
 //go:linkname Time C.time
 func Time(timer *TimeT) TimeT
@@ -72,28 +74,31 @@ func Strftime(buf *c.Char, bufSize uintptr, format *c.Char, timeptr *Tm) uintptr
 
 // -----------------------------------------------------------------------------
 
-type ClockT C.clock_t
+// clock_t
+type ClockT struct {
+	Unused [ClockTSize]c.Char
+}
 
 //go:linkname Clock C.clock
 func Clock() ClockT
 
 // -----------------------------------------------------------------------------
 
-type ClockidT C.clockid_t
+type ClockidT c.Int
 
 const (
 	// the system's real time (i.e. wall time) clock, expressed as the amount of time since the Epoch.
 	// This is the same as the value returned by gettimeofday
-	CLOCK_REALTIME = ClockidT(C.CLOCK_REALTIME)
+	CLOCK_REALTIME = ClockidT(0x0)
 
 	// clock that increments monotonically, tracking the time since an arbitrary point, and will continue
 	// to increment while the system is asleep.
-	CLOCK_MONOTONIC = ClockidT(C.CLOCK_MONOTONIC)
+	CLOCK_MONOTONIC = ClockidT(0x6)
 
 	// clock that increments monotonically, tracking the time since an arbitrary point like CLOCK_MONOTONIC.
 	// However, this clock is unaffected by frequency or time adjustments.  It should not be compared to
 	// other system time sources.
-	CLOCK_MONOTONIC_RAW = ClockidT(C.CLOCK_MONOTONIC_RAW)
+	CLOCK_MONOTONIC_RAW = ClockidT(0x6)
 
 	// like CLOCK_MONOTONIC_RAW, but reads a value cached by the system at context switch. This can be
 	// read faster, but at a loss of accuracy as it may return values that are milliseconds old.
@@ -109,10 +114,10 @@ const (
 	// CLOCK_UPTIME_RAW_APPROX = ClockidT(C.CLOCK_UPTIME_RAW_APPROX)
 
 	// clock that tracks the amount of CPU (in user- or kernel-mode) used by the calling process.
-	CLOCK_PROCESS_CPUTIME_ID = ClockidT(C.CLOCK_PROCESS_CPUTIME_ID)
+	CLOCK_PROCESS_CPUTIME_ID = ClockidT(0xc)
 
 	// clock that tracks the amount of CPU (in user- or kernel-mode) used by the calling thread.
-	CLOCK_THREAD_CPUTIME_ID = ClockidT(C.CLOCK_THREAD_CPUTIME_ID)
+	CLOCK_THREAD_CPUTIME_ID = ClockidT(0x10)
 )
 
 type Timespec struct {

--- a/compiler/cl/_testdata/vargs/out.ll
+++ b/compiler/cl/_testdata/vargs/out.ll
@@ -8,7 +8,7 @@ source_filename = "github.com/goplus/llgo/compiler/cl/_testdata/vargs"
 @"github.com/goplus/llgo/compiler/cl/_testdata/vargs.init$guard" = global i1 false, align 1
 @_llgo_int = linkonce global ptr null, align 8
 @0 = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 1
-@1 = private unnamed_addr constant [40 x i8] c"type assertion interface{} -> int failed", align 1
+@1 = private unnamed_addr constant [32 x i8] c"type assertion any -> int failed", align 1
 @_llgo_string = linkonce global ptr null, align 8
 
 define void @"github.com/goplus/llgo/compiler/cl/_testdata/vargs.init"() {
@@ -87,7 +87,7 @@ _llgo_4:                                          ; preds = %_llgo_2
 _llgo_5:                                          ; preds = %_llgo_2
   %18 = load ptr, ptr @_llgo_string, align 8
   %19 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 40 }, ptr %19, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 32 }, ptr %19, align 8
   %20 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %18, 0
   %21 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %20, ptr %19, 1
   call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %21)

--- a/compiler/cl/_testrt/any/out.ll
+++ b/compiler/cl/_testrt/any/out.ll
@@ -7,10 +7,10 @@ source_filename = "github.com/goplus/llgo/compiler/cl/_testrt/any"
 @"github.com/goplus/llgo/compiler/cl/_testrt/any.init$guard" = global i1 false, align 1
 @_llgo_int8 = linkonce global ptr null, align 8
 @"*_llgo_int8" = linkonce global ptr null, align 8
-@0 = private unnamed_addr constant [42 x i8] c"type assertion interface{} -> *int8 failed", align 1
+@0 = private unnamed_addr constant [34 x i8] c"type assertion any -> *int8 failed", align 1
 @_llgo_string = linkonce global ptr null, align 8
 @_llgo_int = linkonce global ptr null, align 8
-@1 = private unnamed_addr constant [40 x i8] c"type assertion interface{} -> int failed", align 1
+@1 = private unnamed_addr constant [32 x i8] c"type assertion any -> int failed", align 1
 @2 = private unnamed_addr constant [7 x i8] c"%s %d\0A\00", align 1
 @3 = private unnamed_addr constant [6 x i8] c"Hello\00", align 1
 
@@ -29,7 +29,7 @@ _llgo_1:                                          ; preds = %_llgo_0
 _llgo_2:                                          ; preds = %_llgo_0
   %6 = load ptr, ptr @_llgo_string, align 8
   %7 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 42 }, ptr %7, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 34 }, ptr %7, align 8
   %8 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %6, 0
   %9 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %8, ptr %7, 1
   call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %9)
@@ -52,7 +52,7 @@ _llgo_1:                                          ; preds = %_llgo_0
 _llgo_2:                                          ; preds = %_llgo_0
   %7 = load ptr, ptr @_llgo_string, align 8
   %8 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 40 }, ptr %8, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 32 }, ptr %8, align 8
   %9 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %7, 0
   %10 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %9, ptr %8, 1
   call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %10)

--- a/compiler/cl/_testrt/tpabi/out.ll
+++ b/compiler/cl/_testrt/tpabi/out.ll
@@ -23,7 +23,7 @@ source_filename = "github.com/goplus/llgo/compiler/cl/_testrt/tpabi"
 @5 = private unnamed_addr constant [4 x i8] c"Demo", align 1
 @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac" = linkonce global ptr null, align 8
 @6 = private unnamed_addr constant [4 x i8] c"Info", align 1
-@7 = private unnamed_addr constant [100 x i8] c"type assertion interface{} -> github.com/goplus/llgo/compiler/cl/_testrt/tpabi.T[string, int] failed", align 1
+@7 = private unnamed_addr constant [92 x i8] c"type assertion any -> github.com/goplus/llgo/compiler/cl/_testrt/tpabi.T[string, int] failed", align 1
 @8 = private unnamed_addr constant [5 x i8] c"hello", align 1
 @"*_llgo_github.com/goplus/llgo/compiler/cl/_testrt/tpabi.T[string,int]" = linkonce global ptr null, align 8
 @"_llgo_iface$BP0p_lUsEd-IbbtJVukGmgrdQkqzcoYzSiwgUvgFvUs" = linkonce global ptr null, align 8
@@ -107,7 +107,7 @@ _llgo_1:                                          ; preds = %_llgo_0
 _llgo_2:                                          ; preds = %_llgo_0
   %38 = load ptr, ptr @_llgo_string, align 8
   %39 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 100 }, ptr %39, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 92 }, ptr %39, align 8
   %40 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %38, 0
   %41 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %40, ptr %39, 1
   call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %41)

--- a/compiler/ssa/eh.go
+++ b/compiler/ssa/eh.go
@@ -16,21 +16,15 @@
 
 package ssa
 
-// #include <setjmp.h>
-import "C"
-
 import (
 	"go/token"
 	"go/types"
 	"log"
-	"unsafe"
 
 	"github.com/goplus/llvm"
 )
 
 // -----------------------------------------------------------------------------
-
-type sigjmpbuf = C.sigjmp_buf
 
 // func(env unsafe.Pointer, savemask c.Int) c.Int
 func (p Program) tySigsetjmp() *types.Signature {
@@ -57,9 +51,8 @@ func (p Program) tySiglongjmp() *types.Signature {
 
 func (b Builder) AllocaSigjmpBuf() Expr {
 	prog := b.Prog
-	n := unsafe.Sizeof(sigjmpbuf{})
-	size := prog.IntVal(uint64(n), prog.Uintptr())
-	return b.Alloca(size)
+	ty := prog.rtType("SigjmpBuf")
+	return b.AllocaT(ty)
 }
 
 func (b Builder) Sigsetjmp(jb, savemask Expr) Expr {

--- a/runtime/_overlay/net/textproto/textproto.go
+++ b/runtime/_overlay/net/textproto/textproto.go
@@ -24,11 +24,6 @@
 // with a single network connection.
 package textproto
 
-/*
-#include <stdint.h>
-*/
-import "C"
-
 import (
 	"bufio"
 	"errors"
@@ -97,55 +92,55 @@ const (
 type SockAddr struct {
 	Len    uint8
 	Family uint8
-	Data   [14]C.char
+	Data   [14]uint8
 }
 
 type AddrInfo struct {
-	Flags     C.int
-	Family    C.int
-	SockType  C.int
-	Protocol  C.int
-	AddrLen   C.uint
-	CanOnName *C.char
+	Flags     int32
+	Family    int32
+	SockType  int32
+	Protocol  int32
+	AddrLen   uint32
+	CanOnName *uint8
 	Addr      *SockAddr
 	Next      *AddrInfo
 }
 
 //go:linkname Getaddrinfo C.getaddrinfo
-func Getaddrinfo(host *C.char, port *C.char, addrInfo *AddrInfo, result **AddrInfo) C.int
+func Getaddrinfo(host *uint8, port *uint8, addrInfo *AddrInfo, result **AddrInfo) int32
 
 //go:linkname Freeaddrinfo C.freeaddrinfo
-func Freeaddrinfo(addrInfo *AddrInfo) C.int
+func Freeaddrinfo(addrInfo *AddrInfo) int32
 
 //go:linkname GoString llgo.string
-func GoString(cstr *C.char, __llgo_va_list /* n */ ...any) string
+func GoString(cstr *uint8, __llgo_va_list /* n */ ...any) string
 
 //go:linkname AllocaCStr llgo.allocaCStr
-func AllocaCStr(s string) *C.char
+func AllocaCStr(s string) *uint8
 
 //go:linkname Memset C.memset
-func Memset(s unsafe.Pointer, c C.int, n uintptr) unsafe.Pointer
+func Memset(s unsafe.Pointer, c int32, n uintptr) unsafe.Pointer
 
 //go:linkname Read C.read
-func Read(fd C.int, buf unsafe.Pointer, count uintptr) int
+func Read(fd int32, buf unsafe.Pointer, count uintptr) int
 
 //go:linkname Write C.write
-func Write(fd C.int, buf unsafe.Pointer, count uintptr) int
+func Write(fd int32, buf unsafe.Pointer, count uintptr) int
 
 //go:linkname Close C.close
-func Close(fd C.int) C.int
+func Close(fd int32) int32
 
 //go:linkname Strerror strerror
-func Strerror(errnum C.int) *C.char
+func Strerror(errnum int32) *uint8
 
 //go:linkname Errno C.cliteErrno
-func Errno() C.int
+func Errno() int32
 
 //go:linkname Socket C.socket
-func Socket(domain C.int, typ C.int, protocol C.int) C.int
+func Socket(domain int32, typ int32, protocol int32) int32
 
 //go:linkname Connect C.connect
-func Connect(sockfd C.int, addr *SockAddr, addrlen C.uint) C.int
+func Connect(sockfd int32, addr *SockAddr, addrlen uint32) int32
 
 // -----------------------------------------------------------------------------
 
@@ -204,7 +199,7 @@ func Dial(network, addr string) (*Conn, error) {
 }
 
 type cConn struct {
-	socketFd C.int
+	socketFd int32
 	closed   bool
 }
 
@@ -218,7 +213,7 @@ func (conn *cConn) Read(p []byte) (n int, err error) {
 	for n < len(p) {
 		result := Read(conn.socketFd, unsafe.Pointer(&p[n:][0]), uintptr(len(p)-n))
 		if result < 0 {
-			if Errno() == C.int(syscall.EINTR) {
+			if Errno() == int32(syscall.EINTR) {
 				continue
 			}
 			return n, errors.New("read error")
@@ -238,7 +233,7 @@ func (conn *cConn) Write(p []byte) (n int, err error) {
 	for n < len(p) {
 		result := Write(conn.socketFd, unsafe.Pointer(&p[n:][0]), uintptr(len(p)-n))
 		if result < 0 {
-			if Errno() == C.int(syscall.EINTR) {
+			if Errno() == int32(syscall.EINTR) {
 				continue
 			}
 			return n, errors.New("write error")

--- a/runtime/internal/clite/c.go
+++ b/runtime/internal/clite/c.go
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-package clite
+package c
 
-// typedef unsigned int uint;
-// typedef unsigned long ulong;
-// typedef unsigned long long ulonglong;
-// typedef long long longlong;
-import "C"
 import "unsafe"
 
 const (
@@ -41,14 +36,16 @@ type FILE struct {
 }
 
 type (
-	Int  C.int
-	Uint C.uint
+	Int  = int32
+	Uint = uint32
 
-	Long  C.long
-	Ulong C.ulong
+	// Long and Ulong are defined in platform-specific files
+	// Windows (both 32-bit and 64-bit): int32/uint32
+	// Unix/Linux/macOS 32-bit: int32/uint32
+	// Unix/Linux/macOS 64-bit: int64/uint64
 
-	LongLong  C.longlong
-	UlongLong C.ulonglong
+	LongLong  = int64
+	UlongLong = uint64
 )
 
 type integer interface {
@@ -56,6 +53,7 @@ type integer interface {
 }
 
 type SizeT = uintptr
+type SsizeT = Long
 
 type IntptrT = uintptr
 type UintptrT = uintptr
@@ -71,6 +69,8 @@ type Uint64T = uint64
 
 type IntmaxT = LongLong
 type UintmaxT = UlongLong
+
+type VaList = Pointer
 
 //go:linkname Str llgo.cstr
 func Str(string) *Char
@@ -257,6 +257,14 @@ func Perror(s *Char)
 
 // -----------------------------------------------------------------------------
 
+type IconvT = Pointer
+
+// -----------------------------------------------------------------------------
+
+type LocaleT = Pointer
+
+// -----------------------------------------------------------------------------
+
 //go:linkname Usleep C.usleep
 func Usleep(useconds Uint) Int
 
@@ -297,6 +305,3 @@ func GetoptLong(argc Int, argv **Char, optstring *Char, longopts *Option, longin
 func GetoptLongOnly(argc Int, argv **Char, optstring *Char, longopts *Option, longindex *Int) Int
 
 // -----------------------------------------------------------------------------
-
-//go:linkname Sysconf C.sysconf
-func Sysconf(name Int) Long

--- a/runtime/internal/clite/ctypes_32bit.go
+++ b/runtime/internal/clite/ctypes_32bit.go
@@ -1,4 +1,6 @@
-//go:build linux
+//go:build (linux || darwin || freebsd || netbsd || openbsd || solaris) && (386 || arm || mips || mipsle)
+// +build linux darwin freebsd netbsd openbsd solaris
+// +build 386 arm mips mipsle
 
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
@@ -16,14 +18,10 @@
  * limitations under the License.
  */
 
-package os
+package c
 
-import _ "unsafe"
-
-const (
-	LLGoFiles   = "_os/os.c"
-	LLGoPackage = "link"
+// For 32-bit Unix/Linux/macOS, Long is 32-bit
+type (
+	Long  = int32
+	Ulong = uint32
 )
-
-//go:linkname Clearenv C.clearenv
-func Clearenv()

--- a/runtime/internal/clite/ctypes_unix64.go
+++ b/runtime/internal/clite/ctypes_unix64.go
@@ -1,4 +1,6 @@
-//go:build linux
+//go:build (linux || darwin || freebsd || netbsd || openbsd || solaris) && (amd64 || arm64 || ppc64 || ppc64le || mips64 || mips64le || s390x || riscv64)
+// +build linux darwin freebsd netbsd openbsd solaris
+// +build amd64 arm64 ppc64 ppc64le mips64 mips64le s390x riscv64
 
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
@@ -16,14 +18,10 @@
  * limitations under the License.
  */
 
-package os
+package c
 
-import _ "unsafe"
-
-const (
-	LLGoFiles   = "_os/os.c"
-	LLGoPackage = "link"
+// For 64-bit Unix/Linux/macOS, Long is 64-bit
+type (
+	Long  = int64
+	Ulong = uint64
 )
-
-//go:linkname Clearenv C.clearenv
-func Clearenv()

--- a/runtime/internal/clite/ctypes_wasm.go
+++ b/runtime/internal/clite/ctypes_wasm.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build wasip1 || js
+// +build wasip1 js
 
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
@@ -17,15 +17,10 @@
  * limitations under the License.
  */
 
-package clite
+package c
 
-import _ "unsafe"
-
-//go:linkname Stdin stdin
-var Stdin FilePtr
-
-//go:linkname Stdout stdout
-var Stdout FilePtr
-
-//go:linkname Stderr stderr
-var Stderr FilePtr
+// For WebAssembly targets, Long is 32-bit per the spec
+type (
+	Long  = int32
+	Ulong = uint32
+)

--- a/runtime/internal/clite/ctypes_windows.go
+++ b/runtime/internal/clite/ctypes_windows.go
@@ -1,5 +1,5 @@
-//go:build !linux
-// +build !linux
+//go:build windows
+// +build windows
 
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
@@ -17,15 +17,10 @@
  * limitations under the License.
  */
 
-package clite
+package c
 
-import _ "unsafe"
-
-//go:linkname Stdin __stdinp
-var Stdin FilePtr
-
-//go:linkname Stdout __stdoutp
-var Stdout FilePtr
-
-//go:linkname Stderr __stderrp
-var Stderr FilePtr
+// For Windows (LLP64 model), Long is 32-bit, regardless of architecture
+type (
+	Long  = int32
+	Ulong = uint32
+)

--- a/runtime/internal/clite/debug/debug.go
+++ b/runtime/internal/clite/debug/debug.go
@@ -1,9 +1,5 @@
 package debug
 
-/*
-#cgo linux LDFLAGS: -lunwind
-*/
-import "C"
 import (
 	"unsafe"
 
@@ -11,8 +7,7 @@ import (
 )
 
 const (
-	LLGoPackage = "link"
-	LLGoFiles   = "_wrap/debug.c"
+	LLGoFiles = "_wrap/debug.c"
 )
 
 type Info struct {

--- a/runtime/internal/clite/debug/libunwind.go
+++ b/runtime/internal/clite/debug/libunwind.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package debug
+
+const (
+	LLGoPackage = "link"
+)

--- a/runtime/internal/clite/debug/libunwind_linux.go
+++ b/runtime/internal/clite/debug/libunwind_linux.go
@@ -1,0 +1,7 @@
+//go:build linux
+
+package debug
+
+const (
+	LLGoPackage = "link: -lunwind"
+)

--- a/runtime/internal/clite/os/os.go
+++ b/runtime/internal/clite/os/os.go
@@ -16,19 +16,11 @@
 
 package os
 
-// #include <sys/stat.h>
-// #include <limits.h>
-import "C"
-
 import (
 	_ "unsafe"
 
 	c "github.com/goplus/llgo/runtime/internal/clite"
 	"github.com/goplus/llgo/runtime/internal/clite/syscall"
-)
-
-const (
-	PATH_MAX = C.PATH_MAX
 )
 
 const (
@@ -56,14 +48,6 @@ const (
 
 const (
 	EAGAIN = 35
-)
-
-type (
-	ModeT C.mode_t
-	UidT  C.uid_t
-	GidT  C.gid_t
-	OffT  C.off_t
-	DevT  C.dev_t
 )
 
 type (

--- a/runtime/internal/clite/os/os_darwin.go
+++ b/runtime/internal/clite/os/os_darwin.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
  *
@@ -18,12 +16,24 @@
 
 package os
 
-import "C"
+import _ "unsafe"
 
 const (
 	LLGoFiles   = "_os/os.c"
 	LLGoPackage = "link"
 )
 
-//go:linkname Clearenv C.clearenv
+const (
+	PATH_MAX = 1024
+)
+
+type (
+	ModeT uint16
+	UidT  uint32
+	GidT  uint32
+	OffT  int64
+	DevT  int32
+)
+
+//go:linkname Clearenv C.cliteClearenv
 func Clearenv()

--- a/runtime/internal/clite/os/os_other.go
+++ b/runtime/internal/clite/os/os_other.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build !darwin
 
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
@@ -18,12 +18,24 @@
 
 package os
 
-import "C"
+import _ "unsafe"
 
 const (
 	LLGoFiles   = "_os/os.c"
 	LLGoPackage = "link"
 )
 
-//go:linkname Clearenv C.cliteClearenv
+const (
+	PATH_MAX = 4096
+)
+
+type (
+	ModeT uint32
+	UidT  uint32
+	GidT  uint32
+	OffT  int64
+	DevT  uint64
+)
+
+//go:linkname Clearenv C.clearenv
 func Clearenv()

--- a/runtime/internal/clite/pthread/sync/sync.go
+++ b/runtime/internal/clite/pthread/sync/sync.go
@@ -16,9 +16,6 @@
 
 package sync
 
-// #include <pthread.h>
-import "C"
-
 import (
 	_ "unsafe"
 
@@ -31,12 +28,32 @@ const (
 	LLGoPackage = "link"
 )
 
+const (
+	PthreadOnceSize       = 16
+	PthreadMutexSize      = 64
+	PthreadMutexAttrSize  = 16
+	PthreadCondSize       = 48
+	PthreadCondAttrSize   = 16
+	PthreadRWLockSize     = 200
+	PthreadRWLockAttrSize = 24
+)
+
+const (
+	PTHREAD_MUTEX_NORMAL     = 0
+	PTHREAD_MUTEX_ERRORCHECK = 1
+	PTHREAD_MUTEX_RECURSIVE  = 2
+	PTHREAD_MUTEX_DEFAULT    = PTHREAD_MUTEX_NORMAL
+)
+
 // -----------------------------------------------------------------------------
 
 // Once is an object that will perform exactly one action.
-type Once C.pthread_once_t
+// pthread_once_t
+type Once struct {
+	Unused [PthreadOnceSize]c.Char
+}
 
-//go:linkname OnceInit cliteSyncOnceInitVal
+//go:linkname OnceInit once_control
 var OnceInit Once
 
 // llgo:link (*Once).Do C.pthread_once
@@ -47,14 +64,17 @@ func (o *Once) Do(f func()) c.Int { return 0 }
 type MutexType c.Int
 
 const (
-	MUTEX_NORMAL     MutexType = C.PTHREAD_MUTEX_NORMAL
-	MUTEX_ERRORCHECK MutexType = C.PTHREAD_MUTEX_ERRORCHECK
-	MUTEX_RECURSIVE  MutexType = C.PTHREAD_MUTEX_RECURSIVE
-	MUTEX_DEFAULT    MutexType = C.PTHREAD_MUTEX_DEFAULT
+	MUTEX_NORMAL     MutexType = PTHREAD_MUTEX_NORMAL
+	MUTEX_ERRORCHECK MutexType = PTHREAD_MUTEX_ERRORCHECK
+	MUTEX_RECURSIVE  MutexType = PTHREAD_MUTEX_RECURSIVE
+	MUTEX_DEFAULT    MutexType = PTHREAD_MUTEX_DEFAULT
 )
 
 // MutexAttr is a mutex attribute object.
-type MutexAttr C.pthread_mutexattr_t
+// pthread_mutexattr_t
+type MutexAttr struct {
+	Unused [PthreadMutexAttrSize]c.Char
+}
 
 // llgo:link (*MutexAttr).Init C.pthread_mutexattr_init
 func (a *MutexAttr) Init(attr *MutexAttr) c.Int { return 0 }
@@ -68,7 +88,10 @@ func (a *MutexAttr) SetType(typ MutexType) c.Int { return 0 }
 // -----------------------------------------------------------------------------
 
 // Mutex is a mutual exclusion lock.
-type Mutex C.pthread_mutex_t
+// pthread_mutex_t
+type Mutex struct {
+	Unused [PthreadMutexSize]c.Char
+}
 
 // llgo:link (*Mutex).Init C.pthread_mutex_init
 func (m *Mutex) Init(attr *MutexAttr) c.Int { return 0 }
@@ -88,7 +111,10 @@ func (m *Mutex) Unlock() {}
 // -----------------------------------------------------------------------------
 
 // RWLockAttr is a read-write lock attribute object.
-type RWLockAttr C.pthread_rwlockattr_t
+// pthread_rwlockattr_t
+type RWLockAttr struct {
+	Unused [PthreadRWLockAttrSize]c.Char
+}
 
 // llgo:link (*RWLockAttr).Init C.pthread_rwlockattr_init
 func (a *RWLockAttr) Init(attr *RWLockAttr) c.Int { return 0 }
@@ -105,7 +131,10 @@ func (a *RWLockAttr) GetPShared(pshared *c.Int) c.Int { return 0 }
 // -----------------------------------------------------------------------------
 
 // RWLock is a read-write lock.
-type RWLock C.pthread_rwlock_t
+// pthread_rwlock_t
+type RWLock struct {
+	Unused [PthreadRWLockSize]c.Char
+}
 
 // llgo:link (*RWLock).Init C.pthread_rwlock_init
 func (rw *RWLock) Init(attr *RWLockAttr) c.Int { return 0 }
@@ -134,7 +163,10 @@ func (rw *RWLock) Unlock() {}
 // -----------------------------------------------------------------------------
 
 // CondAttr is a condition variable attribute object.
-type CondAttr C.pthread_condattr_t
+// pthread_condattr_t
+type CondAttr struct {
+	Unused [PthreadCondAttrSize]c.Char
+}
 
 // llgo:link (*CondAttr).Init C.pthread_condattr_init
 func (a *CondAttr) Init(attr *CondAttr) c.Int { return 0 }
@@ -151,7 +183,10 @@ func (a *CondAttr) Destroy() {}
 // -----------------------------------------------------------------------------
 
 // Cond is a condition variable.
-type Cond C.pthread_cond_t
+// pthread_cond_t
+type Cond struct {
+	Unused [PthreadCondSize]c.Char
+}
 
 // llgo:link (*Cond).Init C.pthread_cond_init
 func (c *Cond) Init(attr *CondAttr) c.Int { return 0 }

--- a/runtime/internal/clite/pthread/sync/sync.go
+++ b/runtime/internal/clite/pthread/sync/sync.go
@@ -29,16 +29,6 @@ const (
 )
 
 const (
-	PthreadOnceSize       = 16
-	PthreadMutexSize      = 64
-	PthreadMutexAttrSize  = 16
-	PthreadCondSize       = 48
-	PthreadCondAttrSize   = 16
-	PthreadRWLockSize     = 200
-	PthreadRWLockAttrSize = 24
-)
-
-const (
 	PTHREAD_MUTEX_NORMAL     = 0
 	PTHREAD_MUTEX_ERRORCHECK = 1
 	PTHREAD_MUTEX_RECURSIVE  = 2

--- a/runtime/internal/clite/pthread/sync/sync_darwin_amd64.go
+++ b/runtime/internal/clite/pthread/sync/sync_darwin_amd64.go
@@ -1,0 +1,11 @@
+package sync
+
+const (
+	PthreadOnceSize       = 16
+	PthreadMutexSize      = 56
+	PthreadMutexAttrSize  = 8
+	PthreadCondSize       = 40
+	PthreadCondAttrSize   = 8
+	PthreadRWLockSize     = 192
+	PthreadRWLockAttrSize = 16
+)

--- a/runtime/internal/clite/pthread/sync/sync_darwin_arm64.go
+++ b/runtime/internal/clite/pthread/sync/sync_darwin_arm64.go
@@ -1,0 +1,11 @@
+package sync
+
+const (
+	PthreadOnceSize       = 16
+	PthreadMutexSize      = 64
+	PthreadMutexAttrSize  = 16
+	PthreadCondSize       = 48
+	PthreadCondAttrSize   = 16
+	PthreadRWLockSize     = 200
+	PthreadRWLockAttrSize = 24
+)

--- a/runtime/internal/clite/pthread/sync/sync_linux_amd64.go
+++ b/runtime/internal/clite/pthread/sync/sync_linux_amd64.go
@@ -1,0 +1,11 @@
+package sync
+
+const (
+	PthreadOnceSize       = 4
+	PthreadMutexSize      = 40
+	PthreadMutexAttrSize  = 4
+	PthreadCondSize       = 48
+	PthreadCondAttrSize   = 4
+	PthreadRWLockSize     = 56
+	PthreadRWLockAttrSize = 8
+)

--- a/runtime/internal/clite/pthread/sync/sync_linux_arm64.go
+++ b/runtime/internal/clite/pthread/sync/sync_linux_arm64.go
@@ -1,0 +1,11 @@
+package sync
+
+const (
+	PthreadOnceSize       = 4
+	PthreadMutexSize      = 48
+	PthreadMutexAttrSize  = 8
+	PthreadCondSize       = 48
+	PthreadCondAttrSize   = 8
+	PthreadRWLockSize     = 56
+	PthreadRWLockAttrSize = 8
+)

--- a/runtime/internal/clite/setjmp/jmpbuf_darwin_amd64.go
+++ b/runtime/internal/clite/setjmp/jmpbuf_darwin_amd64.go
@@ -1,0 +1,6 @@
+package setjmp
+
+const (
+	SigjmpBufSize = 196
+	JmpBufSize    = 192
+)

--- a/runtime/internal/clite/setjmp/jmpbuf_darwin_arm64.go
+++ b/runtime/internal/clite/setjmp/jmpbuf_darwin_arm64.go
@@ -1,0 +1,6 @@
+package setjmp
+
+const (
+	SigjmpBufSize = 196
+	JmpBufSize    = 192
+)

--- a/runtime/internal/clite/setjmp/jmpbuf_linux_amd64.go
+++ b/runtime/internal/clite/setjmp/jmpbuf_linux_amd64.go
@@ -1,0 +1,12 @@
+//go:build !darwin
+
+package setjmp
+
+import (
+	_ "unsafe"
+)
+
+const (
+	SigjmpBufSize = 200
+	JmpBufSize    = 200
+)

--- a/runtime/internal/clite/setjmp/jmpbuf_linux_arm64.go
+++ b/runtime/internal/clite/setjmp/jmpbuf_linux_arm64.go
@@ -1,0 +1,6 @@
+package setjmp
+
+const (
+	SigjmpBufSize = 312
+	JmpBufSize    = 312
+)

--- a/runtime/internal/clite/setjmp/setjmp.go
+++ b/runtime/internal/clite/setjmp/setjmp.go
@@ -19,7 +19,7 @@ package setjmp
 import (
 	_ "unsafe"
 
-	"github.com/goplus/llgo/c"
+	c "github.com/goplus/llgo/runtime/internal/clite"
 )
 
 const (

--- a/runtime/internal/clite/signal/signal.go
+++ b/runtime/internal/clite/signal/signal.go
@@ -5,7 +5,6 @@ import (
 
 	c "github.com/goplus/llgo/runtime/internal/clite"
 )
-import "C"
 
 const (
 	LLGoPackage = "link"

--- a/runtime/internal/clite/stdio_darwin.go
+++ b/runtime/internal/clite/stdio_darwin.go
@@ -1,4 +1,5 @@
-//go:build linux
+//go:build darwin
+// +build darwin
 
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
@@ -16,14 +17,15 @@
  * limitations under the License.
  */
 
-package os
+package c
 
 import _ "unsafe"
 
-const (
-	LLGoFiles   = "_os/os.c"
-	LLGoPackage = "link"
-)
+//go:linkname Stdin __stdinp
+var Stdin FilePtr
 
-//go:linkname Clearenv C.clearenv
-func Clearenv()
+//go:linkname Stdout __stdoutp
+var Stdout FilePtr
+
+//go:linkname Stderr __stderrp
+var Stderr FilePtr

--- a/runtime/internal/clite/stdio_default.go
+++ b/runtime/internal/clite/stdio_default.go
@@ -1,4 +1,5 @@
-//go:build linux
+//go:build !darwin
+// +build !darwin
 
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
@@ -16,14 +17,15 @@
  * limitations under the License.
  */
 
-package os
+package c
 
 import _ "unsafe"
 
-const (
-	LLGoFiles   = "_os/os.c"
-	LLGoPackage = "link"
-)
+//go:linkname Stdin stdin
+var Stdin FilePtr
 
-//go:linkname Clearenv C.clearenv
-func Clearenv()
+//go:linkname Stdout stdout
+var Stdout FilePtr
+
+//go:linkname Stderr stderr
+var Stderr FilePtr

--- a/runtime/internal/clite/time/time.go
+++ b/runtime/internal/clite/time/time.go
@@ -16,9 +16,6 @@
 
 package time
 
-// #include <time.h>
-import "C"
-
 import (
 	_ "unsafe"
 
@@ -31,7 +28,12 @@ const (
 
 // -----------------------------------------------------------------------------
 
-type TimeT C.time_t
+const (
+	ClockTSize = 8
+)
+
+// time_t
+type TimeT c.IntptrT
 
 //go:linkname Time C.time
 func Time(timer *TimeT) TimeT
@@ -72,28 +74,31 @@ func Strftime(buf *c.Char, bufSize uintptr, format *c.Char, timeptr *Tm) uintptr
 
 // -----------------------------------------------------------------------------
 
-type ClockT C.clock_t
+// clock_t
+type ClockT struct {
+	Unused [ClockTSize]c.Char
+}
 
 //go:linkname Clock C.clock
 func Clock() ClockT
 
 // -----------------------------------------------------------------------------
 
-type ClockidT C.clockid_t
+type ClockidT c.Int
 
 const (
 	// the system's real time (i.e. wall time) clock, expressed as the amount of time since the Epoch.
 	// This is the same as the value returned by gettimeofday
-	CLOCK_REALTIME = ClockidT(C.CLOCK_REALTIME)
+	CLOCK_REALTIME = ClockidT(0x0)
 
 	// clock that increments monotonically, tracking the time since an arbitrary point, and will continue
 	// to increment while the system is asleep.
-	CLOCK_MONOTONIC = ClockidT(C.CLOCK_MONOTONIC)
+	CLOCK_MONOTONIC = ClockidT(0x6)
 
 	// clock that increments monotonically, tracking the time since an arbitrary point like CLOCK_MONOTONIC.
 	// However, this clock is unaffected by frequency or time adjustments.  It should not be compared to
 	// other system time sources.
-	CLOCK_MONOTONIC_RAW = ClockidT(C.CLOCK_MONOTONIC_RAW)
+	CLOCK_MONOTONIC_RAW = ClockidT(0x6)
 
 	// like CLOCK_MONOTONIC_RAW, but reads a value cached by the system at context switch. This can be
 	// read faster, but at a loss of accuracy as it may return values that are milliseconds old.
@@ -109,10 +114,10 @@ const (
 	// CLOCK_UPTIME_RAW_APPROX = ClockidT(C.CLOCK_UPTIME_RAW_APPROX)
 
 	// clock that tracks the amount of CPU (in user- or kernel-mode) used by the calling process.
-	CLOCK_PROCESS_CPUTIME_ID = ClockidT(C.CLOCK_PROCESS_CPUTIME_ID)
+	CLOCK_PROCESS_CPUTIME_ID = ClockidT(0xc)
 
 	// clock that tracks the amount of CPU (in user- or kernel-mode) used by the calling thread.
-	CLOCK_THREAD_CPUTIME_ID = ClockidT(C.CLOCK_THREAD_CPUTIME_ID)
+	CLOCK_THREAD_CPUTIME_ID = ClockidT(0x10)
 )
 
 type Timespec struct {

--- a/runtime/internal/lib/internal/cpu/_wrap/cpu_x86.c
+++ b/runtime/internal/lib/internal/cpu/_wrap/cpu_x86.c
@@ -1,0 +1,21 @@
+#if defined(__GNUC__) || defined(__clang__)
+void llgo_getcpuid(unsigned int eax, unsigned int ecx,
+                   unsigned int *a, unsigned int *b,
+                   unsigned int *c, unsigned int *d)
+{
+#if defined(__i386__) || defined(__x86_64__)
+    __asm__ __volatile__(
+        "pushq %%rbp\n\t"
+        "movq %%rsp, %%rbp\n\t"
+        "andq $-16, %%rsp\n\t" // 16-byte align stack
+        "cpuid\n\t"
+        "movq %%rbp, %%rsp\n\t"
+        "popq %%rbp\n\t"
+        : "=a"(*a), "=b"(*b), "=c"(*c), "=d"(*d)
+        : "a"(eax), "c"(ecx)
+        : "memory");
+#endif
+}
+#else
+#error This code requires GCC or Clang
+#endif

--- a/runtime/internal/lib/internal/cpu/cpu_x86.go
+++ b/runtime/internal/lib/internal/cpu/cpu_x86.go
@@ -2,39 +2,28 @@
 
 package cpu
 
-/*
-#if defined(__GNUC__) || defined(__clang__)
-    static void getcpuid(unsigned int eax, unsigned int ecx,
-                        unsigned int *a, unsigned int *b,
-                        unsigned int *c, unsigned int *d) {
-    #if defined(__i386__) || defined(__x86_64__)
-        __asm__ __volatile__(
-            "pushq %%rbp\n\t"
-            "movq %%rsp, %%rbp\n\t"
-            "andq $-16, %%rsp\n\t"  // 16-byte align stack
-            "cpuid\n\t"
-            "movq %%rbp, %%rsp\n\t"
-            "popq %%rbp\n\t"
-            : "=a"(*a), "=b"(*b), "=c"(*c), "=d"(*d)
-            : "a"(eax), "c"(ecx)
-            : "memory"
-        );
-    #endif
-    }
-#else
-    #error This code requires GCC or Clang
-#endif
-*/
-import "C"
+import (
+	_ "unsafe"
+
+	c "github.com/goplus/llgo/runtime/internal/clite"
+)
+
+const (
+	LLGoPackage = "link"
+	LLGoFiles   = "_wrap/cpu_x86.c"
+)
+
+//go:linkname c_getcpuid C.llgo_getcpuid
+func c_getcpuid(eaxArg, ecxArg uint32, eax, ebx, ecx, edx *c.Uint)
 
 func cpuid(eaxArg, ecxArg uint32) (eax, ebx, ecx, edx uint32) {
-	C.getcpuid(
-		C.uint(eaxArg),
-		C.uint(ecxArg),
-		(*C.uint)(&eax),
-		(*C.uint)(&ebx),
-		(*C.uint)(&ecx),
-		(*C.uint)(&edx),
+	c_getcpuid(
+		c.Uint(eaxArg),
+		c.Uint(ecxArg),
+		(*c.Uint)(&eax),
+		(*c.Uint)(&ebx),
+		(*c.Uint)(&ecx),
+		(*c.Uint)(&edx),
 	)
 	return
 }

--- a/runtime/internal/lib/math/rand/rand.go
+++ b/runtime/internal/lib/math/rand/rand.go
@@ -22,7 +22,7 @@ import (
 	"sync/atomic"
 	_ "unsafe" // for go:linkname
 
-	"github.com/goplus/llgo/runtime/internal/clite"
+	c "github.com/goplus/llgo/runtime/internal/clite"
 	"github.com/goplus/llgo/runtime/internal/clite/math/rand"
 	"github.com/goplus/llgo/runtime/internal/clite/time"
 )
@@ -348,7 +348,7 @@ func fastrand64() uint64 {
 }
 
 func init() {
-	rand.Srandom(clite.Uint(time.Time(nil)))
+	rand.Srandom(c.Uint(time.Time(nil)))
 }
 
 // fastSource is an implementation of Source64 that uses the runtime

--- a/runtime/internal/lib/runtime/_wrap/runtime.c
+++ b/runtime/internal/lib/runtime/_wrap/runtime.c
@@ -1,0 +1,10 @@
+#include <unistd.h>
+
+int llgo_maxprocs()
+{
+#ifdef _SC_NPROCESSORS_ONLN
+    return (int)sysconf(_SC_NPROCESSORS_ONLN);
+#else
+    return 1;
+#endif
+}

--- a/runtime/internal/lib/runtime/runtime.go
+++ b/runtime/internal/lib/runtime/runtime.go
@@ -16,26 +16,20 @@
 
 package runtime
 
-/*
-#include <unistd.h>
-
-int llgo_maxprocs() {
-	#ifdef _SC_NPROCESSORS_ONLN
-		return (int)sysconf(_SC_NPROCESSORS_ONLN);
-	#else
-		return 1;
-	#endif
-}
-*/
-import "C"
 import (
 	"unsafe"
 
+	c "github.com/goplus/llgo/runtime/internal/clite"
 	"github.com/goplus/llgo/runtime/internal/runtime"
 )
 
 // llgo:skipall
 type _runtime struct{}
+
+const (
+	LLGoPackage = "link"
+	LLGoFiles   = "_wrap/runtime.c"
+)
 
 // GOROOT returns the root of the Go tree. It uses the
 // GOROOT environment variable, if set at process start,
@@ -58,6 +52,9 @@ func Goexit() {
 func KeepAlive(x any) {
 }
 
+//go:linkname c_write C.write
+func c_write(fd c.Int, p unsafe.Pointer, n c.SizeT) int32
+
 func write(fd uintptr, p unsafe.Pointer, n int32) int32 {
-	return int32(C.write(C.int(fd), p, C.size_t(n)))
+	return int32(c_write(c.Int(fd), p, c.SizeT(n)))
 }

--- a/runtime/internal/runtime/z_rt.go
+++ b/runtime/internal/runtime/z_rt.go
@@ -22,6 +22,7 @@ import (
 	c "github.com/goplus/llgo/runtime/internal/clite"
 	"github.com/goplus/llgo/runtime/internal/clite/debug"
 	"github.com/goplus/llgo/runtime/internal/clite/pthread"
+	"github.com/goplus/llgo/runtime/internal/clite/setjmp"
 	"github.com/goplus/llgo/runtime/internal/clite/signal"
 	"github.com/goplus/llgo/runtime/internal/clite/syscall"
 )
@@ -148,5 +149,9 @@ func init() {
 		}
 	})
 }
+
+// -----------------------------------------------------------------------------
+
+type SigjmpBuf [setjmp.SigjmpBufSize]byte
 
 // -----------------------------------------------------------------------------

--- a/runtime/internal/test/test.go
+++ b/runtime/internal/test/test.go
@@ -4,12 +4,19 @@ package test
 #include <time.h>
 #include <pthread.h>
 #include <setjmp.h>
+#include <sys/types.h>
 */
 import "C"
 import (
 	"runtime"
 	"unsafe"
 )
+
+var mode C.mode_t
+var uid C.uid_t
+var gid C.gid_t
+var off C.off_t
+var dev C.dev_t
 
 var once C.pthread_once_t
 var mutex C.pthread_mutex_t

--- a/runtime/internal/test/test.go
+++ b/runtime/internal/test/test.go
@@ -1,0 +1,127 @@
+package test
+
+/*
+#include <time.h>
+#include <pthread.h>
+*/
+import "C"
+import (
+	"runtime"
+	"unsafe"
+)
+
+var once C.pthread_once_t
+var mutex C.pthread_mutex_t
+var cond C.pthread_cond_t
+var rwlock C.pthread_rwlock_t
+var mutexattr C.pthread_mutexattr_t
+var condattr C.pthread_condattr_t
+var rwlockattr C.pthread_rwlockattr_t
+var clock C.clock_t
+
+const (
+	// Real sizes from the current platform
+	pthreadOnceSizeReal       = unsafe.Sizeof(once)
+	pthreadMutexSizeReal      = unsafe.Sizeof(mutex)
+	pthreadMutexAttrSizeReal  = unsafe.Sizeof(mutexattr)
+	pthreadCondSizeReal       = unsafe.Sizeof(cond)
+	pthreadCondAttrSizeReal   = unsafe.Sizeof(condattr)
+	pthreadRWLockSizeReal     = unsafe.Sizeof(rwlock)
+	pthreadRWLockAttrSizeReal = unsafe.Sizeof(rwlockattr)
+	clockSizeReal             = unsafe.Sizeof(clock)
+)
+
+// Linux amd64 specific sizes
+var linuxAmd64 = runtime.GOOS == "linux" && runtime.GOARCH == "amd64"
+
+// Linux arm64 specific sizes
+var linuxArm64 = runtime.GOOS == "linux" && runtime.GOARCH == "arm64"
+
+// macOS amd64 specific sizes
+var darwinAmd64 = runtime.GOOS == "darwin" && runtime.GOARCH == "amd64"
+
+// macOS arm64 specific sizes
+var darwinArm64 = runtime.GOOS == "darwin" && runtime.GOARCH == "arm64"
+
+const (
+	// Linux amd64 pthread sizes
+	pthreadOnceSizeLinuxAmd64       = 4
+	pthreadMutextSizeLinuxAmd64     = 40
+	pthreadMutexAttrSizeLinuxAmd64  = 4
+	pthreadCondSizeLinuxAmd64       = 48
+	pthreadCondAttrSizeLinuxAmd64   = 4
+	pthreadRWLockSizeLinuxAmd64     = 56
+	pthreadRWLockAttrSizeLinuxAmd64 = 8
+	clockSizeLinuxAmd64             = 8
+
+	// Linux arm64 pthread sizes
+	pthreadOnceSizeLinuxArm64       = 4
+	pthreadMutextSizeLinuxArm64     = 48
+	pthreadMutexAttrSizeLinuxArm64  = 8
+	pthreadCondSizeLinuxArm64       = 48
+	pthreadCondAttrSizeLinuxArm64   = 8
+	pthreadRWLockSizeLinuxArm64     = 56
+	pthreadRWLockAttrSizeLinuxArm64 = 8
+	clockSizeLinuxArm64             = 8
+
+	// macOS amd64 pthread sizes
+	pthreadOnceSizeDarwinAmd64       = 16
+	pthreadMutextSizeDarwinAmd64     = 56
+	pthreadMutexAttrSizeDarwinAmd64  = 8
+	pthreadCondSizeDarwinAmd64       = 40
+	pthreadCondAttrSizeDarwinAmd64   = 8
+	pthreadRWLockSizeDarwinAmd64     = 192
+	pthreadRWLockAttrSizeDarwinAmd64 = 16
+	clockSizeDarwinAmd64             = 8
+
+	// macOS arm64 pthread sizes
+	pthreadOnceSizeDarwinArm64       = 16
+	pthreadMutextSizeDarwinArm64     = 64
+	pthreadMutexAttrSizeDarwinArm64  = 16
+	pthreadCondSizeDarwinArm64       = 48
+	pthreadCondAttrSizeDarwinArm64   = 16
+	pthreadRWLockSizeDarwinArm64     = 200
+	pthreadRWLockAttrSizeDarwinArm64 = 24
+	clockSizeDarwinArm64             = 8
+)
+
+// Get architecture-specific pthread sizes based on the current platform
+func getPlatformPthreadSizes() (onceSize, mutexSize, mutexAttrSize, condSize, condAttrSize, rwlockSize, rwlockAttrSize, clockSize int) {
+	switch {
+	case linuxAmd64:
+		return pthreadOnceSizeLinuxAmd64, pthreadMutextSizeLinuxAmd64, pthreadMutexAttrSizeLinuxAmd64,
+			pthreadCondSizeLinuxAmd64, pthreadCondAttrSizeLinuxAmd64, pthreadRWLockSizeLinuxAmd64, pthreadRWLockAttrSizeLinuxAmd64, clockSizeLinuxAmd64
+	case linuxArm64:
+		return pthreadOnceSizeLinuxArm64, pthreadMutextSizeLinuxArm64, pthreadMutexAttrSizeLinuxArm64,
+			pthreadCondSizeLinuxArm64, pthreadCondAttrSizeLinuxArm64, pthreadRWLockSizeLinuxArm64, pthreadRWLockAttrSizeLinuxArm64, clockSizeLinuxArm64
+	case darwinAmd64:
+		return pthreadOnceSizeDarwinAmd64, pthreadMutextSizeDarwinAmd64, pthreadMutexAttrSizeDarwinAmd64,
+			pthreadCondSizeDarwinAmd64, pthreadCondAttrSizeDarwinAmd64, pthreadRWLockSizeDarwinAmd64, pthreadRWLockAttrSizeDarwinAmd64, clockSizeDarwinAmd64
+	case darwinArm64:
+		return pthreadOnceSizeDarwinArm64, pthreadMutextSizeDarwinArm64, pthreadMutexAttrSizeDarwinArm64,
+			pthreadCondSizeDarwinArm64, pthreadCondAttrSizeDarwinArm64, pthreadRWLockSizeDarwinArm64, pthreadRWLockAttrSizeDarwinArm64, clockSizeDarwinArm64
+	default:
+		panic("Unsupported platform: " + runtime.GOOS + ", " + runtime.GOARCH)
+	}
+}
+
+func max(a int, others ...int) int {
+	max := a
+	for _, v := range others {
+		if v > max {
+			max = v
+		}
+	}
+	return max
+}
+
+var (
+	pthreadOnceSize       = max(pthreadOnceSizeLinuxAmd64, pthreadOnceSizeDarwinAmd64, pthreadOnceSizeLinuxArm64, pthreadOnceSizeDarwinArm64)
+	pthreadMutexSize      = max(pthreadMutextSizeLinuxAmd64, pthreadMutextSizeLinuxArm64, pthreadMutextSizeDarwinAmd64, pthreadMutextSizeDarwinArm64)
+	pthreadMutexAttrSize  = max(pthreadMutexAttrSizeLinuxAmd64, pthreadMutexAttrSizeLinuxArm64, pthreadMutexAttrSizeDarwinAmd64, pthreadMutexAttrSizeDarwinArm64)
+	pthreadCondSize       = max(pthreadCondSizeLinuxAmd64, pthreadCondSizeLinuxArm64, pthreadCondSizeDarwinAmd64, pthreadCondSizeDarwinArm64)
+	pthreadCondAttrSize   = max(pthreadCondAttrSizeLinuxAmd64, pthreadCondAttrSizeLinuxArm64, pthreadCondAttrSizeDarwinAmd64, pthreadCondAttrSizeDarwinArm64)
+	pthreadRWLockSize     = max(pthreadRWLockSizeLinuxAmd64, pthreadRWLockSizeLinuxArm64, pthreadRWLockSizeDarwinAmd64, pthreadRWLockSizeDarwinArm64)
+	pthreadRWLockAttrSize = max(pthreadRWLockAttrSizeLinuxAmd64, pthreadRWLockAttrSizeLinuxArm64, pthreadRWLockAttrSizeDarwinAmd64, pthreadRWLockAttrSizeDarwinArm64)
+	clockSize             = max(clockSizeLinuxAmd64, clockSizeLinuxArm64, clockSizeDarwinAmd64, clockSizeDarwinArm64)
+)

--- a/runtime/internal/test/test.go
+++ b/runtime/internal/test/test.go
@@ -3,6 +3,7 @@ package test
 /*
 #include <time.h>
 #include <pthread.h>
+#include <setjmp.h>
 */
 import "C"
 import (
@@ -18,6 +19,8 @@ var mutexattr C.pthread_mutexattr_t
 var condattr C.pthread_condattr_t
 var rwlockattr C.pthread_rwlockattr_t
 var clock C.clock_t
+var sigjmpbuf C.sigjmp_buf
+var jmpbuf C.jmp_buf
 
 const (
 	// Real sizes from the current platform
@@ -29,6 +32,8 @@ const (
 	pthreadRWLockSizeReal     = unsafe.Sizeof(rwlock)
 	pthreadRWLockAttrSizeReal = unsafe.Sizeof(rwlockattr)
 	clockSizeReal             = unsafe.Sizeof(clock)
+	sigjmpBufSizeReal         = unsafe.Sizeof(sigjmpbuf)
+	jmpBufSizeReal            = unsafe.Sizeof(jmpbuf)
 )
 
 // Linux amd64 specific sizes
@@ -46,60 +51,98 @@ var darwinArm64 = runtime.GOOS == "darwin" && runtime.GOARCH == "arm64"
 const (
 	// Linux amd64 pthread sizes
 	pthreadOnceSizeLinuxAmd64       = 4
-	pthreadMutextSizeLinuxAmd64     = 40
+	pthreadMutexSizeLinuxAmd64      = 40
 	pthreadMutexAttrSizeLinuxAmd64  = 4
 	pthreadCondSizeLinuxAmd64       = 48
 	pthreadCondAttrSizeLinuxAmd64   = 4
 	pthreadRWLockSizeLinuxAmd64     = 56
 	pthreadRWLockAttrSizeLinuxAmd64 = 8
 	clockSizeLinuxAmd64             = 8
+	sigjmpBufSizeLinuxAmd64         = 200
+	jmpBufSizeLinuxAmd64            = 200
 
 	// Linux arm64 pthread sizes
 	pthreadOnceSizeLinuxArm64       = 4
-	pthreadMutextSizeLinuxArm64     = 48
+	pthreadMutexSizeLinuxArm64      = 48
 	pthreadMutexAttrSizeLinuxArm64  = 8
 	pthreadCondSizeLinuxArm64       = 48
 	pthreadCondAttrSizeLinuxArm64   = 8
 	pthreadRWLockSizeLinuxArm64     = 56
 	pthreadRWLockAttrSizeLinuxArm64 = 8
 	clockSizeLinuxArm64             = 8
+	sigjmpBufSizeLinuxArm64         = 312
+	jmpBufSizeLinuxArm64            = 312
 
 	// macOS amd64 pthread sizes
 	pthreadOnceSizeDarwinAmd64       = 16
-	pthreadMutextSizeDarwinAmd64     = 56
+	pthreadMutexSizeDarwinAmd64      = 56
 	pthreadMutexAttrSizeDarwinAmd64  = 8
 	pthreadCondSizeDarwinAmd64       = 40
 	pthreadCondAttrSizeDarwinAmd64   = 8
 	pthreadRWLockSizeDarwinAmd64     = 192
 	pthreadRWLockAttrSizeDarwinAmd64 = 16
 	clockSizeDarwinAmd64             = 8
+	sigjmpBufSizeDarwinAmd64         = 196
+	jmpBufSizeDarwinAmd64            = 196
 
 	// macOS arm64 pthread sizes
 	pthreadOnceSizeDarwinArm64       = 16
-	pthreadMutextSizeDarwinArm64     = 64
+	pthreadMutexSizeDarwinArm64      = 64
 	pthreadMutexAttrSizeDarwinArm64  = 16
 	pthreadCondSizeDarwinArm64       = 48
 	pthreadCondAttrSizeDarwinArm64   = 16
 	pthreadRWLockSizeDarwinArm64     = 200
 	pthreadRWLockAttrSizeDarwinArm64 = 24
 	clockSizeDarwinArm64             = 8
+	sigjmpBufSizeDarwinArm64         = 196
+	jmpBufSizeDarwinArm64            = 192
 )
 
 // Get architecture-specific pthread sizes based on the current platform
-func getPlatformPthreadSizes() (onceSize, mutexSize, mutexAttrSize, condSize, condAttrSize, rwlockSize, rwlockAttrSize, clockSize int) {
+func getPlatformPthreadSizes() (onceSize, mutexSize, mutexAttrSize, condSize, condAttrSize, rwlockSize, rwlockAttrSize int) {
 	switch {
 	case linuxAmd64:
-		return pthreadOnceSizeLinuxAmd64, pthreadMutextSizeLinuxAmd64, pthreadMutexAttrSizeLinuxAmd64,
-			pthreadCondSizeLinuxAmd64, pthreadCondAttrSizeLinuxAmd64, pthreadRWLockSizeLinuxAmd64, pthreadRWLockAttrSizeLinuxAmd64, clockSizeLinuxAmd64
+		return pthreadOnceSizeLinuxAmd64, pthreadMutexSizeLinuxAmd64, pthreadMutexAttrSizeLinuxAmd64,
+			pthreadCondSizeLinuxAmd64, pthreadCondAttrSizeLinuxAmd64, pthreadRWLockSizeLinuxAmd64, pthreadRWLockAttrSizeLinuxAmd64
 	case linuxArm64:
-		return pthreadOnceSizeLinuxArm64, pthreadMutextSizeLinuxArm64, pthreadMutexAttrSizeLinuxArm64,
-			pthreadCondSizeLinuxArm64, pthreadCondAttrSizeLinuxArm64, pthreadRWLockSizeLinuxArm64, pthreadRWLockAttrSizeLinuxArm64, clockSizeLinuxArm64
+		return pthreadOnceSizeLinuxArm64, pthreadMutexSizeLinuxArm64, pthreadMutexAttrSizeLinuxArm64,
+			pthreadCondSizeLinuxArm64, pthreadCondAttrSizeLinuxArm64, pthreadRWLockSizeLinuxArm64, pthreadRWLockAttrSizeLinuxArm64
 	case darwinAmd64:
-		return pthreadOnceSizeDarwinAmd64, pthreadMutextSizeDarwinAmd64, pthreadMutexAttrSizeDarwinAmd64,
-			pthreadCondSizeDarwinAmd64, pthreadCondAttrSizeDarwinAmd64, pthreadRWLockSizeDarwinAmd64, pthreadRWLockAttrSizeDarwinAmd64, clockSizeDarwinAmd64
+		return pthreadOnceSizeDarwinAmd64, pthreadMutexSizeDarwinAmd64, pthreadMutexAttrSizeDarwinAmd64,
+			pthreadCondSizeDarwinAmd64, pthreadCondAttrSizeDarwinAmd64, pthreadRWLockSizeDarwinAmd64, pthreadRWLockAttrSizeDarwinAmd64
 	case darwinArm64:
-		return pthreadOnceSizeDarwinArm64, pthreadMutextSizeDarwinArm64, pthreadMutexAttrSizeDarwinArm64,
-			pthreadCondSizeDarwinArm64, pthreadCondAttrSizeDarwinArm64, pthreadRWLockSizeDarwinArm64, pthreadRWLockAttrSizeDarwinArm64, clockSizeDarwinArm64
+		return pthreadOnceSizeDarwinArm64, pthreadMutexSizeDarwinArm64, pthreadMutexAttrSizeDarwinArm64,
+			pthreadCondSizeDarwinArm64, pthreadCondAttrSizeDarwinArm64, pthreadRWLockSizeDarwinArm64, pthreadRWLockAttrSizeDarwinArm64
+	default:
+		panic("Unsupported platform: " + runtime.GOOS + ", " + runtime.GOARCH)
+	}
+}
+
+func getPlatformClockSizes() (clockSize int) {
+	switch {
+	case linuxAmd64:
+		return clockSizeLinuxAmd64
+	case linuxArm64:
+		return clockSizeLinuxArm64
+	case darwinAmd64:
+		return clockSizeDarwinAmd64
+	case darwinArm64:
+		return clockSizeDarwinArm64
+	default:
+		panic("Unsupported platform: " + runtime.GOOS + ", " + runtime.GOARCH)
+	}
+}
+
+func getPlatformJmpBufSizes() (sigjmpBufSize, jmpBufSize int) {
+	switch {
+	case linuxAmd64:
+		return sigjmpBufSizeLinuxAmd64, jmpBufSizeLinuxAmd64
+	case linuxArm64:
+		return sigjmpBufSizeLinuxArm64, jmpBufSizeLinuxArm64
+	case darwinAmd64:
+		return sigjmpBufSizeDarwinAmd64, jmpBufSizeDarwinAmd64
+	case darwinArm64:
+		return sigjmpBufSizeDarwinArm64, jmpBufSizeDarwinArm64
 	default:
 		panic("Unsupported platform: " + runtime.GOOS + ", " + runtime.GOARCH)
 	}
@@ -117,11 +160,13 @@ func max(a int, others ...int) int {
 
 var (
 	pthreadOnceSize       = max(pthreadOnceSizeLinuxAmd64, pthreadOnceSizeDarwinAmd64, pthreadOnceSizeLinuxArm64, pthreadOnceSizeDarwinArm64)
-	pthreadMutexSize      = max(pthreadMutextSizeLinuxAmd64, pthreadMutextSizeLinuxArm64, pthreadMutextSizeDarwinAmd64, pthreadMutextSizeDarwinArm64)
+	pthreadMutexSize      = max(pthreadMutexSizeLinuxAmd64, pthreadMutexSizeLinuxArm64, pthreadMutexSizeDarwinAmd64, pthreadMutexSizeDarwinArm64)
 	pthreadMutexAttrSize  = max(pthreadMutexAttrSizeLinuxAmd64, pthreadMutexAttrSizeLinuxArm64, pthreadMutexAttrSizeDarwinAmd64, pthreadMutexAttrSizeDarwinArm64)
 	pthreadCondSize       = max(pthreadCondSizeLinuxAmd64, pthreadCondSizeLinuxArm64, pthreadCondSizeDarwinAmd64, pthreadCondSizeDarwinArm64)
 	pthreadCondAttrSize   = max(pthreadCondAttrSizeLinuxAmd64, pthreadCondAttrSizeLinuxArm64, pthreadCondAttrSizeDarwinAmd64, pthreadCondAttrSizeDarwinArm64)
 	pthreadRWLockSize     = max(pthreadRWLockSizeLinuxAmd64, pthreadRWLockSizeLinuxArm64, pthreadRWLockSizeDarwinAmd64, pthreadRWLockSizeDarwinArm64)
 	pthreadRWLockAttrSize = max(pthreadRWLockAttrSizeLinuxAmd64, pthreadRWLockAttrSizeLinuxArm64, pthreadRWLockAttrSizeDarwinAmd64, pthreadRWLockAttrSizeDarwinArm64)
 	clockSize             = max(clockSizeLinuxAmd64, clockSizeLinuxArm64, clockSizeDarwinAmd64, clockSizeDarwinArm64)
+	sigjmpBufSize         = max(sigjmpBufSizeLinuxAmd64, sigjmpBufSizeLinuxArm64, sigjmpBufSizeDarwinAmd64, sigjmpBufSizeDarwinArm64)
+	jmpBufSize            = max(jmpBufSizeLinuxAmd64, jmpBufSizeLinuxArm64, jmpBufSizeDarwinAmd64, jmpBufSizeDarwinArm64)
 )

--- a/runtime/internal/test/typesize_test.go
+++ b/runtime/internal/test/typesize_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/goplus/llgo/runtime/internal/clite/pthread/sync"
+	"github.com/goplus/llgo/runtime/internal/clite/setjmp"
 	"github.com/goplus/llgo/runtime/internal/clite/time"
 )
 
@@ -16,8 +17,8 @@ func TestTypeSizes(t *testing.T) {
 		if pthreadOnceSizeLinuxAmd64 != pthreadOnceSizeReal {
 			t.Fatalf("pthreadOnceSizeLinuxAmd64 mismatch: %d != %d", pthreadOnceSizeLinuxAmd64, pthreadOnceSizeReal)
 		}
-		if pthreadMutextSizeLinuxAmd64 != pthreadMutexSizeReal {
-			t.Fatalf("pthreadMutextSizeLinuxAmd64 mismatch: %d != %d", pthreadMutextSizeLinuxAmd64, pthreadMutexSizeReal)
+		if pthreadMutexSizeLinuxAmd64 != pthreadMutexSizeReal {
+			t.Fatalf("pthreadMutexSizeLinuxAmd64 mismatch: %d != %d", pthreadMutexSizeLinuxAmd64, pthreadMutexSizeReal)
 		}
 		if pthreadMutexAttrSizeLinuxAmd64 != pthreadMutexAttrSizeReal {
 			t.Fatalf("pthreadMutexAttrSizeLinuxAmd64 mismatch: %d != %d", pthreadMutexAttrSizeLinuxAmd64, pthreadMutexAttrSizeReal)
@@ -37,13 +38,19 @@ func TestTypeSizes(t *testing.T) {
 		if clockSizeLinuxAmd64 != clockSizeReal {
 			t.Fatalf("clockSizeLinuxAmd64 mismatch: %d != %d", clockSizeLinuxAmd64, clockSizeReal)
 		}
+		if sigjmpBufSizeLinuxAmd64 != sigjmpBufSizeReal {
+			t.Fatalf("sigjmpBufSizeLinuxAmd64 mismatch: %d != %d", sigjmpBufSizeLinuxAmd64, sigjmpBufSizeReal)
+		}
+		if jmpBufSizeLinuxAmd64 != jmpBufSizeReal {
+			t.Fatalf("jmpBufSizeLinuxAmd64 mismatch: %d != %d", jmpBufSizeLinuxAmd64, jmpBufSizeReal)
+		}
 	case runtime.GOOS == "linux" && runtime.GOARCH == "arm64":
 		// Linux arm64 specific tests
 		if pthreadOnceSizeLinuxArm64 != pthreadOnceSizeReal {
 			t.Fatalf("pthreadOnceSizeLinuxArm64 mismatch: %d != %d", pthreadOnceSizeLinuxArm64, pthreadOnceSizeReal)
 		}
-		if pthreadMutextSizeLinuxArm64 != pthreadMutexSizeReal {
-			t.Fatalf("pthreadMutextSizeLinuxArm64 mismatch: %d != %d", pthreadMutextSizeLinuxArm64, pthreadMutexSizeReal)
+		if pthreadMutexSizeLinuxArm64 != pthreadMutexSizeReal {
+			t.Fatalf("pthreadMutexSizeLinuxArm64 mismatch: %d != %d", pthreadMutexSizeLinuxArm64, pthreadMutexSizeReal)
 		}
 		if pthreadMutexAttrSizeLinuxArm64 != pthreadMutexAttrSizeReal {
 			t.Fatalf("pthreadMutexAttrSizeLinuxArm64 mismatch: %d != %d", pthreadMutexAttrSizeLinuxArm64, pthreadMutexAttrSizeReal)
@@ -63,13 +70,19 @@ func TestTypeSizes(t *testing.T) {
 		if clockSizeLinuxArm64 != clockSizeReal {
 			t.Fatalf("clockSizeLinuxArm64 mismatch: %d != %d", clockSizeLinuxArm64, clockSizeReal)
 		}
+		if sigjmpBufSizeLinuxArm64 != sigjmpBufSizeReal {
+			t.Fatalf("sigjmpBufSizeLinuxArm64 mismatch: %d != %d", sigjmpBufSizeLinuxArm64, sigjmpBufSizeReal)
+		}
+		if jmpBufSizeLinuxArm64 != jmpBufSizeReal {
+			t.Fatalf("jmpBufSizeLinuxArm64 mismatch: %d != %d", jmpBufSizeLinuxArm64, jmpBufSizeReal)
+		}
 	case runtime.GOOS == "darwin" && runtime.GOARCH == "amd64":
 		// macOS amd64 specific tests
 		if pthreadOnceSizeDarwinAmd64 != pthreadOnceSizeReal {
 			t.Fatalf("pthreadOnceSizeDarwinAmd64 mismatch: %d != %d", pthreadOnceSizeDarwinAmd64, pthreadOnceSizeReal)
 		}
-		if pthreadMutextSizeDarwinAmd64 != pthreadMutexSizeReal {
-			t.Fatalf("pthreadMutextSizeDarwinAmd64 mismatch: %d != %d", pthreadMutextSizeDarwinAmd64, pthreadMutexSizeReal)
+		if pthreadMutexSizeDarwinAmd64 != pthreadMutexSizeReal {
+			t.Fatalf("pthreadMutexSizeDarwinAmd64 mismatch: %d != %d", pthreadMutexSizeDarwinAmd64, pthreadMutexSizeReal)
 		}
 		if pthreadMutexAttrSizeDarwinAmd64 != pthreadMutexAttrSizeReal {
 			t.Fatalf("pthreadMutexAttrSizeDarwinAmd64 mismatch: %d != %d", pthreadMutexAttrSizeDarwinAmd64, pthreadMutexAttrSizeReal)
@@ -89,13 +102,19 @@ func TestTypeSizes(t *testing.T) {
 		if clockSizeDarwinAmd64 != clockSizeReal {
 			t.Fatalf("clockSizeDarwinAmd64 mismatch: %d != %d", clockSizeDarwinAmd64, clockSizeReal)
 		}
+		if sigjmpBufSizeDarwinAmd64 != sigjmpBufSizeReal {
+			t.Fatalf("sigjmpBufSizeDarwinAmd64 mismatch: %d != %d", sigjmpBufSizeDarwinAmd64, sigjmpBufSizeReal)
+		}
+		if jmpBufSizeDarwinAmd64 != jmpBufSizeReal {
+			t.Fatalf("jmpBufSizeDarwinAmd64 mismatch: %d != %d", jmpBufSizeDarwinAmd64, jmpBufSizeReal)
+		}
 	case runtime.GOOS == "darwin" && runtime.GOARCH == "arm64":
 		// macOS arm64 specific tests
 		if pthreadOnceSizeDarwinArm64 != pthreadOnceSizeReal {
 			t.Fatalf("pthreadOnceSizeDarwinArm64 mismatch: %d != %d", pthreadOnceSizeDarwinArm64, pthreadOnceSizeReal)
 		}
-		if pthreadMutextSizeDarwinArm64 != pthreadMutexSizeReal {
-			t.Fatalf("pthreadMutextSizeDarwinArm64 mismatch: %d != %d", pthreadMutextSizeDarwinArm64, pthreadMutexSizeReal)
+		if pthreadMutexSizeDarwinArm64 != pthreadMutexSizeReal {
+			t.Fatalf("pthreadMutexSizeDarwinArm64 mismatch: %d != %d", pthreadMutexSizeDarwinArm64, pthreadMutexSizeReal)
 		}
 		if pthreadMutexAttrSizeDarwinArm64 != pthreadMutexAttrSizeReal {
 			t.Fatalf("pthreadMutexAttrSizeDarwinArm64 mismatch: %d != %d", pthreadMutexAttrSizeDarwinArm64, pthreadMutexAttrSizeReal)
@@ -115,35 +134,49 @@ func TestTypeSizes(t *testing.T) {
 		if clockSizeDarwinArm64 != clockSizeReal {
 			t.Fatalf("clockSizeDarwinArm64 mismatch: %d != %d", clockSizeDarwinArm64, clockSizeReal)
 		}
+		if sigjmpBufSizeDarwinArm64 != sigjmpBufSizeReal {
+			t.Fatalf("sigjmpBufSizeDarwinArm64 mismatch: %d != %d", sigjmpBufSizeDarwinArm64, sigjmpBufSizeReal)
+		}
+		if jmpBufSizeDarwinArm64 != jmpBufSizeReal {
+			t.Fatalf("jmpBufSizeDarwinArm64 mismatch: %d != %d", jmpBufSizeDarwinArm64, jmpBufSizeReal)
+		}
 	default:
 		t.Fatalf("Unsupported platform: %s, %s", runtime.GOOS, runtime.GOARCH)
 	}
 
 	// Sync package size checks
-	onceSize, mutexSize, mutexAttrSize, condSize, condAttrSize, rwlockSize, rwlockAttrSize, clockSize := getPlatformPthreadSizes()
+	onceSize, mutexSize, mutexAttrSize, condSize, condAttrSize, rwlockSize, rwlockAttrSize := getPlatformPthreadSizes()
+	clockSize := getPlatformClockSizes()
+	sigjmpBufSize, jmpBufSize := getPlatformJmpBufSizes()
 
-	if sync.PthreadOnceSize < onceSize {
-		t.Fatalf("PthreadOnceSize mismatch: %d < %d", sync.PthreadOnceSize, onceSize)
+	if sync.PthreadOnceSize != onceSize {
+		t.Fatalf("PthreadOnceSize mismatch: %d != %d", sync.PthreadOnceSize, onceSize)
 	}
-	if sync.PthreadMutexSize < mutexSize {
-		t.Fatalf("PthreadMutexSize mismatch: %d < %d", sync.PthreadMutexSize, mutexSize)
+	if sync.PthreadMutexSize != mutexSize {
+		t.Fatalf("PthreadMutexSize mismatch: %d != %d", sync.PthreadMutexSize, mutexSize)
 	}
-	if sync.PthreadMutexAttrSize < mutexAttrSize {
-		t.Fatalf("PthreadMutexAttrSize mismatch: %d < %d", sync.PthreadMutexAttrSize, mutexAttrSize)
+	if sync.PthreadMutexAttrSize != mutexAttrSize {
+		t.Fatalf("PthreadMutexAttrSize mismatch: %d != %d", sync.PthreadMutexAttrSize, mutexAttrSize)
 	}
-	if sync.PthreadCondSize < condSize {
-		t.Fatalf("PthreadCondSize mismatch: %d < %d", sync.PthreadCondSize, condSize)
+	if sync.PthreadCondSize != condSize {
+		t.Fatalf("PthreadCondSize mismatch: %d != %d", sync.PthreadCondSize, condSize)
 	}
-	if sync.PthreadCondAttrSize < condAttrSize {
-		t.Fatalf("PthreadCondAttrSize mismatch: %d < %d", sync.PthreadCondAttrSize, condAttrSize)
+	if sync.PthreadCondAttrSize != condAttrSize {
+		t.Fatalf("PthreadCondAttrSize mismatch: %d != %d", sync.PthreadCondAttrSize, condAttrSize)
 	}
-	if sync.PthreadRWLockSize < rwlockSize {
-		t.Fatalf("PthreadRWLockSize mismatch: %d < %d", sync.PthreadRWLockSize, rwlockSize)
+	if sync.PthreadRWLockSize != rwlockSize {
+		t.Fatalf("PthreadRWLockSize mismatch: %d != %d", sync.PthreadRWLockSize, rwlockSize)
 	}
-	if sync.PthreadRWLockAttrSize < rwlockAttrSize {
-		t.Fatalf("PthreadRWLockAttrSize mismatch: %d < %d", sync.PthreadRWLockAttrSize, rwlockAttrSize)
+	if sync.PthreadRWLockAttrSize != rwlockAttrSize {
+		t.Fatalf("PthreadRWLockAttrSize mismatch: %d != %d", sync.PthreadRWLockAttrSize, rwlockAttrSize)
 	}
-	if time.ClockTSize < clockSize {
-		t.Fatalf("ClockSize mismatch: %d < %d", time.ClockTSize, clockSize)
+	if time.ClockTSize != clockSize {
+		t.Fatalf("ClockSize mismatch: %d != %d", time.ClockTSize, clockSize)
+	}
+	if setjmp.SigjmpBufSize != sigjmpBufSize {
+		t.Fatalf("SigjmpBufSize mismatch: %d != %d", setjmp.SigjmpBufSize, sigjmpBufSize)
+	}
+	if setjmp.JmpBufSize != jmpBufSize {
+		t.Fatalf("JmpBufSize mismatch: %d != %d", setjmp.JmpBufSize, jmpBufSize)
 	}
 }

--- a/runtime/internal/test/typesize_test.go
+++ b/runtime/internal/test/typesize_test.go
@@ -3,11 +3,31 @@ package test
 import (
 	"runtime"
 	"testing"
+	"unsafe"
 
+	"github.com/goplus/llgo/runtime/internal/clite/os"
 	"github.com/goplus/llgo/runtime/internal/clite/pthread/sync"
 	"github.com/goplus/llgo/runtime/internal/clite/setjmp"
 	"github.com/goplus/llgo/runtime/internal/clite/time"
 )
+
+func TestOSTypes(t *testing.T) {
+	if unsafe.Sizeof(mode) != unsafe.Sizeof(os.ModeT(0)) {
+		t.Fatalf("mode size mismatch: %d != %d", unsafe.Sizeof(mode), unsafe.Sizeof(os.ModeT(0)))
+	}
+	if unsafe.Sizeof(uid) != unsafe.Sizeof(os.UidT(0)) {
+		t.Fatalf("uid size mismatch: %d != %d", unsafe.Sizeof(uid), unsafe.Sizeof(os.UidT(0)))
+	}
+	if unsafe.Sizeof(gid) != unsafe.Sizeof(os.GidT(0)) {
+		t.Fatalf("gid size mismatch: %d != %d", unsafe.Sizeof(gid), unsafe.Sizeof(os.GidT(0)))
+	}
+	if unsafe.Sizeof(off) != unsafe.Sizeof(os.OffT(0)) {
+		t.Fatalf("off size mismatch: %d != %d", unsafe.Sizeof(off), unsafe.Sizeof(os.OffT(0)))
+	}
+	if unsafe.Sizeof(dev) != unsafe.Sizeof(os.DevT(0)) {
+		t.Fatalf("dev size mismatch: %d != %d", unsafe.Sizeof(dev), unsafe.Sizeof(os.DevT(0)))
+	}
+}
 
 func TestTypeSizes(t *testing.T) {
 	// Test platform-specific sizes based on OS and architecture

--- a/runtime/internal/test/typesize_test.go
+++ b/runtime/internal/test/typesize_test.go
@@ -1,0 +1,149 @@
+package test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/goplus/llgo/runtime/internal/clite/pthread/sync"
+	"github.com/goplus/llgo/runtime/internal/clite/time"
+)
+
+func TestTypeSizes(t *testing.T) {
+	// Test platform-specific sizes based on OS and architecture
+	switch {
+	case runtime.GOOS == "linux" && runtime.GOARCH == "amd64":
+		// Linux amd64 specific tests
+		if pthreadOnceSizeLinuxAmd64 != pthreadOnceSizeReal {
+			t.Fatalf("pthreadOnceSizeLinuxAmd64 mismatch: %d != %d", pthreadOnceSizeLinuxAmd64, pthreadOnceSizeReal)
+		}
+		if pthreadMutextSizeLinuxAmd64 != pthreadMutexSizeReal {
+			t.Fatalf("pthreadMutextSizeLinuxAmd64 mismatch: %d != %d", pthreadMutextSizeLinuxAmd64, pthreadMutexSizeReal)
+		}
+		if pthreadMutexAttrSizeLinuxAmd64 != pthreadMutexAttrSizeReal {
+			t.Fatalf("pthreadMutexAttrSizeLinuxAmd64 mismatch: %d != %d", pthreadMutexAttrSizeLinuxAmd64, pthreadMutexAttrSizeReal)
+		}
+		if pthreadCondSizeLinuxAmd64 != pthreadCondSizeReal {
+			t.Fatalf("pthreadCondSizeLinuxAmd64 mismatch: %d != %d", pthreadCondSizeLinuxAmd64, pthreadCondSizeReal)
+		}
+		if pthreadCondAttrSizeLinuxAmd64 != pthreadCondAttrSizeReal {
+			t.Fatalf("pthreadCondAttrSizeLinuxAmd64 mismatch: %d != %d", pthreadCondAttrSizeLinuxAmd64, pthreadCondAttrSizeReal)
+		}
+		if pthreadRWLockSizeLinuxAmd64 != pthreadRWLockSizeReal {
+			t.Fatalf("pthreadRWLockSizeLinuxAmd64 mismatch: %d != %d", pthreadRWLockSizeLinuxAmd64, pthreadRWLockSizeReal)
+		}
+		if pthreadRWLockAttrSizeLinuxAmd64 != pthreadRWLockAttrSizeReal {
+			t.Fatalf("pthreadRWLockAttrSizeLinuxAmd64 mismatch: %d != %d", pthreadRWLockAttrSizeLinuxAmd64, pthreadRWLockAttrSizeReal)
+		}
+		if clockSizeLinuxAmd64 != clockSizeReal {
+			t.Fatalf("clockSizeLinuxAmd64 mismatch: %d != %d", clockSizeLinuxAmd64, clockSizeReal)
+		}
+	case runtime.GOOS == "linux" && runtime.GOARCH == "arm64":
+		// Linux arm64 specific tests
+		if pthreadOnceSizeLinuxArm64 != pthreadOnceSizeReal {
+			t.Fatalf("pthreadOnceSizeLinuxArm64 mismatch: %d != %d", pthreadOnceSizeLinuxArm64, pthreadOnceSizeReal)
+		}
+		if pthreadMutextSizeLinuxArm64 != pthreadMutexSizeReal {
+			t.Fatalf("pthreadMutextSizeLinuxArm64 mismatch: %d != %d", pthreadMutextSizeLinuxArm64, pthreadMutexSizeReal)
+		}
+		if pthreadMutexAttrSizeLinuxArm64 != pthreadMutexAttrSizeReal {
+			t.Fatalf("pthreadMutexAttrSizeLinuxArm64 mismatch: %d != %d", pthreadMutexAttrSizeLinuxArm64, pthreadMutexAttrSizeReal)
+		}
+		if pthreadCondSizeLinuxArm64 != pthreadCondSizeReal {
+			t.Fatalf("pthreadCondSizeLinuxArm64 mismatch: %d != %d", pthreadCondSizeLinuxArm64, pthreadCondSizeReal)
+		}
+		if pthreadCondAttrSizeLinuxArm64 != pthreadCondAttrSizeReal {
+			t.Fatalf("pthreadCondAttrSizeLinuxArm64 mismatch: %d != %d", pthreadCondAttrSizeLinuxArm64, pthreadCondAttrSizeReal)
+		}
+		if pthreadRWLockSizeLinuxArm64 != pthreadRWLockSizeReal {
+			t.Fatalf("pthreadRWLockSizeLinuxArm64 mismatch: %d != %d", pthreadRWLockSizeLinuxArm64, pthreadRWLockSizeReal)
+		}
+		if pthreadRWLockAttrSizeLinuxArm64 != pthreadRWLockAttrSizeReal {
+			t.Fatalf("pthreadRWLockAttrSizeLinuxArm64 mismatch: %d != %d", pthreadRWLockAttrSizeLinuxArm64, pthreadRWLockAttrSizeReal)
+		}
+		if clockSizeLinuxArm64 != clockSizeReal {
+			t.Fatalf("clockSizeLinuxArm64 mismatch: %d != %d", clockSizeLinuxArm64, clockSizeReal)
+		}
+	case runtime.GOOS == "darwin" && runtime.GOARCH == "amd64":
+		// macOS amd64 specific tests
+		if pthreadOnceSizeDarwinAmd64 != pthreadOnceSizeReal {
+			t.Fatalf("pthreadOnceSizeDarwinAmd64 mismatch: %d != %d", pthreadOnceSizeDarwinAmd64, pthreadOnceSizeReal)
+		}
+		if pthreadMutextSizeDarwinAmd64 != pthreadMutexSizeReal {
+			t.Fatalf("pthreadMutextSizeDarwinAmd64 mismatch: %d != %d", pthreadMutextSizeDarwinAmd64, pthreadMutexSizeReal)
+		}
+		if pthreadMutexAttrSizeDarwinAmd64 != pthreadMutexAttrSizeReal {
+			t.Fatalf("pthreadMutexAttrSizeDarwinAmd64 mismatch: %d != %d", pthreadMutexAttrSizeDarwinAmd64, pthreadMutexAttrSizeReal)
+		}
+		if pthreadCondSizeDarwinAmd64 != pthreadCondSizeReal {
+			t.Fatalf("pthreadCondSizeDarwinAmd64 mismatch: %d != %d", pthreadCondSizeDarwinAmd64, pthreadCondSizeReal)
+		}
+		if pthreadCondAttrSizeDarwinAmd64 != pthreadCondAttrSizeReal {
+			t.Fatalf("pthreadCondAttrSizeDarwinAmd64 mismatch: %d != %d", pthreadCondAttrSizeDarwinAmd64, pthreadCondAttrSizeReal)
+		}
+		if pthreadRWLockSizeDarwinAmd64 != pthreadRWLockSizeReal {
+			t.Fatalf("pthreadRWLockSizeDarwinAmd64 mismatch: %d != %d", pthreadRWLockSizeDarwinAmd64, pthreadRWLockSizeReal)
+		}
+		if pthreadRWLockAttrSizeDarwinAmd64 != pthreadRWLockAttrSizeReal {
+			t.Fatalf("pthreadRWLockAttrSizeDarwinAmd64 mismatch: %d != %d", pthreadRWLockAttrSizeDarwinAmd64, pthreadRWLockAttrSizeReal)
+		}
+		if clockSizeDarwinAmd64 != clockSizeReal {
+			t.Fatalf("clockSizeDarwinAmd64 mismatch: %d != %d", clockSizeDarwinAmd64, clockSizeReal)
+		}
+	case runtime.GOOS == "darwin" && runtime.GOARCH == "arm64":
+		// macOS arm64 specific tests
+		if pthreadOnceSizeDarwinArm64 != pthreadOnceSizeReal {
+			t.Fatalf("pthreadOnceSizeDarwinArm64 mismatch: %d != %d", pthreadOnceSizeDarwinArm64, pthreadOnceSizeReal)
+		}
+		if pthreadMutextSizeDarwinArm64 != pthreadMutexSizeReal {
+			t.Fatalf("pthreadMutextSizeDarwinArm64 mismatch: %d != %d", pthreadMutextSizeDarwinArm64, pthreadMutexSizeReal)
+		}
+		if pthreadMutexAttrSizeDarwinArm64 != pthreadMutexAttrSizeReal {
+			t.Fatalf("pthreadMutexAttrSizeDarwinArm64 mismatch: %d != %d", pthreadMutexAttrSizeDarwinArm64, pthreadMutexAttrSizeReal)
+		}
+		if pthreadCondSizeDarwinArm64 != pthreadCondSizeReal {
+			t.Fatalf("pthreadCondSizeDarwinArm64 mismatch: %d != %d", pthreadCondSizeDarwinArm64, pthreadCondSizeReal)
+		}
+		if pthreadCondAttrSizeDarwinArm64 != pthreadCondAttrSizeReal {
+			t.Fatalf("pthreadCondAttrSizeDarwinArm64 mismatch: %d != %d", pthreadCondAttrSizeDarwinArm64, pthreadCondAttrSizeReal)
+		}
+		if pthreadRWLockSizeDarwinArm64 != pthreadRWLockSizeReal {
+			t.Fatalf("pthreadRWLockSizeDarwinArm64 mismatch: %d != %d", pthreadRWLockSizeDarwinArm64, pthreadRWLockSizeReal)
+		}
+		if pthreadRWLockAttrSizeDarwinArm64 != pthreadRWLockAttrSizeReal {
+			t.Fatalf("pthreadRWLockAttrSizeDarwinArm64 mismatch: %d != %d", pthreadRWLockAttrSizeDarwinArm64, pthreadRWLockAttrSizeReal)
+		}
+		if clockSizeDarwinArm64 != clockSizeReal {
+			t.Fatalf("clockSizeDarwinArm64 mismatch: %d != %d", clockSizeDarwinArm64, clockSizeReal)
+		}
+	default:
+		t.Fatalf("Unsupported platform: %s, %s", runtime.GOOS, runtime.GOARCH)
+	}
+
+	// Sync package size checks
+	onceSize, mutexSize, mutexAttrSize, condSize, condAttrSize, rwlockSize, rwlockAttrSize, clockSize := getPlatformPthreadSizes()
+
+	if sync.PthreadOnceSize < onceSize {
+		t.Fatalf("PthreadOnceSize mismatch: %d < %d", sync.PthreadOnceSize, onceSize)
+	}
+	if sync.PthreadMutexSize < mutexSize {
+		t.Fatalf("PthreadMutexSize mismatch: %d < %d", sync.PthreadMutexSize, mutexSize)
+	}
+	if sync.PthreadMutexAttrSize < mutexAttrSize {
+		t.Fatalf("PthreadMutexAttrSize mismatch: %d < %d", sync.PthreadMutexAttrSize, mutexAttrSize)
+	}
+	if sync.PthreadCondSize < condSize {
+		t.Fatalf("PthreadCondSize mismatch: %d < %d", sync.PthreadCondSize, condSize)
+	}
+	if sync.PthreadCondAttrSize < condAttrSize {
+		t.Fatalf("PthreadCondAttrSize mismatch: %d < %d", sync.PthreadCondAttrSize, condAttrSize)
+	}
+	if sync.PthreadRWLockSize < rwlockSize {
+		t.Fatalf("PthreadRWLockSize mismatch: %d < %d", sync.PthreadRWLockSize, rwlockSize)
+	}
+	if sync.PthreadRWLockAttrSize < rwlockAttrSize {
+		t.Fatalf("PthreadRWLockAttrSize mismatch: %d < %d", sync.PthreadRWLockAttrSize, rwlockAttrSize)
+	}
+	if time.ClockTSize < clockSize {
+		t.Fatalf("ClockSize mismatch: %d < %d", time.ClockTSize, clockSize)
+	}
+}


### PR DESCRIPTION
To compile to wasm target, all cgo code must removed. This is a part of wasm progress https://github.com/goplus/llgo/issues/1031

- [x] llgo/c, llgo/runtime/internal/clite
- [x] llgo/c/pthread/sync, llgo/runtime/internal/clite/pthread/sync
  - Rewrite C.pthread* to struct with type size tests (runtime/internal/test)
- [x] llgo/c/debug, llgo/runtime/internal/clite/debug
  - `#cgo linux LDFLAGS: -lunwind` to `LLGoPackage = "link: -lunwind"` with build tag
- [x] c/os, clite/os
- [x] c/setjmp, llgo/runtime/internal/clite/setjmp
  - Rewrite to struct with size tests (runtime/internal/test)
- [x] ssa.sigjmpbuf
  - Rewrite to `rtType("SigjmpBuf")`