### PR TITLE
Split debug and symbols toggle environment variables

### DIFF
--- a/compiler/_lldb/README.md
+++ b/compiler/_lldb/README.md
@@ -3,7 +3,7 @@
 ### Build with debug info
 
 ```shell
-LLGO_DEBUG=1 llgo build -o cl/_testdata/debug/out ./cl/_testdata/debug
+LLGO_DEBUG_SYMBOLS=1 llgo build -o cl/_testdata/debug/out ./cl/_testdata/debug
 ```
 
 ### Debug with lldb

--- a/compiler/_lldb/common.sh
+++ b/compiler/_lldb/common.sh
@@ -44,7 +44,7 @@ build_project() {
         return 1
     fi
 
-    LLGO_DEBUG=1 llgo build -o "debug.out" . || {
+    LLGO_DEBUG_SYMBOLS=1 llgo build -o "debug.out" . || {
         local ret=$?
         cd "$current_dir" || return
         return $ret

--- a/compiler/cl/instr.go
+++ b/compiler/cl/instr.go
@@ -348,7 +348,7 @@ func (p *context) funcOf(fn *ssa.Function) (aFn llssa.Function, pyFn llssa.PyObj
 			}
 			sig := fn.Signature
 			aFn = pkg.NewFuncEx(name, sig, llssa.Background(ftype), false, fn.Origin() != nil)
-			if debugSymbols {
+			if disableInline {
 				aFn.Inline(llssa.NoInline)
 			}
 		}

--- a/compiler/internal/build/build.go
+++ b/compiler/internal/build/build.go
@@ -142,7 +142,8 @@ func Do(args []string, conf *Config) ([]Package, error) {
 		}
 	}
 
-	cl.EnableDebugSymbols(IsDebugEnabled())
+	cl.EnableDebug(IsDbgEnabled())
+	cl.EnableDbgSyms(IsDbgSymsEnabled())
 	cl.EnableTrace(IsTraceEnabled())
 	llssa.Initialize(llssa.InitAll)
 
@@ -201,7 +202,7 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	})
 
 	buildMode := ssaBuildMode
-	if IsDebugEnabled() {
+	if IsDbgEnabled() {
 		buildMode |= ssa.GlobalDebug
 	}
 	if !IsOptimizeEnabled() {
@@ -451,7 +452,7 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, linkArgs
 	if err != nil {
 		panic(err)
 	}
-	defer os.Remove(entryLLFile)
+	// defer os.Remove(entryLLFile)
 	args = append(args, entryLLFile)
 
 	var aPkg *aPackage
@@ -480,7 +481,7 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, linkArgs
 		}
 	}
 	args = append(args, exargs...)
-	if IsDebugEnabled() {
+	if IsDbgSymsEnabled() {
 		args = append(args, "-gdwarf-4")
 	}
 
@@ -751,6 +752,7 @@ var (
 )
 
 const llgoDebug = "LLGO_DEBUG"
+const llgoDbgSyms = "LLGO_DEBUG_SYMBOLS"
 const llgoTrace = "LLGO_TRACE"
 const llgoOptimize = "LLGO_OPTIMIZE"
 const llgoCheck = "LLGO_CHECK"
@@ -768,8 +770,12 @@ func IsTraceEnabled() bool {
 	return isEnvOn(llgoTrace, false)
 }
 
-func IsDebugEnabled() bool {
-	return isEnvOn(llgoDebug, false)
+func IsDbgEnabled() bool {
+	return isEnvOn(llgoDebug, false) || isEnvOn(llgoDbgSyms, false)
+}
+
+func IsDbgSymsEnabled() bool {
+	return isEnvOn(llgoDbgSyms, false)
 }
 
 func IsOptimizeEnabled() bool {

--- a/compiler/internal/llgen/llgenf.go
+++ b/compiler/internal/llgen/llgenf.go
@@ -33,11 +33,16 @@ func GenFrom(fileOrPkg string) string {
 
 func genFrom(pkgPath string) (build.Package, error) {
 	oldDbg := os.Getenv("LLGO_DEBUG")
+	oldDbgSyms := os.Getenv("LLGO_DEBUG_SYMBOLS")
 	dbg := isDbgSymEnabled(filepath.Join(pkgPath, "flags.txt"))
 	if dbg {
 		os.Setenv("LLGO_DEBUG", "1")
+		os.Setenv("LLGO_DEBUG_SYMBOLS", "1")
 	}
-	defer os.Setenv("LLGO_DEBUG", oldDbg)
+	defer func() {
+		os.Setenv("LLGO_DEBUG", oldDbg)
+		os.Setenv("LLGO_DEBUG_SYMBOLS", oldDbgSyms)
+	}()
 
 	conf := &build.Config{
 		Mode:   build.ModeGen,

--- a/compiler/ssa/package.go
+++ b/compiler/ssa/package.go
@@ -759,7 +759,7 @@ func (p Package) AfterInit(b Builder, ret BasicBlock) {
 	}
 }
 
-func (p Package) InitDebugSymbols(name, pkgPath string, positioner Positioner) {
+func (p Package) InitDebug(name, pkgPath string, positioner Positioner) {
 	p.di = newDIBuilder(p.Prog, p, positioner)
 	p.cu = p.di.createCompileUnit(name, pkgPath)
 }


### PR DESCRIPTION
- Toggle module/func debug info with LLGO_DEBUG to enable DILocation
- Toggle variables debug info with LLGO_DEBUG_SYMBOLS, currently it has some bugs so we can only enable LLGO_DEBUG to get stacktrace with filename/line/column 