### PR TITLE
Fix args parsing

### DIFF
--- a/cmd/internal/build/build.go
+++ b/cmd/internal/build/build.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"github.com/goplus/llgo/cmd/internal/base"
+	"github.com/goplus/llgo/cmd/internal/flags"
 	"github.com/goplus/llgo/internal/build"
 	"github.com/goplus/llgo/internal/mockable"
 )
@@ -34,14 +35,22 @@ var Cmd = &base.Command{
 
 func init() {
 	Cmd.Run = runCmd
+	flags.AddBuildFlags(&Cmd.Flag)
+	flags.AddOutputFlags(&Cmd.Flag)
 }
 
 func runCmd(cmd *base.Command, args []string) {
-	conf := build.NewDefaultConf(build.ModeBuild)
-	if len(args) >= 2 && args[0] == "-o" {
-		conf.OutFile = args[1]
-		args = args[2:]
+	if err := cmd.Flag.Parse(args); err != nil {
+		panic(err)
 	}
+
+	conf := build.NewDefaultConf(build.ModeBuild)
+	conf.Tags = flags.Tags
+	conf.Verbose = flags.Verbose
+	conf.OutFile = flags.OutputFile
+
+	args = cmd.Flag.Args()
+
 	_, err := build.Do(args, conf)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/internal/clean/clean.go
+++ b/cmd/internal/clean/clean.go
@@ -19,6 +19,7 @@ package clean
 
 import (
 	"github.com/goplus/llgo/cmd/internal/base"
+	"github.com/goplus/llgo/cmd/internal/flags"
 	"github.com/goplus/llgo/internal/build"
 )
 
@@ -30,9 +31,18 @@ var Cmd = &base.Command{
 
 func init() {
 	Cmd.Run = runCmd
+	flags.AddBuildFlags(&Cmd.Flag)
 }
 
 func runCmd(cmd *base.Command, args []string) {
+	if err := cmd.Flag.Parse(args); err != nil {
+		panic(err)
+	}
+
 	conf := build.NewDefaultConf(0)
+	conf.Tags = flags.Tags
+	conf.Verbose = flags.Verbose
+
+	args = cmd.Flag.Args()
 	build.Clean(args, conf)
 }

--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -1,0 +1,27 @@
+package flags
+
+import (
+	"flag"
+)
+
+var OutputFile string
+
+func AddOutputFlags(fs *flag.FlagSet) {
+	fs.StringVar(&OutputFile, "o", "", "Output file")
+}
+
+var Verbose bool
+var BuildEnv string
+var Tags string
+
+func AddBuildFlags(fs *flag.FlagSet) {
+	fs.BoolVar(&Verbose, "v", false, "Verbose mode")
+	fs.StringVar(&Tags, "tags", "", "Build tags")
+	fs.StringVar(&BuildEnv, "buildenv", "", "Build environment")
+}
+
+var Gen bool
+
+func AddCmpTestFlags(fs *flag.FlagSet) {
+	fs.BoolVar(&Gen, "gen", false, "Generate llgo.expect file")
+}

--- a/cmd/internal/install/install.go
+++ b/cmd/internal/install/install.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"github.com/goplus/llgo/cmd/internal/base"
+	"github.com/goplus/llgo/cmd/internal/flags"
 	"github.com/goplus/llgo/internal/build"
 	"github.com/goplus/llgo/internal/mockable"
 )
@@ -34,10 +35,19 @@ var Cmd = &base.Command{
 
 func init() {
 	Cmd.Run = runCmd
+	flags.AddBuildFlags(&Cmd.Flag)
 }
 
 func runCmd(cmd *base.Command, args []string) {
+	if err := cmd.Flag.Parse(args); err != nil {
+		panic(err)
+	}
+
 	conf := build.NewDefaultConf(build.ModeInstall)
+	conf.Tags = flags.Tags
+	conf.Verbose = flags.Verbose
+
+	args = cmd.Flag.Args()
 	_, err := build.Do(args, conf)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/internal/test/test.go
+++ b/cmd/internal/test/test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/goplus/llgo/cmd/internal/base"
+	"github.com/goplus/llgo/cmd/internal/flags"
 	"github.com/goplus/llgo/internal/build"
 )
 
@@ -16,15 +17,19 @@ var Cmd = &base.Command{
 
 func init() {
 	Cmd.Run = runCmd
+	flags.AddBuildFlags(&Cmd.Flag)
 }
 
 func runCmd(cmd *base.Command, args []string) {
-	runCmdEx(cmd, args, build.ModeRun)
-}
+	if err := cmd.Flag.Parse(args); err != nil {
+		panic(err)
+	}
 
-func runCmdEx(_ *base.Command, args []string, mode build.Mode) {
-	conf := build.NewDefaultConf(mode)
-	conf.Mode = build.ModeTest
+	conf := build.NewDefaultConf(build.ModeTest)
+	conf.Tags = flags.Tags
+	conf.Verbose = flags.Verbose
+
+	args = cmd.Flag.Args()
 	_, err := build.Do(args, conf)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -54,13 +54,13 @@ func mockRun(args []string, cfg *Config) {
 }
 
 func TestRun(t *testing.T) {
-	mockRun([]string{"-v", "../../cl/_testgo/print"}, &Config{Mode: ModeRun})
+	mockRun([]string{"../../cl/_testgo/print"}, &Config{Mode: ModeRun})
 }
 
 func TestTest(t *testing.T) {
-	mockRun([]string{"-v", "../../cl/_testgo/runtest"}, &Config{Mode: ModeTest})
+	mockRun([]string{"../../cl/_testgo/runtest"}, &Config{Mode: ModeTest})
 }
 
 func TestCmpTest(t *testing.T) {
-	mockRun([]string{"-v", "../../cl/_testgo/runtest"}, &Config{Mode: ModeCmpTest})
+	mockRun([]string{"../../cl/_testgo/runtest"}, &Config{Mode: ModeCmpTest})
 }


### PR DESCRIPTION
- [x] extract common cmd flags, for better cmd args parse
  - E.g. currently `llgo build -v -o xxx` failed
