### PR TITLE
xtool/cppkg:install in linux

### DIFF
--- a/xtool/cppkg/command.go
+++ b/xtool/cppkg/command.go
@@ -17,6 +17,7 @@
 package cppkg
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -77,12 +78,14 @@ func (p *Tool) Get(quietInstall bool) (app string, err error) {
 }
 
 func (p *Tool) getAppManager() (amPath string, install []string, err error) {
+	var notFoundMgs []string
 	for _, install = range p.installs {
 		am := install[0]
 		if amPath, err = exec.LookPath(am); err == nil {
 			return
 		}
+		notFoundMgs = append(notFoundMgs, am)
 	}
-	err = ErrNotFound
+	err = fmt.Errorf("app managers not found: %s: %w", strings.Join(notFoundMgs, ", "), ErrNotFound)
 	return
 }

--- a/xtool/cppkg/conan.go
+++ b/xtool/cppkg/conan.go
@@ -37,7 +37,7 @@ import (
 
 var conanCmd = NewTool("conan", []string{
 	"brew install conan",
-	"apt-get install conan",
+	"pipx install conan",
 })
 
 type conandata struct {


### PR DESCRIPTION
1. conan not in apt-get ' resource,so we could not use apt-get to install conan,and use pip install will got follow error,and the suggestion in the error message tips to use pipx.
```bash
> python3 -m pip install conan
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.

    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```

--- 

user need install pipx,so when user not install pipx or brew notify error message with app manager.
```
root@259c7fd049f2:~/llgo/cmd/llgo# llgo cppkg install kspalaiologos/bzip3@1.5.1
From https://github.com/goplus/cppkg
 * branch              main       -> FETCH_HEAD
Already up to date.
panic: app managers not found: brew, pipx: executable file not found in $PATH
```