### PR TITLE
fix runtime/internal/clite/syscall init 

### DIFF
--- a/runtime/internal/clite/os/os.go
+++ b/runtime/internal/clite/os/os.go
@@ -87,12 +87,6 @@ func Remove(path *c.Char) c.Int
 //go:linkname Rename C.rename
 func Rename(oldpath *c.Char, newpath *c.Char) c.Int
 
-//go:linkname Stat C.stat
-func Stat(path *c.Char, buf *StatT) c.Int
-
-//go:linkname Lstat C.lstat
-func Lstat(path *c.Char, buf *StatT) c.Int
-
 //go:linkname Truncate C.truncate
 func Truncate(path *c.Char, length OffT) c.Int
 
@@ -285,7 +279,7 @@ func Exit(c.Int)
 
 // -----------------------------------------------------------------------------
 
-// Upon successful completion, the value 0 is returned; otherwise the value -1
+// Upon successful completion, the value 0 is returned; otherwise the value -1
 // is returned and the global variable errno is set to indicate the error.
 //
 //go:linkname Sysctl C.sysctl

--- a/runtime/internal/clite/os/stat.go
+++ b/runtime/internal/clite/os/stat.go
@@ -1,0 +1,16 @@
+//go:build !darwin
+// +build !darwin
+
+package os
+
+import (
+	_ "unsafe"
+
+	c "github.com/goplus/llgo/runtime/internal/clite"
+)
+
+//go:linkname Stat C.stat
+func Stat(path *c.Char, buf *StatT) c.Int
+
+//go:linkname Lstat C.lstat
+func Lstat(path *c.Char, buf *StatT) c.Int

--- a/runtime/internal/clite/os/stat_darwin.go
+++ b/runtime/internal/clite/os/stat_darwin.go
@@ -1,0 +1,13 @@
+package os
+
+import (
+	_ "unsafe"
+
+	c "github.com/goplus/llgo/runtime/internal/clite"
+)
+
+//go:linkname Stat C.stat64
+func Stat(path *c.Char, buf *StatT) c.Int
+
+//go:linkname Lstat C.lstat64
+func Lstat(path *c.Char, buf *StatT) c.Int

--- a/runtime/internal/clite/syscall/fs_wasip1.go
+++ b/runtime/internal/clite/syscall/fs_wasip1.go
@@ -7,7 +7,6 @@
 package syscall
 
 import (
-	"strings"
 	"structs"
 	"unsafe"
 )
@@ -297,11 +296,19 @@ func joinPath(dir, file string) string {
 }
 
 func isAbs(path string) bool {
-	return strings.HasPrefix(path, "/")
+	return hasPrefix(path, "/")
 }
 
 func isDir(path string) bool {
-	return strings.HasSuffix(path, "/")
+	return hasSuffix(path, "/")
+}
+
+func hasPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}
+
+func hasSuffix(s, suffix string) bool {
+	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
 }
 
 type Stat_t struct {

--- a/runtime/internal/clite/syscall/syscall.go
+++ b/runtime/internal/clite/syscall/syscall.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	LLGoPackage = "noinit"
+	LLGoPackage = true
 )
 
 var (
@@ -73,4 +73,26 @@ func Kill(pid int, signum Signal) error {
 
 func ProcExit(code int32) {
 	panic("not implemented")
+}
+
+func _utoa(buf []byte, val uint64) []byte {
+	i := len(buf) - 1
+	for val >= 10 {
+		buf[i] = byte(val%10 + '0')
+		i--
+		val /= 10
+	}
+	buf[i] = byte(val + '0')
+	return buf[i:]
+}
+
+func utoa(val uint64) string {
+	return string(_utoa(make([]byte, 20), val))
+}
+
+func itoa(val int64) string {
+	if val < 0 {
+		return "-" + string(_utoa(make([]byte, 20), uint64(-val)))
+	}
+	return string(_utoa(make([]byte, 20), uint64(val)))
 }

--- a/runtime/internal/clite/syscall/syscall_unix.go
+++ b/runtime/internal/clite/syscall/syscall_unix.go
@@ -2,8 +2,6 @@
 
 package syscall
 
-import "strconv"
-
 type Errno uintptr
 
 func (e Errno) Error() string {
@@ -13,7 +11,7 @@ func (e Errno) Error() string {
 			return s
 		}
 	}
-	return "errno " + strconv.Itoa(int(e))
+	return "errno " + utoa(uint64(e))
 }
 
 func (e Errno) Is(target error) bool {
@@ -51,5 +49,5 @@ func (s Signal) String() string {
 			return str
 		}
 	}
-	return "signal " + strconv.Itoa(int(s))
+	return "signal " + itoa(int64(s))
 }

--- a/runtime/internal/clite/syscall/syscall_wasm.go
+++ b/runtime/internal/clite/syscall/syscall_wasm.go
@@ -5,7 +5,6 @@
 package syscall
 
 import (
-	"strconv"
 	"unsafe"
 )
 
@@ -79,7 +78,7 @@ func (e Errno) Error() string {
 			return s
 		}
 	}
-	return "errno " + strconv.Itoa(int(e))
+	return "errno " + utoa(uint64(e))
 }
 
 func (e Errno) Is(target error) bool {
@@ -209,7 +208,7 @@ func (s Signal) String() string {
 	case SIGSYS:
 		return "bad system call"
 	default:
-		return "signal " + strconv.Itoa(int(s))
+		return "signal " + utoa(uint64(s))
 	}
 }
 

--- a/runtime/internal/lib/os/stat_unix.go
+++ b/runtime/internal/lib/os/stat_unix.go
@@ -35,6 +35,7 @@ func statNolog(name string) (FileInfo, error) {
 	if err != nil {
 		return nil, &PathError{Op: "stat", Path: name, Err: err}
 	}
+	fillFileStatFromSys(&fs, name)
 	return &fs, nil
 }
 
@@ -47,5 +48,6 @@ func lstatNolog(name string) (FileInfo, error) {
 	if err != nil {
 		return nil, &PathError{Op: "lstat", Path: name, Err: err}
 	}
+	fillFileStatFromSys(&fs, name)
 	return &fs, nil
 }


### PR DESCRIPTION
fix https://github.com/goplus/llgo/issues/1120

- runtime/internal/clite/syscall: fix init for ErrExist(...)
- runtime/internal/clite/os: fix stat for macOS