### PR TITLE
build:exit when test fail

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -513,6 +513,7 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, conf *Co
 		cmd.Run()
 		if s := cmd.ProcessState; s != nil {
 			fmt.Fprintf(os.Stderr, "%s: exit code %d\n", app, s.ExitCode())
+			mockable.Exit(s.ExitCode())
 		}
 	case ModeRun:
 		args := make([]string, 0, len(conf.RunArgs)+1)


### PR DESCRIPTION
with test fail,expect exit with no zero exit code.
```go
package test_test

import "testing"

func TestExample(t *testing.T) {
	if 1 != 2 {
		t.Fatal("1 is not equal to 2")
	}
}
```
```
❯ go test     
echo $?
--- FAIL: TestExample (0.00s)
    test_test.go:7: 1 is not equal to 2
FAIL
exit status 1
FAIL    github.com/goplus/llgo/_xtool/tt        0.723s
1
```
but got 
```
❯ llgo test
echo $?
--- FAIL: TestExample (0.00s)
    ???:1: 1 is not equal to 2
FAIL
/Users/zhangzhiyang/go/bin/tt.test: exit code 1
0
```
after update 
```
FAIL
/Users/zhangzhiyang/go/bin/tt.test: exit code 1
1
```