### PR TITLE
runtime:forkAndExecInChild chdir

### DIFF
--- a/_demo/commandrun/commandrun.go
+++ b/_demo/commandrun/commandrun.go
@@ -3,11 +3,13 @@ package main
 import (
 	"bytes"
 	"os/exec"
+	"path/filepath"
 )
 
 func main() {
 	var data bytes.Buffer
 	cmd := exec.Command("echo", "hello llgo")
+	cmd.Dir = filepath.Dir("./")
 	cmd.Stdout = &data
 	err := cmd.Run()
 	if err != nil {

--- a/runtime/internal/lib/syscall/exec_libc2.go
+++ b/runtime/internal/lib/syscall/exec_libc2.go
@@ -199,13 +199,10 @@ func forkAndExecInChild(argv0 *c.Char, argv, envv **c.Char, chroot, dir *c.Char,
 
 	// Chdir
 	if dir != nil {
-		/* TODO(xsw):
-		_, _, err1 = rawSyscall(abi.FuncPCABI0(libc_chdir_trampoline), uintptr(unsafe.Pointer(dir)), 0, 0)
-		if err1 != 0 {
+		if ret := os.Chdir(dir); ret < 0 {
+			err1 = Errno(os.Errno())
 			goto childerror
 		}
-		*/
-		panic("todo: syscall.forkAndExecInChild - dir")
 	}
 
 	// Pass 1: look for fd[i] < i and move those up above len(fd)

--- a/runtime/internal/lib/syscall/exec_linux.go
+++ b/runtime/internal/lib/syscall/exec_linux.go
@@ -582,13 +582,10 @@ func forkAndExecInChild1(argv0 *c.Char, argv, envv **c.Char, chroot, dir *c.Char
 
 	// Chdir
 	if dir != nil {
-		/**
-		_, _, err1 = RawSyscall(syscall.SYS_CHDIR, uintptr(unsafe.Pointer(dir)), 0, 0)
-		if err1 != 0 {
+		if ret := os.Chdir(dir); ret < 0 {
+			err1 = Errno(os.Errno())
 			goto childerror
 		}
-		*/
-		panic("todo: syscall.forkAndExecInChild1 - dir")
 	}
 
 	// Parent death signal


### PR DESCRIPTION
The way Go calls its assembly function `libc_chdir_trampoline` via `rawSyscall` ultimately means the assembly itself just ends up calling libc's `chdir`.  So use c.Chdir directly.