### PR TITLE
GOOS=js set -sENVIRONMENT=web,worker

### DIFF
--- a/internal/crosscompile/cosscompile.go
+++ b/internal/crosscompile/cosscompile.go
@@ -172,7 +172,7 @@ func Use(goos, goarch string, wasiThreads, changeRpath bool) (export Export, err
 			// "-Wl,--export=malloc", "-Wl,--export=free",
 		}
 		export.EXTRAFLAGS = []string{
-			"-sENVIRONMENT=web",
+			"-sENVIRONMENT=web,worker",
 			"-DPLATFORM_WEB",
 			"-sEXPORT_KEEPALIVE=1",
 			"-sEXPORT_ES6=1",


### PR DESCRIPTION
generate main.js
```
// Determine the runtime environment we are in. You can customize this by
// setting the ENVIRONMENT setting at compile time (see settings.js).

// Attempt to auto-detect the environment
var ENVIRONMENT_IS_WEB = typeof window == 'object';
var ENVIRONMENT_IS_WORKER = typeof WorkerGlobalScope != 'undefined';
// N.b. Electron.js environment is simultaneously a NODE-environment, but
// also a web environment.
var ENVIRONMENT_IS_NODE = typeof process == 'object' && typeof process.versions == 'object' && typeof process.versions.node == 'string' && process.type != 'renderer';
var ENVIRONMENT_IS_SHELL = !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_NODE && !ENVIRONMENT_IS_WORKER;

```