### PR TITLE
ci:go test one package at one time to avoid clang error

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,7 +42,10 @@ jobs:
 
       - name: Test
         if: ${{!startsWith(matrix.os, 'macos')}}
-        run: go test ./...
+        run: go test -p 1 ./...
+        # https://github.com/goplus/llgo/issues/1158
+        # -p 1 is temp use to avoid parallel test
+        # currently without -p 1, the test will fail on linux,the clang will throw error randomly
 
       - name: Test with coverage
         if: startsWith(matrix.os, 'macos')


### PR DESCRIPTION
temp ci test resolution for #1158,but also have question for llgo's concurrency

In the pr test #1157 , `go test -p 1 -count=1 ./...` is used to restrict all packages from running tests concurrently, and the test is repeated one hundred times. It was found that the aforementioned error did not occur. Therefore, the problem should be with clang's concurrent execution. Currently, llgo can temporarily use go test -p 1 ./... to avoid this issue in CI testing.

```bash
count=1
          max_runs=100
          while [ $count -le $max_runs ] && go test -p 1 -count=1 ./...; do 
            echo "=== Run #$((count++)) completed ==="
          done
          if [ $count -gt $max_runs ]; then
            echo "Reached maximum of $max_runs test runs without failure"
            exit 0
          else
            echo "Test failed on run #$count"
            exit 1
          fi
```
* https://github.com/goplus/llgo/actions/runs/15726030403/job/44315996518 https://github.com/goplus/llgo/actions/runs/15726030403/job/44315996522
* https://github.com/goplus/llgo/actions/runs/15726528450/job/44317512371 https://github.com/goplus/llgo/actions/runs/15726528450/job/44317512380
* https://github.com/goplus/llgo/actions/runs/15726541011/job/44317549376
https://github.com/goplus/llgo/actions/runs/15726541011/job/44317549373