### PR TITLE
build: -buildmode=c-archive

### DIFF
--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1048,6 +1048,7 @@ func NewPackageEx(prog llssa.Program, patches Patches, pkg *ssa.Package, files [
 		fn := ret.FuncOf(fnName)
 		if fn != nil {
 			fn.SetName(exportName)
+			fn.SetExport(true)
 		}
 	}
 	return

--- a/cmd/internal/base/pass.go
+++ b/cmd/internal/base/pass.go
@@ -52,6 +52,16 @@ func (p *PassArgs) Tags() string {
 	return ""
 }
 
+func (p *PassArgs) GetVar(name string) string {
+	prefix := "-" + name + "="
+	for _, v := range p.Args {
+		if strings.HasPrefix(v, prefix) {
+			return v[len(prefix):]
+		}
+	}
+	return ""
+}
+
 func (p *PassArgs) Var(names ...string) {
 	for _, name := range names {
 		p.Flag.Var(&stringValue{p: p, name: name}, name, "")

--- a/cmd/internal/build/build.go
+++ b/cmd/internal/build/build.go
@@ -33,20 +33,30 @@ var Cmd = &base.Command{
 	Short:     "Compile packages and dependencies",
 }
 
+var passArgs *base.PassArgs
+
 func init() {
 	Cmd.Run = runCmd
-	base.PassBuildFlags(Cmd)
+	passArgs = base.PassBuildFlags(Cmd)
 	flags.AddBuildFlags(&Cmd.Flag)
 	flags.AddOutputFlags(&Cmd.Flag)
 }
 
-func runCmd(cmd *base.Command, args []string) {
+func buildMode(mode string) build.Mode {
+	switch mode {
+	case "c-archive":
+		return build.ModeCArchive
+	}
+	return build.ModeBuild
+}
 
+func runCmd(cmd *base.Command, args []string) {
 	if err := cmd.Flag.Parse(args); err != nil {
 		return
 	}
+	mode := passArgs.GetVar("buildmode")
 
-	conf := build.NewDefaultConf(build.ModeBuild)
+	conf := build.NewDefaultConf(buildMode(mode))
 	conf.Tags = flags.Tags
 	conf.Verbose = flags.Verbose
 	conf.OutFile = flags.OutputFile

--- a/ssa/decl.go
+++ b/ssa/decl.go
@@ -186,6 +186,7 @@ type aFunction struct {
 	freeVars Expr
 	base     int // base = 1 if hasFreeVars; base = 0 otherwise
 	hasVArg  bool
+	export   bool
 
 	diFunc DIFunction
 }
@@ -250,6 +251,10 @@ func newParams(fn Type, prog Program) (params []Type, hasVArg bool) {
 		}
 	}
 	return
+}
+
+func (p Function) SetExport(b bool) {
+	p.export = b
 }
 
 // Name returns the function's name.


### PR DESCRIPTION
- support buildmode=c-archive
- ssa.BuildExpor for add export funcs first no phi instr call @pkg.init

```
// pkg/main.go
package main

//export add
func add(a,b int32) int32 {
    return a+b
}
func init() {
    println("load pkg init")
}
func main(){}
```
llgo build -buildmode=c-archive -o libmypkg.a .

```
// main.c
#include <stdio.h>
extern int add(int x, int y);
int main() {
    printf("hello world %d\n", add(100,200));
}
```
clang main.c -L./pkg -lmypkg -lgc -lffi -Wl,-dead_strip
