### PR TITLE
os:direntNamePtr for array

### DIFF
--- a/_demo/readdir/main.go
+++ b/_demo/readdir/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	entries, err := os.ReadDir("../")
+	if err != nil {
+		panic(err)
+	}
+	if len(entries) == 0 {
+		panic("No files found")
+	}
+	for _, e := range entries {
+		fmt.Printf("%s isDir[%t]\n", e.Name(), e.IsDir())
+	}
+}

--- a/runtime/internal/lib/os/dir.go
+++ b/runtime/internal/lib/os/dir.go
@@ -120,6 +120,14 @@ func direntNamePtr(name any) *byte {
 		return name
 	case []byte:
 		return &name[0]
+	case [1024]int8:
+		return (*byte)(unsafe.Pointer(&name[0]))
+	case [512]int8:
+		return (*byte)(unsafe.Pointer(&name[0]))
+	case [256]int8:
+		return (*byte)(unsafe.Pointer(&name[0]))
+	case [256]uint8:
+		return (*byte)(unsafe.Pointer(&name[0]))
 	default:
 		panic("invalid type")
 	}


### PR DESCRIPTION
fixed https://github.com/goplus/llgo/issues/1114

the `syscall.Dirent` 's name field in macos、linux、bsd are `[1024]int8`、 `[256]int8` 、`[256]uint8`、`[512]int8` 
```go
name := bytesToString((*[1024]byte)(unsafe.Pointer(direntNamePtr(entry.Name)))[:])
```