### PR TITLE
refactor(internal/build):remove rpath change

### DIFF
--- a/internal/crosscompile/cosscompile.go
+++ b/internal/crosscompile/cosscompile.go
@@ -25,7 +25,7 @@ func cacheDir() string {
 	return filepath.Join(env.LLGoCacheDir(), "crosscompile")
 }
 
-func Use(goos, goarch string, wasiThreads, changeRpath bool) (export Export, err error) {
+func Use(goos, goarch string, wasiThreads bool) (export Export, err error) {
 	targetTriple := llvm.GetTargetTriple(goos, goarch)
 
 	if runtime.GOOS == goos && runtime.GOARCH == goarch {
@@ -41,13 +41,6 @@ func Use(goos, goarch string, wasiThreads, changeRpath bool) (export Export, err
 		// Add OS-specific flags
 		switch goos {
 		case "darwin": // ld64.lld (macOS)
-			if changeRpath {
-				export.LDFLAGS = append(
-					export.LDFLAGS,
-					"-rpath", "@loader_path",
-					"-rpath", "@loader_path/../lib",
-				)
-			}
 			export.LDFLAGS = append(
 				export.LDFLAGS,
 				"-Xlinker", "-dead_strip",

--- a/internal/crosscompile/crosscompile_test.go
+++ b/internal/crosscompile/crosscompile_test.go
@@ -75,7 +75,7 @@ func TestUseCrossCompileSDK(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			export, err := Use(tc.goos, tc.goarch, false, false)
+			export, err := Use(tc.goos, tc.goarch, false)
 
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)


### PR DESCRIPTION
Based on our discussion in the meeting, the "rpath change mode" only accomplishes half of the publishing task. It is incomplete as it only modifies the library file's install_name to start with @rpath. For commands like llgo run . and llgo build ., implementing the full publishing workflow is too "heavy". Publishing should be treated as a separate solution, and therefore, this mode should be removed.

---

- [x] test at https://github.com/Homebrew/homebrew-core/pull/227010


