### PR TITLE
fix: set correct argc=0 in _start() function

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -719,8 +719,7 @@ call i32 @setvbuf(ptr %stderr_ptr, ptr null, i32 2, %size_t 0)
 	startDefine := `
 define weak void @_start() {
   ; argc = 0
-  %argc_val = icmp eq i32 0, 0
-  %argc = zext i1 %argc_val to i32
+  %argc = add i32 0, 0
   ; argv = null
   %argv = inttoptr i64 0 to i8**
   call i32 @main(i32 %argc, i8** %argv)


### PR DESCRIPTION
The original code used `icmp eq i32 0, 0` which always evaluates to true, resulting in argc=1:
```asm
 declare i32 @printf(i8*, ...)
  @fmt = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 1

  define i32 @main() {
  entry:
    %argc_val = icmp eq i32 0, 0
    %argc = zext i1 %argc_val to i32
    %call = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @fmt, i64 0, i64 0), i32 %argc)
    ret i32 0
  }
```
  Output: 1 (incorrect)

  After fix with add i32 0, 0, argc correctly equals 0.