### PR TITLE
internal/build:include target build-tags in Go package compilation

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -170,6 +170,9 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	if conf.Tags != "" {
 		tags += "," + conf.Tags
 	}
+	if len(export.BuildTags) > 0 {
+		tags += "," + strings.Join(export.BuildTags, ",")
+	}
 	cfg := &packages.Config{
 		Mode:       loadSyntax | packages.NeedDeps | packages.NeedModule | packages.NeedExportFile,
 		BuildFlags: []string{"-tags=" + tags},


### PR DESCRIPTION
The `hal` (Hardware Abstraction Layer) libraries depend on target-specific build-tags to compile the correct hardware drivers for each platform.