### PR TITLE
runtime/internal/lib/os: fix readdir for darwin-amd64

### DIFF
--- a/_demo/readdir/main.go
+++ b/_demo/readdir/main.go
@@ -13,7 +13,17 @@ func main() {
 	if len(entries) == 0 {
 		panic("No files found")
 	}
+	var check int
 	for _, e := range entries {
 		fmt.Printf("%s isDir[%t]\n", e.Name(), e.IsDir())
+		if !e.IsDir() {
+			switch e.Name() {
+			case "go.sum", "go.mod":
+				check++
+			}
+		}
+	}
+	if check != 2 {
+		panic("Bad readdir entries go.mod/go.sum")
 	}
 }

--- a/runtime/internal/clite/os/dir.go
+++ b/runtime/internal/clite/os/dir.go
@@ -1,0 +1,17 @@
+package os
+
+import (
+	_ "unsafe"
+
+	c "github.com/goplus/llgo/runtime/internal/clite"
+)
+
+type DIR struct {
+	Unused [0]byte
+}
+
+//go:linkname Opendir C.opendir
+func Opendir(name *c.Char) *DIR
+
+//go:linkname Closedir C.closedir
+func Closedir(dir *DIR) c.Int

--- a/runtime/internal/clite/os/dir_darwin_amd64.go
+++ b/runtime/internal/clite/os/dir_darwin_amd64.go
@@ -1,0 +1,17 @@
+package os
+
+import (
+	_ "unsafe"
+
+	c "github.com/goplus/llgo/runtime/internal/clite"
+	"github.com/goplus/llgo/runtime/internal/clite/syscall"
+)
+
+//go:linkname Fdopendir C.fdopendir$INODE64
+func Fdopendir(fd c.Int) *DIR
+
+//go:linkname Readdir C.readdir$INODE64
+func Readdir(dir *DIR) *syscall.Dirent
+
+//go:linkname Fstatat C.fstatat$INODE64
+func Fstatat(dirfd c.Int, path *c.Char, buf *StatT, flags c.Int) c.Int

--- a/runtime/internal/clite/os/dir_unix.go
+++ b/runtime/internal/clite/os/dir_unix.go
@@ -1,0 +1,20 @@
+//go:build !(darwin && amd64)
+// +build !darwin !amd64
+
+package os
+
+import (
+	_ "unsafe"
+
+	c "github.com/goplus/llgo/runtime/internal/clite"
+	"github.com/goplus/llgo/runtime/internal/clite/syscall"
+)
+
+//go:linkname Fdopendir C.fdopendir
+func Fdopendir(fd c.Int) *DIR
+
+//go:linkname Readdir C.readdir
+func Readdir(dir *DIR) *syscall.Dirent
+
+//go:linkname Fstatat C.fstatat
+func Fstatat(dirfd c.Int, path *c.Char, buf *StatT, flags c.Int) c.Int

--- a/runtime/internal/clite/os/os.go
+++ b/runtime/internal/clite/os/os.go
@@ -135,9 +135,6 @@ func Fchmodat(dirfd c.Int, path *c.Char, mode ModeT, flags c.Int) c.Int
 //go:linkname Fchownat C.fchownat
 func Fchownat(dirfd c.Int, path *c.Char, owner UidT, group GidT, flags c.Int) c.Int
 
-//go:linkname Fstatat C.fstatat
-func Fstatat(dirfd c.Int, path *c.Char, buf *StatT, flags c.Int) c.Int
-
 // -----------------------------------------------------------------------------
 
 //go:linkname Open C.open
@@ -190,9 +187,6 @@ func Fchmod(fd c.Int, mode ModeT) c.Int
 
 //go:linkname Fchown C.fchown
 func Fchown(fd c.Int, owner UidT, group GidT) c.Int
-
-//go:linkname Fstat C.fstat
-func Fstat(fd c.Int, buf *StatT) c.Int
 
 //go:linkname Isatty C.isatty
 func Isatty(fd c.Int) c.Int

--- a/runtime/internal/clite/os/stat.go
+++ b/runtime/internal/clite/os/stat.go
@@ -14,3 +14,6 @@ func Stat(path *c.Char, buf *StatT) c.Int
 
 //go:linkname Lstat C.lstat
 func Lstat(path *c.Char, buf *StatT) c.Int
+
+//go:linkname Fstat C.fstat
+func Fstat(fd c.Int, buf *StatT) c.Int

--- a/runtime/internal/clite/os/stat_darwin.go
+++ b/runtime/internal/clite/os/stat_darwin.go
@@ -11,3 +11,6 @@ func Stat(path *c.Char, buf *StatT) c.Int
 
 //go:linkname Lstat C.lstat64
 func Lstat(path *c.Char, buf *StatT) c.Int
+
+//go:linkname Fstat C.fstat64
+func Fstat(fd c.Int, buf *StatT) c.Int


### PR DESCRIPTION
fix https://github.com/goplus/llgo/issues/1232 

github.com/goplus/llgo/runtime/internal/clite/os
```
Opendir
CloseDir
Readdir
Fdopendir
```

for darwin-amd64 linkname
```
fdopendir$INODE64
readdir$INODE64
```
