### PR TITLE
[WIP]feat:add `llgo get` for python llpkg

### DIFF
--- a/cmd/internal/get/README.md
+++ b/cmd/internal/get/README.md
@@ -1,0 +1,28 @@
+# LLGo get design
+## How install `llgo get`
+```cmd
+cd llgo
+go install -v ./cmd/...
+export LLGO_ROOT=$PWD
+```
+For now, site-packages is downloaded by pip in `llgo/python/lib/python3.12/site-packages`
+
+## How to check if `llgo get` work with a certain \<pylib\>
+use the full path of a package and run command below:
+For example
+```cmd
+go list -m -versions github.com/Bigdata-shiyang/test/numpy
+```
+it should return 
+```cmd
+github.com/Bigdata-shiyang/test/numpy v0.1.0 v0.1.1
+```
+Then
+```
+go get github.com/Bigdata-shiyang/test/numpy
+```
+and
+```
+go: added github.com/Bigdata-shiyang/test/numpy v0.1.1
+```
+This means LLGo can get certain llgo modules

--- a/cmd/internal/get/get.go
+++ b/cmd/internal/get/get.go
@@ -56,7 +56,7 @@ func Main(args []string) error {
 	return firstErr
 }
 
-const llpkgPrefix = "github.com/Bigdata-shiyang/test/"
+const llpkgPrefix = "github.com/PengPengPeng717/llpkg/"
 
 func processModuleArg(arg string, flags []string) error {
 	name, version, _ := strings.Cut(arg, "@")
@@ -89,11 +89,19 @@ func runGoGetWithFlags(flags []string, spec string) error {
 	args = append(args, spec)
 	cmd := exec.Command("go", args...)
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	cmd.Env = append(os.Environ(),
+		"GOSUMDB=off",
+		"GOPROXY=direct",
+	)
 	return cmd.Run()
 }
 
 func runGoModTidy() error {
 	cmd := exec.Command("go", "mod", "tidy")
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	cmd.Env = append(os.Environ(),
+		"GOSUMDB=off",
+		"GOPROXY=direct",
+	)
 	return cmd.Run()
 }

--- a/cmd/internal/get/get.go
+++ b/cmd/internal/get/get.go
@@ -1,36 +1,99 @@
-/*
- * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-// Package get implements the "llgo get" command.
+// llgo/cmd/internal/get/get.go
 package get
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
 	"github.com/goplus/llgo/cmd/internal/base"
 )
 
-// llgo get
 var Cmd = &base.Command{
-	UsageLine: "llgo get [-t -u -v] [build flags] [packages]",
-	Short:     "Add dependencies to current module and install them",
+	UsageLine: "llgo get [-t -u -v] [build flags] [modules...]",
+	Short:     "Fetch modules with Go Modules (no Python actions)",
+	Run:       run,
 }
 
-func init() {
-	Cmd.Run = runCmd
+func run(cmd *base.Command, args []string) {
+	if err := Main(args); err != nil {
+		fmt.Fprintln(os.Stderr, "llgo get:", err)
+		os.Exit(1)
+	}
 }
 
-func runCmd(cmd *base.Command, args []string) {
-	panic("todo")
+func Main(args []string) error {
+	flags := make([]string, 0, len(args))
+	var modules []string
+	flagEndIndex := -1
+	for idx, a := range args {
+		if strings.HasPrefix(a, "-") {
+			flags = append(flags, a)
+			flagEndIndex = idx
+		} else {
+			break
+		}
+	}
+	if flagEndIndex >= 0 {
+		modules = args[flagEndIndex+1:]
+	} else {
+		modules = args
+	}
+	if len(modules) == 0 {
+		return fmt.Errorf("usage: llgo get [-t -u -v] [build flags] [modules...]")
+	}
+
+	var firstErr error
+	for _, m := range modules {
+		if err := processModuleArg(m, flags); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			fmt.Fprintln(os.Stderr, err)
+		}
+	}
+	return firstErr
+}
+
+const llpkgPrefix = "github.com/Bigdata-shiyang/test/"
+
+func processModuleArg(arg string, flags []string) error {
+	name, version, _ := strings.Cut(arg, "@")
+	if name == "" {
+		return fmt.Errorf("invalid module path: %s", arg)
+	}
+
+	if strings.Contains(name, "/") {
+		return handleModuleSpecWithFlags(name, version, flags)
+	}
+	if version == "" {
+		return handleModuleSpecWithFlags(llpkgPrefix+name, "latest", flags)
+	}
+	return handleModuleSpecWithFlags(llpkgPrefix+name, version, flags)
+}
+
+func handleModuleSpecWithFlags(mod string, ver string, flags []string) error {
+	spec := mod
+	if ver != "" {
+		spec = mod + "@" + ver
+	}
+	if err := runGoGetWithFlags(flags, spec); err != nil {
+		return err
+	}
+	return runGoModTidy()
+}
+
+func runGoGetWithFlags(flags []string, spec string) error {
+	args := append([]string{"get"}, flags...)
+	args = append(args, spec)
+	cmd := exec.Command("go", args...)
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	return cmd.Run()
+}
+
+func runGoModTidy() error {
+	cmd := exec.Command("go", "mod", "tidy")
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	return cmd.Run()
 }

--- a/cmd/llgo/xgo_autogen.go
+++ b/cmd/llgo/xgo_autogen.go
@@ -4,6 +4,8 @@ package main
 
 import (
 	"fmt"
+	"runtime"
+
 	"github.com/goplus/cobra/xcmd"
 	"github.com/goplus/llgo/cmd/internal/build"
 	"github.com/goplus/llgo/cmd/internal/clean"
@@ -12,7 +14,8 @@ import (
 	"github.com/goplus/llgo/cmd/internal/test"
 	"github.com/goplus/llgo/internal/env"
 	"github.com/qiniu/x/stringutil"
-	"runtime"
+
+	"github.com/goplus/llgo/cmd/internal/get"
 )
 
 const _ = true
@@ -52,6 +55,7 @@ type Cmd_version struct {
 	xcmd.Command
 	*App
 }
+
 //line cmd/llgo/main_app.gox:1
 func (this *App) MainEntry() {
 //line cmd/llgo/main_app.gox:1:1
@@ -68,6 +72,7 @@ func (this *App) Main() {
 	_xgo_obj7 := &Cmd_version{App: this}
 	xcmd.Gopt_App_Main(this, _xgo_obj0, _xgo_obj1, _xgo_obj2, _xgo_obj3, _xgo_obj4, _xgo_obj5, _xgo_obj6, _xgo_obj7)
 }
+
 //line cmd/llgo/build_cmd.gox:20
 func (this *Cmd_build) Main(_xgo_arg0 string) {
 	this.Command.Main(_xgo_arg0)
@@ -86,6 +91,7 @@ func (this *Cmd_build) Main(_xgo_arg0 string) {
 func (this *Cmd_build) Classfname() string {
 	return "build"
 }
+
 //line cmd/llgo/clean_cmd.gox:20
 func (this *Cmd_clean) Main(_xgo_arg0 string) {
 	this.Command.Main(_xgo_arg0)
@@ -104,6 +110,7 @@ func (this *Cmd_clean) Main(_xgo_arg0 string) {
 func (this *Cmd_clean) Classfname() string {
 	return "clean"
 }
+
 //line cmd/llgo/cmptest_cmd.gox:20
 func (this *Cmd_cmptest) Main(_xgo_arg0 string) {
 	this.Command.Main(_xgo_arg0)
@@ -122,22 +129,22 @@ func (this *Cmd_cmptest) Main(_xgo_arg0 string) {
 func (this *Cmd_cmptest) Classfname() string {
 	return "cmptest"
 }
+
 //line cmd/llgo/get_cmd.gox:16
 func (this *Cmd_get) Main(_xgo_arg0 string) {
-	this.Command.Main(_xgo_arg0)
-//line cmd/llgo/get_cmd.gox:16:1
-	this.Use("get [flags] [packages]")
-//line cmd/llgo/get_cmd.gox:18:1
-	this.Short("Add dependencies to current module and install them")
-//line cmd/llgo/get_cmd.gox:20:1
+	this.Use("get [name@pyVersion | module@version]")
+
+	this.FlagOff()
 	this.Run__1(func(args []string) {
-//line cmd/llgo/get_cmd.gox:21:1
-		panic("todo")
+		if err := get.Main(args); err != nil {
+			panic(err)
+		}
 	})
 }
 func (this *Cmd_get) Classfname() string {
 	return "get"
 }
+
 //line cmd/llgo/install_cmd.gox:20
 func (this *Cmd_install) Main(_xgo_arg0 string) {
 	this.Command.Main(_xgo_arg0)
@@ -156,6 +163,7 @@ func (this *Cmd_install) Main(_xgo_arg0 string) {
 func (this *Cmd_install) Classfname() string {
 	return "install"
 }
+
 //line cmd/llgo/run_cmd.gox:20
 func (this *Cmd_run) Main(_xgo_arg0 string) {
 	this.Command.Main(_xgo_arg0)
@@ -174,6 +182,7 @@ func (this *Cmd_run) Main(_xgo_arg0 string) {
 func (this *Cmd_run) Classfname() string {
 	return "run"
 }
+
 //line cmd/llgo/test_cmd.gox:20
 func (this *Cmd_test) Main(_xgo_arg0 string) {
 	this.Command.Main(_xgo_arg0)
@@ -192,6 +201,7 @@ func (this *Cmd_test) Main(_xgo_arg0 string) {
 func (this *Cmd_test) Classfname() string {
 	return "test"
 }
+
 //line cmd/llgo/version_cmd.gox:22
 func (this *Cmd_version) Main(_xgo_arg0 string) {
 	this.Command.Main(_xgo_arg0)


### PR DESCRIPTION
- new feature for cmd/internal/get
- `llgo get` = analyze prefix + `go get` + `go mod tidy`

Current issues:
- Use personal repo as `github.com/PengPengPeng717/llpkg/` for test.
- Manually modified cmd/llgo/xgo_autogen.go to make cmd work.
- Added environment variables as `GOSUMDB=off, GOPROXY=direct`, to enable llpkg to work properly, which will be fixed soon.