### PR TITLE
release:compile & release with esp clang/llvm

### DIFF
--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: "LLVM version to install"
     required: true
     default: "19"
+  install-llvm:
+    description: "Whether to install LLVM"
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -14,9 +18,17 @@ runs:
       shell: bash
       run: |
         brew update
-        brew install llvm@${{inputs.llvm-version}} lld@${{inputs.llvm-version}} bdw-gc openssl libffi libuv
-        brew link --overwrite llvm@${{inputs.llvm-version}} lld@${{inputs.llvm-version}} libffi
-        echo "$(brew --prefix llvm@${{inputs.llvm-version}})/bin" >> $GITHUB_PATH
+        
+        # Install LLVM if requested
+        if [[ "${{ inputs.install-llvm }}" == "true" ]]; then
+          brew install llvm@${{inputs.llvm-version}} lld@${{inputs.llvm-version}}
+          brew link --overwrite llvm@${{inputs.llvm-version}} lld@${{inputs.llvm-version}}
+          echo "$(brew --prefix llvm@${{inputs.llvm-version}})/bin" >> $GITHUB_PATH
+        fi
+        
+        # Install common dependencies
+        brew install bdw-gc openssl libffi libuv
+        brew link --overwrite libffi
 
         # Install optional deps for demos.
         #
@@ -31,11 +43,19 @@ runs:
       if: runner.os == 'Linux'
       shell: bash
       run: |
-        echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${{inputs.llvm-version}} main" | sudo tee /etc/apt/sources.list.d/llvm.list
-        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        sudo apt-get update
-        sudo apt-get install -y llvm-${{inputs.llvm-version}}-dev clang-${{inputs.llvm-version}} libclang-${{inputs.llvm-version}}-dev lld-${{inputs.llvm-version}} libunwind-${{inputs.llvm-version}}-dev libc++-${{inputs.llvm-version}}-dev pkg-config libgc-dev libssl-dev zlib1g-dev libffi-dev libcjson-dev libuv1-dev 
-        echo "PATH=/usr/lib/llvm-${{inputs.llvm-version}}/bin:$PATH" >> $GITHUB_ENV
+        # Install LLVM if requested
+        if [[ "${{ inputs.install-llvm }}" == "true" ]]; then
+          echo "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-${{inputs.llvm-version}} main" | sudo tee /etc/apt/sources.list.d/llvm.list
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo apt-get update
+          sudo apt-get install -y llvm-${{inputs.llvm-version}}-dev clang-${{inputs.llvm-version}} libclang-${{inputs.llvm-version}}-dev lld-${{inputs.llvm-version}} libunwind-${{inputs.llvm-version}}-dev libc++-${{inputs.llvm-version}}-dev
+          echo "PATH=/usr/lib/llvm-${{inputs.llvm-version}}/bin:$PATH" >> $GITHUB_ENV
+        else
+          sudo apt-get update
+        fi
+        
+        # Install common dependencies
+        sudo apt-get install -y pkg-config libgc-dev libssl-dev zlib1g-dev libffi-dev libcjson-dev libuv1-dev
 
         # Install optional deps for demos.
         #

--- a/.github/actions/setup-goreleaser/action.yml
+++ b/.github/actions/setup-goreleaser/action.yml
@@ -35,3 +35,6 @@ runs:
     - name: Check file
       run: tree .sysroot
       shell: bash
+    - name: Get Esp clang
+      run: bash .github/workflows/download_esp_clang.sh
+      shell: bash

--- a/.github/actions/test-helloworld/action.yml
+++ b/.github/actions/test-helloworld/action.yml
@@ -38,7 +38,7 @@ runs:
         Hello, LLGo!
         Hello, LLGo!
         Hello LLGo by cpp/std.Str"
-        OUTPUT=$(llgo run . 2>&1)
+        OUTPUT=$(llgo run . 2>&1 | tee /dev/stderr)
         if echo "$OUTPUT" | grep -qF "$EXPECTED"; then
             echo "Basic test passed"
         else

--- a/.github/actions/test-helloworld/action.yml
+++ b/.github/actions/test-helloworld/action.yml
@@ -38,7 +38,7 @@ runs:
         Hello, LLGo!
         Hello, LLGo!
         Hello LLGo by cpp/std.Str"
-        OUTPUT=$(llgo run . 2>&1 | tee /dev/stderr)
+        OUTPUT=$(llgo run -v . 2>&1 | tee /dev/stderr)
         if echo "$OUTPUT" | grep -qF "$EXPECTED"; then
             echo "Basic test passed"
         else

--- a/.github/actions/test-helloworld/action.yml
+++ b/.github/actions/test-helloworld/action.yml
@@ -38,7 +38,7 @@ runs:
         Hello, LLGo!
         Hello, LLGo!
         Hello LLGo by cpp/std.Str"
-        OUTPUT=$(llgo run -v . 2>&1 | tee /dev/stderr)
+        OUTPUT=$(llgo run . 2>&1 | tee /dev/stderr)
         if echo "$OUTPUT" | grep -qF "$EXPECTED"; then
             echo "Basic test passed"
         else
@@ -50,4 +50,14 @@ runs:
             exit 1
         fi
 
-        #TODO(zzy): Test embed targets, need dispatch target dir
+        cd ../..
+        mkdir -p _test/emb && cd _test/emb
+        cat > main.go << 'EOL'
+        package main
+
+        func main() {
+        }
+        EOL
+        llgo build -v -target esp32-coreboard-v2 -o demo.out .
+        test -f demo.out.elf && echo "ESP32 cross-compilation test passed: demo.out.elf generated"
+        exit $?

--- a/.github/workflows/download_esp_clang.sh
+++ b/.github/workflows/download_esp_clang.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -e
+
+ESP_CLANG_VERSION="19.1.2_20250905-3"
+BASE_URL="https://github.com/goplus/espressif-llvm-project-prebuilt/releases/download/${ESP_CLANG_VERSION}"
+
+get_esp_clang_platform() {
+    local platform="$1"
+    local os="${platform%-*}"
+    local arch="${platform##*-}"
+    
+    case "${os}" in
+        "darwin")
+            case "${arch}" in
+                "amd64") echo "x86_64-apple-darwin" ;;
+                "arm64") echo "aarch64-apple-darwin" ;;
+                *) echo "Error: Unsupported darwin architecture: ${arch}" >&2; exit 1 ;;
+            esac
+            ;;
+        "linux")
+            case "${arch}" in
+                "amd64") echo "x86_64-linux-gnu" ;;
+                "arm64") echo "aarch64-linux-gnu" ;;
+                *) echo "Error: Unsupported linux architecture: ${arch}" >&2; exit 1 ;;
+            esac
+            ;;
+        *)
+            echo "Error: Unsupported OS: ${os}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+get_filename() {
+    local platform="$1"
+    local platform_suffix=$(get_esp_clang_platform "${platform}")
+    echo "clang-esp-${ESP_CLANG_VERSION}-${platform_suffix}.tar.xz"
+}
+
+download_and_extract() {
+    local platform="$1"
+    local os="${platform%-*}"
+    local arch="${platform##*-}"
+    local filename=$(get_filename "${platform}")
+    local download_url="${BASE_URL}/${filename}"
+    
+    echo "Downloading ESP Clang for ${platform}..."
+    echo "  URL: ${download_url}"
+    
+    mkdir -p ".sysroot/${os}/${arch}/crosscompile/clang"
+    curl -fsSL "${download_url}" | tar -xJ -C ".sysroot/${os}/${arch}/crosscompile/clang" --strip-components=1
+    
+    if [[ ! -f ".sysroot/${os}/${arch}/crosscompile/clang/bin/clang++" ]]; then
+        echo "Error: clang++ not found in ${platform} toolchain"
+        exit 1
+    fi
+    
+    echo "${platform} ESP Clang ready in .sysroot/${os}/${arch}/crosscompile/clang"
+}
+
+echo "Downloading ESP Clang toolchain version ${ESP_CLANG_VERSION}..."
+
+for platform in "darwin-amd64" "darwin-arm64" "linux-amd64" "linux-arm64"; do
+    download_and_extract "${platform}"
+done
+
+echo "ESP Clang toolchain completed successfully!"

--- a/.github/workflows/populate_linux_sysroot.sh
+++ b/.github/workflows/populate_linux_sysroot.sh
@@ -139,7 +139,10 @@ populate_linux_sysroot() {
 		/populate_linux_sysroot.sh
 }
 populate_linux_sysroot amd64 "${LINUX_AMD64_PREFIX}" &
+PID1=$!
 populate_linux_sysroot arm64 "${LINUX_ARM64_PREFIX}" &
+PID2=$!
 
 # Wait for both background processes to complete
-wait
+wait $PID1 || exit $?
+wait $PID2 || exit $?

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -178,6 +178,8 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install dependencies
         uses: ./.github/actions/setup-deps
+        with:
+          install-llvm: false
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -206,7 +206,8 @@ jobs:
           mod-version: ${{ matrix.go-mod-version }}
 
   release:
-    needs: [setup, test-artifacts]
+    needs:
+      [setup, test-artifacts, populate-darwin-sysroot, populate-linux-sysroot]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -27,7 +27,6 @@ jobs:
           LINUX_KEY="linux-sysroot-${{ hashFiles('.github/workflows/populate_linux_sysroot.sh', '.github/workflows/release-build.yml') }}-v1.0.0"
           echo "darwin-key=$DARWIN_KEY" >> $GITHUB_OUTPUT
           echo "linux-key=$LINUX_KEY" >> $GITHUB_OUTPUT
-
   populate-darwin-sysroot:
     runs-on: macos-latest
     timeout-minutes: 30
@@ -107,7 +106,7 @@ jobs:
             -v $(pwd):/go/src/llgo \
             -w /go/src/llgo \
             ghcr.io/goreleaser/goreleaser-cross:v1.22 \
-            release --skip=publish,nfpm,snapcraft --snapshot --clean
+            release --verbose --parallelism=1 --skip=publish,nfpm,snapcraft --snapshot --clean
 
       - name: Upload Darwin AMD64 Artifacts
         uses: actions/upload-artifact@v4
@@ -205,7 +204,7 @@ jobs:
           mod-version: ${{ matrix.go-mod-version }}
 
   release:
-    needs: [setup, build, test-artifacts]
+    needs: [setup, test-artifacts]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -231,4 +230,4 @@ jobs:
             -v $(pwd):/go/src/llgo \
             -w /go/src/llgo \
             ghcr.io/goreleaser/goreleaser-cross:v1.22 \
-            release --clean --skip nfpm,snapcraft
+            release --parallelism=1 --clean --verbose --skip nfpm,snapcraft

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -106,7 +106,7 @@ jobs:
             -v $(pwd):/go/src/llgo \
             -w /go/src/llgo \
             ghcr.io/goreleaser/goreleaser-cross:v1.22 \
-            release --verbose --parallelism=1 --skip=publish,nfpm,snapcraft --snapshot --clean
+            release --verbose --skip=publish,nfpm,snapcraft --snapshot --clean
 
       - name: Upload Darwin AMD64 Artifacts
         uses: actions/upload-artifact@v4
@@ -230,4 +230,4 @@ jobs:
             -v $(pwd):/go/src/llgo \
             -w /go/src/llgo \
             ghcr.io/goreleaser/goreleaser-cross:v1.22 \
-            release --parallelism=1 --clean --verbose --skip nfpm,snapcraft
+            release --clean --verbose --skip nfpm,snapcraft

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,7 +27,6 @@ builds:
     ldflags:
       - -X github.com/goplus/llgo/internal/env.buildVersion=v{{.Version}}
       - -X github.com/goplus/llgo/internal/env.buildTime={{.Date}}
-      - -X github.com/goplus/llgo/xtool/env/llvm.ldLLVMConfigBin=../crosscompile/clang/bin/llvm-config
     env:
       - CC=o64-clang
       - CXX=o64-clang++
@@ -48,7 +47,6 @@ builds:
     ldflags:
       - -X github.com/goplus/llgo/internal/env.buildVersion=v{{.Version}}
       - -X github.com/goplus/llgo/internal/env.buildTime={{.Date}}
-      - -X github.com/goplus/llgo/xtool/env/llvm.ldLLVMConfigBin=../crosscompile/clang/bin/llvm-config
     env:
       - CC=oa64-clang
       - CXX=oa64-clang++
@@ -69,7 +67,6 @@ builds:
     ldflags:
       - -X github.com/goplus/llgo/internal/env.buildVersion=v{{.Version}}
       - -X github.com/goplus/llgo/internal/env.buildTime={{.Date}}
-      - -X github.com/goplus/llgo/xtool/env/llvm.ldLLVMConfigBin=../crosscompile/clang/bin/llvm-config
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
@@ -90,7 +87,6 @@ builds:
     ldflags:
       - -X github.com/goplus/llgo/internal/env.buildVersion=v{{.Version}}
       - -X github.com/goplus/llgo/internal/env.buildTime={{.Date}}
-      - -X github.com/goplus/llgo/xtool/env/llvm.ldLLVMConfigBin=../crosscompile/clang/bin/llvm-config
     env:
       - CC=aarch64-linux-gnu-gcc
       - CXX=aarch64-linux-gnu-g++

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -89,9 +89,8 @@ archives:
       - LICENSE
       - README.md
       - runtime
-      - src: ".sysroot/{{.Os}}/{{.Arch}}/crosscompile/clang/**/*"
+      - src: ".sysroot/{{.Os}}/{{.Arch}}/crosscompile/clang"
         dst: crosscompile/clang
-        strip_parent: true
         info:
           mode: 0755
 checksum:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,7 +27,7 @@ builds:
       - CC=o64-clang
       - CXX=o64-clang++
       - CGO_CPPFLAGS=-I{{.Env.SYSROOT_DARWIN_AMD64}}/crosscompile/clang/include -mmacosx-version-min=10.13 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=-L{{.Env.SYSROOT_DARWIN_AMD64}}/crosscompile/clang/lib -mmacosx-version-min=10.13 -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM-19 -lz -lm
+      - CGO_LDFLAGS=-L{{.Env.SYSROOT_DARWIN_AMD64}}/crosscompile/clang/lib -Wl,-rpath,@executable_path/../crosscompile/clang/lib -mmacosx-version-min=10.13 -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM-19 -lz -lm
     targets:
       - darwin_amd64
     mod_timestamp: "{{.CommitTimestamp}}"
@@ -43,7 +43,7 @@ builds:
       - CC=oa64-clang
       - CXX=oa64-clang++
       - CGO_CPPFLAGS=-I{{.Env.SYSROOT_DARWIN_ARM64}}/crosscompile/clang/include -mmacosx-version-min=10.13 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=-L{{.Env.SYSROOT_DARWIN_ARM64}}/crosscompile/clang/lib -mmacosx-version-min=10.13 -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM-19 -lz -lm
+      - CGO_LDFLAGS=-L{{.Env.SYSROOT_DARWIN_ARM64}}/crosscompile/clang/lib -Wl,-rpath,@executable_path/../crosscompile/clang/lib -mmacosx-version-min=10.13 -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM-19 -lz -lm
     targets:
       - darwin_arm64
     mod_timestamp: "{{.CommitTimestamp}}"
@@ -59,7 +59,7 @@ builds:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
       - CGO_CPPFLAGS=--sysroot={{.Env.SYSROOT_LINUX_AMD64}} -I{{.Env.SYSROOT_LINUX_AMD64}}/crosscompile/clang/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_AMD64}} -L{{.Env.SYSROOT_LINUX_AMD64}}/crosscompile/clang/lib -lLLVM-19
+      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_AMD64}} -L{{.Env.SYSROOT_LINUX_AMD64}}/crosscompile/clang/lib -Wl,-rpath,\$ORIGIN/../crosscompile/clang/lib -lLLVM-19
     targets:
       - linux_amd64
     mod_timestamp: "{{.CommitTimestamp}}"
@@ -75,7 +75,7 @@ builds:
       - CC=aarch64-linux-gnu-gcc
       - CXX=aarch64-linux-gnu-g++
       - CGO_CPPFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -I{{.Env.SYSROOT_LINUX_ARM64}}/crosscompile/clang/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -L{{.Env.SYSROOT_LINUX_ARM64}}/crosscompile/clang/lib -lLLVM-19
+      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -L{{.Env.SYSROOT_LINUX_ARM64}}/crosscompile/clang/lib -Wl,-rpath,\$ORIGIN/../crosscompile/clang/lib -lLLVM-19
     targets:
       - linux_arm64
     mod_timestamp: "{{.CommitTimestamp}}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,7 +27,7 @@ builds:
       - CC=o64-clang
       - CXX=o64-clang++
       - CGO_CPPFLAGS=-I{{.Env.SYSROOT_DARWIN_AMD64}}/crosscompile/clang/include -mmacosx-version-min=10.13 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=-L{{.Env.SYSROOT_DARWIN_AMD64}}/crosscompile/clang/lib -Wl,-rpath,@executable_path/../crosscompile/clang/lib -mmacosx-version-min=10.13 -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM-19 -lz -lm
+      - CGO_LDFLAGS=-L{{.Env.SYSROOT_DARWIN_AMD64}}/crosscompile/clang/lib -mmacosx-version-min=10.13 -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM-19 -lz -lm -Wl,-rpath,@executable_path/../crosscompile/clang/lib
     targets:
       - darwin_amd64
     mod_timestamp: "{{.CommitTimestamp}}"
@@ -43,7 +43,7 @@ builds:
       - CC=oa64-clang
       - CXX=oa64-clang++
       - CGO_CPPFLAGS=-I{{.Env.SYSROOT_DARWIN_ARM64}}/crosscompile/clang/include -mmacosx-version-min=10.13 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=-L{{.Env.SYSROOT_DARWIN_ARM64}}/crosscompile/clang/lib -mmacosx-version-min=10.13 -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM-19 -lz -lm
+      - CGO_LDFLAGS=-L{{.Env.SYSROOT_DARWIN_ARM64}}/crosscompile/clang/lib -mmacosx-version-min=10.13 -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM-19 -lz -lm -Wl,-rpath,@executable_path/../crosscompile/clang/lib
     targets:
       - darwin_arm64
     mod_timestamp: "{{.CommitTimestamp}}"
@@ -59,7 +59,7 @@ builds:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
       - CGO_CPPFLAGS=--sysroot={{.Env.SYSROOT_LINUX_AMD64}} -I{{.Env.SYSROOT_LINUX_AMD64}}/crosscompile/clang/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_AMD64}} -L{{.Env.SYSROOT_LINUX_AMD64}}/crosscompile/clang/lib -Wl,-rpath,\$ORIGIN/../crosscompile/clang/lib -lLLVM-19
+      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_AMD64}} -L{{.Env.SYSROOT_LINUX_AMD64}}/crosscompile/clang/lib -lLLVM-19 -Wl,-rpath,\$ORIGIN/../crosscompile/clang/lib
       - CGO_LDFLAGS_ALLOW=--sysroot.*
     targets:
       - linux_amd64
@@ -76,7 +76,7 @@ builds:
       - CC=aarch64-linux-gnu-gcc
       - CXX=aarch64-linux-gnu-g++
       - CGO_CPPFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -I{{.Env.SYSROOT_LINUX_ARM64}}/crosscompile/clang/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -L{{.Env.SYSROOT_LINUX_ARM64}}/crosscompile/clang/lib -lLLVM-19
+      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -L{{.Env.SYSROOT_LINUX_ARM64}}/crosscompile/clang/lib -lLLVM-19 -Wl,-rpath,\$ORIGIN/../crosscompile/clang/lib
       - CGO_LDFLAGS_ALLOW=--sysroot.*
     targets:
       - linux_arm64

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,10 +18,6 @@ builds:
   - id: llgo-darwin-amd64
     main: ./cmd/llgo
     binary: bin/llgo
-    hooks:
-      pre:
-        - rm -rf crosscompile
-        - cp -r .sysroot/darwin/amd64/crosscompile .
     flags:
       - -tags=darwin,amd64,byollvm
     ldflags:
@@ -30,18 +26,14 @@ builds:
     env:
       - CC=o64-clang
       - CXX=o64-clang++
-      - CGO_CPPFLAGS=-I{{.Env.PWD}}/crosscompile/clang/include -mmacosx-version-min=10.13 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=-L{{.Env.PWD}}/crosscompile/clang/lib -mmacosx-version-min=10.13 -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM-19 -lz -lm
+      - CGO_CPPFLAGS=-I{{.Env.SYSROOT_DARWIN_AMD64}}/crosscompile/clang/include -mmacosx-version-min=10.13 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+      - CGO_LDFLAGS=-L{{.Env.SYSROOT_DARWIN_AMD64}}/crosscompile/clang/lib -mmacosx-version-min=10.13 -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM-19 -lz -lm
     targets:
       - darwin_amd64
     mod_timestamp: "{{.CommitTimestamp}}"
   - id: llgo-darwin-arm64
     main: ./cmd/llgo
     binary: bin/llgo
-    hooks:
-      pre:
-        - rm -rf crosscompile
-        - cp -r .sysroot/darwin/arm64/crosscompile .
     flags:
       - -tags=darwin,arm64,byollvm
     ldflags:
@@ -50,18 +42,14 @@ builds:
     env:
       - CC=oa64-clang
       - CXX=oa64-clang++
-      - CGO_CPPFLAGS=-I{{.Env.PWD}}/crosscompile/clang/include -mmacosx-version-min=10.13 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=-L{{.Env.PWD}}/crosscompile/clang/lib -mmacosx-version-min=10.13 -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM-19 -lz -lm
+      - CGO_CPPFLAGS=-I{{.Env.SYSROOT_DARWIN_ARM64}}/crosscompile/clang/include -mmacosx-version-min=10.13 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+      - CGO_LDFLAGS=-L{{.Env.SYSROOT_DARWIN_ARM64}}/crosscompile/clang/lib -mmacosx-version-min=10.13 -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM-19 -lz -lm
     targets:
       - darwin_arm64
     mod_timestamp: "{{.CommitTimestamp}}"
   - id: llgo-linux-amd64
     main: ./cmd/llgo
     binary: bin/llgo
-    hooks:
-      pre:
-        - rm -rf crosscompile
-        - cp -r .sysroot/linux/amd64/crosscompile .
     flags:
       - -tags=linux,amd64,byollvm
     ldflags:
@@ -70,18 +58,14 @@ builds:
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
-      - CGO_CPPFLAGS=--sysroot={{.Env.SYSROOT_LINUX_AMD64}} -I{{.Env.PWD}}/crosscompile/clang/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_AMD64}} -L{{.Env.PWD}}/crosscompile/clang/lib -lLLVM-19
+      - CGO_CPPFLAGS=--sysroot={{.Env.SYSROOT_LINUX_AMD64}} -I{{.Env.SYSROOT_LINUX_AMD64}}/crosscompile/clang/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_AMD64}} -L{{.Env.SYSROOT_LINUX_AMD64}}/crosscompile/clang/lib -lLLVM-19
     targets:
       - linux_amd64
     mod_timestamp: "{{.CommitTimestamp}}"
   - id: llgo-linux-arm64
     main: ./cmd/llgo
     binary: bin/llgo
-    hooks:
-      pre:
-        - rm -rf crosscompile
-        - cp -r .sysroot/linux/arm64/crosscompile .
     flags:
       - -tags=linux,arm64,byollvm
     ldflags:
@@ -90,8 +74,8 @@ builds:
     env:
       - CC=aarch64-linux-gnu-gcc
       - CXX=aarch64-linux-gnu-g++
-      - CGO_CPPFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -I{{.Env.PWD}}/crosscompile/clang/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -L{{.Env.PWD}}/crosscompile/clang/lib -lLLVM-19
+      - CGO_CPPFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -I{{.Env.SYSROOT_LINUX_ARM64}}/crosscompile/clang/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -L{{.Env.SYSROOT_LINUX_ARM64}}/crosscompile/clang/lib -lLLVM-19
     targets:
       - linux_arm64
     mod_timestamp: "{{.CommitTimestamp}}"
@@ -105,8 +89,11 @@ archives:
       - LICENSE
       - README.md
       - runtime
-      - crosscompile
-
+      - src: ".sysroot/{{.Os}}/{{.Arch}}/crosscompile/clang/**/*"
+        dst: crosscompile/clang
+        strip_parent: true
+        info:
+          mode: 0755
 checksum:
   name_template: "{{.ProjectName}}{{.Version}}.checksums.txt"
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -55,11 +55,12 @@ builds:
     ldflags:
       - -X github.com/goplus/llgo/internal/env.buildVersion=v{{.Version}}
       - -X github.com/goplus/llgo/internal/env.buildTime={{.Date}}
+      - '-extldflags=-Wl,-rpath,$ORIGIN/../crosscompile/clang/lib'
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
       - CGO_CPPFLAGS=--sysroot={{.Env.SYSROOT_LINUX_AMD64}} -I{{.Env.SYSROOT_LINUX_AMD64}}/crosscompile/clang/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_AMD64}} -L{{.Env.SYSROOT_LINUX_AMD64}}/crosscompile/clang/lib -lLLVM-19 -Wl,-rpath,$ORIGIN/../crosscompile/clang/lib
+      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_AMD64}} -L{{.Env.SYSROOT_LINUX_AMD64}}/crosscompile/clang/lib -lLLVM-19
       - CGO_LDFLAGS_ALLOW=--sysroot.*
     targets:
       - linux_amd64
@@ -72,11 +73,12 @@ builds:
     ldflags:
       - -X github.com/goplus/llgo/internal/env.buildVersion=v{{.Version}}
       - -X github.com/goplus/llgo/internal/env.buildTime={{.Date}}
+      - '-extldflags=-Wl,-rpath,$ORIGIN/../crosscompile/clang/lib'
     env:
       - CC=aarch64-linux-gnu-gcc
       - CXX=aarch64-linux-gnu-g++
       - CGO_CPPFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -I{{.Env.SYSROOT_LINUX_ARM64}}/crosscompile/clang/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -L{{.Env.SYSROOT_LINUX_ARM64}}/crosscompile/clang/lib -lLLVM-19 -Wl,-rpath,$ORIGIN/../crosscompile/clang/lib
+      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -L{{.Env.SYSROOT_LINUX_ARM64}}/crosscompile/clang/lib -lLLVM-19
       - CGO_LDFLAGS_ALLOW=--sysroot.*
     targets:
       - linux_arm64

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -91,6 +91,7 @@ archives:
       - LICENSE
       - README.md
       - runtime
+      - targets
       - src: ".sysroot/{{.Os}}/{{.Arch}}/crosscompile/clang"
         dst: crosscompile/clang
         info:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,7 +43,7 @@ builds:
       - CC=oa64-clang
       - CXX=oa64-clang++
       - CGO_CPPFLAGS=-I{{.Env.SYSROOT_DARWIN_ARM64}}/crosscompile/clang/include -mmacosx-version-min=10.13 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=-L{{.Env.SYSROOT_DARWIN_ARM64}}/crosscompile/clang/lib -Wl,-rpath,@executable_path/../crosscompile/clang/lib -mmacosx-version-min=10.13 -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM-19 -lz -lm
+      - CGO_LDFLAGS=-L{{.Env.SYSROOT_DARWIN_ARM64}}/crosscompile/clang/lib -mmacosx-version-min=10.13 -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM-19 -lz -lm
     targets:
       - darwin_arm64
     mod_timestamp: "{{.CommitTimestamp}}"
@@ -75,7 +75,7 @@ builds:
       - CC=aarch64-linux-gnu-gcc
       - CXX=aarch64-linux-gnu-g++
       - CGO_CPPFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -I{{.Env.SYSROOT_LINUX_ARM64}}/crosscompile/clang/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -L{{.Env.SYSROOT_LINUX_ARM64}}/crosscompile/clang/lib -Wl,-rpath,\$ORIGIN/../crosscompile/clang/lib -lLLVM-19
+      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -L{{.Env.SYSROOT_LINUX_ARM64}}/crosscompile/clang/lib -lLLVM-19
     targets:
       - linux_arm64
     mod_timestamp: "{{.CommitTimestamp}}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -59,7 +59,7 @@ builds:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
       - CGO_CPPFLAGS=--sysroot={{.Env.SYSROOT_LINUX_AMD64}} -I{{.Env.SYSROOT_LINUX_AMD64}}/crosscompile/clang/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_AMD64}} -L{{.Env.SYSROOT_LINUX_AMD64}}/crosscompile/clang/lib -lLLVM-19 -Wl,-rpath,\$ORIGIN/../crosscompile/clang/lib
+      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_AMD64}} -L{{.Env.SYSROOT_LINUX_AMD64}}/crosscompile/clang/lib -lLLVM-19 -Wl,-rpath,$ORIGIN/../crosscompile/clang/lib
       - CGO_LDFLAGS_ALLOW=--sysroot.*
     targets:
       - linux_amd64
@@ -76,7 +76,7 @@ builds:
       - CC=aarch64-linux-gnu-gcc
       - CXX=aarch64-linux-gnu-g++
       - CGO_CPPFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -I{{.Env.SYSROOT_LINUX_ARM64}}/crosscompile/clang/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -L{{.Env.SYSROOT_LINUX_ARM64}}/crosscompile/clang/lib -lLLVM-19 -Wl,-rpath,\$ORIGIN/../crosscompile/clang/lib
+      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -L{{.Env.SYSROOT_LINUX_ARM64}}/crosscompile/clang/lib -lLLVM-19 -Wl,-rpath,$ORIGIN/../crosscompile/clang/lib
       - CGO_LDFLAGS_ALLOW=--sysroot.*
     targets:
       - linux_arm64

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -60,6 +60,7 @@ builds:
       - CXX=x86_64-linux-gnu-g++
       - CGO_CPPFLAGS=--sysroot={{.Env.SYSROOT_LINUX_AMD64}} -I{{.Env.SYSROOT_LINUX_AMD64}}/crosscompile/clang/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
       - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_AMD64}} -L{{.Env.SYSROOT_LINUX_AMD64}}/crosscompile/clang/lib -Wl,-rpath,\$ORIGIN/../crosscompile/clang/lib -lLLVM-19
+      - CGO_LDFLAGS_ALLOW=--sysroot.*
     targets:
       - linux_amd64
     mod_timestamp: "{{.CommitTimestamp}}"
@@ -76,6 +77,7 @@ builds:
       - CXX=aarch64-linux-gnu-g++
       - CGO_CPPFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -I{{.Env.SYSROOT_LINUX_ARM64}}/crosscompile/clang/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
       - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -L{{.Env.SYSROOT_LINUX_ARM64}}/crosscompile/clang/lib -lLLVM-19
+      - CGO_LDFLAGS_ALLOW=--sysroot.*
     targets:
       - linux_arm64
     mod_timestamp: "{{.CommitTimestamp}}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -73,8 +73,8 @@ builds:
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
-      - CGO_CPPFLAGS=-I{{.Env.PWD}}/crosscompile/clang/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=-L{{.Env.PWD}}/crosscompile/clang/lib -lLLVM-19
+      - CGO_CPPFLAGS=--sysroot={{.Env.SYSROOT_LINUX_AMD64}} -I{{.Env.PWD}}/crosscompile/clang/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_AMD64}} -L{{.Env.PWD}}/crosscompile/clang/lib -lLLVM-19
     targets:
       - linux_amd64
     mod_timestamp: "{{.CommitTimestamp}}"
@@ -94,8 +94,8 @@ builds:
     env:
       - CC=aarch64-linux-gnu-gcc
       - CXX=aarch64-linux-gnu-g++
-      - CGO_CPPFLAGS=-I{{.Env.PWD}}/crosscompile/clang/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=-L{{.Env.PWD}}/crosscompile/clang/lib -lLLVM-19
+      - CGO_CPPFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -I{{.Env.PWD}}/crosscompile/clang/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -L{{.Env.PWD}}/crosscompile/clang/lib -lLLVM-19
     targets:
       - linux_arm64
     mod_timestamp: "{{.CommitTimestamp}}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,68 +18,84 @@ builds:
   - id: llgo-darwin-amd64
     main: ./cmd/llgo
     binary: bin/llgo
+    hooks:
+      pre:
+        - rm -rf crosscompile
+        - cp -r .sysroot/darwin/amd64/crosscompile .
     flags:
       - -tags=darwin,amd64,byollvm
     ldflags:
       - -X github.com/goplus/llgo/internal/env.buildVersion=v{{.Version}}
       - -X github.com/goplus/llgo/internal/env.buildTime={{.Date}}
-      - -X github.com/goplus/llgo/xtool/env/llvm.ldLLVMConfigBin=/usr/local/opt/llvm@19/bin/llvm-config
+      - -X github.com/goplus/llgo/xtool/env/llvm.ldLLVMConfigBin=../crosscompile/clang/bin/llvm-config
     env:
       - CC=o64-clang
       - CXX=o64-clang++
-      - CGO_CPPFLAGS=-I{{.Env.SYSROOT_DARWIN_AMD64}}/usr/local/opt/llvm@19/include -mmacosx-version-min=10.13 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=-L{{.Env.SYSROOT_DARWIN_AMD64}}/usr/local/opt/llvm@19/lib -mmacosx-version-min=10.13 -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM-19 -lz -lm
+      - CGO_CPPFLAGS=-I{{.Env.PWD}}/crosscompile/clang/include -mmacosx-version-min=10.13 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+      - CGO_LDFLAGS=-L{{.Env.PWD}}/crosscompile/clang/lib -mmacosx-version-min=10.13 -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM-19 -lz -lm
     targets:
       - darwin_amd64
     mod_timestamp: "{{.CommitTimestamp}}"
   - id: llgo-darwin-arm64
     main: ./cmd/llgo
     binary: bin/llgo
+    hooks:
+      pre:
+        - rm -rf crosscompile
+        - cp -r .sysroot/darwin/arm64/crosscompile .
     flags:
       - -tags=darwin,arm64,byollvm
     ldflags:
       - -X github.com/goplus/llgo/internal/env.buildVersion=v{{.Version}}
       - -X github.com/goplus/llgo/internal/env.buildTime={{.Date}}
-      - -X github.com/goplus/llgo/xtool/env/llvm.ldLLVMConfigBin=/opt/homebrew/opt/llvm@19/bin/llvm-config
+      - -X github.com/goplus/llgo/xtool/env/llvm.ldLLVMConfigBin=../crosscompile/clang/bin/llvm-config
     env:
       - CC=oa64-clang
       - CXX=oa64-clang++
-      - CGO_CPPFLAGS=-I{{.Env.SYSROOT_DARWIN_ARM64}}/opt/homebrew/opt/llvm@19/include -mmacosx-version-min=10.13 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=-L{{.Env.SYSROOT_DARWIN_ARM64}}/opt/homebrew/opt/llvm@19/lib -mmacosx-version-min=10.13 -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM-19 -lz -lm
+      - CGO_CPPFLAGS=-I{{.Env.PWD}}/crosscompile/clang/include -mmacosx-version-min=10.13 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+      - CGO_LDFLAGS=-L{{.Env.PWD}}/crosscompile/clang/lib -mmacosx-version-min=10.13 -Wl,-search_paths_first -Wl,-headerpad_max_install_names -lLLVM-19 -lz -lm
     targets:
       - darwin_arm64
     mod_timestamp: "{{.CommitTimestamp}}"
   - id: llgo-linux-amd64
     main: ./cmd/llgo
     binary: bin/llgo
+    hooks:
+      pre:
+        - rm -rf crosscompile
+        - cp -r .sysroot/linux/amd64/crosscompile .
     flags:
       - -tags=linux,amd64,byollvm
     ldflags:
       - -X github.com/goplus/llgo/internal/env.buildVersion=v{{.Version}}
       - -X github.com/goplus/llgo/internal/env.buildTime={{.Date}}
-      - -X github.com/goplus/llgo/xtool/env/llvm.ldLLVMConfigBin=/usr/lib/llvm-19/bin/llvm-config
+      - -X github.com/goplus/llgo/xtool/env/llvm.ldLLVMConfigBin=../crosscompile/clang/bin/llvm-config
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
-      - CGO_CPPFLAGS=--sysroot={{.Env.SYSROOT_LINUX_AMD64}} -I{{.Env.SYSROOT_LINUX_AMD64}}/usr/include/llvm-19 -I{{.Env.SYSROOT_LINUX_AMD64}}/usr/include/llvm-c-19 -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_AMD64}} -L{{.Env.SYSROOT_LINUX_AMD64}}/usr/lib/llvm-19/lib -lLLVM-19
+      - CGO_CPPFLAGS=-I{{.Env.PWD}}/crosscompile/clang/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+      - CGO_LDFLAGS=-L{{.Env.PWD}}/crosscompile/clang/lib -lLLVM-19
     targets:
       - linux_amd64
     mod_timestamp: "{{.CommitTimestamp}}"
   - id: llgo-linux-arm64
     main: ./cmd/llgo
     binary: bin/llgo
+    hooks:
+      pre:
+        - rm -rf crosscompile
+        - cp -r .sysroot/linux/arm64/crosscompile .
     flags:
       - -tags=linux,arm64,byollvm
     ldflags:
       - -X github.com/goplus/llgo/internal/env.buildVersion=v{{.Version}}
       - -X github.com/goplus/llgo/internal/env.buildTime={{.Date}}
-      - -X github.com/goplus/llgo/xtool/env/llvm.ldLLVMConfigBin=/usr/lib/llvm-19/bin/llvm-config
+      - -X github.com/goplus/llgo/xtool/env/llvm.ldLLVMConfigBin=../crosscompile/clang/bin/llvm-config
     env:
       - CC=aarch64-linux-gnu-gcc
       - CXX=aarch64-linux-gnu-g++
-      - CGO_CPPFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -I{{.Env.SYSROOT_LINUX_ARM64}}/usr/include/llvm-19 -I{{.Env.SYSROOT_LINUX_ARM64}}/usr/include/llvm-c-19 -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-      - CGO_LDFLAGS=--sysroot={{.Env.SYSROOT_LINUX_ARM64}} -L{{.Env.SYSROOT_LINUX_ARM64}}/usr/lib/llvm-19/lib -lLLVM-19
+      - CGO_CPPFLAGS=-I{{.Env.PWD}}/crosscompile/clang/include -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+      - CGO_LDFLAGS=-L{{.Env.PWD}}/crosscompile/clang/lib -lLLVM-19
     targets:
       - linux_arm64
     mod_timestamp: "{{.CommitTimestamp}}"
@@ -93,6 +109,7 @@ archives:
       - LICENSE
       - README.md
       - runtime
+      - crosscompile
 
 checksum:
   name_template: "{{.ProjectName}}{{.Version}}.checksums.txt"

--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -15,6 +15,7 @@ import (
 	"github.com/goplus/llgo/internal/flash"
 	"github.com/goplus/llgo/internal/targets"
 	"github.com/goplus/llgo/internal/xtool/llvm"
+	envllvm "github.com/goplus/llgo/xtool/env/llvm"
 )
 
 type Export struct {
@@ -108,7 +109,7 @@ func getESPClangRoot(forceEspClang bool) (clangRoot string, err error) {
 	llgoRoot := env.LLGoROOT()
 
 	// First check if clang exists in LLGoROOT
-	espClangRoot := filepath.Join(llgoRoot, "crosscompile", "clang")
+	espClangRoot := filepath.Join(llgoRoot, envllvm.CrosscompileClangPath)
 	if _, err = os.Stat(espClangRoot); err == nil {
 		clangRoot = espClangRoot
 		return

--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -48,8 +48,8 @@ var (
 )
 
 var (
-	espClangBaseUrl = "https://github.com/goplus/espressif-llvm-project-prebuilt/releases/download/19.1.2_20250820"
-	espClangVersion = "19.1.2_20250820"
+	espClangBaseUrl = "https://github.com/goplus/espressif-llvm-project-prebuilt/releases/download/19.1.2_20250905-3"
+	espClangVersion = "19.1.2_20250905-3"
 )
 
 // cacheRoot can be overridden for testing

--- a/internal/crosscompile/fetch_test.go
+++ b/internal/crosscompile/fetch_test.go
@@ -605,7 +605,7 @@ func TestESPClangDownloadWhenNotExists(t *testing.T) {
 	}
 
 	server := createTestServer(t, map[string]string{
-		"clang-esp-19.1.2_20250820-linux.tar.xz": string(archiveContent),
+		fmt.Sprintf("clang-esp-%s-linux.tar.xz", espClangVersion): string(archiveContent),
 	})
 	defer server.Close()
 

--- a/xtool/env/llvm/llvm.go
+++ b/xtool/env/llvm/llvm.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/goplus/llgo/internal/env"
 	"github.com/goplus/llgo/xtool/clang"
 	"github.com/goplus/llgo/xtool/llvm/install_name_tool"
 	"github.com/goplus/llgo/xtool/llvm/llvmlink"
@@ -30,9 +31,13 @@ import (
 
 // -----------------------------------------------------------------------------
 
-// defaultLLVMConfigBin returns the default path to the llvm-config binary. It
-// checks the LLVM_CONFIG environment variable first, then searches in PATH. If
-// not found, it returns [ldLLVMConfigBin] as a last resort.
+const (
+	// CrosscompileClangPath is the relative path from LLGO_ROOT to the clang installation
+	CrosscompileClangPath = "crosscompile/clang"
+)
+
+// -----------------------------------------------------------------------------
+
 func defaultLLVMConfigBin() string {
 	bin := os.Getenv("LLVM_CONFIG")
 	if bin != "" {
@@ -41,6 +46,13 @@ func defaultLLVMConfigBin() string {
 	bin, _ = exec.LookPath("llvm-config")
 	if bin != "" {
 		return bin
+	}
+
+	llgoRoot := env.LLGoROOT()
+	// Check LLGO_ROOT/crosscompile/clang for llvm-config
+	crossLLVMConfigBin := filepath.Join(llgoRoot, CrosscompileClangPath, "bin", "llvm-config")
+	if _, err := os.Stat(crossLLVMConfigBin); err == nil {
+		return crossLLVMConfigBin
 	}
 	return ldLLVMConfigBin
 }


### PR DESCRIPTION
Resolved https://github.com/goplus/llgo/issues/1251

Release result at https://github.com/luoliwoshang/llgo/releases/tag/v0.0.1-test-espclang-5 and it's action https://github.com/luoliwoshang/llgo/actions/runs/17578939811

- [x] test release build without brew/apt llvm-19
- [x] test with embed target
- [x] update llvm-config find relative `LLGO_ROOT/crosscompile/clang`
- [x] compile llgo with esp-clang/llvm & rpath with `LLGO_ROOT/crosscompile/clang`
----

#### GLIBC Compatibility Issue with LLVM 19.1.2 Prebuilt Libraries (Resolved)
**Problem Description**
The current prebuilt LLVM libraries from [espressif-llvm-project-prebuilt v19.1.2_20250830](https://github.com/goplus/espressif-llvm-project-prebuilt/releases/tag/19.1.2_20250830) are causing linking failures due to GLIBC version incompatibility:
```bash
/usr/bin/ld: /go/src/llgo/crosscompile/clang/lib/libLLVM-19.so: undefined reference to `pthread_getname_np@GLIBC_2.34'
/usr/bin/ld: /go/src/llgo/crosscompile/clang/lib/libLLVM-19.so: undefined reference to `lstat64@GLIBC_2.33'
/usr/bin/ld: /go/src/llgo/crosscompile/clang/lib/libLLVM-19.so: undefined reference to `mallinfo2@GLIBC_2.33'
/usr/bin/ld: /go/src/llgo/crosscompile/clang/lib/libLLVM-19.so: undefined reference to `pthread_rwlock_wrlock@GLIBC_2.34'
/usr/bin/ld: /go/src/llgo/crosscompile/clang/lib/libLLVM-19.so: undefined reference to `stat64@GLIBC_2.33'
```
**Root Cause**
The prebuilt libraries were compiled against newer GLIBC versions (2.33+ and 2.34+) but goreleaser environments still use older GLIBC versions, causing undefined symbol errors during linking.   https://github.com/goreleaser/goreleaser-cross/issues/106.

And the debian 12 is in supporting with lot's hard https://github.com/goreleaser/goreleaser-cross/issues/106#issuecomment-3218744895


**Impact**

Blocks development on systems with GLIBC < 2.34
Affects CI/CD pipelines using older base images
Impacts cross-compilation workflows for embedded targets

**solution**

try to compile the llvm with older linux system

and it's actually a issue about ubuntu20 & debian11 compatibility https://github.com/goplus/llgo/issues/1265

fixed at
linux/arm https://github.com/goplus/espressif-llvm-project-prebuilt/pull/22

linux/amd https://github.com/goplus/espressif-llvm-project-prebuilt/pull/20



----

some verify 

`macos/arm64`

```bash
tar -xzf ./llgo0.0.1-testrefine.11.darwin-arm64.tar.gz -C llgo-testtest
cd llgo-testtest
❯ otool -L ./llgo
./llgo:
	@rpath/libc++.1.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libresolv.9.dylib (compatibility version 1.0.0, current version 1.0.0)
	@rpath/libLLVM.dylib (compatibility version 1.0.0, current version 19.1.2)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.0.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1853.0.0)
	/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit (compatibility version 1.0.0, current version 275.0.0)
	/System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 60157.30.13)

llgo-testtest/demo/c
❯ touch c.go
(base)
llgo-testtest/demo/c via 🐹 v1.24.6
❯ vim c.go


llgo-testtest/demo/c via 🐹 v1.24.6
❯ ../../bin/llgo run c.go
Hello world
Hello world
12


~/Downloads/llgo-testtest
❯ ./bin/llgo build -v -target esp32 -o test ./demo/embed/embed.go


/Users/zhangzhiyang/Downloads/llgo-testtest/crosscompile/clang/bin/clang++ --target=xtensa -mcpu=esp32 -Wno-override-module -Qunused-arguments -Wno-unused-command-line-argument --target=xtensa -Werror -fshort-enums -Wno-macro-redefined -fno-exceptions -fno-unwind-tables -fno-asynchronous-unwind-tables -ffunction-sections -fdata-sections -I/Users/zhangzhiyang/Library/Caches/llgo/crosscompile/newlib-esp32/newlib/libc/include -I/Users/zhangzhiyang/Library/Caches/llgo/crosscompile/newlib-esp32/newlib -I/Users/zhangzhiyang/Library/Caches/llgo/crosscompile/newlib-esp32/newlib/libc -o /Users/zhangzhiyang/Library/Caches/go-build/58/58134e72961bce19ceac5d817514dc8f82cb69cb3ebd14ea8082cb20851d2d6d-d.o-global.o -c /var/folders/5j/sgtxqmbn1hbdqtgx5kkp6y700000gn/T/llgo-3480044487.ll -Wno-override-module
/Users/zhangzhiyang/Downloads/llgo-testtest/crosscompile/clang/bin/ld.lld -mllvm -mcpu=esp32 -mllvm -mattr=+atomctl,+bool,+clamps,+coprocessor,+debug,+density,+dfpaccel,+div32,+exception,+fp,+highpriinterrupts,+interrupt,+loop,+mac16,+memctl,+minmax,+miscsr,+mul32,+mul32high,+nsa,+prid,+regprotect,+rvector,+s32c1i,+sext,+threadptr,+timerint,+windowed -T targets/esp32.memory.elf.ld -L /Users/zhangzhiyang/Downloads/llgo-testtest -nostdlib -L/Users/zhangzhiyang/Library/Caches/llgo/crosscompile/newlib-esp32 -lcrt0-xtensa -lgloss-xtensa -lc-xtensa -nostdlib -L/Users/zhangzhiyang/Library/Caches/llgo/crosscompile/compiler-rt -lclang_builtins-xtensa --gc-sections -o test.elf /Users/zhangzhiyang/Library/Caches/go-build/58/58134e72961bce19ceac5d817514dc8f82cb69cb3ebd14ea8082cb20851d2d6d-d.o /Users/zhangzhiyang/Library/Caches/go-build/58/58134e72961bce19ceac5d817514dc8f82cb69cb3ebd14ea8082cb20851d2d6d-d.o-main.o /Users/zhangzhiyang/Library/Caches/go-build/58/58134e72961bce19ceac5d817514dc8f82cb69cb3ebd14ea8082cb20851d2d6d-d.o-global.o
```


`linux/amd64`
```bash
root@ubuntu24-llgo-homebrew-v1-0:~/temp/llgo-test5# wget https://github.com/luoliwoshang/llgo/releases/download/v0.0.1-test-espclang-5/llgo0.0.1-test-espclang-5.linux-amd64.tar.gz

root@ubuntu24-llgo-homebrew-v1-0:~/temp/llgo-test5# tar -xzf ./llgo0.0.1-test-espclang-5.linux-amd64.tar.gz -C llgo

root@ubuntu24-llgo-homebrew-v1-0:~/temp/llgo-test5/llgo# ldd ./bin/llgo 
        linux-vdso.so.1 (0x00007ffe23e99000)
        libLLVM.so.19.1 => /root/temp/llgo-test5/llgo/./bin/../crosscompile/clang/lib/libLLVM.so.19.1 (0x00007fd5cfc7b000)
        libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2 (0x00007fd5cfc65000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fd5cfc60000)
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fd5cf9e2000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fd5cf9b4000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fd5cf7a0000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fd5cf79b000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fd5cf796000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007fd5cf77a000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fd5cf691000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fd5d634e000)

root@ubuntu24-llgo-homebrew-v1-0:~/temp/llgo-test5/llgo/demo/embed# ../../bin/llgo 
llgo is a Go compiler based on LLVM in order to better integrate Go with the C ecosystem including Python.

Usage:
  llgo [command]

Available Commands:
  build       Compile packages and dependencies
  clean       Remove object files and cached files
  cmptest     Compile and run with llgo, compare result (stdout/stderr/exitcode) with go or llgo.expect; generate llgo.expect file if -gen is specified
  completion  Generate the autocompletion script for the specified shell
  get         Add dependencies to current module and install them
  help        Help about any command
  install     Compile and install packages and dependencies
  monitor     Monitor serial output from device
  run         Compile and run Go program
  test        Compile and run Go test
  version     Print LLGo version

Flags:
  -h, --help   help for llgo

root@ubuntu24-llgo-homebrew-v1-0:~/temp/llgo-test5/llgo/demo/embed# ../../bin/llgo run hello.go 
Hello world
Hello world
12

root@ubuntu24-llgo-homebrew-v1-0:~/temp/llgo-test5/llgo/demo/embed# ../../bin/llgo build -target esp32 -o test .
root@ubuntu24-llgo-homebrew-v1-0:~/temp/llgo-test5/llgo/demo/embed# ls
go.mod  go.sum  hello.go  test.elf
```

`macos/amd64`

```bash
➜  llgo-test ./bin/llgo 
llgo is a Go compiler based on LLVM in order to better integrate Go with the C ecosystem including Python.

Usage:
  llgo [command]

Available Commands:
  build       Compile packages and dependencies
  clean       Remove object files and cached files
  cmptest     Compile and run with llgo, compare result (stdout/stderr/exitcode) with go or llgo.expect; generate llgo.expect file if -gen is specified
  completion  Generate the autocompletion script for the specified shell
  get         Add dependencies to current module and install them
  help        Help about any command
  install     Compile and install packages and dependencies
  monitor     Monitor serial output from device
  run         Compile and run Go program
  test        Compile and run Go test
  version     Print LLGo version

Flags:
  -h, --help   help for llgo

Use "llgo [command] --help" for more information about a command.
➜  llgo-test ./bin/llgo version
llgo v0.0.1-test-espclang-5 darwin/amd64


 bin otool -L ./llgo
./llgo:
        @rpath/libc++.1.dylib (compatibility version 1.0.0, current version 1.0.0)
        /usr/lib/libresolv.9.dylib (compatibility version 1.0.0, current version 1.0.0)
        @rpath/libLLVM.dylib (compatibility version 1.0.0, current version 19.1.2)
        /usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.0.0)
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1853.0.0)
        /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit (compatibility version 1.0.0, current version 275.0.0)
        /System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 60157.30.13)


 embed ../../bin/llgo build -target esp32 -o test .
➜  embed ls
embed.go go.mod   go.sum   test.elf

➜  embed ../../bin/llgo run embed.go                                
Hello world
Hello world
12
```

`linux/arm64`

```bash
root@4daf8338e716:~# wget https://github.com/luoliwoshang/llgo/releases/download/v0.0.1-test-espclang-5/llgo0.0.1-test-espclang-5.linux-arm64.tar.gz
root@4daf8338e716:~# tar -xzf ./llgo0.0.1-test-espclang-5.linux-arm64.tar.gz -C ./llgo-test
root@4daf8338e716:~/llgo-test/demo/cpp# ../../bin/llgo run . 
Hello world
Hello world
12

root@4daf8338e716:~/llgo-test ldd -d ./bin/llgo 
        linux-vdso.so.1 (0x0000ffff83768000)
        libLLVM.so.19.1 => /root/llgo-test/./bin/../crosscompile/clang/lib/libLLVM.so.19.1 (0x0000ffff7d800000)
        libresolv.so.2 => /lib/aarch64-linux-gnu/libresolv.so.2 (0x0000ffff83700000)
        libpthread.so.0 => /lib/aarch64-linux-gnu/libpthread.so.0 (0x0000ffff836d0000)
        libstdc++.so.6 => /lib/aarch64-linux-gnu/libstdc++.so.6 (0x0000ffff7d400000)
        libgcc_s.so.1 => /lib/aarch64-linux-gnu/libgcc_s.so.1 (0x0000ffff83690000)
        libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000ffff7d240000)
        librt.so.1 => /lib/aarch64-linux-gnu/librt.so.1 (0x0000ffff83660000)
        libdl.so.2 => /lib/aarch64-linux-gnu/libdl.so.2 (0x0000ffff83630000)
        libz.so.1 => /lib/aarch64-linux-gnu/libz.so.1 (0x0000ffff835f0000)
        libm.so.6 => /lib/aarch64-linux-gnu/libm.so.6 (0x0000ffff83540000)
        /lib/ld-linux-aarch64.so.1 (0x0000ffff8372b000)

root@4daf8338e716:~/llgo-test/demo/cpp# ../../bin/llgo build -target esp32 -o test .          
root@4daf8338e716:~/llgo-test/demo/cpp# ls
cpp.go  go.mod  go.sum  test.elf
```