### PR TITLE
ci:concurrency config added & timeout at 30min

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   doc_verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
 
@@ -35,6 +36,7 @@ jobs:
 
   remote_install:
     continue-on-error: true
+    timeout-minutes: 30
     strategy:
       matrix:
         os:
@@ -71,6 +73,7 @@ jobs:
 
   local_install:
     continue-on-error: true
+    timeout-minutes: 30
     strategy:
       matrix:
         os:
@@ -122,6 +125,7 @@ jobs:
 
   local_install_full:
     continue-on-error: true
+    timeout-minutes: 30
     strategy:
       matrix:
         os:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ["**"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   doc_verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ["**"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   fmt:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: ["**"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     continue-on-error: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   test:
     continue-on-error: true
+    timeout-minutes: 30
     strategy:
       matrix:
         os:

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   download-model:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Download model file
         run: |
@@ -32,6 +33,7 @@ jobs:
   llgo:
     needs: download-model
     continue-on-error: true
+    timeout-minutes: 30
     strategy:
       matrix:
         os:
@@ -137,6 +139,7 @@ jobs:
 
   test:
     continue-on-error: true
+    timeout-minutes: 30
     strategy:
       matrix:
         os:
@@ -180,6 +183,7 @@ jobs:
 
   hello:
     continue-on-error: true
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [ubuntu-24.04, macos-latest]
@@ -238,6 +242,7 @@ jobs:
 
   cross-compile:
     continue-on-error: true
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [macos-latest]

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: ["**"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   download-model:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   populate-darwin-sysroot:
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
       - name: Check out code
         uses: actions/checkout@v5
@@ -28,6 +29,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: populate-darwin-sysroot
+    timeout-minutes: 30
     steps:
       - name: Check out code
         uses: actions/checkout@v5

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   populate-darwin-sysroot:
     runs-on: macos-latest

--- a/.github/workflows/targets.yml
+++ b/.github/workflows/targets.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: ["**"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   llgo:
     continue-on-error: true

--- a/.github/workflows/targets.yml
+++ b/.github/workflows/targets.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   llgo:
     continue-on-error: true
+    timeout-minutes: 30
     strategy:
       matrix:
         os:


### PR DESCRIPTION
This configuration automatically cancels previous running workflows when new commits are pushed to the same pull request, preventing resource waste and reducing queue times.