### PR TITLE
ci:avoid dependbot trigger reduant push event

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -2,7 +2,9 @@ name: Docs
 
 on:
   push:
-    branches: ["**"]
+    branches: 
+      - "**"
+      - "!dependabot/**"
   pull_request:
     branches: ["**"]
 

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -2,7 +2,9 @@ name: Format Check
 
 on:
   push:
-    branches: ["**"]
+    branches: 
+      - "**"
+      - "!dependabot/**"
   pull_request:
     branches: ["**"]
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,7 +5,9 @@ name: Go
 
 on:
   push:
-    branches: ["**"]
+    branches: 
+      - "**"
+      - "!dependabot/**"
   pull_request:
     branches: ["**"]
 

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -5,7 +5,9 @@ name: LLGo
 
 on:
   push:
-    branches: ["**"]
+    branches: 
+      - "**"
+      - "!dependabot/**"
   pull_request:
     branches: ["**"]
 

--- a/.github/workflows/targets.yml
+++ b/.github/workflows/targets.yml
@@ -3,7 +3,9 @@ name: Targets
 
 on:
   push:
-    branches: ["**"]
+    branches: 
+      - "**"
+      - "!dependabot/**"
   pull_request:
     branches: ["**"]
 


### PR DESCRIPTION
fix follow

<img width="1342" height="652" alt="image" src="https://github.com/user-attachments/assets/2a8206cf-6163-41cf-9233-79da63fad622" />

----

Dependabot PRs trigger both push and pull_request events, causing workflows to run twice. See duplicate runs in https://github.com/luoliwoshang/llgo/pull/170. This excludes Dependabot branches from push triggers while keeping pull_request triggers intact.

you can see the result at https://github.com/luoliwoshang/llgo/pull/172，with the dependabot will only trigger the pr action