### PR TITLE
internal/cabi: call optimization

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -303,8 +303,10 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	})
 
 	buildMode := ssaBuildMode
+	cabiOptimize := true
 	if IsDbgEnabled() {
 		buildMode |= ssa.GlobalDebug
+		cabiOptimize = false
 	}
 	if !IsOptimizeEnabled() {
 		buildMode |= ssa.NaiveForm
@@ -324,7 +326,7 @@ func Do(args []string, conf *Config) ([]Package, error) {
 		needPyInit:   make(map[*packages.Package]bool),
 		buildConf:    conf,
 		crossCompile: export,
-		cTransformer: cabi.NewTransformer(prog, conf.AbiMode),
+		cTransformer: cabi.NewTransformer(prog, conf.AbiMode, cabiOptimize),
 	}
 	pkgs, err := buildAllPkgs(ctx, initial, verbose)
 	check(err)


### PR DESCRIPTION
 call optimization:  check IR `alloca/load/store` =>  `direct ptr` / `bitcast` / `memcpy` 

transform func body

func params
- [x] AttrPointer (byval) : check alloca ptr
- [x] AttrWidthType :  bitcast,  check alloca ptr
- [x] AttrWidthType2:  bitcast, check alloca ptr
- [x] AttrExtract: none

func results
- [x] AttrPointer sret : check memcpy
- [x] AttrWidthType : check alloca ptr, bitcast
- [x] AttrWidthType2: check alloca ptr, bitcast
- [x] AttrExtract: none

transform call instr
- [x] AttrPointer sret : check direct ptr
- [x] AttrPointer (byval) : check direct ptr or memcpy( unsupport byval, arm/arm64 )
- [ ] AttrWidthType
- [ ] AttrWidthType2
- [ ] AttrExtract