### PR TITLE
fix:ldflags -ldl for earlier glibc version

### DIFF
--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -326,7 +326,9 @@ func use(goos, goarch string, wasiThreads bool) (export Export, err error) {
 				"--gc-sections",
 				"-lm",
 				"-latomic",
-				"-lpthread", // libpthread is built-in since glibc 2.34 (2021-08-01); we need to support earlier versions.
+				// libpthread & libdl is built-in since glibc 2.34 (2021-08-01); we need to support earlier versions.
+				"-lpthread",
+				"-ldl",
 			)
 		}
 		return


### PR DESCRIPTION
fixed https://github.com/goplus/llgo/issues/1273

```bash
root@7387dedfb2ce:~/llgo# llgo run _demo/hello/hello.go 
hello world by println
hello world by fmt.Println
Hello world by c.Printf
root@7387dedfb2ce:~/llgo# cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=20.04
DISTRIB_CODENAME=focal
DISTRIB_DESCRIPTION="Ubuntu 20.04.6 LTS"
```