### PR TITLE
internal/crosscompile:update clang with older glibc & more small size

### DIFF
--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -43,8 +43,8 @@ var (
 )
 
 var (
-	espClangBaseUrl = "https://github.com/goplus/espressif-llvm-project-prebuilt/releases/download/19.1.2_20250820"
-	espClangVersion = "19.1.2_20250820"
+	espClangBaseUrl = "https://github.com/goplus/espressif-llvm-project-prebuilt/releases/download/19.1.2_20250905-3"
+	espClangVersion = "19.1.2_20250905-3"
 )
 
 // cacheRoot can be overridden for testing

--- a/internal/crosscompile/fetch_test.go
+++ b/internal/crosscompile/fetch_test.go
@@ -605,7 +605,7 @@ func TestESPClangDownloadWhenNotExists(t *testing.T) {
 	}
 
 	server := createTestServer(t, map[string]string{
-		"clang-esp-19.1.2_20250820-linux.tar.xz": string(archiveContent),
+		fmt.Sprintf("clang-esp-%s-linux.tar.xz", espClangVersion): string(archiveContent),
 	})
 	defer server.Close()
 


### PR DESCRIPTION
fixed https://github.com/goplus/llgo/issues/1273

with embed esp clang compile update

https://github.com/goplus/espressif-llvm-project-prebuilt/pull/22
https://github.com/goplus/espressif-llvm-project-prebuilt/pull/20
https://github.com/goplus/espressif-llvm-project-prebuilt/pull/17
https://github.com/goplus/espressif-llvm-project-prebuilt/pull/13
https://github.com/goplus/espressif-llvm-project-prebuilt/pull/9