### PR TITLE
ci:update .sysroot cache key & catch docker exit

### DIFF
--- a/.github/workflows/populate_linux_sysroot.sh
+++ b/.github/workflows/populate_linux_sysroot.sh
@@ -139,7 +139,10 @@ populate_linux_sysroot() {
 		/populate_linux_sysroot.sh
 }
 populate_linux_sysroot amd64 "${LINUX_AMD64_PREFIX}" &
+PID1=$!
 populate_linux_sysroot arm64 "${LINUX_ARM64_PREFIX}" &
+PID2=$!
 
 # Wait for both background processes to complete
-wait
+wait $PID1 || exit $?
+wait $PID2 || exit $?

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Calculate cache keys
         id: cache-keys
         run: |
-          DARWIN_KEY="darwin-sysroot-${{ hashFiles('.github/workflows/populate_darwin_sysroot.sh', '.github/workflows/release-build.yml') }}"
-          LINUX_KEY="linux-sysroot-${{ hashFiles('.github/workflows/populate_linux_sysroot.sh', '.github/workflows/release-build.yml') }}"
+          DARWIN_KEY="darwin-sysroot-${{ hashFiles('.github/workflows/populate_darwin_sysroot.sh', '.github/workflows/release-build.yml') }}-v1.0.0"
+          LINUX_KEY="linux-sysroot-${{ hashFiles('.github/workflows/populate_linux_sysroot.sh', '.github/workflows/release-build.yml') }}-v1.0.0"
           echo "darwin-key=$DARWIN_KEY" >> $GITHUB_OUTPUT
           echo "linux-key=$LINUX_KEY" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
fixed https://github.com/goplus/llgo/issues/1280


The error occurred because the job below wrote incorrect cache, and subsequently read the wrong .sysroot, leading to missing linux/arm header files during the build process.
https://github.com/goplus/llgo/actions/runs/17542096574/job/49815540894

```bash
tar -czvf .sysroot/linux.tar.gz -C .sysroot linux
......
linux/amd64/lib/x86_64-linux-gnu/libz.so.1
linux/amd64/lib/x86_64-linux-gnu/libpcprofile.so
linux/arm64/
```

The root cause lies in the concurrent Docker pulling and building logic for linux arm64/amd64 when obtaining .sysroot. When Docker was started to pull linux/arm64 to get .sysroot, Docker occasionally failed to create the container, and the script did not exit properly in the background. This resulted in the missing environment for that platform in .sysroot, ultimately causing the go-releaser build to fail.

```bash
7b68ea47bc3c: Pull complete
078965fc7cf3: Pull complete
Digest: sha256:8ec25a9073e8cc89a184a6256e219828196d75203375a8ad4f0977f3011f2115
Digest: sha256:8ec25a9073e8cc89a184a6256e219828196d75203375a8ad4f0977f3011f2115
Status: Downloaded newer image for debian:bullseye
Status: Downloaded newer image for debian:bullseye
WARNING: image with reference debian:bullseye was found but its platform (linux/amd64) does not match the specified platform (linux/arm64)
docker: Error response from daemon: image with reference debian:bullseye was found but its platform (linux/amd64) does not match the specified platform (linux/arm64)
```