### PR TITLE
llgo/embed:compile with `Oz`  & link with `-s` for embed target to reduce size

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -834,7 +834,6 @@ func linkObjFiles(ctx *context, app string, objFiles, linkArgs []string, verbose
 	}
 
 	buildArgs := []string{"-o", app}
-	buildArgs = append(buildArgs, "-s")
 	buildArgs = append(buildArgs, linkArgs...)
 
 	// Add build mode specific linker arguments

--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -481,7 +481,7 @@ func UseTarget(targetName string) (export Export, err error) {
 	envs := buildEnvMap(env.LLGoROOT())
 
 	// Convert LLVMTarget, CPU, Features to CCFLAGS/LDFLAGS
-	var ldflags []string
+	ldflags := []string{"-S"}
 	ccflags := []string{"-Oz"}
 	cflags := []string{"-Wno-override-module", "-Qunused-arguments", "-Wno-unused-command-line-argument"}
 	if config.LLVMTarget != "" {


### PR DESCRIPTION
fixed https://github.com/goplus/llgo/issues/1312

before
```bash
2025-09-16T08:14:33.7708327Z ld.lld: error: section 'text' will not fit in region 'iram_seg': overflowed by 13157 bytes
```
with current pr 190KB -> 86KB
```bash
lib/_demo/emptycheck on  task3/machine [?] via 🐹 v1.24.6 took 7s 
❯ ls -lh ./oz-s.elf                                             
-rwxr-xr-x@ 1 zhangzhiyang  staff    86K Sep 18 15:23 ./oz-s.elf
```