### PR TITLE
chore(ci): migrate from `macos-13` to `macos-15-intel` runner

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -2,7 +2,7 @@ name: Docs
 
 on:
   push:
-    branches: 
+    branches:
       - "**"
       - "!dependabot/**"
   pull_request:
@@ -43,7 +43,7 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - ubuntu-24.04
+          - ubuntu-latest
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v5
@@ -80,7 +80,7 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - ubuntu-24.04
+          - ubuntu-latest
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v5
@@ -132,7 +132,7 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - ubuntu-24.04
+          - ubuntu-latest
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -2,7 +2,7 @@ name: Format Check
 
 on:
   push:
-    branches: 
+    branches:
       - "**"
       - "!dependabot/**"
   pull_request:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,7 +5,7 @@ name: Go
 
 on:
   push:
-    branches: 
+    branches:
       - "**"
       - "!dependabot/**"
   pull_request:
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - ubuntu-24.04
+          - ubuntu-latest
         llvm: [19]
     runs-on: ${{matrix.os}}
     steps:

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -5,7 +5,7 @@ name: LLGo
 
 on:
   push:
-    branches: 
+    branches:
       - "**"
       - "!dependabot/**"
   pull_request:
@@ -40,7 +40,7 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - ubuntu-24.04
+          - ubuntu-latest
         llvm: [19]
         go: ["1.21.13", "1.22.12", "1.23.6", "1.24.2"]
     runs-on: ${{matrix.os}}
@@ -153,7 +153,7 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - ubuntu-24.04
+          - ubuntu-latest
         llvm: [19]
         go: ["1.24.2"]
     runs-on: ${{matrix.os}}
@@ -195,7 +195,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         llvm: [19]
         go: ["1.21.13", "1.22.12", "1.23.6", "1.24.2"]
     runs-on: ${{matrix.os}}

--- a/.github/workflows/populate_linux_sysroot.sh
+++ b/.github/workflows/populate_linux_sysroot.sh
@@ -17,7 +17,7 @@ cat > "${POPULATE_LINUX_SYSROOT_SCRIPT}" << EOF
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get update
-apt-get install -y lsb-release gnupg2 wget rsync
+apt-get install -y lsb-release gnupg wget rsync
 
 echo "deb http://apt.llvm.org/\$(lsb_release -cs)/ llvm-toolchain-\$(lsb_release -cs)-19 main" | tee /etc/apt/sources.list.d/llvm.list
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -153,7 +153,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-13
+          - os: macos-15-intel
             goos: darwin
             goarch: amd64
             go-version: "1.24.2"

--- a/.github/workflows/targets.yml
+++ b/.github/workflows/targets.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - ubuntu-24.04
+          - ubuntu-latest
         llvm: [19]
     runs-on: ${{matrix.os}}
     steps:


### PR DESCRIPTION
GitHub announced the deprecation of the `macos-13` runner image[^1], which will be completely removed by December 4th, 2025.

This commit migrates all workflows to use `macos-15-intel` runners following the announcement's recommendation.

This also uses `ubuntu-latest` alias instead of explicit `ubuntu-24.04`.

[^1]: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/