### PR TITLE
[WIP] ssa: python support kwargs

### DIFF
--- a/ssa/package.go
+++ b/ssa/package.go
@@ -181,6 +181,7 @@ type aProgram struct {
 	callNoArgs   *types.Signature
 	callOneArg   *types.Signature
 	callFOArgs   *types.Signature
+	callArgs     *types.Signature
 	loadPyModS   *types.Signature
 	getAttrStr   *types.Signature
 	pyUniStr     *types.Signature


### PR DESCRIPTION
pass last map[string]*py.Object to kwargs. https://github.com/goplus/llgo/issues/1236

python
```py
def test_lib3(a, b, *args, c=10, **kwargs):
```
test lib
```go
//go:linkname Test_lib py.test_lib
func Test_lib(x *py.Object, y *py.Object, __llgo_va_list ...interface{})
```
test main
```go
mylib.Test_lib3(py.Long(1), py.Long(2), py.Str("helo world"), py.Long(100),
		py.Kwargs{"c": py.Long(102), "d": py.Str("hello world")}) 

```

demo
```
std.Print(py.Str("Hello world"), py.Kwargs{"flush": py.Long(1), "end": py.Str("$\n")})
# output: Hello world$
```

https://github.com/goplus/lib/pull/20: add KwargsToDict
```go
type Kwargs  map[string]*Object

func KwargsToDict(kw Kwargs) *Object {
	dict := NewDict()
	for k, v := range kw {
		dict.DictSetItem(FromGoString(k), v)
	}
	return dict
}
```



