### PR TITLE
ci: prevent duplicate workflow runs for xgopilot branches

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "**"
       - "!dependabot/**"
+      - "!xgopilot/**"
   pull_request:
     branches: ["**"]
 

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "**"
       - "!dependabot/**"
+      - "!xgopilot/**"
   pull_request:
     branches: ["**"]
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - "**"
       - "!dependabot/**"
+      - "!xgopilot/**"
   pull_request:
     branches: ["**"]
 

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - "**"
       - "!dependabot/**"
+      - "!xgopilot/**"
   pull_request:
     branches: ["**"]
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -2,7 +2,10 @@ name: Release Build
 
 on:
   push:
-    branches: ["**"]
+    branches:
+      - "**"
+      - "!dependabot/**"
+      - "!xgopilot/**"
     tags: ["*"]
   pull_request:
     branches: ["**"]

--- a/.github/workflows/targets.yml
+++ b/.github/workflows/targets.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - "**"
       - "!dependabot/**"
+      - "!xgopilot/**"
   pull_request:
     branches: ["**"]
 


### PR DESCRIPTION
## Summary

This PR fixes issue #1340 by preventing duplicate CI workflow runs for xgopilot branches.

## Changes

Added `!xgopilot/**` exclusion pattern to all workflow files, matching the existing `!dependabot/**` pattern:

- ✅ `.github/workflows/targets.yml`
- ✅ `.github/workflows/llgo.yml`
- ✅ `.github/workflows/go.yml`
- ✅ `.github/workflows/fmt.yml`
- ✅ `.github/workflows/doc.yml`
- ✅ `.github/workflows/release-build.yml`

## Impact

After this change:
- xgopilot branches will **only** trigger CI checks on `pull_request` events
- Push events to xgopilot branches will be ignored
- This eliminates redundant CI runs and reduces resource usage
- Matches the existing behavior for dependabot branches

## Test Plan

- [ ] Verify that this PR itself only triggers CI on the pull_request event
- [ ] Confirm no push event workflows run for the `fix-ci-duplicate-runs` branch
- [ ] Check that all workflow syntax is valid

Fixes #1340

🤖 Generated with [Claude Code](https://claude.com/claude-code)