### PR TITLE
ci:avoid auto upgrade before brew install

### DIFF
--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -16,6 +16,8 @@ runs:
     - name: Install macOS dependencies
       if: runner.os == 'macOS'
       shell: bash
+      env:
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
       run: |
         brew update
         


### PR DESCRIPTION
fix ci fail at install dependency
```bash
==> Upgrading python@3.13
  3.13.8 -> 3.13.9_1 
==> Pouring python@3.13--3.13.9_1.sequoia.bottle.tar.gz
Error: The `brew link` step did not complete successfully
```