### PR TITLE
fix(reflect): return name for basic types without TFlagNamed

### DIFF
--- a/_demo/go/reflect-name-1412/reflect_name.go
+++ b/_demo/go/reflect-name-1412/reflect_name.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func main() {
+	// Test all basic types
+	tests := []struct {
+		value    interface{}
+		expected string
+	}{
+		// Integers
+		{int(42), "int"},
+		{int8(42), "int8"},
+		{int16(42), "int16"},
+		{int32(42), "int32"},
+		{int64(42), "int64"},
+		{uint(42), "uint"},
+		{uint8(42), "uint8"},
+		{uint16(42), "uint16"},
+		{uint32(42), "uint32"},
+		{uint64(42), "uint64"},
+		{uintptr(42), "uintptr"},
+
+		// Floats
+		{float32(3.14), "float32"},
+		{float64(3.14), "float64"},
+
+		// Complex
+		{complex64(1 + 2i), "complex64"},
+		{complex128(1 + 2i), "complex128"},
+
+		// Bool
+		{true, "bool"},
+
+		// String
+		{"hello", "string"},
+
+		// Byte and Rune (aliases)
+		{byte(65), "uint8"},
+		{rune(65), "int32"},
+	}
+
+	passed := 0
+	failed := 0
+
+	for _, tt := range tests {
+		rt := reflect.TypeOf(tt.value)
+		name := rt.Name()
+		kind := rt.Kind()
+
+		if name == tt.expected {
+			fmt.Printf("✓ %v (kind=%v): Name=%q\n", tt.expected, kind, name)
+			passed++
+		} else {
+			fmt.Printf("✗ Expected %q, got %q (kind=%v)\n", tt.expected, name, kind)
+			failed++
+		}
+	}
+
+	fmt.Printf("\nResults: %d passed, %d failed\n", passed, failed)
+
+	if failed > 0 {
+		panic(fmt.Sprintf("%d tests failed", failed))
+	}
+
+	fmt.Println("✓ All basic types test passed!")
+}

--- a/runtime/internal/lib/reflect/type.go
+++ b/runtime/internal/lib/reflect/type.go
@@ -344,7 +344,15 @@ func pkgPathFor(t *abi.Type) string {
 
 func (t *rtype) Name() string {
 	if !t.t.HasName() {
-		return ""
+		// For basic types without TFlagNamed, String() returns the type name directly
+		s := t.String()
+		// Check if it's a basic type (no package path)
+		for i := 0; i < len(s); i++ {
+			if s[i] == '.' {
+				return "" // Has package path, not a basic type
+			}
+		}
+		return s // Basic type like "int", "string", etc.
 	}
 	s := t.String()
 	i := len(s) - 1


### PR DESCRIPTION
## Summary

Fix `reflect.Type.Name()` to return the correct name for basic types (`int`, `string`, `bool`, etc.) that don't have the `TFlagNamed` flag set.

## Problem

Previously, `Name()` would return an empty string for basic types because they lack `TFlagNamed`. However, these types do have names stored in the `Str_` field and accessible via `String()`.

Example:
```go
rt := reflect.TypeOf(42)
fmt.Println(rt.Name()) // Expected: "int", Got: "" (empty)
```

## Root Cause

1. Basic types are created via `runtime.Basic()` without `TFlagNamed` flag
2. `reflect.Type.Name()` checks `HasName()` which requires `TFlagNamed`
3. Without the flag, `Name()` returns empty string immediately

## Solution

Modified `runtime/internal/lib/reflect/type.go` to check if a type without `TFlagNamed` is a basic type (no package path, i.e., no `.` in string representation), and return the string directly in that case.

## Test Plan

- [x] Added regression test in `_demo/go/reflect-name-1412/`
- [x] Test passes with the fix
- [x] Verified all basic types (int, string, bool, etc.) now return correct names

Fixes #1412

🤖 Generated with [Claude Code](https://claude.com/claude-code)