### PR TITLE
refactor: move sigsetjmp platform detection from compiler to runtime

### DIFF
--- a/runtime/internal/clite/setjmp/sigsetjmp.go
+++ b/runtime/internal/clite/setjmp/sigsetjmp.go
@@ -1,3 +1,5 @@
+//go:build !linux && !baremetal && !wasm
+
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
  *
@@ -22,21 +24,8 @@ import (
 	c "github.com/goplus/llgo/runtime/internal/clite"
 )
 
-const (
-	LLGoPackage = "link"
-)
+//go:linkname Sigsetjmp C.sigsetjmp
+func Sigsetjmp(env *SigjmpBuf, savemask c.Int) c.Int
 
-type (
-	SigjmpBuf [SigjmpBufSize]byte
-	JmpBuf    [JmpBufSize]byte
-)
-
-// -----------------------------------------------------------------------------
-
-//go:linkname Setjmp C.setjmp
-func Setjmp(env *JmpBuf) c.Int
-
-//go:linkname Longjmp C.longjmp
-func Longjmp(env *JmpBuf, val c.Int)
-
-// -----------------------------------------------------------------------------
+//go:linkname Siglongjmp C.siglongjmp
+func Siglongjmp(env *SigjmpBuf, val c.Int)

--- a/runtime/internal/clite/setjmp/sigsetjmp_baremetal.go
+++ b/runtime/internal/clite/setjmp/sigsetjmp_baremetal.go
@@ -1,3 +1,5 @@
+//go:build baremetal || wasm
+
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
  *
@@ -17,26 +19,16 @@
 package setjmp
 
 import (
-	_ "unsafe"
-
 	c "github.com/goplus/llgo/runtime/internal/clite"
 )
 
-const (
-	LLGoPackage = "link"
-)
+// On baremetal and wasm, use setjmp instead of sigsetjmp
+// since these platforms don't support signal handling.
+func Sigsetjmp(env *SigjmpBuf, savemask c.Int) c.Int {
+	return Setjmp((*JmpBuf)(env))
+}
 
-type (
-	SigjmpBuf [SigjmpBufSize]byte
-	JmpBuf    [JmpBufSize]byte
-)
-
-// -----------------------------------------------------------------------------
-
-//go:linkname Setjmp C.setjmp
-func Setjmp(env *JmpBuf) c.Int
-
-//go:linkname Longjmp C.longjmp
-func Longjmp(env *JmpBuf, val c.Int)
-
-// -----------------------------------------------------------------------------
+// On baremetal and wasm, use longjmp instead of siglongjmp
+func Siglongjmp(env *SigjmpBuf, val c.Int) {
+	Longjmp((*JmpBuf)(env), val)
+}

--- a/runtime/internal/clite/setjmp/sigsetjmp_linux.go
+++ b/runtime/internal/clite/setjmp/sigsetjmp_linux.go
@@ -1,3 +1,5 @@
+//go:build linux && !baremetal
+
 /*
  * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
  *
@@ -22,21 +24,10 @@ import (
 	c "github.com/goplus/llgo/runtime/internal/clite"
 )
 
-const (
-	LLGoPackage = "link"
-)
+// On Linux, sigsetjmp is called __sigsetjmp
+//
+//go:linkname Sigsetjmp C.__sigsetjmp
+func Sigsetjmp(env *SigjmpBuf, savemask c.Int) c.Int
 
-type (
-	SigjmpBuf [SigjmpBufSize]byte
-	JmpBuf    [JmpBufSize]byte
-)
-
-// -----------------------------------------------------------------------------
-
-//go:linkname Setjmp C.setjmp
-func Setjmp(env *JmpBuf) c.Int
-
-//go:linkname Longjmp C.longjmp
-func Longjmp(env *JmpBuf, val c.Int)
-
-// -----------------------------------------------------------------------------
+//go:linkname Siglongjmp C.siglongjmp
+func Siglongjmp(env *SigjmpBuf, val c.Int)

--- a/runtime/internal/runtime/setjmp.go
+++ b/runtime/internal/runtime/setjmp.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024 The GoPlus Authors (goplus.org). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"unsafe"
+
+	"github.com/goplus/llgo/runtime/internal/clite/setjmp"
+)
+
+// Sigsetjmp saves the current execution context for non-local jumps.
+// Platform-specific implementation is handled by clite/setjmp via build tags:
+// - Default: uses sigsetjmp/siglongjmp
+// - Linux: uses __sigsetjmp/siglongjmp
+// - Baremetal/wasm: uses setjmp/longjmp
+func Sigsetjmp(env unsafe.Pointer, savemask int32) int32 {
+	return int32(setjmp.Sigsetjmp((*setjmp.SigjmpBuf)(env), savemask))
+}
+
+// Siglongjmp performs a non-local jump to the context saved by Sigsetjmp.
+func Siglongjmp(env unsafe.Pointer, val int32) {
+	setjmp.Siglongjmp((*setjmp.SigjmpBuf)(env), val)
+}


### PR DESCRIPTION
## Summary

Move platform-specific sigsetjmp/siglongjmp logic from `ssa/eh.go` to runtime using build tags, following the same pattern as `AllocU`.

### Architecture

```
ssa/eh.go
    ↓ calls rtFunc("Sigsetjmp")/rtFunc("Siglongjmp")
runtime/setjmp.go (wrapper)
    ↓ calls setjmp.Sigsetjmp()
clite/setjmp (build tags)
    ├── sigsetjmp.go: default (C.sigsetjmp/C.siglongjmp)
    ├── sigsetjmp_linux.go: Linux (C.__sigsetjmp/C.siglongjmp)
    └── sigsetjmp_baremetal.go: baremetal/wasm (setjmp/longjmp)
```

### Changes

- Remove platform checks from `ssa/eh.go` Sigsetjmp/Siglongjmp
- Add runtime wrapper functions for Sigsetjmp/Siglongjmp
- Add platform-specific implementations in clite/setjmp
- Change clite/setjmp LLGoPackage from "decl" to "link"

## ⚠️ Known Issue

**This approach has issues with setjmp/longjmp semantics.**

The wrapper functions create intermediate stack frames which break the non-local jump behavior:

```
defer code -> runtime.Sigsetjmp() -> setjmp.Sigsetjmp() -> C.sigsetjmp
              ↑ new stack frame 1    ↑ new stack frame 2
```

`sigsetjmp` saves the stack frame of `setjmp.Sigsetjmp()`, not the original defer code location. When `longjmp` jumps back, it goes to the wrong stack position.

**This PR is for discussion purposes** to explore whether there's a way to make this work (e.g., inline expansion in llgo).

## Test Results

- macOS: crash (exit code -1)
- Linux: defer execution order is wrong

🤖 Generated with [Claude Code](https://claude.com/claude-code)