### PR TITLE
ssa: fix jmp_buf size for cross-compilation

### DIFF
--- a/ssa/eh.go
+++ b/ssa/eh.go
@@ -16,22 +16,6 @@
 
 package ssa
 
-/*
-#include <setjmp.h>
-#ifdef WIN32
-#if defined(__MINGW64__) && !defined(_UCRT)
-typedef intptr_t sigjmp_buf[5];
-#define sigsetjmp(x,y) __builtin_setjmp(x)
-#define siglongjmp __builtin_longjmp
-#else
-#define sigjmp_buf jmp_buf
-#define sigsetjmp(x,y) setjmp(x)
-#define siglongjmp longjmp
-#endif
-#endif
-*/
-import "C"
-
 import (
 	"go/token"
 	"go/types"
@@ -42,8 +26,6 @@ import (
 )
 
 // -----------------------------------------------------------------------------
-
-type sigjmpbuf = C.sigjmp_buf
 
 // func setjmp(env unsafe.Pointer) c.Int
 func (p Program) tySetjmp() *types.Signature {
@@ -103,8 +85,9 @@ func (p Program) tyStacksave() *types.Signature {
 
 func (b Builder) AllocaSigjmpBuf() Expr {
 	prog := b.Prog
-	n := unsafe.Sizeof(sigjmpbuf{})
-	size := prog.IntVal(uint64(n), prog.Uintptr())
+	sigjmpBufTy := prog.rtType("SigjmpBuf") // Get type from runtime (target architecture)
+	n := prog.SizeOf(sigjmpBufTy)           // Get size for target architecture
+	size := prog.IntVal(n, prog.Uintptr())
 	return b.Alloca(size)
 }
 


### PR DESCRIPTION
## Summary

- Fix `AllocaSigjmpBuf()` to use `rtType("SigjmpBuf")` to get the correct jmp_buf size from the runtime package for the target architecture
- Remove cgo dependency for determining jmp_buf size, which incorrectly used host machine size instead of target architecture size
- Add `getSigjmpBufSize()` helper function in runtime for debugging/testing purposes

## Problem

Previously, `AllocaSigjmpBuf()` used `unsafe.Sizeof(C.sigjmp_buf{})` which determined the jmp_buf size at **llgo build time** (host machine), not at compile time for the target architecture. This caused issues in cross-compilation scenarios:

| Architecture | sigjmp_buf size |
|--------------|-----------------|
| x86_64 Mac | ~196 bytes |
| ESP32 (Xtensa) | ~68 bytes |

Size mismatch could lead to stack corruption or wasted stack space.

## Solution

Use `prog.rtType("SigjmpBuf")` and `prog.SizeOf()` to get the size from the runtime package, which is compiled for the target architecture.

## Test plan

- [x] Build llgo successfully
- [x] Run setjmp test program
- [x] Verify `SigjmpBuf size: 196` output on darwin arm64

Fixes #1484

🤖 Generated with [Claude Code](https://claude.com/claude-code)