### PR TITLE
crosscompile: add mquickjs JavaScript engine support

### DIFF
--- a/_demo/embed/esp32/hello/main.go
+++ b/_demo/embed/esp32/hello/main.go
@@ -1,6 +1,16 @@
 package main
 
-import "github.com/goplus/lib/c"
+import (
+	"unsafe"
+
+	"github.com/goplus/lib/c"
+	"github.com/luoliwoshang/mquickjs/mquickjs"
+)
+
+// Link to the js_stdlib symbol exported from libmquickjs
+//
+//go:linkname jsStdlib js_stdlib
+var jsStdlib mquickjs.JSSTDLibraryDef
 
 func myprint(s *c.Char) {
 	for i := 0; i < int(c.Strlen(s)); i++ {
@@ -8,9 +18,61 @@ func myprint(s *c.Char) {
 	}
 }
 
+// js_print - Override the weak symbol in libmquickjs to provide actual print functionality
+// This function is called when JavaScript code calls print()
+//
+//export js_print
+func js_print(ctx *mquickjs.JSContext, thisVal *mquickjs.JSValue, argc c.Int, argv *mquickjs.JSValue) mquickjs.JSValue {
+	// Iterate through all arguments
+	for i := c.Int(0); i < argc; i++ {
+		// Get argument at index i
+		argPtr := (*mquickjs.JSValue)(unsafe.Pointer(uintptr(unsafe.Pointer(argv)) + uintptr(i)*unsafe.Sizeof(*argv)))
+
+		// Convert JS value to C string
+		var buf mquickjs.JSCStringBuf
+		str := ctx.JSToCString(*argPtr, &buf)
+		if str != nil {
+			myprint(str)
+		}
+
+		// Add space between arguments
+		if i < argc-1 {
+			WriteByte(' ')
+		}
+	}
+	// Add newline at the end
+	WriteByte('\n')
+
+	return mquickjs.JSValue(mquickjs.JS_TAG_UNDEFINED)
+}
+
 func main() {
+	// Allocate memory for JS context (64KB)
+	const memSize = 64 * 1024
+	mem := c.Malloc(memSize)
+
+	// Create JS context with js_stdlib
+	ctx := mquickjs.JSNewContext(mem, c.Int(memSize), &jsStdlib)
+	if ctx == nil {
+		myprint(c.Str("Failed to create JS context\n"))
+		return
+	}
+
+	// Run JavaScript code
+	code := c.Str("console.log('Hello from MQuickJS on ESP32!')")
+	result := ctx.JSEval(code, c.Int(c.Strlen(code)), c.Str("<eval>"), 0)
+
+	// Check for exception
+	if mquickjs.JSValue(result) == mquickjs.JSValue(mquickjs.JS_TAG_EXCEPTION) {
+		myprint(c.Str("JS Exception occurred\n"))
+	}
+
+	// Free context
+	ctx.JSFreeContext()
+	c.Free(unsafe.Pointer(mem))
+
 	for {
-		myprint(c.Str("hello world"))
+		myprint(c.Str("hello world\n"))
 		sleep(1)
 	}
 }

--- a/_demo/embed/esp32/hello/main.go
+++ b/_demo/embed/esp32/hello/main.go
@@ -46,6 +46,20 @@ func js_print(ctx *mquickjs.JSContext, thisVal *mquickjs.JSValue, argc c.Int, ar
 	return mquickjs.JSValue(mquickjs.JS_TAG_UNDEFINED)
 }
 
+func runTest(ctx *mquickjs.JSContext, name *c.Char, code *c.Char) {
+	myprint(c.Str("Test: "))
+	myprint(name)
+	myprint(c.Str("\n"))
+
+	result := ctx.JSEval(code, c.Int(c.Strlen(code)), c.Str("<eval>"), 0)
+
+	// Check for exception
+	if mquickjs.JSValue(result) == mquickjs.JSValue(mquickjs.JS_TAG_EXCEPTION) {
+		myprint(c.Str("  Exception occurred!\n"))
+	}
+	myprint(c.Str("\n"))
+}
+
 func main() {
 	// Allocate memory for JS context (64KB)
 	const memSize = 64 * 1024
@@ -58,21 +72,48 @@ func main() {
 		return
 	}
 
-	// Run JavaScript code
-	code := c.Str("console.log('Hello from MQuickJS on ESP32!')")
-	result := ctx.JSEval(code, c.Int(c.Strlen(code)), c.Str("<eval>"), 0)
+	myprint(c.Str("=== MQuickJS on ESP32 ===\n\n"))
 
-	// Check for exception
-	if mquickjs.JSValue(result) == mquickjs.JSValue(mquickjs.JS_TAG_EXCEPTION) {
-		myprint(c.Str("JS Exception occurred\n"))
-	}
+	// Test 1: String output
+	runTest(ctx, c.Str("String output"), c.Str("print('Hello from MQuickJS on ESP32!')"))
+
+	// Test 2: Number output
+	runTest(ctx, c.Str("Number output"), c.Str("print(123)"))
+
+	// Test 3: Math expression
+	runTest(ctx, c.Str("Math expression"), c.Str("print(1 + 2 * 3)"))
+
+	// Test 4: Multiple arguments
+	runTest(ctx, c.Str("Multiple args"), c.Str("print('Result:', 10 + 20)"))
+
+	// Test 5: Define JS functions (no output expected)
+	runTest(ctx, c.Str("Define functions"), c.Str(`
+function add(a, b) {
+    return a + b;
+}
+
+function factorial(n) {
+    if (n <= 1) return 1;
+    return n * factorial(n - 1);
+}
+
+var multiply = function(a, b) { return a * b; };
+`))
+
+	// Test 6: Call the previously defined functions
+	runTest(ctx, c.Str("Call add"), c.Str("print('add(3, 5) =', add(3, 5))"))
+
+	runTest(ctx, c.Str("Call factorial"), c.Str("print('factorial(5) =', factorial(5))"))
+
+	runTest(ctx, c.Str("Call multiply"), c.Str("print('multiply(4, 7) =', multiply(4, 7))"))
 
 	// Free context
 	ctx.JSFreeContext()
 	c.Free(unsafe.Pointer(mem))
 
+	myprint(c.Str("=== Tests complete ===\n"))
+
 	for {
-		myprint(c.Str("hello world\n"))
 		sleep(1)
 	}
 }

--- a/_demo/embed/go.mod
+++ b/_demo/embed/go.mod
@@ -2,4 +2,7 @@ module github.com/goplus/llgo/_demo/embed
 
 go 1.20
 
-require github.com/goplus/lib v0.3.0
+require (
+	github.com/goplus/lib v0.3.0
+	github.com/luoliwoshang/mquickjs/mquickjs v1.0.5
+)

--- a/_demo/embed/go.sum
+++ b/_demo/embed/go.sum
@@ -1,2 +1,4 @@
 github.com/goplus/lib v0.3.0 h1:y0ZGb5Q/RikW1oMMB4Di7XIZIpuzh/7mlrR8HNbxXCA=
 github.com/goplus/lib v0.3.0/go.mod h1:SgJv3oPqLLHCu0gcL46ejOP3x7/2ry2Jtxu7ta32kp0=
+github.com/luoliwoshang/mquickjs/mquickjs v1.0.5 h1:4Vxy5NzJtBQeyF6ZLJd/oK1KcozlYoEEykKvefcdyFo=
+github.com/luoliwoshang/mquickjs/mquickjs v1.0.5/go.mod h1:Jc8sJQTYvvwCmvQJhyrGvTi+BOBOizCNsFuipcpyAu4=

--- a/internal/crosscompile/compile/mquickjs/mquickjs.go
+++ b/internal/crosscompile/compile/mquickjs/mquickjs.go
@@ -108,10 +108,12 @@ func GenerateHeaders(baseDir string) error {
 
 // mquickjs compile flags for embedded targets
 var _mquickjsCCFlags = []string{
-	"-fdata-sections",
+	"-fno-jump-tables", // Required for ESP32 IRAM/Flash architecture
 	"-ffunction-sections",
+	"-fdata-sections",
 	"-fno-math-errno",
 	"-fno-trapping-math",
+	"-std=gnu17",
 }
 
 var _mquickjsLDFlags = []string{

--- a/internal/crosscompile/compile/mquickjs/mquickjs.go
+++ b/internal/crosscompile/compile/mquickjs/mquickjs.go
@@ -19,18 +19,22 @@ func GetMquickjsConfig() compile.LibConfig {
 	}
 }
 
-// GenerateHeaders generates mquickjs_atom.h and mqjs_stdlib.h by compiling
+// GenerateHeaders generates mquickjs_atom.h and mqjs_stdlib_llgo32.h by compiling
 // the mqjs_stdlib tool for the HOST machine and running it with -m32 flag.
+// It also generates stdlib_export.c to export js_stdlib symbol.
 // This must be called after downloading the mquickjs source and before compiling.
 func GenerateHeaders(baseDir string) error {
 	atomHeader := filepath.Join(baseDir, "mquickjs_atom.h")
-	stdlibHeader := filepath.Join(baseDir, "mqjs_stdlib.h")
+	stdlibHeader := filepath.Join(baseDir, "mqjs_stdlib_llgo32.h")
+	stdlibExport := filepath.Join(baseDir, "stdlib_export.c")
 
-	// Check if headers already exist
+	// Check if all generated files already exist
 	if _, err := os.Stat(atomHeader); err == nil {
 		if _, err := os.Stat(stdlibHeader); err == nil {
-			// Both headers exist, skip generation
-			return nil
+			if _, err := os.Stat(stdlibExport); err == nil {
+				// All files exist, skip generation
+				return nil
+			}
 		}
 	}
 
@@ -52,22 +56,30 @@ func GenerateHeaders(baseDir string) error {
 	// Output binary path (in the same directory)
 	generatorBin := filepath.Join(baseDir, "mqjs_stdlib")
 
-	// Compile the generator tool for HOST machine using system cc
-	// We use "cc" which should work on most systems (maps to gcc/clang)
-	compileArgs := []string{
-		"-o", generatorBin,
-		"-I" + baseDir,
-		"-lm", // link math library
+	// Check if generator binary already exists
+	needCompile := true
+	if _, err := os.Stat(generatorBin); err == nil {
+		needCompile = false
 	}
-	compileArgs = append(compileArgs, generatorSources...)
 
-	fmt.Fprintf(os.Stderr, "  Compiling mqjs_stdlib tool...\n")
-	cmd := exec.Command("cc", compileArgs...)
-	cmd.Dir = baseDir
-	cmd.Stdout = os.Stderr
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to compile mqjs_stdlib generator: %w", err)
+	if needCompile {
+		// Compile the generator tool for HOST machine using system cc
+		// We use "cc" which should work on most systems (maps to gcc/clang)
+		compileArgs := []string{
+			"-o", generatorBin,
+			"-I" + baseDir,
+			"-lm", // link math library
+		}
+		compileArgs = append(compileArgs, generatorSources...)
+
+		fmt.Fprintf(os.Stderr, "  Compiling mqjs_stdlib tool...\n")
+		cmd := exec.Command("cc", compileArgs...)
+		cmd.Dir = baseDir
+		cmd.Stdout = os.Stderr
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("failed to compile mqjs_stdlib generator: %w", err)
+		}
 	}
 
 	// Generate mquickjs_atom.h with -m32 -a flags
@@ -78,7 +90,7 @@ func GenerateHeaders(baseDir string) error {
 	}
 	defer atomFile.Close()
 
-	cmd = exec.Command(generatorBin, "-m32", "-a")
+	cmd := exec.Command(generatorBin, "-m32", "-a")
 	cmd.Dir = baseDir
 	cmd.Stdout = atomFile
 	cmd.Stderr = os.Stderr
@@ -86,11 +98,11 @@ func GenerateHeaders(baseDir string) error {
 		return fmt.Errorf("failed to generate mquickjs_atom.h: %w", err)
 	}
 
-	// Generate mqjs_stdlib.h with -m32 flag
-	fmt.Fprintf(os.Stderr, "  Generating mqjs_stdlib.h...\n")
+	// Generate mqjs_stdlib_llgo32.h with -m32 flag
+	fmt.Fprintf(os.Stderr, "  Generating mqjs_stdlib_llgo32.h...\n")
 	stdlibFile, err := os.Create(stdlibHeader)
 	if err != nil {
-		return fmt.Errorf("failed to create mqjs_stdlib.h: %w", err)
+		return fmt.Errorf("failed to create mqjs_stdlib_llgo32.h: %w", err)
 	}
 	defer stdlibFile.Close()
 
@@ -99,7 +111,90 @@ func GenerateHeaders(baseDir string) error {
 	cmd.Stdout = stdlibFile
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to generate mqjs_stdlib.h: %w", err)
+		return fmt.Errorf("failed to generate mqjs_stdlib_llgo32.h: %w", err)
+	}
+
+	// Generate stdlib_export.c to export js_stdlib symbol
+	fmt.Fprintf(os.Stderr, "  Generating stdlib_export.c...\n")
+	exportContent := `// Auto-generated file to export js_stdlib symbol for embedded use
+#include <stddef.h>
+#include <stdint.h>
+#include <math.h>
+#include "mquickjs.h"
+
+// __fpclassifyd implementation for embedded platforms
+// This function classifies a double-precision floating point number
+// Required by mquickjs for isnan/isinf/isfinite macros
+int __fpclassifyd(double a) {
+    union { double d; uint64_t u; } u;
+    u.d = a;
+    uint32_t h = u.u >> 32;
+    uint32_t l = (uint32_t)u.u;
+
+    h &= 0x7fffffff;
+    if (h >= 0x7ff00000) {
+        if (h == 0x7ff00000 && l == 0)
+            return FP_INFINITE;
+        else
+            return FP_NAN;
+    } else if (h < 0x00100000) {
+        if (h == 0 && l == 0)
+            return FP_ZERO;
+        else
+            return FP_SUBNORMAL;
+    } else {
+        return FP_NORMAL;
+    }
+}
+
+// Stub implementations for platform-specific functions
+// Users should provide their own implementations using __attribute__((weak))
+__attribute__((weak))
+JSValue js_print(JSContext *ctx, JSValue *this_val, int argc, JSValue *argv) {
+    (void)ctx; (void)this_val; (void)argc; (void)argv;
+    return JS_UNDEFINED;
+}
+
+__attribute__((weak))
+JSValue js_gc(JSContext *ctx, JSValue *this_val, int argc, JSValue *argv) {
+    (void)ctx; (void)this_val; (void)argc; (void)argv;
+    return JS_UNDEFINED;
+}
+
+__attribute__((weak))
+JSValue js_load(JSContext *ctx, JSValue *this_val, int argc, JSValue *argv) {
+    (void)ctx; (void)this_val; (void)argc; (void)argv;
+    return JS_UNDEFINED;
+}
+
+__attribute__((weak))
+JSValue js_setTimeout(JSContext *ctx, JSValue *this_val, int argc, JSValue *argv) {
+    (void)ctx; (void)this_val; (void)argc; (void)argv;
+    return JS_UNDEFINED;
+}
+
+__attribute__((weak))
+JSValue js_clearTimeout(JSContext *ctx, JSValue *this_val, int argc, JSValue *argv) {
+    (void)ctx; (void)this_val; (void)argc; (void)argv;
+    return JS_UNDEFINED;
+}
+
+__attribute__((weak))
+JSValue js_date_now(JSContext *ctx, JSValue *this_val, int argc, JSValue *argv) {
+    (void)ctx; (void)this_val; (void)argc; (void)argv;
+    return JS_NewInt32(ctx, 0); // Returns 0 as timestamp
+}
+
+__attribute__((weak))
+JSValue js_performance_now(JSContext *ctx, JSValue *this_val, int argc, JSValue *argv) {
+    (void)ctx; (void)this_val; (void)argc; (void)argv;
+    return JS_NewFloat64(ctx, 0.0); // Returns 0 as timestamp
+}
+
+#include "mqjs_stdlib_llgo32.h"
+`
+	if err := os.WriteFile(stdlibExport, []byte(exportContent), 0644); err != nil {
+		return fmt.Errorf("failed to create stdlib_export.c: %w", err)
 	}
 
 	fmt.Fprintln(os.Stderr, "  Headers generated successfully.")
@@ -134,6 +229,7 @@ func GetMquickjsCompileConfig(baseDir, target string) compile.CompileConfig {
 					filepath.Join(baseDir, "cutils.c"),
 					filepath.Join(baseDir, "dtoa.c"),
 					filepath.Join(baseDir, "libm.c"),
+					filepath.Join(baseDir, "stdlib_export.c"), // exports js_stdlib symbol
 				},
 				CFlags: []string{
 					"-DCONFIG_VERSION=\"1.0.0\"",

--- a/internal/crosscompile/compile/mquickjs/mquickjs.go
+++ b/internal/crosscompile/compile/mquickjs/mquickjs.go
@@ -1,0 +1,58 @@
+package mquickjs
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/goplus/llgo/internal/crosscompile/compile"
+)
+
+// GetMquickjsConfig returns the configuration for downloading mquickjs
+func GetMquickjsConfig() compile.LibConfig {
+	return compile.LibConfig{
+		Name:           "mquickjs",
+		Version:        "v1.0.0",
+		Url:            "https://github.com/luoliwoshang/mquickjs/archive/refs/tags/v1.0.0.tar.gz",
+		ResourceSubDir: "mquickjs-1.0.0",
+	}
+}
+
+// mquickjs compile flags for embedded targets
+var _mquickjsCCFlags = []string{
+	"-fdata-sections",
+	"-ffunction-sections",
+	"-fno-math-errno",
+	"-fno-trapping-math",
+}
+
+var _mquickjsLDFlags = []string{
+	"-Wl,--gc-sections",
+}
+
+// GetMquickjsCompileConfig returns configuration for compiling mquickjs
+func GetMquickjsCompileConfig(baseDir, target string) compile.CompileConfig {
+	return compile.CompileConfig{
+		ExportCFlags: []string{
+			"-I" + baseDir,
+		},
+		Groups: []compile.CompileGroup{
+			{
+				OutputFileName: fmt.Sprintf("libmquickjs-%s.a", target),
+				Files: []string{
+					filepath.Join(baseDir, "mquickjs.c"),
+					filepath.Join(baseDir, "cutils.c"),
+					filepath.Join(baseDir, "dtoa.c"),
+					filepath.Join(baseDir, "libm.c"),
+				},
+				CFlags: []string{
+					"-DCONFIG_VERSION=\"1.0.0\"",
+					"-D_GNU_SOURCE",
+					"-nostdlib",
+					"-I" + baseDir,
+				},
+				CCFlags: _mquickjsCCFlags,
+				LDFlags: _mquickjsLDFlags,
+			},
+		},
+	}
+}

--- a/internal/crosscompile/compile/mquickjs/mquickjs.go
+++ b/internal/crosscompile/compile/mquickjs/mquickjs.go
@@ -2,6 +2,8 @@ package mquickjs
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/goplus/llgo/internal/crosscompile/compile"
@@ -15,6 +17,93 @@ func GetMquickjsConfig() compile.LibConfig {
 		Url:            "https://github.com/luoliwoshang/mquickjs/archive/refs/tags/v1.0.0.tar.gz",
 		ResourceSubDir: "mquickjs-1.0.0",
 	}
+}
+
+// GenerateHeaders generates mquickjs_atom.h and mqjs_stdlib.h by compiling
+// the mqjs_stdlib tool for the HOST machine and running it with -m32 flag.
+// This must be called after downloading the mquickjs source and before compiling.
+func GenerateHeaders(baseDir string) error {
+	atomHeader := filepath.Join(baseDir, "mquickjs_atom.h")
+	stdlibHeader := filepath.Join(baseDir, "mqjs_stdlib.h")
+
+	// Check if headers already exist
+	if _, err := os.Stat(atomHeader); err == nil {
+		if _, err := os.Stat(stdlibHeader); err == nil {
+			// Both headers exist, skip generation
+			return nil
+		}
+	}
+
+	fmt.Fprintln(os.Stderr, "Generating mquickjs headers...")
+
+	// Source files needed for the generator tool
+	generatorSources := []string{
+		filepath.Join(baseDir, "mqjs_stdlib.c"),
+		filepath.Join(baseDir, "mquickjs_build.c"),
+	}
+
+	// Check if source files exist
+	for _, src := range generatorSources {
+		if _, err := os.Stat(src); err != nil {
+			return fmt.Errorf("mquickjs generator source file not found: %s", src)
+		}
+	}
+
+	// Output binary path (in the same directory)
+	generatorBin := filepath.Join(baseDir, "mqjs_stdlib")
+
+	// Compile the generator tool for HOST machine using system cc
+	// We use "cc" which should work on most systems (maps to gcc/clang)
+	compileArgs := []string{
+		"-o", generatorBin,
+		"-I" + baseDir,
+		"-lm", // link math library
+	}
+	compileArgs = append(compileArgs, generatorSources...)
+
+	fmt.Fprintf(os.Stderr, "  Compiling mqjs_stdlib tool...\n")
+	cmd := exec.Command("cc", compileArgs...)
+	cmd.Dir = baseDir
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to compile mqjs_stdlib generator: %w", err)
+	}
+
+	// Generate mquickjs_atom.h with -m32 -a flags
+	fmt.Fprintf(os.Stderr, "  Generating mquickjs_atom.h...\n")
+	atomFile, err := os.Create(atomHeader)
+	if err != nil {
+		return fmt.Errorf("failed to create mquickjs_atom.h: %w", err)
+	}
+	defer atomFile.Close()
+
+	cmd = exec.Command(generatorBin, "-m32", "-a")
+	cmd.Dir = baseDir
+	cmd.Stdout = atomFile
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to generate mquickjs_atom.h: %w", err)
+	}
+
+	// Generate mqjs_stdlib.h with -m32 flag
+	fmt.Fprintf(os.Stderr, "  Generating mqjs_stdlib.h...\n")
+	stdlibFile, err := os.Create(stdlibHeader)
+	if err != nil {
+		return fmt.Errorf("failed to create mqjs_stdlib.h: %w", err)
+	}
+	defer stdlibFile.Close()
+
+	cmd = exec.Command(generatorBin, "-m32")
+	cmd.Dir = baseDir
+	cmd.Stdout = stdlibFile
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to generate mqjs_stdlib.h: %w", err)
+	}
+
+	fmt.Fprintln(os.Stderr, "  Headers generated successfully.")
+	return nil
 }
 
 // mquickjs compile flags for embedded targets

--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -644,6 +644,30 @@ func UseTarget(targetName string) (export Export, err error) {
 		ldflags = append(ldflags, rtLibLDFlags...)
 	}
 
+	if config.JSLib != "" {
+		var outputDir string
+		var jslibLDFlags []string
+		var compileConfig compile.CompileConfig
+		baseDir := filepath.Join(cacheRoot(), "crosscompile")
+
+		outputDir, compileConfig, err = getJSLibCompileConfigByName(baseDir, config.JSLib, config.LLVMTarget)
+		if err != nil {
+			return
+		}
+		jslibLDFlags, err = compileWithConfig(compileConfig, outputDir, compile.CompileOptions{
+			CC:      export.CC,
+			Linker:  export.Linker,
+			CCFLAGS: ccflags,
+			LDFLAGS: ldflags,
+			CFLAGS:  libcIncludeDir,
+		})
+		if err != nil {
+			return
+		}
+		cflags = append(cflags, compileConfig.ExportCFlags...)
+		ldflags = append(ldflags, jslibLDFlags...)
+	}
+
 	// Combine with config flags and expand template variables
 	export.CFLAGS = cflags
 	export.CCFLAGS = ccflags

--- a/internal/crosscompile/libc.go
+++ b/internal/crosscompile/libc.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/goplus/llgo/internal/crosscompile/compile"
 	"github.com/goplus/llgo/internal/crosscompile/compile/libc"
+	"github.com/goplus/llgo/internal/crosscompile/compile/mquickjs"
 	"github.com/goplus/llgo/internal/crosscompile/compile/rtlib"
 )
 
@@ -75,4 +76,35 @@ func getRTCompileConfigByName(baseDir, rtName, target string) (outputDir string,
 	}
 
 	return rtDir, compileConfig, nil
+}
+
+// getJSLibCompileConfigByName retrieves JavaScript engine compilation configuration by name
+// Returns the actual jslib output dir, compilation config and err
+func getJSLibCompileConfigByName(baseDir, jslibName, target string) (outputDir string, cfg compile.CompileConfig, err error) {
+	if jslibName == "" {
+		err = fmt.Errorf("jslib name cannot be empty")
+		return
+	}
+	var jslibDir string
+	var config compile.LibConfig
+	var compileConfig compile.CompileConfig
+
+	switch jslibName {
+	case "mquickjs":
+		config = mquickjs.GetMquickjsConfig()
+		jslibDir = filepath.Join(baseDir, config.String())
+		compileConfig = mquickjs.GetMquickjsCompileConfig(jslibDir, target)
+	default:
+		err = fmt.Errorf("unsupported jslib: %s", jslibName)
+		return
+	}
+	if needSkipDownload {
+		return jslibDir, compileConfig, err
+	}
+
+	if err = checkDownloadAndExtractLib(config.Url, jslibDir, config.ResourceSubDir); err != nil {
+		return
+	}
+
+	return jslibDir, compileConfig, nil
 }

--- a/internal/crosscompile/libc.go
+++ b/internal/crosscompile/libc.go
@@ -106,5 +106,12 @@ func getJSLibCompileConfigByName(baseDir, jslibName, target string) (outputDir s
 		return
 	}
 
+	// Generate headers for mquickjs (mquickjs_atom.h and mqjs_stdlib.h)
+	if jslibName == "mquickjs" {
+		if err = mquickjs.GenerateHeaders(jslibDir); err != nil {
+			return
+		}
+	}
+
 	return jslibDir, compileConfig, nil
 }

--- a/internal/targets/config.go
+++ b/internal/targets/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	// Compiler and linker configuration
 	Libc         string   `json:"libc"`
 	RTLib        string   `json:"rtlib"`
+	JSLib        string   `json:"jslib"` // JavaScript engine library (e.g., "mquickjs")
 	Linker       string   `json:"linker"`
 	LinkerScript string   `json:"linkerscript"`
 	CFlags       []string `json:"cflags"`

--- a/internal/targets/loader.go
+++ b/internal/targets/loader.go
@@ -140,6 +140,9 @@ func (l *Loader) mergeConfig(dst, src *Config) {
 	if src.RTLib != "" {
 		dst.RTLib = src.RTLib
 	}
+	if src.JSLib != "" {
+		dst.JSLib = src.JSLib
+	}
 	if src.Linker != "" {
 		dst.Linker = src.Linker
 	}

--- a/targets/esp32.json
+++ b/targets/esp32.json
@@ -14,6 +14,7 @@
 	"default-stack-size": 2048,
 	"rtlib": "compiler-rt",
 	"libc": "newlib-esp32",
+	"jslib": "mquickjs",
 	"linkerscript": "targets/esp32.memory.elf.ld",
 	"extra-files": [],
 	"binary-format": "esp32",


### PR DESCRIPTION
## Summary

- Add support for compiling [mquickjs](https://github.com/luoliwoshang/mquickjs) as an embedded JavaScript engine for bare-metal targets
- Follow the same pattern as libc and rtlib compilation
- Auto-download and cache mquickjs source from GitHub release

## Changes

- Add `internal/crosscompile/compile/mquickjs/mquickjs.go` - mquickjs download and compile configuration
- Add `JSLib` field to `targets.Config` for target configuration
- Add `getJSLibCompileConfigByName()` function for jslib compilation
- Integrate jslib compilation in `UseTarget()`

## Usage

Add `"jslib": "mquickjs"` to target configuration JSON:

```json
{
  "libc": "newlib-esp32",
  "rtlib": "compiler-rt",
  "jslib": "mquickjs"
}
```

## Test plan

- [ ] Test mquickjs compilation for ESP32 target
- [ ] Verify auto-download and caching works correctly
- [ ] Test linking with libc

🤖 Generated with [Claude Code](https://claude.com/claude-code)