### PR TITLE
fix: reuse normalized archives for caching

### DIFF
--- a/internal/build/collect.go
+++ b/internal/build/collect.go
@@ -462,7 +462,7 @@ func (c *context) saveToCache(pkg *aPackage) error {
 			return nil
 		}
 
-		if err := createArchiveFile(paths.Archive, objectFiles); err != nil {
+		if err := c.createArchiveFile(paths.Archive, objectFiles); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Requested by @xgopilot

## Summary
- keep normalized archives alive via a dedicated `aPackage.ArchiveFile` so the linker and cache share the same `.a`
- reuse that archive when saving/loading cache entries to avoid recompiling every package on subsequent builds
- fall back to archiving the raw `.o/.ll` inputs only when an archive hasn’t been produced yet (legacy paths)

## Testing
- go test ./internal/build -run SaveToCache
- go install ./cmd/llgo
- (cd _demo/c/hello && llgo run -v .)
