### PR TITLE
feat: support compiling to object file (.o) for unconditional linking

### DIFF
--- a/internal/crosscompile/compile/libc/newlibesp.go
+++ b/internal/crosscompile/compile/libc/newlibesp.go
@@ -48,6 +48,20 @@ func getNewlibESP32ConfigRISCV(baseDir, target string) compile.CompileConfig {
 	return compile.CompileConfig{
 		ExportCFlags: libcIncludeDir,
 		Groups: []compile.CompileGroup{
+			// libsemihost provides semihosting _exit for QEMU emulator support
+			// Compiled as .o to ensure unconditional linking (overrides weak _exit in syscalls.c)
+			{
+				OutputFileName: fmt.Sprintf("libsemihost-%s.o", target),
+				Files: []string{
+					filepath.Join(baseDir, "libgloss", "riscv", "semihost-sys_exit.c"),
+				},
+				CFlags: []string{
+					"-isystem" + filepath.Join(libcDir, "include"),
+					"-I" + filepath.Join(baseDir, "libgloss", "riscv"),
+				},
+				LDFlags: _libcLDFlags,
+				CCFlags: _libcCCFlags,
+			},
 			{
 				OutputFileName: fmt.Sprintf("libcrt0-%s.a", target),
 				Files: []string{

--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -190,9 +190,12 @@ func compileWithConfig(
 			break
 		}
 		if filepath.Ext(group.OutputFileName) == ".o" {
-			continue
+			// .o files are linked directly (unconditionally)
+			ldflags = append(ldflags, filepath.Join(outputDir, filepath.Base(group.OutputFileName)))
+		} else {
+			// .a files use -l flag (on-demand linking)
+			ldflags = append(ldflags, "-l"+ldFlagsFromFileName(group.OutputFileName))
 		}
-		ldflags = append(ldflags, "-l"+ldFlagsFromFileName(group.OutputFileName))
 	}
 	return
 }


### PR DESCRIPTION
## Summary
- Add support for `CompileGroup` to output `.o` files instead of `.a` archives
- Enable unconditional linking of object files (`.o` files are linked directly, not on-demand like `.a`)
- Add `libsemihost.o` for ESP32-C3 QEMU semihosting support

## Background
Static libraries (`.a`) use on-demand linking - object files are only pulled in when they resolve undefined symbols. This causes issues when a strong symbol needs to override a weak symbol in another library.

For example, `syscalls.c` contains a weak `_exit` that uses `asm("unimp")`, which crashes in QEMU. The semihosting `_exit` from `semihost-sys_exit.c` uses proper semihosting protocol, but when compiled into a `.a`, it won't be linked because the weak `_exit` is already satisfied.

By compiling to `.o` and linking directly, the strong `_exit` is unconditionally included and overrides the weak version.

## Changes
- `compile.go`: Support `.o` output (single file compilation, no `ar` packaging)
- `crosscompile.go`: Link `.o` files directly as path instead of using `-l` flag
- `newlibesp.go`: Add `libsemihost.o` group for ESP32-C3 RISC-V semihosting

## Test plan
- [ ] Build ESP32-C3 target with QEMU emulator
- [ ] Verify `_exit` uses semihosting implementation (not `unimp`)
- [ ] Run existing crosscompile tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)