### PR TITLE
support os.File.WriteString

### DIFF
--- a/_demo/go/oswritestring/main.go
+++ b/_demo/go/oswritestring/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	f, err := os.CreateTemp("", "llgo-writestring-*.txt")
+	if err != nil {
+		panic(err)
+	}
+	defer os.Remove(f.Name())
+
+	const content = "hello writestring"
+	if n, err := f.WriteString(content); err != nil {
+		panic(err)
+	} else if n != len(content) {
+		panic(fmt.Sprintf("WriteString wrote %d bytes, want %d", n, len(content)))
+	}
+
+	if err := f.Close(); err != nil {
+		panic(err)
+	}
+
+	data, err := os.ReadFile(f.Name())
+	if err != nil {
+		panic(err)
+	}
+	if string(data) != content {
+		panic(fmt.Sprintf("content mismatch: got %q, want %q", string(data), content))
+	}
+
+	fmt.Println("ok")
+}

--- a/runtime/internal/lib/os/file.go
+++ b/runtime/internal/lib/os/file.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"syscall"
 	"time"
+	"unsafe"
 )
 
 // Name returns the name of the file as presented to Open.
@@ -201,11 +202,8 @@ func (f *File) Seek(offset int64, whence int) (ret int64, err error) {
 // WriteString is like Write, but writes the contents of string s rather than
 // a slice of bytes.
 func (f *File) WriteString(s string) (n int, err error) {
-	/*
-		b := unsafe.Slice(unsafe.StringData(s), len(s))
-		return f.Write(b)
-	*/
-	panic("todo: os.(*File).WriteString")
+	b := unsafe.Slice(unsafe.StringData(s), len(s))
+	return f.Write(b)
 }
 
 // Open opens the named file for reading. If successful, methods on


### PR DESCRIPTION
## Summary
- implement `os.File.WriteString` by delegating to `Write` with an unsafe string-to-byte conversion
- add a regression demo under `_demo/go/oswritestring` that writes, closes, and verifies file contents

## Details
- mirrors Go stdlib behavior for `WriteString` to avoid extra allocations
- demo checks byte count, closes the file, then validates content via `os.ReadFile`

## Testing
- not run (demo added under `_demo/go/oswritestring`)

## Issue
- Fixes #1409
