### PR TITLE
fix(os): implement File.Seek

### DIFF
--- a/_demo/go/osseek/main.go
+++ b/_demo/go/osseek/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	path := "seek_demo.txt"
+	f, err := os.Create(path)
+	if err != nil {
+		fmt.Println("create:", err)
+		return
+	}
+	defer func() {
+		f.Close()
+		os.Remove(path)
+	}()
+
+	_, err = f.WriteString("hello-llgo")
+	if err != nil {
+		fmt.Println("write:", err)
+		return
+	}
+
+	pos, err := f.Seek(6, 0)
+	if err != nil {
+		fmt.Println("seek:", err)
+		return
+	}
+
+	buf := make([]byte, 4)
+	n, err := f.Read(buf)
+	if err != nil {
+		fmt.Println("read:", err)
+		return
+	}
+
+	fmt.Println("pos:", pos)
+	fmt.Println("read:", string(buf[:n]))
+}

--- a/runtime/internal/lib/os/file.go
+++ b/runtime/internal/lib/os/file.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"syscall"
 	"time"
+	"unsafe"
 )
 
 // Name returns the name of the file as presented to Open.
@@ -182,30 +183,21 @@ func (f *File) WriteAt(b []byte, off int64) (n int, err error) {
 // It returns the new offset and an error, if any.
 // The behavior of Seek on a file opened with O_APPEND is not specified.
 func (f *File) Seek(offset int64, whence int) (ret int64, err error) {
-	/*
-		if err := f.checkValid("seek"); err != nil {
-			return 0, err
-		}
-		r, e := f.seek(offset, whence)
-		if e == nil && f.dirinfo != nil && r != 0 {
-			e = syscall.EISDIR
-		}
-		if e != nil {
-			return 0, f.wrapErr("seek", e)
-		}
-		return r, nil
-	*/
-	panic("todo: os.(*File).Seek")
+	if err := f.checkValid("seek"); err != nil {
+		return 0, err
+	}
+	r, e := syscall.Seek(int(f.fd), offset, whence)
+	if e != nil {
+		return 0, f.wrapErr("seek", e)
+	}
+	return r, nil
 }
 
 // WriteString is like Write, but writes the contents of string s rather than
 // a slice of bytes.
 func (f *File) WriteString(s string) (n int, err error) {
-	/*
-		b := unsafe.Slice(unsafe.StringData(s), len(s))
-		return f.Write(b)
-	*/
-	panic("todo: os.(*File).WriteString")
+	b := unsafe.Slice(unsafe.StringData(s), len(s))
+	return f.Write(b)
 }
 
 // Open opens the named file for reading. If successful, methods on


### PR DESCRIPTION
## Summary
- implement `os.(*File).Seek` by delegating to `syscall.Seek` and wrapping errors
- add a focused demo `_demo/go/osseek` to validate seek + read behavior

## Background
`os.(*File).Seek` was a TODO that panicked at runtime. This blocked any code path that relies on seeking within files. The new demo demonstrates the intended semantics and provides a quick smoke test under llgo.

## Changes
1. `runtime/internal/lib/os/file.go`: implement `Seek` with `checkValid`, `syscall.Seek`, and `wrapErr` for consistent error reporting.
2. `_demo/go/osseek/main.go`: create a file, write `hello-llgo`, seek to offset 6, read 4 bytes, and print the new offset and substring.

## Testing
- `cd _demo/go/osseek && llgo run .`
  - output:
    - `pos: 6`
    - `read: llgo`

## Notes
- No changes to append-mode semantics beyond existing Go behavior.