### PR TITLE
runtime: align pointer print formatting

### DIFF
--- a/runtime/internal/runtime/z_print.go
+++ b/runtime/internal/runtime/z_print.go
@@ -70,7 +70,9 @@ func PrintHex(v uint64) {
 }
 
 func PrintPointer(p unsafe.Pointer) {
-	c.Fprintf(c.Stderr, c.Str("%p"), p)
+	// Match Go's builtin print/println pointer formatting (0x... even for nil).
+	c.Fprintf(c.Stderr, c.Str("0x"))
+	c.Fprintf(c.Stderr, printFormatPrefixHex, uintptr(p))
 }
 
 func PrintString(s String) {


### PR DESCRIPTION
Fixed https://github.com/goplus/llgo/issues/1557

## Summary
- On Linux, using %p directly formats nil as "nil"; to align with Go, always emit "0x" prefix plus hex digits so nil becomes 0x0.

## Validation
- Confirmed in https://github.com/goplus/llgo/pull/1545 outputs:
  - TestRunFromTestgo / invoke
  - TestRunFromTestgo / reader
  - TestRunFromTestgo / struczero
  - TestRunFromTestrt / tpmethod
