### PR TITLE
feat: enable icf to reduce binary size

### DIFF
--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -224,6 +224,9 @@ func use(goos, goarch string, wasiThreads, forceEspClang bool) (export Export, e
 			"-Wno-unused-command-line-argument",
 			"-Wl,--error-limit=0",
 			"-fuse-ld=lld",
+			// Enable ICF (Identical Code Folding) to reduce binary size
+			"-Xlinker",
+			"--icf=safe",
 		}
 		if clangRoot != "" {
 			clangLib := filepath.Join(clangRoot, "lib")
@@ -280,7 +283,6 @@ func use(goos, goarch string, wasiThreads, forceEspClang bool) (export Export, e
 				"-ffunction-sections",
 				"-Xlinker",
 				"--gc-sections",
-				"-lm",
 				"-latomic",
 				// libpthread & libdl is built-in since glibc 2.34 (2021-08-01); we need to support earlier versions.
 				"-lpthread",
@@ -485,7 +487,8 @@ func UseTarget(targetName string) (export Export, err error) {
 	envs := buildEnvMap(env.LLGoROOT())
 
 	// Convert LLVMTarget, CPU, Features to CCFLAGS/LDFLAGS
-	ldflags := []string{"-S"}
+	// Enable ICF (Identical Code Folding) to reduce binary size
+	ldflags := []string{"-S", "--icf=safe"}
 	ccflags := []string{"-Oz"}
 	cflags := []string{"-Wno-override-module", "-Qunused-arguments", "-Wno-unused-command-line-argument"}
 	if config.LLVMTarget != "" {


### PR DESCRIPTION
Try to enable icf option for lld.

Using icf, address-insensitive symbols with the same content can be folded into one.

The "hello world" case on linux-amd64:
|     |   code | rodata  |  data  |   bss |   flash  |   ram |
|-----|----------|----------|----------- | ------|--------- | ----------------|
|  no icf |1193686  | 41199 | 153040  | 27499 | 1387925 | 180539 |
| icf |1193686  | 39286 | 153040 |  27499 | 1386012 | 180539 |
|diff |   -|-1913|-|-|-1319|-|

Case "llgo/_demo/embed/esp32/rt/main.go" on esp32:
|   |   code | rodata  |  data  |   bss |   flash  |   ram |
|-----|----------|----------|----------- | ------|--------- | ----------------|
| no icf  |  31031  |  3553 |    276 |    876 |   34860  |  1152 |
| icf |  30823 |   3545  |   276  |   876 |   34644 |   1152 | 
|diff |   -208|-8|-|-|-216|-|