### PR TITLE
refactor: remove init$patchDeps mechanism (no longer needed after PR #1450)

### DIFF
--- a/cl/compile.go
+++ b/cl/compile.go
@@ -484,12 +484,6 @@ func (p *context) compileBlock(b llssa.Builder, block *ssa.BasicBlock, n int, do
 		p.debugParams(b, block.Parent())
 	}
 
-	// Handle init$hasPatch: split dependency init calls into separate function
-	if doModInit && p.state == pkgHasPatch {
-		baseName := strings.TrimSuffix(p.fn.Name(), "$hasPatch")
-		instrs = p.createInitDepsFunction(pkg, baseName, instrs)
-	}
-
 	if doModInit {
 		if pyModInit = p.pyMod != ""; pyModInit {
 			last = len(instrs) - 1
@@ -508,15 +502,7 @@ func (p *context) compileBlock(b llssa.Builder, block *ssa.BasicBlock, n int, do
 	isCgoCmacro := isCgoCmacro(fnName)
 	for i, instr := range instrs {
 		if i == 1 && doModInit && p.state == pkgInPatch { // in patch package but no pkgFNoOldInit
-			name := p.fn.Name()
-			initFnNameOld := initFnNameOfHasPatch(name)
-			initPatchDepsFnName := initDepsFnNameOfHasPatch(name)
-
-			// Call deps function first
-			fnDeps := pkg.NewFunc(initPatchDepsFnName, llssa.NoArgsNoRet, llssa.InC)
-			b.Call(fnDeps.Expr)
-
-			// Then call hasPatch (global vars)
+			initFnNameOld := initFnNameOfHasPatch(p.fn.Name())
 			fnOld := pkg.NewFunc(initFnNameOld, llssa.NoArgsNoRet, llssa.InC)
 			b.Call(fnOld.Expr)
 		}
@@ -1172,79 +1158,6 @@ func NewPackageEx(prog llssa.Program, patches Patches, rewrites map[string]strin
 
 func initFnNameOfHasPatch(name string) string {
 	return name + "$hasPatch"
-}
-
-func initDepsFnNameOfHasPatch(name string) string {
-	return name + "$patchDeps"
-}
-
-// findFirstNonInitInstruction finds the index of the first non-init instruction
-// in the given instructions. Returns -1 if all instructions are init calls.
-// Skips non-call instructions (like store for guard).
-func findFirstNonInitInstruction(instrs []ssa.Instruction) int {
-	for i, instr := range instrs {
-		call, ok := instr.(*ssa.Call)
-		if !ok {
-			// Skip non-call instructions (like guard store)
-			continue
-		}
-		fn, ok := call.Call.Value.(*ssa.Function)
-		if !ok {
-			// Not a direct function call
-			return i
-		}
-		if fn.Name() == "init" && fn.Signature.Recv() == nil {
-			// This is an init call, continue looking
-			continue
-		}
-		// Found a non-init call
-		return i
-	}
-	return -1
-}
-
-// createInitDepsFunction creates and fills the init$patchDeps function
-// for the given init function, extracting dependency init calls from instrs.
-// Returns the remaining instructions after removing dependency inits.
-func (p *context) createInitDepsFunction(pkg llssa.Package, baseName string, instrs []ssa.Instruction) []ssa.Instruction {
-	// Create deps function
-	depsName := initDepsFnNameOfHasPatch(baseName)
-	depsFn := pkg.NewFunc(depsName, llssa.NoArgsNoRet, llssa.InC)
-	depsFn.MakeBlocks(1)
-	depsBuilder := depsFn.NewBuilder()
-	depsBuilder.SetBlock(depsFn.Block(0))
-
-	// Find and split dependency init calls
-	firstNonInit := findFirstNonInitInstruction(instrs)
-	var depsInstrs []ssa.Instruction
-	if firstNonInit > 0 {
-		depsInstrs = instrs[:firstNonInit]
-		instrs = instrs[firstNonInit:]
-
-		// Fill deps function body with dependency init calls
-		for _, instr := range depsInstrs {
-			if call, ok := instr.(*ssa.Call); ok {
-				if fn, ok := call.Call.Value.(*ssa.Function); ok {
-					if fn.Name() == "init" && fn.Signature.Recv() == nil {
-						// Skip packages that don't need init (like unsafe)
-						if p.pkgNoInit(fn.Pkg.Pkg) {
-							continue
-						}
-						// This is a dependency init call
-						// Use funcName to get the correct function name (handles patches, linkname, etc.)
-						_, depInitName, ftype := p.funcName(fn)
-						if ftype == goFunc {
-							depInitFn := pkg.NewFunc(depInitName, llssa.NoArgsNoRet, llssa.InC)
-							depsBuilder.Call(depInitFn.Expr)
-						}
-					}
-				}
-			}
-		}
-	}
-	depsBuilder.Return()
-
-	return instrs
 }
 
 func processPkg(ctx *context, ret llssa.Package, pkg *ssa.Package) {

--- a/ssa/stmt_builder.go
+++ b/ssa/stmt_builder.go
@@ -151,8 +151,8 @@ func notInit(instr llvm.Value) bool {
 		if n := instr.OperandsCount(); n == 1 {
 			fn := instr.Operand(0)
 			name := fn.Name()
-			// Skip .init and .init$patchDeps calls
-			return !strings.HasSuffix(name, ".init") && !strings.HasSuffix(name, ".init$patchDeps")
+			// Skip .init calls
+			return !strings.HasSuffix(name, ".init")
 		}
 	}
 	return true


### PR DESCRIPTION
## Summary

Since PR #1450 changed ABI types to compile-time constant data, the `init$after` lazy loading mechanism no longer exists. This means the initialization order issue that PR #1414 fixed is no longer possible.

### Before PR #1450
- Types were initialized at runtime via `init$after` with lazy loading (check null → create)
- Cross-package initialization order could cause types to be skipped
- Required `init$patchDeps` to ensure correct initialization order

### After PR #1450
- Types are compile-time constants embedded directly in LLVM IR
- No runtime initialization, no lazy loading, no order issues
- `init$patchDeps` mechanism is no longer needed

## LLVM IR Changes

### Before (with `init$patchDeps`)

```llvm
define void @"go/build.init"() {
_llgo_1:
  store i1 true, ptr @"go/build.init$guard", align 1
  call void @"go/build.init$patchDeps"()    ; Separate function for dependency inits
  call void @"go/build.init$hasPatch"()     ; Only global var initialization
  ...
}

define void @"go/build.init$patchDeps"() {
  call void @"bufio.init"()
  call void @"bytes.init"()
  ; ... more dependency inits
  ret void
}

define void @"go/build.init$hasPatch"() {
  ; Only global variable initialization (guard check with inverted branches)
}
```

### After (simplified)

```llvm
define void @"go/build.init"() {
_llgo_1:
  store i1 true, ptr @"go/build.init$guard", align 1
  call void @"go/build.init$hasPatch"()     ; Contains BOTH dependency inits AND global vars
  ...
}

; No more init$patchDeps function!

define void @"go/build.init$hasPatch"() {
  ; Dependency init calls stay here (not extracted):
  call void @"bufio.init"()
  call void @"bytes.init"()
  ; ... more dependency inits
  ; Global variable initialization
}
```

### Diff

```diff
 define void @"go/build.init"() {
   store i1 true, ptr @"go/build.init$guard", align 1
-  call void @"go/build.init$patchDeps"()
   call void @"go/build.init$hasPatch"()
 }

-define void @"go/build.init$patchDeps"() {
-  call void @"bufio.init"()
-  call void @"bytes.init"()
-  ; ...
-  ret void
-}

 define void @"go/build.init$hasPatch"() {
+  call void @"bufio.init"()      ; dependency inits now stay here
+  call void @"bytes.init"()
+  ; ...
   ; global variable initialization
 }
```

## Code Changes

This PR removes:
- `init$patchDeps` function generation
- `initDepsFnNameOfHasPatch()` helper
- `findFirstNonInitInstruction()` helper
- `createInitDepsFunction()` method
- Related `.init$patchDeps` handling in `notInit()`

## Related PRs
- #1450 - ssa: abi type global constant data
- #1414 - Fix: Correct initialization order for overlay packages (this PR reverts it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)