### PR TITLE
build: use LLVM memcpyopt pass to replace cabi load/store optimization

### DIFF
--- a/internal/llgen/llgenf.go
+++ b/internal/llgen/llgenf.go
@@ -45,9 +45,8 @@ func genFrom(pkgPath string, abiMode build.AbiMode) (build.Package, error) {
 	}()
 
 	conf := &build.Config{
-		Mode:           build.ModeGen,
-		AbiMode:        abiMode,
-		SkipTargetInfo: true,
+		Mode:    build.ModeGen,
+		AbiMode: abiMode,
 	}
 	pkgs, err := build.Do([]string{pkgPath}, conf)
 	if err != nil {

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -1188,6 +1188,45 @@ attributes #0 = { returns_twice }
 `)
 }
 
+func TestTargetMachineAndDataLayout(t *testing.T) {
+	tests := []struct {
+		goos       string
+		goarch     string
+		dataLayout string
+		triple     string
+	}{
+		{"linux", "amd64", "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128", "x86_64-unknown-linux"},
+		{"linux", "arm64", "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32", "aarch64-unknown-linux"},
+		{"darwin", "amd64", "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128", "x86_64-apple-macosx"},
+		{"darwin", "arm64", "e-m:o-i64:64-i128:128-n32:64-S128-Fn32", "arm64-apple-macosx"},
+	}
+	for _, tt := range tests {
+		prog := NewProgram(&Target{GOOS: tt.goos, GOARCH: tt.goarch})
+
+		// Test TargetMachine() returns a valid target machine
+		tm := prog.TargetMachine()
+		if tm.C == nil {
+			t.Fatalf("%s/%s TargetMachine() returned nil", tt.goos, tt.goarch)
+		}
+
+		// Test TargetData() returns a valid target data
+		td := prog.TargetData()
+		if td.C == nil {
+			t.Fatalf("%s/%s TargetData() returned nil", tt.goos, tt.goarch)
+		}
+
+		// Test DataLayout() returns the expected data layout string
+		if dl := prog.DataLayout(); dl != tt.dataLayout {
+			t.Fatalf("%s/%s DataLayout mismatch: got %q, want %q", tt.goos, tt.goarch, dl, tt.dataLayout)
+		}
+
+		// Test Target().Spec().Triple returns the expected triple
+		if triple := prog.Target().Spec().Triple; triple != tt.triple {
+			t.Fatalf("%s/%s Triple mismatch: got %q, want %q", tt.goos, tt.goarch, triple, tt.triple)
+		}
+	}
+}
+
 func TestAbiTables(t *testing.T) {
 	prog := NewProgram(nil)
 	prog.sizes = types.SizesFor("gc", runtime.GOARCH)

--- a/ssa/target.go
+++ b/ssa/target.go
@@ -31,36 +31,6 @@ type Target struct {
 	Target string // target name from -target flag (e.g., "esp32", "arm7tdmi", "wasi")
 }
 
-// CtxRegister describes the closure context register for a target architecture.
-// Requirements for a ctx register:
-//  1. Must survive the call boundary long enough for the callee to read it.
-//  2. Not used for C ABI parameters/returns.
-//  3. Must be usable in LLVM inline asm constraints.
-//
-// Supported platforms:
-//   - amd64: MM0 - MMX register, x87 disabled via -mno-80387
-//   - 386:   MM0 - MMX register, x87 disabled via -mfpmath=sse -msse2 -mno-80387
-//   - arm64: X26 - callee-saved, reservable via +reserve-x26
-//   - riscv64/riscv32: X27 (s11) - callee-saved register
-//
-// Platforms without a ctx register:
-//   - arm: r8-r15 are "high registers", LLVM can't use {rN} constraint in ARM mode
-//   - wasm: no registers available
-type CtxRegister struct {
-	Name       string // LLVM register name for inline asm, e.g., "r12", "x26"
-	Constraint string // LLVM inline asm constraint, e.g., "{r12}", "{x26}"
-}
-
-// CtxRegister returns the closure context register for the target architecture.
-func (t *Target) CtxRegister() CtxRegister {
-	goarch := t.GOARCH
-	if goarch == "" {
-		goarch = runtime.GOARCH
-	}
-	info := ctxreg.Get(goarch)
-	return CtxRegister{Name: info.Name, Constraint: info.Constraint}
-}
-
 func (p *Target) targetInfo() (llvm.TargetData, llvm.TargetMachine) {
 	spec := p.Spec()
 	if spec.Triple == "" {


### PR DESCRIPTION
Fixed https://github.com/goplus/llgo/issues/1604 https://github.com/goplus/llgo/issues/1606 https://github.com/goplus/llgo/issues/1608
## Summary

Use LLVM's built-in `memcpyopt` pass to replace the manual load/store optimization in cabi. This pass handles the same optimization more safely and robustly.

## Changes

- **ssa/target.go**: Add `targetInfo()` to return both `TargetData` and `TargetMachine`
- **ssa/package.go**: 
  - Store `TargetMachine` in Program struct
  - Add `TargetMachine()` and `DataLayout()` methods
- **internal/build/build.go**: 
  - Set data layout and target triple before running LLVM passes
  - Run `memcpyopt` pass after IR generation

## Example

For returning large structs, this pass achieves the same optimization as the cabi code, converting load/store patterns to memcpy:

```llvm
define void @command-line-arguments.returnStruct(ptr sret(%command-line-arguments.T) %0) {
_llgo_0:
  %1 = alloca %command-line-arguments.T, align 8
  call void @llvm.memset(ptr %1, i8 0, i64 24, i1 false)
  %2 = getelementptr inbounds %command-line-arguments.T, ptr %1, i32 0, i32 0
  %3 = getelementptr inbounds %command-line-arguments.T, ptr %1, i32 0, i32 1
  store i64 1, ptr %2, align 8
  store i64 2, ptr %3, align 8
  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %0, ptr align 8 %1, i64 24, i1 false)
  ret void
}
```

## Why use memcpyopt?

1. **Safer**: LLVM's pass handles alias analysis and memory overlap detection automatically
2. **More robust**: Handles more edge cases than manual implementation
3. **Maintained**: Benefits from LLVM's ongoing improvements

## Background

LLVM's `memcpyopt` pass (Memory Copy Optimization) is enabled at `-O1` and above. It recognizes patterns like:

```llvm
%val = load { i64, i64, i64 }, ptr %src
store { i64, i64, i64 } %val, ptr %dst
```

And converts them to:

```llvm
call void @llvm.memcpy.p0.p0.i64(ptr %dst, ptr %src, i64 24, i1 false)
```

Fixes #1605