### PR TITLE
[wip] esp32c3 println path + linker map output

### DIFF
--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -42,6 +42,7 @@ var SizeFormat string
 var SizeLevel string
 var ForceRebuild bool
 var PrintCommands bool
+var LinkMapFile string
 
 const DefaultTestTimeout = "10m" // Matches Go's default test timeout
 
@@ -52,6 +53,7 @@ func AddCommonFlags(fs *flag.FlagSet) {
 func AddBuildFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&ForceRebuild, "a", false, "Force rebuilding of packages that are already up-to-date")
 	fs.BoolVar(&PrintCommands, "x", false, "Print the commands")
+	fs.StringVar(&LinkMapFile, "map", "", "Write linker map file to path (or use 'auto' for <output>.map)")
 	fs.StringVar(&Tags, "tags", "", "Build tags")
 	fs.StringVar(&BuildEnv, "buildenv", "", "Build environment")
 	if buildenv.Dev {
@@ -181,6 +183,7 @@ func UpdateConfig(conf *build.Config) error {
 	conf.Port = Port
 	conf.BaudRate = BaudRate
 	conf.ForceRebuild = ForceRebuild
+	conf.LinkMapFile = LinkMapFile
 	if SizeReport || SizeFormat != "" || SizeLevel != "" {
 		conf.SizeReport = true
 		if SizeFormat != "" {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -136,6 +136,7 @@ type Config struct {
 	ForceEspClang bool // force to use esp-clang
 	ForceRebuild  bool // force rebuilding of packages that are already up-to-date
 	Tags          string
+	LinkMapFile   string // Linker map output path; use "auto" for <output>.map
 	SizeReport    bool   // print size report after successful build
 	SizeFormat    string // size report format: text,json (default text)
 	SizeLevel     string // size aggregation level: full,module,package (default module)
@@ -987,6 +988,12 @@ func linkObjFiles(ctx *context, app string, objFiles, linkArgs []string, verbose
 
 	buildArgs := []string{"-o", app}
 	buildArgs = append(buildArgs, linkArgs...)
+	if mapFile, mapArgs := ctx.resolveLinkMapArgs(app); len(mapArgs) > 0 {
+		buildArgs = append(buildArgs, mapArgs...)
+		if printCmds {
+			fmt.Fprintf(os.Stderr, "Link map: %s\n", mapFile)
+		}
+	}
 
 	// Add build mode specific linker arguments
 	switch ctx.buildConf.BuildMode {
@@ -1026,6 +1033,42 @@ func linkObjFiles(ctx *context, app string, objFiles, linkArgs []string, verbose
 	cmd := ctx.linker()
 	cmd.Verbose = printCmds
 	return cmd.Link(buildArgs...)
+}
+
+func (c *context) resolveLinkMapArgs(outputPath string) (string, []string) {
+	mapFile := strings.TrimSpace(c.buildConf.LinkMapFile)
+	if mapFile == "" {
+		return "", nil
+	}
+	if mapFile == "auto" {
+		ext := filepath.Ext(outputPath)
+		if ext != "" {
+			mapFile = strings.TrimSuffix(outputPath, ext) + ".map"
+		} else {
+			mapFile = outputPath + ".map"
+		}
+	}
+	if useCompilerDriverMapFlags(c.crossCompile.Linker, c.crossCompile.CC) {
+		return mapFile, []string{"-Xlinker", "-Map=" + mapFile}
+	}
+	return mapFile, []string{"-Map=" + mapFile}
+}
+
+func useCompilerDriverMapFlags(linker, cc string) bool {
+	tool := linker
+	if tool == "" {
+		tool = cc
+	}
+	if tool == "" {
+		// Default tool is clang when nothing is specified.
+		return true
+	}
+	base := strings.ToLower(filepath.Base(tool))
+	return strings.Contains(base, "clang") ||
+		strings.Contains(base, "gcc") ||
+		base == "cc" ||
+		base == "c++" ||
+		strings.HasSuffix(base, "g++")
 }
 
 // archiver returns the archiving tool to use for the current context.

--- a/internal/build/link_map_test.go
+++ b/internal/build/link_map_test.go
@@ -1,0 +1,110 @@
+package build
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/goplus/llgo/internal/crosscompile"
+)
+
+func TestUseCompilerDriverMapFlags(t *testing.T) {
+	tests := []struct {
+		name   string
+		linker string
+		cc     string
+		want   bool
+	}{
+		{name: "empty defaults to clang", linker: "", cc: "", want: true},
+		{name: "clang linker", linker: "clang++", cc: "", want: true},
+		{name: "gcc linker", linker: "riscv32-unknown-elf-gcc", cc: "", want: true},
+		{name: "cc linker", linker: "cc", cc: "", want: true},
+		{name: "ld lld linker", linker: "ld.lld", cc: "", want: false},
+		{name: "wasm ld linker", linker: "wasm-ld", cc: "", want: false},
+		{name: "derive from cc", linker: "", cc: "clang++", want: true},
+		{name: "derive ld from cc", linker: "", cc: "ld.lld", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := useCompilerDriverMapFlags(tt.linker, tt.cc)
+			if got != tt.want {
+				t.Fatalf("useCompilerDriverMapFlags(%q, %q) = %v, want %v", tt.linker, tt.cc, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveLinkMapArgs(t *testing.T) {
+	tests := []struct {
+		name       string
+		outputPath string
+		linkMap    string
+		linker     string
+		cc         string
+		wantFile   string
+		wantArgs   []string
+	}{
+		{
+			name:       "disabled when empty",
+			outputPath: "/tmp/app.elf",
+			linkMap:    "",
+			linker:     "ld.lld",
+			wantFile:   "",
+			wantArgs:   nil,
+		},
+		{
+			name:       "explicit file with linker backend",
+			outputPath: "/tmp/app.elf",
+			linkMap:    "debug.map",
+			linker:     "ld.lld",
+			wantFile:   "debug.map",
+			wantArgs:   []string{"-Map=debug.map"},
+		},
+		{
+			name:       "explicit file with compiler driver",
+			outputPath: "/tmp/app.elf",
+			linkMap:    "debug.map",
+			linker:     "",
+			cc:         "clang++",
+			wantFile:   "debug.map",
+			wantArgs:   []string{"-Xlinker", "-Map=debug.map"},
+		},
+		{
+			name:       "auto from output extension",
+			outputPath: "/tmp/app.elf",
+			linkMap:    "auto",
+			linker:     "ld.lld",
+			wantFile:   "/tmp/app.map",
+			wantArgs:   []string{"-Map=/tmp/app.map"},
+		},
+		{
+			name:       "auto without output extension",
+			outputPath: "/tmp/app",
+			linkMap:    "auto",
+			linker:     "ld.lld",
+			wantFile:   "/tmp/app.map",
+			wantArgs:   []string{"-Map=/tmp/app.map"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &context{
+				buildConf: &Config{
+					LinkMapFile: tt.linkMap,
+				},
+				crossCompile: crosscompile.Export{
+					Linker: tt.linker,
+					CC:     tt.cc,
+				},
+			}
+			gotFile, gotArgs := ctx.resolveLinkMapArgs(tt.outputPath)
+			if gotFile != tt.wantFile {
+				t.Fatalf("resolveLinkMapArgs() file = %q, want %q", gotFile, tt.wantFile)
+			}
+			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+				t.Fatalf("resolveLinkMapArgs() args = %#v, want %#v", gotArgs, tt.wantArgs)
+			}
+		})
+	}
+}

--- a/runtime/internal/clite/c.go
+++ b/runtime/internal/clite/c.go
@@ -258,6 +258,9 @@ func Fopen(c *Char, mod *Char) FilePtr
 //go:linkname Fclose C.fclose
 func Fclose(fp FilePtr) Int
 
+//go:linkname Write C.write
+func Write(fd Int, buf Pointer, count uintptr) Int
+
 //go:linkname Perror C.perror
 func Perror(s *Char)
 

--- a/runtime/internal/runtime/z_print.go
+++ b/runtime/internal/runtime/z_print.go
@@ -34,7 +34,7 @@ func PrintBool(v bool) {
 }
 
 func PrintByte(v byte) {
-	c.Fputc(c.Int(v), c.Stderr)
+	printByte(v)
 }
 
 func PrintFloat(v float64) {
@@ -76,7 +76,7 @@ func PrintPointer(p unsafe.Pointer) {
 }
 
 func PrintString(s String) {
-	c.Fwrite(s.data, 1, uintptr(s.len), c.Stderr)
+	printString(s)
 }
 
 func PrintSlice(s Slice) {

--- a/runtime/internal/runtime/z_print_impl_baremetal_esp.go
+++ b/runtime/internal/runtime/z_print_impl_baremetal_esp.go
@@ -1,0 +1,32 @@
+//go:build baremetal && esp
+
+/*
+ * Copyright (c) 2024 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import c "github.com/goplus/llgo/runtime/internal/clite"
+
+const stderrFD c.Int = 2
+
+func printByte(v byte) {
+	ch := v
+	c.Write(stderrFD, c.Pointer(&ch), 1)
+}
+
+func printString(s String) {
+	c.Write(stderrFD, s.data, uintptr(s.len))
+}

--- a/runtime/internal/runtime/z_print_impl_default.go
+++ b/runtime/internal/runtime/z_print_impl_default.go
@@ -1,0 +1,29 @@
+//go:build !(baremetal && esp)
+
+/*
+ * Copyright (c) 2024 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import c "github.com/goplus/llgo/runtime/internal/clite"
+
+func printByte(v byte) {
+	c.Fputc(c.Int(v), c.Stderr)
+}
+
+func printString(s String) {
+	c.Fwrite(s.data, 1, uintptr(s.len), c.Stderr)
+}


### PR DESCRIPTION
## Summary
- add `-map` build flag to emit linker map files (supports explicit path and `auto`)
- wire linker map handling through build config and linker argument selection
- add unit tests for map flag resolution and driver/linker argument selection
- route `runtime.PrintString/PrintByte` through platform-specific helpers
- on `baremetal && esp`, send println output via `C.write` (fd=2) to avoid stdio path issues

## Validation
- `go test ./internal/build -run "Test(UseCompilerDriverMapFlags|ResolveLinkMapArgs)$"`
- `llgo build -a -target=esp32c3 _demo/embed/esp32c3/println`
- hardware run confirms `println("Hello")` now prints `Hello`, then exits via `_exit` panic path (current runtime behavior)