### PR TITLE
test: split cl/ssa golden tests into subpackages

### DIFF
--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -20,10 +20,8 @@
 package cl_test
 
 import (
-	"runtime"
 	"testing"
 
-	"github.com/goplus/llgo/cl"
 	"github.com/goplus/llgo/cl/cltest"
 	"github.com/goplus/llgo/internal/build"
 )
@@ -31,69 +29,6 @@ import (
 func testCompile(t *testing.T, src, expected string) {
 	t.Helper()
 	cltest.TestCompileEx(t, src, "foo.go", expected, false)
-}
-
-func TestFromTestgo(t *testing.T) {
-	cltest.FromDir(t, "", "./_testgo")
-}
-
-func TestRunFromTestgo(t *testing.T) {
-	cltest.RunFromDir(t, "", "./_testgo", nil)
-}
-
-func TestFromTestpy(t *testing.T) {
-	cltest.FromDir(t, "", "./_testpy")
-}
-
-func TestRunFromTestpy(t *testing.T) {
-	cltest.RunFromDir(t, "", "./_testpy", nil)
-}
-
-func TestFromTestlibgo(t *testing.T) {
-	cltest.FromDir(t, "", "./_testlibgo")
-}
-
-func TestRunFromTestlibgo(t *testing.T) {
-	cltest.RunFromDir(t, "", "./_testlibgo", nil)
-}
-
-func TestFromTestlibc(t *testing.T) {
-	cltest.FromDir(t, "", "./_testlibc")
-}
-
-func TestRunFromTestlibc(t *testing.T) {
-	var ignore []string
-	if runtime.GOOS == "linux" {
-		ignore = []string{
-			"./_testlibc/demangle", // Linux demangle symbol differs (itaniumDemangle linkage mismatch).
-		}
-	}
-	cltest.RunFromDir(t, "", "./_testlibc", ignore)
-}
-
-func TestFromTestrt(t *testing.T) {
-	cl.SetDebug(cl.DbgFlagAll)
-	cltest.FromDir(t, "", "./_testrt")
-	cl.SetDebug(0)
-}
-
-func TestRunFromTestrt(t *testing.T) {
-	var ignore []string
-	if runtime.GOOS == "linux" {
-		ignore = []string{
-			"./_testrt/asmfull", // Output is macOS-specific.
-			"./_testrt/fprintf", // Linux uses different stderr symbol (no __stderrp).
-		}
-	}
-	cltest.RunFromDir(t, "", "./_testrt", ignore)
-}
-
-func TestFromTestdata(t *testing.T) {
-	cltest.FromDir(t, "", "./_testdata")
-}
-
-func TestRunFromTestdata(t *testing.T) {
-	cltest.RunFromDir(t, "", "./_testdata", nil)
 }
 
 func TestGoPkgMath(t *testing.T) {

--- a/cl/tests/testdata/main_test.go
+++ b/cl/tests/testdata/main_test.go
@@ -1,0 +1,23 @@
+//go:build !llgo
+// +build !llgo
+
+package testdata_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller failed")
+	}
+	clDir := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	if err := os.Chdir(clDir); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}

--- a/cl/tests/testdata/test_test.go
+++ b/cl/tests/testdata/test_test.go
@@ -1,0 +1,18 @@
+//go:build !llgo
+// +build !llgo
+
+package testdata_test
+
+import (
+	"testing"
+
+	"github.com/goplus/llgo/cl/cltest"
+)
+
+func TestFrom(t *testing.T) {
+	cltest.FromDir(t, "", "./_testdata")
+}
+
+func TestRun(t *testing.T) {
+	cltest.RunFromDir(t, "", "./_testdata", nil)
+}

--- a/cl/tests/testgo/main_test.go
+++ b/cl/tests/testgo/main_test.go
@@ -1,0 +1,23 @@
+//go:build !llgo
+// +build !llgo
+
+package testgo_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller failed")
+	}
+	clDir := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	if err := os.Chdir(clDir); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}

--- a/cl/tests/testgo/test_test.go
+++ b/cl/tests/testgo/test_test.go
@@ -1,0 +1,18 @@
+//go:build !llgo
+// +build !llgo
+
+package testgo_test
+
+import (
+	"testing"
+
+	"github.com/goplus/llgo/cl/cltest"
+)
+
+func TestFrom(t *testing.T) {
+	cltest.FromDir(t, "", "./_testgo")
+}
+
+func TestRun(t *testing.T) {
+	cltest.RunFromDir(t, "", "./_testgo", nil)
+}

--- a/cl/tests/testlibc/main_test.go
+++ b/cl/tests/testlibc/main_test.go
@@ -1,0 +1,23 @@
+//go:build !llgo
+// +build !llgo
+
+package testlibc_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller failed")
+	}
+	clDir := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	if err := os.Chdir(clDir); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}

--- a/cl/tests/testlibc/test_test.go
+++ b/cl/tests/testlibc/test_test.go
@@ -1,0 +1,25 @@
+//go:build !llgo
+// +build !llgo
+
+package testlibc_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/goplus/llgo/cl/cltest"
+)
+
+func TestFrom(t *testing.T) {
+	cltest.FromDir(t, "", "./_testlibc")
+}
+
+func TestRun(t *testing.T) {
+	var ignore []string
+	if runtime.GOOS == "linux" {
+		ignore = []string{
+			"./_testlibc/demangle", // Linux demangle symbol differs (itaniumDemangle linkage mismatch).
+		}
+	}
+	cltest.RunFromDir(t, "", "./_testlibc", ignore)
+}

--- a/cl/tests/testlibgo/main_test.go
+++ b/cl/tests/testlibgo/main_test.go
@@ -1,0 +1,23 @@
+//go:build !llgo
+// +build !llgo
+
+package testlibgo_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller failed")
+	}
+	clDir := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	if err := os.Chdir(clDir); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}

--- a/cl/tests/testlibgo/test_test.go
+++ b/cl/tests/testlibgo/test_test.go
@@ -1,0 +1,18 @@
+//go:build !llgo
+// +build !llgo
+
+package testlibgo_test
+
+import (
+	"testing"
+
+	"github.com/goplus/llgo/cl/cltest"
+)
+
+func TestFrom(t *testing.T) {
+	cltest.FromDir(t, "", "./_testlibgo")
+}
+
+func TestRun(t *testing.T) {
+	cltest.RunFromDir(t, "", "./_testlibgo", nil)
+}

--- a/cl/tests/testpy/main_test.go
+++ b/cl/tests/testpy/main_test.go
@@ -1,0 +1,23 @@
+//go:build !llgo
+// +build !llgo
+
+package testpy_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller failed")
+	}
+	clDir := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	if err := os.Chdir(clDir); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}

--- a/cl/tests/testpy/test_test.go
+++ b/cl/tests/testpy/test_test.go
@@ -1,0 +1,18 @@
+//go:build !llgo
+// +build !llgo
+
+package testpy_test
+
+import (
+	"testing"
+
+	"github.com/goplus/llgo/cl/cltest"
+)
+
+func TestFrom(t *testing.T) {
+	cltest.FromDir(t, "", "./_testpy")
+}
+
+func TestRun(t *testing.T) {
+	cltest.RunFromDir(t, "", "./_testpy", nil)
+}

--- a/cl/tests/testrt/main_test.go
+++ b/cl/tests/testrt/main_test.go
@@ -1,0 +1,23 @@
+//go:build !llgo
+// +build !llgo
+
+package testrt_test
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller failed")
+	}
+	clDir := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	if err := os.Chdir(clDir); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}

--- a/cl/tests/testrt/test_test.go
+++ b/cl/tests/testrt/test_test.go
@@ -1,0 +1,29 @@
+//go:build !llgo
+// +build !llgo
+
+package testrt_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/goplus/llgo/cl"
+	"github.com/goplus/llgo/cl/cltest"
+)
+
+func TestFrom(t *testing.T) {
+	cl.SetDebug(cl.DbgFlagAll)
+	cltest.FromDir(t, "", "./_testrt")
+	cl.SetDebug(0)
+}
+
+func TestRun(t *testing.T) {
+	var ignore []string
+	if runtime.GOOS == "linux" {
+		ignore = []string{
+			"./_testrt/asmfull", // Output is macOS-specific.
+			"./_testrt/fprintf", // Linux uses different stderr symbol (no __stderrp).
+		}
+	}
+	cltest.RunFromDir(t, "", "./_testrt", ignore)
+}

--- a/ssa/cl_test.go
+++ b/ssa/cl_test.go
@@ -28,41 +28,17 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/goplus/llgo/cl/cltest"
 	"github.com/goplus/llgo/ssa"
 )
 
 func TestMain(m *testing.M) {
 	flag.Parse()
 	ssa.SetDebug(ssa.DbgFlagAll)
+	ssa.Initialize(ssa.InitAll | ssa.InitNative)
 	if !testing.Verbose() {
 		log.SetOutput(io.Discard)
 	}
 	m.Run()
-}
-
-func TestFromTestlibgo(t *testing.T) {
-	cltest.FromDir(t, "", "../cl/_testlibgo")
-}
-
-func TestFromTestgo(t *testing.T) {
-	cltest.FromDir(t, "", "../cl/_testgo")
-}
-
-func TestFromTestpy(t *testing.T) {
-	cltest.FromDir(t, "", "../cl/_testpy")
-}
-
-func TestFromTestlibc(t *testing.T) {
-	cltest.FromDir(t, "", "../cl/_testlibc")
-}
-
-func TestFromTestrt(t *testing.T) {
-	cltest.FromDir(t, "", "../cl/_testrt")
-}
-
-func TestFromTestdata(t *testing.T) {
-	cltest.FromDir(t, "", "../cl/_testdata")
 }
 
 func TestMakeInterface(t *testing.T) {

--- a/ssa/tests/testdata/main_test.go
+++ b/ssa/tests/testdata/main_test.go
@@ -1,0 +1,33 @@
+//go:build !llgo
+// +build !llgo
+
+package testdata_test
+
+import (
+	"flag"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/goplus/llgo/ssa"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	ssa.SetDebug(ssa.DbgFlagAll)
+	if !testing.Verbose() {
+		log.SetOutput(io.Discard)
+	}
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller failed")
+	}
+	ssaDir := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	if err := os.Chdir(ssaDir); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}

--- a/ssa/tests/testdata/test_test.go
+++ b/ssa/tests/testdata/test_test.go
@@ -1,0 +1,14 @@
+//go:build !llgo
+// +build !llgo
+
+package testdata_test
+
+import (
+	"testing"
+
+	"github.com/goplus/llgo/cl/cltest"
+)
+
+func TestFrom(t *testing.T) {
+	cltest.FromDir(t, "", "../cl/_testdata")
+}

--- a/ssa/tests/testgo/main_test.go
+++ b/ssa/tests/testgo/main_test.go
@@ -1,0 +1,33 @@
+//go:build !llgo
+// +build !llgo
+
+package testgo_test
+
+import (
+	"flag"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/goplus/llgo/ssa"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	ssa.SetDebug(ssa.DbgFlagAll)
+	if !testing.Verbose() {
+		log.SetOutput(io.Discard)
+	}
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller failed")
+	}
+	ssaDir := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	if err := os.Chdir(ssaDir); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}

--- a/ssa/tests/testgo/test_test.go
+++ b/ssa/tests/testgo/test_test.go
@@ -1,0 +1,14 @@
+//go:build !llgo
+// +build !llgo
+
+package testgo_test
+
+import (
+	"testing"
+
+	"github.com/goplus/llgo/cl/cltest"
+)
+
+func TestFrom(t *testing.T) {
+	cltest.FromDir(t, "", "../cl/_testgo")
+}

--- a/ssa/tests/testlibc/main_test.go
+++ b/ssa/tests/testlibc/main_test.go
@@ -1,0 +1,33 @@
+//go:build !llgo
+// +build !llgo
+
+package testlibc_test
+
+import (
+	"flag"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/goplus/llgo/ssa"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	ssa.SetDebug(ssa.DbgFlagAll)
+	if !testing.Verbose() {
+		log.SetOutput(io.Discard)
+	}
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller failed")
+	}
+	ssaDir := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	if err := os.Chdir(ssaDir); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}

--- a/ssa/tests/testlibc/test_test.go
+++ b/ssa/tests/testlibc/test_test.go
@@ -1,0 +1,14 @@
+//go:build !llgo
+// +build !llgo
+
+package testlibc_test
+
+import (
+	"testing"
+
+	"github.com/goplus/llgo/cl/cltest"
+)
+
+func TestFrom(t *testing.T) {
+	cltest.FromDir(t, "", "../cl/_testlibc")
+}

--- a/ssa/tests/testlibgo/main_test.go
+++ b/ssa/tests/testlibgo/main_test.go
@@ -1,0 +1,33 @@
+//go:build !llgo
+// +build !llgo
+
+package testlibgo_test
+
+import (
+	"flag"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/goplus/llgo/ssa"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	ssa.SetDebug(ssa.DbgFlagAll)
+	if !testing.Verbose() {
+		log.SetOutput(io.Discard)
+	}
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller failed")
+	}
+	ssaDir := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	if err := os.Chdir(ssaDir); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}

--- a/ssa/tests/testlibgo/test_test.go
+++ b/ssa/tests/testlibgo/test_test.go
@@ -1,0 +1,14 @@
+//go:build !llgo
+// +build !llgo
+
+package testlibgo_test
+
+import (
+	"testing"
+
+	"github.com/goplus/llgo/cl/cltest"
+)
+
+func TestFrom(t *testing.T) {
+	cltest.FromDir(t, "", "../cl/_testlibgo")
+}

--- a/ssa/tests/testpy/main_test.go
+++ b/ssa/tests/testpy/main_test.go
@@ -1,0 +1,33 @@
+//go:build !llgo
+// +build !llgo
+
+package testpy_test
+
+import (
+	"flag"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/goplus/llgo/ssa"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	ssa.SetDebug(ssa.DbgFlagAll)
+	if !testing.Verbose() {
+		log.SetOutput(io.Discard)
+	}
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller failed")
+	}
+	ssaDir := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	if err := os.Chdir(ssaDir); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}

--- a/ssa/tests/testpy/test_test.go
+++ b/ssa/tests/testpy/test_test.go
@@ -1,0 +1,14 @@
+//go:build !llgo
+// +build !llgo
+
+package testpy_test
+
+import (
+	"testing"
+
+	"github.com/goplus/llgo/cl/cltest"
+)
+
+func TestFrom(t *testing.T) {
+	cltest.FromDir(t, "", "../cl/_testpy")
+}

--- a/ssa/tests/testrt/main_test.go
+++ b/ssa/tests/testrt/main_test.go
@@ -1,0 +1,33 @@
+//go:build !llgo
+// +build !llgo
+
+package testrt_test
+
+import (
+	"flag"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/goplus/llgo/ssa"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	ssa.SetDebug(ssa.DbgFlagAll)
+	if !testing.Verbose() {
+		log.SetOutput(io.Discard)
+	}
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller failed")
+	}
+	ssaDir := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	if err := os.Chdir(ssaDir); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}

--- a/ssa/tests/testrt/test_test.go
+++ b/ssa/tests/testrt/test_test.go
@@ -1,0 +1,14 @@
+//go:build !llgo
+// +build !llgo
+
+package testrt_test
+
+import (
+	"testing"
+
+	"github.com/goplus/llgo/cl/cltest"
+)
+
+func TestFrom(t *testing.T) {
+	cltest.FromDir(t, "", "../cl/_testrt")
+}


### PR DESCRIPTION
This splits the cl/_test* and ssa-driven directory suites into separate test packages so `go test` can parallelize them at the package/process level, avoiding in-process LLVM(cgo) concurrency (which can crash).

It also filters toolchain/devel warnings from captured run output to keep expect.txt comparisons stable.
