### PR TITLE
ssa: preserve export functions with llvm.compiler.used

### DIFF
--- a/cl/_testdata/cpkg/out.ll
+++ b/cl/_testdata/cpkg/out.ll
@@ -2,6 +2,7 @@
 source_filename = "github.com/goplus/llgo/cl/_testdata/cpkg"
 
 @"github.com/goplus/llgo/cl/_testdata/cpkg.init$guard" = global i1 false, align 1
+@llvm.compiler.used = appending global [2 x ptr] [ptr @Double, ptr @add], section "llvm.metadata"
 
 define double @Double(double %0) {
 _llgo_0:

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1246,6 +1246,7 @@ func newPackageEx(prog llssa.Program, patches Patches, rewrites map[string]strin
 		ctx.initAfter = nil
 		fn()
 	}
+	ret.MaterializePreserveSyms()
 	externs = ctx.cgoSymbols
 	return
 }

--- a/ssa/decl.go
+++ b/ssa/decl.go
@@ -211,6 +211,9 @@ func (p Package) NewFuncEx(name string, sig *types.Signature, bg Background, has
 	if instantiated {
 		fn.SetLinkage(llvm.LinkOnceAnyLinkage)
 	}
+	if p.isPreservedName(name) {
+		p.markLLVMUsed(fn)
+	}
 	ret := newFunction(fn, t, p, p.Prog, hasFreeVars)
 	p.fns[name] = ret
 	return ret

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -436,7 +436,9 @@ func (p Program) NewPackage(name, pkgPath string) Package {
 		mod: mod, Prog: p, vars: gbls, fns: fns,
 		pyobjs: pyobjs, pymods: pymods, strs: strs,
 		di: nil, cu: nil, glbDbgVars: glbDbgVars,
-		export: make(map[string]string),
+		export:         make(map[string]string),
+		preserveSyms:   make(map[string]struct{}),
+		llvmUsedValues: make([]llvm.Value, 0, 4),
 	}
 	ret.abi.Init(pkgPath, uintptr(p.ptrSize), (*goProgram)(unsafe.Pointer(p)))
 	return ret
@@ -701,7 +703,9 @@ type aPackage struct {
 	NeedPyInit  bool
 	NeedAbiInit bool // need load all abi types for reflect make type
 
-	export map[string]string // pkgPath.nameInPkg => exportname
+	export         map[string]string   // pkgPath.nameInPkg => exportname
+	preserveSyms   map[string]struct{} // set of exported symbol names
+	llvmUsedValues []llvm.Value
 }
 
 type Package = *aPackage
@@ -712,10 +716,33 @@ func (p Package) Module() llvm.Module {
 
 func (p Package) SetExport(name, export string) {
 	p.export[name] = export
+	p.preserveSyms[export] = struct{}{}
 }
 
 func (p Package) ExportFuncs() map[string]string {
 	return p.export
+}
+
+func (p Package) isPreservedName(name string) bool {
+	_, ok := p.preserveSyms[name]
+	return ok
+}
+
+func (p Package) markLLVMUsed(v llvm.Value) {
+	elemTyp := p.Prog.VoidPtr().ll
+	p.llvmUsedValues = append(p.llvmUsedValues, llvm.ConstBitCast(v, elemTyp))
+}
+
+func (p Package) MaterializePreserveSyms() {
+	if len(p.llvmUsedValues) == 0 {
+		return
+	}
+	elemTyp := p.Prog.VoidPtr().ll
+	init := llvm.ConstArray(elemTyp, p.llvmUsedValues)
+	global := llvm.AddGlobal(p.mod, init.Type(), "llvm.compiler.used")
+	global.SetInitializer(init)
+	global.SetLinkage(llvm.AppendingLinkage)
+	global.SetSection("llvm.metadata")
 }
 
 func (p Package) rtFunc(fnName string) Expr {

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -107,6 +107,34 @@ func TestPointerSize(t *testing.T) {
 	}
 }
 
+func TestNewFuncExLLVMUsed(t *testing.T) {
+	prog := NewProgram(nil)
+	pkg := prog.NewPackage("main", "main")
+	sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+
+	// Mark the exported name before function creation so NewFuncEx can protect it via llvm.compiler.used.
+	pkg.SetExport("main.Foo", "Foo")
+	pkg.SetExport("main.Bar", "Bar")
+	pkg.NewFunc("Foo", sig, InGo)
+	pkg.NewFunc("Bar", sig, InGo)
+	pkg.NewFunc("Baz", sig, InGo)
+	pkg.MaterializePreserveSyms()
+
+	used := pkg.Module().NamedGlobal("llvm.compiler.used")
+	if used.IsNil() {
+		t.Fatal("missing llvm.compiler.used")
+	}
+	if got := used.Linkage(); got != llvm.AppendingLinkage {
+		t.Fatalf("llvm.compiler.used linkage = %v, want %v", got, llvm.AppendingLinkage)
+	}
+	if got := used.Section(); got != "llvm.metadata" {
+		t.Fatalf("llvm.compiler.used section = %q, want %q", got, "llvm.metadata")
+	}
+	if got := pkg.String(); !strings.Contains(got, `@llvm.compiler.used = appending global [2 x ptr] [ptr @Foo, ptr @Bar], section "llvm.metadata"`) {
+		t.Fatalf("module missing llvm.compiler.used entry:\n%s", got)
+	}
+}
+
 func TestSetBlock(t *testing.T) {
 	defer func() {
 		if r := recover(); r == nil {


### PR DESCRIPTION
## Summary

Use `llvm.compiler.used` to preserve exported symbols during LTO.

## Changes

- preserve exported symbols with `@llvm.compiler.used`
- stop relying on reading or merging pre-existing `@llvm.used` entries
- mark preserved symbols explicitly from export handling
- keep the preservation logic local to the current package state
- update SSA coverage for the `llvm.compiler.used` behavior

## Notes

This version treats `llvm.compiler.used` as its own preservation list and does not depend on any existing `llvm.used` contents in the module.