### PR TITLE
build: introduce new LTO CLI control with target-aware defaults

### DIFF
--- a/_demo/embed/targetsbuild/build.sh
+++ b/_demo/embed/targetsbuild/build.sh
@@ -111,6 +111,9 @@ case "$test_dir" in
 			"riscv32"
 			"riscv64"
 			"rp2040"
+			# nintendoswitch: undefined symbol under lto, the compiled files is not enough.
+			# For no-lto, it works because the testcases does not use the missing fucntions.
+			"nintendoswitch"
 		)
 		;;
 	defer)

--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -2,6 +2,8 @@ package flags
 
 import (
 	"flag"
+	"fmt"
+	"strconv"
 
 	"github.com/goplus/llgo/cmd/internal/compilerhash"
 	"github.com/goplus/llgo/internal/build"
@@ -43,6 +45,49 @@ var SizeLevel string
 var ForceRebuild bool
 var PrintCommands bool
 
+type optionalBool struct {
+	Specified bool
+	Value     bool
+}
+
+func (o *optionalBool) String() string {
+	if !o.Specified {
+		return "auto"
+	}
+	return strconv.FormatBool(o.Value)
+}
+
+func (o *optionalBool) SetValue(v string) error {
+	val, err := strconv.ParseBool(v)
+	if err != nil {
+		return fmt.Errorf("invalid bool value %q", v)
+	}
+	o.Specified = true
+	o.Value = val
+	return nil
+}
+
+func (o *optionalBool) Set(v string) error {
+	return o.SetValue(v)
+}
+
+func (o *optionalBool) IsBoolFlag() bool {
+	return true
+}
+
+var LTO optionalBool
+
+func AddLTOFlag(fs *flag.FlagSet) {
+	fs.Var(&LTO, "lto", "Enable LTO optimization (default: on for -target builds, off for non-target builds)")
+}
+
+func ResolveLTO(defaultValue bool) bool {
+	if LTO.Specified {
+		return LTO.Value
+	}
+	return defaultValue
+}
+
 const DefaultTestTimeout = "10m" // Matches Go's default test timeout
 
 func AddCommonFlags(fs *flag.FlagSet) {
@@ -52,6 +97,7 @@ func AddCommonFlags(fs *flag.FlagSet) {
 func AddBuildFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&ForceRebuild, "a", false, "Force rebuilding of packages that are already up-to-date")
 	fs.BoolVar(&PrintCommands, "x", false, "Print the commands")
+	AddLTOFlag(fs)
 	fs.StringVar(&Tags, "tags", "", "Build tags")
 	fs.StringVar(&BuildEnv, "buildenv", "", "Build environment")
 	if buildenv.Dev {
@@ -181,6 +227,10 @@ func UpdateConfig(conf *build.Config) error {
 	conf.Port = Port
 	conf.BaudRate = BaudRate
 	conf.ForceRebuild = ForceRebuild
+	if LTO.Specified {
+		lto := LTO.Value
+		conf.LTO = &lto
+	}
 	if SizeReport || SizeFormat != "" || SizeLevel != "" {
 		conf.SizeReport = true
 		if SizeFormat != "" {

--- a/cmd/internal/monitor/monitor.go
+++ b/cmd/internal/monitor/monitor.go
@@ -34,6 +34,7 @@ var Cmd = &base.Command{
 
 func init() {
 	flags.AddCommonFlags(&Cmd.Flag)
+	flags.AddLTOFlag(&Cmd.Flag)
 	flags.AddEmbeddedFlags(&Cmd.Flag)
 	Cmd.Run = runMonitor
 }
@@ -54,7 +55,7 @@ func runMonitor(cmd *base.Command, args []string) {
 
 	var serialPort []string
 	if flags.Target != "" {
-		conf, err := crosscompile.UseTarget(flags.Target)
+		conf, err := crosscompile.UseTarget(flags.Target, flags.ResolveLTO(true))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "llgo monitor: %v\n", err)
 			os.Exit(1)

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -118,6 +118,7 @@ type Config struct {
 	Goos          string
 	Goarch        string
 	Target        string // target name (e.g., "rp2040", "wasi") - takes precedence over Goos/Goarch
+	LTO           *bool  // nil means auto: on for target builds, off for non-target builds
 	BinPath       string
 	AppExt        string  // ".exe" on Windows, empty on Unix
 	OutFile       string  // only valid for ModeBuild when len(pkgs) == 1
@@ -194,6 +195,13 @@ func envGOPATH() (string, error) {
 	return filepath.Join(home, "go"), nil
 }
 
+func (c *Config) ltoEnabled() bool {
+	if c.LTO != nil {
+		return *c.LTO
+	}
+	return c.Target != ""
+}
+
 // -----------------------------------------------------------------------------
 
 const (
@@ -227,7 +235,7 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	}
 	// Handle crosscompile configuration first to set correct GOOS/GOARCH
 	forceEspClang := conf.ForceEspClang || conf.Target != ""
-	export, err := crosscompile.Use(conf.Goos, conf.Goarch, conf.Target, IsWasiThreadsEnabled(), forceEspClang)
+	export, err := crosscompile.Use(conf.Goos, conf.Goarch, conf.Target, IsWasiThreadsEnabled(), forceEspClang, conf.ltoEnabled())
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup crosscompile: %w", err)
 	}

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -307,3 +307,30 @@ func TestTestMultiplePackagesWithOutputFile(t *testing.T) {
 		t.Errorf("Expected error about -o with multiple packages, got: %v", err)
 	}
 }
+
+func TestLTOEnabledDefault(t *testing.T) {
+	host := &Config{Target: ""}
+	if host.ltoEnabled() {
+		t.Fatal("expected LTO disabled by default for non-target builds")
+	}
+
+	target := &Config{Target: "rp2040"}
+	if !target.ltoEnabled() {
+		t.Fatal("expected LTO enabled by default for target builds")
+	}
+}
+
+func TestLTOEnabledExplicitOverride(t *testing.T) {
+	on := true
+	off := false
+
+	hostOn := &Config{Target: "", LTO: &on}
+	if !hostOn.ltoEnabled() {
+		t.Fatal("expected explicit LTO=true to enable LTO for non-target build")
+	}
+
+	targetOff := &Config{Target: "rp2040", LTO: &off}
+	if targetOff.ltoEnabled() {
+		t.Fatal("expected explicit LTO=false to disable LTO for target build")
+	}
+}

--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -197,7 +197,7 @@ func compileWithConfig(
 	return
 }
 
-func use(goos, goarch string, wasiThreads, forceEspClang bool) (export Export, err error) {
+func use(goos, goarch string, wasiThreads, forceEspClang, enableLTO bool) (export Export, err error) {
 	targetTriple := llvm.GetTargetTriple(goos, goarch)
 	llgoRoot := env.LLGoROOT()
 
@@ -225,8 +225,11 @@ func use(goos, goarch string, wasiThreads, forceEspClang bool) (export Export, e
 			"-Wl,--error-limit=0",
 			"-fuse-ld=lld",
 			// Enable ICF (Identical Code Folding) to reduce binary size
-			"-Xlinker",
-			"--icf=safe",
+			"-Wl,--icf=safe",
+		}
+		if enableLTO {
+			// Enable ThinLTO, using default lto kind(thinlto).
+			export.LDFLAGS = append(export.LDFLAGS, "-Wl,--lto-O0")
 		}
 		if clangRoot != "" {
 			clangLib := filepath.Join(clangRoot, "lib")
@@ -249,6 +252,9 @@ func use(goos, goarch string, wasiThreads, forceEspClang bool) (export Export, e
 		export.CCFLAGS = []string{
 			"-Qunused-arguments",
 			"-Wno-unused-command-line-argument",
+		}
+		if enableLTO {
+			export.CCFLAGS = append(export.CCFLAGS, "-flto=thin")
 		}
 
 		// Add sysroot for macOS only
@@ -424,7 +430,7 @@ func use(goos, goarch string, wasiThreads, forceEspClang bool) (export Export, e
 }
 
 // UseTarget loads configuration from a target name (e.g., "rp2040", "wasi")
-func UseTarget(targetName string) (export Export, err error) {
+func UseTarget(targetName string, enableLTO bool) (export Export, err error) {
 	resolver := targets.NewDefaultResolver()
 
 	config, err := resolver.Resolve(targetName)
@@ -499,6 +505,13 @@ func UseTarget(targetName string) (export Export, err error) {
 	expandedCFlags := env.ExpandEnvSlice(config.CFlags, envs)
 	cflags = append(cflags, expandedCFlags...)
 
+	if config.Linker == "ld.lld" && enableLTO {
+		// Enable ThinLTO, Using default lto kind(thinlto).
+		ldflags = append(ldflags, "--lto-O0")
+		cflags = append(cflags, "-flto=thin")
+		ccflags = append(ccflags, "-flto=thin")
+	}
+
 	// The following parameters are inspired by tinygo/builder/library.go
 	// Handle CPU configuration
 	if cpu != "" {
@@ -545,6 +558,8 @@ func UseTarget(targetName string) (export Export, err error) {
 		ccflags = append(ccflags, "-fforce-enable-int128")
 	case "riscv64":
 		ccflags = append(ccflags, "-march=rv64gc")
+		// codegen option should be added to ldflags for lto
+		ldflags = append(ldflags, "-mllvm", "-march=rv64gc")
 	case "mips":
 		ccflags = append(ccflags, "-fno-pic")
 	}
@@ -574,9 +589,17 @@ func UseTarget(targetName string) (export Export, err error) {
 	// Handle code generation configuration
 	if config.CodeModel != "" {
 		ccflags = append(ccflags, "-mcmodel="+config.CodeModel)
+		if enableLTO {
+			// codegen option should be added to ldflags for lto
+			ldflags = append(ldflags, "-mllvm", "-code-model="+config.CodeModel)
+		}
 	}
 	if config.TargetABI != "" {
 		ccflags = append(ccflags, "-mabi="+config.TargetABI)
+		if enableLTO {
+			// codegen option should be added to ldflags for lto
+			ldflags = append(ldflags, "-mllvm", "-target-abi="+config.TargetABI)
+		}
 	}
 	if config.RelocationModel != "" {
 		switch config.RelocationModel {
@@ -658,9 +681,9 @@ func UseTarget(targetName string) (export Export, err error) {
 
 // Use extends the original Use function to support target-based configuration
 // If targetName is provided, it takes precedence over goos/goarch
-func Use(goos, goarch, targetName string, wasiThreads, forceEspClang bool) (export Export, err error) {
+func Use(goos, goarch, targetName string, wasiThreads, forceEspClang, enableLTO bool) (export Export, err error) {
 	if targetName != "" && !strings.HasPrefix(targetName, "wasm") && !strings.HasPrefix(targetName, "wasi") {
-		return UseTarget(targetName)
+		return UseTarget(targetName, enableLTO)
 	}
-	return use(goos, goarch, wasiThreads, forceEspClang)
+	return use(goos, goarch, wasiThreads, forceEspClang, enableLTO)
 }

--- a/internal/crosscompile/crosscompile_test.go
+++ b/internal/crosscompile/crosscompile_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"runtime"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -76,7 +77,7 @@ func TestUseCrossCompileSDK(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			export, err := use(tc.goos, tc.goarch, false, false)
+			export, err := use(tc.goos, tc.goarch, false, false, true)
 
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
@@ -231,7 +232,7 @@ func TestUseTarget(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			export, err := UseTarget(tc.targetName)
+			export, err := UseTarget(tc.targetName, true)
 
 			if tc.expectError {
 				if err == nil {
@@ -311,7 +312,7 @@ func TestUseTarget(t *testing.T) {
 
 func TestUseWithTarget(t *testing.T) {
 	// Test target-based configuration takes precedence
-	export, err := Use("linux", "amd64", "esp32", false, true)
+	export, err := Use("linux", "amd64", "esp32", false, true, true)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -323,7 +324,7 @@ func TestUseWithTarget(t *testing.T) {
 	}
 
 	// Test fallback to goos/goarch when no target specified
-	export, err = Use(runtime.GOOS, runtime.GOARCH, "", false, false)
+	export, err = Use(runtime.GOOS, runtime.GOARCH, "", false, false, true)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -331,5 +332,63 @@ func TestUseWithTarget(t *testing.T) {
 	// Should use native configuration (only check for macOS since that's where tests run)
 	if runtime.GOOS == "darwin" && len(export.LDFLAGS) == 0 {
 		t.Error("Expected LDFLAGS to be set for native build")
+	}
+}
+
+func TestUseLTOFlagsControlledByOption(t *testing.T) {
+	export, err := use(runtime.GOOS, runtime.GOARCH, false, false, false)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	for _, flag := range export.CCFLAGS {
+		if strings.HasPrefix(flag, "-flto") {
+			t.Fatalf("unexpected LTO ccflag when disabled: %q", flag)
+		}
+	}
+	for _, flag := range export.LDFLAGS {
+		if strings.Contains(flag, "lto-") {
+			t.Fatalf("unexpected LTO ldflag when disabled: %q", flag)
+		}
+	}
+}
+
+func hasMllvmOption(flags []string, opt string) bool {
+	for i := 0; i+1 < len(flags); i++ {
+		if flags[i] == "-mllvm" && flags[i+1] == opt {
+			return true
+		}
+	}
+	return false
+}
+
+func TestUseTargetCodegenFlagsOnlyAddedToLDFlagsWithLTO(t *testing.T) {
+	const target = "k210"
+
+	noLTO, err := UseTarget(target, false)
+	if err != nil {
+		t.Fatalf("UseTarget(%q, false) error: %v", target, err)
+	}
+	if hasMllvmOption(noLTO.LDFLAGS, "-code-model=medium") {
+		t.Fatalf("unexpected -mllvm -code-model=medium in LDFLAGS when LTO disabled: %v", noLTO.LDFLAGS)
+	}
+	if hasMllvmOption(noLTO.LDFLAGS, "-target-abi=lp64") {
+		t.Fatalf("unexpected -mllvm -target-abi=lp64 in LDFLAGS when LTO disabled: %v", noLTO.LDFLAGS)
+	}
+	if !slices.Contains(noLTO.CCFLAGS, "-mcmodel=medium") {
+		t.Fatalf("missing -mcmodel=medium in CCFLAGS: %v", noLTO.CCFLAGS)
+	}
+	if !slices.Contains(noLTO.CCFLAGS, "-mabi=lp64") {
+		t.Fatalf("missing -mabi=lp64 in CCFLAGS: %v", noLTO.CCFLAGS)
+	}
+
+	withLTO, err := UseTarget(target, true)
+	if err != nil {
+		t.Fatalf("UseTarget(%q, true) error: %v", target, err)
+	}
+	if !hasMllvmOption(withLTO.LDFLAGS, "-code-model=medium") {
+		t.Fatalf("missing -mllvm -code-model=medium in LDFLAGS when LTO enabled: %v", withLTO.LDFLAGS)
+	}
+	if !hasMllvmOption(withLTO.LDFLAGS, "-target-abi=lp64") {
+		t.Fatalf("missing -mllvm -target-abi=lp64 in LDFLAGS when LTO enabled: %v", withLTO.LDFLAGS)
 	}
 }


### PR DESCRIPTION
## Summary
- introduce a new tri-state `-lto` option (auto/true/false)
- default LTO to ON for `-target` builds and OFF for non-target builds
- apply LTO decision when generating crosscompile flags (instead of post-filtering)
- make `llgo monitor` follow the same LTO rule path

## Details
- add shared LTO flag parsing helpers in `cmd/internal/flags`
- thread LTO decision through build config into `internal/crosscompile`
- gate `-flto=thin` and `--lto-*` emission on the resolved LTO switch
- update crosscompile/build tests for default and explicit override behavior

## Validation
- `go test ./internal/crosscompile -run TestUseLTOFlagsControlledByOption`
- `go test ./cmd/internal/monitor ./cmd/internal/flags ./internal/crosscompile -run TestUseLTOFlagsControlledByOption`
- `go test ./cmd/internal/flags ./cmd/internal/build ./cmd/internal/run ./cmd/internal/test ./cmd/internal/install ./cmd/internal/monitor ./internal/build -run TestLTOEnabled`
