### PR TITLE
fix: preserve locals across setjmp/longjmp

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -352,11 +352,18 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	patches := make(cl.Patches, len(altPkgPaths))
 	altSSAPkgs(progSSA, patches, altPkgs[1:], conf, verbose)
 
+	naivePkgs := naiveProgramPackages(initial)
+	var progSSANaive *ssa.Program
+	if len(naivePkgs) != 0 {
+		progSSANaive = ssa.NewProgram(initial[0].Fset, buildMode|ssa.NaiveForm)
+		altSSAPkgs(progSSANaive, patches, altPkgs[1:], conf, verbose)
+	}
+
 	env := llvm.New("")
 	os.Setenv("PATH", env.BinDir()+":"+os.Getenv("PATH")) // TODO(xsw): check windows
 
 	output := conf.OutFile != ""
-	ctx := &context{env: env, conf: cfg, progSSA: progSSA, prog: prog, dedup: dedup,
+	ctx := &context{env: env, conf: cfg, progSSA: progSSA, progSSANaive: progSSANaive, naivePkgs: naivePkgs, prog: prog, dedup: dedup,
 		patches: patches, built: make(map[string]none), initial: initial, mode: mode,
 		fingerprinting: make(map[string]bool),
 		pkgs:           map[*packages.Package]Package{},
@@ -524,6 +531,8 @@ type context struct {
 	env            *llvm.Env
 	conf           *packages.Config
 	progSSA        *ssa.Program
+	progSSANaive   *ssa.Program
+	naivePkgs      map[*packages.Package]bool
 	prog           llssa.Program
 	dedup          packages.Deduper
 	patches        cl.Patches
@@ -1359,6 +1368,113 @@ func altPkgs(initial []*packages.Package, conf *Config, alts ...string) []string
 	return alts
 }
 
+func naiveProgramPackages(initial []*packages.Package) map[*packages.Package]bool {
+	memo := make(map[*packages.Package]bool)
+	state := make(map[*packages.Package]uint8)
+	var visit func(*packages.Package) bool
+	visit = func(p *packages.Package) bool {
+		if p == nil || p.Types == nil || p.IllTyped {
+			return false
+		}
+		switch state[p] {
+		case 1:
+			return false
+		case 2:
+			return memo[p]
+		}
+		state[p] = 1
+		need := pkgRequiresNaiveForm(p)
+		for _, imp := range p.Imports {
+			if visit(imp) {
+				need = true
+			}
+		}
+		state[p] = 2
+		memo[p] = need
+		return need
+	}
+	packages.Visit(initial, nil, func(p *packages.Package) {
+		if p != nil {
+			visit(p)
+		}
+	})
+	for p, need := range memo {
+		if !need {
+			delete(memo, p)
+		}
+	}
+	return memo
+}
+
+func pkgRequiresNaiveForm(pkg *packages.Package) bool {
+	for _, file := range pkg.Syntax {
+		if file == nil {
+			continue
+		}
+		imports := make(map[string]string, len(file.Imports))
+		dotImports := make(map[string]bool)
+		for _, imp := range file.Imports {
+			pathValue := strings.Trim(imp.Path.Value, "\"")
+			switch pathValue {
+			case "github.com/goplus/lib/c", "github.com/goplus/lib/c/setjmp":
+			default:
+				continue
+			}
+			if imp.Name != nil {
+				switch imp.Name.Name {
+				case "_":
+					continue
+				case ".":
+					dotImports[pathValue] = true
+					continue
+				default:
+					imports[imp.Name.Name] = pathValue
+					continue
+				}
+			}
+			imports[path.Base(pathValue)] = pathValue
+		}
+		found := false
+		ast.Inspect(file, func(n ast.Node) bool {
+			if found {
+				return false
+			}
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			switch fn := call.Fun.(type) {
+			case *ast.SelectorExpr:
+				pkgIdent, ok := fn.X.(*ast.Ident)
+				if !ok {
+					return true
+				}
+				switch imports[pkgIdent.Name] {
+				case "github.com/goplus/lib/c/setjmp":
+					found = fn.Sel.Name == "Setjmp"
+				case "github.com/goplus/lib/c":
+					found = fn.Sel.Name == "Sigsetjmp"
+				}
+				return !found
+			case *ast.Ident:
+				if dotImports["github.com/goplus/lib/c/setjmp"] && fn.Name == "Setjmp" {
+					found = true
+					return false
+				}
+				if dotImports["github.com/goplus/lib/c"] && fn.Name == "Sigsetjmp" {
+					found = true
+					return false
+				}
+			}
+			return true
+		})
+		if found {
+			return true
+		}
+	}
+	return false
+}
+
 func altSSAPkgs(prog *ssa.Program, patches cl.Patches, alts []*packages.Package, conf *Config, verbose bool) {
 	packages.Visit(alts, nil, func(p *packages.Package) {
 		if typs := p.Types; typs != nil && !p.IllTyped {
@@ -1407,7 +1523,6 @@ type aPackage struct {
 type Package = *aPackage
 
 func buildSSAPkgs(ctx *context, initial []*packages.Package, verbose bool) ([]*aPackage, error) {
-	prog := ctx.progSSA
 	var all []*aPackage
 	var errs []*packages.Package
 	packages.Visit(initial, nil, func(p *packages.Package) {
@@ -1418,7 +1533,7 @@ func buildSSAPkgs(ctx *context, initial []*packages.Package, verbose bool) ([]*a
 				return
 			}
 			var altPkg *packages.Cached
-			var ssaPkg = createSSAPkg(ctx, prog, p, verbose)
+			var ssaPkg = createSSAPkg(ctx, p, verbose)
 			if ctx.hasAltPkg(pkgPath) {
 				if altPkg = ctx.dedup.Check(altPkgPathPrefix + pkgPath); altPkg == nil {
 					return
@@ -1557,18 +1672,35 @@ func applyPatches(ctx *context, p *packages.Package, verbose bool) {
 	}
 }
 
-func createSSAPkg(ctx *context, prog *ssa.Program, p *packages.Package, verbose bool) *ssa.Package {
-	pkgSSA := prog.ImportedPackage(p.ID)
-	if pkgSSA == nil {
-		if debugBuild || verbose {
-			log.Println("==> BuildSSA", p.ID)
+func createSSAPkg(ctx *context, p *packages.Package, verbose bool) *ssa.Package {
+	prog := ctx.progSSA
+	useNaive := ctx.progSSANaive != nil && ctx.naivePkgs[p]
+	if useNaive {
+		prog = ctx.progSSANaive
+	}
+	if pkgSSA := prog.Package(p.Types); pkgSSA != nil {
+		return pkgSSA
+	}
+	if debugBuild || verbose {
+		log.Println("==> BuildSSA", p.ID)
+	}
+	if useNaive {
+		for _, imp := range p.Imports {
+			if imp == nil || imp.Types == nil || imp.IllTyped || prog.Package(imp.Types) != nil {
+				continue
+			}
+			prog.CreatePackage(imp.Types, nil, nil, true)
 		}
 		applyPatches(ctx, p, verbose)
-		pkgSSA = prog.CreatePackage(p.Types, p.Syntax, p.TypesInfo, true)
-		pkgSSA.Build() // TODO(xsw): build concurrently
-		// Apply local SSA fixups once when package SSA is first built.
-		fixSSAOrder(pkgSSA)
+		prog.CreatePackage(p.Types, p.Syntax, p.TypesInfo, true)
+	} else {
+		applyPatches(ctx, p, verbose)
+		prog.CreatePackage(p.Types, p.Syntax, p.TypesInfo, true)
 	}
+	pkgSSA := prog.Package(p.Types)
+	pkgSSA.Build() // TODO(xsw): build concurrently
+	// Apply local SSA fixups once when package SSA is first built.
+	fixSSAOrder(pkgSSA)
 	return pkgSSA
 }
 

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -6,6 +6,10 @@ package build
 import (
 	"bytes"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
 	"io"
 	"os"
 	"os/exec"
@@ -305,5 +309,103 @@ func TestTestMultiplePackagesWithOutputFile(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "cannot use -o flag with multiple packages") {
 		t.Errorf("Expected error about -o with multiple packages, got: %v", err)
+	}
+}
+
+func TestPkgRequiresNaiveForm(t *testing.T) {
+	parsePkg := func(t *testing.T, src string) *packages.Package {
+		t.Helper()
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, "main.go", src, 0)
+		if err != nil {
+			t.Fatalf("ParseFile: %v", err)
+		}
+		return &packages.Package{Syntax: []*ast.File{file}}
+	}
+
+	t.Run("setjmp package call", func(t *testing.T) {
+		pkg := parsePkg(t, `package main
+			import setjmp "github.com/goplus/lib/c/setjmp"
+			func f(jb *setjmp.JmpBuf) int { return int(setjmp.Setjmp(jb)) }
+		`)
+		if !pkgRequiresNaiveForm(pkg) {
+			t.Fatal("pkgRequiresNaiveForm = false, want true")
+		}
+	})
+
+	t.Run("c sigsetjmp call", func(t *testing.T) {
+		pkg := parsePkg(t, `package main
+			import c "github.com/goplus/lib/c"
+			func f(jb c.Pointer) int { return int(c.Sigsetjmp(jb, 0)) }
+		`)
+		if !pkgRequiresNaiveForm(pkg) {
+			t.Fatal("pkgRequiresNaiveForm = false, want true")
+		}
+	})
+
+	t.Run("dot import", func(t *testing.T) {
+		pkg := parsePkg(t, `package main
+			import . "github.com/goplus/lib/c/setjmp"
+			func f(jb *JmpBuf) int { return int(Setjmp(jb)) }
+		`)
+		if !pkgRequiresNaiveForm(pkg) {
+			t.Fatal("pkgRequiresNaiveForm = false, want true")
+		}
+	})
+
+	t.Run("plain c import without setjmp", func(t *testing.T) {
+		pkg := parsePkg(t, `package main
+			import c "github.com/goplus/lib/c"
+			func f(s *c.Char) uintptr { return c.Strlen(s) }
+		`)
+		if pkgRequiresNaiveForm(pkg) {
+			t.Fatal("pkgRequiresNaiveForm = true, want false")
+		}
+	})
+}
+
+func TestNaiveProgramPackagesPropagatesToImporters(t *testing.T) {
+	parsePkg := func(t *testing.T, path, src string, imports ...*packages.Package) *packages.Package {
+		t.Helper()
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path+".go", src, 0)
+		if err != nil {
+			t.Fatalf("ParseFile: %v", err)
+		}
+		typesPkg := types.NewPackage(path, filepath.Base(path))
+		importMap := make(map[string]*packages.Package, len(imports))
+		for _, imp := range imports {
+			importMap[imp.PkgPath] = imp
+		}
+		return &packages.Package{
+			ID:      path,
+			PkgPath: path,
+			Types:   typesPkg,
+			Syntax:  []*ast.File{file},
+			Imports: importMap,
+		}
+	}
+
+	leaf := parsePkg(t, "example.com/leaf", `package leaf
+		import setjmp "github.com/goplus/lib/c/setjmp"
+		func F(jb *setjmp.JmpBuf) int { return int(setjmp.Setjmp(jb)) }
+	`)
+	parent := parsePkg(t, "example.com/parent", `package parent
+		import "example.com/leaf"
+		func Use() int { return 0 }
+	`, leaf)
+	plain := parsePkg(t, "example.com/plain", `package plain
+		func Use() int { return 0 }
+	`)
+
+	got := naiveProgramPackages([]*packages.Package{parent, plain})
+	if !got[leaf] {
+		t.Fatal("naiveProgramPackages missing direct setjmp package")
+	}
+	if !got[parent] {
+		t.Fatal("naiveProgramPackages missing importer of direct setjmp package")
+	}
+	if got[plain] {
+		t.Fatal("naiveProgramPackages unexpectedly marked unrelated package")
 	}
 }

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -1291,6 +1291,8 @@ func (b Builder) BuiltinCall(fn string, args ...Expr) (ret Expr) {
 		}
 	case "recover":
 		return b.Recover()
+	case "ssa:deferstack":
+		return b.Prog.Nil(b.Prog.VoidPtr())
 	case "print", "println":
 		return b.PrintEx(fn == "println", args...)
 	case "complex":

--- a/ssa/type_cvt.go
+++ b/ssa/type_cvt.go
@@ -72,10 +72,22 @@ func (p Program) Closure(sig *types.Signature) Type {
 	return p.rawType(closure)
 }
 
+func isSSAOpaqueType(typ types.Type) bool {
+	switch types.TypeString(typ, nil) {
+	case "deferStack", "iter":
+		return true
+	default:
+		return false
+	}
+}
+
 func (p goTypes) cvtType(typ types.Type) (raw types.Type, cvt bool) {
 	switch t := typ.(type) {
 	case *types.Basic:
 	case *types.Pointer:
+		if isSSAOpaqueType(t.Elem()) {
+			return types.Typ[types.UnsafePointer], true
+		}
 		if elem, cvt := p.cvtType(t.Elem()); cvt {
 			return types.NewPointer(elem), true
 		}
@@ -118,6 +130,9 @@ func (p goTypes) cvtType(typ types.Type) (raw types.Type, cvt bool) {
 	case *types.Alias:
 		return p.cvtType(types.Unalias(t))
 	default:
+		if isSSAOpaqueType(typ) {
+			return types.Typ[types.UnsafePointer], true
+		}
 		panic(fmt.Sprintf("cvtType: unexpected type - %T", typ))
 	}
 	return typ, false

--- a/test/c_setjmp_test.go
+++ b/test/c_setjmp_test.go
@@ -1,0 +1,24 @@
+//go:build llgo
+// +build llgo
+
+package test
+
+import (
+	"testing"
+
+	"github.com/goplus/lib/c"
+	"github.com/goplus/lib/c/setjmp"
+)
+
+func TestSetjmpPreservesUpdatedLocalAcrossLongjmp(t *testing.T) {
+	var jb setjmp.JmpBuf
+	var count c.Int
+	ret := setjmp.Setjmp(&jb)
+	if ret == 0 {
+		count++
+		setjmp.Longjmp(&jb, count)
+	}
+	if want := c.Int(1); ret != want || count != want {
+		t.Fatalf("after longjmp: ret=%d count=%d, want 1/1", ret, count)
+	}
+}


### PR DESCRIPTION
Fixes #1009

## Summary
- detect packages that call `setjmp.Setjmp` or `c.Sigsetjmp` and build them in `ssa.NaiveForm`
- propagate that requirement to importers so test main packages stay in the same SSA graph
- add minimal SSA support for `ssa:deferstack` and opaque `deferStack` / `iter` types emitted by NaiveForm
- add an llgo regression test that checks a local updated after `setjmp` remains visible after `longjmp`

## Root Cause
`x/tools/go/ssa` normal form can keep locals in SSA values across `setjmp` / `longjmp`. After `longjmp` returns to the earlier `setjmp` point, llgo could still observe the old SSA value instead of reloading the updated local from memory.

That is why the repro behaved like this before the fix:
- `ret == 1`
- but `count == 0`

## Why Two SSA Programs
`ssa.Program` build mode is chosen when the program is created. `x/tools/go/ssa` does not provide a package-level switch that lets one package use normal form and another package use `ssa.NaiveForm` inside the same `Program`.

Because of that, this change keeps two SSA programs:
- a normal `Program` for regular packages
- a `NaiveForm` `Program` for packages that need `setjmp` semantics

Importers of those packages are also moved into the same naive SSA graph so package imports remain consistent inside one `ssa.Program`.

## Why NaiveForm Fixes It
`ssa.NaiveForm` is more conservative and keeps locals in memory instead of aggressively keeping them only as SSA temporaries. That matches the observable semantics needed for `setjmp` / `longjmp`, where control can jump back to an earlier point and must still observe the updated local state.

## Validation
- `go test ./internal/build -count=1`
- `go test ./ssa -count=1`
- `go build -tags=dev -o /tmp/llgo1009-fix ./cmd/llgo`
- `/tmp/llgo1009-fix test ./test -run TestSetjmpPreservesUpdatedLocalAcrossLongjmp -count=1`
- `/tmp/llgo1009-fix test ./test -count=1`
- `/tmp/llgo1009-fix run ./cl/_testlibc/setjmp`
