### PR TITLE
ssa: resolve runtime linknames before rtFunc lookup

### DIFF
--- a/cl/builtin_test.go
+++ b/cl/builtin_test.go
@@ -413,10 +413,10 @@ func TestErrImport(t *testing.T) {
 
 func TestErrInitLinkname(t *testing.T) {
 	var ctx context
-	ctx.initLinkname("//llgo:link abc", func(name string, isExport bool) (string, bool, bool) {
+	ctx.initLinkname("//llgo:link abc", true, func(name string, isExport bool) (string, bool, bool) {
 		return "", false, false
 	})
-	ctx.initLinkname("//go:linkname Printf printf", func(name string, isExport bool) (string, bool, bool) {
+	ctx.initLinkname("//go:linkname Printf printf", true, func(name string, isExport bool) (string, bool, bool) {
 		return "", false, false
 	})
 	defer func() {
@@ -424,7 +424,7 @@ func TestErrInitLinkname(t *testing.T) {
 			t.Fatal("initLinkname: no error?")
 		}
 	}()
-	ctx.initLinkname("//go:linkname Printf printf", func(name string, isExport bool) (string, bool, bool) {
+	ctx.initLinkname("//go:linkname Printf printf", true, func(name string, isExport bool) (string, bool, bool) {
 		return "foo.Printf", false, name == "Printf"
 	})
 }
@@ -598,7 +598,7 @@ func TestHandleExportDiffName(t *testing.T) {
 			}
 
 			// Call initLinkname with closure that mimics initLinknameByDoc behavior
-			ret := ctx.initLinkname(tt.line, func(name string, isExport bool) (string, bool, bool) {
+			ret := ctx.initLinkname(tt.line, true, func(name string, isExport bool) (string, bool, bool) {
 				return tt.fullName, false, name == tt.inPkgName || (isExport && enableExportRename)
 			})
 
@@ -692,7 +692,7 @@ func TestInitLinknameByDocExportDiffNames(t *testing.T) {
 			}
 
 			// Call initLinknameByDoc
-			ctx.initLinknameByDoc(tt.doc, tt.fullName, tt.inPkgName, false)
+			ctx.processLinknameByDoc(tt.doc, tt.fullName, tt.inPkgName, false, true)
 
 			// Verify export behavior
 			exports := pkg.ExportFuncs()
@@ -754,7 +754,7 @@ func TestInitLinkExportDiffNames(t *testing.T) {
 				pkg:  pkg,
 			}
 
-			ctx.initLinkname(tt.line, func(inPkgName string, isExport bool) (fullName string, isVar, ok bool) {
+			ctx.initLinkname(tt.line, true, func(inPkgName string, isExport bool) (fullName string, isVar, ok bool) {
 				// Simulate initLinknames scenario: symbol not found (like in decl packages)
 				return "", false, false
 			})

--- a/cl/import.go
+++ b/cl/import.go
@@ -73,7 +73,7 @@ func (p *pkgSymInfo) initLinknames(ctx *context) {
 		lines := bytes.Split(b, sep)
 		for _, line := range lines {
 			if bytes.HasPrefix(line, commentPrefix) {
-				ctx.initLinkname(string(line), func(inPkgName string, isExport bool) (fullName string, isVar, ok bool) {
+				ctx.initLinkname(string(line), true, func(inPkgName string, isExport bool) (fullName string, isVar, ok bool) {
 					if sym, ok := p.syms[inPkgName]; ok && file == sym.file {
 						return sym.fullName, sym.isVar, true
 					}
@@ -180,7 +180,7 @@ func (p *context) initFiles(pkgPath string, files []*ast.File, cPkg bool) {
 			switch decl := decl.(type) {
 			case *ast.FuncDecl:
 				fullName, inPkgName := astFuncName(pkgPath, decl)
-				if !p.initLinknameByDoc(decl.Doc, fullName, inPkgName, false) && cPkg {
+				if !p.processLinknameByDoc(decl.Doc, fullName, inPkgName, false, true) && cPkg {
 					// package C (https://github.com/goplus/llgo/issues/1165)
 					if decl.Recv == nil && token.IsExported(inPkgName) {
 						exportName := strings.TrimPrefix(inPkgName, "X")
@@ -194,7 +194,7 @@ func (p *context) initFiles(pkgPath string, files []*ast.File, cPkg bool) {
 					if len(decl.Specs) == 1 {
 						if names := decl.Specs[0].(*ast.ValueSpec).Names; len(names) == 1 {
 							inPkgName := names[0].Name
-							p.initLinknameByDoc(decl.Doc, pkgPath+"."+inPkgName, inPkgName, true)
+							p.processLinknameByDoc(decl.Doc, pkgPath+"."+inPkgName, inPkgName, true, true)
 						}
 					}
 				case token.CONST:
@@ -228,12 +228,12 @@ func PreCollectLinknames(prog llssa.Program, pkgPath string, files []*ast.File) 
 			switch decl := decl.(type) {
 			case *ast.FuncDecl:
 				fullName, inPkgName := astFuncName(pkgPath, decl)
-				ctx.preCollectLinknameByDoc(decl.Doc, fullName, inPkgName, false)
+				ctx.processLinknameByDoc(decl.Doc, fullName, inPkgName, false, false)
 			case *ast.GenDecl:
 				if decl.Tok == token.VAR && len(decl.Specs) == 1 {
 					if names := decl.Specs[0].(*ast.ValueSpec).Names; len(names) == 1 {
 						inPkgName := names[0].Name
-						ctx.preCollectLinknameByDoc(decl.Doc, pkgPath+"."+inPkgName, inPkgName, true)
+						ctx.processLinknameByDoc(decl.Doc, pkgPath+"."+inPkgName, inPkgName, true, false)
 					}
 				}
 			}
@@ -297,19 +297,11 @@ func (p *context) collectSkip(line string, prefix int) {
 	}
 }
 
-func (p *context) initLinknameByDoc(doc *ast.CommentGroup, fullName, inPkgName string, isVar bool) bool {
-	return p.processLinknameByDoc(doc, fullName, inPkgName, isVar, true)
-}
-
-func (p *context) preCollectLinknameByDoc(doc *ast.CommentGroup, fullName, inPkgName string, isVar bool) bool {
-	return p.processLinknameByDoc(doc, fullName, inPkgName, isVar, false)
-}
-
 func (p *context) processLinknameByDoc(doc *ast.CommentGroup, fullName, inPkgName string, isVar, allowExport bool) bool {
 	if doc != nil {
 		for n := len(doc.List) - 1; n >= 0; n-- {
 			line := doc.List[n].Text
-			ret := p.initLinknameMode(line, allowExport, func(name string, isExport bool) (_ string, _, ok bool) {
+			ret := p.initLinkname(line, allowExport, func(name string, isExport bool) (_ string, _, ok bool) {
 				return fullName, isVar, name == inPkgName || (isExport && enableExportRename)
 			})
 			if ret != unknownDirective {
@@ -326,11 +318,7 @@ const (
 	unknownDirective = -1
 )
 
-func (p *context) initLinkname(line string, f func(inPkgName string, isExport bool) (fullName string, isVar, ok bool)) int {
-	return p.initLinknameMode(line, true, f)
-}
-
-func (p *context) initLinknameMode(line string, allowExport bool, f func(inPkgName string, isExport bool) (fullName string, isVar, ok bool)) int {
+func (p *context) initLinkname(line string, allowExport bool, f func(inPkgName string, isExport bool) (fullName string, isVar, ok bool)) int {
 	const (
 		linkname  = "//go:linkname "
 		llgolink  = "//llgo:link "

--- a/cl/import.go
+++ b/cl/import.go
@@ -217,6 +217,60 @@ func (p *context) initFiles(pkgPath string, files []*ast.File, cPkg bool) {
 	}
 }
 
+// PreCollectLinknames scans syntax files before SSA compilation and populates
+// prog.Linkname for package-level //go:linkname / //llgo:link declarations.
+// It intentionally ignores //export because there is no package export context
+// during the pre-collection phase.
+func PreCollectLinknames(prog llssa.Program, pkgPath string, files []*ast.File) {
+	ctx := &context{prog: prog}
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			switch decl := decl.(type) {
+			case *ast.FuncDecl:
+				fullName, inPkgName := astFuncName(pkgPath, decl)
+				preCollectLinknameByDoc(ctx, decl.Doc, fullName, inPkgName, false)
+			case *ast.GenDecl:
+				if decl.Tok == token.VAR && len(decl.Specs) == 1 {
+					if names := decl.Specs[0].(*ast.ValueSpec).Names; len(names) == 1 {
+						inPkgName := names[0].Name
+						preCollectLinknameByDoc(ctx, decl.Doc, pkgPath+"."+inPkgName, inPkgName, true)
+					}
+				}
+			}
+		}
+	}
+}
+
+func preCollectLinknameByDoc(ctx *context, doc *ast.CommentGroup, fullName, inPkgName string, isVar bool) {
+	if doc == nil {
+		return
+	}
+	for n := len(doc.List) - 1; n >= 0; n-- {
+		line := doc.List[n].Text
+		switch {
+		case strings.HasPrefix(line, "//go:linkname "):
+			ctx.initLink(line, len("//go:linkname "), false, func(name string, isExport bool) (string, bool, bool) {
+				return fullName, isVar, name == inPkgName || (isExport && enableExportRename)
+			})
+			return
+		case strings.HasPrefix(line, "//llgo:link "):
+			ctx.initLink(line, len("//llgo:link "), false, func(name string, isExport bool) (string, bool, bool) {
+				return fullName, isVar, name == inPkgName || (isExport && enableExportRename)
+			})
+			return
+		case strings.HasPrefix(line, "// llgo:link "):
+			ctx.initLink(line, len("// llgo:link "), false, func(name string, isExport bool) (string, bool, bool) {
+				return fullName, isVar, name == inPkgName || (isExport && enableExportRename)
+			})
+			return
+		case strings.HasPrefix(line, "//go:"):
+			continue
+		default:
+			return
+		}
+	}
+}
+
 // Collect skip names and skip other annotations, such as go: and llgo:
 // llgo:skip symbol1 symbol2 ...
 // llgo:skipall

--- a/cl/import.go
+++ b/cl/import.go
@@ -228,45 +228,15 @@ func PreCollectLinknames(prog llssa.Program, pkgPath string, files []*ast.File) 
 			switch decl := decl.(type) {
 			case *ast.FuncDecl:
 				fullName, inPkgName := astFuncName(pkgPath, decl)
-				preCollectLinknameByDoc(ctx, decl.Doc, fullName, inPkgName, false)
+				ctx.preCollectLinknameByDoc(decl.Doc, fullName, inPkgName, false)
 			case *ast.GenDecl:
 				if decl.Tok == token.VAR && len(decl.Specs) == 1 {
 					if names := decl.Specs[0].(*ast.ValueSpec).Names; len(names) == 1 {
 						inPkgName := names[0].Name
-						preCollectLinknameByDoc(ctx, decl.Doc, pkgPath+"."+inPkgName, inPkgName, true)
+						ctx.preCollectLinknameByDoc(decl.Doc, pkgPath+"."+inPkgName, inPkgName, true)
 					}
 				}
 			}
-		}
-	}
-}
-
-func preCollectLinknameByDoc(ctx *context, doc *ast.CommentGroup, fullName, inPkgName string, isVar bool) {
-	if doc == nil {
-		return
-	}
-	for n := len(doc.List) - 1; n >= 0; n-- {
-		line := doc.List[n].Text
-		switch {
-		case strings.HasPrefix(line, "//go:linkname "):
-			ctx.initLink(line, len("//go:linkname "), false, func(name string, isExport bool) (string, bool, bool) {
-				return fullName, isVar, name == inPkgName || (isExport && enableExportRename)
-			})
-			return
-		case strings.HasPrefix(line, "//llgo:link "):
-			ctx.initLink(line, len("//llgo:link "), false, func(name string, isExport bool) (string, bool, bool) {
-				return fullName, isVar, name == inPkgName || (isExport && enableExportRename)
-			})
-			return
-		case strings.HasPrefix(line, "// llgo:link "):
-			ctx.initLink(line, len("// llgo:link "), false, func(name string, isExport bool) (string, bool, bool) {
-				return fullName, isVar, name == inPkgName || (isExport && enableExportRename)
-			})
-			return
-		case strings.HasPrefix(line, "//go:"):
-			continue
-		default:
-			return
 		}
 	}
 }
@@ -328,10 +298,18 @@ func (p *context) collectSkip(line string, prefix int) {
 }
 
 func (p *context) initLinknameByDoc(doc *ast.CommentGroup, fullName, inPkgName string, isVar bool) bool {
+	return p.processLinknameByDoc(doc, fullName, inPkgName, isVar, true)
+}
+
+func (p *context) preCollectLinknameByDoc(doc *ast.CommentGroup, fullName, inPkgName string, isVar bool) bool {
+	return p.processLinknameByDoc(doc, fullName, inPkgName, isVar, false)
+}
+
+func (p *context) processLinknameByDoc(doc *ast.CommentGroup, fullName, inPkgName string, isVar, allowExport bool) bool {
 	if doc != nil {
 		for n := len(doc.List) - 1; n >= 0; n-- {
 			line := doc.List[n].Text
-			ret := p.initLinkname(line, func(name string, isExport bool) (_ string, _, ok bool) {
+			ret := p.initLinknameMode(line, allowExport, func(name string, isExport bool) (_ string, _, ok bool) {
 				return fullName, isVar, name == inPkgName || (isExport && enableExportRename)
 			})
 			if ret != unknownDirective {
@@ -349,6 +327,10 @@ const (
 )
 
 func (p *context) initLinkname(line string, f func(inPkgName string, isExport bool) (fullName string, isVar, ok bool)) int {
+	return p.initLinknameMode(line, true, f)
+}
+
+func (p *context) initLinknameMode(line string, allowExport bool, f func(inPkgName string, isExport bool) (fullName string, isVar, ok bool)) int {
 	const (
 		linkname  = "//go:linkname "
 		llgolink  = "//llgo:link "
@@ -365,7 +347,7 @@ func (p *context) initLinkname(line string, f func(inPkgName string, isExport bo
 	} else if strings.HasPrefix(line, llgolink) {
 		p.initLink(line, len(llgolink), false, f)
 		return hasLinkname
-	} else if strings.HasPrefix(line, export) {
+	} else if allowExport && strings.HasPrefix(line, export) {
 		// rewrite //export FuncName to //export FuncName FuncName
 		funcName := strings.TrimSpace(line[len(export):])
 		line = line + " " + funcName

--- a/cl/import_coverage_test.go
+++ b/cl/import_coverage_test.go
@@ -150,3 +150,21 @@ func TestAstAndTypesFuncNameCoverage(t *testing.T) {
 		t.Fatalf("typesFuncName(func)=(%q,%q), want (%q,%q)", full, inPkg, "example.com/p.Top", "Top")
 	}
 }
+
+func TestPreCollectLinknames(t *testing.T) {
+	src := `package runtime
+import _ "unsafe"
+//go:linkname Sigsetjmp C.sigsetjmp
+func Sigsetjmp()
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "runtime.go", src, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+	prog := llssa.NewProgram(nil)
+	PreCollectLinknames(prog, llssa.PkgRuntime, []*ast.File{file})
+	if got, ok := prog.Linkname(llssa.PkgRuntime + ".Sigsetjmp"); !ok || got != "C.sigsetjmp" {
+		t.Fatalf("pre-collected linkname = (%q,%v), want (%q,%v)", got, ok, "C.sigsetjmp", true)
+	}
+}

--- a/cl/import_coverage_test.go
+++ b/cl/import_coverage_test.go
@@ -152,19 +152,28 @@ func TestAstAndTypesFuncNameCoverage(t *testing.T) {
 }
 
 func TestPreCollectLinknames(t *testing.T) {
-	src := `package runtime
-import _ "unsafe"
-//go:linkname Sigsetjmp C.sigsetjmp
-func Sigsetjmp()
-`
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, "runtime.go", src, parser.ParseComments)
-	if err != nil {
-		t.Fatalf("ParseFile failed: %v", err)
+	cases := []struct {
+		name      string
+		directive string
+		want      string
+	}{
+		{name: "go-linkname", directive: "//go:linkname Sigsetjmp C.sigsetjmp", want: "C.sigsetjmp"},
+		{name: "llgo-linkname", directive: "//llgo:link Sigsetjmp C.sigsetjmp", want: "C.sigsetjmp"},
+		{name: "llgo-linkname-spaced", directive: "// llgo:link Sigsetjmp C.sigsetjmp", want: "C.sigsetjmp"},
 	}
-	prog := llssa.NewProgram(nil)
-	PreCollectLinknames(prog, llssa.PkgRuntime, []*ast.File{file})
-	if got, ok := prog.Linkname(llssa.PkgRuntime + ".Sigsetjmp"); !ok || got != "C.sigsetjmp" {
-		t.Fatalf("pre-collected linkname = (%q,%v), want (%q,%v)", got, ok, "C.sigsetjmp", true)
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			src := "package runtime\nimport _ \"unsafe\"\n" + tt.directive + "\nfunc Sigsetjmp()\n"
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "runtime.go", src, parser.ParseComments)
+			if err != nil {
+				t.Fatalf("ParseFile failed: %v", err)
+			}
+			prog := llssa.NewProgram(nil)
+			PreCollectLinknames(prog, llssa.PkgRuntime, []*ast.File{file})
+			if got, ok := prog.Linkname(llssa.PkgRuntime + ".Sigsetjmp"); !ok || got != tt.want {
+				t.Fatalf("pre-collected linkname = (%q,%v), want (%q,%v)", got, ok, tt.want, true)
+			}
+		})
 	}
 }

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -338,6 +338,7 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	prog.SetPython(func() *types.Package {
 		return dedup.Check(llssa.PkgPython).Types
 	})
+	preCollectRuntimeLinknames(prog, altPkgs)
 
 	buildMode := ssaBuildMode
 	cabiOptimize := true
@@ -1367,6 +1368,15 @@ func altPkgs(initial []*packages.Package, conf *Config, alts ...string) []string
 		}
 	})
 	return alts
+}
+
+func preCollectRuntimeLinknames(prog llssa.Program, pkgs []*packages.Package) {
+	for _, pkg := range pkgs {
+		if pkg != nil && pkg.PkgPath == llssa.PkgRuntime && len(pkg.Syntax) != 0 {
+			cl.PreCollectLinknames(prog, pkg.PkgPath, pkg.Syntax)
+			return
+		}
+	}
 }
 
 func altSSAPkgs(prog *ssa.Program, patches cl.Patches, alts []*packages.Package, conf *Config, verbose bool) {

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -6,6 +6,9 @@ package build
 import (
 	"bytes"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"io"
 	"os"
 	"os/exec"
@@ -16,6 +19,7 @@ import (
 
 	"github.com/goplus/llgo/internal/mockable"
 	"github.com/goplus/llgo/internal/packages"
+	llssa "github.com/goplus/llgo/ssa"
 )
 
 func TestMain(m *testing.M) {
@@ -316,5 +320,25 @@ func TestCmpTestNonexistentPatternReturnsError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "cannot build SSA for packages") && !strings.Contains(err.Error(), "no such file or directory") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPreCollectRuntimeLinknames(t *testing.T) {
+	prog := llssa.NewProgram(nil)
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "runtime.go", `package runtime
+import _ "unsafe"
+//go:linkname Sigsetjmp C.sigsetjmp
+func Sigsetjmp()
+`, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+	preCollectRuntimeLinknames(prog, []*packages.Package{{
+		PkgPath: llssa.PkgRuntime,
+		Syntax:  []*ast.File{file},
+	}})
+	if got, ok := prog.Linkname(llssa.PkgRuntime + ".Sigsetjmp"); !ok || got != "C.sigsetjmp" {
+		t.Fatalf("pre-collected runtime linkname = (%q,%v), want (%q,%v)", got, ok, "C.sigsetjmp", true)
 	}
 }

--- a/runtime/internal/runtime/setjmp_default.go
+++ b/runtime/internal/runtime/setjmp_default.go
@@ -1,0 +1,15 @@
+//go:build !linux && !baremetal && !wasm
+
+package runtime
+
+import (
+	_ "unsafe"
+
+	c "github.com/goplus/llgo/runtime/internal/clite"
+)
+
+//go:linkname Sigsetjmp C.sigsetjmp
+func Sigsetjmp(env *SigjmpBuf, savemask c.Int) c.Int
+
+//go:linkname Siglongjmp C.siglongjmp
+func Siglongjmp(env *SigjmpBuf, val c.Int)

--- a/runtime/internal/runtime/setjmp_linux.go
+++ b/runtime/internal/runtime/setjmp_linux.go
@@ -1,0 +1,15 @@
+//go:build linux && !baremetal && !wasm
+
+package runtime
+
+import (
+	_ "unsafe"
+
+	c "github.com/goplus/llgo/runtime/internal/clite"
+)
+
+//go:linkname Sigsetjmp C.__sigsetjmp
+func Sigsetjmp(env *SigjmpBuf, savemask c.Int) c.Int
+
+//go:linkname Siglongjmp C.siglongjmp
+func Siglongjmp(env *SigjmpBuf, val c.Int)

--- a/ssa/eh.go
+++ b/ssa/eh.go
@@ -50,29 +50,6 @@ func (p Program) tyLongjmp() *types.Signature {
 	return p.longjmpTy
 }
 
-// func(env unsafe.Pointer, savemask c.Int) c.Int
-func (p Program) tySigsetjmp() *types.Signature {
-	if p.sigsetjmpTy == nil {
-		paramPtr := types.NewParam(token.NoPos, nil, "", p.VoidPtr().raw.Type)
-		paramCInt := types.NewParam(token.NoPos, nil, "", p.CInt().raw.Type)
-		params := types.NewTuple(paramPtr, paramCInt)
-		results := types.NewTuple(paramCInt)
-		p.sigsetjmpTy = types.NewSignatureType(nil, nil, nil, params, results, false)
-	}
-	return p.sigsetjmpTy
-}
-
-// func(env unsafe.Pointer, retval c.Int)
-func (p Program) tySiglongjmp() *types.Signature {
-	if p.sigljmpTy == nil {
-		paramPtr := types.NewParam(token.NoPos, nil, "", p.VoidPtr().raw.Type)
-		paramCInt := types.NewParam(token.NoPos, nil, "", p.CInt().raw.Type)
-		params := types.NewTuple(paramPtr, paramCInt)
-		p.sigljmpTy = types.NewSignatureType(nil, nil, nil, params, nil, false)
-	}
-	return p.sigljmpTy
-}
-
 // func() unsafe.Pointer
 func (p Program) tyStacksave() *types.Signature {
 	if p.stackSaveTy == nil {

--- a/ssa/eh.go
+++ b/ssa/eh.go
@@ -113,11 +113,7 @@ func (b Builder) Sigsetjmp(jb, savemask Expr) Expr {
 	if b.Prog.target.GOARCH == "wasm" || b.Prog.target.Target != "" {
 		return b.Setjmp(jb)
 	}
-	fname := "sigsetjmp"
-	if b.Prog.target.GOOS == "linux" {
-		fname = "__sigsetjmp"
-	}
-	fn := b.Pkg.cFunc(fname, b.Prog.tySigsetjmp())
+	fn := b.Pkg.rtFunc("Sigsetjmp")
 	b.addReturnsTwiceAttr(fn)
 	return b.Call(fn, jb, savemask)
 }
@@ -128,7 +124,7 @@ func (b Builder) Siglongjmp(jb, retval Expr) {
 		b.Longjmp(jb, retval)
 		return
 	}
-	fn := b.Pkg.cFunc("siglongjmp", b.Prog.tySiglongjmp()) // TODO(xsw): mark as noreturn
+	fn := b.Pkg.rtFunc("Siglongjmp") // TODO(xsw): mark as noreturn
 	b.Call(fn, jb, retval)
 	// b.Unreachable()
 }

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -749,6 +749,9 @@ func (p Package) rtFunc(fnName string) Expr {
 	p.NeedRuntime = true
 	fn := p.Prog.runtime().Scope().Lookup(fnName).(*types.Func)
 	name := FullName(fn.Pkg(), fnName)
+	if p.fnlink != nil {
+		name = p.fnlink(name)
+	}
 	sig := fn.Type().(*types.Signature)
 	return p.NewFunc(name, sig, InGo).Expr
 }

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -205,8 +205,6 @@ type aProgram struct {
 	destructTy  *types.Signature
 	setjmpTy    *types.Signature
 	longjmpTy   *types.Signature
-	sigsetjmpTy *types.Signature
-	sigljmpTy   *types.Signature
 
 	printfTy *types.Signature
 

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -1449,3 +1449,36 @@ func TestInitAbiTypesForEmptySelection(t *testing.T) {
 		t.Fatalf("InitAbiTypesFor with empty selection = %v, want nil", fn)
 	}
 }
+
+func TestRtFuncResolvesLinkname(t *testing.T) {
+	prog := NewProgram(nil)
+	rt := types.NewPackage(PkgRuntime, PkgRuntime)
+	sig := types.NewSignatureType(nil, nil, nil,
+		types.NewTuple(
+			types.NewVar(0, nil, "env", types.NewPointer(types.NewStruct(nil, nil))),
+			types.NewVar(0, nil, "savemask", types.Typ[types.Int32]),
+		),
+		types.NewTuple(types.NewVar(0, nil, "", types.Typ[types.Int32])),
+		false,
+	)
+	if err := rt.Scope().Insert(types.NewFunc(token.NoPos, rt, "Sigsetjmp", sig)); err != nil {
+		t.Fatal(err)
+	}
+	prog.SetRuntime(rt)
+	prog.SetLinkname(PkgRuntime+".Sigsetjmp", "C.sigsetjmp")
+
+	pkg := prog.NewPackage("foo", "foo")
+	pkg.SetResolveLinkname(func(name string) string {
+		if link, ok := prog.Linkname(name); ok {
+			prefix, target, _ := strings.Cut(link, ".")
+			if prefix == "C" {
+				return target
+			}
+		}
+		return name
+	})
+
+	if got := pkg.rtFunc("Sigsetjmp").impl.Name(); got != "sigsetjmp" {
+		t.Fatalf("rtFunc linkname = %q, want %q", got, "sigsetjmp")
+	}
+}


### PR DESCRIPTION
## Summary
- resolve runtime linknames before `rtFunc` lookup
- teach `rtFunc` to apply `fnlink` when resolving runtime functions
- switch hosted `setjmp/longjmp` lowering to runtime declarations instead of compiler-side C symbol selection

## Root cause
`Package.rtFunc` previously resolved runtime helpers by raw package symbol name and ignored
`fnlink`. That meant runtime declarations using `//go:linkname` were invisible to `rtFunc`.

At the same time, runtime linknames were not collected early enough. By the time user packages
were compiled, `prog.Linkname` had not yet seen the runtime declarations, so the compiler kept
using direct `cFunc("sigsetjmp")` / `cFunc("siglongjmp")` workarounds in `ssa/eh.go`.

## Fix
- pre-collect runtime linknames before SSA package compilation
- apply `fnlink` inside `Package.rtFunc`
- add hosted runtime declarations for `Sigsetjmp` / `Siglongjmp`
- route hosted `setjmp/longjmp` lowering through `rtFunc`

## Validation
- `go test ./ssa -run 'TestRtFuncResolvesLinkname|TestSetjmpLongjmpIRPaths|TestSigjmpUsesSetjmpOnExplicitTarget' -count=1`
- `go test ./cl -run 'TestPreCollectLinknames|TestPkgSymInfoAddSymAndInitLinknamesCoverage' -count=1`
- `go test ./internal/build -run TestPreCollectRuntimeLinknames -count=1`
- `go build -tags=dev -o /tmp/llgo-1483 ./cmd/llgo`
- `cd _demo/go/defer && /tmp/llgo-1483 build .`
