### PR TITLE
fix(cl,ssa,runtime): route sync/atomic builtins through action-aware lowering

### DIFF
--- a/cl/_testlibgo/atomic/expect.txt
+++ b/cl/_testlibgo/atomic/expect.txt
@@ -1,1 +1,5 @@
-;
+store: 100
+ret: 101 v: 101
+swp: false v: 101
+swp: true v: 102
+ret: 101 v: 101

--- a/cl/_testlibgo/atomic/out.ll
+++ b/cl/_testlibgo/atomic/out.ll
@@ -26,33 +26,25 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
 define void @"github.com/goplus/llgo/cl/_testlibgo/atomic.main"() {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
-  call void @"sync/atomic.StoreInt64"(ptr %0, i64 100)
-  %1 = call i64 @"sync/atomic.LoadInt64"(ptr %0)
+  store atomic i64 100, ptr %0 seq_cst, align 4
+  %1 = load atomic i64, ptr %0 seq_cst, align 4
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 6 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %1)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
-  %2 = call i64 @"sync/atomic.AddInt64"(ptr %0, i64 1)
-  %3 = load i64, ptr %0, align 4
+  %2 = atomicrmw add ptr %0, i64 1 seq_cst, align 8
+  %3 = add i64 %2, 1
+  %4 = load i64, ptr %0, align 4
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 4 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %2)
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @2, i64 2 })
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %3)
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
-  %4 = call i1 @"sync/atomic.CompareAndSwapInt64"(ptr %0, i64 100, i64 102)
-  %5 = load i64, ptr %0, align 4
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @3, i64 4 })
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1 %4)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @2, i64 2 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %5)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %4)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
-  %6 = call i1 @"sync/atomic.CompareAndSwapInt64"(ptr %0, i64 101, i64 102)
+  %5 = cmpxchg ptr %0, i64 100, i64 102 seq_cst seq_cst, align 8
+  %6 = extractvalue { i64, i1 } %5, 1
   %7 = load i64, ptr %0, align 4
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @3, i64 4 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
@@ -62,15 +54,27 @@ _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %7)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
-  %8 = call i64 @"sync/atomic.AddInt64"(ptr %0, i64 -1)
-  %9 = load i64, ptr %0, align 4
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 4 })
+  %8 = cmpxchg ptr %0, i64 101, i64 102 seq_cst seq_cst, align 8
+  %9 = extractvalue { i64, i1 } %8, 1
+  %10 = load i64, ptr %0, align 4
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @3, i64 4 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %8)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1 %9)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @2, i64 2 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %9)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %10)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  %11 = atomicrmw add ptr %0, i64 -1 seq_cst, align 8
+  %12 = add i64 %11, -1
+  %13 = load i64, ptr %0, align 4
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 4 })
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %12)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @2, i64 2 })
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %13)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
   ret void
 }
@@ -79,18 +83,10 @@ declare void @"sync/atomic.init"()
 
 declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
 
-declare void @"sync/atomic.StoreInt64"(ptr, i64)
-
-declare i64 @"sync/atomic.LoadInt64"(ptr)
-
 declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
 
 declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
 
 declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
-
-declare i64 @"sync/atomic.AddInt64"(ptr, i64)
-
-declare i1 @"sync/atomic.CompareAndSwapInt64"(ptr, i64, i64)
 
 declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1)

--- a/cl/import.go
+++ b/cl/import.go
@@ -499,17 +499,17 @@ const (
 	llgoAtomicCmpXchg = llgoInstrBase + 0x1f
 	llgoAtomicOpBase  = llgoInstrBase + 0x20
 
-	llgoAtomicXchg = llgoAtomicOpBase + llssa.OpXchg
-	llgoAtomicAdd  = llgoAtomicOpBase + llssa.OpAdd
-	llgoAtomicSub  = llgoAtomicOpBase + llssa.OpSub
-	llgoAtomicAnd  = llgoAtomicOpBase + llssa.OpAnd
-	llgoAtomicNand = llgoAtomicOpBase + llssa.OpNand
-	llgoAtomicOr   = llgoAtomicOpBase + llssa.OpOr
-	llgoAtomicXor  = llgoAtomicOpBase + llssa.OpXor
-	llgoAtomicMax  = llgoAtomicOpBase + llssa.OpMax
-	llgoAtomicMin  = llgoAtomicOpBase + llssa.OpMin
-	llgoAtomicUMax = llgoAtomicOpBase + llssa.OpUMax
-	llgoAtomicUMin = llgoAtomicOpBase + llssa.OpUMin
+	llgoAtomicXchg = int(llgoAtomicOpBase + llssa.OpXchg)
+	llgoAtomicAdd  = int(llgoAtomicOpBase + llssa.OpAdd)
+	llgoAtomicSub  = int(llgoAtomicOpBase + llssa.OpSub)
+	llgoAtomicAnd  = int(llgoAtomicOpBase + llssa.OpAnd)
+	llgoAtomicNand = int(llgoAtomicOpBase + llssa.OpNand)
+	llgoAtomicOr   = int(llgoAtomicOpBase + llssa.OpOr)
+	llgoAtomicXor  = int(llgoAtomicOpBase + llssa.OpXor)
+	llgoAtomicMax  = int(llgoAtomicOpBase + llssa.OpMax)
+	llgoAtomicMin  = int(llgoAtomicOpBase + llssa.OpMin)
+	llgoAtomicUMax = int(llgoAtomicOpBase + llssa.OpUMax)
+	llgoAtomicUMin = int(llgoAtomicOpBase + llssa.OpUMin)
 
 	llgoCgoBase         = llgoInstrBase + 0x30
 	llgoCgoCString      = llgoCgoBase + 0x0
@@ -521,12 +521,13 @@ const (
 	llgoCgoCheckPointer = llgoCgoBase + 0x6
 	llgoCgoCgocall      = llgoCgoBase + 0x7
 
-	llgoAsm             = llgoInstrBase + 0x40
-	llgoStackSave       = llgoInstrBase + 0x41
-	llgoFuncPCABI0      = llgoInstrBase + 0x42
-	llgoSkip            = llgoInstrBase + 0x43
-	llgoSyscall         = llgoInstrBase + 0x44
-	llgoAtomicCmpXchgOK = llgoInstrBase + 0x45
+	llgoAsm                = llgoInstrBase + 0x40
+	llgoStackSave          = llgoInstrBase + 0x41
+	llgoFuncPCABI0         = llgoInstrBase + 0x42
+	llgoSkip               = llgoInstrBase + 0x43
+	llgoSyscall            = llgoInstrBase + 0x44
+	llgoAtomicCmpXchgOK    = llgoInstrBase + 0x45
+	llgoAtomicAddReturnNew = llgoInstrBase + 0x46
 
 	llgoAtomicOpLast = llgoAtomicOpBase + int(llssa.OpUMin)
 )

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -510,44 +510,43 @@ func (p *context) siglongjmp(b llssa.Builder, args []ssa.Value) {
 	panic("siglongjmp(jb c.SigjmpBuf, retval c.Int): invalid arguments")
 }
 
-func (p *context) atomic(b llssa.Builder, op llssa.AtomicOp, args []ssa.Value) (ret llssa.Expr) {
+func (p *context) atomic(b llssa.Builder, op llssa.AtomicOp, args []llssa.Expr) (ret llssa.Expr) {
 	if len(args) == 2 {
-		addr := p.compileValue(b, args[0])
-		val := p.compileValue(b, args[1])
+		addr := args[0]
+		val := args[1]
 		return b.Atomic(op, addr, val)
 	}
 	panic("atomicOp(addr *T, val T) T: invalid arguments")
 }
 
-func (p *context) atomicLoad(b llssa.Builder, args []ssa.Value) llssa.Expr {
+func (p *context) atomicLoad(b llssa.Builder, args []llssa.Expr) llssa.Expr {
 	if len(args) == 1 {
-		addr := p.compileValue(b, args[0])
+		addr := args[0]
 		return b.Load(addr).SetOrdering(llssa.OrderingSeqConsistent)
 	}
 	panic("atomicLoad(addr *T) T: invalid arguments")
 }
 
-func (p *context) atomicStore(b llssa.Builder, args []ssa.Value) {
+func (p *context) atomicStore(b llssa.Builder, args []llssa.Expr) llssa.Expr {
 	if len(args) == 2 {
-		addr := p.compileValue(b, args[0])
-		val := p.compileValue(b, args[1])
-		b.Store(addr, val).SetOrdering(llssa.OrderingSeqConsistent)
-		return
+		addr := args[0]
+		val := args[1]
+		return b.Store(addr, val).SetOrdering(llssa.OrderingSeqConsistent)
 	}
 	panic("atomicStore(addr *T, val T) T: invalid arguments")
 }
 
-func (p *context) atomicCmpXchg(b llssa.Builder, args []ssa.Value) llssa.Expr {
+func (p *context) atomicCmpXchg(b llssa.Builder, args []llssa.Expr) llssa.Expr {
 	if len(args) == 3 {
-		addr := p.compileValue(b, args[0])
-		old := p.compileValue(b, args[1])
-		new := p.compileValue(b, args[2])
+		addr := args[0]
+		old := args[1]
+		new := args[2]
 		return b.AtomicCmpXchg(addr, old, new)
 	}
 	panic("atomicCmpXchg(addr *T, old, new T) T: invalid arguments")
 }
 
-func (p *context) atomicCmpXchgOK(b llssa.Builder, args []ssa.Value) llssa.Expr {
+func (p *context) atomicCmpXchgOK(b llssa.Builder, args []llssa.Expr) llssa.Expr {
 	ret := p.atomicCmpXchg(b, args)
 	return b.Extract(ret, 1)
 }
@@ -577,10 +576,11 @@ var llgoInstrs = map[string]int{
 	"deferData":   llgoDeferData,
 	"unreachable": llgoUnreachable,
 
-	"atomicLoad":      llgoAtomicLoad,
-	"atomicStore":     llgoAtomicStore,
-	"atomicCmpXchg":   llgoAtomicCmpXchg,
-	"atomicCmpXchgOK": llgoAtomicCmpXchgOK,
+	"atomicLoad":         llgoAtomicLoad,
+	"atomicStore":        llgoAtomicStore,
+	"atomicCmpXchg":      llgoAtomicCmpXchg,
+	"atomicCmpXchgOK":    llgoAtomicCmpXchgOK,
+	"atomicAddReturnNew": llgoAtomicAddReturnNew,
 
 	"atomicXchg": int(llgoAtomicXchg),
 	"atomicAdd":  int(llgoAtomicAdd),
@@ -690,7 +690,7 @@ func (p *context) call(b llssa.Builder, act llssa.DoAction, call *ssa.CallCommon
 			hasVArg = fnHasVArg
 		}
 		args := p.compileValues(b, call.Args, hasVArg)
-		ret = b.Do(act, fn, args...)
+		ret = b.Do(act, fn, llssa.Builder.Call, args...)
 		return
 	}
 	kind := p.funcKind(cv)
@@ -709,7 +709,7 @@ func (p *context) call(b llssa.Builder, act llssa.DoAction, call *ssa.CallCommon
 			ret = p.compileValue(b, arg)
 		} else {
 			args := p.compileValues(b, args, kind)
-			ret = b.Do(act, llssa.Builtin(fn), args...)
+			ret = b.Do(act, llssa.Builtin(fn), llssa.Builder.Call, args...)
 		}
 	case *ssa.Function:
 		aFn, pyFn, ftype := p.compileFunction(cv)
@@ -719,13 +719,13 @@ func (p *context) call(b llssa.Builder, act llssa.DoAction, call *ssa.CallCommon
 			p.inCFunc = true
 			args := p.compileValues(b, args, kind)
 			p.inCFunc = false
-			ret = b.Do(act, aFn.Expr, args...)
+			ret = b.Do(act, aFn.Expr, llssa.Builder.Call, args...)
 		case goFunc:
 			args := p.compileValues(b, args, kind)
-			ret = b.Do(act, aFn.Expr, args...)
+			ret = b.Do(act, aFn.Expr, llssa.Builder.Call, args...)
 		case pyFunc:
 			args := p.compileValues(b, args, kind)
-			ret = b.Do(act, pyFn.Expr, args...)
+			ret = b.Do(act, pyFn.Expr, llssa.Builder.Call, args...)
 		case llgoPyList:
 			args := p.compileValues(b, args, fnHasVArg)
 			ret = b.PyList(args...)
@@ -770,14 +770,6 @@ func (p *context) call(b llssa.Builder, act llssa.DoAction, call *ssa.CallCommon
 			ret = p.string(b, args)
 		case llgoStringData:
 			ret = p.stringData(b, args)
-		case llgoAtomicLoad:
-			ret = p.atomicLoad(b, args)
-		case llgoAtomicStore:
-			p.atomicStore(b, args)
-		case llgoAtomicCmpXchg:
-			ret = p.atomicCmpXchg(b, args)
-		case llgoAtomicCmpXchgOK:
-			ret = p.atomicCmpXchgOK(b, args)
 		case llgoSigsetjmp:
 			ret = p.sigsetjmp(b, args)
 		case llgoSiglongjmp:
@@ -800,9 +792,37 @@ func (p *context) call(b llssa.Builder, act llssa.DoAction, call *ssa.CallCommon
 			ret = p.syscallIntrinsic(b, args, call.Signature().Results())
 		case llgoUnreachable: // func unreachable()
 			b.Unreachable()
+		case llgoAtomicLoad:
+			args := p.compileValues(b, args, kind)
+			ret = b.Do(act, llssa.Nil, func(b llssa.Builder, _ llssa.Expr, args ...llssa.Expr) llssa.Expr {
+				return p.atomicLoad(b, args)
+			}, args...)
+		case llgoAtomicStore:
+			args := p.compileValues(b, args, kind)
+			b.Do(act, llssa.Nil, func(b llssa.Builder, _ llssa.Expr, args ...llssa.Expr) llssa.Expr {
+				return p.atomicStore(b, args)
+			}, args...)
+		case llgoAtomicCmpXchg:
+			args := p.compileValues(b, args, kind)
+			ret = b.Do(act, llssa.Nil, func(b llssa.Builder, _ llssa.Expr, args ...llssa.Expr) llssa.Expr {
+				return p.atomicCmpXchg(b, args)
+			}, args...)
+		case llgoAtomicCmpXchgOK:
+			args := p.compileValues(b, args, kind)
+			ret = b.Do(act, llssa.Nil, func(b llssa.Builder, _ llssa.Expr, args ...llssa.Expr) llssa.Expr {
+				return p.atomicCmpXchgOK(b, args)
+			}, args...)
+		case llgoAtomicAddReturnNew:
+			args := p.compileValues(b, args, kind)
+			ret = b.Do(act, llssa.Nil, func(b llssa.Builder, _ llssa.Expr, args ...llssa.Expr) llssa.Expr {
+				return b.BinOp(token.ADD, p.atomic(b, llssa.OpAdd, args), args[1])
+			}, args...)
 		default:
 			if ftype >= llgoAtomicOpBase && ftype <= llgoAtomicOpLast {
-				ret = p.atomic(b, llssa.AtomicOp(ftype-llgoAtomicOpBase), args)
+				args := p.compileValues(b, args, kind)
+				ret = b.Do(act, llssa.Nil, func(b llssa.Builder, _ llssa.Expr, args ...llssa.Expr) llssa.Expr {
+					return p.atomic(b, llssa.AtomicOp(ftype-llgoAtomicOpBase), args)
+				}, args...)
 			} else {
 				log.Panicf("unknown ftype: %d for %s", ftype, cv.Name())
 			}
@@ -810,7 +830,7 @@ func (p *context) call(b llssa.Builder, act llssa.DoAction, call *ssa.CallCommon
 	default:
 		fn := p.compileValue(b, cv)
 		args := p.compileValues(b, args, kind)
-		ret = b.Do(act, fn, args...)
+		ret = b.Do(act, fn, llssa.Builder.Call, args...)
 	}
 	return
 }

--- a/runtime/build.go
+++ b/runtime/build.go
@@ -33,4 +33,5 @@ var altPkgs = map[string]altPkgMode{
 	"runtime":               altPkgReplace,
 	"unique":                altPkgReplace,
 	"syscall/js":            altPkgReplace,
+	"sync/atomic":           altPkgReplace,
 }

--- a/runtime/internal/lib/sync/atomic/atomic.go
+++ b/runtime/internal/lib/sync/atomic/atomic.go
@@ -49,58 +49,41 @@ func SwapPointer(addr *unsafe.Pointer, new unsafe.Pointer) (old unsafe.Pointer)
 // llgo:link atomicCmpXchg llgo.atomicCmpXchg
 func atomicCmpXchg[T valtype](ptr *T, old, new T) (T, bool) { return old, false }
 
-func CompareAndSwapInt32(addr *int32, old, new int32) (swapped bool) {
-	_, swapped = atomicCmpXchg(addr, old, new)
-	return
-}
+//go:linkname CompareAndSwapInt32 llgo.atomicCmpXchgOK
+func CompareAndSwapInt32(addr *int32, old, new int32) (swapped bool)
 
-func CompareAndSwapInt64(addr *int64, old, new int64) (swapped bool) {
-	_, swapped = atomicCmpXchg(addr, old, new)
-	return
-}
+//go:linkname CompareAndSwapInt64 llgo.atomicCmpXchgOK
+func CompareAndSwapInt64(addr *int64, old, new int64) (swapped bool)
 
-func CompareAndSwapUint32(addr *uint32, old, new uint32) (swapped bool) {
-	_, swapped = atomicCmpXchg(addr, old, new)
-	return
-}
+//go:linkname CompareAndSwapUint32 llgo.atomicCmpXchgOK
+func CompareAndSwapUint32(addr *uint32, old, new uint32) (swapped bool)
 
-func CompareAndSwapUint64(addr *uint64, old, new uint64) (swapped bool) {
-	_, swapped = atomicCmpXchg(addr, old, new)
-	return
-}
+//go:linkname CompareAndSwapUint64 llgo.atomicCmpXchgOK
+func CompareAndSwapUint64(addr *uint64, old, new uint64) (swapped bool)
 
-func CompareAndSwapUintptr(addr *uintptr, old, new uintptr) (swapped bool) {
-	_, swapped = atomicCmpXchg(addr, old, new)
-	return
-}
+//go:linkname CompareAndSwapUintptr llgo.atomicCmpXchgOK
+func CompareAndSwapUintptr(addr *uintptr, old, new uintptr) (swapped bool)
 
-func CompareAndSwapPointer(addr *unsafe.Pointer, old, new unsafe.Pointer) (swapped bool) {
-	_, swapped = atomicCmpXchg(addr, old, new)
-	return
-}
+//go:linkname CompareAndSwapPointer llgo.atomicCmpXchgOK
+func CompareAndSwapPointer(addr *unsafe.Pointer, old, new unsafe.Pointer) (swapped bool)
 
-// llgo:link atomicAdd llgo.atomicAdd
+// llgo:link atomicAdd llgo.atomicAddReturnNew
 func atomicAdd[T valtype](ptr *T, v T) T { return v }
 
-func AddInt32(addr *int32, delta int32) (new int32) {
-	return atomicAdd(addr, delta) + delta
-}
+//go:linkname AddInt32 llgo.atomicAddReturnNew
+func AddInt32(addr *int32, delta int32) (new int32)
 
-func AddUint32(addr *uint32, delta uint32) (new uint32) {
-	return atomicAdd(addr, delta) + delta
-}
+//go:linkname AddUint32 llgo.atomicAddReturnNew
+func AddUint32(addr *uint32, delta uint32) (new uint32)
 
-func AddInt64(addr *int64, delta int64) (new int64) {
-	return atomicAdd(addr, delta) + delta
-}
+//go:linkname AddInt64 llgo.atomicAddReturnNew
+func AddInt64(addr *int64, delta int64) (new int64)
 
-func AddUint64(addr *uint64, delta uint64) (new uint64) {
-	return atomicAdd(addr, delta) + delta
-}
+//go:linkname AddUint64 llgo.atomicAddReturnNew
+func AddUint64(addr *uint64, delta uint64) (new uint64)
 
-func AddUintptr(addr *uintptr, delta uintptr) (new uintptr) {
-	return atomicAdd(addr, delta) + delta
-}
+//go:linkname AddUintptr llgo.atomicAddReturnNew
+func AddUintptr(addr *uintptr, delta uintptr) (new uintptr)
 
 //go:linkname LoadInt32 llgo.atomicLoad
 func LoadInt32(addr *int32) (val int32)

--- a/ssa/eh.go
+++ b/ssa/eh.go
@@ -177,10 +177,11 @@ type aDefer struct {
 // The id uniquely identifies the defer call site for dispatch during drain.
 // typ is the node struct type needed to decode the linked-list node.
 type loopDeferCase struct {
-	id   Expr
-	typ  Type
-	fn   Expr
-	args []Expr
+	id        Expr
+	typ       Type
+	fn        Expr
+	args      []Expr
+	buildCall func(Builder, Expr, ...Expr) Expr
 }
 
 const (
@@ -268,7 +269,7 @@ func (b Builder) DeferData() Expr {
 }
 
 // Defer emits a defer instruction.
-func (b Builder) Defer(kind DoAction, fn Expr, args ...Expr) {
+func (b Builder) Defer(kind DoAction, fn Expr, buildCall func(Builder, Expr, ...Expr) Expr, args ...Expr) {
 	if debugInstr {
 		logCall("Defer", fn, args)
 	}
@@ -295,7 +296,8 @@ func (b Builder) Defer(kind DoAction, fn Expr, args ...Expr) {
 	}
 	typ := b.saveDeferArgs(self, kind, id, fn, args)
 	if kind == DeferInLoop {
-		self.loopCases = append(self.loopCases, loopDeferCase{id: id, typ: typ, fn: fn, args: args})
+		loopCase := loopDeferCase{id: id, typ: typ, fn: fn, args: args, buildCall: buildCall}
+		self.loopCases = append(self.loopCases, loopCase)
 	}
 	self.stmts = append(self.stmts, func(bits Expr) {
 		switch kind {
@@ -306,13 +308,13 @@ func (b Builder) Defer(kind DoAction, fn Expr, args ...Expr) {
 			zero := prog.Val(uintptr(0))
 			has := b.BinOp(token.NEQ, b.BinOp(token.AND, bits, nextbit), zero)
 			b.IfThen(has, func() {
-				b.callDefer(self, typ, fn, args)
+				b.callDefer(self, typ, buildCall, fn, args)
 			})
 		case DeferAlways:
 			// Leaving a run of loop defers; allow the next loop-defer statement
 			// (earlier in source order) to generate its own drainer.
 			self.loopDrainerGenerated = false
-			b.callDefer(self, typ, fn, args)
+			b.callDefer(self, typ, buildCall, fn, args)
 		case DeferInLoop:
 			// Only one drainer is needed per contiguous run of loop defers.
 			// (Multiple loop-defer statements inside the same loop share the same
@@ -374,7 +376,7 @@ func (b Builder) Defer(kind DoAction, fn Expr, args ...Expr) {
 
 				b.SetBlockEx(caseBlks[i], AtEnd, true)
 				b.Store(self.rethPtr, drainEntryAddr)
-				b.callDefer(self, c.typ, c.fn, c.args)
+				b.callDefer(self, c.typ, c.buildCall, c.fn, c.args)
 				b.Jump(condBlk)
 			}
 
@@ -399,12 +401,12 @@ free(node)
 */
 
 func (b Builder) saveDeferArgs(self *aDefer, kind DoAction, id Expr, fn Expr, args []Expr) Type {
-	if kind != DeferInLoop && fn.kind != vkClosure && len(args) == 0 {
+	if kind != DeferInLoop && fn != Nil && fn.kind != vkClosure && len(args) == 0 {
 		return nil
 	}
 	prog := b.Prog
 	offset := 2 // prev + id
-	if fn.kind == vkClosure {
+	if fn != Nil && fn.kind == vkClosure {
 		offset++
 	}
 	typs := make([]Type, len(args)+offset)
@@ -413,7 +415,7 @@ func (b Builder) saveDeferArgs(self *aDefer, kind DoAction, id Expr, fn Expr, ar
 	flds[0] = b.Load(self.argsPtr).impl
 	typs[1] = prog.Uintptr()
 	flds[1] = id.impl
-	if fn.kind == vkClosure {
+	if fn != Nil && fn.kind == vkClosure {
 		typs[2] = fn.Type
 		flds[2] = fn.impl
 	}
@@ -427,9 +429,9 @@ func (b Builder) saveDeferArgs(self *aDefer, kind DoAction, id Expr, fn Expr, ar
 	return typ
 }
 
-func (b Builder) callDefer(self *aDefer, typ Type, fn Expr, args []Expr) {
+func (b Builder) callDefer(self *aDefer, typ Type, buildCall func(Builder, Expr, ...Expr) Expr, fn Expr, args []Expr) {
 	if typ == nil {
-		b.Call(fn, args...)
+		buildCall(b, fn, args...)
 		return
 	}
 	prog := b.Prog
@@ -444,15 +446,14 @@ func (b Builder) callDefer(self *aDefer, typ Type, fn Expr, args []Expr) {
 		data := b.Load(Expr{ptr.impl, prog.Pointer(typ)})
 		offset := 2 // prev + id
 		b.Store(self.argsPtr, Expr{b.getField(data, 0).impl, prog.VoidPtr()})
-		callFn := fn
-		if callFn.kind == vkClosure {
-			callFn = b.getField(data, 2)
+		if fn != Nil && fn.kind == vkClosure {
+			fn = b.getField(data, 2)
 			offset++
 		}
 		for i := 0; i < len(args); i++ {
 			args[i] = b.getField(data, i+offset)
 		}
-		b.Call(callFn, args...)
+		buildCall(b, fn, args...)
 		b.Call(b.Pkg.rtFunc("FreeDeferNode"), ptr)
 	})
 }

--- a/ssa/eh_loop_test.go
+++ b/ssa/eh_loop_test.go
@@ -19,6 +19,10 @@
 package ssa_test
 
 import (
+	"fmt"
+	"go/constant"
+	"go/token"
+	"go/types"
 	"strings"
 	"testing"
 
@@ -43,7 +47,7 @@ func TestDeferInLoopIR(t *testing.T) {
 	b.Return()
 	b.SetBlockEx(fn.Block(0), ssa.BeforeLast, true)
 
-	b.Defer(ssa.DeferInLoop, callee.Expr)
+	b.Defer(ssa.DeferInLoop, callee.Expr, ssa.Builder.Call)
 	b.EndBuild()
 
 	ir := pkg.Module().String()
@@ -53,6 +57,41 @@ func TestDeferInLoopIR(t *testing.T) {
 	// Loop defers must record each execution (even with no args) so the drain loop
 	// can run deferred calls the correct number of times.
 	if !strings.Contains(ir, "FreeDeferNode") {
+		t.Fatalf("expected loop defer node free in IR, got:\n%s", ir)
+	}
+}
+
+func TestDeferAtomicInLoopIR(t *testing.T) {
+	prog := ssatest.NewProgram(t, nil)
+	pkg := prog.NewPackage("foo", "foo")
+
+	int64PtrType := types.NewPointer(types.Typ[types.Int64])
+	params := types.NewTuple(types.NewParam(token.NoPos, nil, "", int64PtrType))
+	IntPtrArgSig := types.NewSignatureType(nil, nil, nil, params, nil, false)
+	fn := pkg.NewFunc("main", IntPtrArgSig, ssa.InGo)
+	b := fn.MakeBody(1)
+	fn.SetRecover(fn.MakeBlock())
+
+	// Ensure entry block has a terminator like real codegen
+	b.Return()
+	b.SetBlockEx(fn.Block(0), ssa.BeforeLast, true)
+
+	ptr := fn.Param(0)
+	val := b.Const(constant.MakeInt64(1), prog.Int64())
+	b.Defer(ssa.DeferInLoop, ssa.Nil, func(b ssa.Builder, _ ssa.Expr, args ...ssa.Expr) ssa.Expr {
+		return b.Store(ptr, val).SetOrdering(ssa.OrderingSeqConsistent)
+	})
+	b.EndBuild()
+
+	ir := pkg.Module().String()
+	fmt.Println(ir)
+	atomicIdx := strings.Index(ir, "store atomic i64 1, ptr %0 seq_cst")
+	if atomicIdx == -1 {
+		t.Fatalf("expected store atomic in IR, got:\n%s", ir)
+	}
+	// Loop defers must record each execution (even with no args) so the drain loop
+	// can run deferred calls the correct number of times.
+	if !strings.Contains(ir[atomicIdx:], "FreeDeferNode") {
 		t.Fatalf("expected loop defer node free in IR, got:\n%s", ir)
 	}
 }

--- a/ssa/eh_patch_test.go
+++ b/ssa/eh_patch_test.go
@@ -77,10 +77,10 @@ func TestDeferInLoopContiguousDrainerGeneration(t *testing.T) {
 	b.SetBlockEx(fn.Block(0), ssa.BeforeLast, true)
 
 	// Two contiguous loop defers should share one drain-loop generation pass.
-	b.Defer(ssa.DeferInLoop, c1.Expr)
-	b.Defer(ssa.DeferInLoop, c2.Expr)
+	b.Defer(ssa.DeferInLoop, c1.Expr, ssa.Builder.Call)
+	b.Defer(ssa.DeferInLoop, c2.Expr, ssa.Builder.Call)
 	// Non-loop defer resets loop drainer state while walking deferred stmts.
-	b.Defer(ssa.DeferAlways, c1.Expr)
+	b.Defer(ssa.DeferAlways, c1.Expr, ssa.Builder.Call)
 	b.EndBuild()
 
 	ir := pkg.Module().String()

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -1130,7 +1130,7 @@ var (
 )
 
 func logCall(da string, fn Expr, args []Expr) {
-	if fn.kind == vkBuiltin {
+	if fn == Nil || fn.kind == vkBuiltin {
 		return
 	}
 	var b bytes.Buffer
@@ -1158,14 +1158,14 @@ const (
 )
 
 // Do call a function with an action.
-func (b Builder) Do(da DoAction, fn Expr, args ...Expr) (ret Expr) {
+func (b Builder) Do(da DoAction, fn Expr, buildCall func(Builder, Expr, ...Expr) Expr, args ...Expr) (ret Expr) {
 	switch da {
 	case Call:
-		return b.Call(fn, args...)
+		return buildCall(b, fn, args...)
 	case Go:
-		b.Go(fn, args...)
+		b.Go(fn, buildCall, args...)
 	default:
-		b.Defer(da, fn, args...)
+		b.Defer(da, fn, buildCall, args...)
 	}
 	return
 }

--- a/ssa/goroutine.go
+++ b/ssa/goroutine.go
@@ -51,7 +51,7 @@ func (b Builder) pthreadCreate(pp, attr, routine, arg Expr) Expr {
 //	go println(t0, t1)
 //	go t3()
 //	go invoke t5.Println(...t6)
-func (b Builder) Go(fn Expr, args ...Expr) {
+func (b Builder) Go(fn Expr, buildCall func(Builder, Expr, ...Expr) Expr, args ...Expr) {
 	if debugInstr {
 		logCall("Go", fn, args)
 	}
@@ -60,7 +60,7 @@ func (b Builder) Go(fn Expr, args ...Expr) {
 	pkg := b.Pkg
 
 	var offset int
-	if fn.kind != vkBuiltin {
+	if fn != Nil && fn.kind != vkBuiltin {
 		offset = 1
 	}
 	typs := make([]Type, len(args)+offset)
@@ -78,7 +78,7 @@ func (b Builder) Go(fn Expr, args ...Expr) {
 	data := Expr{b.aggregateMalloc(t, flds...), voidPtr}
 	size := prog.SizeOf(voidPtr)
 	pthd := b.Alloca(prog.IntVal(uint64(size), prog.Uintptr()))
-	b.pthreadCreate(pthd, prog.Nil(voidPtr), pkg.routine(t, fn, len(args)), data)
+	b.pthreadCreate(pthd, prog.Nil(voidPtr), pkg.routine(t, fn, buildCall, len(args)), data)
 }
 
 func (p Package) routineName() string {
@@ -86,7 +86,7 @@ func (p Package) routineName() string {
 	return p.Path() + "._llgo_routine$" + strconv.Itoa(p.iRoutine)
 }
 
-func (p Package) routine(t Type, fn Expr, n int) Expr {
+func (p Package) routine(t Type, fn Expr, buildCall func(Builder, Expr, ...Expr) Expr, n int) Expr {
 	prog := p.Prog
 	routine := p.NewFunc(p.routineName(), prog.tyRoutine(), InC)
 	b := routine.MakeBody(1)
@@ -94,14 +94,14 @@ func (p Package) routine(t Type, fn Expr, n int) Expr {
 	data := Expr{llvm.CreateLoad(b.impl, t.ll, param.impl), t}
 	args := make([]Expr, n)
 	var offset int
-	if fn.kind != vkBuiltin {
+	if fn != Nil && fn.kind != vkBuiltin {
 		fn = b.getField(data, 0)
 		offset = 1
 	}
 	for i := 0; i < n; i++ {
 		args[i] = b.getField(data, i+offset)
 	}
-	b.Call(fn, args...)
+	buildCall(b, fn, args...)
 	b.free(param)
 	b.Return(prog.Nil(prog.VoidPtr()))
 	return routine.Expr

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -97,7 +97,7 @@ func TestTooManyConditionalDefers(t *testing.T) {
 
 	b.Return()
 	for i := 0; i < 65; i++ {
-		b.Defer(DeferInCond, target.Expr)
+		b.Defer(DeferInCond, target.Expr, Builder.Call)
 	}
 }
 

--- a/test/defer_test.go
+++ b/test/defer_test.go
@@ -23,6 +23,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	"unsafe"
 )
 
 // runLoopDefers exercises a defer statement inside a loop and relies on
@@ -410,5 +411,304 @@ func TestDeferInLoopDoesNotDrainOtherDefers(t *testing.T) {
 	runLoopDeferTimerStopWithOuterDefer()
 	if got := loopDeferOuterRan.Load(); got != 1 {
 		t.Fatalf("outer defer was not executed: got %d, want %d", got, 1)
+	}
+}
+
+func runDeferAtomicStoreUint32() (before, after uint32) {
+	var v uint32
+	func() {
+		defer atomic.StoreUint32(&v, 1)
+		before = atomic.LoadUint32(&v)
+	}()
+	after = atomic.LoadUint32(&v)
+	return
+}
+
+func TestDeferAtomicStoreUint32(t *testing.T) {
+	before, after := runDeferAtomicStoreUint32()
+	if before != 0 {
+		t.Fatalf("before defer = %d, want 0", before)
+	}
+	if after != 1 {
+		t.Fatalf("after defer = %d, want 1", after)
+	}
+}
+
+func runDeferAtomicCompareAndSwapUint32() (before, after uint32) {
+	var v uint32 = 1
+	func() {
+		defer atomic.CompareAndSwapUint32(&v, 1, 2)
+		before = atomic.LoadUint32(&v)
+	}()
+	after = atomic.LoadUint32(&v)
+	return
+}
+
+func TestDeferAtomicCompareAndSwapUint32(t *testing.T) {
+	before, after := runDeferAtomicCompareAndSwapUint32()
+	if before != 1 {
+		t.Fatalf("before defer = %d, want 1", before)
+	}
+	if after != 2 {
+		t.Fatalf("after defer = %d, want 2", after)
+	}
+}
+
+func runGoAtomicAddInt64() int64 {
+	var v int64
+	go atomic.AddInt64(&v, 2)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := atomic.LoadInt64(&v); got == 2 {
+			return got
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return atomic.LoadInt64(&v)
+}
+
+func TestGoAtomicAddInt64(t *testing.T) {
+	if got := runGoAtomicAddInt64(); got != 2 {
+		t.Fatalf("go atomic add = %d, want 2", got)
+	}
+}
+
+type loopDeferAtomicScalarResults struct {
+	int32Load    int32
+	int32Final   int32
+	int64Load    int64
+	int64Final   int64
+	uint32Load   uint32
+	uint32Final  uint32
+	uint64Load   uint64
+	uint64Final  uint64
+	uintptrLoad  uintptr
+	uintptrFinal uintptr
+}
+
+func runLoopDeferAtomicScalars() (res loopDeferAtomicScalarResults) {
+	var v32 int32 = 10
+	func() {
+		for i := 0; i < 5; i++ {
+			switch i {
+			case 0:
+				defer atomic.StoreInt32(&v32, 7)
+			case 1:
+				defer func() {
+					res.int32Load = atomic.LoadInt32(&v32)
+				}()
+			case 2:
+				defer atomic.AddInt32(&v32, 5)
+			case 3:
+				defer atomic.CompareAndSwapInt32(&v32, 15, 21)
+			case 4:
+				defer atomic.SwapInt32(&v32, 15)
+			}
+		}
+	}()
+
+	var v64 int64 = 20
+	func() {
+		for i := 0; i < 5; i++ {
+			switch i {
+			case 0:
+				defer atomic.StoreInt64(&v64, 9)
+			case 1:
+				defer func() {
+					res.int64Load = atomic.LoadInt64(&v64)
+				}()
+			case 2:
+				defer atomic.AddInt64(&v64, 4)
+			case 3:
+				defer atomic.CompareAndSwapInt64(&v64, 30, 40)
+			case 4:
+				defer atomic.SwapInt64(&v64, 30)
+			}
+		}
+	}()
+
+	var u32 uint32 = 11
+	func() {
+		for i := 0; i < 5; i++ {
+			switch i {
+			case 0:
+				defer atomic.StoreUint32(&u32, 3)
+			case 1:
+				defer func() {
+					res.uint32Load = atomic.LoadUint32(&u32)
+				}()
+			case 2:
+				defer atomic.AddUint32(&u32, 2)
+			case 3:
+				defer atomic.CompareAndSwapUint32(&u32, 13, 17)
+			case 4:
+				defer atomic.SwapUint32(&u32, 13)
+			}
+		}
+	}()
+
+	var u64 uint64 = 50
+	func() {
+		for i := 0; i < 5; i++ {
+			switch i {
+			case 0:
+				defer atomic.StoreUint64(&u64, 8)
+			case 1:
+				defer func() {
+					res.uint64Load = atomic.LoadUint64(&u64)
+				}()
+			case 2:
+				defer atomic.AddUint64(&u64, 7)
+			case 3:
+				defer atomic.CompareAndSwapUint64(&u64, 60, 90)
+			case 4:
+				defer atomic.SwapUint64(&u64, 60)
+			}
+		}
+	}()
+
+	var up uintptr = 100
+	func() {
+		for i := 0; i < 5; i++ {
+			switch i {
+			case 0:
+				defer atomic.StoreUintptr(&up, 5)
+			case 1:
+				defer func() {
+					res.uintptrLoad = atomic.LoadUintptr(&up)
+				}()
+			case 2:
+				defer atomic.AddUintptr(&up, 6)
+			case 3:
+				defer atomic.CompareAndSwapUintptr(&up, 120, 140)
+			case 4:
+				defer atomic.SwapUintptr(&up, 120)
+			}
+		}
+	}()
+
+	res.int32Final = atomic.LoadInt32(&v32)
+	res.int64Final = atomic.LoadInt64(&v64)
+	res.uint32Final = atomic.LoadUint32(&u32)
+	res.uint64Final = atomic.LoadUint64(&u64)
+	res.uintptrFinal = atomic.LoadUintptr(&up)
+	return
+}
+
+func TestDeferAtomicInLoopScalars(t *testing.T) {
+	got := runLoopDeferAtomicScalars()
+	want := loopDeferAtomicScalarResults{
+		int32Load:    26,
+		int32Final:   7,
+		int64Load:    44,
+		int64Final:   9,
+		uint32Load:   19,
+		uint32Final:  3,
+		uint64Load:   97,
+		uint64Final:  8,
+		uintptrLoad:  146,
+		uintptrFinal: 5,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected scalar defer+atomic results: got %+v, want %+v", got, want)
+	}
+}
+
+type loopDeferAtomicPointerResults struct {
+	loadValue  int
+	finalValue int
+}
+
+func runLoopDeferAtomicPointer() (res loopDeferAtomicPointerResults) {
+	values := []int{11, 22, 33, 44}
+	var ptr unsafe.Pointer = unsafe.Pointer(&values[0])
+
+	func() {
+		for i := 0; i < 4; i++ {
+			switch i {
+			case 0:
+				defer atomic.StorePointer(&ptr, unsafe.Pointer(&values[1]))
+			case 1:
+				defer func() {
+					res.loadValue = *(*int)(atomic.LoadPointer(&ptr))
+				}()
+			case 2:
+				defer atomic.CompareAndSwapPointer(&ptr, unsafe.Pointer(&values[2]), unsafe.Pointer(&values[3]))
+			case 3:
+				defer atomic.SwapPointer(&ptr, unsafe.Pointer(&values[2]))
+			}
+		}
+	}()
+
+	res.finalValue = *(*int)(atomic.LoadPointer(&ptr))
+	return
+}
+
+func TestDeferAtomicInLoopPointer(t *testing.T) {
+	got := runLoopDeferAtomicPointer()
+	want := loopDeferAtomicPointerResults{
+		loadValue:  44,
+		finalValue: 22,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected pointer defer+atomic results: got %+v, want %+v", got, want)
+	}
+}
+
+func runConditionalDeferAtomic(flag bool) (before, after uint32) {
+	var v uint32 = 10
+	func() {
+		if flag {
+			defer atomic.AddUint32(&v, 1)
+			defer atomic.CompareAndSwapUint32(&v, 10, 20)
+		} else {
+			defer atomic.StoreUint32(&v, 30)
+			defer atomic.SwapUint32(&v, 40)
+		}
+		before = atomic.LoadUint32(&v)
+	}()
+	after = atomic.LoadUint32(&v)
+	return
+}
+
+func TestDeferAtomicInConditional(t *testing.T) {
+	before, after := runConditionalDeferAtomic(true)
+	if before != 10 || after != 21 {
+		t.Fatalf("flag=true: got before=%d after=%d, want before=10 after=21", before, after)
+	}
+
+	before, after = runConditionalDeferAtomic(false)
+	if before != 10 || after != 30 {
+		t.Fatalf("flag=false: got before=%d after=%d, want before=10 after=30", before, after)
+	}
+}
+
+func runLoopControlDeferAtomic() (before, after uint32) {
+	var v uint32 = 5
+	func() {
+		for i := 0; i < 4; i++ {
+			if i == 1 {
+				defer atomic.AddUint32(&v, 10)
+				continue
+			}
+			if i == 3 {
+				defer atomic.SwapUint32(&v, 99)
+				break
+			}
+			defer atomic.AddUint32(&v, 1)
+		}
+		before = atomic.LoadUint32(&v)
+	}()
+	after = atomic.LoadUint32(&v)
+	return
+}
+
+func TestDeferAtomicInLoopControlFlow(t *testing.T) {
+	before, after := runLoopControlDeferAtomic()
+	if before != 5 {
+		t.Fatalf("before loop control defers = %d, want 5", before)
+	}
+	if after != 111 {
+		t.Fatalf("after loop control defers = %d, want 111", after)
 	}
 }


### PR DESCRIPTION
Fixes #1686.

## Summary
- route `sync/atomic` builtin lowering through the action-aware `Builder.Do/Go/Defer` path
- switch `sync/atomic` to the llgo runtime replacement package
- add dedicated llgo intrinsics for `CompareAndSwap*` and `Add*` so these operations lower correctly in plain call, `defer`, and `go` contexts

## Root cause
Atomic intrinsics were emitted directly from `cl/instr.go`. That bypassed the normal `defer`/`go` lowering path, so builtin-backed atomic operations could break action semantics or IR instruction ordering under complex control flow.

## What changed
- thread an explicit call builder through `Builder.Do`, `Builder.Go`, and `Builder.Defer`
- make defer/go lowering tolerate builtin-backed calls that do not have a callable `Expr`
- route atomic builtin operations through the same action-aware lowering path as normal calls
- replace stdlib `sync/atomic` with the llgo runtime variant in `runtime/build.go`
- expose `CompareAndSwap*` and `Add*` through dedicated llgo intrinsics in `runtime/internal/lib/sync/atomic/atomic.go`
