### PR TITLE
build: report empty package matches in cmptest

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -299,6 +299,9 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	}
 	initial, err := packages.LoadEx(dedup, sizes, cfg, patterns...)
 	check(err)
+	if len(initial) == 0 {
+		return nil, fmt.Errorf("no packages matched pattern(s): %s", strings.Join(patterns, " "))
+	}
 	mode := conf.Mode
 	if mode == ModeTest {
 		initial, err = filterTestPackages(initial, conf.OutFile)

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -99,6 +99,32 @@ func TestCmpTest(t *testing.T) {
 	mockRun([]string{"../../cl/_testgo/runtest"}, &Config{Mode: ModeCmpTest})
 }
 
+func TestNoPackagesMatchedReturnsError(t *testing.T) {
+	tmp := t.TempDir()
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd failed: %v", err)
+	}
+	defer func() { _ = os.Chdir(oldwd) }()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("Chdir failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "go.mod"), []byte("module example.com/empty\n\ngo 1.24\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(go.mod) failed: %v", err)
+	}
+
+	if err := os.Mkdir(filepath.Join(tmp, "missing"), 0o755); err != nil {
+		t.Fatalf("Mkdir failed: %v", err)
+	}
+	_, err = Do([]string{"./missing/..."}, &Config{Mode: ModeCmpTest})
+	if err == nil {
+		t.Fatal("expected no packages matched error, got nil")
+	}
+	if got := err.Error(); !strings.Contains(got, "no packages matched pattern(s): ./missing/...") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestFilterTestPackages(t *testing.T) {
 	pkg := func(id string) *packages.Package {
 		return &packages.Package{ID: id}


### PR DESCRIPTION
Fix #895

## Summary
- return a clear error when package loading matches no packages instead of panicking on initial[0]
- add a build.Do regression test for existing-but-empty directory patterns

## Repro
- `llgo cmptest ./_xtool/llcppsymg/_cmptest/...` from the llcppg project root no longer panics with `index out of range`
- it now reports `no packages matched pattern(s): ./_xtool/llcppsymg/_cmptest/...`

## Validation
- `go test ./internal/build -run 'TestNoPackagesMatchedReturnsError|TestCmpTest' -count=1`
- `go build -tags=dev -o /tmp/llgo-895 ./cmd/llgo`
- `LLGO_ROOT=/Users/lijie/source/goplus/llgo-wt-issue-895-cmptest-root /tmp/llgo-895 cmptest ./_xtool/llcppsymg/_cmptest/...` run from `/tmp/llcppg-verify`