### PR TITLE
build: return errors for invalid cmptest patterns

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -298,7 +298,9 @@ func Do(args []string, conf *Config) ([]Package, error) {
 		patterns = []string{"."}
 	}
 	initial, err := packages.LoadEx(dedup, sizes, cfg, patterns...)
-	check(err)
+	if err != nil {
+		return nil, err
+	}
 	mode := conf.Mode
 	if mode == ModeTest {
 		initial, err = filterTestPackages(initial, conf.OutFile)
@@ -326,7 +328,9 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	altPkgPaths := altPkgs(initial, conf, llssa.PkgRuntime)
 	cfg.Dir = env.LLGoRuntimeDir()
 	altPkgs, err := packages.LoadEx(dedup, sizes, cfg, altPkgPaths...)
-	check(err)
+	if err != nil {
+		return nil, err
+	}
 
 	prog.SetRuntime(func() *types.Package {
 		return altPkgs[0].Types
@@ -372,14 +376,20 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	addGlobalString(conf, "runtime.defaultGOROOT="+runtime.GOROOT(), nil)
 	addGlobalString(conf, "runtime.buildVersion="+runtime.Version(), nil)
 	pkgs, err := buildSSAPkgs(ctx, initial, verbose)
-	check(err)
+	if err != nil {
+		return nil, err
+	}
 	depPkgs, err := buildSSAPkgs(ctx, altPkgs, verbose)
-	check(err)
+	if err != nil {
+		return nil, err
+	}
 
 	allPkgs := append([]*aPackage{}, pkgs...)
 	allPkgs = append(allPkgs, depPkgs...)
 	allPkgs, err = buildAllPkgs(ctx, allPkgs, verbose)
-	check(err)
+	if err != nil {
+		return nil, err
+	}
 
 	if mode == ModeGen {
 		for _, pkg := range allPkgs {

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -307,3 +307,14 @@ func TestTestMultiplePackagesWithOutputFile(t *testing.T) {
 		t.Errorf("Expected error about -o with multiple packages, got: %v", err)
 	}
 }
+
+func TestCmpTestNonexistentPatternReturnsError(t *testing.T) {
+	cfg := &Config{Mode: ModeCmpTest}
+	_, err := Do([]string{"./this/path/does/not/exist/..."}, cfg)
+	if err == nil {
+		t.Fatal("expected error for nonexistent cmptest pattern")
+	}
+	if !strings.Contains(err.Error(), "cannot build SSA for packages") && !strings.Contains(err.Error(), "no such file or directory") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- return ordinary errors for invalid `cmptest` package patterns instead of panicking inside `internal/build.Do`
- add a regression test for nonexistent `cmptest` patterns

## Root cause
`cmptest` drives `internal/build.Do` in `ModeCmpTest`. When package loading or SSA construction failed for an invalid pattern, `Do` still used `check(err)`, which panicked instead of returning an error to the caller.

## Fix
- replace the early `check(err)` calls on the `cmptest` package-load / SSA-build path with `return nil, err`
- keep the existing error text from `buildSSAPkgs`
- add a test covering `Do([]string{"./this/path/does/not/exist/..."}, &Config{Mode: ModeCmpTest})`

## Validation
- `go test ./internal/build -run TestCmpTestNonexistentPatternReturnsError -count=1`
- `GOWORK=off go build -tags=dev -o /tmp/llgo-issue895 ./cmd/llgo`
- `LLGO_ROOT=$PWD /tmp/llgo-issue895 cmptest ./this/path/does/not/exist/...`
