### PR TITLE
runtime/internal/lib/runtime: remove deps time

### DIFF
--- a/.github/workflows/test_demo.sh
+++ b/.github/workflows/test_demo.sh
@@ -106,6 +106,7 @@ ignore_esp32=(
   "./_demo/go/reflectname-1412" # panic: internal/bytealg selected .s files require plan9asm translation
   "./_demo/go/reflectpointerto" # panic: internal/bytealg selected .s files require plan9asm translation
   "./_demo/go/return-1605" # runtime output: fatal error
+  "./_demo/go/runtime" # panic: internal/bytealg selected .s files require plan9asm translation
   "./_demo/go/sync" # panic: internal/bytealg selected .s files require plan9asm translation
   "./_demo/go/syscall" # panic: internal/bytealg selected .s files require plan9asm translation
   "./_demo/go/sysexec" # panic: internal/bytealg selected .s files require plan9asm translation
@@ -173,6 +174,7 @@ ignore_esp32c3_basic=(
   "./_demo/go/reflectmake" # panic: internal/bytealg selected .s files require plan9asm translation
   "./_demo/go/reflectname-1412" # panic: internal/bytealg selected .s files require plan9asm translation
   "./_demo/go/reflectpointerto" # panic: internal/bytealg selected .s files require plan9asm translation
+  "./_demo/go/runtime" # panic: internal/bytealg selected .s files require plan9asm translation
   "./_demo/go/sync" # panic: internal/bytealg selected .s files require plan9asm translation
   "./_demo/go/sysopen-1654" # panic: internal/bytealg selected .s files require plan9asm translation
   "./_demo/go/syscall" # panic: internal/bytealg selected .s files require plan9asm translation

--- a/_demo/go/runtime/main.go
+++ b/_demo/go/runtime/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"runtime"
+)
+
+func main() {
+	println(runtime.GOROOT())
+}

--- a/runtime/internal/lib/runtime/debug_linkname_llgo.go
+++ b/runtime/internal/lib/runtime/debug_linkname_llgo.go
@@ -1,7 +1,6 @@
 package runtime
 
 import (
-	"time"
 	_ "unsafe"
 )
 
@@ -16,7 +15,7 @@ var (
 func setTraceback(level string) {}
 
 //go:linkname readGCStats runtime/debug.readGCStats
-func readGCStats(_ *[]time.Duration) {}
+func readGCStats(_ *[]uint64) {}
 
 //go:linkname freeOSMemory runtime/debug.freeOSMemory
 func freeOSMemory() {}


### PR DESCRIPTION
fix build error ( runtime deps error )
```
package main

import (
	"runtime"
)

func main() {
	println(runtime.GOROOT())
}

```
output
```
ld64.lld: error: undefined symbol: internal/reflectlite.TypeOf
>>> referenced by /var/folders/7v/w0xgrxhj1hdcgs68yyx8mmfw0000gn/T/pkg-2890766100.a(2188b9ac88d5cdb55b90f16ee092205cef3ca56efc1e3086dc3496c568ac9580-d-661779579.o):(symbol errors.init+0x83)

ld64.lld: error: undefined symbol: internal/reflectlite.init
>>> referenced by /var/folders/7v/w0xgrxhj1hdcgs68yyx8mmfw0000gn/T/pkg-2890766100.a(2188b9ac88d5cdb55b90f16ee092205cef3ca56efc1e3086dc3496c568ac9580-d-661779579.o):(symbol errors.init+0x19)
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
exit status 1
```