### PR TITLE
runtime: avoid alt-only itoa dependency in reflect

### DIFF
--- a/runtime/internal/lib/reflect/itoa.go
+++ b/runtime/internal/lib/reflect/itoa.go
@@ -1,0 +1,25 @@
+package reflect
+
+// Local decimal formatting avoids depending on an alt-only internal helper.
+func itoa(val int) string {
+	if val < 0 {
+		return "-" + uitoa(uint(-val))
+	}
+	return uitoa(uint(val))
+}
+
+func uitoa(val uint) string {
+	if val == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf) - 1
+	for val >= 10 {
+		q := val / 10
+		buf[i] = byte('0' + val - q*10)
+		i--
+		val = q
+	}
+	buf[i] = byte('0' + val)
+	return string(buf[i:])
+}

--- a/runtime/internal/lib/reflect/value.go
+++ b/runtime/internal/lib/reflect/value.go
@@ -28,7 +28,6 @@ import (
 	"github.com/goplus/llgo/runtime/abi"
 	"github.com/goplus/llgo/runtime/internal/clite/bitcast"
 	"github.com/goplus/llgo/runtime/internal/ffi"
-	"github.com/goplus/llgo/runtime/internal/lib/internal/itoa"
 	"github.com/goplus/llgo/runtime/internal/runtime"
 	"github.com/goplus/llgo/runtime/internal/runtime/goarch"
 )
@@ -3166,7 +3165,7 @@ func cvtStringRunes(v Value, t Type) Value {
 func cvtSliceArrayPtr(v Value, t Type) Value {
 	n := t.Elem().Len()
 	if n > v.Len() {
-		panic("reflect: cannot convert slice with length " + itoa.Itoa(v.Len()) + " to pointer to array with length " + itoa.Itoa(n))
+		panic("reflect: cannot convert slice with length " + itoa(v.Len()) + " to pointer to array with length " + itoa(n))
 	}
 	h := (*unsafeheaderSlice)(v.ptr)
 	return Value{t.common(), h.Data, v.flag&^(flagIndir|flagAddr|flagKindMask) | flag(Pointer)}
@@ -3176,7 +3175,7 @@ func cvtSliceArrayPtr(v Value, t Type) Value {
 func cvtSliceArray(v Value, t Type) Value {
 	n := t.Len()
 	if n > v.Len() {
-		panic("reflect: cannot convert slice with length " + itoa.Itoa(v.Len()) + " to array with length " + itoa.Itoa(n))
+		panic("reflect: cannot convert slice with length " + itoa(v.Len()) + " to array with length " + itoa(n))
 	}
 	h := (*unsafeheaderSlice)(v.ptr)
 	typ := t.common()


### PR DESCRIPTION
## Summary
- inline the tiny decimal formatting helper used by alt `reflect` slice-to-array panic paths
- avoid depending on an alt-only `internal/itoa` package on the `go1.26` path
- keep the change local to alt `reflect` without touching debug/trace/gc paths

## Validation
- rebuilt `llgo` with Go `1.26.0` toolchain
- reproduced the previous darwin/arm64 `go1.26` link failure with a tiny `reflect` program
- after this change, the `internal/itoa.init` / `internal/itoa.Itoa` linker errors disappear; the remaining failure is the independent `syscall.rawSyscall*` duplicate-symbol issue handled in a separate PR
