### PR TITLE
cmd/build: support clang-style optimization flags

### DIFF
--- a/_lldb/common.sh
+++ b/_lldb/common.sh
@@ -32,6 +32,7 @@ export LLDB_PATH
 
 # Default package path
 export DEFAULT_PACKAGE_PATH="./_lldb/lldbtest"
+export LLDB_TEST_OPTLEVEL="${LLDB_TEST_OPTLEVEL:--O0}"
 
 # Function to build the project
 build_project() {
@@ -44,7 +45,7 @@ build_project() {
         return 1
     fi
 
-    LLGO_DEBUG_SYMBOLS=1 llgo build -o "debug.out" . || {
+    LLGO_DEBUG_SYMBOLS=1 llgo build "${LLDB_TEST_OPTLEVEL}" -o "debug.out" . || {
         local ret=$?
         cd "$current_dir" || return
         return $ret

--- a/cl/_testdata/apkg/out.ll
+++ b/cl/_testdata/apkg/out.ll
@@ -3,7 +3,8 @@ source_filename = "github.com/goplus/llgo/cl/_testdata/apkg"
 
 @"github.com/goplus/llgo/cl/_testdata/apkg.init$guard" = global i1 false, align 1
 
-define double @"github.com/goplus/llgo/cl/_testdata/apkg.Max"(double %0, double %1) {
+; Function Attrs: null_pointer_is_valid
+define double @"github.com/goplus/llgo/cl/_testdata/apkg.Max"(double %0, double %1) #0 {
 _llgo_0:
   %2 = fcmp ogt double %0, %1
   br i1 %2, label %_llgo_1, label %_llgo_2
@@ -15,7 +16,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret double %1
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/apkg.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/apkg.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testdata/apkg.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -27,3 +29,5 @@ _llgo_1:                                          ; preds = %_llgo_0
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testdata/cpkg/out.ll
+++ b/cl/_testdata/cpkg/out.ll
@@ -4,25 +4,29 @@ source_filename = "github.com/goplus/llgo/cl/_testdata/cpkg"
 @"github.com/goplus/llgo/cl/_testdata/cpkg.init$guard" = global i1 false, align 1
 @llvm.compiler.used = appending global [2 x ptr] [ptr @Double, ptr @add], section "llvm.metadata"
 
-define double @Double(double %0) {
+; Function Attrs: null_pointer_is_valid
+define double @Double(double %0) #0 {
 _llgo_0:
   %1 = fmul double 2.000000e+00, %0
   ret double %1
 }
 
-define i64 @add(i64 %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @add(i64 %0, i64 %1) #0 {
 _llgo_0:
   %2 = call i64 @"github.com/goplus/llgo/cl/_testdata/cpkg.add"(i64 %0, i64 %1)
   ret i64 %2
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testdata/cpkg.add"(i64 %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testdata/cpkg.add"(i64 %0, i64 %1) #0 {
 _llgo_0:
   %2 = add i64 %0, %1
   ret i64 %2
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/cpkg.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/cpkg.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testdata/cpkg.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -34,3 +38,5 @@ _llgo_1:                                          ; preds = %_llgo_0
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testdata/cpkgimp/out.ll
+++ b/cl/_testdata/cpkgimp/out.ll
@@ -3,7 +3,8 @@ source_filename = "github.com/goplus/llgo/cl/_testdata/cpkgimp"
 
 @"github.com/goplus/llgo/cl/_testdata/cpkgimp.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testdata/cpkgimp.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/cpkgimp.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testdata/cpkgimp.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -17,7 +18,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/cpkgimp.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/cpkgimp.main"() #0 {
 _llgo_0:
   %0 = call i64 @add(i64 1, i64 2)
   %1 = call double @Double(double 3.140000e+00)
@@ -28,14 +30,22 @@ _llgo_0:
   ret void
 }
 
-declare void @"github.com/goplus/llgo/cl/_testdata/cpkg.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/cl/_testdata/cpkg.init"() #0
 
-declare i64 @add(i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare i64 @add(i64, i64) #0
 
-declare double @Double(double)
+; Function Attrs: null_pointer_is_valid
+declare double @Double(double) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintFloat"(double)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintFloat"(double) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testdata/embedunexport/out.ll
+++ b/cl/_testdata/embedunexport/out.ll
@@ -8,21 +8,24 @@ source_filename = "github.com/goplus/llgo/cl/_testdata/embedunexport"
 @"github.com/goplus/llgo/cl/_testdata/embedunexport.init$guard" = global i1 false, align 1
 @0 = private unnamed_addr constant [8 x i8] c"modified", align 1
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testdata/embedunexport.(*Base).Name"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testdata/embedunexport.(*Base).Name"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testdata/embedunexport.Base", ptr %0, i32 0, i32 0
   %2 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %1, align 8
   ret %"github.com/goplus/llgo/runtime/internal/runtime.String" %2
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/embedunexport.(*Base).setName"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.String" %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/embedunexport.(*Base).setName"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.String" %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testdata/embedunexport.Base", ptr %0, i32 0, i32 0
   store %"github.com/goplus/llgo/runtime/internal/runtime.String" %1, ptr %2, align 8
   ret void
 }
 
-define ptr @"github.com/goplus/llgo/cl/_testdata/embedunexport.NewBase"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0) {
+; Function Attrs: null_pointer_is_valid
+define ptr @"github.com/goplus/llgo/cl/_testdata/embedunexport.NewBase"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testdata/embedunexport.Base", ptr %1, i32 0, i32 0
@@ -30,7 +33,8 @@ _llgo_0:
   ret ptr %1
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/embedunexport.Use"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/embedunexport.Use"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
   %2 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 0
@@ -44,7 +48,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/embedunexport.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/embedunexport.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testdata/embedunexport.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -57,6 +62,10 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testdata/fncall/out.ll
+++ b/cl/_testdata/fncall/out.ll
@@ -3,7 +3,8 @@ source_filename = "github.com/goplus/llgo/cl/_testdata/fncall"
 
 @"github.com/goplus/llgo/cl/_testdata/fncall.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testdata/fncall.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/fncall.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testdata/fncall.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -16,13 +17,15 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/fncall.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/fncall.main"() #0 {
 _llgo_0:
   %0 = call i64 @"github.com/goplus/llgo/cl/_testdata/fncall.max"(i64 1, i64 2)
   ret void
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testdata/fncall.max"(i64 %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testdata/fncall.max"(i64 %0, i64 %1) #0 {
 _llgo_0:
   %2 = icmp sgt i64 %0, %1
   br i1 %2, label %_llgo_1, label %_llgo_2
@@ -33,3 +36,5 @@ _llgo_1:                                          ; preds = %_llgo_0
 _llgo_2:                                          ; preds = %_llgo_0
   ret i64 %1
 }
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testdata/foo/out.ll
+++ b/cl/_testdata/foo/out.ll
@@ -27,7 +27,8 @@ source_filename = "github.com/goplus/llgo/cl/_testdata/foo"
 @"github.com/goplus/llgo/cl/_testdata/foo.struct$MYpsoM99ZwFY087IpUOkIw1zjBA_sgFXVodmn1m-G88$fields" = weak_odr constant [1 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @5, i64 1 }, ptr @_llgo_int, i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
 @6 = private unnamed_addr constant [4 x i8] c"load", align 1
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.eface" @"github.com/goplus/llgo/cl/_testdata/foo.Bar"() {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.eface" @"github.com/goplus/llgo/cl/_testdata/foo.Bar"() #0 {
 _llgo_0:
   %0 = alloca { i64 }, align 8
   call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
@@ -40,7 +41,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.eface" %5
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.eface" @"github.com/goplus/llgo/cl/_testdata/foo.F"() {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.eface" @"github.com/goplus/llgo/cl/_testdata/foo.F"() #0 {
 _llgo_0:
   %0 = alloca { i64 }, align 8
   call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
@@ -53,7 +55,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.eface" %5
 }
 
-define ptr @"github.com/goplus/llgo/cl/_testdata/foo.Foo.Pb"(%"github.com/goplus/llgo/cl/_testdata/foo.Foo" %0) {
+; Function Attrs: null_pointer_is_valid
+define ptr @"github.com/goplus/llgo/cl/_testdata/foo.Foo.Pb"(%"github.com/goplus/llgo/cl/_testdata/foo.Foo" %0) #0 {
 _llgo_0:
   %1 = alloca %"github.com/goplus/llgo/cl/_testdata/foo.Foo", align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -63,26 +66,30 @@ _llgo_0:
   ret ptr %3
 }
 
-define ptr @"github.com/goplus/llgo/cl/_testdata/foo.(*Foo).Pb"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define ptr @"github.com/goplus/llgo/cl/_testdata/foo.(*Foo).Pb"(ptr %0) #0 {
 _llgo_0:
   %1 = load %"github.com/goplus/llgo/cl/_testdata/foo.Foo", ptr %0, align 8
   %2 = call ptr @"github.com/goplus/llgo/cl/_testdata/foo.Foo.Pb"(%"github.com/goplus/llgo/cl/_testdata/foo.Foo" %1)
   ret ptr %2
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/foo.(*Game).Load"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/foo.(*Game).Load"(ptr %0) #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @6, i64 4 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/foo.(*Game).initGame"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/foo.(*Game).initGame"(ptr %0) #0 {
 _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/foo.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/foo.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testdata/foo.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -96,11 +103,13 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -108,7 +117,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -116,8 +126,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testdata/geometry1370/out.ll
+++ b/cl/_testdata/geometry1370/out.ll
@@ -6,7 +6,8 @@ source_filename = "github.com/goplus/llgo/cl/_testdata/geometry1370"
 
 @"github.com/goplus/llgo/cl/_testdata/geometry1370.init$guard" = global i1 false, align 1
 
-define ptr @"github.com/goplus/llgo/cl/_testdata/geometry1370.NewRectangle"(double %0, double %1) {
+; Function Attrs: null_pointer_is_valid
+define ptr @"github.com/goplus/llgo/cl/_testdata/geometry1370.NewRectangle"(double %0, double %1) #0 {
 _llgo_0:
   %2 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 24)
   %3 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testdata/geometry1370.Rectangle", ptr %2, i32 0, i32 0
@@ -16,7 +17,8 @@ _llgo_0:
   ret ptr %2
 }
 
-define double @"github.com/goplus/llgo/cl/_testdata/geometry1370.(*Rectangle).Area"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define double @"github.com/goplus/llgo/cl/_testdata/geometry1370.(*Rectangle).Area"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testdata/geometry1370.Rectangle", ptr %0, i32 0, i32 0
   %2 = load double, ptr %1, align 8
@@ -26,21 +28,24 @@ _llgo_0:
   ret double %5
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testdata/geometry1370.(*Rectangle).GetID"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testdata/geometry1370.(*Rectangle).GetID"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testdata/geometry1370.Rectangle", ptr %0, i32 0, i32 2
   %2 = load i64, ptr %1, align 4
   ret i64 %2
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/geometry1370.(*Rectangle).setID"(ptr %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/geometry1370.(*Rectangle).setID"(ptr %0, i64 %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testdata/geometry1370.Rectangle", ptr %0, i32 0, i32 2
   store i64 %1, ptr %2, align 4
   ret void
 }
 
-define i1 @"github.com/goplus/llgo/cl/_testdata/geometry1370.(*Rectangle).validate"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i1 @"github.com/goplus/llgo/cl/_testdata/geometry1370.(*Rectangle).validate"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testdata/geometry1370.Rectangle", ptr %0, i32 0, i32 0
   %2 = load double, ptr %1, align 8
@@ -58,7 +63,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret i1 %7
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/geometry1370.RegisterShape"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/geometry1370.RegisterShape"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, i64 %1) #0 {
 _llgo_0:
   %2 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
   %3 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 0
@@ -72,7 +78,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/geometry1370.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/geometry1370.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testdata/geometry1370.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -85,6 +92,10 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testdata/importpkg/out.ll
+++ b/cl/_testdata/importpkg/out.ll
@@ -4,7 +4,8 @@ source_filename = "github.com/goplus/llgo/cl/_testdata/importpkg"
 @"github.com/goplus/llgo/cl/_testdata/importpkg.hello" = global [7 x i8] zeroinitializer, align 1
 @"github.com/goplus/llgo/cl/_testdata/importpkg.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testdata/importpkg.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/importpkg.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testdata/importpkg.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -25,15 +26,20 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/importpkg.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/importpkg.main"() #0 {
 _llgo_0:
   %0 = call i64 @"github.com/goplus/llgo/cl/_testdata/importpkg/stdio.Max"(i64 2, i64 100)
   call void (ptr, ...) @printf(ptr @"github.com/goplus/llgo/cl/_testdata/importpkg.hello")
   ret void
 }
 
-declare void @"github.com/goplus/llgo/cl/_testdata/importpkg/stdio.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/cl/_testdata/importpkg/stdio.init"() #0
 
-declare i64 @"github.com/goplus/llgo/cl/_testdata/importpkg/stdio.Max"(i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/cl/_testdata/importpkg/stdio.Max"(i64, i64) #0
 
 declare void @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testdata/llgointrinsics/out.ll
+++ b/cl/_testdata/llgointrinsics/out.ll
@@ -3,22 +3,26 @@ source_filename = "github.com/goplus/llgo/cl/_testdata/llgointrinsics"
 
 @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.init$guard" = global i1 false, align 1
 
-define i64 @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.UseBare"() {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.UseBare"() #0 {
 _llgo_0:
   ret i64 ptrtoint (ptr @bar to i64)
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.UseC"() {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.UseC"() #0 {
 _llgo_0:
   ret i64 ptrtoint (ptr @write to i64)
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.UseCTrampoline"() {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.UseCTrampoline"() #0 {
 _llgo_0:
   ret i64 ptrtoint (ptr @write to i64)
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.UseClosure"() {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.UseClosure"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 8)
@@ -28,7 +32,8 @@ _llgo_0:
   ret i64 ptrtoint (ptr @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.UseClosure$1" to i64)
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.UseClosure$1"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.UseClosure$1"(ptr %0) #0 {
 _llgo_0:
   %1 = load { ptr }, ptr %0, align 8
   %2 = extractvalue { ptr } %1, 0
@@ -39,22 +44,26 @@ _llgo_0:
   ret void
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.UseFunc"() {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.UseFunc"() #0 {
 _llgo_0:
   ret i64 ptrtoint (ptr @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.UseFunc$1" to i64)
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.UseFunc$1"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.UseFunc$1"() #0 {
 _llgo_0:
   ret void
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.UseLibc"() {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.UseLibc"() #0 {
 _llgo_0:
   ret i64 ptrtoint (ptr @foo to i64)
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.UseSkip"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.UseSkip"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64 0)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64 0)
@@ -62,7 +71,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testdata/llgointrinsics.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -79,10 +89,15 @@ declare i64 @bar(...)
 
 declare i64 @write(i64, ptr, i64)
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
 declare i64 @foo(...)
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testdata/llgosyscall/out.ll
+++ b/cl/_testdata/llgosyscall/out.ll
@@ -3,7 +3,8 @@ source_filename = "github.com/goplus/llgo/cl/_testdata/llgosyscall"
 
 @"github.com/goplus/llgo/cl/_testdata/llgosyscall.init$guard" = global i1 false, align 1
 
-define i64 @"github.com/goplus/llgo/cl/_testdata/llgosyscall.Use"() {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testdata/llgosyscall.Use"() #0 {
 _llgo_0:
   %0 = call i64 null(i64 1, i64 2, i64 3)
   %1 = icmp eq i64 %0, -1
@@ -19,7 +20,8 @@ _llgo_0:
   ret i64 %8
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testdata/llgosyscall.Use6"() {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testdata/llgosyscall.Use6"() #0 {
 _llgo_0:
   %0 = call i64 null(i64 1, i64 2, i64 3, i64 4, i64 5, i64 6)
   %1 = icmp eq i64 %0, -1
@@ -35,7 +37,8 @@ _llgo_0:
   ret i64 %8
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testdata/llgosyscall.Use6X"() {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testdata/llgosyscall.Use6X"() #0 {
 _llgo_0:
   %0 = call i64 null(i64 1, i64 2, i64 3, i64 4, i64 5, i64 6)
   %1 = icmp eq i64 %0, -1
@@ -51,7 +54,8 @@ _llgo_0:
   ret i64 %8
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testdata/llgosyscall.UsePtr"() {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testdata/llgosyscall.UsePtr"() #0 {
 _llgo_0:
   %0 = call i64 null(i64 1, i64 2, i64 3)
   %1 = icmp eq i64 %0, -1
@@ -67,7 +71,8 @@ _llgo_0:
   ret i64 %8
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testdata/llgosyscall.UseRaw"() {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testdata/llgosyscall.UseRaw"() #0 {
 _llgo_0:
   %0 = call i64 null(i64 1, i64 2, i64 3)
   %1 = icmp eq i64 %0, -1
@@ -83,7 +88,8 @@ _llgo_0:
   ret i64 %8
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testdata/llgosyscall.UseRaw6"() {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testdata/llgosyscall.UseRaw6"() #0 {
 _llgo_0:
   %0 = call i64 null(i64 1, i64 2, i64 3, i64 4, i64 5, i64 6)
   %1 = icmp eq i64 %0, -1
@@ -99,7 +105,8 @@ _llgo_0:
   ret i64 %8
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/llgosyscall.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/llgosyscall.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testdata/llgosyscall.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -113,3 +120,5 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
 }
 
 declare i32 @cliteErrno()
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testdata/llgotag/out.ll
+++ b/cl/_testdata/llgotag/out.ll
@@ -3,12 +3,14 @@ source_filename = "github.com/goplus/llgo/cl/_testdata/llgotag"
 
 @"github.com/goplus/llgo/cl/_testdata/llgotag.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testdata/llgotag.Foo"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/llgotag.Foo"() #0 {
 _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/llgotag.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/llgotag.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testdata/llgotag.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -20,3 +22,5 @@ _llgo_1:                                          ; preds = %_llgo_0
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testdata/method/out.ll
+++ b/cl/_testdata/method/out.ll
@@ -4,20 +4,23 @@ source_filename = "github.com/goplus/llgo/cl/_testdata/method"
 @"github.com/goplus/llgo/cl/_testdata/method.format" = global [10 x i8] zeroinitializer, align 1
 @"github.com/goplus/llgo/cl/_testdata/method.init$guard" = global i1 false, align 1
 
-define i64 @"github.com/goplus/llgo/cl/_testdata/method.T.Add"(i64 %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testdata/method.T.Add"(i64 %0, i64 %1) #0 {
 _llgo_0:
   %2 = add i64 %0, %1
   ret i64 %2
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testdata/method.(*T).Add"(ptr %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testdata/method.(*T).Add"(ptr %0, i64 %1) #0 {
 _llgo_0:
   %2 = load i64, ptr %0, align 4
   %3 = call i64 @"github.com/goplus/llgo/cl/_testdata/method.T.Add"(i64 %2, i64 %1)
   ret i64 %3
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/method.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/method.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testdata/method.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -40,7 +43,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/method.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/method.main"() #0 {
 _llgo_0:
   %0 = call i64 @"github.com/goplus/llgo/cl/_testdata/method.T.Add"(i64 1, i64 2)
   call void (ptr, ...) @printf(ptr @"github.com/goplus/llgo/cl/_testdata/method.format", i64 %0)
@@ -48,3 +52,5 @@ _llgo_0:
 }
 
 declare void @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testdata/print/out.ll
+++ b/cl/_testdata/print/out.ll
@@ -78,7 +78,8 @@ source_filename = "github.com/goplus/llgo/cl/_testdata/print"
 @30 = private unnamed_addr constant [1 x i8] c" ", align 1
 @31 = private unnamed_addr constant [1 x i8] c"\0A", align 1
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testdata/print.bytes"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testdata/print.bytes"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
   store %"github.com/goplus/llgo/runtime/internal/runtime.String" %0, ptr %1, align 8
@@ -100,7 +101,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %13
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/print.gwrite"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/print.gwrite"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0) #0 {
 _llgo_0:
   %1 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0, 1
   %2 = icmp eq i64 %1, 0
@@ -135,7 +137,8 @@ _llgo_5:                                          ; preds = %_llgo_3
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/print.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/print.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testdata/print.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -149,7 +152,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/print.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/print.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/cl/_testdata/print.printstring"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 4 })
   call void @"github.com/goplus/llgo/cl/_testdata/print.printnl"()
@@ -257,21 +261,24 @@ _llgo_3:                                          ; preds = %_llgo_0
   br i1 true, label %_llgo_1, label %_llgo_2
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/print.prinfsub"(double %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/print.prinfsub"(double %0) #0 {
 _llgo_0:
   %1 = fneg double %0
   call void @"github.com/goplus/llgo/cl/_testdata/print.printfloat"(double %1)
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/print.prinsub"(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/print.prinsub"(i64 %0) #0 {
 _llgo_0:
   %1 = sub i64 0, %0
   call void @"github.com/goplus/llgo/cl/_testdata/print.printint"(i64 %1)
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/print.printany"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/print.printany"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %0) #0 {
 _llgo_0:
   %1 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %0, 0
   %2 = icmp eq ptr %1, @_llgo_bool
@@ -730,7 +737,8 @@ _llgo_85:                                         ; preds = %_llgo_84, %_llgo_83
   br i1 %176, label %_llgo_34, label %_llgo_1
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/print.printbool"(i1 %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/print.printbool"(i1 %0) #0 {
 _llgo_0:
   br i1 %0, label %_llgo_1, label %_llgo_3
 
@@ -746,7 +754,8 @@ _llgo_3:                                          ; preds = %_llgo_0
   br label %_llgo_2
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/print.printfloat"(double %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/print.printfloat"(double %0) #0 {
 _llgo_0:
   %1 = fcmp une double %0, %0
   br i1 %1, label %_llgo_1, label %_llgo_3
@@ -935,7 +944,8 @@ _llgo_29:                                         ; preds = %_llgo_28, %_llgo_27
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/print.printhex"(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/print.printhex"(i64 %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 100)
   br label %_llgo_3
@@ -992,7 +1002,8 @@ _llgo_5:                                          ; preds = %_llgo_1
   br i1 %29, label %_llgo_2, label %_llgo_4
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/print.printint"(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/print.printint"(i64 %0) #0 {
 _llgo_0:
   %1 = icmp slt i64 %0, 0
   br i1 %1, label %_llgo_1, label %_llgo_2
@@ -1008,7 +1019,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/print.println"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/print.println"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0) #0 {
 _llgo_0:
   %1 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0, 1
   br label %_llgo_1
@@ -1044,26 +1056,30 @@ _llgo_5:                                          ; preds = %_llgo_4, %_llgo_2
   br label %_llgo_1
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/print.printnl"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/print.printnl"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/cl/_testdata/print.printstring"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @31, i64 1 })
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/print.printsp"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/print.printsp"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/cl/_testdata/print.printstring"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @30, i64 1 })
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/print.printstring"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/print.printstring"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0) #0 {
 _llgo_0:
   %1 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testdata/print.bytes"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0)
   call void @"github.com/goplus/llgo/cl/_testdata/print.gwrite"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1)
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/print.printuint"(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/print.printuint"(i64 %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 100)
   br label %_llgo_3
@@ -1098,32 +1114,38 @@ _llgo_4:                                          ; preds = %_llgo_1
   br label %_llgo_3
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/print.prinusub"(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/print.prinusub"(i64 %0) #0 {
 _llgo_0:
   %1 = sub i64 0, %0
   call void @"github.com/goplus/llgo/cl/_testdata/print.printuint"(i64 %1)
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/print.prinxor"(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/print.prinxor"(i64 %0) #0 {
 _llgo_0:
   %1 = xor i64 %0, -1
   call void @"github.com/goplus/llgo/cl/_testdata/print.printint"(i64 %1)
   ret void
 }
 
-define ptr @"github.com/goplus/llgo/cl/_testdata/print.stringStructOf"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define ptr @"github.com/goplus/llgo/cl/_testdata/print.stringStructOf"(ptr %0) #0 {
 _llgo_0:
   ret ptr %0
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1) #0
 
 declare i32 @printf(ptr, ...)
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.f32equal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.f32equal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.f32equal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1131,7 +1153,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1139,7 +1162,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.f64equal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.f64equal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.f64equal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1147,7 +1171,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1155,9 +1180,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1165,7 +1192,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1173,7 +1201,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal16"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal16"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal16"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1181,7 +1210,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1189,7 +1219,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.c128equal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.c128equal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.c128equal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1197,7 +1228,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.c64equal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.c64equal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.c64equal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1205,4 +1237,7 @@ _llgo_0:
   ret i1 %3
 }
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.NewSlice3"(ptr, i64, i64, i64, i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.NewSlice3"(ptr, i64, i64, i64, i64, i64) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testdata/printf/out.ll
+++ b/cl/_testdata/printf/out.ll
@@ -4,7 +4,8 @@ source_filename = "github.com/goplus/llgo/cl/_testdata/printf"
 @"github.com/goplus/llgo/cl/_testdata/printf.hello" = global [7 x i8] zeroinitializer, align 1
 @"github.com/goplus/llgo/cl/_testdata/printf.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testdata/printf.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/printf.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testdata/printf.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -24,10 +25,13 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/printf.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/printf.main"() #0 {
 _llgo_0:
   call void (ptr, ...) @printf(ptr @"github.com/goplus/llgo/cl/_testdata/printf.hello")
   ret void
 }
 
 declare void @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testdata/printval/out.ll
+++ b/cl/_testdata/printval/out.ll
@@ -4,7 +4,8 @@ source_filename = "github.com/goplus/llgo/cl/_testdata/printval"
 @"github.com/goplus/llgo/cl/_testdata/printval.format" = global [10 x i8] zeroinitializer, align 1
 @"github.com/goplus/llgo/cl/_testdata/printval.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testdata/printval.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/printval.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testdata/printval.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -27,10 +28,13 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/printval.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/printval.main"() #0 {
 _llgo_0:
   call void (ptr, ...) @printf(ptr @"github.com/goplus/llgo/cl/_testdata/printval.format", i64 100)
   ret void
 }
 
 declare void @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testdata/ptrmthd/out.ll
+++ b/cl/_testdata/ptrmthd/out.ll
@@ -4,13 +4,15 @@ source_filename = "github.com/goplus/llgo/cl/_testdata/ptrmthd"
 @"github.com/goplus/llgo/cl/_testdata/ptrmthd.format" = global [10 x i8] zeroinitializer, align 1
 @"github.com/goplus/llgo/cl/_testdata/ptrmthd.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testdata/ptrmthd.(*T).Print"(ptr %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/ptrmthd.(*T).Print"(ptr %0, i64 %1) #0 {
 _llgo_0:
   call void (ptr, ...) @printf(ptr %0, i64 %1)
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/ptrmthd.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/ptrmthd.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testdata/ptrmthd.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -33,10 +35,13 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/ptrmthd.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/ptrmthd.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/cl/_testdata/ptrmthd.(*T).Print"(ptr @"github.com/goplus/llgo/cl/_testdata/ptrmthd.format", i64 100)
   ret void
 }
 
 declare void @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testdata/uint/out.ll
+++ b/cl/_testdata/uint/out.ll
@@ -4,13 +4,15 @@ source_filename = "github.com/goplus/llgo/cl/_testdata/uint"
 @"github.com/goplus/llgo/cl/_testdata/uint.init$guard" = global i1 false, align 1
 @0 = private unnamed_addr constant [11 x i8] c"Hello, %u\0A\00", align 1
 
-define i32 @"github.com/goplus/llgo/cl/_testdata/uint.f"(i32 %0) {
+; Function Attrs: null_pointer_is_valid
+define i32 @"github.com/goplus/llgo/cl/_testdata/uint.f"(i32 %0) #0 {
 _llgo_0:
   %1 = add i32 %0, 1
   ret i32 %1
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/uint.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/uint.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testdata/uint.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -23,7 +25,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/uint.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/uint.main"() #0 {
 _llgo_0:
   %0 = call i32 @"github.com/goplus/llgo/cl/_testdata/uint.f"(i32 100)
   %1 = call i32 (ptr, ...) @printf(ptr @0, i32 %0)
@@ -31,3 +34,5 @@ _llgo_0:
 }
 
 declare i32 @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testdata/untyped/out.ll
+++ b/cl/_testdata/untyped/out.ll
@@ -4,7 +4,8 @@ source_filename = "github.com/goplus/llgo/cl/_testdata/untyped"
 @"github.com/goplus/llgo/cl/_testdata/untyped.a" = global double 0.000000e+00, align 8
 @"github.com/goplus/llgo/cl/_testdata/untyped.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testdata/untyped.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/untyped.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testdata/untyped.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -18,7 +19,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/untyped.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/untyped.main"() #0 {
 _llgo_0:
   br i1 false, label %_llgo_1, label %_llgo_2
 
@@ -29,3 +31,5 @@ _llgo_1:                                          ; preds = %_llgo_0
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testdata/utf8/out.ll
+++ b/cl/_testdata/utf8/out.ll
@@ -7,7 +7,8 @@ source_filename = "github.com/goplus/llgo/cl/_testdata/utf8"
 @"github.com/goplus/llgo/cl/_testdata/utf8.init$guard" = global i1 false, align 1
 @0 = private unnamed_addr constant [7 x i8] c"\E4\B8\ADabcd", align 1
 
-define i8 @"github.com/goplus/llgo/cl/_testdata/utf8.index"(i8 %0) {
+; Function Attrs: null_pointer_is_valid
+define i8 @"github.com/goplus/llgo/cl/_testdata/utf8.index"(i8 %0) #0 {
 _llgo_0:
   %1 = sext i8 %0 to i64
   %2 = icmp slt i64 %1, 0
@@ -19,7 +20,8 @@ _llgo_0:
   ret i8 %6
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/utf8.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/utf8.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testdata/utf8.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -41,7 +43,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/utf8.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/utf8.main"() #0 {
 _llgo_0:
   br label %_llgo_1
 
@@ -69,16 +72,25 @@ _llgo_3:                                          ; preds = %_llgo_1
   ret void
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1) #0
 
-declare void @"unicode/utf8.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"unicode/utf8.init"() #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringSlice"(%"github.com/goplus/llgo/runtime/internal/runtime.String", i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringSlice"(%"github.com/goplus/llgo/runtime/internal/runtime.String", i64, i64) #0
 
-declare { i32, i64 } @"unicode/utf8.DecodeRuneInString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare { i32, i64 } @"unicode/utf8.DecodeRuneInString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testdata/vargs/out.ll
+++ b/cl/_testdata/vargs/out.ll
@@ -17,7 +17,8 @@ source_filename = "github.com/goplus/llgo/cl/_testdata/vargs"
 @3 = private unnamed_addr constant [6 x i8] c"string", align 1
 @"*_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1323879264, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @3, i64 6 }, ptr null }, ptr @_llgo_string }, align 8
 
-define void @"github.com/goplus/llgo/cl/_testdata/vargs.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/vargs.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testdata/vargs.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -30,7 +31,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/vargs.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/vargs.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 48)
   %1 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.eface", ptr %0, i64 0
@@ -46,7 +48,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/vargs.test"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/vargs.test"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0) #0 {
 _llgo_0:
   %1 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0, 1
   br label %_llgo_1
@@ -87,9 +90,11 @@ _llgo_5:                                          ; preds = %_llgo_2
   unreachable
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -97,7 +102,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -105,9 +111,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -115,8 +123,12 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
 declare i32 @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testdata/varinit/out.ll
+++ b/cl/_testdata/varinit/out.ll
@@ -4,7 +4,8 @@ source_filename = "github.com/goplus/llgo/cl/_testdata/varinit"
 @"github.com/goplus/llgo/cl/_testdata/varinit.a" = global i64 0, align 8
 @"github.com/goplus/llgo/cl/_testdata/varinit.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testdata/varinit.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/varinit.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testdata/varinit.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -18,7 +19,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testdata/varinit.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testdata/varinit.main"() #0 {
 _llgo_0:
   %0 = load i64, ptr @"github.com/goplus/llgo/cl/_testdata/varinit.a", align 4
   %1 = add i64 %0, 1
@@ -26,3 +28,5 @@ _llgo_0:
   %2 = load i64, ptr @"github.com/goplus/llgo/cl/_testdata/varinit.a", align 4
   ret void
 }
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testgo/abimethod/out.ll
+++ b/cl/_testgo/abimethod/out.ll
@@ -279,7 +279,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/abimethod"
 @111 = private unnamed_addr constant [16 x i8] c"testNamed2 error", align 1
 @112 = private unnamed_addr constant [16 x i8] c"testNamed4 error", align 1
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.T.Demo1"(%"github.com/goplus/llgo/cl/_testgo/abimethod.T" %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.T.Demo1"(%"github.com/goplus/llgo/cl/_testgo/abimethod.T" %0) #0 {
 _llgo_0:
   %1 = alloca %"github.com/goplus/llgo/cl/_testgo/abimethod.T", align 8
   call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
@@ -289,28 +290,32 @@ _llgo_0:
   ret i64 %3
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.(*T).Demo1"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.(*T).Demo1"(ptr %0) #0 {
 _llgo_0:
   %1 = load %"github.com/goplus/llgo/cl/_testgo/abimethod.T", ptr %0, align 4
   %2 = call i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.T.Demo1"(%"github.com/goplus/llgo/cl/_testgo/abimethod.T" %1)
   ret i64 %2
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.(*T).Demo2"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.(*T).Demo2"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/abimethod.T", ptr %0, i32 0, i32 0
   %2 = load i64, ptr %1, align 4
   ret i64 %2
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.(*T).demo3"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.(*T).demo3"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/abimethod.T", ptr %0, i32 0, i32 0
   %2 = load i64, ptr %1, align 4
   ret i64 %2
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/abimethod.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/abimethod.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/abimethod.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -326,7 +331,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/abimethod.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/abimethod.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/cl/_testgo/abimethod.testGeneric"()
   call void @"github.com/goplus/llgo/cl/_testgo/abimethod.testNamed1"()
@@ -344,7 +350,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testAnonymous1"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testAnonymous1"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
@@ -380,7 +387,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testAnonymous2"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testAnonymous2"() #0 {
 _llgo_0:
   %0 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
@@ -420,7 +428,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testAnonymous3"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testAnonymous3"() #0 {
 _llgo_0:
   %0 = alloca { i64, %"github.com/goplus/llgo/cl/_testgo/abimethod.T" }, align 8
   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
@@ -458,7 +467,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testAnonymous4"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testAnonymous4"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
   %1 = getelementptr inbounds { i64, %"github.com/goplus/llgo/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 0
@@ -492,7 +502,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testAnonymous5"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testAnonymous5"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
   %1 = getelementptr inbounds { i64, %"github.com/goplus/llgo/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 0
@@ -526,7 +537,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testAnonymous6"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testAnonymous6"() #0 {
 _llgo_0:
   %0 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
@@ -566,7 +578,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testAnonymous7"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testAnonymous7"() #0 {
 _llgo_0:
   %0 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
@@ -626,7 +639,8 @@ _llgo_4:                                          ; preds = %_llgo_2
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testAnonymous8"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testAnonymous8"() #0 {
 _llgo_0:
   %0 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
@@ -706,7 +720,8 @@ _llgo_6:                                          ; preds = %_llgo_4
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testAnonymousBuffer"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testAnonymousBuffer"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
@@ -741,7 +756,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testGeneric"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testGeneric"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uinGjIxPTfzB5e5h5gH-0VIvLl5rQdJ_yx2UsrxQqds", ptr @"*_llgo_github.com/goplus/llgo/cl/_testgo/abimethod.Pointer[any]")
@@ -795,14 +811,16 @@ _llgo_4:                                          ; preds = %_llgo_0
   unreachable
 }
 
-define ptr @"github.com/goplus/llgo/cl/_testgo/abimethod.testGeneric$1"() {
+; Function Attrs: null_pointer_is_valid
+define ptr @"github.com/goplus/llgo/cl/_testgo/abimethod.testGeneric$1"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
   store %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 100 to ptr) }, ptr %0, align 8
   ret ptr %0
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testNamed1"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testNamed1"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/abimethod.T", ptr %0, i32 0, i32 0
@@ -833,7 +851,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testNamed2"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testNamed2"() #0 {
 _llgo_0:
   %0 = alloca %"github.com/goplus/llgo/cl/_testgo/abimethod.T", align 8
   call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
@@ -868,7 +887,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testNamed3"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/abimethod.testNamed3"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/abimethod.T", ptr %0, i32 0, i32 0
@@ -900,17 +920,22 @@ _llgo_2:                                          ; preds = %_llgo_0
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-declare void @bytes.init()
+; Function Attrs: null_pointer_is_valid
+declare void @bytes.init() #0
 
-declare void @fmt.init()
+; Function Attrs: null_pointer_is_valid
+declare void @fmt.init() #0
 
-declare void @"sync/atomic.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"sync/atomic.init"() #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *github.com/goplus/llgo/cl/_testgo/abimethod.T}.Demo1"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *github.com/goplus/llgo/cl/_testgo/abimethod.T}.Demo1"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %2 = load ptr, ptr %1, align 8
@@ -919,7 +944,8 @@ _llgo_0:
   ret i64 %4
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *github.com/goplus/llgo/cl/_testgo/abimethod.T}.Demo2"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *github.com/goplus/llgo/cl/_testgo/abimethod.T}.Demo2"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %2 = load ptr, ptr %1, align 8
@@ -927,7 +953,8 @@ _llgo_0:
   ret i64 %3
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *github.com/goplus/llgo/cl/_testgo/abimethod.T}.demo3"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *github.com/goplus/llgo/cl/_testgo/abimethod.T}.demo3"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %2 = load ptr, ptr %1, align 8
@@ -935,7 +962,8 @@ _llgo_0:
   ret i64 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -943,7 +971,8 @@ _llgo_0:
   ret i1 %3
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *github.com/goplus/llgo/cl/_testgo/abimethod.T}.Demo1"({ i64, ptr } %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *github.com/goplus/llgo/cl/_testgo/abimethod.T}.Demo1"({ i64, ptr } %0) #0 {
 _llgo_0:
   %1 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -955,7 +984,8 @@ _llgo_0:
   ret i64 %5
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *github.com/goplus/llgo/cl/_testgo/abimethod.T}.Demo2"({ i64, ptr } %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *github.com/goplus/llgo/cl/_testgo/abimethod.T}.Demo2"({ i64, ptr } %0) #0 {
 _llgo_0:
   %1 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -966,7 +996,8 @@ _llgo_0:
   ret i64 %4
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *github.com/goplus/llgo/cl/_testgo/abimethod.T}.demo3"({ i64, ptr } %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *github.com/goplus/llgo/cl/_testgo/abimethod.T}.demo3"({ i64, ptr } %0) #0 {
 _llgo_0:
   %1 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -977,9 +1008,11 @@ _llgo_0:
   ret i64 %4
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -987,7 +1020,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -995,11 +1029,14 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1007,11 +1044,14 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; github.com/goplus/llgo/cl/_testgo/abimethod.T}.Demo1"({ i64, %"github.com/goplus/llgo/cl/_testgo/abimethod.T" } %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; github.com/goplus/llgo/cl/_testgo/abimethod.T}.Demo1"({ i64, %"github.com/goplus/llgo/cl/_testgo/abimethod.T" } %0) #0 {
 _llgo_0:
   %1 = alloca { i64, %"github.com/goplus/llgo/cl/_testgo/abimethod.T" }, align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1022,7 +1062,8 @@ _llgo_0:
   ret i64 %4
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; github.com/goplus/llgo/cl/_testgo/abimethod.T}.Demo1"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; github.com/goplus/llgo/cl/_testgo/abimethod.T}.Demo1"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds { i64, %"github.com/goplus/llgo/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
   %2 = load %"github.com/goplus/llgo/cl/_testgo/abimethod.T", ptr %1, align 4
@@ -1030,23 +1071,27 @@ _llgo_0:
   ret i64 %3
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; github.com/goplus/llgo/cl/_testgo/abimethod.T}.Demo2"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; github.com/goplus/llgo/cl/_testgo/abimethod.T}.Demo2"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds { i64, %"github.com/goplus/llgo/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
   %2 = call i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.(*T).Demo2"(ptr %1)
   ret i64 %2
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; github.com/goplus/llgo/cl/_testgo/abimethod.T}.demo3"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; github.com/goplus/llgo/cl/_testgo/abimethod.T}.demo3"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds { i64, %"github.com/goplus/llgo/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
   %2 = call i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.(*T).demo3"(ptr %1)
   ret i64 %2
 }
 
-declare ptr @bytes.NewBufferString(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare ptr @bytes.NewBufferString(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Available"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Available"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %2 = load ptr, ptr %1, align 8
@@ -1054,7 +1099,8 @@ _llgo_0:
   ret i64 %3
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.AvailableBuffer"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.AvailableBuffer"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %2 = load ptr, ptr %1, align 8
@@ -1062,7 +1108,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %3
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Bytes"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Bytes"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %2 = load ptr, ptr %1, align 8
@@ -1070,7 +1117,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %3
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Cap"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Cap"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %2 = load ptr, ptr %1, align 8
@@ -1078,7 +1126,8 @@ _llgo_0:
   ret i64 %3
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Grow"(ptr %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Grow"(ptr %0, i64 %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %3 = load ptr, ptr %2, align 8
@@ -1086,7 +1135,8 @@ _llgo_0:
   ret void
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Len"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Len"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %2 = load ptr, ptr %1, align 8
@@ -1094,7 +1144,8 @@ _llgo_0:
   ret i64 %3
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Next"(ptr %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Next"(ptr %0, i64 %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %3 = load ptr, ptr %2, align 8
@@ -1102,7 +1153,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %4
 }
 
-define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Read"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+; Function Attrs: null_pointer_is_valid
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Read"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %3 = load ptr, ptr %2, align 8
@@ -1114,7 +1166,8 @@ _llgo_0:
   ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %8
 }
 
-define { i8, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadByte"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define { i8, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadByte"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %2 = load ptr, ptr %1, align 8
@@ -1126,7 +1179,8 @@ _llgo_0:
   ret { i8, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %7
 }
 
-define { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadBytes"(ptr %0, i8 %1) {
+; Function Attrs: null_pointer_is_valid
+define { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadBytes"(ptr %0, i8 %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %3 = load ptr, ptr %2, align 8
@@ -1138,7 +1192,8 @@ _llgo_0:
   ret { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %8
 }
 
-define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadFrom"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) {
+; Function Attrs: null_pointer_is_valid
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadFrom"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %3 = load ptr, ptr %2, align 8
@@ -1150,7 +1205,8 @@ _llgo_0:
   ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %8
 }
 
-define { i32, i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadRune"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define { i32, i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadRune"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %2 = load ptr, ptr %1, align 8
@@ -1164,7 +1220,8 @@ _llgo_0:
   ret { i32, i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %9
 }
 
-define { %"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadString"(ptr %0, i8 %1) {
+; Function Attrs: null_pointer_is_valid
+define { %"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadString"(ptr %0, i8 %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %3 = load ptr, ptr %2, align 8
@@ -1176,7 +1233,8 @@ _llgo_0:
   ret { %"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %8
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Reset"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Reset"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %2 = load ptr, ptr %1, align 8
@@ -1184,7 +1242,8 @@ _llgo_0:
   ret void
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.String"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.String"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %2 = load ptr, ptr %1, align 8
@@ -1192,7 +1251,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.String" %3
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Truncate"(ptr %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Truncate"(ptr %0, i64 %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %3 = load ptr, ptr %2, align 8
@@ -1200,7 +1260,8 @@ _llgo_0:
   ret void
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadByte"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadByte"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %2 = load ptr, ptr %1, align 8
@@ -1208,7 +1269,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %3
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadRune"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadRune"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %2 = load ptr, ptr %1, align 8
@@ -1216,7 +1278,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %3
 }
 
-define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Write"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+; Function Attrs: null_pointer_is_valid
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Write"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %3 = load ptr, ptr %2, align 8
@@ -1228,7 +1291,8 @@ _llgo_0:
   ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %8
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteByte"(ptr %0, i8 %1) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteByte"(ptr %0, i8 %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %3 = load ptr, ptr %2, align 8
@@ -1236,7 +1300,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %4
 }
 
-define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteRune"(ptr %0, i32 %1) {
+; Function Attrs: null_pointer_is_valid
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteRune"(ptr %0, i32 %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %3 = load ptr, ptr %2, align 8
@@ -1248,7 +1313,8 @@ _llgo_0:
   ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %8
 }
 
-define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteString"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.String" %1) {
+; Function Attrs: null_pointer_is_valid
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteString"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.String" %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %3 = load ptr, ptr %2, align 8
@@ -1260,7 +1326,8 @@ _llgo_0:
   ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %8
 }
 
-define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteTo"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) {
+; Function Attrs: null_pointer_is_valid
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteTo"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %3 = load ptr, ptr %2, align 8
@@ -1272,7 +1339,8 @@ _llgo_0:
   ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %8
 }
 
-define i1 @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.empty"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i1 @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.empty"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %2 = load ptr, ptr %1, align 8
@@ -1280,7 +1348,8 @@ _llgo_0:
   ret i1 %3
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.grow"(ptr %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.grow"(ptr %0, i64 %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %3 = load ptr, ptr %2, align 8
@@ -1288,7 +1357,8 @@ _llgo_0:
   ret i64 %4
 }
 
-define { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.readSlice"(ptr %0, i8 %1) {
+; Function Attrs: null_pointer_is_valid
+define { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.readSlice"(ptr %0, i8 %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %3 = load ptr, ptr %2, align 8
@@ -1300,7 +1370,8 @@ _llgo_0:
   ret { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %8
 }
 
-define { i64, i1 } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.tryGrowByReslice"(ptr %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define { i64, i1 } @"github.com/goplus/llgo/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.tryGrowByReslice"(ptr %0, i64 %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
   %3 = load ptr, ptr %2, align 8
@@ -1312,7 +1383,8 @@ _llgo_0:
   ret { i64, i1 } %8
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Available"({ i64, ptr } %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Available"({ i64, ptr } %0) #0 {
 _llgo_0:
   %1 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1323,7 +1395,8 @@ _llgo_0:
   ret i64 %4
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.AvailableBuffer"({ i64, ptr } %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.AvailableBuffer"({ i64, ptr } %0) #0 {
 _llgo_0:
   %1 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1334,7 +1407,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %4
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Bytes"({ i64, ptr } %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Bytes"({ i64, ptr } %0) #0 {
 _llgo_0:
   %1 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1345,7 +1419,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %4
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Cap"({ i64, ptr } %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Cap"({ i64, ptr } %0) #0 {
 _llgo_0:
   %1 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1356,7 +1431,8 @@ _llgo_0:
   ret i64 %4
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Grow"({ i64, ptr } %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Grow"({ i64, ptr } %0, i64 %1) #0 {
 _llgo_0:
   %2 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1367,7 +1443,8 @@ _llgo_0:
   ret void
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Len"({ i64, ptr } %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Len"({ i64, ptr } %0) #0 {
 _llgo_0:
   %1 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1378,7 +1455,8 @@ _llgo_0:
   ret i64 %4
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Next"({ i64, ptr } %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Next"({ i64, ptr } %0, i64 %1) #0 {
 _llgo_0:
   %2 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1389,7 +1467,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %5
 }
 
-define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Read"({ i64, ptr } %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+; Function Attrs: null_pointer_is_valid
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Read"({ i64, ptr } %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) #0 {
 _llgo_0:
   %2 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1404,7 +1483,8 @@ _llgo_0:
   ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %9
 }
 
-define { i8, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadByte"({ i64, ptr } %0) {
+; Function Attrs: null_pointer_is_valid
+define { i8, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadByte"({ i64, ptr } %0) #0 {
 _llgo_0:
   %1 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1419,7 +1499,8 @@ _llgo_0:
   ret { i8, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %8
 }
 
-define { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadBytes"({ i64, ptr } %0, i8 %1) {
+; Function Attrs: null_pointer_is_valid
+define { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadBytes"({ i64, ptr } %0, i8 %1) #0 {
 _llgo_0:
   %2 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1434,7 +1515,8 @@ _llgo_0:
   ret { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %9
 }
 
-define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadFrom"({ i64, ptr } %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) {
+; Function Attrs: null_pointer_is_valid
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadFrom"({ i64, ptr } %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) #0 {
 _llgo_0:
   %2 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1449,7 +1531,8 @@ _llgo_0:
   ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %9
 }
 
-define { i32, i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadRune"({ i64, ptr } %0) {
+; Function Attrs: null_pointer_is_valid
+define { i32, i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadRune"({ i64, ptr } %0) #0 {
 _llgo_0:
   %1 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1466,7 +1549,8 @@ _llgo_0:
   ret { i32, i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %10
 }
 
-define { %"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadString"({ i64, ptr } %0, i8 %1) {
+; Function Attrs: null_pointer_is_valid
+define { %"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadString"({ i64, ptr } %0, i8 %1) #0 {
 _llgo_0:
   %2 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1481,7 +1565,8 @@ _llgo_0:
   ret { %"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %9
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Reset"({ i64, ptr } %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Reset"({ i64, ptr } %0) #0 {
 _llgo_0:
   %1 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1492,7 +1577,8 @@ _llgo_0:
   ret void
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.String"({ i64, ptr } %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.String"({ i64, ptr } %0) #0 {
 _llgo_0:
   %1 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1503,7 +1589,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.String" %4
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Truncate"({ i64, ptr } %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Truncate"({ i64, ptr } %0, i64 %1) #0 {
 _llgo_0:
   %2 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1514,7 +1601,8 @@ _llgo_0:
   ret void
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.UnreadByte"({ i64, ptr } %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.UnreadByte"({ i64, ptr } %0) #0 {
 _llgo_0:
   %1 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1525,7 +1613,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %4
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.UnreadRune"({ i64, ptr } %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.UnreadRune"({ i64, ptr } %0) #0 {
 _llgo_0:
   %1 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1536,7 +1625,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %4
 }
 
-define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Write"({ i64, ptr } %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+; Function Attrs: null_pointer_is_valid
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Write"({ i64, ptr } %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) #0 {
 _llgo_0:
   %2 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1551,7 +1641,8 @@ _llgo_0:
   ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %9
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteByte"({ i64, ptr } %0, i8 %1) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteByte"({ i64, ptr } %0, i8 %1) #0 {
 _llgo_0:
   %2 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1562,7 +1653,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %5
 }
 
-define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteRune"({ i64, ptr } %0, i32 %1) {
+; Function Attrs: null_pointer_is_valid
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteRune"({ i64, ptr } %0, i32 %1) #0 {
 _llgo_0:
   %2 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1577,7 +1669,8 @@ _llgo_0:
   ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %9
 }
 
-define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteString"({ i64, ptr } %0, %"github.com/goplus/llgo/runtime/internal/runtime.String" %1) {
+; Function Attrs: null_pointer_is_valid
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteString"({ i64, ptr } %0, %"github.com/goplus/llgo/runtime/internal/runtime.String" %1) #0 {
 _llgo_0:
   %2 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1592,7 +1685,8 @@ _llgo_0:
   ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %9
 }
 
-define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteTo"({ i64, ptr } %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) {
+; Function Attrs: null_pointer_is_valid
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteTo"({ i64, ptr } %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) #0 {
 _llgo_0:
   %2 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1607,7 +1701,8 @@ _llgo_0:
   ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %9
 }
 
-define i1 @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.empty"({ i64, ptr } %0) {
+; Function Attrs: null_pointer_is_valid
+define i1 @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.empty"({ i64, ptr } %0) #0 {
 _llgo_0:
   %1 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1618,7 +1713,8 @@ _llgo_0:
   ret i1 %4
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.grow"({ i64, ptr } %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.grow"({ i64, ptr } %0, i64 %1) #0 {
 _llgo_0:
   %2 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1629,7 +1725,8 @@ _llgo_0:
   ret i64 %5
 }
 
-define { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.readSlice"({ i64, ptr } %0, i8 %1) {
+; Function Attrs: null_pointer_is_valid
+define { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.readSlice"({ i64, ptr } %0, i8 %1) #0 {
 _llgo_0:
   %2 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1644,7 +1741,8 @@ _llgo_0:
   ret { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %9
 }
 
-define { i64, i1 } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.tryGrowByReslice"({ i64, ptr } %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define { i64, i1 } @"github.com/goplus/llgo/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.tryGrowByReslice"({ i64, ptr } %0, i64 %1) #0 {
 _llgo_0:
   %2 = alloca { i64, ptr }, align 8
   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1659,7 +1757,8 @@ _llgo_0:
   ret { i64, i1 } %9
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1667,31 +1766,44 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i64 @"bytes.(*Buffer).Available"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"bytes.(*Buffer).Available"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"bytes.(*Buffer).AvailableBuffer"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"bytes.(*Buffer).AvailableBuffer"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"bytes.(*Buffer).Bytes"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"bytes.(*Buffer).Bytes"(ptr) #0
 
-declare i64 @"bytes.(*Buffer).Cap"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"bytes.(*Buffer).Cap"(ptr) #0
 
-declare void @"bytes.(*Buffer).Grow"(ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"bytes.(*Buffer).Grow"(ptr, i64) #0
 
-declare i64 @"bytes.(*Buffer).Len"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"bytes.(*Buffer).Len"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"bytes.(*Buffer).Next"(ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"bytes.(*Buffer).Next"(ptr, i64) #0
 
-declare { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).Read"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+; Function Attrs: null_pointer_is_valid
+declare { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).Read"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.Slice") #0
 
-declare { i8, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).ReadByte"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare { i8, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).ReadByte"(ptr) #0
 
-declare { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).ReadBytes"(ptr, i8)
+; Function Attrs: null_pointer_is_valid
+declare { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).ReadBytes"(ptr, i8) #0
 
-declare { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).ReadFrom"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).ReadFrom"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare { i32, i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).ReadRune"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare { i32, i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).ReadRune"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1699,55 +1811,75 @@ _llgo_0:
   ret i1 %3
 }
 
-declare { %"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).ReadString"(ptr, i8)
+; Function Attrs: null_pointer_is_valid
+declare { %"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).ReadString"(ptr, i8) #0
 
-declare void @"bytes.(*Buffer).Reset"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"bytes.(*Buffer).Reset"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"bytes.(*Buffer).String"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"bytes.(*Buffer).String"(ptr) #0
 
-declare void @"bytes.(*Buffer).Truncate"(ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"bytes.(*Buffer).Truncate"(ptr, i64) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"bytes.(*Buffer).UnreadByte"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"bytes.(*Buffer).UnreadByte"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"bytes.(*Buffer).UnreadRune"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"bytes.(*Buffer).UnreadRune"(ptr) #0
 
-declare { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).Write"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+; Function Attrs: null_pointer_is_valid
+declare { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).Write"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.Slice") #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"bytes.(*Buffer).WriteByte"(ptr, i8)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"bytes.(*Buffer).WriteByte"(ptr, i8) #0
 
-declare { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).WriteRune"(ptr, i32)
+; Function Attrs: null_pointer_is_valid
+declare { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).WriteRune"(ptr, i32) #0
 
-declare { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).WriteString"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).WriteString"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).WriteTo"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).WriteTo"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare i1 @"bytes.(*Buffer).empty"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"bytes.(*Buffer).empty"(ptr) #0
 
-declare i64 @"bytes.(*Buffer).grow"(ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"bytes.(*Buffer).grow"(ptr, i64) #0
 
-declare { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).readSlice"(ptr, i8)
+; Function Attrs: null_pointer_is_valid
+declare { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).readSlice"(ptr, i8) #0
 
-declare { i64, i1 } @"bytes.(*Buffer).tryGrowByReslice"(ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare { i64, i1 } @"bytes.(*Buffer).tryGrowByReslice"(ptr, i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-define linkonce ptr @"github.com/goplus/llgo/cl/_testgo/abimethod.(*Pointer[any]).Load"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define linkonce ptr @"github.com/goplus/llgo/cl/_testgo/abimethod.(*Pointer[any]).Load"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/abimethod.Pointer[any]", ptr %0, i32 0, i32 1
   %2 = load atomic ptr, ptr %1 seq_cst, align 8
   ret ptr %2
 }
 
-define linkonce void @"github.com/goplus/llgo/cl/_testgo/abimethod.(*Pointer[any]).Store"(ptr %0, ptr %1) {
+; Function Attrs: null_pointer_is_valid
+define linkonce void @"github.com/goplus/llgo/cl/_testgo/abimethod.(*Pointer[any]).Store"(ptr %0, ptr %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/abimethod.Pointer[any]", ptr %0, i32 0, i32 1
   store atomic ptr %1, ptr %2 seq_cst, align 8
   ret void
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1755,4 +1887,5 @@ _llgo_0:
   ret i1 %3
 }
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/alias/out.ll
+++ b/cl/_testgo/alias/out.ll
@@ -5,7 +5,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/alias"
 
 @"github.com/goplus/llgo/cl/_testgo/alias.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testgo/alias.(*Point).Move"(ptr %0, double %1, double %2) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/alias.(*Point).Move"(ptr %0, double %1, double %2) #0 {
 _llgo_0:
   %3 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/alias.Point", ptr %0, i32 0, i32 0
   %4 = load double, ptr %3, align 8
@@ -20,7 +21,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/alias.(*Point).Scale"(ptr %0, double %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/alias.(*Point).Scale"(ptr %0, double %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/alias.Point", ptr %0, i32 0, i32 0
   %3 = load double, ptr %2, align 8
@@ -35,7 +37,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/alias.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/alias.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/alias.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -48,7 +51,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/alias.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/alias.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/alias.Point", ptr %0, i32 0, i32 0
@@ -68,8 +72,13 @@ _llgo_0:
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintFloat"(double)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintFloat"(double) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testgo/allocinloop/out.ll
+++ b/cl/_testgo/allocinloop/out.ll
@@ -6,13 +6,15 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/allocinloop"
 @"github.com/goplus/llgo/cl/_testgo/allocinloop.init$guard" = global i1 false, align 1
 @0 = private unnamed_addr constant [5 x i8] c"hello", align 1
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/allocinloop.Foo"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/allocinloop.Foo"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0) #0 {
 _llgo_0:
   %1 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %0, 1
   ret i64 %1
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/allocinloop.Test"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/allocinloop.Test"() #0 {
 _llgo_0:
   br label %_llgo_1
 
@@ -34,7 +36,8 @@ _llgo_3:                                          ; preds = %_llgo_1
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/allocinloop.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/allocinloop.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/allocinloop.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -47,12 +50,17 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/allocinloop.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/allocinloop.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/cl/_testgo/allocinloop.Test"()
   ret void
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testgo/closure/out.ll
+++ b/cl/_testgo/closure/out.ll
@@ -9,7 +9,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/closure"
 @1 = private unnamed_addr constant [4 x i8] c"func", align 1
 @2 = private unnamed_addr constant [7 x i8] c"closure", align 1
 
-define void @"github.com/goplus/llgo/cl/_testgo/closure.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/closure.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/closure.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -22,7 +23,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/closure.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/closure.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
   store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 3 }, ptr %0, align 8
@@ -40,7 +42,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/closure.main$1"(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/closure.main$1"(i64 %0) #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 4 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
@@ -49,7 +52,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/closure.main$2"(ptr %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/closure.main$2"(ptr %0, i64 %1) #0 {
 _llgo_0:
   %2 = load { ptr }, ptr %0, align 8
   %3 = extractvalue { ptr } %2, 0
@@ -63,7 +67,8 @@ _llgo_0:
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
 define linkonce void @"__llgo_stub.github.com/goplus/llgo/cl/_testgo/closure.main$1"(ptr %0, i64 %1) {
 _llgo_0:
@@ -71,10 +76,16 @@ _llgo_0:
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testgo/closure2/out.ll
+++ b/cl/_testgo/closure2/out.ll
@@ -6,7 +6,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/closure2"
 @"github.com/goplus/llgo/cl/_testgo/closure2.init$guard" = global i1 false, align 1
 @0 = private unnamed_addr constant [7 x i8] c"closure", align 1
 
-define void @"github.com/goplus/llgo/cl/_testgo/closure2.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/closure2.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/closure2.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -19,7 +20,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/closure2.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/closure2.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   store i64 1, ptr %0, align 4
@@ -36,7 +38,8 @@ _llgo_0:
   ret void
 }
 
-define { ptr, ptr } @"github.com/goplus/llgo/cl/_testgo/closure2.main$1"(ptr %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define { ptr, ptr } @"github.com/goplus/llgo/cl/_testgo/closure2.main$1"(ptr %0, i64 %1) #0 {
 _llgo_0:
   %2 = load { ptr }, ptr %0, align 8
   %3 = extractvalue { ptr } %2, 0
@@ -47,7 +50,8 @@ _llgo_0:
   ret { ptr, ptr } %6
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/closure2.main$1$1"(ptr %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/closure2.main$1$1"(ptr %0, i64 %1) #0 {
 _llgo_0:
   %2 = load { ptr }, ptr %0, align 8
   %3 = extractvalue { ptr } %2, 0
@@ -61,12 +65,19 @@ _llgo_0:
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testgo/closureall/out.ll
+++ b/cl/_testgo/closureall/out.ll
@@ -43,7 +43,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/closureall"
 @9 = private unnamed_addr constant [6 x i8] c"string", align 1
 @"*_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1323879264, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @9, i64 6 }, ptr null }, ptr @_llgo_string }, align 8
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/closureall.S.Inc"(%"github.com/goplus/llgo/cl/_testgo/closureall.S" %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/closureall.S.Inc"(%"github.com/goplus/llgo/cl/_testgo/closureall.S" %0, i64 %1) #0 {
 _llgo_0:
   %2 = alloca %"github.com/goplus/llgo/cl/_testgo/closureall.S", align 8
   call void @llvm.memset(ptr %2, i8 0, i64 8, i1 false)
@@ -54,7 +55,8 @@ _llgo_0:
   ret i64 %5
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/closureall.(*S).Add"(ptr %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/closureall.(*S).Add"(ptr %0, i64 %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/closureall.S", ptr %0, i32 0, i32 0
   %3 = load i64, ptr %2, align 4
@@ -62,26 +64,30 @@ _llgo_0:
   ret i64 %4
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/closureall.(*S).Inc"(ptr %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/closureall.(*S).Inc"(ptr %0, i64 %1) #0 {
 _llgo_0:
   %2 = load %"github.com/goplus/llgo/cl/_testgo/closureall.S", ptr %0, align 4
   %3 = call i64 @"github.com/goplus/llgo/cl/_testgo/closureall.S.Inc"(%"github.com/goplus/llgo/cl/_testgo/closureall.S" %2, i64 %1)
   ret i64 %3
 }
 
-define i32 @"github.com/goplus/llgo/cl/_testgo/closureall.callCallback"(ptr %0, i32 %1) {
+; Function Attrs: null_pointer_is_valid
+define i32 @"github.com/goplus/llgo/cl/_testgo/closureall.callCallback"(ptr %0, i32 %1) #0 {
 _llgo_0:
   %2 = call i32 %0(i32 %1)
   ret i32 %2
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/closureall.globalAdd"(i64 %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/closureall.globalAdd"(i64 %0, i64 %1) #0 {
 _llgo_0:
   %2 = add i64 %0, %1
   ret i64 %2
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/closureall.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/closureall.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/closureall.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -94,7 +100,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/closureall.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/closureall.main"() #0 {
 _llgo_0:
   %0 = call %"github.com/goplus/llgo/cl/_testgo/closureall.Fn" @"github.com/goplus/llgo/cl/_testgo/closureall.makeNoFree"()
   %1 = call %"github.com/goplus/llgo/cl/_testgo/closureall.Fn" @"github.com/goplus/llgo/cl/_testgo/closureall.makeWithFree"(i64 3)
@@ -144,24 +151,28 @@ _llgo_2:                                          ; preds = %_llgo_0
   unreachable
 }
 
-define i32 @"github.com/goplus/llgo/cl/_testgo/closureall.main$1"(i32 %0) {
+; Function Attrs: null_pointer_is_valid
+define i32 @"github.com/goplus/llgo/cl/_testgo/closureall.main$1"(i32 %0) #0 {
 _llgo_0:
   %1 = add i32 %0, 1
   ret i32 %1
 }
 
-define %"github.com/goplus/llgo/cl/_testgo/closureall.Fn" @"github.com/goplus/llgo/cl/_testgo/closureall.makeNoFree"() {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/cl/_testgo/closureall.Fn" @"github.com/goplus/llgo/cl/_testgo/closureall.makeNoFree"() #0 {
 _llgo_0:
   ret %"github.com/goplus/llgo/cl/_testgo/closureall.Fn" { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testgo/closureall.makeNoFree$1", ptr null }
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/closureall.makeNoFree$1"(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/closureall.makeNoFree$1"(i64 %0) #0 {
 _llgo_0:
   %1 = add i64 %0, 1
   ret i64 %1
 }
 
-define %"github.com/goplus/llgo/cl/_testgo/closureall.Fn" @"github.com/goplus/llgo/cl/_testgo/closureall.makeWithFree"(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/cl/_testgo/closureall.Fn" @"github.com/goplus/llgo/cl/_testgo/closureall.makeWithFree"(i64 %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   store i64 %0, ptr %1, align 4
@@ -175,7 +186,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/cl/_testgo/closureall.Fn" %6
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/closureall.makeWithFree$1"(ptr %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/closureall.makeWithFree$1"(ptr %0, i64 %1) #0 {
 _llgo_0:
   %2 = load { ptr }, ptr %0, align 8
   %3 = extractvalue { ptr } %2, 0
@@ -185,11 +197,13 @@ _llgo_0:
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/closureall.(*S).Add$bound"(ptr %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/closureall.(*S).Add$bound"(ptr %0, i64 %1) #0 {
 _llgo_0:
   %2 = load { ptr }, ptr %0, align 8
   %3 = extractvalue { ptr } %2, 0
@@ -197,15 +211,18 @@ _llgo_0:
   ret i64 %4
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/closureall.(*S).Add$thunk"(ptr %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/closureall.(*S).Add$thunk"(ptr %0, i64 %1) #0 {
 _llgo_0:
   %2 = call i64 @"github.com/goplus/llgo/cl/_testgo/closureall.(*S).Add"(ptr %0, i64 %1)
   ret i64 %2
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -213,9 +230,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -223,7 +242,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -231,11 +251,14 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -243,9 +266,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/closureall.interface{Add(int) int}.Add$bound"(ptr %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/closureall.interface{Add(int) int}.Add$bound"(ptr %0, i64 %1) #0 {
 _llgo_0:
   %2 = load { %"github.com/goplus/llgo/runtime/internal/runtime.iface" }, ptr %0, align 8
   %3 = extractvalue { %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %2, 0
@@ -271,6 +296,8 @@ _llgo_0:
   ret i64 %2
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/constconv/out.ll
+++ b/cl/_testgo/constconv/out.ll
@@ -3,7 +3,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/constconv"
 
 @"github.com/goplus/llgo/cl/_testgo/constconv.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testgo/constconv.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/constconv.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/constconv.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -16,7 +17,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/constconv.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/constconv.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64 1)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
@@ -29,8 +31,13 @@ _llgo_0:
   ret void
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testgo/cursor/out.ll
+++ b/cl/_testgo/cursor/out.ll
@@ -525,7 +525,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/cursor"
 @230 = private unnamed_addr constant [6 x i8] c"Values", align 1
 @"_llgo_struct$sOcAC_ZOq0zUTjfUC4WQUDA-kMpBFrGHc6qNh-82d-Q$fields" = weak_odr constant [5 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @109, i64 3 }, ptr @"*_llgo_go/ast.CommentGroup", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @110, i64 5 }, ptr @"[]*_llgo_go/ast.Ident", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @22, i64 4 }, ptr @"_llgo_go/ast.Expr", i64 32, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @230, i64 6 }, ptr @"[]_llgo_go/ast.Expr", i64 48, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @113, i64 7 }, ptr @"*_llgo_go/ast.CommentGroup", i64 72, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
 
-define { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.FindNode"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) {
+; Function Attrs: null_pointer_is_valid
+define { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.FindNode"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) #0 {
 _llgo_0:
   %2 = alloca %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", align 8
   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -716,7 +717,8 @@ _llgo_17:                                         ; preds = %_llgo_15
   br label %_llgo_13
 }
 
-define i1 @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.FindNode$1"(ptr %0, %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %1) {
+; Function Attrs: null_pointer_is_valid
+define i1 @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.FindNode$1"(ptr %0, %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %1) #0 {
 _llgo_0:
   %2 = load { ptr, ptr, ptr, ptr }, ptr %0, align 8
   %3 = extractvalue { ptr, ptr, ptr, ptr } %2, 0
@@ -763,7 +765,8 @@ _llgo_4:                                          ; preds = %_llgo_1
   ret i1 true
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.Node"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.Node"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %0) #0 {
 _llgo_0:
   %1 = alloca %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -796,7 +799,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %19
 }
 
-define %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]" @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.Preorder"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+; Function Attrs: null_pointer_is_valid
+define %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]" @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.Preorder"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) #0 {
 _llgo_0:
   %2 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
   store %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %0, ptr %2, align 8
@@ -815,7 +819,8 @@ _llgo_0:
   ret %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]" %10
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.Preorder$1"(ptr %0, { ptr, ptr } %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.Preorder$1"(ptr %0, { ptr, ptr } %1) #0 {
 _llgo_0:
   %2 = load { ptr, ptr }, ptr %0, align 8
   %3 = extractvalue { ptr, ptr } %2, 0
@@ -909,7 +914,8 @@ _llgo_8:                                          ; preds = %_llgo_6
   br label %_llgo_1
 }
 
-define { i32, i32 } @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.indices"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %0) {
+; Function Attrs: null_pointer_is_valid
+define { i32, i32 } @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.indices"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %0) #0 {
 _llgo_0:
   %1 = alloca %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -954,7 +960,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret { i32, i32 } %31
 }
 
-define { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } @"github.com/goplus/llgo/cl/_testgo/cursor.(*Cursor).FindNode"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) {
+; Function Attrs: null_pointer_is_valid
+define { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } @"github.com/goplus/llgo/cl/_testgo/cursor.(*Cursor).FindNode"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) #0 {
 _llgo_0:
   %2 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %0, align 8
   %3 = call { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.FindNode"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %2, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1)
@@ -965,21 +972,24 @@ _llgo_0:
   ret { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %7
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/cursor.(*Cursor).Node"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/cursor.(*Cursor).Node"(ptr %0) #0 {
 _llgo_0:
   %1 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %0, align 8
   %2 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.Node"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %1)
   ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %2
 }
 
-define %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]" @"github.com/goplus/llgo/cl/_testgo/cursor.(*Cursor).Preorder"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+; Function Attrs: null_pointer_is_valid
+define %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]" @"github.com/goplus/llgo/cl/_testgo/cursor.(*Cursor).Preorder"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) #0 {
 _llgo_0:
   %2 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %0, align 8
   %3 = call %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]" @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.Preorder"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %2, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1)
   ret %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]" %3
 }
 
-define { i32, i32 } @"github.com/goplus/llgo/cl/_testgo/cursor.(*Cursor).indices"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define { i32, i32 } @"github.com/goplus/llgo/cl/_testgo/cursor.(*Cursor).indices"(ptr %0) #0 {
 _llgo_0:
   %1 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %0, align 8
   %2 = call { i32, i32 } @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.indices"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %1)
@@ -990,7 +1000,8 @@ _llgo_0:
   ret { i32, i32 } %6
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/cursor.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/cursor.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/cursor.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -1006,7 +1017,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/cursor.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/cursor.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %0, i32 0, i32 0
@@ -1015,7 +1027,8 @@ _llgo_0:
   ret void
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/cursor.maskOf"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/cursor.maskOf"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0) #0 {
 _llgo_0:
   %1 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0, 1
   %2 = icmp eq i64 %1, 0
@@ -1052,7 +1065,8 @@ _llgo_5:                                          ; preds = %_llgo_3
   ret i64 %4
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/cursor.typeOf"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/cursor.typeOf"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
   %2 = icmp eq ptr %1, @"*_llgo_go/ast.Ident"
@@ -2369,13 +2383,16 @@ _llgo_285:                                        ; preds = %_llgo_284, %_llgo_2
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -2383,7 +2400,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -2391,23 +2409,32 @@ _llgo_0:
   ret i1 %3
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface", %"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface", %"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare void @"go/ast.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.init"() #0
 
-declare void @iter.init()
+; Function Attrs: null_pointer_is_valid
+declare void @iter.init() #0
 
-declare void @math.init()
+; Function Attrs: null_pointer_is_valid
+declare void @math.init() #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -2415,9 +2442,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"go/token.(*Pos).IsValid"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"go/token.(*Pos).IsValid"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -2425,13 +2454,17 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"go/token.Pos.IsValid"(i64)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"go/token.Pos.IsValid"(i64) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"go/ast.(*ObjKind).String"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"go/ast.(*ObjKind).String"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"go/ast.ObjKind.String"(i64)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"go/ast.ObjKind.String"(i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -2439,19 +2472,26 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i64 @"go/ast.(*Object).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*Object).Pos"(ptr) #0
 
-declare i64 @"go/ast.(*Ident).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*Ident).End"(ptr) #0
 
-declare i1 @"go/ast.(*Ident).IsExported"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"go/ast.(*Ident).IsExported"(ptr) #0
 
-declare i64 @"go/ast.(*Ident).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*Ident).Pos"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"go/ast.(*Ident).String"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"go/ast.(*Ident).String"(ptr) #0
 
-declare void @"go/ast.(*Ident).exprNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*Ident).exprNode"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -2459,356 +2499,533 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i64 @"go/ast.(*ArrayType).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*ArrayType).End"(ptr) #0
 
-declare i64 @"go/ast.(*ArrayType).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*ArrayType).Pos"(ptr) #0
 
-declare void @"go/ast.(*ArrayType).exprNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*ArrayType).exprNode"(ptr) #0
 
-declare i1 @"go/token.(*Token).IsKeyword"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"go/token.(*Token).IsKeyword"(ptr) #0
 
-declare i1 @"go/token.(*Token).IsLiteral"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"go/token.(*Token).IsLiteral"(ptr) #0
 
-declare i1 @"go/token.(*Token).IsOperator"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"go/token.(*Token).IsOperator"(ptr) #0
 
-declare i64 @"go/token.(*Token).Precedence"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/token.(*Token).Precedence"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"go/token.(*Token).String"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"go/token.(*Token).String"(ptr) #0
 
-declare i1 @"go/token.Token.IsKeyword"(i64)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"go/token.Token.IsKeyword"(i64) #0
 
-declare i1 @"go/token.Token.IsLiteral"(i64)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"go/token.Token.IsLiteral"(i64) #0
 
-declare i1 @"go/token.Token.IsOperator"(i64)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"go/token.Token.IsOperator"(i64) #0
 
-declare i64 @"go/token.Token.Precedence"(i64)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/token.Token.Precedence"(i64) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"go/token.Token.String"(i64)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"go/token.Token.String"(i64) #0
 
-declare i64 @"go/ast.(*AssignStmt).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*AssignStmt).End"(ptr) #0
 
-declare i64 @"go/ast.(*AssignStmt).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*AssignStmt).Pos"(ptr) #0
 
-declare void @"go/ast.(*AssignStmt).stmtNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*AssignStmt).stmtNode"(ptr) #0
 
-declare i64 @"go/ast.(*BadDecl).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*BadDecl).End"(ptr) #0
 
-declare i64 @"go/ast.(*BadDecl).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*BadDecl).Pos"(ptr) #0
 
-declare void @"go/ast.(*BadDecl).declNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*BadDecl).declNode"(ptr) #0
 
-declare i64 @"go/ast.(*BadExpr).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*BadExpr).End"(ptr) #0
 
-declare i64 @"go/ast.(*BadExpr).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*BadExpr).Pos"(ptr) #0
 
-declare void @"go/ast.(*BadExpr).exprNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*BadExpr).exprNode"(ptr) #0
 
-declare i64 @"go/ast.(*BadStmt).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*BadStmt).End"(ptr) #0
 
-declare i64 @"go/ast.(*BadStmt).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*BadStmt).Pos"(ptr) #0
 
-declare void @"go/ast.(*BadStmt).stmtNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*BadStmt).stmtNode"(ptr) #0
 
-declare i64 @"go/ast.(*BasicLit).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*BasicLit).End"(ptr) #0
 
-declare i64 @"go/ast.(*BasicLit).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*BasicLit).Pos"(ptr) #0
 
-declare void @"go/ast.(*BasicLit).exprNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*BasicLit).exprNode"(ptr) #0
 
-declare i64 @"go/ast.(*BinaryExpr).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*BinaryExpr).End"(ptr) #0
 
-declare i64 @"go/ast.(*BinaryExpr).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*BinaryExpr).Pos"(ptr) #0
 
-declare void @"go/ast.(*BinaryExpr).exprNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*BinaryExpr).exprNode"(ptr) #0
 
-declare i64 @"go/ast.(*BlockStmt).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*BlockStmt).End"(ptr) #0
 
-declare i64 @"go/ast.(*BlockStmt).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*BlockStmt).Pos"(ptr) #0
 
-declare void @"go/ast.(*BlockStmt).stmtNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*BlockStmt).stmtNode"(ptr) #0
 
-declare i64 @"go/ast.(*BranchStmt).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*BranchStmt).End"(ptr) #0
 
-declare i64 @"go/ast.(*BranchStmt).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*BranchStmt).Pos"(ptr) #0
 
-declare void @"go/ast.(*BranchStmt).stmtNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*BranchStmt).stmtNode"(ptr) #0
 
-declare i64 @"go/ast.(*CallExpr).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*CallExpr).End"(ptr) #0
 
-declare i64 @"go/ast.(*CallExpr).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*CallExpr).Pos"(ptr) #0
 
-declare void @"go/ast.(*CallExpr).exprNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*CallExpr).exprNode"(ptr) #0
 
-declare i64 @"go/ast.(*CaseClause).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*CaseClause).End"(ptr) #0
 
-declare i64 @"go/ast.(*CaseClause).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*CaseClause).Pos"(ptr) #0
 
-declare void @"go/ast.(*CaseClause).stmtNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*CaseClause).stmtNode"(ptr) #0
 
-declare i64 @"go/ast.(*ChanType).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*ChanType).End"(ptr) #0
 
-declare i64 @"go/ast.(*ChanType).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*ChanType).Pos"(ptr) #0
 
-declare void @"go/ast.(*ChanType).exprNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*ChanType).exprNode"(ptr) #0
 
-declare i64 @"go/ast.(*CommClause).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*CommClause).End"(ptr) #0
 
-declare i64 @"go/ast.(*CommClause).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*CommClause).Pos"(ptr) #0
 
-declare void @"go/ast.(*CommClause).stmtNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*CommClause).stmtNode"(ptr) #0
 
-declare i64 @"go/ast.(*Comment).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*Comment).End"(ptr) #0
 
-declare i64 @"go/ast.(*Comment).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*Comment).Pos"(ptr) #0
 
-declare i64 @"go/ast.(*CommentGroup).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*CommentGroup).End"(ptr) #0
 
-declare i64 @"go/ast.(*CommentGroup).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*CommentGroup).Pos"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"go/ast.(*CommentGroup).Text"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"go/ast.(*CommentGroup).Text"(ptr) #0
 
-declare i64 @"go/ast.(*CompositeLit).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*CompositeLit).End"(ptr) #0
 
-declare i64 @"go/ast.(*CompositeLit).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*CompositeLit).Pos"(ptr) #0
 
-declare void @"go/ast.(*CompositeLit).exprNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*CompositeLit).exprNode"(ptr) #0
 
-declare i64 @"go/ast.(*DeclStmt).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*DeclStmt).End"(ptr) #0
 
-declare i64 @"go/ast.(*DeclStmt).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*DeclStmt).Pos"(ptr) #0
 
-declare void @"go/ast.(*DeclStmt).stmtNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*DeclStmt).stmtNode"(ptr) #0
 
-declare i64 @"go/ast.(*DeferStmt).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*DeferStmt).End"(ptr) #0
 
-declare i64 @"go/ast.(*DeferStmt).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*DeferStmt).Pos"(ptr) #0
 
-declare void @"go/ast.(*DeferStmt).stmtNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*DeferStmt).stmtNode"(ptr) #0
 
-declare i64 @"go/ast.(*Ellipsis).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*Ellipsis).End"(ptr) #0
 
-declare i64 @"go/ast.(*Ellipsis).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*Ellipsis).Pos"(ptr) #0
 
-declare void @"go/ast.(*Ellipsis).exprNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*Ellipsis).exprNode"(ptr) #0
 
-declare i64 @"go/ast.(*EmptyStmt).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*EmptyStmt).End"(ptr) #0
 
-declare i64 @"go/ast.(*EmptyStmt).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*EmptyStmt).Pos"(ptr) #0
 
-declare void @"go/ast.(*EmptyStmt).stmtNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*EmptyStmt).stmtNode"(ptr) #0
 
-declare i64 @"go/ast.(*ExprStmt).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*ExprStmt).End"(ptr) #0
 
-declare i64 @"go/ast.(*ExprStmt).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*ExprStmt).Pos"(ptr) #0
 
-declare void @"go/ast.(*ExprStmt).stmtNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*ExprStmt).stmtNode"(ptr) #0
 
-declare i64 @"go/ast.(*Field).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*Field).End"(ptr) #0
 
-declare i64 @"go/ast.(*Field).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*Field).Pos"(ptr) #0
 
-declare i64 @"go/ast.(*FieldList).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*FieldList).End"(ptr) #0
 
-declare i64 @"go/ast.(*FieldList).NumFields"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*FieldList).NumFields"(ptr) #0
 
-declare i64 @"go/ast.(*FieldList).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*FieldList).Pos"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.typehash"(ptr, ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.typehash"(ptr, ptr, i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr) #0
 
-declare ptr @"go/ast.(*Scope).Insert"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"go/ast.(*Scope).Insert"(ptr, ptr) #0
 
-declare ptr @"go/ast.(*Scope).Lookup"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"go/ast.(*Scope).Lookup"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"go/ast.(*Scope).String"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"go/ast.(*Scope).String"(ptr) #0
 
-declare i64 @"go/ast.(*ImportSpec).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*ImportSpec).End"(ptr) #0
 
-declare i64 @"go/ast.(*ImportSpec).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*ImportSpec).Pos"(ptr) #0
 
-declare void @"go/ast.(*ImportSpec).specNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*ImportSpec).specNode"(ptr) #0
 
-declare i64 @"go/ast.(*File).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*File).End"(ptr) #0
 
-declare i64 @"go/ast.(*File).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*File).Pos"(ptr) #0
 
-declare i64 @"go/ast.(*ForStmt).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*ForStmt).End"(ptr) #0
 
-declare i64 @"go/ast.(*ForStmt).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*ForStmt).Pos"(ptr) #0
 
-declare void @"go/ast.(*ForStmt).stmtNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*ForStmt).stmtNode"(ptr) #0
 
-declare i64 @"go/ast.(*FuncType).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*FuncType).End"(ptr) #0
 
-declare i64 @"go/ast.(*FuncType).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*FuncType).Pos"(ptr) #0
 
-declare void @"go/ast.(*FuncType).exprNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*FuncType).exprNode"(ptr) #0
 
-declare i64 @"go/ast.(*FuncDecl).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*FuncDecl).End"(ptr) #0
 
-declare i64 @"go/ast.(*FuncDecl).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*FuncDecl).Pos"(ptr) #0
 
-declare void @"go/ast.(*FuncDecl).declNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*FuncDecl).declNode"(ptr) #0
 
-declare i64 @"go/ast.(*FuncLit).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*FuncLit).End"(ptr) #0
 
-declare i64 @"go/ast.(*FuncLit).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*FuncLit).Pos"(ptr) #0
 
-declare void @"go/ast.(*FuncLit).exprNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*FuncLit).exprNode"(ptr) #0
 
-declare i64 @"go/ast.(*GenDecl).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*GenDecl).End"(ptr) #0
 
-declare i64 @"go/ast.(*GenDecl).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*GenDecl).Pos"(ptr) #0
 
-declare void @"go/ast.(*GenDecl).declNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*GenDecl).declNode"(ptr) #0
 
-declare i64 @"go/ast.(*GoStmt).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*GoStmt).End"(ptr) #0
 
-declare i64 @"go/ast.(*GoStmt).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*GoStmt).Pos"(ptr) #0
 
-declare void @"go/ast.(*GoStmt).stmtNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*GoStmt).stmtNode"(ptr) #0
 
-declare i64 @"go/ast.(*IfStmt).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*IfStmt).End"(ptr) #0
 
-declare i64 @"go/ast.(*IfStmt).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*IfStmt).Pos"(ptr) #0
 
-declare void @"go/ast.(*IfStmt).stmtNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*IfStmt).stmtNode"(ptr) #0
 
-declare i64 @"go/ast.(*IncDecStmt).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*IncDecStmt).End"(ptr) #0
 
-declare i64 @"go/ast.(*IncDecStmt).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*IncDecStmt).Pos"(ptr) #0
 
-declare void @"go/ast.(*IncDecStmt).stmtNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*IncDecStmt).stmtNode"(ptr) #0
 
-declare i64 @"go/ast.(*IndexExpr).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*IndexExpr).End"(ptr) #0
 
-declare i64 @"go/ast.(*IndexExpr).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*IndexExpr).Pos"(ptr) #0
 
-declare void @"go/ast.(*IndexExpr).exprNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*IndexExpr).exprNode"(ptr) #0
 
-declare i64 @"go/ast.(*IndexListExpr).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*IndexListExpr).End"(ptr) #0
 
-declare i64 @"go/ast.(*IndexListExpr).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*IndexListExpr).Pos"(ptr) #0
 
-declare void @"go/ast.(*IndexListExpr).exprNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*IndexListExpr).exprNode"(ptr) #0
 
-declare i64 @"go/ast.(*InterfaceType).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*InterfaceType).End"(ptr) #0
 
-declare i64 @"go/ast.(*InterfaceType).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*InterfaceType).Pos"(ptr) #0
 
-declare void @"go/ast.(*InterfaceType).exprNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*InterfaceType).exprNode"(ptr) #0
 
-declare i64 @"go/ast.(*KeyValueExpr).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*KeyValueExpr).End"(ptr) #0
 
-declare i64 @"go/ast.(*KeyValueExpr).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*KeyValueExpr).Pos"(ptr) #0
 
-declare void @"go/ast.(*KeyValueExpr).exprNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*KeyValueExpr).exprNode"(ptr) #0
 
-declare i64 @"go/ast.(*LabeledStmt).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*LabeledStmt).End"(ptr) #0
 
-declare i64 @"go/ast.(*LabeledStmt).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*LabeledStmt).Pos"(ptr) #0
 
-declare void @"go/ast.(*LabeledStmt).stmtNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*LabeledStmt).stmtNode"(ptr) #0
 
-declare i64 @"go/ast.(*MapType).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*MapType).End"(ptr) #0
 
-declare i64 @"go/ast.(*MapType).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*MapType).Pos"(ptr) #0
 
-declare void @"go/ast.(*MapType).exprNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*MapType).exprNode"(ptr) #0
 
-declare i64 @"go/ast.(*Package).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*Package).End"(ptr) #0
 
-declare i64 @"go/ast.(*Package).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*Package).Pos"(ptr) #0
 
-declare i64 @"go/ast.(*ParenExpr).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*ParenExpr).End"(ptr) #0
 
-declare i64 @"go/ast.(*ParenExpr).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*ParenExpr).Pos"(ptr) #0
 
-declare void @"go/ast.(*ParenExpr).exprNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*ParenExpr).exprNode"(ptr) #0
 
-declare i64 @"go/ast.(*RangeStmt).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*RangeStmt).End"(ptr) #0
 
-declare i64 @"go/ast.(*RangeStmt).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*RangeStmt).Pos"(ptr) #0
 
-declare void @"go/ast.(*RangeStmt).stmtNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*RangeStmt).stmtNode"(ptr) #0
 
-declare i64 @"go/ast.(*ReturnStmt).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*ReturnStmt).End"(ptr) #0
 
-declare i64 @"go/ast.(*ReturnStmt).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*ReturnStmt).Pos"(ptr) #0
 
-declare void @"go/ast.(*ReturnStmt).stmtNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*ReturnStmt).stmtNode"(ptr) #0
 
-declare i64 @"go/ast.(*SelectStmt).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*SelectStmt).End"(ptr) #0
 
-declare i64 @"go/ast.(*SelectStmt).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*SelectStmt).Pos"(ptr) #0
 
-declare void @"go/ast.(*SelectStmt).stmtNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*SelectStmt).stmtNode"(ptr) #0
 
-declare i64 @"go/ast.(*SelectorExpr).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*SelectorExpr).End"(ptr) #0
 
-declare i64 @"go/ast.(*SelectorExpr).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*SelectorExpr).Pos"(ptr) #0
 
-declare void @"go/ast.(*SelectorExpr).exprNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*SelectorExpr).exprNode"(ptr) #0
 
-declare i64 @"go/ast.(*SendStmt).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*SendStmt).End"(ptr) #0
 
-declare i64 @"go/ast.(*SendStmt).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*SendStmt).Pos"(ptr) #0
 
-declare void @"go/ast.(*SendStmt).stmtNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*SendStmt).stmtNode"(ptr) #0
 
-declare i64 @"go/ast.(*SliceExpr).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*SliceExpr).End"(ptr) #0
 
-declare i64 @"go/ast.(*SliceExpr).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*SliceExpr).Pos"(ptr) #0
 
-declare void @"go/ast.(*SliceExpr).exprNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*SliceExpr).exprNode"(ptr) #0
 
-declare i64 @"go/ast.(*StarExpr).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*StarExpr).End"(ptr) #0
 
-declare i64 @"go/ast.(*StarExpr).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*StarExpr).Pos"(ptr) #0
 
-declare void @"go/ast.(*StarExpr).exprNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*StarExpr).exprNode"(ptr) #0
 
-declare i64 @"go/ast.(*StructType).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*StructType).End"(ptr) #0
 
-declare i64 @"go/ast.(*StructType).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*StructType).Pos"(ptr) #0
 
-declare void @"go/ast.(*StructType).exprNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*StructType).exprNode"(ptr) #0
 
-declare i64 @"go/ast.(*SwitchStmt).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*SwitchStmt).End"(ptr) #0
 
-declare i64 @"go/ast.(*SwitchStmt).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*SwitchStmt).Pos"(ptr) #0
 
-declare void @"go/ast.(*SwitchStmt).stmtNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*SwitchStmt).stmtNode"(ptr) #0
 
-declare i64 @"go/ast.(*TypeAssertExpr).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*TypeAssertExpr).End"(ptr) #0
 
-declare i64 @"go/ast.(*TypeAssertExpr).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*TypeAssertExpr).Pos"(ptr) #0
 
-declare void @"go/ast.(*TypeAssertExpr).exprNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*TypeAssertExpr).exprNode"(ptr) #0
 
-declare i64 @"go/ast.(*TypeSpec).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*TypeSpec).End"(ptr) #0
 
-declare i64 @"go/ast.(*TypeSpec).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*TypeSpec).Pos"(ptr) #0
 
-declare void @"go/ast.(*TypeSpec).specNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*TypeSpec).specNode"(ptr) #0
 
-declare i64 @"go/ast.(*TypeSwitchStmt).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*TypeSwitchStmt).End"(ptr) #0
 
-declare i64 @"go/ast.(*TypeSwitchStmt).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*TypeSwitchStmt).Pos"(ptr) #0
 
-declare void @"go/ast.(*TypeSwitchStmt).stmtNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*TypeSwitchStmt).stmtNode"(ptr) #0
 
-declare i64 @"go/ast.(*UnaryExpr).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*UnaryExpr).End"(ptr) #0
 
-declare i64 @"go/ast.(*UnaryExpr).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*UnaryExpr).Pos"(ptr) #0
 
-declare void @"go/ast.(*UnaryExpr).exprNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*UnaryExpr).exprNode"(ptr) #0
 
-declare i64 @"go/ast.(*ValueSpec).End"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*ValueSpec).End"(ptr) #0
 
-declare i64 @"go/ast.(*ValueSpec).Pos"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"go/ast.(*ValueSpec).Pos"(ptr) #0
 
-declare void @"go/ast.(*ValueSpec).specNode"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"go/ast.(*ValueSpec).specNode"(ptr) #0
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/embedunexport-1598/out.ll
+++ b/cl/_testgo/embedunexport-1598/out.ll
@@ -48,7 +48,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/embedunexport-1598"
 @"*github.com/goplus/llgo/cl/_testdata/embedunexport.iface$gGW7PSocDeRlTvk5kuSew8C-TZ8OXQrGkMlj2EUlZ9E" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1886130721, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @13, i64 58 }, ptr null }, ptr @"github.com/goplus/llgo/cl/_testdata/embedunexport.iface$gGW7PSocDeRlTvk5kuSew8C-TZ8OXQrGkMlj2EUlZ9E" }, align 8
 @"github.com/goplus/llgo/cl/_testdata/embedunexport.iface$gGW7PSocDeRlTvk5kuSew8C-TZ8OXQrGkMlj2EUlZ9E$imethods" = weak_odr constant [2 x %"github.com/goplus/llgo/runtime/abi.Imethod"] [%"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 4 }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" }, %"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @10, i64 57 }, ptr @"_llgo_func$dlTgtqQDYoqfVBQYEBE1Fa3ytcia1pdKaKVOnw8ZjkA" }], align 8
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/embedunexport-1598.Wrapped.Name"(%"github.com/goplus/llgo/cl/_testgo/embedunexport-1598.Wrapped" %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/embedunexport-1598.Wrapped.Name"(%"github.com/goplus/llgo/cl/_testgo/embedunexport-1598.Wrapped" %0) #0 {
 _llgo_0:
   %1 = alloca %"github.com/goplus/llgo/cl/_testgo/embedunexport-1598.Wrapped", align 8
   call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
@@ -59,7 +60,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.String" %4
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/embedunexport-1598.Wrapped.setName"(%"github.com/goplus/llgo/cl/_testgo/embedunexport-1598.Wrapped" %0, %"github.com/goplus/llgo/runtime/internal/runtime.String" %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/embedunexport-1598.Wrapped.setName"(%"github.com/goplus/llgo/cl/_testgo/embedunexport-1598.Wrapped" %0, %"github.com/goplus/llgo/runtime/internal/runtime.String" %1) #0 {
 _llgo_0:
   %2 = alloca %"github.com/goplus/llgo/cl/_testgo/embedunexport-1598.Wrapped", align 8
   call void @llvm.memset(ptr %2, i8 0, i64 8, i1 false)
@@ -70,7 +72,8 @@ _llgo_0:
   ret void
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/embedunexport-1598.(*Wrapped).Name"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/embedunexport-1598.(*Wrapped).Name"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/embedunexport-1598.Wrapped", ptr %0, i32 0, i32 0
   %2 = load ptr, ptr %1, align 8
@@ -78,7 +81,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.String" %3
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/embedunexport-1598.(*Wrapped).setName"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.String" %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/embedunexport-1598.(*Wrapped).setName"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.String" %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/embedunexport-1598.Wrapped", ptr %0, i32 0, i32 0
   %3 = load ptr, ptr %2, align 8
@@ -86,7 +90,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/embedunexport-1598.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/embedunexport-1598.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/embedunexport-1598.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -100,7 +105,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/embedunexport-1598.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/embedunexport-1598.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/cl/_testdata/embedunexport.NewBase"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 4 })
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
@@ -125,19 +131,25 @@ _llgo_0:
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testdata/embedunexport.(*Base).Name"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testdata/embedunexport.(*Base).Name"(ptr) #0
 
-declare void @"github.com/goplus/llgo/cl/_testdata/embedunexport.(*Base).setName"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/cl/_testdata/embedunexport.(*Base).setName"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/cl/_testdata/embedunexport.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/cl/_testdata/embedunexport.init"() #0
 
-declare ptr @"github.com/goplus/llgo/cl/_testdata/embedunexport.NewBase"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/cl/_testdata/embedunexport.NewBase"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -145,9 +157,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -155,7 +169,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -163,14 +178,20 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr) #0
 
-declare void @"github.com/goplus/llgo/cl/_testdata/embedunexport.Use"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/cl/_testdata/embedunexport.Use"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/equal/out.ll
+++ b/cl/_testgo/equal/out.ll
@@ -81,7 +81,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/equal"
 @"*_llgo_Pointer" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1134390089, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @27, i64 14 }, ptr null }, ptr @_llgo_Pointer }, align 8
 @"_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ$fields" = weak_odr constant [4 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @16, i64 7 }, ptr @"[8]_llgo_uint8", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @20, i64 4 }, ptr @"[8]_llgo_int", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 5 }, ptr @"[8]_llgo_string", i64 72, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @26, i64 8 }, ptr @_llgo_Pointer, i64 200, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
 
-define void @"github.com/goplus/llgo/cl/_testgo/equal.assert"(i1 %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/equal.assert"(i1 %0) #0 {
 _llgo_0:
   br i1 %0, label %_llgo_2, label %_llgo_1
 
@@ -96,7 +97,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/equal.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/equal.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/equal.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -116,7 +118,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/equal.init#1"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/equal.init#1"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 8)
@@ -140,13 +143,15 @@ _llgo_0:
   ret void
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/equal.init#1$1"(i64 %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/equal.init#1$1"(i64 %0, i64 %1) #0 {
 _llgo_0:
   %2 = add i64 %0, %1
   ret i64 %2
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/equal.init#1$2"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/equal.init#1$2"(ptr %0) #0 {
 _llgo_0:
   %1 = load { ptr }, ptr %0, align 8
   %2 = extractvalue { ptr } %1, 0
@@ -156,7 +161,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/equal.init#2"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/equal.init#2"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/cl/_testgo/equal.assert"(i1 true)
   %0 = alloca [3 x i64], align 8
@@ -211,7 +217,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/equal.init#3"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/equal.init#3"() #0 {
 _llgo_0:
   %0 = alloca %"github.com/goplus/llgo/cl/_testgo/equal.T", align 8
   call void @llvm.memset(ptr %0, i8 0, i64 48, i1 false)
@@ -314,7 +321,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/equal.init#4"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/equal.init#4"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 24)
   %1 = getelementptr inbounds i64, ptr %0, i64 0
@@ -344,7 +352,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/equal.init#5"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/equal.init#5"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 0)
   store {} zeroinitializer, ptr %0, align 1
@@ -415,7 +424,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/equal.init#6"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/equal.init#6"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewChan"(i64 8, i64 0)
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewChan"(i64 8, i64 0)
@@ -428,7 +438,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/equal.init#7"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/equal.init#7"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_string", i64 0)
   %1 = icmp ne ptr %0, null
@@ -437,17 +448,20 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/equal.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/equal.main"() #0 {
 _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/equal.test"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/equal.test"() #0 {
 _llgo_0:
   ret void
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -455,7 +469,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -463,20 +478,26 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -484,13 +505,17 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface", %"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface", %"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.NewSlice3"(ptr, i64, i64, i64, i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.NewSlice3"(ptr, i64, i64, i64, i64, i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal0"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal0"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -498,9 +523,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -508,13 +535,17 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewChan"(i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewChan"(i64, i64) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.typehash"(ptr, ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.typehash"(ptr, ptr, i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -522,6 +553,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr, i64) #0
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/errors/out.ll
+++ b/cl/_testgo/errors/out.ll
@@ -36,7 +36,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/errors"
 @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU$imethods" = weak_odr constant [1 x %"github.com/goplus/llgo/runtime/abi.Imethod"] [%"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @4, i64 5 }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" }], align 8
 @7 = private unnamed_addr constant [8 x i8] c"an error", align 1
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/errors.New"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/errors.New"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/errors.errorString", ptr %1, i32 0, i32 0
@@ -47,14 +48,16 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %5
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/errors.(*errorString).Error"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/errors.(*errorString).Error"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/errors.errorString", ptr %0, i32 0, i32 0
   %2 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %1, align 8
   ret %"github.com/goplus/llgo/runtime/internal/runtime.String" %2
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/errors.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/errors.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/errors.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -67,7 +70,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/errors.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/errors.main"() #0 {
 _llgo_0:
   %0 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/errors.New"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 8 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintIface"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
@@ -86,9 +90,11 @@ _llgo_0:
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -96,9 +102,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -106,7 +114,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -114,12 +123,19 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintIface"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintIface"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testgo/goroutine/out.ll
+++ b/cl/_testgo/goroutine/out.ll
@@ -8,7 +8,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/goroutine"
 @1 = private unnamed_addr constant [16 x i8] c"Hello, goroutine", align 1
 @2 = private unnamed_addr constant [1 x i8] c".", align 1
 
-define void @"github.com/goplus/llgo/cl/_testgo/goroutine.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/goroutine.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/goroutine.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -21,7 +22,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/goroutine.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/goroutine.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 1)
   store i1 false, ptr %0, align 1
@@ -55,7 +57,8 @@ _llgo_3:                                          ; preds = %_llgo_1, %_llgo_0
   br i1 %13, label %_llgo_2, label %_llgo_1
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/goroutine.main$1"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.String" %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/goroutine.main$1"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.String" %1) #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %1)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
@@ -65,7 +68,8 @@ _llgo_0:
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
 declare ptr @malloc(i64)
 
@@ -79,15 +83,19 @@ _llgo_0:
   ret ptr null
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
 declare void @free(ptr)
 
-declare i32 @"github.com/goplus/llgo/runtime/internal/runtime.CreateThread"(ptr, ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i32 @"github.com/goplus/llgo/runtime/internal/runtime.CreateThread"(ptr, ptr, ptr, ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
 define ptr @"github.com/goplus/llgo/cl/_testgo/goroutine._llgo_routine$2"(ptr %0) {
 _llgo_0:
@@ -100,3 +108,5 @@ _llgo_0:
   call void @free(ptr %0)
   ret ptr null
 }
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testgo/ifaceconv/out.ll
+++ b/cl/_testgo/ifaceconv/out.ll
@@ -64,43 +64,50 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/ifaceconv"
 @24 = private unnamed_addr constant [17 x i8] c"C1 I1(i1) was nil", align 1
 @25 = private unnamed_addr constant [4 x i8] c"pass", align 1
 
-define void @"github.com/goplus/llgo/cl/_testgo/ifaceconv.C1.f"(%"github.com/goplus/llgo/cl/_testgo/ifaceconv.C1" %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/ifaceconv.C1.f"(%"github.com/goplus/llgo/cl/_testgo/ifaceconv.C1" %0) #0 {
 _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/ifaceconv.(*C1).f"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/ifaceconv.(*C1).f"(ptr %0) #0 {
 _llgo_0:
   %1 = load %"github.com/goplus/llgo/cl/_testgo/ifaceconv.C1", ptr %0, align 1
   call void @"github.com/goplus/llgo/cl/_testgo/ifaceconv.C1.f"(%"github.com/goplus/llgo/cl/_testgo/ifaceconv.C1" %1)
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/ifaceconv.C2.f"(%"github.com/goplus/llgo/cl/_testgo/ifaceconv.C2" %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/ifaceconv.C2.f"(%"github.com/goplus/llgo/cl/_testgo/ifaceconv.C2" %0) #0 {
 _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/ifaceconv.C2.g"(%"github.com/goplus/llgo/cl/_testgo/ifaceconv.C2" %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/ifaceconv.C2.g"(%"github.com/goplus/llgo/cl/_testgo/ifaceconv.C2" %0) #0 {
 _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/ifaceconv.(*C2).f"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/ifaceconv.(*C2).f"(ptr %0) #0 {
 _llgo_0:
   %1 = load %"github.com/goplus/llgo/cl/_testgo/ifaceconv.C2", ptr %0, align 1
   call void @"github.com/goplus/llgo/cl/_testgo/ifaceconv.C2.f"(%"github.com/goplus/llgo/cl/_testgo/ifaceconv.C2" %1)
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/ifaceconv.(*C2).g"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/ifaceconv.(*C2).g"(ptr %0) #0 {
 _llgo_0:
   %1 = load %"github.com/goplus/llgo/cl/_testgo/ifaceconv.C2", ptr %0, align 1
   call void @"github.com/goplus/llgo/cl/_testgo/ifaceconv.C2.g"(%"github.com/goplus/llgo/cl/_testgo/ifaceconv.C2" %1)
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/ifaceconv.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/ifaceconv.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/ifaceconv.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -113,7 +120,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/ifaceconv.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/ifaceconv.main"() #0 {
 _llgo_0:
   br i1 false, label %_llgo_23, label %_llgo_24
 
@@ -416,7 +424,8 @@ _llgo_49:                                         ; preds = %_llgo_48, %_llgo_47
   br i1 %123, label %_llgo_18, label %_llgo_17
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -424,7 +433,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -432,7 +442,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -440,13 +451,17 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -454,9 +469,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal0"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal0"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -464,10 +481,16 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.Implements"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.Implements"(ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface", %"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface", %"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testgo/ifaceprom/out.ll
+++ b/cl/_testgo/ifaceprom/out.ll
@@ -49,7 +49,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/ifaceprom"
 @12 = private unnamed_addr constant [116 x i8] c"type assertion github.com/goplus/llgo/cl/_testgo/ifaceprom.I -> github.com/goplus/llgo/cl/_testgo/ifaceprom.I failed", align 1
 @13 = private unnamed_addr constant [4 x i8] c"pass", align 1
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/ifaceprom.S.one"(%"github.com/goplus/llgo/cl/_testgo/ifaceprom.S" %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/ifaceprom.S.one"(%"github.com/goplus/llgo/cl/_testgo/ifaceprom.S" %0) #0 {
 _llgo_0:
   %1 = alloca %"github.com/goplus/llgo/cl/_testgo/ifaceprom.S", align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -68,7 +69,8 @@ _llgo_0:
   ret i64 %12
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/ifaceprom.S.two"(%"github.com/goplus/llgo/cl/_testgo/ifaceprom.S" %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/ifaceprom.S.two"(%"github.com/goplus/llgo/cl/_testgo/ifaceprom.S" %0) #0 {
 _llgo_0:
   %1 = alloca %"github.com/goplus/llgo/cl/_testgo/ifaceprom.S", align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -87,7 +89,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.String" %12
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/ifaceprom.(*S).one"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/ifaceprom.(*S).one"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/ifaceprom.S", ptr %0, i32 0, i32 0
   %2 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %1, align 8
@@ -103,7 +106,8 @@ _llgo_0:
   ret i64 %11
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/ifaceprom.(*S).two"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/ifaceprom.(*S).two"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/ifaceprom.S", ptr %0, i32 0, i32 0
   %2 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %1, align 8
@@ -119,31 +123,36 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.String" %11
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/ifaceprom.impl.one"(%"github.com/goplus/llgo/cl/_testgo/ifaceprom.impl" %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/ifaceprom.impl.one"(%"github.com/goplus/llgo/cl/_testgo/ifaceprom.impl" %0) #0 {
 _llgo_0:
   ret i64 1
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/ifaceprom.impl.two"(%"github.com/goplus/llgo/cl/_testgo/ifaceprom.impl" %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/ifaceprom.impl.two"(%"github.com/goplus/llgo/cl/_testgo/ifaceprom.impl" %0) #0 {
 _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 3 }
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/ifaceprom.(*impl).one"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/ifaceprom.(*impl).one"(ptr %0) #0 {
 _llgo_0:
   %1 = load %"github.com/goplus/llgo/cl/_testgo/ifaceprom.impl", ptr %0, align 1
   %2 = call i64 @"github.com/goplus/llgo/cl/_testgo/ifaceprom.impl.one"(%"github.com/goplus/llgo/cl/_testgo/ifaceprom.impl" %1)
   ret i64 %2
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/ifaceprom.(*impl).two"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/ifaceprom.(*impl).two"(ptr %0) #0 {
 _llgo_0:
   %1 = load %"github.com/goplus/llgo/cl/_testgo/ifaceprom.impl", ptr %0, align 1
   %2 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/ifaceprom.impl.two"(%"github.com/goplus/llgo/cl/_testgo/ifaceprom.impl" %1)
   ret %"github.com/goplus/llgo/runtime/internal/runtime.String" %2
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/ifaceprom.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/ifaceprom.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/ifaceprom.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -156,7 +165,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/ifaceprom.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/ifaceprom.main"() #0 {
 _llgo_0:
   %0 = alloca %"github.com/goplus/llgo/cl/_testgo/ifaceprom.S", align 8
   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
@@ -389,11 +399,13 @@ _llgo_24:                                         ; preds = %_llgo_14
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal0"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal0"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -401,7 +413,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -409,7 +422,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -417,7 +431,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -425,9 +440,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -435,13 +452,17 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/ifaceprom.I.one$bound"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/ifaceprom.I.one$bound"(ptr %0) #0 {
 _llgo_0:
   %1 = load { %"github.com/goplus/llgo/runtime/internal/runtime.iface" }, ptr %0, align 8
   %2 = extractvalue { %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %1, 0
@@ -457,9 +478,11 @@ _llgo_0:
   ret i64 %11
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/ifaceprom.I.two$bound"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/ifaceprom.I.two$bound"(ptr %0) #0 {
 _llgo_0:
   %1 = load { %"github.com/goplus/llgo/runtime/internal/runtime.iface" }, ptr %0, align 8
   %2 = extractvalue { %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %1, 0
@@ -475,8 +498,11 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.String" %11
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/interface/out.ll
+++ b/cl/_testgo/interface/out.ll
@@ -47,7 +47,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/interface"
 @13 = private unnamed_addr constant [2 x i8] c"OK", align 1
 @14 = private unnamed_addr constant [4 x i8] c"FAIL", align 1
 
-define void @"github.com/goplus/llgo/cl/_testgo/interface.Game1.Load"(%"github.com/goplus/llgo/cl/_testgo/interface.Game1" %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/interface.Game1.Load"(%"github.com/goplus/llgo/cl/_testgo/interface.Game1" %0) #0 {
 _llgo_0:
   %1 = alloca %"github.com/goplus/llgo/cl/_testgo/interface.Game1", align 8
   call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
@@ -58,7 +59,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/interface.Game1.initGame"(%"github.com/goplus/llgo/cl/_testgo/interface.Game1" %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/interface.Game1.initGame"(%"github.com/goplus/llgo/cl/_testgo/interface.Game1" %0) #0 {
 _llgo_0:
   %1 = alloca %"github.com/goplus/llgo/cl/_testgo/interface.Game1", align 8
   call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
@@ -69,7 +71,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/interface.(*Game1).Load"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/interface.(*Game1).Load"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/interface.Game1", ptr %0, i32 0, i32 0
   %2 = load ptr, ptr %1, align 8
@@ -77,7 +80,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/interface.(*Game1).initGame"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/interface.(*Game1).initGame"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/interface.Game1", ptr %0, i32 0, i32 0
   %2 = load ptr, ptr %1, align 8
@@ -85,12 +89,14 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/interface.(*Game2).initGame"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/interface.(*Game2).initGame"(ptr %0) #0 {
 _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/interface.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/interface.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/interface.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -104,7 +110,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/interface.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/interface.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/interface.Game1", ptr %0, i32 0, i32 0
@@ -184,17 +191,22 @@ _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-declare void @"github.com/goplus/llgo/cl/_testdata/foo.(*Game).Load"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/cl/_testdata/foo.(*Game).Load"(ptr) #0
 
-declare void @"github.com/goplus/llgo/cl/_testdata/foo.(*Game).initGame"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/cl/_testdata/foo.(*Game).initGame"(ptr) #0
 
-declare void @"github.com/goplus/llgo/cl/_testdata/foo.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/cl/_testdata/foo.init"() #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -202,9 +214,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal0"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal0"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -212,7 +226,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -220,18 +235,26 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.Implements"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.Implements"(ptr, ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintIface"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintIface"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/interface1370/out.ll
+++ b/cl/_testgo/interface1370/out.ll
@@ -61,7 +61,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/interface1370"
 @"github.com/goplus/llgo/cl/_testdata/geometry1370.iface$OopIVfjRcxQr1gmJyGi5G7hHt__vH05AREEM7PthH9o$imethods" = weak_odr constant [3 x %"github.com/goplus/llgo/runtime/abi.Imethod"] [%"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 4 }, ptr @"_llgo_func$UYiLlmcWxoOKZPPzvR4LByitNeKoVGoTrB_5ubdOWW8" }, %"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @12, i64 54 }, ptr @"_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA" }, %"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 57 }, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk" }], align 8
 @20 = private unnamed_addr constant [3 x i8] c"ID:", align 1
 
-define void @"github.com/goplus/llgo/cl/_testgo/interface1370.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/interface1370.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/interface1370.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -75,7 +76,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/interface1370.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/interface1370.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/cl/_testdata/geometry1370.NewRectangle"(double 5.000000e+00, double 3.000000e+00)
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr @"github.com/goplus/llgo/cl/_testdata/geometry1370.iface$OopIVfjRcxQr1gmJyGi5G7hHt__vH05AREEM7PthH9o", ptr @"*_llgo_github.com/goplus/llgo/cl/_testdata/geometry1370.Rectangle")
@@ -90,13 +92,17 @@ _llgo_0:
   ret void
 }
 
-declare void @"github.com/goplus/llgo/cl/_testdata/geometry1370.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/cl/_testdata/geometry1370.init"() #0
 
-declare ptr @"github.com/goplus/llgo/cl/_testdata/geometry1370.NewRectangle"(double, double)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/cl/_testdata/geometry1370.NewRectangle"(double, double) #0
 
-declare void @"github.com/goplus/llgo/cl/_testdata/geometry1370.RegisterShape"(%"github.com/goplus/llgo/runtime/internal/runtime.iface", i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/cl/_testdata/geometry1370.RegisterShape"(%"github.com/goplus/llgo/runtime/internal/runtime.iface", i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -104,9 +110,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.f64equal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.f64equal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.f64equal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -114,7 +122,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -122,15 +131,20 @@ _llgo_0:
   ret i1 %3
 }
 
-declare double @"github.com/goplus/llgo/cl/_testdata/geometry1370.(*Rectangle).Area"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare double @"github.com/goplus/llgo/cl/_testdata/geometry1370.(*Rectangle).Area"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/cl/_testdata/geometry1370.(*Rectangle).GetID"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/cl/_testdata/geometry1370.(*Rectangle).GetID"(ptr) #0
 
-declare void @"github.com/goplus/llgo/cl/_testdata/geometry1370.(*Rectangle).setID"(ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/cl/_testdata/geometry1370.(*Rectangle).setID"(ptr, i64) #0
 
-declare i1 @"github.com/goplus/llgo/cl/_testdata/geometry1370.(*Rectangle).validate"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/cl/_testdata/geometry1370.(*Rectangle).validate"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -138,7 +152,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -146,10 +161,16 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testgo/invoke/out.ll
+++ b/cl/_testgo/invoke/out.ll
@@ -98,7 +98,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/invoke"
 @34 = private unnamed_addr constant [32 x i8] c"type assertion any -> any failed", align 1
 @35 = private unnamed_addr constant [52 x i8] c"type assertion any -> interface{Invoke() int} failed", align 1
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.T.Invoke"(%"github.com/goplus/llgo/cl/_testgo/invoke.T" %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.T.Invoke"(%"github.com/goplus/llgo/cl/_testgo/invoke.T" %0) #0 {
 _llgo_0:
   %1 = alloca %"github.com/goplus/llgo/cl/_testgo/invoke.T", align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -112,19 +113,22 @@ _llgo_0:
   ret i64 0
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.(*T).Invoke"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.(*T).Invoke"(ptr %0) #0 {
 _llgo_0:
   %1 = load %"github.com/goplus/llgo/cl/_testgo/invoke.T", ptr %0, align 8
   %2 = call i64 @"github.com/goplus/llgo/cl/_testgo/invoke.T.Invoke"(%"github.com/goplus/llgo/cl/_testgo/invoke.T" %1)
   ret i64 %2
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/invoke.(*T).Method"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/invoke.(*T).Method"(ptr %0) #0 {
 _llgo_0:
   ret void
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.T1.Invoke"(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.T1.Invoke"(i64 %0) #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 7 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
@@ -133,14 +137,16 @@ _llgo_0:
   ret i64 1
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.(*T1).Invoke"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.(*T1).Invoke"(ptr %0) #0 {
 _llgo_0:
   %1 = load i64, ptr %0, align 4
   %2 = call i64 @"github.com/goplus/llgo/cl/_testgo/invoke.T1.Invoke"(i64 %1)
   ret i64 %2
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.T2.Invoke"(double %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.T2.Invoke"(double %0) #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @2, i64 7 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
@@ -149,14 +155,16 @@ _llgo_0:
   ret i64 2
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.(*T2).Invoke"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.(*T2).Invoke"(ptr %0) #0 {
 _llgo_0:
   %1 = load double, ptr %0, align 8
   %2 = call i64 @"github.com/goplus/llgo/cl/_testgo/invoke.T2.Invoke"(double %1)
   ret i64 %2
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.(*T3).Invoke"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.(*T3).Invoke"(ptr %0) #0 {
 _llgo_0:
   %1 = load i8, ptr %0, align 1
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @3, i64 7 })
@@ -167,7 +175,8 @@ _llgo_0:
   ret i64 3
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.T4.Invoke"([1 x i64] %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.T4.Invoke"([1 x i64] %0) #0 {
 _llgo_0:
   %1 = alloca [1 x i64], align 8
   call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
@@ -181,14 +190,16 @@ _llgo_0:
   ret i64 4
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.(*T4).Invoke"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.(*T4).Invoke"(ptr %0) #0 {
 _llgo_0:
   %1 = load [1 x i64], ptr %0, align 4
   %2 = call i64 @"github.com/goplus/llgo/cl/_testgo/invoke.T4.Invoke"([1 x i64] %1)
   ret i64 %2
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.T5.Invoke"(%"github.com/goplus/llgo/cl/_testgo/invoke.T5" %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.T5.Invoke"(%"github.com/goplus/llgo/cl/_testgo/invoke.T5" %0) #0 {
 _llgo_0:
   %1 = alloca %"github.com/goplus/llgo/cl/_testgo/invoke.T5", align 8
   call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
@@ -202,14 +213,16 @@ _llgo_0:
   ret i64 5
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.(*T5).Invoke"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.(*T5).Invoke"(ptr %0) #0 {
 _llgo_0:
   %1 = load %"github.com/goplus/llgo/cl/_testgo/invoke.T5", ptr %0, align 4
   %2 = call i64 @"github.com/goplus/llgo/cl/_testgo/invoke.T5.Invoke"(%"github.com/goplus/llgo/cl/_testgo/invoke.T5" %1)
   ret i64 %2
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.T6.Invoke"(%"github.com/goplus/llgo/cl/_testgo/invoke.T6" %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.T6.Invoke"(%"github.com/goplus/llgo/cl/_testgo/invoke.T6" %0) #0 {
 _llgo_0:
   %1 = extractvalue %"github.com/goplus/llgo/cl/_testgo/invoke.T6" %0, 1
   %2 = extractvalue %"github.com/goplus/llgo/cl/_testgo/invoke.T6" %0, 0
@@ -221,14 +234,16 @@ _llgo_0:
   ret i64 6
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.(*T6).Invoke"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.(*T6).Invoke"(ptr %0) #0 {
 _llgo_0:
   %1 = load %"github.com/goplus/llgo/cl/_testgo/invoke.T6", ptr %0, align 8
   %2 = call i64 @"github.com/goplus/llgo/cl/_testgo/invoke.T6.Invoke"(%"github.com/goplus/llgo/cl/_testgo/invoke.T6" %1)
   ret i64 %2
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/invoke.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/invoke.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/invoke.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -241,7 +256,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/invoke.invoke"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/invoke.invoke"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
   %2 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 0
@@ -257,7 +273,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/invoke.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/invoke.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/invoke.T", ptr %0, i32 0, i32 0
@@ -419,25 +436,32 @@ _llgo_6:                                          ; preds = %_llgo_3
   unreachable
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.main$1"() {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.main$1"() #0 {
 _llgo_0:
   ret i64 400
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintFloat"(double)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintFloat"(double) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
 define linkonce i64 @"__llgo_stub.github.com/goplus/llgo/cl/_testgo/invoke.main$1"(ptr %0) {
 _llgo_0:
@@ -445,9 +469,11 @@ _llgo_0:
   ret i64 %1
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -455,7 +481,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -463,7 +490,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -471,9 +499,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -481,9 +511,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.f64equal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.f64equal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.f64equal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -491,7 +523,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -499,17 +532,23 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintIface"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintIface"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.Implements"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.Implements"(ptr, ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -517,4 +556,5 @@ _llgo_0:
   ret i1 %3
 }
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/multiret/out.ll
+++ b/cl/_testgo/multiret/out.ll
@@ -4,7 +4,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/multiret"
 @"github.com/goplus/llgo/cl/_testgo/multiret.a" = global i64 0, align 8
 @"github.com/goplus/llgo/cl/_testgo/multiret.init$guard" = global i1 false, align 1
 
-define { i64, double } @"github.com/goplus/llgo/cl/_testgo/multiret.foo"(double %0) {
+; Function Attrs: null_pointer_is_valid
+define { i64, double } @"github.com/goplus/llgo/cl/_testgo/multiret.foo"(double %0) #0 {
 _llgo_0:
   %1 = load i64, ptr @"github.com/goplus/llgo/cl/_testgo/multiret.a", align 4
   %2 = insertvalue { i64, double } undef, i64 %1, 0
@@ -12,7 +13,8 @@ _llgo_0:
   ret { i64, double } %3
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/multiret.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/multiret.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/multiret.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -26,7 +28,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/multiret.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/multiret.main"() #0 {
 _llgo_0:
   %0 = call { i64, double } @"github.com/goplus/llgo/cl/_testgo/multiret.foo"(double 2.000000e+00)
   %1 = extractvalue { i64, double } %0, 0
@@ -38,8 +41,13 @@ _llgo_0:
   ret void
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintFloat"(double)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintFloat"(double) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testgo/print/out.ll
+++ b/cl/_testgo/print/out.ll
@@ -3,7 +3,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/print"
 
 @"github.com/goplus/llgo/cl/_testgo/print.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testgo/print.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/print.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/print.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -16,7 +17,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/print.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/print.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 46)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
@@ -25,8 +27,13 @@ _llgo_0:
   ret void
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testgo/reader/out.ll
+++ b/cl/_testgo/reader/out.ll
@@ -172,7 +172,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/reader"
 @59 = private unnamed_addr constant [62 x i8] c"strings.Reader.UnreadRune: previous operation was not ReadRune", align 1
 @60 = private unnamed_addr constant [48 x i8] c"stringsReader.WriteTo: invalid WriteString count", align 1
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.NopCloser"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.NopCloser"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
   %2 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.Implements"(ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reader.WriterTo", ptr %1)
@@ -223,7 +224,8 @@ _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
   br i1 %25, label %_llgo_1, label %_llgo_2
 }
 
-define { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.ReadAll"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0) {
+; Function Attrs: null_pointer_is_valid
+define { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.ReadAll"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 512)
   %2 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.NewSlice3"(ptr %1, i64 1, i64 512, i64 0, i64 0, i64 512)
@@ -308,7 +310,8 @@ _llgo_6:                                          ; preds = %_llgo_3
   br label %_llgo_1
 }
 
-define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.WriteString"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, %"github.com/goplus/llgo/runtime/internal/runtime.String" %1) {
+; Function Attrs: null_pointer_is_valid
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.WriteString"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, %"github.com/goplus/llgo/runtime/internal/runtime.String" %1) #0 {
 _llgo_0:
   %2 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
   %3 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.Implements"(ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reader.StringWriter", ptr %2)
@@ -366,14 +369,16 @@ _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
   br i1 %39, label %_llgo_1, label %_llgo_2
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/reader.(*errorString).Error"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/reader.(*errorString).Error"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.errorString", ptr %0, i32 0, i32 0
   %2 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %1, align 8
   ret %"github.com/goplus/llgo/runtime/internal/runtime.String" %2
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/reader.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/reader.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/reader.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -391,7 +396,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/reader.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/reader.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 32)
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
@@ -410,7 +416,8 @@ _llgo_0:
   ret void
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.newError"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.newError"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.errorString", ptr %1, i32 0, i32 0
@@ -421,12 +428,14 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %5
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.nopCloser.Close"(%"github.com/goplus/llgo/cl/_testgo/reader.nopCloser" %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.nopCloser.Close"(%"github.com/goplus/llgo/cl/_testgo/reader.nopCloser" %0) #0 {
 _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" zeroinitializer
 }
 
-define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.nopCloser.Read"(%"github.com/goplus/llgo/cl/_testgo/reader.nopCloser" %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+; Function Attrs: null_pointer_is_valid
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.nopCloser.Read"(%"github.com/goplus/llgo/cl/_testgo/reader.nopCloser" %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) #0 {
 _llgo_0:
   %2 = alloca %"github.com/goplus/llgo/cl/_testgo/reader.nopCloser", align 8
   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -449,14 +458,16 @@ _llgo_0:
   ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %17
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloser).Close"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloser).Close"(ptr %0) #0 {
 _llgo_0:
   %1 = load %"github.com/goplus/llgo/cl/_testgo/reader.nopCloser", ptr %0, align 8
   %2 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.nopCloser.Close"(%"github.com/goplus/llgo/cl/_testgo/reader.nopCloser" %1)
   ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %2
 }
 
-define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloser).Read"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+; Function Attrs: null_pointer_is_valid
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloser).Read"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.nopCloser", ptr %0, i32 0, i32 0
   %3 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %2, align 8
@@ -476,12 +487,14 @@ _llgo_0:
   ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %16
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo.Close"(%"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo" %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo.Close"(%"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo" %0) #0 {
 _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" zeroinitializer
 }
 
-define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo.Read"(%"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo" %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+; Function Attrs: null_pointer_is_valid
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo.Read"(%"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo" %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) #0 {
 _llgo_0:
   %2 = alloca %"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo", align 8
   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -504,7 +517,8 @@ _llgo_0:
   ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %17
 }
 
-define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo.WriteTo"(%"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo" %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) {
+; Function Attrs: null_pointer_is_valid
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo.WriteTo"(%"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo" %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) #0 {
 _llgo_0:
   %2 = alloca %"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo", align 8
   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -543,14 +557,16 @@ _llgo_2:                                          ; preds = %_llgo_0
   unreachable
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloserWriterTo).Close"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloserWriterTo).Close"(ptr %0) #0 {
 _llgo_0:
   %1 = load %"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo", ptr %0, align 8
   %2 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo.Close"(%"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo" %1)
   ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %2
 }
 
-define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloserWriterTo).Read"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+; Function Attrs: null_pointer_is_valid
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloserWriterTo).Read"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo", ptr %0, i32 0, i32 0
   %3 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %2, align 8
@@ -570,7 +586,8 @@ _llgo_0:
   ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %16
 }
 
-define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloserWriterTo).WriteTo"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) {
+; Function Attrs: null_pointer_is_valid
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloserWriterTo).WriteTo"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) #0 {
 _llgo_0:
   %2 = load %"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo", ptr %0, align 8
   %3 = call { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo.WriteTo"(%"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo" %2, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1)
@@ -581,7 +598,8 @@ _llgo_0:
   ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %7
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).Len"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).Len"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
   %2 = load i64, ptr %1, align 4
@@ -604,7 +622,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret i64 %12
 }
 
-define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).Read"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+; Function Attrs: null_pointer_is_valid
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).Read"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
   %3 = load i64, ptr %2, align 4
@@ -641,7 +660,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %25
 }
 
-define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).ReadAt"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1, i64 %2) {
+; Function Attrs: null_pointer_is_valid
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).ReadAt"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1, i64 %2) #0 {
 _llgo_0:
   %3 = icmp slt i64 %2, 0
   br i1 %3, label %_llgo_1, label %_llgo_2
@@ -686,7 +706,8 @@ _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
   ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %24
 }
 
-define { i8, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).ReadByte"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define { i8, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).ReadByte"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 2
   store i64 -1, ptr %1, align 4
@@ -726,7 +747,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret { i8, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %26
 }
 
-define { i32, i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).ReadRune"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define { i32, i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).ReadRune"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
   %2 = load i64, ptr %1, align 4
@@ -796,7 +818,8 @@ _llgo_4:                                          ; preds = %_llgo_2
   ret { i32, i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %48
 }
 
-define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).Seek"(ptr %0, i64 %1, i64 %2) {
+; Function Attrs: null_pointer_is_valid
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).Seek"(ptr %0, i64 %1, i64 %2) #0 {
 _llgo_0:
   %3 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 2
   store i64 -1, ptr %3, align 4
@@ -850,7 +873,8 @@ _llgo_9:                                          ; preds = %_llgo_1
   ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %22
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).Size"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).Size"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
   %2 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %1, align 8
@@ -858,7 +882,8 @@ _llgo_0:
   ret i64 %3
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).UnreadByte"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).UnreadByte"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
   %2 = load i64, ptr %1, align 4
@@ -880,7 +905,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" zeroinitializer
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).UnreadRune"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).UnreadRune"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
   %2 = load i64, ptr %1, align 4
@@ -911,7 +937,8 @@ _llgo_4:                                          ; preds = %_llgo_2
   ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" zeroinitializer
 }
 
-define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).WriteTo"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) {
+; Function Attrs: null_pointer_is_valid
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).WriteTo"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 2
   store i64 -1, ptr %2, align 4
@@ -979,9 +1006,11 @@ _llgo_7:                                          ; preds = %_llgo_4
   br i1 %39, label %_llgo_5, label %_llgo_6
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -989,7 +1018,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -997,7 +1027,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1005,7 +1036,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1013,7 +1045,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1021,32 +1054,44 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.Implements"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.Implements"(ptr, ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr) #0
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.NewSlice3"(ptr, i64, i64, i64, i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.NewSlice3"(ptr, i64, i64, i64, i64, i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface", %"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface", %"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.SliceAppend"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr, i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.SliceAppend"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr, i64, i64) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"unicode/utf8.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"unicode/utf8.init"() #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1054,22 +1099,32 @@ _llgo_0:
   ret i1 %3
 }
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringFromBytes"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringFromBytes"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintIface"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintIface"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringSlice"(%"github.com/goplus/llgo/runtime/internal/runtime.String", i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringSlice"(%"github.com/goplus/llgo/runtime/internal/runtime.String", i64, i64) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.SliceCopy"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr, i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.SliceCopy"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr, i64, i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1) #0
 
-declare { i32, i64 } @"unicode/utf8.DecodeRuneInString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare { i32, i64 } @"unicode/utf8.DecodeRuneInString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/reflect/out.ll
+++ b/cl/_testgo/reflect/out.ll
@@ -116,7 +116,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/reflect"
 @43 = private unnamed_addr constant [12 x i8] c"must invalid", align 1
 @44 = private unnamed_addr constant [13 x i8] c"MapIter error", align 1
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/reflect.(*T).Add"(ptr %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/reflect.(*T).Add"(ptr %0, i64 %1) #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 11 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
@@ -130,7 +131,8 @@ _llgo_0:
   ret i64 %7
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/reflect.callClosure"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/reflect.callClosure"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   store i64 100, ptr %0, align 4
@@ -211,7 +213,8 @@ _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
   br i1 %45, label %_llgo_2, label %_llgo_1
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/reflect.callClosure$1"(ptr %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/reflect.callClosure$1"(ptr %0, i64 %1) #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @10, i64 12 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
@@ -223,7 +226,8 @@ _llgo_0:
   ret i64 %6
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/reflect.callFunc"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/reflect.callFunc"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
   store { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testgo/reflect.callFunc$1", ptr null }, ptr %0, align 8
@@ -298,7 +302,8 @@ _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
   br i1 %41, label %_llgo_2, label %_llgo_1
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/reflect.callFunc$1"(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/reflect.callFunc$1"(i64 %0) #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @12, i64 9 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
@@ -306,7 +311,8 @@ _llgo_0:
   ret i64 %1
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/reflect.callIMethod"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/reflect.callIMethod"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reflect.T", ptr %0, i32 0, i32 0
@@ -408,7 +414,8 @@ _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
   br i1 %64, label %_llgo_2, label %_llgo_1
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/reflect.callMethod"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/reflect.callMethod"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reflect.T", ptr %0, i32 0, i32 0
@@ -504,7 +511,8 @@ _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
   br i1 %58, label %_llgo_2, label %_llgo_1
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/reflect.callSlice"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/reflect.callSlice"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
   store { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testgo/reflect.demo", ptr null }, ptr %0, align 8
@@ -625,7 +633,8 @@ _llgo_0:
   ret void
 }
 
-define { i64, i64 } @"github.com/goplus/llgo/cl/_testgo/reflect.demo"(i64 %0, i64 %1, i64 %2, i64 %3, i64 %4, i64 %5, i64 %6, i64 %7, i64 %8, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %9) {
+; Function Attrs: null_pointer_is_valid
+define { i64, i64 } @"github.com/goplus/llgo/cl/_testgo/reflect.demo"(i64 %0, i64 %1, i64 %2, i64 %3, i64 %4, i64 %5, i64 %6, i64 %7, i64 %8, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %9) #0 {
 _llgo_0:
   %10 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %9, 1
   br label %_llgo_1
@@ -677,7 +686,8 @@ _llgo_5:                                          ; preds = %_llgo_2
   unreachable
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/reflect.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/reflect.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/reflect.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -691,7 +701,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/reflect.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/reflect.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/cl/_testgo/reflect.callSlice"()
   call void @"github.com/goplus/llgo/cl/_testgo/reflect.callFunc"()
@@ -703,7 +714,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/reflect.mapDemo1"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/reflect.mapDemo1"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_string", i64 2)
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 8)
@@ -840,7 +852,8 @@ _llgo_14:                                         ; preds = %_llgo_10
   br i1 %71, label %_llgo_13, label %_llgo_12
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/reflect.mapDemo2"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/reflect.mapDemo2"() #0 {
 _llgo_0:
   %0 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.TypeOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr null })
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
@@ -985,17 +998,23 @@ _llgo_14:                                         ; preds = %_llgo_10
   br i1 %78, label %_llgo_13, label %_llgo_12
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1003,7 +1022,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1011,27 +1031,38 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i64 @reflect.Value.Kind(%reflect.Value)
+; Function Attrs: null_pointer_is_valid
+declare i64 @reflect.Value.Kind(%reflect.Value) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.Value.Type(%reflect.Value)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.Value.Type(%reflect.Value) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value, %"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value, %"github.com/goplus/llgo/runtime/internal/runtime.Slice") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1) #0
 
-declare i64 @reflect.Value.Int(%reflect.Value)
+; Function Attrs: null_pointer_is_valid
+declare i64 @reflect.Value.Int(%reflect.Value) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.MatchesClosure"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.MatchesClosure"(ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1039,7 +1070,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
 define linkonce i64 @"__llgo_stub.github.com/goplus/llgo/cl/_testgo/reflect.callFunc$1"(ptr %0, i64 %1) {
 _llgo_0:
@@ -1047,9 +1079,11 @@ _llgo_0:
   ret i64 %2
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1057,11 +1091,14 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare %reflect.Value @reflect.Value.Method(%reflect.Value, i64)
+; Function Attrs: null_pointer_is_valid
+declare %reflect.Value @reflect.Value.Method(%reflect.Value, i64) #0
 
 define linkonce { i64, i64 } @"__llgo_stub.github.com/goplus/llgo/cl/_testgo/reflect.demo"(ptr %0, i64 %1, i64 %2, i64 %3, i64 %4, i64 %5, i64 %6, i64 %7, i64 %8, i64 %9, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %10) {
 _llgo_0:
@@ -1069,7 +1106,8 @@ _llgo_0:
   ret { i64, i64 } %11
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1077,15 +1115,20 @@ _llgo_0:
   ret i1 %3
 }
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.CallSlice(%reflect.Value, %"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.CallSlice(%reflect.Value, %"github.com/goplus/llgo/runtime/internal/runtime.Slice") #0
 
-declare void @reflect.init()
+; Function Attrs: null_pointer_is_valid
+declare void @reflect.init() #0
 
-declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.typehash"(ptr, ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.typehash"(ptr, ptr, i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -1093,42 +1136,64 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr, i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAssign"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAssign"(ptr, ptr, ptr) #0
 
-declare i64 @reflect.Value.Len(%reflect.Value)
+; Function Attrs: null_pointer_is_valid
+declare i64 @reflect.Value.Len(%reflect.Value) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.MapKeys(%reflect.Value)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.MapKeys(%reflect.Value) #0
 
-declare %reflect.Value @reflect.Value.MapIndex(%reflect.Value, %reflect.Value)
+; Function Attrs: null_pointer_is_valid
+declare %reflect.Value @reflect.Value.MapIndex(%reflect.Value, %reflect.Value) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @reflect.Value.SetMapIndex(%reflect.Value, %reflect.Value, %reflect.Value)
+; Function Attrs: null_pointer_is_valid
+declare void @reflect.Value.SetMapIndex(%reflect.Value, %reflect.Value, %reflect.Value) #0
 
-declare i1 @reflect.Value.IsValid(%reflect.Value)
+; Function Attrs: null_pointer_is_valid
+declare i1 @reflect.Value.IsValid(%reflect.Value) #0
 
-declare %reflect.Value @reflect.New(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare %reflect.Value @reflect.New(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare %reflect.Value @reflect.Value.Elem(%reflect.Value)
+; Function Attrs: null_pointer_is_valid
+declare %reflect.Value @reflect.Value.Elem(%reflect.Value) #0
 
-declare ptr @reflect.Value.MapRange(%reflect.Value)
+; Function Attrs: null_pointer_is_valid
+declare ptr @reflect.Value.MapRange(%reflect.Value) #0
 
-declare i1 @"reflect.(*MapIter).Next"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"reflect.(*MapIter).Next"(ptr) #0
 
-declare void @reflect.Value.SetIterKey(%reflect.Value, ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @reflect.Value.SetIterKey(%reflect.Value, ptr) #0
 
-declare void @reflect.Value.SetIterValue(%reflect.Value, ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @reflect.Value.SetIterValue(%reflect.Value, ptr) #0
 
-declare %reflect.Value @"reflect.(*MapIter).Key"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %reflect.Value @"reflect.(*MapIter).Key"(ptr) #0
 
-declare %reflect.Value @"reflect.(*MapIter).Value"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %reflect.Value @"reflect.(*MapIter).Value"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.TypeOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.TypeOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.MapOf(%"github.com/goplus/llgo/runtime/internal/runtime.iface", %"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.MapOf(%"github.com/goplus/llgo/runtime/internal/runtime.iface", %"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare %reflect.Value @reflect.MakeMap(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare %reflect.Value @reflect.MakeMap(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testgo/reflectfn/out.ll
+++ b/cl/_testgo/reflectfn/out.ll
@@ -27,14 +27,16 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/reflectfn"
 @"*_llgo_Pointer" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1134390089, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @5, i64 14 }, ptr null }, ptr @_llgo_Pointer }, align 8
 @"_llgo_closure$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8$fields" = weak_odr constant [2 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @2, i64 2 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @4, i64 5 }, ptr @_llgo_Pointer, i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
 
-define void @"github.com/goplus/llgo/cl/_testgo/reflectfn.demo"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/reflectfn.demo"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 4 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/reflectfn.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/reflectfn.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/reflectfn.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -49,7 +51,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/reflectfn.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/reflectfn.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   store i64 100, ptr %0, align 4
@@ -129,7 +132,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/reflectfn.main$1"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/reflectfn.main$1"(ptr %0) #0 {
 _llgo_0:
   %1 = load { ptr }, ptr %0, align 8
   %2 = extractvalue { ptr } %1, 0
@@ -139,19 +143,26 @@ _llgo_0:
   ret void
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @fmt.init()
+; Function Attrs: null_pointer_is_valid
+declare void @fmt.init() #0
 
-declare void @reflect.init()
+; Function Attrs: null_pointer_is_valid
+declare void @reflect.init() #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -159,7 +170,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @fmt.Println(%"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+; Function Attrs: null_pointer_is_valid
+declare { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @fmt.Println(%"github.com/goplus/llgo/runtime/internal/runtime.Slice") #0
 
 define linkonce void @"__llgo_stub.github.com/goplus/llgo/cl/_testgo/reflectfn.demo"(ptr %0) {
 _llgo_0:
@@ -167,8 +179,13 @@ _llgo_0:
   ret void
 }
 
-declare %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare ptr @reflect.Value.UnsafePointer(%reflect.Value)
+; Function Attrs: null_pointer_is_valid
+declare ptr @reflect.Value.UnsafePointer(%reflect.Value) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testgo/reflectmk/out.ll
+++ b/cl/_testgo/reflectmk/out.ll
@@ -56,7 +56,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/reflectmk"
 @22 = private unnamed_addr constant [18 x i8] c"value.Method error", align 1
 @23 = private unnamed_addr constant [24 x i8] c"value.MethodByName error", align 1
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/reflectmk.Point.String"(%"github.com/goplus/llgo/cl/_testgo/reflectmk.Point" %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/reflectmk.Point.String"(%"github.com/goplus/llgo/cl/_testgo/reflectmk.Point" %0) #0 {
 _llgo_0:
   %1 = alloca %"github.com/goplus/llgo/cl/_testgo/reflectmk.Point", align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -81,7 +82,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.String" %16
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/reflectmk.(*Point).Set"(ptr %0, i64 %1, i64 %2) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/reflectmk.(*Point).Set"(ptr %0, i64 %1, i64 %2) #0 {
 _llgo_0:
   %3 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reflectmk.Point", ptr %0, i32 0, i32 0
   store i64 %1, ptr %3, align 4
@@ -90,14 +92,16 @@ _llgo_0:
   ret void
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/reflectmk.(*Point).String"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/reflectmk.(*Point).String"(ptr %0) #0 {
 _llgo_0:
   %1 = load %"github.com/goplus/llgo/cl/_testgo/reflectmk.Point", ptr %0, align 4
   %2 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/reflectmk.Point.String"(%"github.com/goplus/llgo/cl/_testgo/reflectmk.Point" %1)
   ret %"github.com/goplus/llgo/runtime/internal/runtime.String" %2
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/reflectmk.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/reflectmk.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/reflectmk.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -112,7 +116,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/reflectmk.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/reflectmk.main"() #0 {
 _llgo_0:
   %0 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.TypeOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @"*_llgo_github.com/goplus/llgo/cl/_testgo/reflectmk.Point", ptr null })
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
@@ -511,7 +516,8 @@ _llgo_25:                                         ; preds = %_llgo_23
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/reflectmk.method"(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/reflectmk.method"(i64 %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reflectmk.Point", ptr %1, i32 0, i32 0
@@ -544,7 +550,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/reflectmk.methodByName"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/reflectmk.methodByName"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reflectmk.Point", ptr %1, i32 0, i32 0
@@ -578,11 +585,13 @@ _llgo_2:                                          ; preds = %_llgo_0
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -590,7 +599,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -598,17 +608,23 @@ _llgo_0:
   ret i1 %3
 }
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @fmt.Sprintf(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @fmt.Sprintf(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.Slice") #0
 
-declare void @fmt.init()
+; Function Attrs: null_pointer_is_valid
+declare void @fmt.init() #0
 
-declare void @reflect.init()
+; Function Attrs: null_pointer_is_valid
+declare void @reflect.init() #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.TypeOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.TypeOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -616,42 +632,62 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.ArrayOf(i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.ArrayOf(i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface", %"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface", %"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.ChanOf(i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.ChanOf(i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.FuncOf(%"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.Slice", i1)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.FuncOf(%"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.Slice", i1) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.MapOf(%"github.com/goplus/llgo/runtime/internal/runtime.iface", %"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.MapOf(%"github.com/goplus/llgo/runtime/internal/runtime.iface", %"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.PointerTo(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.PointerTo(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.SliceOf(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.SliceOf(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.StructOf(%"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.StructOf(%"github.com/goplus/llgo/runtime/internal/runtime.Slice") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare %reflect.Value @reflect.Value.Method(%reflect.Value, i64)
+; Function Attrs: null_pointer_is_valid
+declare %reflect.Value @reflect.Value.Method(%reflect.Value, i64) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value, %"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value, %"github.com/goplus/llgo/runtime/internal/runtime.Slice") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value) #0
 
-declare %reflect.Value @reflect.Value.MethodByName(%reflect.Value, %"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare %reflect.Value @reflect.Value.MethodByName(%reflect.Value, %"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/reflectmkfn/out.ll
+++ b/cl/_testgo/reflectmkfn/out.ll
@@ -38,7 +38,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/reflectmkfn"
 @9 = private unnamed_addr constant [6 x i8] c"abcabc", align 1
 @10 = private unnamed_addr constant [5 x i8] c"error", align 1
 
-define void @"github.com/goplus/llgo/cl/_testgo/reflectmkfn.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/reflectmkfn.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/reflectmkfn.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -53,7 +54,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/reflectmkfn.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/reflectmkfn.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 32)
   %1 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %0, i64 0
@@ -113,7 +115,8 @@ _llgo_4:                                          ; preds = %_llgo_0
   unreachable
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/reflectmkfn.main$1"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/reflectmkfn.main$1"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0) #0 {
 _llgo_0:
   %1 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0, 0
   %2 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0, 1
@@ -143,15 +146,20 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %21
 }
 
-declare void @reflect.init()
+; Function Attrs: null_pointer_is_valid
+declare void @reflect.init() #0
 
-declare void @strings.init()
+; Function Attrs: null_pointer_is_valid
+declare void @strings.init() #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.TypeOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.TypeOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -159,7 +167,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -167,9 +176,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -177,9 +188,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.FuncOf(%"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.Slice", i1)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.FuncOf(%"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.Slice", i1) #0
 
-declare %reflect.Value @reflect.MakeFunc(%"github.com/goplus/llgo/runtime/internal/runtime.iface", { ptr, ptr })
+; Function Attrs: null_pointer_is_valid
+declare %reflect.Value @reflect.MakeFunc(%"github.com/goplus/llgo/runtime/internal/runtime.iface", { ptr, ptr }) #0
 
 define linkonce %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"__llgo_stub.github.com/goplus/llgo/cl/_testgo/reflectmkfn.main$1"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
 _llgo_0:
@@ -187,20 +200,31 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %2
 }
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.MatchesClosure"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.MatchesClosure"(ptr, ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value) #0
 
-declare i64 @reflect.Value.Int(%reflect.Value)
+; Function Attrs: null_pointer_is_valid
+declare i64 @reflect.Value.Int(%reflect.Value) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @strings.Repeat(%"github.com/goplus/llgo/runtime/internal/runtime.String", i64)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @strings.Repeat(%"github.com/goplus/llgo/runtime/internal/runtime.String", i64) #0
 
-declare %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testgo/returnorder/out.ll
+++ b/cl/_testgo/returnorder/out.ll
@@ -18,7 +18,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/returnorder"
 @"*_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1323879264, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @2, i64 6 }, ptr null }, ptr @_llgo_string }, align 8
 @3 = private unnamed_addr constant [2 x i8] c"ok", align 1
 
-define void @"github.com/goplus/llgo/cl/_testgo/returnorder.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/returnorder.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/returnorder.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -32,7 +33,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/returnorder.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/returnorder.main"() #0 {
 _llgo_0:
   %0 = alloca %"github.com/goplus/llgo/cl/_testgo/returnorder.state", align 8
   call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
@@ -77,7 +79,8 @@ _llgo_3:                                          ; preds = %_llgo_0
   br i1 %22, label %_llgo_1, label %_llgo_2
 }
 
-define { %"github.com/goplus/llgo/cl/_testgo/returnorder.state", i64 } @"github.com/goplus/llgo/cl/_testgo/returnorder.returnStateAndMut"() {
+; Function Attrs: null_pointer_is_valid
+define { %"github.com/goplus/llgo/cl/_testgo/returnorder.state", i64 } @"github.com/goplus/llgo/cl/_testgo/returnorder.returnStateAndMut"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/returnorder.state", ptr %0, i32 0, i32 0
@@ -89,7 +92,8 @@ _llgo_0:
   ret { %"github.com/goplus/llgo/cl/_testgo/returnorder.state", i64 } %5
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/returnorder.(*state).mutate"(ptr %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/returnorder.(*state).mutate"(ptr %0, i64 %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/returnorder.state", ptr %0, i32 0, i32 0
   store i64 %1, ptr %2, align 4
@@ -98,14 +102,17 @@ _llgo_0:
   ret i64 %4
 }
 
-declare void @fmt.init()
+; Function Attrs: null_pointer_is_valid
+declare void @fmt.init() #0
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -113,7 +120,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -121,9 +129,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @fmt.Sprintf(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @fmt.Sprintf(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.Slice") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -131,12 +141,17 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/selects/out.ll
+++ b/cl/_testgo/selects/out.ll
@@ -20,7 +20,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/selects"
 @6 = private unnamed_addr constant [4 x i8] c"c2<-", align 1
 @7 = private unnamed_addr constant [4 x i8] c"<-c3", align 1
 
-define void @"github.com/goplus/llgo/cl/_testgo/selects.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/selects.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/selects.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -33,7 +34,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/selects.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/selects.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewChan"(i64 0, i64 1)
@@ -126,7 +128,8 @@ _llgo_5:                                          ; preds = %_llgo_3
   unreachable
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/selects.main$1"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/selects.main$1"(ptr %0) #0 {
 _llgo_0:
   %1 = load { ptr, ptr, ptr }, ptr %0, align 8
   %2 = extractvalue { ptr, ptr, ptr } %1, 0
@@ -199,11 +202,14 @@ _llgo_5:                                          ; preds = %_llgo_3
   unreachable
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewChan"(i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewChan"(i64, i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
 declare ptr @malloc(i64)
 
@@ -220,20 +226,26 @@ _llgo_0:
 
 declare void @free(ptr)
 
-declare i32 @"github.com/goplus/llgo/runtime/internal/runtime.CreateThread"(ptr, ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i32 @"github.com/goplus/llgo/runtime/internal/runtime.CreateThread"(ptr, ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.ChanSend"(ptr, ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.ChanSend"(ptr, ptr, i64) #0
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare { i64, i1 } @"github.com/goplus/llgo/runtime/internal/runtime.Select"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+; Function Attrs: null_pointer_is_valid
+declare { i64, i1 } @"github.com/goplus/llgo/runtime/internal/runtime.Select"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -241,7 +253,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -249,8 +262,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.ChanRecv"(ptr, ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.ChanRecv"(ptr, ptr, i64) #0
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/strucintf/out.ll
+++ b/cl/_testgo/strucintf/out.ll
@@ -28,7 +28,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/strucintf"
 @7 = private unnamed_addr constant [11 x i8] c"Bar: not ok", align 1
 @8 = private unnamed_addr constant [9 x i8] c"F: not ok", align 1
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.eface" @"github.com/goplus/llgo/cl/_testgo/strucintf.Foo"() {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.eface" @"github.com/goplus/llgo/cl/_testgo/strucintf.Foo"() #0 {
 _llgo_0:
   %0 = alloca { i64 }, align 8
   call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
@@ -41,7 +42,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.eface" %5
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/strucintf.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/strucintf.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/strucintf.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -55,7 +57,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/strucintf.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/strucintf.main"() #0 {
 _llgo_0:
   %0 = call %"github.com/goplus/llgo/runtime/internal/runtime.eface" @"github.com/goplus/llgo/cl/_testgo/strucintf.Foo"()
   %1 = alloca { i64 }, align 8
@@ -175,11 +178,13 @@ _llgo_18:                                         ; preds = %_llgo_17, %_llgo_16
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -187,7 +192,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -195,16 +201,23 @@ _llgo_0:
   ret i1 %3
 }
 
-declare void @"github.com/goplus/llgo/cl/_testdata/foo.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/cl/_testdata/foo.init"() #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.eface" @"github.com/goplus/llgo/cl/_testdata/foo.Bar"()
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.eface" @"github.com/goplus/llgo/cl/_testdata/foo.Bar"() #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.eface" @"github.com/goplus/llgo/cl/_testdata/foo.F"()
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.eface" @"github.com/goplus/llgo/cl/_testdata/foo.F"() #0
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/struczero/out.ll
+++ b/cl/_testgo/struczero/out.ll
@@ -41,7 +41,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/struczero"
 @"github.com/goplus/llgo/cl/_testgo/struczero.struct$2215Oa2lkpk-YZ2pdVVs2mMqzhx1jppOCrAxbrX70ko$fields" = weak_odr constant [2 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @5, i64 2 }, ptr @"*_llgo_uint8", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @10, i64 1 }, ptr @_llgo_float32, i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
 @11 = private unnamed_addr constant [6 x i8] c"notOk:", align 1
 
-define { %"github.com/goplus/llgo/cl/_testdata/foo.Foo", i1 } @"github.com/goplus/llgo/cl/_testgo/struczero.Bar"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %0) {
+; Function Attrs: null_pointer_is_valid
+define { %"github.com/goplus/llgo/cl/_testdata/foo.Foo", i1 } @"github.com/goplus/llgo/cl/_testgo/struczero.Bar"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %0) #0 {
 _llgo_0:
   %1 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %0, 0
   %2 = icmp eq ptr %1, @"_llgo_github.com/goplus/llgo/cl/_testdata/foo.Foo"
@@ -66,7 +67,8 @@ _llgo_3:                                          ; preds = %_llgo_2, %_llgo_1
   ret { %"github.com/goplus/llgo/cl/_testdata/foo.Foo", i1 } %11
 }
 
-define { %"github.com/goplus/llgo/cl/_testgo/struczero.bar", i1 } @"github.com/goplus/llgo/cl/_testgo/struczero.Foo"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %0) {
+; Function Attrs: null_pointer_is_valid
+define { %"github.com/goplus/llgo/cl/_testgo/struczero.bar", i1 } @"github.com/goplus/llgo/cl/_testgo/struczero.Foo"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %0) #0 {
 _llgo_0:
   %1 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %0, 0
   %2 = icmp eq ptr %1, @"_llgo_github.com/goplus/llgo/cl/_testgo/struczero.bar"
@@ -91,7 +93,8 @@ _llgo_3:                                          ; preds = %_llgo_2, %_llgo_1
   ret { %"github.com/goplus/llgo/cl/_testgo/struczero.bar", i1 } %11
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/struczero.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/struczero.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/struczero.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -105,7 +108,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/struczero.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/struczero.main"() #0 {
 _llgo_0:
   %0 = alloca %"github.com/goplus/llgo/cl/_testgo/struczero.bar", align 8
   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
@@ -150,9 +154,11 @@ _llgo_0:
   ret void
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -160,9 +166,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/cl/_testdata/foo.(*Foo).Pb"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/cl/_testdata/foo.(*Foo).Pb"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -170,7 +178,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.f32equal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.f32equal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.f32equal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -178,23 +187,32 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/cl/_testdata/foo.Foo.Pb"(%"github.com/goplus/llgo/cl/_testdata/foo.Foo")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/cl/_testdata/foo.Foo.Pb"(%"github.com/goplus/llgo/cl/_testdata/foo.Foo") #0
 
-declare void @"github.com/goplus/llgo/cl/_testdata/foo.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/cl/_testdata/foo.init"() #0
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintFloat"(double)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintFloat"(double) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/tpindex/out.ll
+++ b/cl/_testgo/tpindex/out.ll
@@ -5,7 +5,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/tpindex"
 
 @"github.com/goplus/llgo/cl/_testgo/tpindex.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testgo/tpindex.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/tpindex.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/tpindex.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -18,7 +19,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/tpindex.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/tpindex.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 40)
   %1 = getelementptr inbounds i64, ptr %0, i64 0
@@ -43,9 +45,11 @@ _llgo_0:
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-define linkonce i64 @"github.com/goplus/llgo/cl/_testgo/tpindex.index[int]"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define linkonce i64 @"github.com/goplus/llgo/cl/_testgo/tpindex.index[int]"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0, i64 %1) #0 {
 _llgo_0:
   %2 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0, 1
   br label %_llgo_1
@@ -75,8 +79,13 @@ _llgo_4:                                          ; preds = %_llgo_2
   ret i64 %4
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testgo/tpinst/out.ll
+++ b/cl/_testgo/tpinst/out.ll
@@ -63,7 +63,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/tpinst"
 @"github.com/goplus/llgo/cl/_testgo/tpinst.iface$2sV9fFeqOv1SzesvwIdhTqCFzDT8ZX5buKUSAoHNSww$imethods" = weak_odr constant [1 x %"github.com/goplus/llgo/runtime/abi.Imethod"] [%"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 46 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" }], align 8
 @16 = private unnamed_addr constant [95 x i8] c"type assertion github.com/goplus/llgo/cl/_testgo/tpinst.I[int] -> interface{value() int} failed", align 1
 
-define void @"github.com/goplus/llgo/cl/_testgo/tpinst.demo"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/tpinst.demo"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tpinst.M[int]", ptr %0, i32 0, i32 0
@@ -156,7 +157,8 @@ _llgo_8:                                          ; preds = %_llgo_4
   unreachable
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/tpinst.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/tpinst.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/tpinst.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -169,29 +171,34 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/tpinst.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/tpinst.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/cl/_testgo/tpinst.demo"()
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-define linkonce i64 @"github.com/goplus/llgo/cl/_testgo/tpinst.(*M[int]).Value"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define linkonce i64 @"github.com/goplus/llgo/cl/_testgo/tpinst.(*M[int]).Value"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tpinst.M[int]", ptr %0, i32 0, i32 0
   %2 = load i64, ptr %1, align 4
   ret i64 %2
 }
 
-define linkonce i64 @"github.com/goplus/llgo/cl/_testgo/tpinst.(*M[int]).value"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define linkonce i64 @"github.com/goplus/llgo/cl/_testgo/tpinst.(*M[int]).value"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tpinst.M[int]", ptr %0, i32 0, i32 0
   %2 = load i64, ptr %1, align 4
   ret i64 %2
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -199,9 +206,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -209,7 +218,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -217,11 +227,14 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -229,25 +242,30 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-define linkonce double @"github.com/goplus/llgo/cl/_testgo/tpinst.(*M[float64]).Value"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define linkonce double @"github.com/goplus/llgo/cl/_testgo/tpinst.(*M[float64]).Value"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tpinst.M[float64]", ptr %0, i32 0, i32 0
   %2 = load double, ptr %1, align 8
   ret double %2
 }
 
-define linkonce double @"github.com/goplus/llgo/cl/_testgo/tpinst.(*M[float64]).value"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define linkonce double @"github.com/goplus/llgo/cl/_testgo/tpinst.(*M[float64]).value"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tpinst.M[float64]", ptr %0, i32 0, i32 0
   %2 = load double, ptr %1, align 8
   ret double %2
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.f64equal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.f64equal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.f64equal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -255,6 +273,10 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.Implements"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.Implements"(ptr, ptr) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testgo/tplocaltype/out.ll
+++ b/cl/_testgo/tplocaltype/out.ll
@@ -3,7 +3,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/tplocaltype"
 
 @"github.com/goplus/llgo/cl/_testgo/tplocaltype.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testgo/tplocaltype.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/tplocaltype.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/tplocaltype.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -16,31 +17,38 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/tplocaltype.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/tplocaltype.main"() #0 {
 _llgo_0:
   %0 = call i64 @"github.com/goplus/llgo/cl/_testgo/tplocaltype.use1"()
   %1 = call i64 @"github.com/goplus/llgo/cl/_testgo/tplocaltype.use2"()
   ret void
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/tplocaltype.use1"() {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/tplocaltype.use1"() #0 {
 _llgo_0:
   %0 = call i64 @"github.com/goplus/llgo/cl/_testgo/tplocaltype.id[github.com/goplus/llgo/cl/_testgo/tplocaltype.T.1.0]"(i64 1)
   ret i64 %0
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testgo/tplocaltype.use2"() {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testgo/tplocaltype.use2"() #0 {
 _llgo_0:
   %0 = call i64 @"github.com/goplus/llgo/cl/_testgo/tplocaltype.id[github.com/goplus/llgo/cl/_testgo/tplocaltype.T.2.0]"(i64 2)
   ret i64 %0
 }
 
-define linkonce i64 @"github.com/goplus/llgo/cl/_testgo/tplocaltype.id[github.com/goplus/llgo/cl/_testgo/tplocaltype.T.1.0]"(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define linkonce i64 @"github.com/goplus/llgo/cl/_testgo/tplocaltype.id[github.com/goplus/llgo/cl/_testgo/tplocaltype.T.1.0]"(i64 %0) #0 {
 _llgo_0:
   ret i64 %0
 }
 
-define linkonce i64 @"github.com/goplus/llgo/cl/_testgo/tplocaltype.id[github.com/goplus/llgo/cl/_testgo/tplocaltype.T.2.0]"(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define linkonce i64 @"github.com/goplus/llgo/cl/_testgo/tplocaltype.id[github.com/goplus/llgo/cl/_testgo/tplocaltype.T.2.0]"(i64 %0) #0 {
 _llgo_0:
   ret i64 %0
 }
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testgo/tpnamed/out.ll
+++ b/cl/_testgo/tpnamed/out.ll
@@ -10,22 +10,26 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/tpnamed"
 
 @"github.com/goplus/llgo/cl/_testgo/tpnamed.init$guard" = global i1 false, align 1
 
-define %"github.com/goplus/llgo/cl/_testgo/tpnamed.IO[error]" @"github.com/goplus/llgo/cl/_testgo/tpnamed.WriteFile"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/cl/_testgo/tpnamed.IO[error]" @"github.com/goplus/llgo/cl/_testgo/tpnamed.WriteFile"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0) #0 {
 _llgo_0:
   ret %"github.com/goplus/llgo/cl/_testgo/tpnamed.IO[error]" { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testgo/tpnamed.WriteFile$1", ptr null }
 }
 
-define %"github.com/goplus/llgo/cl/_testgo/tpnamed.Future[error]" @"github.com/goplus/llgo/cl/_testgo/tpnamed.WriteFile$1"() {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/cl/_testgo/tpnamed.Future[error]" @"github.com/goplus/llgo/cl/_testgo/tpnamed.WriteFile$1"() #0 {
 _llgo_0:
   ret %"github.com/goplus/llgo/cl/_testgo/tpnamed.Future[error]" { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testgo/tpnamed.WriteFile$1$1", ptr null }
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/tpnamed.WriteFile$1$1"() {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/tpnamed.WriteFile$1$1"() #0 {
 _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" zeroinitializer
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/tpnamed.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/tpnamed.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/tpnamed.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -38,18 +42,21 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/tpnamed.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/tpnamed.main"() #0 {
 _llgo_0:
   %0 = call [0 x i8] @"github.com/goplus/llgo/cl/_testgo/tpnamed.RunIO[[0]byte]"(%"github.com/goplus/llgo/cl/_testgo/tpnamed.IO[[0]byte]" { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testgo/tpnamed.main$1", ptr null })
   ret void
 }
 
-define %"github.com/goplus/llgo/cl/_testgo/tpnamed.Future[[0]byte]" @"github.com/goplus/llgo/cl/_testgo/tpnamed.main$1"() {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/cl/_testgo/tpnamed.Future[[0]byte]" @"github.com/goplus/llgo/cl/_testgo/tpnamed.main$1"() #0 {
 _llgo_0:
   ret %"github.com/goplus/llgo/cl/_testgo/tpnamed.Future[[0]byte]" { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testgo/tpnamed.main$1$1", ptr null }
 }
 
-define [0 x i8] @"github.com/goplus/llgo/cl/_testgo/tpnamed.main$1$1"() {
+; Function Attrs: null_pointer_is_valid
+define [0 x i8] @"github.com/goplus/llgo/cl/_testgo/tpnamed.main$1$1"() #0 {
 _llgo_0:
   ret [0 x i8] zeroinitializer
 }
@@ -72,7 +79,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/cl/_testgo/tpnamed.Future[[0]byte]" %1
 }
 
-define linkonce [0 x i8] @"github.com/goplus/llgo/cl/_testgo/tpnamed.RunIO[[0]byte]"(%"github.com/goplus/llgo/cl/_testgo/tpnamed.IO[[0]byte]" %0) {
+; Function Attrs: null_pointer_is_valid
+define linkonce [0 x i8] @"github.com/goplus/llgo/cl/_testgo/tpnamed.RunIO[[0]byte]"(%"github.com/goplus/llgo/cl/_testgo/tpnamed.IO[[0]byte]" %0) #0 {
 _llgo_0:
   %1 = extractvalue %"github.com/goplus/llgo/cl/_testgo/tpnamed.IO[[0]byte]" %0, 1
   %2 = extractvalue %"github.com/goplus/llgo/cl/_testgo/tpnamed.IO[[0]byte]" %0, 0
@@ -88,3 +96,5 @@ _llgo_0:
   %1 = tail call [0 x i8] @"github.com/goplus/llgo/cl/_testgo/tpnamed.main$1$1"()
   ret [0 x i8] %1
 }
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testgo/tprecur/out.ll
+++ b/cl/_testgo/tprecur/out.ll
@@ -13,7 +13,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/tprecur"
 @1 = private unnamed_addr constant [6 x i8] c"string", align 1
 @"*_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1323879264, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 6 }, ptr null }, ptr @_llgo_string }, align 8
 
-define void @"github.com/goplus/llgo/cl/_testgo/tprecur.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/tprecur.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/tprecur.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -26,13 +27,15 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/tprecur.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/tprecur.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/cl/_testgo/tprecur.recursive"()
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/tprecur.recursive"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/tprecur.recursive"() #0 {
 _llgo_0:
   %0 = call i64 @"github.com/goplus/llgo/cl/_testgo/tprecur.recur1[github.com/goplus/llgo/cl/_testgo/tprecur.T.1.0]"(i64 5)
   %1 = icmp ne i64 %0, 110
@@ -49,7 +52,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define linkonce i64 @"github.com/goplus/llgo/cl/_testgo/tprecur.recur1[github.com/goplus/llgo/cl/_testgo/tprecur.T.1.0]"(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define linkonce i64 @"github.com/goplus/llgo/cl/_testgo/tprecur.recur1[github.com/goplus/llgo/cl/_testgo/tprecur.T.1.0]"(i64 %0) #0 {
 _llgo_0:
   %1 = icmp eq i64 %0, 0
   br i1 %1, label %_llgo_1, label %_llgo_3
@@ -68,7 +72,8 @@ _llgo_3:                                          ; preds = %_llgo_0
   br i1 %5, label %_llgo_1, label %_llgo_2
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -76,7 +81,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -84,11 +90,14 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-define linkonce i64 @"github.com/goplus/llgo/cl/_testgo/tprecur.recur2[github.com/goplus/llgo/cl/_testgo/tprecur.T.1.0]"(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define linkonce i64 @"github.com/goplus/llgo/cl/_testgo/tprecur.recur2[github.com/goplus/llgo/cl/_testgo/tprecur.T.1.0]"(i64 %0) #0 {
 _llgo_0:
   %1 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.MakeSlice"(i64 %0, i64 %0, i64 8)
   %2 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1, 1
@@ -142,6 +151,10 @@ _llgo_6:                                          ; preds = %_llgo_4
   ret i64 %28
 }
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.MakeSlice"(i64, i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.MakeSlice"(i64, i64, i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testgo/tprecurfn/out.ll
+++ b/cl/_testgo/tprecurfn/out.ll
@@ -5,7 +5,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/tprecurfn"
 
 @"github.com/goplus/llgo/cl/_testgo/tprecurfn.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testgo/tprecurfn.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/tprecurfn.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/tprecurfn.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -18,7 +19,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/tprecurfn.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/tprecurfn.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 24)
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tprecurfn.My[int]", ptr %0, i32 0, i32 1
@@ -36,14 +38,16 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/tprecurfn.main$1"(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/tprecurfn.main$1"(i64 %0) #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %0)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
 define linkonce void @"__llgo_stub.github.com/goplus/llgo/cl/_testgo/tprecurfn.main$1"(ptr %0, i64 %1) {
 _llgo_0:
@@ -51,6 +55,10 @@ _llgo_0:
   ret void
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testgo/tptypes/out.ll
+++ b/cl/_testgo/tptypes/out.ll
@@ -11,7 +11,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/tptypes"
 @"github.com/goplus/llgo/cl/_testgo/tptypes.init$guard" = global i1 false, align 1
 @0 = private unnamed_addr constant [5 x i8] c"hello", align 1
 
-define void @"github.com/goplus/llgo/cl/_testgo/tptypes.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/tptypes.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/tptypes.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -24,7 +25,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/tptypes.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/tptypes.main"() #0 {
 _llgo_0:
   %0 = alloca %"github.com/goplus/llgo/cl/_testgo/tptypes.Data[int]", align 8
   call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
@@ -149,17 +151,22 @@ _llgo_0:
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-define linkonce %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/tptypes.(*Slice[[]int,int]).Append"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+; Function Attrs: null_pointer_is_valid
+define linkonce %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/tptypes.(*Slice[[]int,int]).Append"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tptypes.Slice[[]int,int]", ptr %0, i32 0, i32 0
   %3 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %2, align 8
@@ -173,7 +180,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %9
 }
 
-define linkonce %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/tptypes.(*Slice[[]string,string]).Append"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+; Function Attrs: null_pointer_is_valid
+define linkonce %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/tptypes.(*Slice[[]string,string]).Append"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tptypes.Slice[[]string,string]", ptr %0, i32 0, i32 0
   %3 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %2, align 8
@@ -187,7 +195,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %9
 }
 
-define linkonce %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/tptypes.(*Slice[[]int,int]).Append2"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+; Function Attrs: null_pointer_is_valid
+define linkonce %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/tptypes.(*Slice[[]int,int]).Append2"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tptypes.Slice[[]int,int]", ptr %0, i32 0, i32 0
   %3 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %2, align 8
@@ -201,10 +210,14 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %9
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice") #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.SliceAppend"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr, i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.SliceAppend"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr, i64, i64) #0
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/typerecur/out.ll
+++ b/cl/_testgo/typerecur/out.ll
@@ -8,7 +8,8 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/typerecur"
 @"github.com/goplus/llgo/cl/_testgo/typerecur.init$guard" = global i1 false, align 1
 @0 = private unnamed_addr constant [6 x i8] c"count:", align 1
 
-define %"github.com/goplus/llgo/cl/_testgo/typerecur.stateFn" @"github.com/goplus/llgo/cl/_testgo/typerecur.countState"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/cl/_testgo/typerecur.stateFn" @"github.com/goplus/llgo/cl/_testgo/typerecur.countState"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/typerecur.counter", ptr %0, i32 0, i32 0
   %2 = load i64, ptr %1, align 4
@@ -35,7 +36,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret %"github.com/goplus/llgo/cl/_testgo/typerecur.stateFn" { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testgo/typerecur.countState", ptr null }
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/typerecur.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/typerecur.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/typerecur.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -48,7 +50,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testgo/typerecur.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testgo/typerecur.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 32)
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/typerecur.counter", ptr %0, i32 0, i32 1
@@ -78,11 +81,14 @@ _llgo_3:                                          ; preds = %_llgo_1, %_llgo_0
   br i1 %12, label %_llgo_1, label %_llgo_2
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
 define linkonce %"github.com/goplus/llgo/cl/_testgo/typerecur.stateFn" @"__llgo_stub.github.com/goplus/llgo/cl/_testgo/typerecur.countState"(ptr %0, ptr %1) {
 _llgo_0:
@@ -90,4 +96,7 @@ _llgo_0:
   ret %"github.com/goplus/llgo/cl/_testgo/typerecur.stateFn" %2
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testlibc/allocacstrs/out.ll
+++ b/cl/_testlibc/allocacstrs/out.ll
@@ -10,7 +10,8 @@ source_filename = "github.com/goplus/llgo/cl/_testlibc/allocacstrs"
 @2 = private unnamed_addr constant [1 x i8] c"c", align 1
 @3 = private unnamed_addr constant [4 x i8] c"%s\0A\00", align 1
 
-define void @"github.com/goplus/llgo/cl/_testlibc/allocacstrs.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibc/allocacstrs.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testlibc/allocacstrs.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -23,7 +24,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testlibc/allocacstrs.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibc/allocacstrs.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 48)
   %1 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %0, i64 0
@@ -84,10 +86,15 @@ _llgo_6:                                          ; preds = %_llgo_4
   br label %_llgo_1
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.CStrCopy"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.CStrCopy"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
 declare i32 @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testlibc/argv/out.ll
+++ b/cl/_testlibc/argv/out.ll
@@ -6,7 +6,8 @@ source_filename = "github.com/goplus/llgo/cl/_testlibc/argv"
 @0 = private unnamed_addr constant [4 x i8] c"%s\0A\00", align 1
 @__llgo_argv = external global ptr, align 8
 
-define void @"github.com/goplus/llgo/cl/_testlibc/argv.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibc/argv.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testlibc/argv.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -19,7 +20,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testlibc/argv.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibc/argv.main"() #0 {
 _llgo_0:
   br label %_llgo_1
 
@@ -42,3 +44,5 @@ _llgo_3:                                          ; preds = %_llgo_1
 }
 
 declare i32 @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testlibc/atomic/out.ll
+++ b/cl/_testlibc/atomic/out.ll
@@ -8,7 +8,8 @@ source_filename = "github.com/goplus/llgo/cl/_testlibc/atomic"
 @3 = private unnamed_addr constant [25 x i8] c"ret: %ld vs 101, v: %ld\0A\00", align 1
 @4 = private unnamed_addr constant [18 x i8] c"ret: %ld, v: %ld\0A\00", align 1
 
-define void @"github.com/goplus/llgo/cl/_testlibc/atomic.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibc/atomic.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testlibc/atomic.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -21,7 +22,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testlibc/atomic.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibc/atomic.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   store atomic i64 100, ptr %0 seq_cst, align 4
@@ -46,6 +48,9 @@ _llgo_0:
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
 declare i32 @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testlibc/demangle/out.ll
+++ b/cl/_testlibc/demangle/out.ll
@@ -8,7 +8,8 @@ source_filename = "github.com/goplus/llgo/cl/_testlibc/demangle"
 @1 = private unnamed_addr constant [4 x i8] c"%s\0A\00", align 1
 @2 = private unnamed_addr constant [18 x i8] c"Failed to demangle", align 1
 
-define void @"github.com/goplus/llgo/cl/_testlibc/demangle.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibc/demangle.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testlibc/demangle.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -21,7 +22,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testlibc/demangle.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibc/demangle.main"() #0 {
 _llgo_0:
   %0 = call ptr @_ZN4llvm15itaniumDemangleENSt3__117basic_string_viewIcNS0_11char_traitsIcEEEEb(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 29 }, i1 true)
   %1 = icmp ne ptr %0, null
@@ -44,6 +46,10 @@ declare ptr @_ZN4llvm15itaniumDemangleENSt3__117basic_string_viewIcNS0_11char_tr
 
 declare i32 @printf(ptr, ...)
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testlibc/sqlite/out.ll
+++ b/cl/_testlibc/sqlite/out.ll
@@ -5,7 +5,8 @@ source_filename = "github.com/goplus/llgo/cl/_testlibc/sqlite"
 @0 = private unnamed_addr constant [20 x i8] c"==> Error: (%d) %s\0A\00", align 1
 @1 = private unnamed_addr constant [9 x i8] c":memory:\00", align 1
 
-define void @"github.com/goplus/llgo/cl/_testlibc/sqlite.check"(i32 %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibc/sqlite.check"(i32 %0) #0 {
 _llgo_0:
   %1 = icmp ne i32 %0, 0
   br i1 %1, label %_llgo_1, label %_llgo_2
@@ -20,7 +21,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testlibc/sqlite.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibc/sqlite.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testlibc/sqlite.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -33,7 +35,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testlibc/sqlite.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibc/sqlite.main"() #0 {
 _llgo_0:
   %0 = call { ptr, i32 } @"github.com/goplus/lib/c/sqlite.OpenV2"(ptr @1, i32 130, ptr null)
   %1 = extractvalue { ptr, i32 } %0, 0
@@ -49,6 +52,9 @@ declare i32 @printf(ptr, ...)
 
 declare void @exit(i32)
 
-declare { ptr, i32 } @"github.com/goplus/lib/c/sqlite.OpenV2"(ptr, i32, ptr)
+; Function Attrs: null_pointer_is_valid
+declare { ptr, i32 } @"github.com/goplus/lib/c/sqlite.OpenV2"(ptr, i32, ptr) #0
 
 declare i32 @sqlite3_close(ptr)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testlibgo/atomic/out.ll
+++ b/cl/_testlibgo/atomic/out.ll
@@ -9,7 +9,8 @@ source_filename = "github.com/goplus/llgo/cl/_testlibgo/atomic"
 @2 = private unnamed_addr constant [2 x i8] c"v:", align 1
 @3 = private unnamed_addr constant [4 x i8] c"swp:", align 1
 
-define void @"github.com/goplus/llgo/cl/_testlibgo/atomic.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibgo/atomic.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testlibgo/atomic.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -23,7 +24,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testlibgo/atomic.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibgo/atomic.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   store atomic i64 100, ptr %0 seq_cst, align 4
@@ -79,14 +81,22 @@ _llgo_0:
   ret void
 }
 
-declare void @"sync/atomic.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"sync/atomic.init"() #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testlibgo/bytes/out.ll
+++ b/cl/_testlibgo/bytes/out.ll
@@ -12,7 +12,8 @@ source_filename = "github.com/goplus/llgo/cl/_testlibgo/bytes"
 @3 = private unnamed_addr constant [2 x i8] c"Go", align 1
 @4 = private unnamed_addr constant [2 x i8] c"go", align 1
 
-define void @"github.com/goplus/llgo/cl/_testlibgo/bytes.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibgo/bytes.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testlibgo/bytes.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -26,7 +27,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testlibgo/bytes.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibgo/bytes.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 40)
   %1 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 6 })
@@ -48,26 +50,40 @@ _llgo_0:
   ret void
 }
 
-declare void @bytes.init()
+; Function Attrs: null_pointer_is_valid
+declare void @bytes.init() #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).Write"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+; Function Attrs: null_pointer_is_valid
+declare { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).Write"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.Slice") #0
 
-declare { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).WriteString"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"bytes.(*Buffer).WriteString"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"bytes.(*Buffer).Bytes"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"bytes.(*Buffer).Bytes"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"bytes.(*Buffer).String"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"bytes.(*Buffer).String"(ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice") #0
 
-declare i1 @bytes.EqualFold(%"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+; Function Attrs: null_pointer_is_valid
+declare i1 @bytes.EqualFold(%"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.Slice") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testlibgo/complex/out.ll
+++ b/cl/_testlibgo/complex/out.ll
@@ -8,7 +8,8 @@ source_filename = "github.com/goplus/llgo/cl/_testlibgo/complex"
 @1 = private unnamed_addr constant [11 x i8] c"real(3+4i):", align 1
 @2 = private unnamed_addr constant [11 x i8] c"imag(3+4i):", align 1
 
-define void @"github.com/goplus/llgo/cl/_testlibgo/complex.f"({ double, double } %0, { double, double } %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibgo/complex.f"({ double, double } %0, { double, double } %1) #0 {
 _llgo_0:
   %2 = call double @"math/cmplx.Abs"({ double, double } %0)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 10 })
@@ -28,7 +29,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testlibgo/complex.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibgo/complex.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testlibgo/complex.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -42,18 +44,26 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testlibgo/complex.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibgo/complex.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/cl/_testlibgo/complex.f"({ double, double } { double 3.000000e+00, double 4.000000e+00 }, { double, double } { double 3.000000e+00, double 4.000000e+00 })
   ret void
 }
 
-declare double @"math/cmplx.Abs"({ double, double })
+; Function Attrs: null_pointer_is_valid
+declare double @"math/cmplx.Abs"({ double, double }) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintFloat"(double)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintFloat"(double) #0
 
-declare void @"math/cmplx.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"math/cmplx.init"() #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testlibgo/errors/out.ll
+++ b/cl/_testlibgo/errors/out.ll
@@ -8,7 +8,8 @@ source_filename = "github.com/goplus/llgo/cl/_testlibgo/errors"
 @"github.com/goplus/llgo/cl/_testlibgo/errors.init$guard" = global i1 false, align 1
 @0 = private unnamed_addr constant [5 x i8] c"error", align 1
 
-define void @"github.com/goplus/llgo/cl/_testlibgo/errors.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibgo/errors.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testlibgo/errors.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -22,7 +23,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testlibgo/errors.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibgo/errors.main"() #0 {
 _llgo_0:
   %0 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @errors.New(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 5 })
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
@@ -33,10 +35,16 @@ _llgo_0:
   unreachable
 }
 
-declare void @errors.init()
+; Function Attrs: null_pointer_is_valid
+declare void @errors.init() #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @errors.New(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @errors.New(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testlibgo/math/out.ll
+++ b/cl/_testlibgo/math/out.ll
@@ -3,7 +3,8 @@ source_filename = "github.com/goplus/llgo/cl/_testlibgo/math"
 
 @"github.com/goplus/llgo/cl/_testlibgo/math.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testlibgo/math.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibgo/math.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testlibgo/math.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -17,7 +18,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testlibgo/math.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibgo/math.main"() #0 {
 _llgo_0:
   %0 = call double @math.Sqrt(double 2.000000e+00)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintFloat"(double %0)
@@ -31,14 +33,22 @@ _llgo_0:
   ret void
 }
 
-declare void @math.init()
+; Function Attrs: null_pointer_is_valid
+declare void @math.init() #0
 
-declare double @math.Sqrt(double)
+; Function Attrs: null_pointer_is_valid
+declare double @math.Sqrt(double) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintFloat"(double)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintFloat"(double) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare double @math.Abs(double)
+; Function Attrs: null_pointer_is_valid
+declare double @math.Abs(double) #0
 
-declare double @math.Ldexp(double, i64)
+; Function Attrs: null_pointer_is_valid
+declare double @math.Ldexp(double, i64) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testlibgo/mathbits/out.ll
+++ b/cl/_testlibgo/mathbits/out.ll
@@ -3,7 +3,8 @@ source_filename = "github.com/goplus/llgo/cl/_testlibgo/mathbits"
 
 @"github.com/goplus/llgo/cl/_testlibgo/mathbits.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testlibgo/mathbits.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibgo/mathbits.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testlibgo/mathbits.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -17,7 +18,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testlibgo/mathbits.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibgo/mathbits.main"() #0 {
 _llgo_0:
   %0 = call i64 @"math/bits.Len8"(i8 20)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %0)
@@ -28,12 +30,19 @@ _llgo_0:
   ret void
 }
 
-declare void @"math/bits.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"math/bits.init"() #0
 
-declare i64 @"math/bits.Len8"(i8)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"math/bits.Len8"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare i64 @"math/bits.OnesCount"(i64)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"math/bits.OnesCount"(i64) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testlibgo/nettextproto/out.ll
+++ b/cl/_testlibgo/nettextproto/out.ll
@@ -6,7 +6,8 @@ source_filename = "github.com/goplus/llgo/cl/_testlibgo/nettextproto"
 @"github.com/goplus/llgo/cl/_testlibgo/nettextproto.init$guard" = global i1 false, align 1
 @0 = private unnamed_addr constant [4 x i8] c"host", align 1
 
-define void @"github.com/goplus/llgo/cl/_testlibgo/nettextproto.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibgo/nettextproto.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testlibgo/nettextproto.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -20,7 +21,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testlibgo/nettextproto.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibgo/nettextproto.main"() #0 {
 _llgo_0:
   %0 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @"net/textproto.CanonicalMIMEHeaderKey"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 4 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0)
@@ -28,10 +30,16 @@ _llgo_0:
   ret void
 }
 
-declare void @"net/textproto.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"net/textproto.init"() #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"net/textproto.CanonicalMIMEHeaderKey"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"net/textproto.CanonicalMIMEHeaderKey"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testlibgo/os/out.ll
+++ b/cl/_testlibgo/os/out.ll
@@ -8,7 +8,8 @@ source_filename = "github.com/goplus/llgo/cl/_testlibgo/os"
 @"github.com/goplus/llgo/cl/_testlibgo/os.init$guard" = global i1 false, align 1
 @0 = private unnamed_addr constant [4 x i8] c"cwd:", align 1
 
-define void @"github.com/goplus/llgo/cl/_testlibgo/os.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibgo/os.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testlibgo/os.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -22,7 +23,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testlibgo/os.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibgo/os.main"() #0 {
 _llgo_0:
   %0 = call { %"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @os.Getwd()
   %1 = extractvalue { %"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %0, 0
@@ -54,16 +56,25 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-declare void @os.init()
+; Function Attrs: null_pointer_is_valid
+declare void @os.init() #0
 
-declare { %"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @os.Getwd()
+; Function Attrs: null_pointer_is_valid
+declare { %"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @os.Getwd() #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface", %"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface", %"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testlibgo/strings/out.ll
+++ b/cl/_testlibgo/strings/out.ll
@@ -15,7 +15,8 @@ source_filename = "github.com/goplus/llgo/cl/_testlibgo/strings"
 @6 = private unnamed_addr constant [12 x i8] c"Hello, world", align 1
 @unicode.Han = external global ptr, align 8
 
-define void @"github.com/goplus/llgo/cl/_testlibgo/strings.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibgo/strings.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testlibgo/strings.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -30,7 +31,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testlibgo/strings.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testlibgo/strings.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 32)
   %1 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 6 })
@@ -60,38 +62,52 @@ _llgo_0:
   ret void
 }
 
-define i1 @"github.com/goplus/llgo/cl/_testlibgo/strings.main$1"(i32 %0) {
+; Function Attrs: null_pointer_is_valid
+define i1 @"github.com/goplus/llgo/cl/_testlibgo/strings.main$1"(i32 %0) #0 {
 _llgo_0:
   %1 = load ptr, ptr @unicode.Han, align 8
   %2 = call i1 @unicode.Is(ptr %1, i32 %0)
   ret i1 %2
 }
 
-declare void @strings.init()
+; Function Attrs: null_pointer_is_valid
+declare void @strings.init() #0
 
-declare void @unicode.init()
+; Function Attrs: null_pointer_is_valid
+declare void @unicode.init() #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"strings.(*Builder).Write"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+; Function Attrs: null_pointer_is_valid
+declare { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"strings.(*Builder).Write"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.Slice") #0
 
-declare { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"strings.(*Builder).WriteString"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"strings.(*Builder).WriteString"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare i64 @"strings.(*Builder).Len"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"strings.(*Builder).Len"(ptr) #0
 
-declare i64 @"strings.(*Builder).Cap"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"strings.(*Builder).Cap"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"strings.(*Builder).String"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"strings.(*Builder).String"(ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare i64 @strings.IndexFunc(%"github.com/goplus/llgo/runtime/internal/runtime.String", { ptr, ptr })
+; Function Attrs: null_pointer_is_valid
+declare i64 @strings.IndexFunc(%"github.com/goplus/llgo/runtime/internal/runtime.String", { ptr, ptr }) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/cl/_testlibgo/strings.main$1"(ptr %0, i32 %1) {
 _llgo_0:
@@ -99,4 +115,7 @@ _llgo_0:
   ret i1 %2
 }
 
-declare i1 @unicode.Is(ptr, i32)
+; Function Attrs: null_pointer_is_valid
+declare i1 @unicode.Is(ptr, i32) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testpy/callpy/out.ll
+++ b/cl/_testpy/callpy/out.ll
@@ -14,7 +14,8 @@ source_filename = "github.com/goplus/llgo/cl/_testpy/callpy"
 @__llgo_py.os = external global ptr, align 8
 @4 = private unnamed_addr constant [7 x i8] c"getcwd\00", align 1
 
-define void @"github.com/goplus/llgo/cl/_testpy/callpy.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testpy/callpy.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testpy/callpy.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -36,7 +37,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testpy/callpy.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testpy/callpy.main"() #0 {
 _llgo_0:
   %0 = call ptr @PyFloat_FromDouble(double 2.000000e+00)
   %1 = load ptr, ptr @__llgo_py.math.sqrt, align 8
@@ -51,11 +53,14 @@ _llgo_0:
   ret void
 }
 
-declare void @"github.com/goplus/lib/py/math.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/lib/py/math.init"() #0
 
-declare void @"github.com/goplus/lib/py/os.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/lib/py/os.init"() #0
 
-declare void @"github.com/goplus/lib/py/std.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/lib/py/std.init"() #0
 
 declare ptr @PyFloat_FromDouble(double)
 
@@ -72,3 +77,5 @@ declare ptr @PyUnicode_FromString(ptr)
 declare ptr @PyObject_CallFunctionObjArgs(ptr, ...)
 
 declare void @llgoLoadPyModSyms(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testpy/gcd/out.ll
+++ b/cl/_testpy/gcd/out.ll
@@ -7,7 +7,8 @@ source_filename = "github.com/goplus/llgo/cl/_testpy/gcd"
 @__llgo_py.math = external global ptr, align 8
 @1 = private unnamed_addr constant [4 x i8] c"gcd\00", align 1
 
-define void @"github.com/goplus/llgo/cl/_testpy/gcd.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testpy/gcd.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testpy/gcd.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -23,7 +24,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testpy/gcd.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testpy/gcd.main"() #0 {
 _llgo_0:
   %0 = call ptr @PyLong_FromLong(i64 60)
   %1 = call ptr @PyLong_FromLong(i64 20)
@@ -35,7 +37,8 @@ _llgo_0:
   ret void
 }
 
-declare void @"github.com/goplus/lib/py/math.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/lib/py/math.init"() #0
 
 declare ptr @PyLong_FromLong(i64)
 
@@ -46,3 +49,5 @@ declare i64 @PyLong_AsLong(ptr)
 declare i32 @printf(ptr, ...)
 
 declare void @llgoLoadPyModSyms(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testpy/list/out.ll
+++ b/cl/_testpy/list/out.ll
@@ -15,7 +15,8 @@ source_filename = "github.com/goplus/llgo/cl/_testpy/list"
 @3 = private unnamed_addr constant [4 x i8] c"abs\00", align 1
 @4 = private unnamed_addr constant [6 x i8] c"print\00", align 1
 
-define void @"github.com/goplus/llgo/cl/_testpy/list.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testpy/list.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testpy/list.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -32,7 +33,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testpy/list.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testpy/list.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   store i64 100, ptr %0, align 4
@@ -96,16 +98,20 @@ _llgo_0:
   ret void
 }
 
-declare void @"github.com/goplus/lib/py/math.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/lib/py/math.init"() #0
 
-declare void @"github.com/goplus/lib/py/std.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/lib/py/std.init"() #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
 declare ptr @PyList_New(i64)
 
@@ -133,4 +139,5 @@ declare ptr @PyObject_CallFunctionObjArgs(ptr, ...)
 
 declare void @llgoLoadPyModSyms(ptr, ...)
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testpy/math/out.ll
+++ b/cl/_testpy/math/out.ll
@@ -5,7 +5,8 @@ source_filename = "github.com/goplus/llgo/cl/_testpy/math"
 @__llgo_py.math = linkonce global ptr null, align 8
 @0 = private unnamed_addr constant [5 x i8] c"math\00", align 1
 
-define void @"github.com/goplus/llgo/cl/_testpy/math.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testpy/math.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testpy/math.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -26,3 +27,5 @@ _llgo_3:                                          ; preds = %_llgo_1
 }
 
 declare ptr @PyImport_ImportModule(ptr)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testpy/matrix/out.ll
+++ b/cl/_testpy/matrix/out.ll
@@ -9,7 +9,8 @@ source_filename = "github.com/goplus/llgo/cl/_testpy/matrix"
 @__llgo_py.numpy = external global ptr, align 8
 @3 = private unnamed_addr constant [4 x i8] c"add\00", align 1
 
-define void @"github.com/goplus/llgo/cl/_testpy/matrix.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testpy/matrix.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testpy/matrix.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -25,7 +26,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testpy/matrix.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testpy/matrix.main"() #0 {
 _llgo_0:
   %0 = call ptr @PyList_New(i64 3)
   %1 = call ptr @PyFloat_FromDouble(double 1.000000e+00)
@@ -91,7 +93,8 @@ _llgo_0:
   ret void
 }
 
-declare void @"github.com/goplus/lib/py/numpy.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/lib/py/numpy.init"() #0
 
 declare ptr @PyList_New(i64)
 
@@ -108,3 +111,5 @@ declare ptr @PyUnicode_AsUTF8(ptr)
 declare i32 @printf(ptr, ...)
 
 declare void @llgoLoadPyModSyms(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testpy/max/out.ll
+++ b/cl/_testpy/max/out.ll
@@ -10,7 +10,8 @@ source_filename = "github.com/goplus/llgo/cl/_testpy/max"
 @1 = private unnamed_addr constant [4 x i8] c"max\00", align 1
 @2 = private unnamed_addr constant [6 x i8] c"print\00", align 1
 
-define void @"github.com/goplus/llgo/cl/_testpy/max.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testpy/max.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testpy/max.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -26,7 +27,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testpy/max.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testpy/max.main"() #0 {
 _llgo_0:
   %0 = call ptr @PyFloat_FromDouble(double 3.000000e+00)
   %1 = call ptr @PyFloat_FromDouble(double 9.000000e+00)
@@ -67,7 +69,8 @@ _llgo_0:
   ret void
 }
 
-declare void @"github.com/goplus/lib/py/std.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/lib/py/std.init"() #0
 
 declare ptr @PyFloat_FromDouble(double)
 
@@ -84,3 +87,5 @@ declare ptr @PyTuple_New(i64)
 declare i32 @PyTuple_SetItem(ptr, i64, ptr)
 
 declare void @llgoLoadPyModSyms(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testpy/pi/out.ll
+++ b/cl/_testpy/pi/out.ll
@@ -6,7 +6,8 @@ source_filename = "github.com/goplus/llgo/cl/_testpy/pi"
 @__llgo_py.math = external global ptr, align 8
 @1 = private unnamed_addr constant [3 x i8] c"pi\00", align 1
 
-define void @"github.com/goplus/llgo/cl/_testpy/pi.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testpy/pi.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testpy/pi.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -20,7 +21,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testpy/pi.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testpy/pi.main"() #0 {
 _llgo_0:
   %0 = load ptr, ptr @__llgo_py.math, align 8
   %1 = call ptr @PyObject_GetAttrString(ptr %0, ptr @1)
@@ -29,10 +31,13 @@ _llgo_0:
   ret void
 }
 
-declare void @"github.com/goplus/lib/py/math.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/lib/py/math.init"() #0
 
 declare ptr @PyObject_GetAttrString(ptr, ptr)
 
 declare double @PyFloat_AsDouble(ptr)
 
 declare i32 @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testpy/pow/out.ll
+++ b/cl/_testpy/pow/out.ll
@@ -7,7 +7,8 @@ source_filename = "github.com/goplus/llgo/cl/_testpy/pow"
 @__llgo_py.math = external global ptr, align 8
 @1 = private unnamed_addr constant [4 x i8] c"pow\00", align 1
 
-define void @"github.com/goplus/llgo/cl/_testpy/pow.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testpy/pow.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testpy/pow.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -23,7 +24,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testpy/pow.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testpy/pow.main"() #0 {
 _llgo_0:
   %0 = call ptr @PyFloat_FromDouble(double 2.000000e+00)
   %1 = call ptr @PyFloat_FromDouble(double 3.000000e+00)
@@ -34,7 +36,8 @@ _llgo_0:
   ret void
 }
 
-declare void @"github.com/goplus/lib/py/math.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/lib/py/math.init"() #0
 
 declare ptr @PyFloat_FromDouble(double)
 
@@ -45,3 +48,5 @@ declare double @PyFloat_AsDouble(ptr)
 declare i32 @printf(ptr, ...)
 
 declare void @llgoLoadPyModSyms(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/abinamed/out.ll
+++ b/cl/_testrt/abinamed/out.ll
@@ -275,7 +275,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/abinamed"
 @129 = private unnamed_addr constant [13 x i8] c"error field 2", align 1
 @130 = private unnamed_addr constant [13 x i8] c"error field 3", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/abinamed.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/abinamed.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/abinamed.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -289,7 +290,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/abinamed.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/abinamed.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 48)
   store %"github.com/goplus/llgo/cl/_testrt/abinamed.T" zeroinitializer, ptr %0, align 8
@@ -485,16 +487,19 @@ _llgo_12:                                         ; preds = %_llgo_10
   ret void
 }
 
-define ptr @"github.com/goplus/llgo/cl/_testrt/abinamed.toEface"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %0) {
+; Function Attrs: null_pointer_is_valid
+define ptr @"github.com/goplus/llgo/cl/_testrt/abinamed.toEface"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
   store %"github.com/goplus/llgo/runtime/internal/runtime.eface" %0, ptr %1, align 8
   ret ptr %1
 }
 
-declare void @"github.com/goplus/llgo/runtime/abi.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/abi.init"() #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -502,7 +507,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -510,7 +516,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -518,7 +525,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -526,7 +534,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -534,99 +543,146 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*Type).Align"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*Type).Align"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*Type).ArrayType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*Type).ArrayType"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*ArrayType).Align"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*ArrayType).Align"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*ArrayType).ArrayType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*ArrayType).ArrayType"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*ArrayType).ChanDir"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*ArrayType).ChanDir"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*ArrayType).Common"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*ArrayType).Common"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*ArrayType).ExportedMethods"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*ArrayType).ExportedMethods"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*Method).Exported"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*Method).Exported"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*Method).Name"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*Method).Name"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*Method).PkgPath"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*Method).PkgPath"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*FuncType).Align"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*FuncType).Align"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*FuncType).ArrayType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*FuncType).ArrayType"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*FuncType).ChanDir"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*FuncType).ChanDir"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*FuncType).Common"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*FuncType).Common"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*FuncType).Elem"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*FuncType).Elem"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*FuncType).ExportedMethods"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*FuncType).ExportedMethods"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*FuncType).FieldAlign"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*FuncType).FieldAlign"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*FuncType).FuncType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*FuncType).FuncType"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*FuncType).GcSlice"(ptr, i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*FuncType).GcSlice"(ptr, i64, i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*FuncType).HasName"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*FuncType).HasName"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*FuncType).IfaceIndir"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*FuncType).IfaceIndir"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*FuncType).InterfaceType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*FuncType).InterfaceType"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*Imethod).Exported"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*Imethod).Exported"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*Imethod).Name"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*Imethod).Name"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*Imethod).PkgPath"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*Imethod).PkgPath"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).Align"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).Align"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).ArrayType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).ArrayType"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).ChanDir"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).ChanDir"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).Common"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).Common"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).Elem"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).Elem"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).ExportedMethods"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).ExportedMethods"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).FieldAlign"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).FieldAlign"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).FuncType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).FuncType"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).GcSlice"(ptr, i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).GcSlice"(ptr, i64, i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).HasName"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).HasName"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).IfaceIndir"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).IfaceIndir"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).InterfaceType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).InterfaceType"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).IsClosure"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).IsClosure"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).IsDirectIface"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).IsDirectIface"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).Key"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).Key"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).Kind"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).Kind"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*Kind).String"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*Kind).String"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.Kind.String"(i64)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.Kind.String"(i64) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).Len"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).Len"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).MapType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).MapType"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal16"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal16"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal16"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -634,245 +690,365 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*MapType).Align"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*MapType).Align"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*MapType).ArrayType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*MapType).ArrayType"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*MapType).ChanDir"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*MapType).ChanDir"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*MapType).Common"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*MapType).Common"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*MapType).ExportedMethods"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*MapType).ExportedMethods"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*MapType).FieldAlign"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*MapType).FieldAlign"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*MapType).FuncType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*MapType).FuncType"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*MapType).GcSlice"(ptr, i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*MapType).GcSlice"(ptr, i64, i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*MapType).HasName"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*MapType).HasName"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*MapType).HashMightPanic"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*MapType).HashMightPanic"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*MapType).IfaceIndir"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*MapType).IfaceIndir"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*MapType).IndirectElem"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*MapType).IndirectElem"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*MapType).IndirectKey"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*MapType).IndirectKey"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*MapType).InterfaceType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*MapType).InterfaceType"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*MapType).IsClosure"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*MapType).IsClosure"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*MapType).IsDirectIface"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*MapType).IsDirectIface"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*MapType).Kind"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*MapType).Kind"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*MapType).Len"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*MapType).Len"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*MapType).MapType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*MapType).MapType"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*MapType).NeedKeyUpdate"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*MapType).NeedKeyUpdate"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*MapType).NumMethod"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*MapType).NumMethod"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*MapType).Pointers"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*MapType).Pointers"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*MapType).ReflexiveKey"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*MapType).ReflexiveKey"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*MapType).Size"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*MapType).Size"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*MapType).String"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*MapType).String"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*MapType).StructType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*MapType).StructType"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*StructField).Embedded"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*StructField).Embedded"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*StructField).Exported"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*StructField).Exported"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*StructType).Align"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*StructType).Align"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*StructType).ArrayType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*StructType).ArrayType"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*StructType).ChanDir"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*StructType).ChanDir"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*StructType).Common"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*StructType).Common"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*StructType).Elem"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*StructType).Elem"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*StructType).ExportedMethods"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*StructType).ExportedMethods"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*StructType).FieldAlign"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*StructType).FieldAlign"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*StructType).FuncType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*StructType).FuncType"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*StructType).GcSlice"(ptr, i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*StructType).GcSlice"(ptr, i64, i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*StructType).HasName"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*StructType).HasName"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*StructType).IfaceIndir"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*StructType).IfaceIndir"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*StructType).InterfaceType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*StructType).InterfaceType"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*StructType).IsClosure"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*StructType).IsClosure"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*StructType).IsDirectIface"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*StructType).IsDirectIface"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*StructType).Key"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*StructType).Key"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*StructType).Kind"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*StructType).Kind"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*StructType).Len"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*StructType).Len"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*StructType).MapType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*StructType).MapType"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*StructType).NumMethod"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*StructType).NumMethod"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*StructType).Pointers"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*StructType).Pointers"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*StructType).Size"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*StructType).Size"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*StructType).String"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*StructType).String"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*StructType).StructType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*StructType).StructType"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*StructType).Uncommon"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*StructType).Uncommon"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*UncommonType).ExportedMethods"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*UncommonType).ExportedMethods"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*UncommonType).Methods"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*UncommonType).Methods"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*MapType).Uncommon"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*MapType).Uncommon"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).NumMethod"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).NumMethod"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).Pointers"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).Pointers"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).Size"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).Size"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).String"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).String"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).StructType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).StructType"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).Uncommon"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*InterfaceType).Uncommon"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*FuncType).IsClosure"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*FuncType).IsClosure"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*FuncType).IsDirectIface"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*FuncType).IsDirectIface"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*FuncType).Key"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*FuncType).Key"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*FuncType).Kind"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*FuncType).Kind"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*FuncType).Len"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*FuncType).Len"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*FuncType).MapType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*FuncType).MapType"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*FuncType).NumMethod"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*FuncType).NumMethod"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*FuncType).Pointers"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*FuncType).Pointers"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*FuncType).Size"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*FuncType).Size"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*FuncType).String"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*FuncType).String"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*FuncType).StructType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*FuncType).StructType"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*FuncType).Uncommon"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*FuncType).Uncommon"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*FuncType).Variadic"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*FuncType).Variadic"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*ArrayType).FieldAlign"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*ArrayType).FieldAlign"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*ArrayType).FuncType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*ArrayType).FuncType"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*ArrayType).GcSlice"(ptr, i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*ArrayType).GcSlice"(ptr, i64, i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*ArrayType).HasName"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*ArrayType).HasName"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*ArrayType).IfaceIndir"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*ArrayType).IfaceIndir"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*ArrayType).InterfaceType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*ArrayType).InterfaceType"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*ArrayType).IsClosure"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*ArrayType).IsClosure"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*ArrayType).IsDirectIface"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*ArrayType).IsDirectIface"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*ArrayType).Key"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*ArrayType).Key"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*ArrayType).Kind"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*ArrayType).Kind"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*ArrayType).MapType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*ArrayType).MapType"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*ArrayType).NumMethod"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*ArrayType).NumMethod"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*ArrayType).Pointers"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*ArrayType).Pointers"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*ArrayType).Size"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*ArrayType).Size"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*ArrayType).String"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*ArrayType).String"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*ArrayType).StructType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*ArrayType).StructType"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*ArrayType).Uncommon"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*ArrayType).Uncommon"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*Type).ChanDir"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*Type).ChanDir"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*Type).Common"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*Type).Common"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*Type).Elem"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*Type).Elem"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*Type).ExportedMethods"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*Type).ExportedMethods"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*Type).FieldAlign"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*Type).FieldAlign"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*Type).FuncType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*Type).FuncType"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*Type).GcSlice"(ptr, i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/abi.(*Type).GcSlice"(ptr, i64, i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*Type).HasName"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*Type).HasName"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*Type).IfaceIndir"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*Type).IfaceIndir"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*Type).InterfaceType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*Type).InterfaceType"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*Type).IsClosure"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*Type).IsClosure"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*Type).IsDirectIface"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*Type).IsDirectIface"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*Type).Key"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*Type).Key"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*Type).Kind"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*Type).Kind"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*Type).Len"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*Type).Len"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*Type).MapType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*Type).MapType"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*Type).NumMethod"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*Type).NumMethod"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/abi.(*Type).Pointers"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/abi.(*Type).Pointers"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*Type).Size"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*Type).Size"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*Type).String"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*Type).String"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*Type).StructType"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*Type).StructType"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*Type).Uncommon"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*Type).Uncommon"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testrt/abitype/out.ll
+++ b/cl/_testrt/abitype/out.ll
@@ -20,7 +20,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/abitype"
 @"*_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1277858201, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @3, i64 5 }, ptr null }, ptr @_llgo_uint8 }, align 8
 @4 = private unnamed_addr constant [14 x i8] c"abi byte error", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/abitype.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/abitype.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/abitype.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -34,7 +35,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/abitype.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/abitype.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
   store %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int32, ptr null }, ptr %0, align 8
@@ -72,11 +74,14 @@ _llgo_4:                                          ; preds = %_llgo_2
   ret void
 }
 
-declare void @"github.com/goplus/llgo/runtime/abi.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/abi.init"() #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -84,7 +89,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -92,11 +98,14 @@ _llgo_0:
   ret i1 %3
 }
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*Type).String"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*Type).String"(ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -104,14 +113,19 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
   %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %1, ptr %2)
   ret i1 %3
 }
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/alloca/out.ll
+++ b/cl/_testrt/alloca/out.ll
@@ -5,7 +5,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/alloca"
 @0 = private unnamed_addr constant [4 x i8] c"Hi\0A\00", align 1
 @1 = private unnamed_addr constant [3 x i8] c"%s\00", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/alloca.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/alloca.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/alloca.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -18,7 +19,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/alloca.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/alloca.main"() #0 {
 _llgo_0:
   %0 = alloca i8, i64 4, align 1
   %1 = call ptr @memcpy(ptr %0, ptr @0, i64 4)
@@ -29,3 +31,5 @@ _llgo_0:
 declare ptr @memcpy(ptr, ptr, i64)
 
 declare i32 @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/allocstr/out.ll
+++ b/cl/_testrt/allocstr/out.ll
@@ -6,12 +6,14 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/allocstr"
 @"github.com/goplus/llgo/cl/_testrt/allocstr.init$guard" = global i1 false, align 1
 @0 = private unnamed_addr constant [12 x i8] c"Hello world\0A", align 1
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testrt/allocstr.hello"() {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testrt/allocstr.hello"() #0 {
 _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 12 }
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/allocstr.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/allocstr.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/allocstr.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -24,7 +26,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/allocstr.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/allocstr.main"() #0 {
 _llgo_0:
   %0 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testrt/allocstr.hello"()
   %1 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %0, 1
@@ -35,6 +38,9 @@ _llgo_0:
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.CStrCopy"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.CStrCopy"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
 declare i32 @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/any/out.ll
+++ b/cl/_testrt/any/out.ll
@@ -21,7 +21,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/any"
 @5 = private unnamed_addr constant [7 x i8] c"%s %d\0A\00", align 1
 @6 = private unnamed_addr constant [6 x i8] c"Hello\00", align 1
 
-define ptr @"github.com/goplus/llgo/cl/_testrt/any.hi"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %0) {
+; Function Attrs: null_pointer_is_valid
+define ptr @"github.com/goplus/llgo/cl/_testrt/any.hi"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %0) #0 {
 _llgo_0:
   %1 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %0, 0
   %2 = icmp eq ptr %1, @"*_llgo_int8"
@@ -39,7 +40,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   unreachable
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/any.incVal"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/any.incVal"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %0) #0 {
 _llgo_0:
   %1 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %0, 0
   %2 = icmp eq ptr %1, @_llgo_int
@@ -59,7 +61,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   unreachable
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/any.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/any.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/any.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -72,7 +75,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/any.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/any.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/cl/_testrt/any.hi"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @"*_llgo_int8", ptr @6 })
   %1 = call i64 @"github.com/goplus/llgo/cl/_testrt/any.incVal"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 100 to ptr) })
@@ -80,7 +84,8 @@ _llgo_0:
   ret void
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -88,7 +93,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -96,7 +102,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -104,11 +111,14 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -117,3 +127,5 @@ _llgo_0:
 }
 
 declare i32 @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/asm/out.ll
+++ b/cl/_testrt/asm/out.ll
@@ -3,7 +3,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/asm"
 
 @"github.com/goplus/llgo/cl/_testrt/asm.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/asm.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/asm.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/asm.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -16,8 +17,11 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/asm.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/asm.main"() #0 {
 _llgo_0:
   call void asm sideeffect "nop", ""()
   ret void
 }
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/asmfull/expect.txt
+++ b/cl/_testrt/asmfull/expect.txt
@@ -1,2 +1,1 @@
 Result: 42
-Result: 0

--- a/cl/_testrt/asmfull/in.go
+++ b/cl/_testrt/asmfull/in.go
@@ -23,5 +23,6 @@ func main() {
 		"x": 25,
 		"y": 17,
 	})
-	println("Result:", res2)
+	// the result of asmFull on a comment is undefined, just make sure it can be compiled successfully.
+	_ = res2
 }

--- a/cl/_testrt/asmfull/out.ll
+++ b/cl/_testrt/asmfull/out.ll
@@ -64,7 +64,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/asmfull"
 @20 = private unnamed_addr constant [1 x i8] c"x", align 1
 @21 = private unnamed_addr constant [1 x i8] c"y", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/asmfull.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/asmfull.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/asmfull.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -77,7 +78,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/asmfull.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/asmfull.main"() #0 {
 _llgo_0:
   call void asm sideeffect "nop", ""()
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_string]_llgo_any", i64 1)
@@ -106,14 +108,11 @@ _llgo_0:
   %11 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_string]_llgo_any", ptr %7, ptr %10)
   store %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 17 to ptr) }, ptr %11, align 8
   %12 = call i64 asm sideeffect "# calc ${1} + ${2} -> $0", "=&r,r,r"(i64 25, i64 17)
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @19, i64 7 })
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64 %12)
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
   ret void
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -121,9 +120,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.typehash"(ptr, ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.typehash"(ptr, ptr, i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -131,7 +132,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -139,11 +141,14 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -151,9 +156,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr, i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -161,12 +168,19 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAssign"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAssign"(ptr, ptr, ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/builtin/out.ll
+++ b/cl/_testrt/builtin/out.ll
@@ -22,7 +22,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/builtin"
 @6 = private unnamed_addr constant [3 x i8] c"abd", align 1
 @7 = private unnamed_addr constant [2 x i8] c"fn", align 1
 
-define double @"github.com/goplus/llgo/cl/_testrt/builtin.Float64frombits"(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define double @"github.com/goplus/llgo/cl/_testrt/builtin.Float64frombits"(i64 %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   store i64 %0, ptr %1, align 4
@@ -30,7 +31,8 @@ _llgo_0:
   ret double %2
 }
 
-define double @"github.com/goplus/llgo/cl/_testrt/builtin.Inf"(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define double @"github.com/goplus/llgo/cl/_testrt/builtin.Inf"(i64 %0) #0 {
 _llgo_0:
   %1 = icmp sge i64 %0, 0
   br i1 %1, label %_llgo_1, label %_llgo_3
@@ -47,24 +49,28 @@ _llgo_3:                                          ; preds = %_llgo_0
   br label %_llgo_2
 }
 
-define i1 @"github.com/goplus/llgo/cl/_testrt/builtin.IsNaN"(double %0) {
+; Function Attrs: null_pointer_is_valid
+define i1 @"github.com/goplus/llgo/cl/_testrt/builtin.IsNaN"(double %0) #0 {
 _llgo_0:
   %1 = fcmp une double %0, %0
   ret i1 %1
 }
 
-define double @"github.com/goplus/llgo/cl/_testrt/builtin.NaN"() {
+; Function Attrs: null_pointer_is_valid
+define double @"github.com/goplus/llgo/cl/_testrt/builtin.NaN"() #0 {
 _llgo_0:
   %0 = call double @"github.com/goplus/llgo/cl/_testrt/builtin.Float64frombits"(i64 9221120237041090561)
   ret double %0
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/builtin.demo"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/builtin.demo"() #0 {
 _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/builtin.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/builtin.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/builtin.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -80,7 +86,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/builtin.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/builtin.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 32)
   %1 = getelementptr inbounds i64, ptr %0, i64 0
@@ -445,19 +452,22 @@ _llgo_3:                                          ; preds = %_llgo_1
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/builtin.main$1"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/builtin.main$1"() #0 {
 _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/builtin.main$2"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/builtin.main$2"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 2 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/builtin.main$3"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/builtin.main$3"(ptr %0) #0 {
 _llgo_0:
   %1 = load { ptr }, ptr %0, align 8
   %2 = extractvalue { ptr } %1, 0
@@ -467,21 +477,29 @@ _llgo_0:
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.NewSlice3"(ptr, i64, i64, i64, i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.NewSlice3"(ptr, i64, i64, i64, i64, i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringSlice"(%"github.com/goplus/llgo/runtime/internal/runtime.String", i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringSlice"(%"github.com/goplus/llgo/runtime/internal/runtime.String", i64, i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.SliceAppend"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr, i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.SliceAppend"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr, i64, i64) #0
 
 define linkonce void @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/builtin.main$1"(ptr %0) {
 _llgo_0:
@@ -489,7 +507,8 @@ _llgo_0:
   ret void
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -497,7 +516,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -505,36 +525,55 @@ _llgo_0:
   ret i1 %3
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintFloat"(double)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintFloat"(double) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintEface"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintEface"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.SliceCopy"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr, i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.SliceCopy"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr, i64, i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewStringIter"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewStringIter"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare { i1, i64, i32 } @"github.com/goplus/llgo/runtime/internal/runtime.StringIterNext"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare { i1, i64, i32 } @"github.com/goplus/llgo/runtime/internal/runtime.StringIterNext"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.StringToRunes"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.StringToRunes"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringFromBytes"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringFromBytes"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice") #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringFromRunes"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringFromRunes"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringFromRune"(i32)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringFromRune"(i32) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringLess"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringLess"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String") #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/callback/out.ll
+++ b/cl/_testrt/callback/out.ll
@@ -5,7 +5,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/callback"
 @0 = private unnamed_addr constant [7 x i8] c"Hello\0A\00", align 1
 @1 = private unnamed_addr constant [10 x i8] c"callback\0A\00", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/callback.callback"(ptr %0, { ptr, ptr } %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/callback.callback"(ptr %0, { ptr, ptr } %1) #0 {
 _llgo_0:
   %2 = extractvalue { ptr, ptr } %1, 1
   %3 = extractvalue { ptr, ptr } %1, 0
@@ -13,7 +14,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/callback.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/callback.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/callback.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -26,14 +28,16 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/callback.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/callback.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/cl/_testrt/callback.callback"(ptr @0, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/callback.print", ptr null })
   call void @"github.com/goplus/llgo/cl/_testrt/callback.callback"(ptr @1, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/callback.print", ptr null })
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/callback.print"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/callback.print"(ptr %0) #0 {
 _llgo_0:
   %1 = call i32 (ptr, ...) @printf(ptr %0)
   ret void
@@ -46,3 +50,5 @@ _llgo_0:
 }
 
 declare i32 @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/cast/out.ll
+++ b/cl/_testrt/cast/out.ll
@@ -12,7 +12,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/cast"
 @1 = private unnamed_addr constant [6 x i8] c"string", align 1
 @"*_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1323879264, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 6 }, ptr null }, ptr @_llgo_string }, align 8
 
-define void @"github.com/goplus/llgo/cl/_testrt/cast.cvt32Fto32"(float %0, i32 %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/cast.cvt32Fto32"(float %0, i32 %1) #0 {
 _llgo_0:
   %2 = fptosi float %0 to i64
   %3 = trunc i64 %2 to i32
@@ -30,7 +31,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/cast.cvt32Fto32U"(float %0, i32 %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/cast.cvt32Fto32U"(float %0, i32 %1) #0 {
 _llgo_0:
   %2 = fcmp olt float %0, 0.000000e+00
   %3 = fptosi float %0 to i64
@@ -51,7 +53,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/cast.cvt32Fto64F"(float %0, double %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/cast.cvt32Fto64F"(float %0, double %1) #0 {
 _llgo_0:
   %2 = fpext float %0 to double
   %3 = fcmp une double %2, %1
@@ -68,7 +71,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/cast.cvt32Fto8"(float %0, i8 %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/cast.cvt32Fto8"(float %0, i8 %1) #0 {
 _llgo_0:
   %2 = fptosi float %0 to i64
   %3 = trunc i64 %2 to i8
@@ -86,7 +90,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/cast.cvt32Fto8U"(float %0, i8 %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/cast.cvt32Fto8U"(float %0, i8 %1) #0 {
 _llgo_0:
   %2 = fcmp olt float %0, 0.000000e+00
   %3 = fptosi float %0 to i64
@@ -107,7 +112,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/cast.cvt32to64"(i32 %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/cast.cvt32to64"(i32 %0, i64 %1) #0 {
 _llgo_0:
   %2 = sext i32 %0 to i64
   %3 = icmp ne i64 %2, %1
@@ -124,7 +130,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/cast.cvt64Fto32F"(double %0, float %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/cast.cvt64Fto32F"(double %0, float %1) #0 {
 _llgo_0:
   %2 = fptrunc double %0 to float
   %3 = fcmp une float %2, %1
@@ -141,7 +148,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/cast.cvt64Uto64F"(i64 %0, double %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/cast.cvt64Uto64F"(i64 %0, double %1) #0 {
 _llgo_0:
   %2 = uitofp i64 %0 to double
   %3 = fcmp une double %2, %1
@@ -158,7 +166,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/cast.cvt64to64F"(i64 %0, double %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/cast.cvt64to64F"(i64 %0, double %1) #0 {
 _llgo_0:
   %2 = sitofp i64 %0 to double
   %3 = fcmp une double %2, %1
@@ -175,7 +184,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/cast.cvt64to8"(i64 %0, i8 %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/cast.cvt64to8"(i64 %0, i8 %1) #0 {
 _llgo_0:
   %2 = trunc i64 %0 to i8
   %3 = icmp ne i8 %2, %1
@@ -192,7 +202,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/cast.cvt64to8U"(i64 %0, i8 %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/cast.cvt64to8U"(i64 %0, i8 %1) #0 {
 _llgo_0:
   %2 = trunc i64 %0 to i8
   %3 = icmp ne i8 %2, %1
@@ -209,7 +220,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/cast.cvtFtoUintptr"(double %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/cast.cvtFtoUintptr"(double %0, i64 %1) #0 {
 _llgo_0:
   %2 = fptoui double %0 to i64
   %3 = icmp ne i64 %2, %1
@@ -226,7 +238,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/cast.cvtUinptr"(i32 %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/cast.cvtUinptr"(i32 %0, i64 %1) #0 {
 _llgo_0:
   %2 = sext i32 %0 to i64
   %3 = icmp ne i64 %2, %1
@@ -255,7 +268,8 @@ _llgo_4:                                          ; preds = %_llgo_2
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/cast.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/cast.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/cast.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -268,7 +282,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/cast.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/cast.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/cl/_testrt/cast.cvt64to8"(i64 0, i8 0)
   call void @"github.com/goplus/llgo/cl/_testrt/cast.cvt64to8"(i64 127, i8 127)
@@ -328,7 +343,8 @@ _llgo_0:
   ret void
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -336,7 +352,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -344,6 +361,10 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/clear/out.ll
+++ b/cl/_testrt/clear/out.ll
@@ -45,7 +45,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/clear"
 @"*_llgo_uintptr" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1684891952, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @12, i64 7 }, ptr null }, ptr @_llgo_uintptr }, align 8
 @"_llgo_struct$RSTTp_pTKglBmcdy0CMmgLp9HSGRvgD8UwNIoMFFyOg$fields" = weak_odr constant [4 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @4, i64 7 }, ptr @"[8]_llgo_uint8", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 4 }, ptr @"[8]_llgo_int", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @10, i64 5 }, ptr @"[8]_llgo_int", i64 72, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @11, i64 8 }, ptr @_llgo_uintptr, i64 136, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
 
-define void @"github.com/goplus/llgo/cl/_testrt/clear.Clear"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/clear.Clear"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 32)
   %1 = getelementptr inbounds i64, ptr %0, i64 0
@@ -85,7 +86,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/clear.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/clear.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/clear.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -98,9 +100,11 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -108,7 +112,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -116,19 +121,26 @@ _llgo_0:
   ret i1 %3
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.SliceClear"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.SliceClear"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.Slice") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.typehash"(ptr, ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.typehash"(ptr, ptr, i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -136,12 +148,19 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr, i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAssign"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAssign"(ptr, ptr, ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.MapClear"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.MapClear"(ptr, ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/closure/out.ll
+++ b/cl/_testrt/closure/out.ll
@@ -5,7 +5,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/closure"
 @0 = private unnamed_addr constant [7 x i8] c"%d %d\0A\00", align 1
 @1 = private unnamed_addr constant [7 x i8] c"%d %d\0A\00", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/closure.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/closure.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/closure.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -18,7 +19,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/closure.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/closure.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/cl/_testrt/closure.main$1"(i64 100, i64 200)
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
@@ -33,19 +35,22 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/closure.main$1"(i64 %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/closure.main$1"(i64 %0, i64 %1) #0 {
 _llgo_0:
   %2 = call i32 (ptr, ...) @printf(ptr @0, i64 %0, i64 %1)
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/closure.main$2"(i64 %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/closure.main$2"(i64 %0, i64 %1) #0 {
 _llgo_0:
   %2 = call i32 (ptr, ...) @printf(ptr @1, i64 %0, i64 %1)
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/closure.main$3"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/closure.main$3"(ptr %0) #0 {
 _llgo_0:
   %1 = load { ptr }, ptr %0, align 8
   %2 = extractvalue { ptr } %1, 0
@@ -56,7 +61,8 @@ _llgo_0:
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
 define linkonce void @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/closure.main$2"(ptr %0, i64 %1, i64 %2) {
 _llgo_0:
@@ -64,6 +70,9 @@ _llgo_0:
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
 declare i32 @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/closurebound/out.ll
+++ b/cl/_testrt/closurebound/out.ll
@@ -15,31 +15,36 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/closurebound"
 @1 = private unnamed_addr constant [6 x i8] c"string", align 1
 @"*_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1323879264, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 6 }, ptr null }, ptr @_llgo_string }, align 8
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/closurebound.demo1.encode"(%"github.com/goplus/llgo/cl/_testrt/closurebound.demo1" %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/closurebound.demo1.encode"(%"github.com/goplus/llgo/cl/_testrt/closurebound.demo1" %0) #0 {
 _llgo_0:
   ret i64 1
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/closurebound.(*demo1).encode"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/closurebound.(*demo1).encode"(ptr %0) #0 {
 _llgo_0:
   %1 = load %"github.com/goplus/llgo/cl/_testrt/closurebound.demo1", ptr %0, align 1
   %2 = call i64 @"github.com/goplus/llgo/cl/_testrt/closurebound.demo1.encode"(%"github.com/goplus/llgo/cl/_testrt/closurebound.demo1" %1)
   ret i64 %2
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/closurebound.demo2.encode"(%"github.com/goplus/llgo/cl/_testrt/closurebound.demo2" %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/closurebound.demo2.encode"(%"github.com/goplus/llgo/cl/_testrt/closurebound.demo2" %0) #0 {
 _llgo_0:
   ret i64 2
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/closurebound.(*demo2).encode"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/closurebound.(*demo2).encode"(ptr %0) #0 {
 _llgo_0:
   %1 = load %"github.com/goplus/llgo/cl/_testrt/closurebound.demo2", ptr %0, align 1
   %2 = call i64 @"github.com/goplus/llgo/cl/_testrt/closurebound.demo2.encode"(%"github.com/goplus/llgo/cl/_testrt/closurebound.demo2" %1)
   ret i64 %2
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/closurebound.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/closurebound.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/closurebound.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -57,7 +62,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/closurebound.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/closurebound.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 0)
   %1 = getelementptr inbounds { %"github.com/goplus/llgo/cl/_testrt/closurebound.demo1" }, ptr %0, i32 0, i32 0
@@ -80,7 +86,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/closurebound.demo2.encode$bound"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/closurebound.demo2.encode$bound"(ptr %0) #0 {
 _llgo_0:
   %1 = load { %"github.com/goplus/llgo/cl/_testrt/closurebound.demo2" }, ptr %0, align 1
   %2 = extractvalue { %"github.com/goplus/llgo/cl/_testrt/closurebound.demo2" } %1, 0
@@ -88,9 +95,11 @@ _llgo_0:
   ret i64 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/closurebound.demo1.encode$bound"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/closurebound.demo1.encode$bound"(ptr %0) #0 {
 _llgo_0:
   %1 = load { %"github.com/goplus/llgo/cl/_testrt/closurebound.demo1" }, ptr %0, align 1
   %2 = extractvalue { %"github.com/goplus/llgo/cl/_testrt/closurebound.demo1" } %1, 0
@@ -98,7 +107,8 @@ _llgo_0:
   ret i64 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -106,7 +116,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -114,4 +125,7 @@ _llgo_0:
   ret i1 %3
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/closureconv/out.ll
+++ b/cl/_testrt/closureconv/out.ll
@@ -6,7 +6,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/closureconv"
 
 @"github.com/goplus/llgo/cl/_testrt/closureconv.init$guard" = global i1 false, align 1
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/closureconv.(*Call).add"(ptr %0, i64 %1, i64 %2) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/closureconv.(*Call).add"(ptr %0, i64 %1, i64 %2) #0 {
 _llgo_0:
   %3 = add i64 %1, %2
   %4 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testrt/closureconv.Call", ptr %0, i32 0, i32 1
@@ -15,13 +16,15 @@ _llgo_0:
   ret i64 %6
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/closureconv.add"(i64 %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/closureconv.add"(i64 %0, i64 %1) #0 {
 _llgo_0:
   %2 = add i64 %0, %1
   ret i64 %2
 }
 
-define %"github.com/goplus/llgo/cl/_testrt/closureconv.Func" @"github.com/goplus/llgo/cl/_testrt/closureconv.demo1"(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/cl/_testrt/closureconv.Func" @"github.com/goplus/llgo/cl/_testrt/closureconv.demo1"(i64 %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 24)
   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testrt/closureconv.Call", ptr %1, i32 0, i32 1
@@ -40,7 +43,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/cl/_testrt/closureconv.Func" %10
 }
 
-define %"github.com/goplus/llgo/cl/_testrt/closureconv.Func" @"github.com/goplus/llgo/cl/_testrt/closureconv.demo2"() {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/cl/_testrt/closureconv.Func" @"github.com/goplus/llgo/cl/_testrt/closureconv.demo2"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 24)
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 8)
@@ -53,23 +57,27 @@ _llgo_0:
   ret %"github.com/goplus/llgo/cl/_testrt/closureconv.Func" %5
 }
 
-define %"github.com/goplus/llgo/cl/_testrt/closureconv.Func" @"github.com/goplus/llgo/cl/_testrt/closureconv.demo3"() {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/cl/_testrt/closureconv.Func" @"github.com/goplus/llgo/cl/_testrt/closureconv.demo3"() #0 {
 _llgo_0:
   ret %"github.com/goplus/llgo/cl/_testrt/closureconv.Func" { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/closureconv.add", ptr null }
 }
 
-define %"github.com/goplus/llgo/cl/_testrt/closureconv.Func" @"github.com/goplus/llgo/cl/_testrt/closureconv.demo4"() {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/cl/_testrt/closureconv.Func" @"github.com/goplus/llgo/cl/_testrt/closureconv.demo4"() #0 {
 _llgo_0:
   ret %"github.com/goplus/llgo/cl/_testrt/closureconv.Func" { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/closureconv.demo4$1", ptr null }
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/closureconv.demo4$1"(i64 %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/closureconv.demo4$1"(i64 %0, i64 %1) #0 {
 _llgo_0:
   %2 = add i64 %0, %1
   ret i64 %2
 }
 
-define %"github.com/goplus/llgo/cl/_testrt/closureconv.Func" @"github.com/goplus/llgo/cl/_testrt/closureconv.demo5"(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/cl/_testrt/closureconv.Func" @"github.com/goplus/llgo/cl/_testrt/closureconv.demo5"(i64 %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   store i64 %0, ptr %1, align 4
@@ -83,7 +91,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/cl/_testrt/closureconv.Func" %6
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/closureconv.demo5$1"(ptr %0, i64 %1, i64 %2) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/closureconv.demo5$1"(ptr %0, i64 %1, i64 %2) #0 {
 _llgo_0:
   %3 = add i64 %1, %2
   %4 = load { ptr }, ptr %0, align 8
@@ -93,7 +102,8 @@ _llgo_0:
   ret i64 %7
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/closureconv.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/closureconv.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/closureconv.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -106,7 +116,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/closureconv.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/closureconv.main"() #0 {
 _llgo_0:
   %0 = call %"github.com/goplus/llgo/cl/_testrt/closureconv.Func" @"github.com/goplus/llgo/cl/_testrt/closureconv.demo1"(i64 1)
   %1 = extractvalue %"github.com/goplus/llgo/cl/_testrt/closureconv.Func" %0, 1
@@ -156,9 +167,11 @@ _llgo_0:
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/closureconv.(*Call).add$bound"(ptr %0, i64 %1, i64 %2) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/closureconv.(*Call).add$bound"(ptr %0, i64 %1, i64 %2) #0 {
 _llgo_0:
   %3 = load { ptr }, ptr %0, align 8
   %4 = extractvalue { ptr } %3, 0
@@ -166,7 +179,8 @@ _llgo_0:
   ret i64 %5
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
 define linkonce i64 @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/closureconv.add"(ptr %0, i64 %1, i64 %2) {
 _llgo_0:
@@ -180,6 +194,10 @@ _llgo_0:
   ret i64 %3
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/closureiface/out.ll
+++ b/cl/_testrt/closureiface/out.ll
@@ -33,7 +33,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/closureiface"
 @7 = private unnamed_addr constant [6 x i8] c"string", align 1
 @"*_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1323879264, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 6 }, ptr null }, ptr @_llgo_string }, align 8
 
-define void @"github.com/goplus/llgo/cl/_testrt/closureiface.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/closureiface.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/closureiface.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -46,7 +47,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/closureiface.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/closureiface.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   store i64 200, ptr %0, align 4
@@ -93,7 +95,8 @@ _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
   br i1 %19, label %_llgo_2, label %_llgo_1
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/closureiface.main$1"(ptr %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/closureiface.main$1"(ptr %0, i64 %1) #0 {
 _llgo_0:
   %2 = load { ptr }, ptr %0, align 8
   %3 = extractvalue { ptr } %2, 0
@@ -102,11 +105,14 @@ _llgo_0:
   ret i64 %5
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -114,7 +120,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -122,13 +129,17 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.MatchesClosure"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.MatchesClosure"(ptr, ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -136,4 +147,7 @@ _llgo_0:
   ret i1 %3
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/complex/out.ll
+++ b/cl/_testrt/complex/out.ll
@@ -3,7 +3,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/complex"
 
 @"github.com/goplus/llgo/cl/_testrt/complex.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/complex.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/complex.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/complex.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -16,7 +17,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/complex.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/complex.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintFloat"(double 1.000000e+00)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
@@ -49,10 +51,16 @@ _llgo_0:
   ret void
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintFloat"(double)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintFloat"(double) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintComplex"({ double, double })
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintComplex"({ double, double }) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/concat/out.ll
+++ b/cl/_testrt/concat/out.ll
@@ -10,7 +10,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/concat"
 @2 = private unnamed_addr constant [1 x i8] c" ", align 1
 @3 = private unnamed_addr constant [5 x i8] c"World", align 1
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testrt/concat.concat"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testrt/concat.concat"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0) #0 {
 _llgo_0:
   %1 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0, 1
   br label %_llgo_1
@@ -38,14 +39,16 @@ _llgo_3:                                          ; preds = %_llgo_1
   ret %"github.com/goplus/llgo/runtime/internal/runtime.String" %2
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testrt/concat.info"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testrt/concat.info"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0) #0 {
 _llgo_0:
   %1 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringCat"(%"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.String" %0)
   %2 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringCat"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %1, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 3 })
   ret %"github.com/goplus/llgo/runtime/internal/runtime.String" %2
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/concat.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/concat.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/concat.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -58,7 +61,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/concat.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/concat.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 48)
   %1 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %0, i64 0
@@ -76,12 +80,19 @@ _llgo_0:
   ret void
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringCat"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringCat"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/constuptr/out.ll
+++ b/cl/_testrt/constuptr/out.ll
@@ -3,7 +3,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/constuptr"
 
 @"github.com/goplus/llgo/cl/_testrt/constuptr.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/constuptr.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/constuptr.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/constuptr.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -16,13 +17,18 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/constuptr.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/constuptr.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr inttoptr (i64 100 to ptr))
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
   ret void
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/cstr/out.ll
+++ b/cl/_testrt/cstr/out.ll
@@ -4,7 +4,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/cstr"
 @"github.com/goplus/llgo/cl/_testrt/cstr.init$guard" = global i1 false, align 1
 @0 = private unnamed_addr constant [14 x i8] c"Hello, world\0A\00", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/cstr.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/cstr.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/cstr.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -17,10 +18,13 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/cstr.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/cstr.main"() #0 {
 _llgo_0:
   call void (ptr, ...) @printf(ptr @0)
   ret void
 }
 
 declare void @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/cvar/out.ll
+++ b/cl/_testrt/cvar/out.ll
@@ -5,7 +5,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/cvar"
 @_bar_y = external global { [16 x i8] }, align 1
 @"github.com/goplus/llgo/cl/_testrt/cvar.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/cvar.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/cvar.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/cvar.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -18,9 +19,12 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/cvar.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/cvar.main"() #0 {
 _llgo_0:
   %0 = load { [16 x i8], [2 x ptr] }, ptr @_bar_x, align 8
   %1 = load { [16 x i8] }, ptr @_bar_y, align 1
   ret void
 }
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/eface/out.ll
+++ b/cl/_testrt/eface/out.ll
@@ -96,14 +96,16 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/eface"
 @"*_llgo_github.com/goplus/llgo/cl/_testrt/eface.T" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [1 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1884578979, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @31, i64 6 }, ptr null }, ptr @"_llgo_github.com/goplus/llgo/cl/_testrt/eface.T" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @27, i64 39 }, i16 1, i16 1, i32 24 }, [1 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @32, i64 6 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"github.com/goplus/llgo/cl/_testrt/eface.(*T).Invoke", ptr @"github.com/goplus/llgo/cl/_testrt/eface.(*T).Invoke" }] }, align 8
 @32 = private unnamed_addr constant [6 x i8] c"Invoke", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/eface.(*T).Invoke"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/eface.(*T).Invoke"(ptr %0) #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 6 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/eface.dump"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/eface.dump"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
   store %"github.com/goplus/llgo/runtime/internal/runtime.eface" %0, ptr %1, align 8
@@ -113,7 +115,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/eface.dumpTyp"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.String" %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/eface.dumpTyp"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.String" %1) #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %1)
   %2 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*Type).String"(ptr %0)
@@ -188,7 +191,8 @@ _llgo_5:                                          ; preds = %_llgo_3
   br label %_llgo_4
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/eface.dumpUncommon"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.String" %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/eface.dumpUncommon"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.String" %1) #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %1)
   %2 = getelementptr inbounds %"github.com/goplus/llgo/runtime/abi.UncommonType", ptr %0, i32 0, i32 0
@@ -208,7 +212,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/eface.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/eface.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/eface.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -222,7 +227,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/eface.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/eface.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/cl/_testrt/eface.dump"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_bool, ptr inttoptr (i64 -1 to ptr) })
   call void @"github.com/goplus/llgo/cl/_testrt/eface.dump"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr null })
@@ -270,34 +276,47 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/eface.main$1"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/eface.main$1"() #0 {
 _llgo_0:
   ret void
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*Type).String"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/abi.(*Type).String"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/abi.(*Type).Kind"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/abi.(*Type).Kind"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*Type).Uncommon"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*Type).Uncommon"(ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/abi.(*Type).Elem"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/abi.(*Type).Elem"(ptr) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringCat"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringCat"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/abi.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/abi.init"() #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -305,7 +324,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -313,7 +333,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -321,7 +342,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal16"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal16"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal16"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -329,7 +351,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -337,7 +360,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.f32equal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.f32equal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.f32equal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -345,7 +369,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.f64equal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.f64equal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.f64equal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -353,9 +378,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
 define linkonce void @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/eface.main$1"(ptr %0) {
 _llgo_0:
@@ -363,7 +390,8 @@ _llgo_0:
   ret void
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -371,4 +399,7 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/float2any/out.ll
+++ b/cl/_testrt/float2any/out.ll
@@ -21,7 +21,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/float2any"
 @5 = private unnamed_addr constant [36 x i8] c"type assertion any -> float64 failed", align 1
 @6 = private unnamed_addr constant [9 x i8] c"error f64", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/float2any.check32"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/float2any.check32"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %0) #0 {
 _llgo_0:
   %1 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %0, 0
   %2 = icmp eq ptr %1, @_llgo_float32
@@ -53,7 +54,8 @@ _llgo_4:                                          ; preds = %_llgo_0
   unreachable
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/float2any.check64"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/float2any.check64"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %0) #0 {
 _llgo_0:
   %1 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %0, 0
   %2 = icmp eq ptr %1, @_llgo_float64
@@ -84,17 +86,20 @@ _llgo_4:                                          ; preds = %_llgo_0
   unreachable
 }
 
-define float @"github.com/goplus/llgo/cl/_testrt/float2any.f32"() {
+; Function Attrs: null_pointer_is_valid
+define float @"github.com/goplus/llgo/cl/_testrt/float2any.f32"() #0 {
 _llgo_0:
   ret float 0x400921FB60000000
 }
 
-define double @"github.com/goplus/llgo/cl/_testrt/float2any.f64"() {
+; Function Attrs: null_pointer_is_valid
+define double @"github.com/goplus/llgo/cl/_testrt/float2any.f64"() #0 {
 _llgo_0:
   ret double 0x400921FB53C8D4F1
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/float2any.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/float2any.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/float2any.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -107,7 +112,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/float2any.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/float2any.main"() #0 {
 _llgo_0:
   %0 = call float @"github.com/goplus/llgo/cl/_testrt/float2any.f32"()
   %1 = bitcast float %0 to i32
@@ -122,7 +128,8 @@ _llgo_0:
   ret void
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.f32equal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.f32equal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.f32equal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -130,7 +137,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -138,7 +146,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -146,14 +155,19 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.f64equal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.f64equal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.f64equal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
   %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.f64equal"(ptr %1, ptr %2)
   ret i1 %3
 }
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/fprintf/out.ll
+++ b/cl/_testrt/fprintf/out.ll
@@ -5,7 +5,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/fprintf"
 @__stderrp = external global ptr, align 8
 @0 = private unnamed_addr constant [10 x i8] c"Hello %d\0A\00", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/fprintf.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/fprintf.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/fprintf.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -18,7 +19,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/fprintf.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/fprintf.main"() #0 {
 _llgo_0:
   %0 = load ptr, ptr @__stderrp, align 8
   call void (ptr, ptr, ...) @fprintf(ptr %0, ptr @0, i64 100)
@@ -26,3 +28,5 @@ _llgo_0:
 }
 
 declare void @fprintf(ptr, ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/freevars/out.ll
+++ b/cl/_testrt/freevars/out.ll
@@ -6,7 +6,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/freevars"
 
 @"github.com/goplus/llgo/cl/_testrt/freevars.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/freevars.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/freevars.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/freevars.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -19,13 +20,15 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/freevars.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/freevars.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/cl/_testrt/freevars.main$1"({ ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/freevars.main$2", ptr null })
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/freevars.main$1"({ ptr, ptr } %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/freevars.main$1"({ ptr, ptr } %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
   store { ptr, ptr } %0, ptr %1, align 8
@@ -39,7 +42,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/freevars.main$1$1"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/freevars.main$1$1"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) #0 {
 _llgo_0:
   %2 = load { ptr }, ptr %0, align 8
   %3 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %1)
@@ -70,7 +74,8 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/freevars.main$2"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/freevars.main$2"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0) #0 {
 _llgo_0:
   ret void
 }
@@ -81,10 +86,16 @@ _llgo_0:
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface", %"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface", %"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/funcaddr/out.ll
+++ b/cl/_testrt/funcaddr/out.ll
@@ -3,13 +3,15 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/funcaddr"
 
 @"github.com/goplus/llgo/cl/_testrt/funcaddr.init$guard" = global i1 false, align 1
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/funcaddr.add"(i64 %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/funcaddr.add"(i64 %0, i64 %1) #0 {
 _llgo_0:
   %2 = add i64 %0, %1
   ret i64 %2
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/funcaddr.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/funcaddr.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/funcaddr.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -22,7 +24,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/funcaddr.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/funcaddr.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   store ptr @"github.com/goplus/llgo/cl/_testrt/funcaddr.add", ptr %0, align 8
@@ -45,14 +48,20 @@ _llgo_0:
   ret void
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/funcaddr.main$1"(i64 %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/funcaddr.main$1"(i64 %0, i64 %1) #0 {
 _llgo_0:
   %2 = add i64 %0, %1
   ret i64 %2
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/funcdecl/out.ll
+++ b/cl/_testrt/funcdecl/out.ll
@@ -31,7 +31,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/funcdecl"
 @7 = private unnamed_addr constant [4 x i8] c"demo", align 1
 @8 = private unnamed_addr constant [5 x i8] c"hello", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/funcdecl.check"({ ptr, ptr } %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/funcdecl.check"({ ptr, ptr } %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
   store { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/funcdecl.demo", ptr null }, ptr %1, align 8
@@ -90,7 +91,8 @@ _llgo_4:                                          ; preds = %_llgo_1
   unreachable
 }
 
-define ptr @"github.com/goplus/llgo/cl/_testrt/funcdecl.closurePtr"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %0) {
+; Function Attrs: null_pointer_is_valid
+define ptr @"github.com/goplus/llgo/cl/_testrt/funcdecl.closurePtr"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
   store %"github.com/goplus/llgo/runtime/internal/runtime.eface" %0, ptr %1, align 8
@@ -101,14 +103,16 @@ _llgo_0:
   ret ptr %5
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/funcdecl.demo"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/funcdecl.demo"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 4 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/funcdecl.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/funcdecl.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/funcdecl.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -121,7 +125,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/funcdecl.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/funcdecl.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 5 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
@@ -135,7 +140,8 @@ _llgo_0:
   ret void
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -143,11 +149,14 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.MatchesClosure"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.MatchesClosure"(ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -155,16 +164,25 @@ _llgo_0:
   ret i1 %3
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintEface"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintEface"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/gblarray/out.ll
+++ b/cl/_testrt/gblarray/out.ll
@@ -9,7 +9,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/gblarray"
 @"github.com/goplus/llgo/cl/_testrt/gblarray.sizeBasicTypes" = global [25 x i64] zeroinitializer, align 8
 @0 = private unnamed_addr constant [20 x i8] c"Kind: %d, Size: %d\0A\00", align 1
 
-define ptr @"github.com/goplus/llgo/cl/_testrt/gblarray.Basic"(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define ptr @"github.com/goplus/llgo/cl/_testrt/gblarray.Basic"(i64 %0) #0 {
 _llgo_0:
   %1 = icmp sge i64 %0, 25
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %1)
@@ -18,7 +19,8 @@ _llgo_0:
   ret ptr %3
 }
 
-define ptr @"github.com/goplus/llgo/cl/_testrt/gblarray.basicType"(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define ptr @"github.com/goplus/llgo/cl/_testrt/gblarray.basicType"(i64 %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 72)
   %2 = getelementptr inbounds %"github.com/goplus/llgo/runtime/abi.Type", ptr %1, i32 0, i32 0
@@ -36,7 +38,8 @@ _llgo_0:
   ret ptr %1
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/gblarray.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/gblarray.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/gblarray.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -53,7 +56,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/gblarray.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/gblarray.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/cl/_testrt/gblarray.Basic"(i64 24)
   %1 = getelementptr inbounds %"github.com/goplus/llgo/runtime/abi.Type", ptr %0, i32 0, i32 6
@@ -65,10 +69,15 @@ _llgo_0:
   ret void
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/abi.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/abi.init"() #0
 
 declare i32 @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/gotypes/out.ll
+++ b/cl/_testrt/gotypes/out.ll
@@ -5,12 +5,14 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/gotypes"
 
 @"github.com/goplus/llgo/cl/_testrt/gotypes.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/gotypes.foo"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/gotypes.foo"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0) #0 {
 _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/gotypes.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/gotypes.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/gotypes.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -23,8 +25,11 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/gotypes.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/gotypes.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/cl/_testrt/gotypes.foo"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" zeroinitializer)
   ret void
 }
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/hello/out.ll
+++ b/cl/_testrt/hello/out.ll
@@ -4,7 +4,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/hello"
 @"github.com/goplus/llgo/cl/_testrt/hello.format" = global [10 x i8] zeroinitializer, align 1
 @"github.com/goplus/llgo/cl/_testrt/hello.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/hello.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/hello.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/hello.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -27,7 +28,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/hello.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/hello.main"() #0 {
 _llgo_0:
   %0 = call i32 @strlen(ptr @"github.com/goplus/llgo/cl/_testrt/hello.format")
   call void (ptr, ...) @printf(ptr @"github.com/goplus/llgo/cl/_testrt/hello.format", i32 %0)
@@ -37,3 +39,5 @@ _llgo_0:
 declare i32 @strlen(ptr)
 
 declare void @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/index/out.ll
+++ b/cl/_testrt/index/out.ll
@@ -8,7 +8,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/index"
 @"github.com/goplus/llgo/cl/_testrt/index.init$guard" = global i1 false, align 1
 @0 = private unnamed_addr constant [6 x i8] c"123456", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/index.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/index.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/index.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -21,7 +22,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/index.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/index.main"() #0 {
 _llgo_0:
   %0 = alloca %"github.com/goplus/llgo/cl/_testrt/index.point", align 8
   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
@@ -142,18 +144,25 @@ _llgo_0:
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringFromRune"(i32)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringFromRune"(i32) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1) #0
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testrt/intgen/out.ll
+++ b/cl/_testrt/intgen/out.ll
@@ -9,7 +9,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/intgen"
 @1 = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 1
 @2 = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 1
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testrt/intgen.genInts"(i64 %0, { ptr, ptr } %1) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testrt/intgen.genInts"(i64 %0, { ptr, ptr } %1) #0 {
 _llgo_0:
   %2 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.MakeSlice"(i64 %0, i64 %0, i64 4)
   %3 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %2, 1
@@ -39,7 +40,8 @@ _llgo_3:                                          ; preds = %_llgo_1
   ret %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %2
 }
 
-define i32 @"github.com/goplus/llgo/cl/_testrt/intgen.(*generator).next"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i32 @"github.com/goplus/llgo/cl/_testrt/intgen.(*generator).next"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testrt/intgen.generator", ptr %0, i32 0, i32 0
   %2 = load i32, ptr %1, align 4
@@ -51,7 +53,8 @@ _llgo_0:
   ret i32 %6
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/intgen.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/intgen.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/intgen.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -64,7 +67,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/intgen.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/intgen.main"() #0 {
 _llgo_0:
   %0 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testrt/intgen.genInts"(i64 5, { ptr, ptr } { ptr @__llgo_stub.rand, ptr null })
   %1 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0, 1
@@ -151,7 +155,8 @@ _llgo_9:                                          ; preds = %_llgo_7
   ret void
 }
 
-define i32 @"github.com/goplus/llgo/cl/_testrt/intgen.main$1"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i32 @"github.com/goplus/llgo/cl/_testrt/intgen.main$1"(ptr %0) #0 {
 _llgo_0:
   %1 = load { ptr }, ptr %0, align 8
   %2 = extractvalue { ptr } %1, 0
@@ -164,9 +169,11 @@ _llgo_0:
   ret i32 %7
 }
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.MakeSlice"(i64, i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.MakeSlice"(i64, i64, i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1) #0
 
 declare i32 @rand()
 
@@ -178,14 +185,19 @@ _llgo_0:
 
 declare i32 @printf(ptr, ...)
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-define i32 @"github.com/goplus/llgo/cl/_testrt/intgen.(*generator).next$bound"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i32 @"github.com/goplus/llgo/cl/_testrt/intgen.(*generator).next$bound"(ptr %0) #0 {
 _llgo_0:
   %1 = load { ptr }, ptr %0, align 8
   %2 = extractvalue { ptr } %1, 0
   %3 = call i32 @"github.com/goplus/llgo/cl/_testrt/intgen.(*generator).next"(ptr %2)
   ret i32 %3
 }
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/len/out.ll
+++ b/cl/_testrt/len/out.ll
@@ -56,7 +56,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/len"
 @"_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ$fields" = weak_odr constant [4 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @4, i64 7 }, ptr @"[8]_llgo_uint8", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 4 }, ptr @"[8]_llgo_int", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @11, i64 5 }, ptr @"[8]_llgo_string", i64 72, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @14, i64 8 }, ptr @_llgo_Pointer, i64 200, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
 @16 = private unnamed_addr constant [5 x i8] c"hello", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/len.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/len.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/len.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -69,7 +70,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/len.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/len.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 56)
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testrt/len.data", ptr %0, i32 0, i32 0
@@ -160,21 +162,29 @@ _llgo_0:
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.ChanLen"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.ChanLen"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.MapLen"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.MapLen"(ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.ChanCap"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.ChanCap"(ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewChan"(i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewChan"(i64, i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -182,9 +192,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.typehash"(ptr, ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.typehash"(ptr, ptr, i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -192,7 +204,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -200,11 +213,14 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -212,8 +228,13 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr, i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAssign"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAssign"(ptr, ptr, ptr) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/linkname/out.ll
+++ b/cl/_testrt/linkname/out.ll
@@ -15,9 +15,11 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/linkname"
 @7 = private unnamed_addr constant [2 x i8] c"4\00", align 1
 @8 = private unnamed_addr constant [5 x i8] c"hello", align 1
 
-declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testrt/linkname/linktarget.m.info"(%"github.com/goplus/llgo/cl/_testrt/linkname.m")
+; Function Attrs: null_pointer_is_valid
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testrt/linkname/linktarget.m.info"(%"github.com/goplus/llgo/cl/_testrt/linkname.m") #0
 
-define void @"github.com/goplus/llgo/cl/_testrt/linkname.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/linkname.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/linkname.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -31,7 +33,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/linkname.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/linkname.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/cl/_testrt/linkname/linktarget.F"(ptr @0, ptr @1, ptr @2, ptr @3)
   call void @"github.com/goplus/llgo/cl/_testrt/linkname/linktarget.F"(ptr @4, ptr @5, ptr @6, ptr @7)
@@ -44,14 +47,22 @@ _llgo_0:
   ret void
 }
 
-declare void @"github.com/goplus/llgo/cl/_testrt/linkname/linktarget.F"(ptr, ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/cl/_testrt/linkname/linktarget.F"(ptr, ptr, ptr, ptr) #0
 
-declare void @"github.com/goplus/llgo/cl/_testrt/linkname/linktarget.(*m).setInfo"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/cl/_testrt/linkname/linktarget.(*m).setInfo"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/cl/_testrt/linkname/linktarget.init"()
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/cl/_testrt/linkname/linktarget.init"() #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/makemap/out.ll
+++ b/cl/_testrt/makemap/out.ll
@@ -151,7 +151,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/makemap"
 @"*[]_llgo_github.com/goplus/llgo/cl/_testrt/makemap.N.7.0" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1663940180, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @38, i64 8 }, ptr null }, ptr @"[]_llgo_github.com/goplus/llgo/cl/_testrt/makemap.N.7.0" }, align 8
 @"_llgo_struct$tJooAKjBfWFVdIN3UQAErvHaJ-wlhiEZpoJy2GckluU$fields" = weak_odr constant [4 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @4, i64 7 }, ptr @"[8]_llgo_uint8", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 4 }, ptr @"[8]_llgo_github.com/goplus/llgo/cl/_testrt/makemap.N.7.0", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @11, i64 5 }, ptr @"[8]_llgo_string", i64 72, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @14, i64 8 }, ptr @_llgo_Pointer, i64 200, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
 
-define void @"github.com/goplus/llgo/cl/_testrt/makemap.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/makemap.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/makemap.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -164,7 +165,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/makemap.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/makemap.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/cl/_testrt/makemap.make1"()
   call void @"github.com/goplus/llgo/cl/_testrt/makemap.make2"()
@@ -176,7 +178,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/makemap.make1"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/makemap.make1"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_string", i64 0)
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 8)
@@ -352,7 +355,8 @@ _llgo_16:                                         ; preds = %_llgo_15, %_llgo_14
   br i1 %77, label %_llgo_5, label %_llgo_6
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/makemap.make2"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/makemap.make2"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_string", i64 0)
   %1 = call i64 @"github.com/goplus/llgo/runtime/internal/runtime.MapLen"(ptr %0)
@@ -476,7 +480,8 @@ _llgo_8:                                          ; preds = %_llgo_2
   unreachable
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/makemap.make3"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/makemap.make3"() #0 {
 _llgo_0:
   %0 = alloca [1 x %"github.com/goplus/llgo/cl/_testrt/makemap.N"], align 8
   call void @llvm.memset(ptr %0, i8 0, i64 2, i1 false)
@@ -593,7 +598,8 @@ _llgo_8:                                          ; preds = %_llgo_2
   unreachable
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/makemap.make4"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/makemap.make4"() #0 {
 _llgo_0:
   %0 = alloca [1 x ptr], align 8
   call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
@@ -709,7 +715,8 @@ _llgo_8:                                          ; preds = %_llgo_2
   unreachable
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/makemap.make5"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/makemap.make5"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewChan"(i64 8, i64 0)
   %1 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @"chan _llgo_int", ptr undef }, ptr %0, 1
@@ -764,7 +771,8 @@ _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
   br i1 %21, label %_llgo_2, label %_llgo_3
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/makemap.make6"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/makemap.make6"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_string", i64 0)
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 8)
@@ -809,7 +817,8 @@ _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
   br i1 %15, label %_llgo_2, label %_llgo_3
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/makemap.make7"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/makemap.make7"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_github.com/goplus/llgo/cl/_testrt/makemap.N.7.0]_llgo_string", i64 2)
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 8)
@@ -864,7 +873,8 @@ _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
   br i1 %20, label %_llgo_2, label %_llgo_3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -872,9 +882,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.typehash"(ptr, ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.typehash"(ptr, ptr, i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -882,7 +894,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -890,11 +903,14 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -902,37 +918,53 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr, i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAssign"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAssign"(ptr, ptr, ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAccess1"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAccess1"(ptr, ptr, ptr) #0
 
-declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.MapLen"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.MapLen"(ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewMapIter"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewMapIter"(ptr, ptr) #0
 
-declare { i1, ptr, ptr } @"github.com/goplus/llgo/runtime/internal/runtime.MapIterNext"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare { i1, ptr, ptr } @"github.com/goplus/llgo/runtime/internal/runtime.MapIterNext"(ptr) #0
 
-declare { ptr, i1 } @"github.com/goplus/llgo/runtime/internal/runtime.MapAccess2"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare { ptr, i1 } @"github.com/goplus/llgo/runtime/internal/runtime.MapAccess2"(ptr, ptr, ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.MapDelete"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.MapDelete"(ptr, ptr, ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -941,12 +973,16 @@ _llgo_0:
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface", %"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface", %"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewChan"(i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewChan"(i64, i64) #0
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testrt/map/out.ll
+++ b/cl/_testrt/map/out.ll
@@ -46,7 +46,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/map"
 @"_llgo_struct$RSTTp_pTKglBmcdy0CMmgLp9HSGRvgD8UwNIoMFFyOg$fields" = weak_odr constant [4 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @3, i64 7 }, ptr @"[8]_llgo_uint8", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 4 }, ptr @"[8]_llgo_int", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @10, i64 5 }, ptr @"[8]_llgo_int", i64 72, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @11, i64 8 }, ptr @_llgo_uintptr, i64 136, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
 @13 = private unnamed_addr constant [10 x i8] c"Hello %d\0A\00", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/map.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/map.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/map.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -59,7 +60,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/map.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/map.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_int", i64 2)
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 8)
@@ -78,7 +80,8 @@ _llgo_0:
   ret void
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -86,9 +89,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.typehash"(ptr, ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.typehash"(ptr, ptr, i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -96,11 +101,14 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -108,12 +116,18 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr, i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAssign"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAssign"(ptr, ptr, ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAccess1"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAccess1"(ptr, ptr, ptr) #0
 
 declare i32 @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/mapclosure/out.ll
+++ b/cl/_testrt/mapclosure/out.ll
@@ -93,7 +93,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/mapclosure"
 @"*_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 876051709, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @27, i64 29 }, ptr null }, ptr @"_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U" }, align 8
 @28 = private unnamed_addr constant [5 x i8] c"error", align 1
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testrt/mapclosure.demo"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testrt/mapclosure.demo"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
   %2 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 0
@@ -107,7 +108,8 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.String" %9
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/mapclosure.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/mapclosure.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/mapclosure.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -133,7 +135,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/mapclosure.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/mapclosure.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testrt/mapclosure.typ", ptr %0, i32 0, i32 0
@@ -177,16 +180,19 @@ _llgo_2:                                          ; preds = %_llgo_0
   ret void
 }
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testrt/mapclosure.(*typ).String"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testrt/mapclosure.(*typ).String"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testrt/mapclosure.typ", ptr %0, i32 0, i32 0
   %2 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %1, align 8
   ret %"github.com/goplus/llgo/runtime/internal/runtime.String" %2
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -194,9 +200,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.typehash"(ptr, ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.typehash"(ptr, ptr, i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -204,7 +212,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -212,9 +221,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -222,7 +233,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr, i64) #0
 
 define linkonce %"github.com/goplus/llgo/runtime/internal/runtime.String" @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/mapclosure.demo"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) {
 _llgo_0:
@@ -230,20 +242,31 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.String" %2
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAssign"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAssign"(ptr, ptr, ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAccess1"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAccess1"(ptr, ptr, ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/mask/out.ll
+++ b/cl/_testrt/mask/out.ll
@@ -3,7 +3,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/mask"
 
 @"github.com/goplus/llgo/cl/_testrt/mask.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/mask.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/mask.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/mask.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -16,7 +17,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/mask.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/mask.main"() #0 {
 _llgo_0:
   %0 = call i32 @"github.com/goplus/llgo/cl/_testrt/mask.mask"(i8 1)
   %1 = sext i32 %0 to i64
@@ -59,7 +61,8 @@ _llgo_0:
   ret void
 }
 
-define i32 @"github.com/goplus/llgo/cl/_testrt/mask.mask"(i8 %0) {
+; Function Attrs: null_pointer_is_valid
+define i32 @"github.com/goplus/llgo/cl/_testrt/mask.mask"(i8 %0) #0 {
 _llgo_0:
   %1 = sext i8 %0 to i32
   %2 = shl i32 %1, 31
@@ -68,7 +71,8 @@ _llgo_0:
   ret i32 %4
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/mask.mask_shl"(i64 %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/mask.mask_shl"(i64 %0, i64 %1) #0 {
 _llgo_0:
   %2 = icmp slt i64 %1, 0
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertNegativeShift"(i1 %2)
@@ -78,7 +82,8 @@ _llgo_0:
   ret i64 %5
 }
 
-define i8 @"github.com/goplus/llgo/cl/_testrt/mask.mask_shl8"(i8 %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i8 @"github.com/goplus/llgo/cl/_testrt/mask.mask_shl8"(i8 %0, i64 %1) #0 {
 _llgo_0:
   %2 = icmp slt i64 %1, 0
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertNegativeShift"(i1 %2)
@@ -89,7 +94,8 @@ _llgo_0:
   ret i8 %6
 }
 
-define i8 @"github.com/goplus/llgo/cl/_testrt/mask.mask_shl8u"(i8 %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i8 @"github.com/goplus/llgo/cl/_testrt/mask.mask_shl8u"(i8 %0, i64 %1) #0 {
 _llgo_0:
   %2 = icmp slt i64 %1, 0
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertNegativeShift"(i1 %2)
@@ -100,7 +106,8 @@ _llgo_0:
   ret i8 %6
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/mask.mask_shr"(i64 %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/mask.mask_shr"(i64 %0, i64 %1) #0 {
 _llgo_0:
   %2 = icmp slt i64 %1, 0
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertNegativeShift"(i1 %2)
@@ -110,7 +117,8 @@ _llgo_0:
   ret i64 %5
 }
 
-define i8 @"github.com/goplus/llgo/cl/_testrt/mask.mask_shr8"(i8 %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i8 @"github.com/goplus/llgo/cl/_testrt/mask.mask_shr8"(i8 %0, i64 %1) #0 {
 _llgo_0:
   %2 = icmp slt i64 %1, 0
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertNegativeShift"(i1 %2)
@@ -121,7 +129,8 @@ _llgo_0:
   ret i8 %6
 }
 
-define i8 @"github.com/goplus/llgo/cl/_testrt/mask.mask_shr8u"(i8 %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i8 @"github.com/goplus/llgo/cl/_testrt/mask.mask_shr8u"(i8 %0, i64 %1) #0 {
 _llgo_0:
   %2 = icmp slt i64 %1, 0
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertNegativeShift"(i1 %2)
@@ -132,10 +141,16 @@ _llgo_0:
   ret i8 %6
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertNegativeShift"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertNegativeShift"(i1) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/methodthunk/out.ll
+++ b/cl/_testrt/methodthunk/out.ll
@@ -70,21 +70,24 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/methodthunk"
 @20 = private unnamed_addr constant [6 x i8] c"string", align 1
 @"*_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1323879264, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @20, i64 6 }, ptr null }, ptr @_llgo_string }, align 8
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/methodthunk.(*InnerInt).M"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/methodthunk.(*InnerInt).M"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testrt/methodthunk.InnerInt", ptr %0, i32 0, i32 0
   %2 = load i64, ptr %1, align 4
   ret i64 %2
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/methodthunk.(*OuterInt).M"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/methodthunk.(*OuterInt).M"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testrt/methodthunk.OuterInt", ptr %0, i32 0, i32 1
   %2 = call i64 @"github.com/goplus/llgo/cl/_testrt/methodthunk.(*InnerInt).M"(ptr %1)
   ret i64 %2
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/methodthunk.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/methodthunk.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/methodthunk.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -97,12 +100,14 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/methodthunk.(*inner).M"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/methodthunk.(*inner).M"(ptr %0) #0 {
 _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/methodthunk.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/methodthunk.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
   store { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/methodthunk.(*outer).M$thunk", ptr null }, ptr %0, align 8
@@ -169,12 +174,14 @@ _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
   br i1 %24, label %_llgo_1, label %_llgo_2
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/methodthunk.(*outer).M"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/methodthunk.(*outer).M"(ptr %0) #0 {
 _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/methodthunk.(*outer).M$thunk"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/methodthunk.(*outer).M$thunk"(ptr %0) #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/cl/_testrt/methodthunk.(*outer).M"(ptr %0)
   ret void
@@ -186,7 +193,8 @@ _llgo_0:
   ret void
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -194,9 +202,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -204,9 +214,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/methodthunk.(*InnerInt).M$thunk"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/methodthunk.(*InnerInt).M$thunk"(ptr %0) #0 {
 _llgo_0:
   %1 = call i64 @"github.com/goplus/llgo/cl/_testrt/methodthunk.(*InnerInt).M"(ptr %0)
   ret i64 %1
@@ -218,15 +230,20 @@ _llgo_0:
   ret i64 %2
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.MatchesClosure"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.MatchesClosure"(ptr, ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -234,4 +251,7 @@ _llgo_0:
   ret i1 %3
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/named/out.ll
+++ b/cl/_testrt/named/out.ll
@@ -8,7 +8,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/named"
 @"github.com/goplus/llgo/cl/_testrt/named.init$guard" = global i1 false, align 1
 @0 = private unnamed_addr constant [19 x i8] c"%d %d %d %d %d %d\0A\00", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/named.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/named.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/named.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -21,7 +22,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/named.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/named.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 64)
@@ -112,7 +114,8 @@ _llgo_0:
   ret void
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/named.main$1"(ptr %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/named.main$1"(ptr %0, i64 %1) #0 {
 _llgo_0:
   %2 = load { ptr }, ptr %0, align 8
   %3 = extractvalue { ptr } %2, 0
@@ -123,8 +126,12 @@ _llgo_0:
   ret i64 %7
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
 declare i32 @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/namedslice/out.ll
+++ b/cl/_testrt/namedslice/out.ll
@@ -23,7 +23,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/namedslice"
 @4 = private unnamed_addr constant [6 x i8] c"string", align 1
 @"*_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1323879264, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @4, i64 6 }, ptr null }, ptr @_llgo_string }, align 8
 
-define void @"github.com/goplus/llgo/cl/_testrt/namedslice.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/namedslice.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/namedslice.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -36,7 +37,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/namedslice.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/namedslice.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 0)
   %1 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %0, 0
@@ -76,9 +78,11 @@ _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
   br i1 %16, label %_llgo_2, label %_llgo_1
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -86,7 +90,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -94,9 +99,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -104,4 +111,7 @@ _llgo_0:
   ret i1 %3
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/panic/out.ll
+++ b/cl/_testrt/panic/out.ll
@@ -12,7 +12,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/panic"
 @1 = private unnamed_addr constant [6 x i8] c"string", align 1
 @"*_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1323879264, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 6 }, ptr null }, ptr @_llgo_string }, align 8
 
-define void @"github.com/goplus/llgo/cl/_testrt/panic.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/panic.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/panic.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -25,7 +26,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/panic.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/panic.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
   store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 13 }, ptr %0, align 8
@@ -34,7 +36,8 @@ _llgo_0:
   unreachable
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -42,7 +45,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -50,6 +54,10 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/qsort/out.ll
+++ b/cl/_testrt/qsort/out.ll
@@ -4,7 +4,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/qsort"
 @"github.com/goplus/llgo/cl/_testrt/qsort.init$guard" = global i1 false, align 1
 @0 = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/qsort.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/qsort.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/qsort.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -17,7 +18,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/qsort.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/qsort.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 40)
   %1 = getelementptr inbounds i64, ptr %0, i64 0
@@ -55,7 +57,8 @@ _llgo_3:                                          ; preds = %_llgo_1
   ret void
 }
 
-define i32 @"github.com/goplus/llgo/cl/_testrt/qsort.main$1"(ptr %0, ptr %1) {
+; Function Attrs: null_pointer_is_valid
+define i32 @"github.com/goplus/llgo/cl/_testrt/qsort.main$1"(ptr %0, ptr %1) #0 {
 _llgo_0:
   %2 = load i64, ptr %0, align 4
   %3 = load i64, ptr %1, align 4
@@ -64,10 +67,14 @@ _llgo_0:
   ret i32 %5
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
 declare void @qsort(ptr, i64, i64, ptr)
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1) #0
 
 declare i32 @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/qsortfn/out.ll
+++ b/cl/_testrt/qsortfn/out.ll
@@ -23,7 +23,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/qsortfn"
 @18 = private unnamed_addr constant [22 x i8] c"Comp => qsort.Comp()\0A\00", align 1
 @19 = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/qsortfn.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -36,7 +37,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort1a"()
   call void @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort1b"()
@@ -51,7 +53,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort1a"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort1a"() #0 {
 _llgo_0:
   %0 = call i32 (ptr, ...) @printf(ptr @0)
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 40)
@@ -90,7 +93,8 @@ _llgo_3:                                          ; preds = %_llgo_1
   ret void
 }
 
-define i32 @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort1a$1"(ptr %0, ptr %1) {
+; Function Attrs: null_pointer_is_valid
+define i32 @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort1a$1"(ptr %0, ptr %1) #0 {
 _llgo_0:
   %2 = load i64, ptr %0, align 4
   %3 = load i64, ptr %1, align 4
@@ -99,7 +103,8 @@ _llgo_0:
   ret i32 %5
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort1b"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort1b"() #0 {
 _llgo_0:
   %0 = call i32 (ptr, ...) @printf(ptr @2)
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 40)
@@ -138,7 +143,8 @@ _llgo_3:                                          ; preds = %_llgo_1
   ret void
 }
 
-define i32 @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort1b$1"(ptr %0, ptr %1) {
+; Function Attrs: null_pointer_is_valid
+define i32 @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort1b$1"(ptr %0, ptr %1) #0 {
 _llgo_0:
   %2 = load i64, ptr %0, align 4
   %3 = load i64, ptr %1, align 4
@@ -147,7 +153,8 @@ _llgo_0:
   ret i32 %5
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort2a"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort2a"() #0 {
 _llgo_0:
   %0 = call i32 (ptr, ...) @printf(ptr @4)
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 40)
@@ -186,7 +193,8 @@ _llgo_3:                                          ; preds = %_llgo_1
   ret void
 }
 
-define i32 @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort2a$1"(ptr %0, ptr %1) {
+; Function Attrs: null_pointer_is_valid
+define i32 @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort2a$1"(ptr %0, ptr %1) #0 {
 _llgo_0:
   %2 = load i64, ptr %0, align 4
   %3 = load i64, ptr %1, align 4
@@ -195,7 +203,8 @@ _llgo_0:
   ret i32 %5
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort2b"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort2b"() #0 {
 _llgo_0:
   %0 = call i32 (ptr, ...) @printf(ptr @6)
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 40)
@@ -234,7 +243,8 @@ _llgo_3:                                          ; preds = %_llgo_1
   ret void
 }
 
-define i32 @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort2b$1"(ptr %0, ptr %1) {
+; Function Attrs: null_pointer_is_valid
+define i32 @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort2b$1"(ptr %0, ptr %1) #0 {
 _llgo_0:
   %2 = load i64, ptr %0, align 4
   %3 = load i64, ptr %1, align 4
@@ -243,7 +253,8 @@ _llgo_0:
   ret i32 %5
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort3a"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort3a"() #0 {
 _llgo_0:
   %0 = call i32 (ptr, ...) @printf(ptr @8)
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 40)
@@ -282,7 +293,8 @@ _llgo_3:                                          ; preds = %_llgo_1
   ret void
 }
 
-define i32 @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort3a$1"(ptr %0, ptr %1) {
+; Function Attrs: null_pointer_is_valid
+define i32 @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort3a$1"(ptr %0, ptr %1) #0 {
 _llgo_0:
   %2 = load i64, ptr %0, align 4
   %3 = load i64, ptr %1, align 4
@@ -291,7 +303,8 @@ _llgo_0:
   ret i32 %5
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort3b"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort3b"() #0 {
 _llgo_0:
   %0 = call i32 (ptr, ...) @printf(ptr @10)
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 40)
@@ -330,7 +343,8 @@ _llgo_3:                                          ; preds = %_llgo_1
   ret void
 }
 
-define i32 @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort3b$1"(ptr %0, ptr %1) {
+; Function Attrs: null_pointer_is_valid
+define i32 @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort3b$1"(ptr %0, ptr %1) #0 {
 _llgo_0:
   %2 = load i64, ptr %0, align 4
   %3 = load i64, ptr %1, align 4
@@ -339,7 +353,8 @@ _llgo_0:
   ret i32 %5
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort4a"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort4a"() #0 {
 _llgo_0:
   %0 = call i32 (ptr, ...) @printf(ptr @12)
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 40)
@@ -378,7 +393,8 @@ _llgo_3:                                          ; preds = %_llgo_1
   ret void
 }
 
-define i32 @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort4a$1"(ptr %0, ptr %1) {
+; Function Attrs: null_pointer_is_valid
+define i32 @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort4a$1"(ptr %0, ptr %1) #0 {
 _llgo_0:
   %2 = load i64, ptr %0, align 4
   %3 = load i64, ptr %1, align 4
@@ -387,7 +403,8 @@ _llgo_0:
   ret i32 %5
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort4b"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort4b"() #0 {
 _llgo_0:
   %0 = call i32 (ptr, ...) @printf(ptr @14)
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 40)
@@ -426,7 +443,8 @@ _llgo_3:                                          ; preds = %_llgo_1
   ret void
 }
 
-define i32 @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort4b$1"(ptr %0, ptr %1) {
+; Function Attrs: null_pointer_is_valid
+define i32 @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort4b$1"(ptr %0, ptr %1) #0 {
 _llgo_0:
   %2 = load i64, ptr %0, align 4
   %3 = load i64, ptr %1, align 4
@@ -435,7 +453,8 @@ _llgo_0:
   ret i32 %5
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort5a"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort5a"() #0 {
 _llgo_0:
   %0 = call i32 (ptr, ...) @printf(ptr @16)
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 40)
@@ -474,7 +493,8 @@ _llgo_3:                                          ; preds = %_llgo_1
   ret void
 }
 
-define i32 @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort5a$1"(ptr %0, ptr %1) {
+; Function Attrs: null_pointer_is_valid
+define i32 @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort5a$1"(ptr %0, ptr %1) #0 {
 _llgo_0:
   %2 = load i64, ptr %0, align 4
   %3 = load i64, ptr %1, align 4
@@ -483,7 +503,8 @@ _llgo_0:
   ret i32 %5
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort5b"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort5b"() #0 {
 _llgo_0:
   %0 = call i32 (ptr, ...) @printf(ptr @18)
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 40)
@@ -522,7 +543,8 @@ _llgo_3:                                          ; preds = %_llgo_1
   ret void
 }
 
-define i32 @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort5b$1"(ptr %0, ptr %1) {
+; Function Attrs: null_pointer_is_valid
+define i32 @"github.com/goplus/llgo/cl/_testrt/qsortfn.sort5b$1"(ptr %0, ptr %1) #0 {
 _llgo_0:
   %2 = load i64, ptr %0, align 4
   %3 = load i64, ptr %1, align 4
@@ -533,8 +555,12 @@ _llgo_0:
 
 declare i32 @printf(ptr, ...)
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
 declare void @qsort(ptr, i64, i64, ptr)
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/result/out.ll
+++ b/cl/_testrt/result/out.ll
@@ -6,29 +6,34 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/result"
 @1 = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 1
 @2 = private unnamed_addr constant [7 x i8] c"%d %d\0A\00", align 1
 
-define { ptr, ptr } @"github.com/goplus/llgo/cl/_testrt/result.add"() {
+; Function Attrs: null_pointer_is_valid
+define { ptr, ptr } @"github.com/goplus/llgo/cl/_testrt/result.add"() #0 {
 _llgo_0:
   ret { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/result.add$1", ptr null }
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/result.add$1"(i64 %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/result.add$1"(i64 %0, i64 %1) #0 {
 _llgo_0:
   %2 = add i64 %0, %1
   ret i64 %2
 }
 
-define { { ptr, ptr }, i64 } @"github.com/goplus/llgo/cl/_testrt/result.add2"() {
+; Function Attrs: null_pointer_is_valid
+define { { ptr, ptr }, i64 } @"github.com/goplus/llgo/cl/_testrt/result.add2"() #0 {
 _llgo_0:
   ret { { ptr, ptr }, i64 } { { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/result.add2$1", ptr null }, i64 1 }
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/result.add2$1"(i64 %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/result.add2$1"(i64 %0, i64 %1) #0 {
 _llgo_0:
   %2 = add i64 %0, %1
   ret i64 %2
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/result.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/result.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/result.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -41,7 +46,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/result.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/result.main"() #0 {
 _llgo_0:
   %0 = call { ptr, ptr } @"github.com/goplus/llgo/cl/_testrt/result.main$1"()
   %1 = extractvalue { ptr, ptr } %0, 1
@@ -64,12 +70,14 @@ _llgo_0:
   ret void
 }
 
-define { ptr, ptr } @"github.com/goplus/llgo/cl/_testrt/result.main$1"() {
+; Function Attrs: null_pointer_is_valid
+define { ptr, ptr } @"github.com/goplus/llgo/cl/_testrt/result.main$1"() #0 {
 _llgo_0:
   ret { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/result.main$1$1", ptr null }
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/result.main$1$1"(i64 %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/result.main$1$1"(i64 %0, i64 %1) #0 {
 _llgo_0:
   %2 = add i64 %0, %1
   ret i64 %2
@@ -94,3 +102,5 @@ _llgo_0:
   %3 = tail call i64 @"github.com/goplus/llgo/cl/_testrt/result.main$1$1"(i64 %1, i64 %2)
   ret i64 %3
 }
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/slice2array/out.ll
+++ b/cl/_testrt/slice2array/out.ll
@@ -5,7 +5,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/slice2array"
 
 @"github.com/goplus/llgo/cl/_testrt/slice2array.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/slice2array.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/slice2array.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/slice2array.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -18,7 +19,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/slice2array.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/slice2array.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 4)
   %1 = getelementptr inbounds i8, ptr %0, i64 0
@@ -98,15 +100,20 @@ _llgo_4:                                          ; preds = %_llgo_3, %_llgo_2
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PanicSliceConvert"(i64, i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PanicSliceConvert"(i64, i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testrt/slicelen/out.ll
+++ b/cl/_testrt/slicelen/out.ll
@@ -6,7 +6,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/slicelen"
 @"github.com/goplus/llgo/cl/_testrt/slicelen.init$guard" = global i1 false, align 1
 @0 = private unnamed_addr constant [7 x i8] c"len > 0", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/slicelen.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/slicelen.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/slicelen.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -19,7 +20,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/slicelen.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/slicelen.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 0)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
@@ -34,8 +36,13 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/stacksave/out.ll
+++ b/cl/_testrt/stacksave/out.ll
@@ -3,7 +3,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/stacksave"
 
 @"github.com/goplus/llgo/cl/_testrt/stacksave.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/stacksave.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/stacksave.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/stacksave.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -16,7 +17,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/stacksave.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/stacksave.main"() #0 {
 _llgo_0:
   %0 = call ptr @llvm.stacksave()
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr %0)
@@ -25,10 +27,13 @@ _llgo_0:
 }
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn
-declare ptr @llvm.stacksave() #0
+declare ptr @llvm.stacksave() #1
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-attributes #0 = { nocallback nofree nosync nounwind willreturn }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nosync nounwind willreturn }

--- a/cl/_testrt/strlen/out.ll
+++ b/cl/_testrt/strlen/out.ll
@@ -7,16 +7,20 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/strlen"
 @"github.com/goplus/llgo/cl/_testrt/strlen.format" = global [10 x i8] zeroinitializer, align 1
 @"github.com/goplus/llgo/cl/_testrt/strlen.init$guard" = global i1 false, align 1
 
-define ptr @"github.com/goplus/llgo/cl/_testrt/strlen._Cgo_ptr"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define ptr @"github.com/goplus/llgo/cl/_testrt/strlen._Cgo_ptr"(ptr %0) #0 {
 _llgo_0:
   ret ptr %0
 }
 
-declare void @runtime.cgoUse(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @runtime.cgoUse(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare void @runtime.cgoCheckResult(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @runtime.cgoCheckResult(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-define void @"github.com/goplus/llgo/cl/_testrt/strlen.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/strlen.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/strlen.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -40,15 +44,19 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/strlen.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/strlen.main"() #0 {
 _llgo_0:
   %0 = call i32 @strlen(ptr @"github.com/goplus/llgo/cl/_testrt/strlen.format")
   call void (ptr, ...) @printf(ptr @"github.com/goplus/llgo/cl/_testrt/strlen.format", i32 %0)
   ret void
 }
 
-declare void @syscall.init()
+; Function Attrs: null_pointer_is_valid
+declare void @syscall.init() #0
 
 declare i32 @strlen(ptr)
 
 declare void @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/struct/out.ll
+++ b/cl/_testrt/struct/out.ll
@@ -8,7 +8,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/struct"
 @"github.com/goplus/llgo/cl/_testrt/struct.format" = global [10 x i8] zeroinitializer, align 1
 @"github.com/goplus/llgo/cl/_testrt/struct.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/struct.Foo.Print"(%"github.com/goplus/llgo/cl/_testrt/struct.Foo" %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/struct.Foo.Print"(%"github.com/goplus/llgo/cl/_testrt/struct.Foo" %0) #0 {
 _llgo_0:
   %1 = alloca %"github.com/goplus/llgo/cl/_testrt/struct.Foo", align 8
   call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
@@ -27,23 +28,28 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/struct.(*Foo).Print"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/struct.(*Foo).Print"(ptr %0) #0 {
 _llgo_0:
   %1 = load %"github.com/goplus/llgo/cl/_testrt/struct.Foo", ptr %0, align 4
   call void @"github.com/goplus/llgo/cl/_testrt/struct.Foo.Print"(%"github.com/goplus/llgo/cl/_testrt/struct.Foo" %1)
   ret void
 }
 
-define ptr @"github.com/goplus/llgo/cl/_testrt/struct._Cgo_ptr"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define ptr @"github.com/goplus/llgo/cl/_testrt/struct._Cgo_ptr"(ptr %0) #0 {
 _llgo_0:
   ret ptr %0
 }
 
-declare void @runtime.cgoUse(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @runtime.cgoUse(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare void @runtime.cgoCheckResult(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @runtime.cgoCheckResult(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-define void @"github.com/goplus/llgo/cl/_testrt/struct.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/struct.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/struct.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -67,7 +73,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/struct.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/struct.main"() #0 {
 _llgo_0:
   %0 = alloca %"github.com/goplus/llgo/cl/_testrt/struct.Foo", align 8
   call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
@@ -81,10 +88,12 @@ _llgo_0:
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
 declare void @printf(ptr, ...)
 
-declare void @syscall.init()
+; Function Attrs: null_pointer_is_valid
+declare void @syscall.init() #0
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testrt/structsize/out.ll
+++ b/cl/_testrt/structsize/out.ll
@@ -4,7 +4,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/structsize"
 @"github.com/goplus/llgo/cl/_testrt/structsize.init$guard" = global i1 false, align 1
 @0 = private unnamed_addr constant [3 x i8] c"%d\00", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/structsize.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/structsize.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/structsize.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -17,10 +18,13 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/structsize.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/structsize.main"() #0 {
 _llgo_0:
   %0 = call i32 (ptr, ...) @printf(ptr @0, i64 14)
   ret void
 }
 
 declare i32 @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/sum/out.ll
+++ b/cl/_testrt/sum/out.ll
@@ -6,7 +6,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/sum"
 @"github.com/goplus/llgo/cl/_testrt/sum.init$guard" = global i1 false, align 1
 @0 = private unnamed_addr constant [10 x i8] c"Hello %d\0A\00", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/sum.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/sum.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/sum.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -19,7 +20,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/sum.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/sum.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 32)
   %1 = getelementptr inbounds i64, ptr %0, i64 0
@@ -38,7 +40,8 @@ _llgo_0:
   ret void
 }
 
-define i64 @"github.com/goplus/llgo/cl/_testrt/sum.sum"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @"github.com/goplus/llgo/cl/_testrt/sum.sum"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0) #0 {
 _llgo_0:
   %1 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0, 1
   br label %_llgo_1
@@ -66,8 +69,12 @@ _llgo_3:                                          ; preds = %_llgo_1
   ret i64 %2
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
 declare i32 @printf(ptr, ...)
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/tpabi/out.ll
+++ b/cl/_testrt/tpabi/out.ll
@@ -43,7 +43,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/tpabi"
 @"*_llgo_iface$BP0p_lUsEd-IbbtJVukGmgrdQkqzcoYzSiwgUvgFvUs" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 2055694132, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @12, i64 20 }, ptr null }, ptr @"_llgo_iface$BP0p_lUsEd-IbbtJVukGmgrdQkqzcoYzSiwgUvgFvUs" }, align 8
 @"_llgo_iface$BP0p_lUsEd-IbbtJVukGmgrdQkqzcoYzSiwgUvgFvUs$imethods" = weak_odr constant [1 x %"github.com/goplus/llgo/runtime/abi.Imethod"] [%"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @3, i64 4 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac" }], align 8
 
-define void @"github.com/goplus/llgo/cl/_testrt/tpabi.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/tpabi.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/tpabi.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -56,7 +57,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/tpabi.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/tpabi.main"() #0 {
 _llgo_0:
   %0 = alloca %"github.com/goplus/llgo/cl/_testrt/tpabi.T[string,int]", align 8
   call void @llvm.memset(ptr %0, i8 0, i64 24, i1 false)
@@ -121,9 +123,10 @@ _llgo_2:                                          ; preds = %_llgo_0
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-define linkonce void @"github.com/goplus/llgo/cl/_testrt/tpabi.T[string,int].Info"(%"github.com/goplus/llgo/cl/_testrt/tpabi.T[string,int]" %0) {
+; Function Attrs: null_pointer_is_valid
+define linkonce void @"github.com/goplus/llgo/cl/_testrt/tpabi.T[string,int].Info"(%"github.com/goplus/llgo/cl/_testrt/tpabi.T[string,int]" %0) #0 {
 _llgo_0:
   %1 = alloca %"github.com/goplus/llgo/cl/_testrt/tpabi.T[string,int]", align 8
   call void @llvm.memset(ptr %1, i8 0, i64 24, i1 false)
@@ -139,9 +142,11 @@ _llgo_0:
   ret void
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-define linkonce void @"github.com/goplus/llgo/cl/_testrt/tpabi.(*T[string,int]).Demo"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define linkonce void @"github.com/goplus/llgo/cl/_testrt/tpabi.(*T[string,int]).Demo"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testrt/tpabi.T[string,int]", ptr %0, i32 0, i32 0
   %2 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %1, align 8
@@ -154,14 +159,16 @@ _llgo_0:
   ret void
 }
 
-define linkonce void @"github.com/goplus/llgo/cl/_testrt/tpabi.(*T[string,int]).Info"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define linkonce void @"github.com/goplus/llgo/cl/_testrt/tpabi.(*T[string,int]).Info"(ptr %0) #0 {
 _llgo_0:
   %1 = load %"github.com/goplus/llgo/cl/_testrt/tpabi.T[string,int]", ptr %0, align 8
   call void @"github.com/goplus/llgo/cl/_testrt/tpabi.T[string,int].Info"(%"github.com/goplus/llgo/cl/_testrt/tpabi.T[string,int]" %1)
   ret void
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -169,7 +176,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -177,7 +185,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -185,17 +194,23 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -203,12 +218,17 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintPointer"(ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testrt/tpfunc/out.ll
+++ b/cl/_testrt/tpfunc/out.ll
@@ -3,7 +3,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/tpfunc"
 
 @"github.com/goplus/llgo/cl/_testrt/tpfunc.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/tpfunc.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/tpfunc.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/tpfunc.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -16,7 +17,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/tpfunc.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/tpfunc.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64 16)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
@@ -27,7 +29,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/tpfunc.main$1"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/tpfunc.main$1"(ptr %0) #0 {
 _llgo_0:
   %1 = load i64, ptr %0, align 4
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %1)
@@ -35,7 +38,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/tpfunc.main$2"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/tpfunc.main$2"(ptr %0) #0 {
 _llgo_0:
   %1 = load i64, ptr %0, align 4
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %1)
@@ -43,7 +47,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/tpfunc.main$3"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/tpfunc.main$3"(ptr %0) #0 {
 _llgo_0:
   %1 = load i64, ptr %0, align 4
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %1)
@@ -57,8 +62,13 @@ _llgo_0:
   ret void
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/tpmap/out.ll
+++ b/cl/_testrt/tpmap/out.ll
@@ -90,7 +90,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/tpmap"
 @"_llgo_struct$ibdiBmDH7G4iiypsSuNnfN36hpedh02DKMXmXLR4D0g$fields" = weak_odr constant [4 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @17, i64 7 }, ptr @"[8]_llgo_uint8", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @21, i64 4 }, ptr @"[8]_llgo_github.com/goplus/llgo/cl/_testrt/tpmap.cacheKey", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @24, i64 5 }, ptr @"[8]_llgo_string", i64 392, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @27, i64 8 }, ptr @_llgo_Pointer, i64 520, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
 @29 = private unnamed_addr constant [5 x i8] c"world", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/tpmap.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/tpmap.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/tpmap.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -103,7 +104,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/tpmap.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/tpmap.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_github.com/goplus/llgo/cl/_testrt/tpmap.cacheKey]_llgo_string", i64 0)
   %1 = alloca %"github.com/goplus/llgo/cl/_testrt/tpmap.cacheKey", align 8
@@ -157,7 +159,8 @@ _llgo_0:
   ret void
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -165,11 +168,14 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.typehash"(ptr, ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.typehash"(ptr, ptr, i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -177,7 +183,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -185,7 +192,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -193,9 +201,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -203,21 +213,29 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr, i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr, i64) #0
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAssign"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAssign"(ptr, ptr, ptr) #0
 
-declare { ptr, i1 } @"github.com/goplus/llgo/runtime/internal/runtime.MapAccess2"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare { ptr, i1 } @"github.com/goplus/llgo/runtime/internal/runtime.MapAccess2"(ptr, ptr, ptr) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1) #0
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testrt/tpmethod/out.ll
+++ b/cl/_testrt/tpmethod/out.ll
@@ -73,13 +73,15 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/tpmethod"
 @"*_llgo_iface$XcsCI4xRViVu44YvSfJySCCik7Xq487CpVScS6LGI70" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1232808231, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @20, i64 79 }, ptr null }, ptr @"_llgo_iface$XcsCI4xRViVu44YvSfJySCCik7Xq487CpVScS6LGI70" }, align 8
 @"_llgo_iface$XcsCI4xRViVu44YvSfJySCCik7Xq487CpVScS6LGI70$imethods" = weak_odr constant [1 x %"github.com/goplus/llgo/runtime/abi.Imethod"] [%"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @19, i64 4 }, ptr @"_llgo_func$YDtAFTesCi1EpIfGs4nqPSJzLIDwkg-8FAbVKMCx8cg" }], align 8
 
-define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testrt/tpmethod.ReadFile"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0) {
+; Function Attrs: null_pointer_is_valid
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testrt/tpmethod.ReadFile"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0) #0 {
 _llgo_0:
   %1 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testrt/tpmethod.Async[github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]]"({ ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/tpmethod.ReadFile$1", ptr null })
   ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/tpmethod.ReadFile$1"({ ptr, ptr } %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/tpmethod.ReadFile$1"({ ptr, ptr } %0) #0 {
 _llgo_0:
   %1 = alloca %"github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]", align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -92,7 +94,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/tpmethod.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/tpmethod.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/tpmethod.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -105,7 +108,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/tpmethod.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/tpmethod.main"() #0 {
 _llgo_0:
   %0 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testrt/tpmethod.ReadFile"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 7 })
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
@@ -120,7 +124,8 @@ _llgo_0:
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/tpmethod.main$1"(%"github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]" %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/tpmethod.main$1"(%"github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]" %0) #0 {
 _llgo_0:
   %1 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error].Get"(%"github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]" %0)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintIface"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %1)
@@ -128,7 +133,8 @@ _llgo_0:
   ret void
 }
 
-define linkonce %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testrt/tpmethod.Async[github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]]"({ ptr, ptr } %0) {
+; Function Attrs: null_pointer_is_valid
+define linkonce %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testrt/tpmethod.Async[github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]]"({ ptr, ptr } %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testrt/tpmethod.future[github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]]", ptr %1, i32 0, i32 0
@@ -146,9 +152,10 @@ _llgo_0:
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
 define linkonce void @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/tpmethod.main$1"(ptr %0, %"github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]" %1) {
 _llgo_0:
@@ -156,7 +163,8 @@ _llgo_0:
   ret void
 }
 
-define linkonce %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error].Get"(%"github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]" %0) {
+; Function Attrs: null_pointer_is_valid
+define linkonce %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error].Get"(%"github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]" %0) #0 {
 _llgo_0:
   %1 = alloca %"github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]", align 8
   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -166,13 +174,17 @@ _llgo_0:
   ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %3
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintIface"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintIface"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-define linkonce void @"github.com/goplus/llgo/cl/_testrt/tpmethod.(*future[github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]]).Then"(ptr %0, { ptr, ptr } %1) {
+; Function Attrs: null_pointer_is_valid
+define linkonce void @"github.com/goplus/llgo/cl/_testrt/tpmethod.(*future[github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]]).Then"(ptr %0, { ptr, ptr } %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testrt/tpmethod.future[github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]]", ptr %0, i32 0, i32 0
   %3 = load { ptr, ptr }, ptr %2, align 8
@@ -182,7 +194,8 @@ _llgo_0:
   ret void
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -190,16 +203,19 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-define linkonce %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testrt/tpmethod.(*Tuple[error]).Get"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define linkonce %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testrt/tpmethod.(*Tuple[error]).Get"(ptr %0) #0 {
 _llgo_0:
   %1 = load %"github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]", ptr %0, align 8
   %2 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error].Get"(%"github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]" %1)
   ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %2
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -207,7 +223,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -215,6 +232,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr) #0
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testrt/tpunsafe/out.ll
+++ b/cl/_testrt/tpunsafe/out.ll
@@ -19,7 +19,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/tpunsafe"
 @"*_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1323879264, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @3, i64 6 }, ptr null }, ptr @_llgo_string }, align 8
 @4 = private unnamed_addr constant [21 x i8] c"unsafe.Offsetof error", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/tpunsafe.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/tpunsafe.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/tpunsafe.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -32,7 +33,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/tpunsafe.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/tpunsafe.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 12)
   call void @"github.com/goplus/llgo/cl/_testrt/tpunsafe.(*M[bool]).check"(ptr %0, i64 1, i64 8, i64 1)
@@ -41,9 +43,11 @@ _llgo_0:
   ret void
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-define linkonce void @"github.com/goplus/llgo/cl/_testrt/tpunsafe.(*M[bool]).check"(ptr %0, i64 %1, i64 %2, i64 %3) {
+; Function Attrs: null_pointer_is_valid
+define linkonce void @"github.com/goplus/llgo/cl/_testrt/tpunsafe.(*M[bool]).check"(ptr %0, i64 %1, i64 %2, i64 %3) #0 {
 _llgo_0:
   %4 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testrt/tpunsafe.M[bool]", ptr %0, i32 0, i32 2
   %5 = load %"github.com/goplus/llgo/cl/_testrt/tpunsafe.N[bool]", ptr %4, align 1
@@ -112,7 +116,8 @@ _llgo_6:                                          ; preds = %_llgo_4
   ret void
 }
 
-define linkonce void @"github.com/goplus/llgo/cl/_testrt/tpunsafe.(*M[int64]).check"(ptr %0, i64 %1, i64 %2, i64 %3) {
+; Function Attrs: null_pointer_is_valid
+define linkonce void @"github.com/goplus/llgo/cl/_testrt/tpunsafe.(*M[int64]).check"(ptr %0, i64 %1, i64 %2, i64 %3) #0 {
 _llgo_0:
   %4 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testrt/tpunsafe.M[int64]", ptr %0, i32 0, i32 2
   %5 = load %"github.com/goplus/llgo/cl/_testrt/tpunsafe.N[int64]", ptr %4, align 4
@@ -181,15 +186,20 @@ _llgo_6:                                          ; preds = %_llgo_4
   ret void
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -197,7 +207,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -205,6 +216,10 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/typalias/out.ll
+++ b/cl/_testrt/typalias/out.ll
@@ -7,7 +7,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/typalias"
 @"github.com/goplus/llgo/cl/_testrt/typalias.format" = global [10 x i8] zeroinitializer, align 1
 @"github.com/goplus/llgo/cl/_testrt/typalias.init$guard" = global i1 false, align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/typalias.Print"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/typalias.Print"(ptr %0) #0 {
 _llgo_0:
   %1 = getelementptr inbounds { i32, i1 }, ptr %0, i32 0, i32 1
   %2 = load i1, ptr %1, align 1
@@ -23,16 +24,20 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define ptr @"github.com/goplus/llgo/cl/_testrt/typalias._Cgo_ptr"(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define ptr @"github.com/goplus/llgo/cl/_testrt/typalias._Cgo_ptr"(ptr %0) #0 {
 _llgo_0:
   ret ptr %0
 }
 
-declare void @runtime.cgoUse(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @runtime.cgoUse(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare void @runtime.cgoCheckResult(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @runtime.cgoCheckResult(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-define void @"github.com/goplus/llgo/cl/_testrt/typalias.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/typalias.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/typalias.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -56,7 +61,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/typalias.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/typalias.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   %1 = getelementptr inbounds { i32, i1 }, ptr %0, i32 0, i32 0
@@ -69,6 +75,10 @@ _llgo_0:
 
 declare void @printf(ptr, ...)
 
-declare void @syscall.init()
+; Function Attrs: null_pointer_is_valid
+declare void @syscall.init() #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/typed/out.ll
+++ b/cl/_testrt/typed/out.ll
@@ -30,7 +30,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/typed"
 @7 = private unnamed_addr constant [5 x i8] c"[]int", align 1
 @"*[]_llgo_int" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1428175521, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr null }, ptr @"[]_llgo_int" }, align 8
 
-define void @"github.com/goplus/llgo/cl/_testrt/typed.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/typed.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/typed.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -43,7 +44,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/typed.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/typed.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
   store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %0, align 8
@@ -130,7 +132,8 @@ _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
   ret void
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -138,7 +141,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -146,22 +150,29 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintBool"(i1) #0
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -169,6 +180,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64) #0
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testrt/unreachable/out.ll
+++ b/cl/_testrt/unreachable/out.ll
@@ -4,13 +4,15 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/unreachable"
 @"github.com/goplus/llgo/cl/_testrt/unreachable.init$guard" = global i1 false, align 1
 @0 = private unnamed_addr constant [7 x i8] c"Hello\0A\00", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/unreachable.foo"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/unreachable.foo"() #0 {
 _llgo_0:
   unreachable
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/unreachable.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/unreachable.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/unreachable.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -23,7 +25,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/unreachable.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/unreachable.main"() #0 {
 _llgo_0:
   call void @"github.com/goplus/llgo/cl/_testrt/unreachable.foo"()
   %0 = call i32 (ptr, ...) @printf(ptr @0)
@@ -31,3 +34,5 @@ _llgo_0:
 }
 
 declare i32 @printf(ptr, ...)
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/unsafe/out.ll
+++ b/cl/_testrt/unsafe/out.ll
@@ -15,7 +15,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/unsafe"
 @2 = private unnamed_addr constant [4 x i8] c"abc\00", align 1
 @3 = private unnamed_addr constant [3 x i8] c"abc", align 1
 
-define void @"github.com/goplus/llgo/cl/_testrt/unsafe.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/unsafe.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/unsafe.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -28,7 +29,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/unsafe.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/unsafe.main"() #0 {
 _llgo_0:
   br i1 false, label %_llgo_1, label %_llgo_2
 
@@ -227,7 +229,8 @@ _llgo_33:                                         ; preds = %_llgo_31
   ret void
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -235,7 +238,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -243,12 +247,19 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String")
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String") #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1) #0
+
+attributes #0 = { null_pointer_is_valid }

--- a/cl/_testrt/vamethod/out.ll
+++ b/cl/_testrt/vamethod/out.ll
@@ -68,7 +68,8 @@ source_filename = "github.com/goplus/llgo/cl/_testrt/vamethod"
 @21 = private unnamed_addr constant [6 x i8] c"string", align 1
 @"*_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1323879264, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @21, i64 6 }, ptr null }, ptr @_llgo_string }, align 8
 
-define i32 @"github.com/goplus/llgo/cl/_testrt/vamethod.CFmt.Printf"(%"github.com/goplus/llgo/cl/_testrt/vamethod.CFmt" %0, ...) {
+; Function Attrs: null_pointer_is_valid
+define i32 @"github.com/goplus/llgo/cl/_testrt/vamethod.CFmt.Printf"(%"github.com/goplus/llgo/cl/_testrt/vamethod.CFmt" %0, ...) #0 {
 _llgo_0:
   %1 = alloca %"github.com/goplus/llgo/cl/_testrt/vamethod.CFmt", align 8
   call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
@@ -79,7 +80,8 @@ _llgo_0:
   ret i32 %4
 }
 
-define i32 @"github.com/goplus/llgo/cl/_testrt/vamethod.(*CFmt).Printf"(ptr %0, ...) {
+; Function Attrs: null_pointer_is_valid
+define i32 @"github.com/goplus/llgo/cl/_testrt/vamethod.(*CFmt).Printf"(ptr %0, ...) #0 {
 _llgo_0:
   %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testrt/vamethod.CFmt", ptr %0, i32 0, i32 0
   %2 = load ptr, ptr %1, align 8
@@ -87,14 +89,16 @@ _llgo_0:
   ret i32 %3
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/vamethod.(*CFmt).SetFormat"(ptr %0, ptr %1) {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/vamethod.(*CFmt).SetFormat"(ptr %0, ptr %1) #0 {
 _llgo_0:
   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testrt/vamethod.CFmt", ptr %0, i32 0, i32 0
   store ptr %1, ptr %2, align 8
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/vamethod.init"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/vamethod.init"() #0 {
 _llgo_0:
   %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testrt/vamethod.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -107,7 +111,8 @@ _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
 
-define void @"github.com/goplus/llgo/cl/_testrt/vamethod.main"() {
+; Function Attrs: null_pointer_is_valid
+define void @"github.com/goplus/llgo/cl/_testrt/vamethod.main"() #0 {
 _llgo_0:
   %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
   call void @"github.com/goplus/llgo/cl/_testrt/vamethod.(*CFmt).SetFormat"(ptr %0, ptr @0)
@@ -172,13 +177,15 @@ _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #1
 
 declare i32 @printf(ptr, ...)
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -186,9 +193,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr) #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -196,7 +205,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -204,7 +214,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -212,7 +223,8 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -220,13 +232,17 @@ _llgo_0:
   ret i1 %3
 }
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.Implements"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.Implements"(ptr, ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr) #0
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
 
-declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+; Function Attrs: null_pointer_is_valid
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr) #0
 
 define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
 _llgo_0:
@@ -234,8 +250,11 @@ _llgo_0:
   ret i1 %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
 
-declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+; Function Attrs: null_pointer_is_valid
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface") #0
 
-attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -335,7 +335,8 @@ source_filename = "foo"
 @foo.a = global i64 0, align 8
 @"foo.init$guard" = global i1 false, align 1
 
-define void @foo.init() {
+; Function Attrs: null_pointer_is_valid
+define void @foo.init() #0 {
 _llgo_0:
   %0 = load i1, ptr @"foo.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -347,6 +348,8 @@ _llgo_1:                                          ; preds = %_llgo_0
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
+
+attributes #0 = { null_pointer_is_valid }
 `)
 }
 
@@ -361,12 +364,14 @@ source_filename = "foo"
 
 @"foo.init$guard" = global i1 false, align 1
 
-define i64 @foo.fn(i64 %0, double %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @foo.fn(i64 %0, double %1) #0 {
 _llgo_0:
   ret i64 1
 }
 
-define void @foo.init() {
+; Function Attrs: null_pointer_is_valid
+define void @foo.init() #0 {
 _llgo_0:
   %0 = load i1, ptr @"foo.init$guard", align 1
   br i1 %0, label %_llgo_2, label %_llgo_1
@@ -378,5 +383,7 @@ _llgo_1:                                          ; preds = %_llgo_0
 _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
   ret void
 }
+
+attributes #0 = { null_pointer_is_valid }
 `)
 }

--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -6,6 +6,7 @@ import (
 	"github.com/goplus/llgo/cmd/internal/compilerhash"
 	"github.com/goplus/llgo/internal/build"
 	"github.com/goplus/llgo/internal/buildenv"
+	"github.com/goplus/llgo/internal/optlevel"
 )
 
 var OutputFile string
@@ -42,6 +43,7 @@ var SizeFormat string
 var SizeLevel string
 var ForceRebuild bool
 var PrintCommands bool
+var OptLevel optlevel.Level
 
 const DefaultTestTimeout = "10m" // Matches Go's default test timeout
 
@@ -52,6 +54,20 @@ func AddCommonFlags(fs *flag.FlagSet) {
 func AddBuildFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&ForceRebuild, "a", false, "Force rebuilding of packages that are already up-to-date")
 	fs.BoolVar(&PrintCommands, "x", false, "Print the commands")
+	fs.Var(optLevelFlag(optlevel.O0), "O0", "Disable optimizations")
+	fs.Var(optLevelFlag(optlevel.O1), "O1", "Optimize lightly")
+	fs.Var(optLevelFlag(optlevel.O2), "O2", "Optimize for performance")
+	fs.Var(optLevelFlag(optlevel.O3), "O3", "Optimize aggressively")
+	fs.Var(optLevelFlag(optlevel.Os), "Os", "Optimize for size")
+	fs.Var(optLevelFlag(optlevel.Oz), "Oz", "Optimize aggressively for size")
+	fs.Func("O", "Optimization level (0,1,2,3,s,z)", func(val string) error {
+		level, err := optlevel.Parse(val)
+		if err != nil {
+			return err
+		}
+		OptLevel = level
+		return nil
+	})
 	fs.StringVar(&Tags, "tags", "", "Build tags")
 	fs.StringVar(&BuildEnv, "buildenv", "", "Build environment")
 	if buildenv.Dev {
@@ -177,6 +193,7 @@ func UpdateConfig(conf *build.Config) error {
 	conf.Tags = Tags
 	conf.Verbose = Verbose
 	conf.PrintCommands = PrintCommands
+	conf.OptLevel = OptLevel
 	conf.Target = Target
 	conf.Port = Port
 	conf.BaudRate = BaudRate
@@ -234,4 +251,19 @@ func UpdateBuildConfig(conf *build.Config) error {
 	conf.BuildMode = build.BuildMode(BuildMode)
 
 	return nil
+}
+
+type optLevelFlag optlevel.Level
+
+func (f optLevelFlag) String() string {
+	return optlevel.Level(f).Suffix()
+}
+
+func (f optLevelFlag) Set(string) error {
+	OptLevel = optlevel.Level(f)
+	return nil
+}
+
+func (f optLevelFlag) IsBoolFlag() bool {
+	return true
 }

--- a/cmd/internal/flags/flags_test.go
+++ b/cmd/internal/flags/flags_test.go
@@ -1,0 +1,49 @@
+package flags
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/goplus/llgo/internal/optlevel"
+)
+
+func resetBuildFlagGlobals() {
+	OptLevel = optlevel.Unset
+}
+
+func TestOptimizationFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want optlevel.Level
+	}{
+		{name: "shorthand O2", args: []string{"-O2"}, want: optlevel.O2},
+		{name: "shorthand Oz", args: []string{"-Oz"}, want: optlevel.Oz},
+		{name: "explicit O value", args: []string{"-O=s"}, want: optlevel.Os},
+		{name: "space separated O value", args: []string{"-O", "3"}, want: optlevel.O3},
+		{name: "last flag wins", args: []string{"-O1", "-Oz"}, want: optlevel.Oz},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetBuildFlagGlobals()
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			AddBuildFlags(fs)
+			if err := fs.Parse(tt.args); err != nil {
+				t.Fatalf("Parse(%v) failed: %v", tt.args, err)
+			}
+			if OptLevel != tt.want {
+				t.Fatalf("OptLevel = %v, want %v", OptLevel, tt.want)
+			}
+		})
+	}
+}
+
+func TestOptimizationFlagsRejectInvalidLevel(t *testing.T) {
+	resetBuildFlagGlobals()
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	AddBuildFlags(fs)
+	if err := fs.Parse([]string{"-O=fast"}); err == nil {
+		t.Fatal("Parse(-O=fast) succeeded, want error")
+	}
+}

--- a/cmd/internal/monitor/monitor.go
+++ b/cmd/internal/monitor/monitor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/goplus/llgo/cmd/internal/flags"
 	"github.com/goplus/llgo/internal/crosscompile"
 	"github.com/goplus/llgo/internal/monitor"
+	"github.com/goplus/llgo/internal/optlevel"
 )
 
 // Cmd represents the monitor command.
@@ -34,6 +35,7 @@ var Cmd = &base.Command{
 
 func init() {
 	flags.AddCommonFlags(&Cmd.Flag)
+	flags.AddBuildFlags(&Cmd.Flag)
 	flags.AddEmbeddedFlags(&Cmd.Flag)
 	Cmd.Run = runMonitor
 }
@@ -54,7 +56,11 @@ func runMonitor(cmd *base.Command, args []string) {
 
 	var serialPort []string
 	if flags.Target != "" {
-		conf, err := crosscompile.UseTarget(flags.Target)
+		level := flags.OptLevel
+		if !level.IsValid() {
+			level = optlevel.Oz
+		}
+		conf, err := crosscompile.UseTarget(flags.Target, level)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "llgo monitor: %v\n", err)
 			os.Exit(1)

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -48,6 +48,7 @@ import (
 	"github.com/goplus/llgo/internal/header"
 	"github.com/goplus/llgo/internal/mockable"
 	"github.com/goplus/llgo/internal/monitor"
+	"github.com/goplus/llgo/internal/optlevel"
 	"github.com/goplus/llgo/internal/packages"
 	"github.com/goplus/llgo/internal/typepatch"
 	"github.com/goplus/llgo/ssa/abi"
@@ -117,6 +118,7 @@ type Config struct {
 	Goos          string
 	Goarch        string
 	Target        string // target name (e.g., "rp2040", "wasi") - takes precedence over Goos/Goarch
+	OptLevel      optlevel.Level
 	BinPath       string
 	AppExt        string  // ".exe" on Windows, empty on Unix
 	OutFile       string  // only valid for ModeBuild when len(pkgs) == 1
@@ -224,9 +226,11 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	if err := ensureSizeReporting(conf); err != nil {
 		return nil, err
 	}
+	conf.OptLevel = effectiveOptLevel(conf)
+
 	// Handle crosscompile configuration first to set correct GOOS/GOARCH
 	forceEspClang := conf.ForceEspClang || conf.Target != ""
-	export, err := crosscompile.Use(conf.Goos, conf.Goarch, conf.Target, IsWasiThreadsEnabled(), forceEspClang)
+	export, err := crosscompile.Use(conf.Goos, conf.Goarch, conf.Target, IsWasiThreadsEnabled(), forceEspClang, conf.OptLevel)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup crosscompile: %w", err)
 	}
@@ -1689,6 +1693,16 @@ func Plan9ASMPkgs() string {
 
 func WasmRuntime() string {
 	return defaultEnv(llgoWasmRuntime, defaultWasmRuntime)
+}
+
+func effectiveOptLevel(conf *Config) optlevel.Level {
+	if conf != nil && conf.OptLevel.IsValid() {
+		return conf.OptLevel
+	}
+	if conf != nil && conf.Target != "" {
+		return optlevel.Oz
+	}
+	return optlevel.O2
 }
 
 func concatPkgLinkFiles(ctx *context, pkg *packages.Package, verbose bool) (parts []string) {

--- a/internal/build/optlevel_test.go
+++ b/internal/build/optlevel_test.go
@@ -1,0 +1,54 @@
+package build
+
+import (
+	"testing"
+
+	"github.com/goplus/llgo/internal/optlevel"
+)
+
+func TestEffectiveOptLevelDefaults(t *testing.T) {
+	if got := effectiveOptLevel(&Config{}); got != optlevel.O2 {
+		t.Fatalf("host default opt level = %v, want %v", got, optlevel.O2)
+	}
+	if got := effectiveOptLevel(&Config{Target: "rp2040"}); got != optlevel.Oz {
+		t.Fatalf("embedded default opt level = %v, want %v", got, optlevel.Oz)
+	}
+}
+
+func TestEffectiveOptLevelOverride(t *testing.T) {
+	if got := effectiveOptLevel(&Config{OptLevel: optlevel.O3}); got != optlevel.O3 {
+		t.Fatalf("explicit opt level = %v, want %v", got, optlevel.O3)
+	}
+	if got := effectiveOptLevel(&Config{Target: "esp32", OptLevel: optlevel.Os}); got != optlevel.Os {
+		t.Fatalf("explicit embedded opt level = %v, want %v", got, optlevel.Os)
+	}
+}
+
+func TestEffectiveOptLevelIgnoresLegacyEnv(t *testing.T) {
+	t.Setenv(llgoOptimize, "off")
+	if got := effectiveOptLevel(&Config{}); got != optlevel.O2 {
+		t.Fatalf("LLGO_OPTIMIZE=off opt level = %v, want %v", got, optlevel.O2)
+	}
+
+	t.Setenv(llgoOptimize, "on")
+	if got := effectiveOptLevel(&Config{Target: "rp2040"}); got != optlevel.Oz {
+		t.Fatalf("LLGO_OPTIMIZE=on embedded opt level = %v, want %v", got, optlevel.Oz)
+	}
+
+	t.Setenv(llgoOptimize, "O1")
+	if got := effectiveOptLevel(&Config{}); got != optlevel.O2 {
+		t.Fatalf("LLGO_OPTIMIZE=O1 opt level = %v, want %v", got, optlevel.O2)
+	}
+}
+
+func TestIsOptimizeEnabledLegacyEnv(t *testing.T) {
+	t.Setenv(llgoOptimize, "off")
+	if IsOptimizeEnabled() {
+		t.Fatal("LLGO_OPTIMIZE=off should disable optimization")
+	}
+
+	t.Setenv(llgoOptimize, "on")
+	if !IsOptimizeEnabled() {
+		t.Fatal("LLGO_OPTIMIZE=on should enable optimization")
+	}
+}

--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -13,6 +13,7 @@ import (
 	"github.com/goplus/llgo/internal/crosscompile/compile"
 	"github.com/goplus/llgo/internal/env"
 	"github.com/goplus/llgo/internal/flash"
+	"github.com/goplus/llgo/internal/optlevel"
 	"github.com/goplus/llgo/internal/targets"
 	"github.com/goplus/llgo/internal/xtool/llvm"
 	envllvm "github.com/goplus/llgo/xtool/env/llvm"
@@ -197,7 +198,10 @@ func compileWithConfig(
 	return
 }
 
-func use(goos, goarch string, wasiThreads, forceEspClang bool) (export Export, err error) {
+func use(goos, goarch string, wasiThreads, forceEspClang bool, optLevel optlevel.Level) (export Export, err error) {
+	if !optLevel.IsValid() {
+		return export, fmt.Errorf("invalid optimization level: %s", optLevel)
+	}
 	targetTriple := llvm.GetTargetTriple(goos, goarch)
 	llgoRoot := env.LLGoROOT()
 
@@ -247,6 +251,7 @@ func use(goos, goarch string, wasiThreads, forceEspClang bool) (export Export, e
 			}
 		}
 		export.CCFLAGS = []string{
+			optLevel.Flag(),
 			"-Qunused-arguments",
 			"-Wno-unused-command-line-argument",
 		}
@@ -323,6 +328,7 @@ func use(goos, goarch string, wasiThreads, forceEspClang bool) (export Export, e
 		// Use system clang and sysroot of wasi-sdk
 		// Add compiler flags
 		export.CCFLAGS = []string{
+			optLevel.Flag(),
 			"-target", targetTriple,
 			"--sysroot=" + sysrootDir,
 			"-resource-dir=" + libclangDir,
@@ -382,6 +388,7 @@ func use(goos, goarch string, wasiThreads, forceEspClang bool) (export Export, e
 		export.CC = "emcc"
 		// Add compiler flags
 		export.CCFLAGS = []string{
+			optLevel.Flag(),
 			"-target", targetTriple,
 			"-Qunused-arguments",
 			"-Wno-unused-command-line-argument",
@@ -424,7 +431,10 @@ func use(goos, goarch string, wasiThreads, forceEspClang bool) (export Export, e
 }
 
 // UseTarget loads configuration from a target name (e.g., "rp2040", "wasi")
-func UseTarget(targetName string) (export Export, err error) {
+func UseTarget(targetName string, optLevel optlevel.Level) (export Export, err error) {
+	if !optLevel.IsValid() {
+		return export, fmt.Errorf("invalid optimization level: %s", optLevel)
+	}
 	resolver := targets.NewDefaultResolver()
 
 	config, err := resolver.Resolve(targetName)
@@ -489,7 +499,7 @@ func UseTarget(targetName string) (export Export, err error) {
 	// Convert LLVMTarget, CPU, Features to CCFLAGS/LDFLAGS
 	// Enable ICF (Identical Code Folding) to reduce binary size
 	ldflags := []string{"-S", "--icf=safe"}
-	ccflags := []string{"-Oz"}
+	ccflags := []string{optLevel.Flag()}
 	cflags := []string{"-Wno-override-module", "-Qunused-arguments", "-Wno-unused-command-line-argument"}
 	if config.LLVMTarget != "" {
 		cflags = append(cflags, "--target="+config.LLVMTarget)
@@ -658,9 +668,9 @@ func UseTarget(targetName string) (export Export, err error) {
 
 // Use extends the original Use function to support target-based configuration
 // If targetName is provided, it takes precedence over goos/goarch
-func Use(goos, goarch, targetName string, wasiThreads, forceEspClang bool) (export Export, err error) {
+func Use(goos, goarch, targetName string, wasiThreads, forceEspClang bool, optLevel optlevel.Level) (export Export, err error) {
 	if targetName != "" && !strings.HasPrefix(targetName, "wasm") && !strings.HasPrefix(targetName, "wasi") {
-		return UseTarget(targetName)
+		return UseTarget(targetName, optLevel)
 	}
-	return use(goos, goarch, wasiThreads, forceEspClang)
+	return use(goos, goarch, wasiThreads, forceEspClang, optLevel)
 }

--- a/internal/crosscompile/crosscompile_test.go
+++ b/internal/crosscompile/crosscompile_test.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 	"slices"
 	"testing"
+
+	"github.com/goplus/llgo/internal/optlevel"
 )
 
 const (
@@ -76,7 +78,7 @@ func TestUseCrossCompileSDK(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			export, err := use(tc.goos, tc.goarch, false, false)
+			export, err := use(tc.goos, tc.goarch, false, false, optlevel.O2)
 
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
@@ -231,7 +233,7 @@ func TestUseTarget(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			export, err := UseTarget(tc.targetName)
+			export, err := UseTarget(tc.targetName, optlevel.Oz)
 
 			if tc.expectError {
 				if err == nil {
@@ -309,9 +311,27 @@ func TestUseTarget(t *testing.T) {
 	}
 }
 
+func TestOptimizationFlagPlacement(t *testing.T) {
+	export, err := UseTarget("rp2040", optlevel.Oz)
+	if err != nil {
+		t.Fatalf("UseTarget(rp2040) failed: %v", err)
+	}
+	if len(export.CCFLAGS) == 0 || export.CCFLAGS[0] != "-Oz" {
+		t.Fatalf("embedded default optimization flag = %v, want first flag -Oz", export.CCFLAGS)
+	}
+
+	export, err = Use(runtime.GOOS, runtime.GOARCH, "", false, false, optlevel.O3)
+	if err != nil {
+		t.Fatalf("Use(host, O3) failed: %v", err)
+	}
+	if !slices.Contains(export.CCFLAGS, "-O3") {
+		t.Fatalf("host optimization flags = %v, want -O3 in CCFLAGS", export.CCFLAGS)
+	}
+}
+
 func TestUseWithTarget(t *testing.T) {
 	// Test target-based configuration takes precedence
-	export, err := Use("linux", "amd64", "esp32", false, true)
+	export, err := Use("linux", "amd64", "esp32", false, true, optlevel.Oz)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -323,7 +343,7 @@ func TestUseWithTarget(t *testing.T) {
 	}
 
 	// Test fallback to goos/goarch when no target specified
-	export, err = Use(runtime.GOOS, runtime.GOARCH, "", false, false)
+	export, err = Use(runtime.GOOS, runtime.GOARCH, "", false, false, optlevel.O2)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/internal/optlevel/optlevel.go
+++ b/internal/optlevel/optlevel.go
@@ -1,0 +1,81 @@
+package optlevel
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Level uint8
+
+const (
+	Unset Level = iota
+	O0
+	O1
+	O2
+	O3
+	Os
+	Oz
+)
+
+func Parse(level string) (Level, error) {
+	normalizedLevel := strings.TrimSpace(strings.ToLower(level))
+	normalizedLevel = strings.TrimPrefix(normalizedLevel, "-")
+	normalizedLevel = strings.TrimPrefix(normalizedLevel, "o")
+	switch normalizedLevel {
+	case "0":
+		return O0, nil
+	case "1":
+		return O1, nil
+	case "2":
+		return O2, nil
+	case "3":
+		return O3, nil
+	case "s":
+		return Os, nil
+	case "z":
+		return Oz, nil
+	default:
+		return Unset, fmt.Errorf("invalid optimization level %q, must be one of: 0, 1, 2, 3, s, z", level)
+	}
+}
+
+func (l Level) IsValid() bool {
+	return l >= O0 && l <= Oz
+}
+
+func (l Level) IsOptimized() bool {
+	return l.IsValid() && l != O0
+}
+
+func (l Level) String() string {
+	if !l.IsValid() {
+		return "unset"
+	}
+	return l.Flag()
+}
+
+func (l Level) Flag() string {
+	if !l.IsValid() {
+		return ""
+	}
+	return "-O" + l.Suffix()
+}
+
+func (l Level) Suffix() string {
+	switch l {
+	case O0:
+		return "0"
+	case O1:
+		return "1"
+	case O2:
+		return "2"
+	case O3:
+		return "3"
+	case Os:
+		return "s"
+	case Oz:
+		return "z"
+	default:
+		return ""
+	}
+}

--- a/internal/optlevel/optlevel_test.go
+++ b/internal/optlevel/optlevel_test.go
@@ -1,0 +1,87 @@
+package optlevel
+
+import "testing"
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    Level
+		wantErr bool
+	}{
+		{name: "o0", input: "0", want: O0},
+		{name: "o1", input: "1", want: O1},
+		{name: "o2", input: "2", want: O2},
+		{name: "o3", input: "3", want: O3},
+		{name: "os", input: "s", want: Os},
+		{name: "oz", input: "z", want: Oz},
+		{name: "trim and lowercase", input: "  S  ", want: Os},
+		{name: "prefixed with dash and o", input: "-O2", want: O2},
+		{name: "prefixed with o", input: "o3", want: O3},
+		{name: "prefixed with dash lowercase", input: "-oz", want: Oz},
+		{name: "invalid empty", input: "", want: Unset, wantErr: true},
+		{name: "invalid value", input: "fast", want: Unset, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Parse(%q) succeeded, want error", tt.input)
+				}
+				if got != Unset {
+					t.Fatalf("Parse(%q) = %v, want %v on error", tt.input, got, Unset)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Parse(%q) failed: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("Parse(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLevelHelpers(t *testing.T) {
+	tests := []struct {
+		name        string
+		level       Level
+		valid       bool
+		optimized   bool
+		stringValue string
+		flag        string
+		suffix      string
+	}{
+		{name: "unset", level: Unset, stringValue: "unset"},
+		{name: "invalid", level: Level(99), stringValue: "unset"},
+		{name: "o0", level: O0, valid: true, stringValue: "-O0", flag: "-O0", suffix: "0"},
+		{name: "o1", level: O1, valid: true, optimized: true, stringValue: "-O1", flag: "-O1", suffix: "1"},
+		{name: "o2", level: O2, valid: true, optimized: true, stringValue: "-O2", flag: "-O2", suffix: "2"},
+		{name: "o3", level: O3, valid: true, optimized: true, stringValue: "-O3", flag: "-O3", suffix: "3"},
+		{name: "os", level: Os, valid: true, optimized: true, stringValue: "-Os", flag: "-Os", suffix: "s"},
+		{name: "oz", level: Oz, valid: true, optimized: true, stringValue: "-Oz", flag: "-Oz", suffix: "z"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.level.IsValid(); got != tt.valid {
+				t.Fatalf("IsValid(%v) = %v, want %v", tt.level, got, tt.valid)
+			}
+			if got := tt.level.IsOptimized(); got != tt.optimized {
+				t.Fatalf("IsOptimized(%v) = %v, want %v", tt.level, got, tt.optimized)
+			}
+			if got := tt.level.String(); got != tt.stringValue {
+				t.Fatalf("String(%v) = %q, want %q", tt.level, got, tt.stringValue)
+			}
+			if got := tt.level.Flag(); got != tt.flag {
+				t.Fatalf("Flag(%v) = %q, want %q", tt.level, got, tt.flag)
+			}
+			if got := tt.level.Suffix(); got != tt.suffix {
+				t.Fatalf("Suffix(%v) = %q, want %q", tt.level, got, tt.suffix)
+			}
+		})
+	}
+}

--- a/ssa/decl.go
+++ b/ssa/decl.go
@@ -205,6 +205,9 @@ func (p Package) NewFuncEx(name string, sig *types.Signature, bg Background, has
 	t := p.Prog.FuncDecl(sig, bg)
 	dbgInstrln("NewFunc", name, t.raw.Type, "hasFreeVars:", hasFreeVars)
 	fn := llvm.AddFunction(p.mod, name, t.ll)
+	if bg == InGo {
+		fn.AddFunctionAttr(p.nullPointerIsValidAttr)
+	}
 	if instantiated {
 		fn.SetLinkage(llvm.LinkOnceAnyLinkage)
 	}

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -453,11 +453,13 @@ func (p Program) NewPackage(name, pkgPath string) Package {
 	pymods := make(map[string]Global)
 	strs := make(map[string]llvm.Value)
 	glbDbgVars := make(map[Expr]bool)
+	nullPointerIsValidAttr := mod.Context().CreateEnumAttribute(llvm.AttributeKindID("null_pointer_is_valid"), 0)
 	// Don't need reset p.needPyInit here
 	// p.needPyInit = false
 	ret := &aPackage{
 		mod: mod, path: pkgPath, Prog: p, vars: gbls, fns: fns,
-		pyobjs: pyobjs, pymods: pymods, strs: strs,
+		nullPointerIsValidAttr: nullPointerIsValidAttr,
+		pyobjs:                 pyobjs, pymods: pymods, strs: strs,
 		di: nil, cu: nil, glbDbgVars: glbDbgVars,
 		export:         make(map[string]string),
 		preserveSyms:   make(map[string]struct{}),
@@ -706,6 +708,8 @@ type aPackage struct {
 	path string
 
 	Prog Program
+
+	nullPointerIsValidAttr llvm.Attribute
 
 	di         diBuilder
 	cu         CompilationUnit

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -195,12 +195,14 @@ func TestClosureNoCtxValue(t *testing.T) {
 	assertPkg(t, pkg, `; ModuleID = 'foo/bar'
 source_filename = "foo/bar"
 
-define i64 @fn(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @fn(i64 %0) #0 {
 _llgo_0:
   ret i64 %0
 }
 
-define void @holder() {
+; Function Attrs: null_pointer_is_valid
+define void @holder() #0 {
 _llgo_0:
   %0 = alloca { ptr, ptr }, align 8
   store { ptr, ptr } { ptr @__llgo_stub.fn, ptr null }, ptr %0, align 8
@@ -212,6 +214,8 @@ _llgo_0:
   %2 = tail call i64 @fn(i64 %1)
   ret i64 %2
 }
+
+attributes #0 = { null_pointer_is_valid }
 `)
 }
 
@@ -250,12 +254,14 @@ func TestClosureFuncPtrValue(t *testing.T) {
 	expected := fmt.Sprintf(`; ModuleID = 'foo/bar'
 source_filename = "foo/bar"
 
-define i64 @fn(i64 %%0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @fn(i64 %%0) #0 {
 _llgo_0:
   ret i64 %%0
 }
 
-define void @holder() {
+; Function Attrs: null_pointer_is_valid
+define void @holder() #0 {
 _llgo_0:
   %%0 = alloca { ptr, ptr }, align 8
   %%1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 8)
@@ -272,7 +278,10 @@ _llgo_0:
   ret i64 %%3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
+
+attributes #0 = { null_pointer_is_valid }
 `, wrapRef, wrapRef)
 	assertPkg(t, pkg, expected)
 }
@@ -332,13 +341,16 @@ func TestCallClosureDynamic(t *testing.T) {
 	assertPkg(t, pkg, `; ModuleID = 'foo/bar'
 source_filename = "foo/bar"
 
-define i64 @caller({ ptr, ptr } %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @caller({ ptr, ptr } %0, i64 %1) #0 {
 _llgo_0:
   %2 = extractvalue { ptr, ptr } %0, 1
   %3 = extractvalue { ptr, ptr } %0, 0
   %4 = call i64 %3(ptr %2, i64 %1)
   ret i64 %4
 }
+
+attributes #0 = { null_pointer_is_valid }
 `)
 }
 
@@ -376,12 +388,14 @@ func TestMakeClosureWithCtx(t *testing.T) {
 	assertPkg(t, pkg, `; ModuleID = 'foo/bar'
 source_filename = "foo/bar"
 
-define i64 @inner(ptr %0, i64 %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @inner(ptr %0, i64 %1) #0 {
 _llgo_0:
   ret i64 %1
 }
 
-define { ptr, ptr } @outer(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define { ptr, ptr } @outer(i64 %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 8)
   %2 = getelementptr inbounds { i64 }, ptr %1, i32 0, i32 0
@@ -390,7 +404,10 @@ _llgo_0:
   ret { ptr, ptr } %3
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64) #0
+
+attributes #0 = { null_pointer_is_valid }
 `)
 }
 
@@ -459,7 +476,8 @@ source_filename = "foo/bar"
 
 %"github.com/goplus/llgo/runtime/internal/runtime.iface" = type { ptr, ptr }
 
-define i64 @caller(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @caller(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0) #0 {
 _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
   %2 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 0
@@ -473,7 +491,10 @@ _llgo_0:
   ret i64 %9
 }
 
-declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+; Function Attrs: null_pointer_is_valid
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface") #0
+
+attributes #0 = { null_pointer_is_valid }
 `)
 }
 
@@ -828,10 +849,13 @@ func TestConst(t *testing.T) {
 	assertPkg(t, pkg, `; ModuleID = 'foo/bar'
 source_filename = "foo/bar"
 
-define i1 @fn() {
+; Function Attrs: null_pointer_is_valid
+define i1 @fn() #0 {
 _llgo_0:
   ret i1 true
 }
+
+attributes #0 = { null_pointer_is_valid }
 `)
 }
 
@@ -885,7 +909,10 @@ func TestDeclFunc(t *testing.T) {
 	assertPkg(t, pkg, `; ModuleID = 'foo/bar'
 source_filename = "foo/bar"
 
-declare void @fn(i64)
+; Function Attrs: null_pointer_is_valid
+declare void @fn(i64) #0
+
+attributes #0 = { null_pointer_is_valid }
 `)
 }
 
@@ -902,10 +929,13 @@ func TestBasicFunc(t *testing.T) {
 	assertPkg(t, pkg, `; ModuleID = 'foo/bar'
 source_filename = "foo/bar"
 
-define i64 @fn(i64 %0, double %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @fn(i64 %0, double %1) #0 {
 _llgo_0:
   ret i64 1
 }
+
+attributes #0 = { null_pointer_is_valid }
 `)
 }
 
@@ -922,10 +952,13 @@ func TestFuncParam(t *testing.T) {
 	assertPkg(t, pkg, `; ModuleID = 'foo/bar'
 source_filename = "foo/bar"
 
-define i64 @fn(i64 %0, double %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @fn(i64 %0, double %1) #0 {
 _llgo_0:
   ret i64 %0
 }
+
+attributes #0 = { null_pointer_is_valid }
 `)
 }
 
@@ -949,16 +982,20 @@ func TestFuncCall(t *testing.T) {
 	assertPkg(t, pkg, `; ModuleID = 'foo/bar'
 source_filename = "foo/bar"
 
-define i64 @fn(i64 %0, double %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @fn(i64 %0, double %1) #0 {
 _llgo_0:
   ret i64 1
 }
 
-define void @main() {
+; Function Attrs: null_pointer_is_valid
+define void @main() #0 {
 _llgo_0:
   %0 = call i64 @fn(i64 1, double 1.200000e+00)
   ret void
 }
+
+attributes #0 = { null_pointer_is_valid }
 `)
 }
 
@@ -980,11 +1017,14 @@ source_filename = "foo/bar"
 
 @a = external global i64, align 8
 
-define { i64, double } @fn(double %0) {
+; Function Attrs: null_pointer_is_valid
+define { i64, double } @fn(double %0) #0 {
 _llgo_0:
   %1 = insertvalue { i64, double } { ptr @a, double undef }, double %0, 1
   ret { i64, double } %1
 }
+
+attributes #0 = { null_pointer_is_valid }
 `)
 }
 
@@ -997,10 +1037,13 @@ func TestJump(t *testing.T) {
 	assertPkg(t, pkg, `; ModuleID = 'foo/bar'
 source_filename = "foo/bar"
 
-define void @loop() {
+; Function Attrs: null_pointer_is_valid
+define void @loop() #0 {
 _llgo_0:
   br label %_llgo_0
 }
+
+attributes #0 = { null_pointer_is_valid }
 `)
 }
 
@@ -1024,7 +1067,8 @@ func TestIf(t *testing.T) {
 	assertPkg(t, pkg, `; ModuleID = 'foo/bar'
 source_filename = "foo/bar"
 
-define i64 @fn(i64 %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @fn(i64 %0) #0 {
 _llgo_0:
   %1 = icmp sgt i64 %0, 0
   br i1 %1, label %_llgo_1, label %_llgo_2
@@ -1035,6 +1079,8 @@ _llgo_1:                                          ; preds = %_llgo_0
 _llgo_2:                                          ; preds = %_llgo_0
   ret i64 0
 }
+
+attributes #0 = { null_pointer_is_valid }
 `)
 }
 
@@ -1068,11 +1114,14 @@ func TestBinOp(t *testing.T) {
 	assertPkg(t, pkg, `; ModuleID = 'foo/bar'
 source_filename = "foo/bar"
 
-define i64 @fn(i64 %0, double %1) {
+; Function Attrs: null_pointer_is_valid
+define i64 @fn(i64 %0, double %1) #0 {
 _llgo_0:
   %2 = add i64 %0, 1
   ret i64 %2
 }
+
+attributes #0 = { null_pointer_is_valid }
 `)
 }
 
@@ -1094,13 +1143,16 @@ func TestUnOp(t *testing.T) {
 	assertPkg(t, pkg, `; ModuleID = 'foo/bar'
 source_filename = "foo/bar"
 
-define i64 @fn(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i64 @fn(ptr %0) #0 {
 _llgo_0:
   %1 = load i64, ptr %0, align 4
   %2 = xor i64 %1, 1
   store i64 %2, ptr %0, align 4
   ret i64 %2
 }
+
+attributes #0 = { null_pointer_is_valid }
 `)
 }
 
@@ -1149,7 +1201,8 @@ func TestCompareSelect(t *testing.T) {
 	assertPkg(t, pkg, `; ModuleID = 'foo/bar'
 source_filename = "foo/bar"
 
-define i64 @fn(i64 %0, i64 %1, i64 %2) {
+; Function Attrs: null_pointer_is_valid
+define i64 @fn(i64 %0, i64 %1, i64 %2) #0 {
 _llgo_0:
   %3 = icmp sgt i64 %0, %1
   %4 = select i1 %3, i64 %0, i64 %1
@@ -1157,6 +1210,8 @@ _llgo_0:
   %6 = select i1 %5, i64 %4, i64 %2
   ret i64 %6
 }
+
+attributes #0 = { null_pointer_is_valid }
 `)
 }
 
@@ -1274,16 +1329,18 @@ func TestSetjmpReturnsTwice(t *testing.T) {
 	assertPkg(t, pkg, `; ModuleID = 'foo/bar'
 source_filename = "foo/bar"
 
-define i32 @test(ptr %0) {
+; Function Attrs: null_pointer_is_valid
+define i32 @test(ptr %0) #0 {
 _llgo_0:
   %1 = call i32 @setjmp(ptr %0)
   ret i32 %1
 }
 
 ; Function Attrs: returns_twice
-declare i32 @setjmp(ptr) #0
+declare i32 @setjmp(ptr) #1
 
-attributes #0 = { returns_twice }
+attributes #0 = { null_pointer_is_valid }
+attributes #1 = { returns_twice }
 `)
 }
 


### PR DESCRIPTION
## Summary

This change adds clang-style optimization flags to `llgo` and propagates the selected `-O*` level to the final clang command line.

## What changed

- add CLI support for `-O0/-O1/-O2/-O3/-Os/-Oz` and `-O=<level>`
- normalize optimization levels through a shared `optlevel.Level` type
- store the selected optimization level in `build.Config`
- pass the normalized optimization level into `crosscompile.Use` / `UseTarget`
- inject the final `-O*` flag into `crosscompile.Export.CCFLAGS`, so the eventual clang invocation carries the requested optimization level
- keep `-O` limited to clang-facing flags only; existing internal optimization behavior remains controlled by the previous build logic
- keep default clang optimization levels target-aware:
  - host builds: `-O2`
  - embedded target builds: `-Oz`
- make `llgo monitor` honor the same optimization flag behavior for target lookups
- build LLDB debugger fixtures with `-O0` to preserve stack traces during debugger tests
- add tests for CLI parsing, optimization defaults, and optimization flag placement

## Testing

- `PATH=/opt/tools/go1.24.5.linux-amd64/go/bin:$PATH GOROOT=/opt/tools/go1.24.5.linux-amd64/go /opt/tools/go1.24.5.linux-amd64/go/bin/go test ./internal/build -run 'TestEffectiveOptLevelDefaults|TestEffectiveOptLevelOverride|TestEffectiveOptLevelIgnoresLegacyEnv|TestIsOptimizeEnabledLegacyEnv|TestTest' -count=1`
- `PATH=/opt/tools/go1.24.5.linux-amd64/go/bin:$PATH GOROOT=/opt/tools/go1.24.5.linux-amd64/go /opt/tools/go1.24.5.linux-amd64/go/bin/go test ./cmd/internal/flags ./cmd/internal/monitor ./internal/crosscompile ./ssa -count=1`
- `PATH=/opt/tools/go1.24.5.linux-amd64/go/bin:$PATH GOROOT=/opt/tools/go1.24.5.linux-amd64/go GOWORK=off <rebuilt-llgo> build -O0 -o <tmp-out> ./_lldb/lldbtest`
