### PR TITLE
test: fix _testgo source checks cases reasonable

### DIFF
--- a/cl/_testgo/abimethod/in.go
+++ b/cl/_testgo/abimethod/in.go
@@ -8,43 +8,208 @@ import (
 	"unsafe"
 )
 
+// CHECK: @"*{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8" = weak_odr constant { %"{{.*}}/runtime/abi.PtrType", %"{{.*}}/runtime/abi.UncommonType", [3 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -712860747, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 25 }, ptr null }, ptr @"{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8" }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, i16 3, i16 2, i32 24 }, [3 x %"{{.*}}/runtime/abi.Method"] [%"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo1", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo1" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @9, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo2", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo2" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @11, i64 49 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.demo3", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.demo3" }] }, align 8
+// CHECK: @"{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8" = weak_odr constant { %"{{.*}}/runtime/abi.StructType", %"{{.*}}/runtime/abi.UncommonType", [3 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.StructType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 235980794, i8 9, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"{{.*}}/runtime/internal/runtime.structequal", ptr @"{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8" }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 25 }, ptr @"*{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8$fields", i64 2, i64 2 } }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, i16 3, i16 2, i32 24 }, [3 x %"{{.*}}/runtime/abi.Method"] [%"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo1", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo1" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @9, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo2", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo2" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @11, i64 49 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.demo3", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *{{.*}}/_testgo/abimethod.T}.demo3" }] }, align 8
+// CHECK: @"*_llgo_{{.*}}/_testgo/abimethod.T" = weak_odr constant { %"{{.*}}/runtime/abi.PtrType", %"{{.*}}/runtime/abi.UncommonType", [3 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -908752194, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 6 }, ptr null }, ptr @"_llgo_{{.*}}/_testgo/abimethod.T" }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, i16 3, i16 2, i32 24 }, [3 x %"{{.*}}/runtime/abi.Method"] [%"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.(*T).Demo1", ptr @"{{.*}}/_testgo/abimethod.(*T).Demo1" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @9, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.(*T).Demo2", ptr @"{{.*}}/_testgo/abimethod.(*T).Demo2" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @11, i64 49 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.(*T).demo3", ptr @"{{.*}}/_testgo/abimethod.(*T).demo3" }] }, align 8
+// CHECK: @"_llgo_{{.*}}/_testgo/abimethod.T" = weak_odr constant { %"{{.*}}/runtime/abi.StructType", %"{{.*}}/runtime/abi.UncommonType", [1 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.StructType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 0, i32 -666093743, i8 13, i8 8, i8 8, i8 57, { ptr, ptr } { ptr @"{{.*}}/runtime/internal/runtime.structequal", ptr @"_llgo_{{.*}}/_testgo/abimethod.T" }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 6 }, ptr @"*_llgo_{{.*}}/_testgo/abimethod.T" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"{{.*}}/_testgo/abimethod.struct$eovYmOhZg4X0zMSsuscSshndnbbAGvB2E3cyG8E7Y4U$fields", i64 1, i64 1 } }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, i16 1, i16 1, i32 24 }, [1 x %"{{.*}}/runtime/abi.Method"] [%"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.(*T).Demo1", ptr @"{{.*}}/_testgo/abimethod.T.Demo1" }] }, align 8
+// CHECK: @"{{.*}}/_testgo/abimethod.struct$eovYmOhZg4X0zMSsuscSshndnbbAGvB2E3cyG8E7Y4U$fields" = weak_odr constant [1 x %"{{.*}}/runtime/abi.StructField"] [%"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 1 }, ptr @_llgo_int, i64 0, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+// CHECK: @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 2131144854, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @8, i64 10 }, ptr @"*_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA$out", i64 1, i64 1 } }, align 8
+// CHECK: @"*_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1805835775, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @8, i64 10 }, ptr null }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" }, align 8
+// CHECK: @"{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8$fields" = weak_odr constant [2 x %"{{.*}}/runtime/abi.StructField"] [%"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 1 }, ptr @_llgo_int, i64 0, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @4, i64 1 }, ptr @"*_llgo_{{.*}}/_testgo/abimethod.T", i64 8, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 true }], align 8
+// CHECK: @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc" = weak_odr constant %"{{.*}}/runtime/abi.InterfaceType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 -1807485229, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @12, i64 25 }, ptr @"*_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc$imethods", i64 1, i64 1 } }, align 8
+// CHECK: @"*_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 929086049, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @12, i64 25 }, ptr null }, ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc" }, align 8
+// CHECK: @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc$imethods" = weak_odr constant [1 x %"{{.*}}/runtime/abi.Imethod"] [%"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" }], align 8
+// CHECK: @"{{.*}}/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088" = weak_odr constant { %"{{.*}}/runtime/abi.StructType", %"{{.*}}/runtime/abi.UncommonType", [1 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.StructType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 0, i32 179876865, i8 9, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"{{.*}}/runtime/internal/runtime.structequal", ptr @"{{.*}}/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088" }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @16, i64 24 }, ptr @"*{{.*}}/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"{{.*}}/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088$fields", i64 2, i64 2 } }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, i16 1, i16 1, i32 24 }, [1 x %"{{.*}}/runtime/abi.Method"] [%"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; {{.*}}/_testgo/abimethod.T}.Demo1", ptr @"{{.*}}/_testgo/abimethod.struct{m int; {{.*}}/_testgo/abimethod.T}.Demo1" }] }, align 8
+// CHECK: @"*{{.*}}/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088" = weak_odr constant { %"{{.*}}/runtime/abi.PtrType", %"{{.*}}/runtime/abi.UncommonType", [3 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -343027978, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @16, i64 24 }, ptr null }, ptr @"{{.*}}/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088" }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, i16 3, i16 2, i32 24 }, [3 x %"{{.*}}/runtime/abi.Method"] [%"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; {{.*}}/_testgo/abimethod.T}.Demo1", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; {{.*}}/_testgo/abimethod.T}.Demo1" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @9, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; {{.*}}/_testgo/abimethod.T}.Demo2", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; {{.*}}/_testgo/abimethod.T}.Demo2" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @11, i64 49 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; {{.*}}/_testgo/abimethod.T}.demo3", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; {{.*}}/_testgo/abimethod.T}.demo3" }] }, align 8
+// CHECK: @"{{.*}}/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088$fields" = weak_odr constant [2 x %"{{.*}}/runtime/abi.StructField"] [%"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 1 }, ptr @_llgo_int, i64 0, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @4, i64 1 }, ptr @"_llgo_{{.*}}/_testgo/abimethod.T", i64 8, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 true }], align 8
+// CHECK: @"_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4" = weak_odr constant %"{{.*}}/runtime/abi.InterfaceType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 1090904853, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @19, i64 25 }, ptr @"*_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4$imethods", i64 1, i64 1 } }, align 8
+// CHECK: @"*_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1063382362, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @19, i64 25 }, ptr null }, ptr @"_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4" }, align 8
+// CHECK: @"_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4$imethods" = weak_odr constant [1 x %"{{.*}}/runtime/abi.Imethod"] [%"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @9, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" }], align 8
+// CHECK: @"_llgo_iface$58AxoxqQ6sGUOM73FOqFrXsMlgxkU4HGd-S1Wl-ssYw" = weak_odr constant %"{{.*}}/runtime/abi.InterfaceType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 541709743, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 38 }, ptr @"*_llgo_iface$58AxoxqQ6sGUOM73FOqFrXsMlgxkU4HGd-S1Wl-ssYw" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$58AxoxqQ6sGUOM73FOqFrXsMlgxkU4HGd-S1Wl-ssYw$imethods", i64 2, i64 2 } }, align 8
+// CHECK: @"*_llgo_iface$58AxoxqQ6sGUOM73FOqFrXsMlgxkU4HGd-S1Wl-ssYw" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 945986433, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 38 }, ptr null }, ptr @"_llgo_iface$58AxoxqQ6sGUOM73FOqFrXsMlgxkU4HGd-S1Wl-ssYw" }, align 8
+// CHECK: @"_llgo_iface$58AxoxqQ6sGUOM73FOqFrXsMlgxkU4HGd-S1Wl-ssYw$imethods" = weak_odr constant [2 x %"{{.*}}/runtime/abi.Imethod"] [%"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" }, %"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @9, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" }], align 8
+// CHECK: @"{{.*}}/_testgo/abimethod.iface$kT5SIXt45Cspjl04Bof3DZVSOIltlDo-njpk6KqtZvA" = weak_odr constant %"{{.*}}/runtime/abi.InterfaceType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 -601152795, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @24, i64 56 }, ptr @"*{{.*}}/_testgo/abimethod.iface$kT5SIXt45Cspjl04Bof3DZVSOIltlDo-njpk6KqtZvA" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"{{.*}}/_testgo/abimethod.iface$kT5SIXt45Cspjl04Bof3DZVSOIltlDo-njpk6KqtZvA$imethods", i64 3, i64 3 } }, align 8
+// CHECK: @"*{{.*}}/_testgo/abimethod.iface$kT5SIXt45Cspjl04Bof3DZVSOIltlDo-njpk6KqtZvA" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 162233315, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @24, i64 56 }, ptr null }, ptr @"{{.*}}/_testgo/abimethod.iface$kT5SIXt45Cspjl04Bof3DZVSOIltlDo-njpk6KqtZvA" }, align 8
+// CHECK: @"{{.*}}/_testgo/abimethod.iface$kT5SIXt45Cspjl04Bof3DZVSOIltlDo-njpk6KqtZvA$imethods" = weak_odr constant [3 x %"{{.*}}/runtime/abi.Imethod"] [%"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" }, %"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @9, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" }, %"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @11, i64 49 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" }], align 8
+// CHECK: @"*{{.*}}/_testgo/abimethod.struct$RGW016k7zllXgGPm1CvD5-IBe-9lphOOTCFtYyDGLjY" = weak_odr constant { %"{{.*}}/runtime/abi.PtrType", %"{{.*}}/runtime/abi.UncommonType", [27 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1554050967, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @27, i64 31 }, ptr null }, ptr @"{{.*}}/_testgo/abimethod.struct$RGW016k7zllXgGPm1CvD5-IBe-9lphOOTCFtYyDGLjY" }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, i16 27, i16 23, i32 24 }, [27 x %"{{.*}}/runtime/abi.Method"] [%"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @37, i64 9 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Available", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Available" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @38, i64 15 }, ptr @"_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.AvailableBuffer", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.AvailableBuffer" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @40, i64 5 }, ptr @"_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Bytes", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Bytes" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @41, i64 3 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Cap", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Cap" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @42, i64 4 }, ptr @"_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Grow", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Grow" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @44, i64 3 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Len", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Len" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @45, i64 4 }, ptr @"_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Next", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Next" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @47, i64 4 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Read", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Read" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @52, i64 8 }, ptr @"_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadByte", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadByte" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @54, i64 9 }, ptr @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadBytes", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadBytes" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @56, i64 8 }, ptr @"_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadFrom", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadFrom" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @60, i64 8 }, ptr @"_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadRune", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadRune" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @63, i64 10 }, ptr @"_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadString", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadString" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @65, i64 5 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Reset", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Reset" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @67, i64 6 }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.String", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.String" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @68, i64 8 }, ptr @"_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Truncate", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Truncate" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @69, i64 10 }, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadByte", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadByte" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @71, i64 10 }, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadRune", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadRune" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @72, i64 5 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Write", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Write" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @73, i64 9 }, ptr @"_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteByte", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteByte" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @75, i64 9 }, ptr @"_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteRune", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteRune" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @77, i64 11 }, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteString", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteString" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @79, i64 7 }, ptr @"_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteTo", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteTo" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @83, i64 11 }, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.empty", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.empty" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @87, i64 10 }, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.grow", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.grow" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @90, i64 15 }, ptr @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.readSlice", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.readSlice" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @92, i64 22 }, ptr @"_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.tryGrowByReslice", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.tryGrowByReslice" }] }, align 8
+// CHECK: @"{{.*}}/_testgo/abimethod.struct$RGW016k7zllXgGPm1CvD5-IBe-9lphOOTCFtYyDGLjY" = weak_odr constant { %"{{.*}}/runtime/abi.StructType", %"{{.*}}/runtime/abi.UncommonType", [27 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.StructType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 -1137763463, i8 9, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"{{.*}}/runtime/internal/runtime.structequal", ptr @"{{.*}}/_testgo/abimethod.struct$RGW016k7zllXgGPm1CvD5-IBe-9lphOOTCFtYyDGLjY" }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @27, i64 31 }, ptr @"*{{.*}}/_testgo/abimethod.struct$RGW016k7zllXgGPm1CvD5-IBe-9lphOOTCFtYyDGLjY" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"{{.*}}/_testgo/abimethod.struct$RGW016k7zllXgGPm1CvD5-IBe-9lphOOTCFtYyDGLjY$fields", i64 2, i64 2 } }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, i16 27, i16 23, i32 24 }, [27 x %"{{.*}}/runtime/abi.Method"] [%"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @37, i64 9 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Available", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Available" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @38, i64 15 }, ptr @"_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.AvailableBuffer", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.AvailableBuffer" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @40, i64 5 }, ptr @"_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Bytes", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Bytes" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @41, i64 3 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Cap", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Cap" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @42, i64 4 }, ptr @"_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Grow", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Grow" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @44, i64 3 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Len", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Len" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @45, i64 4 }, ptr @"_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Next", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Next" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @47, i64 4 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Read", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Read" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @52, i64 8 }, ptr @"_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadByte", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadByte" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @54, i64 9 }, ptr @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadBytes", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadBytes" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @56, i64 8 }, ptr @"_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadFrom", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadFrom" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @60, i64 8 }, ptr @"_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadRune", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadRune" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @63, i64 10 }, ptr @"_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadString", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadString" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @65, i64 5 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Reset", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Reset" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @67, i64 6 }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.String", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.String" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @68, i64 8 }, ptr @"_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Truncate", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Truncate" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @69, i64 10 }, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadByte", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.UnreadByte" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @71, i64 10 }, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadRune", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.UnreadRune" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @72, i64 5 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Write", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Write" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @73, i64 9 }, ptr @"_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteByte", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteByte" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @75, i64 9 }, ptr @"_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteRune", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteRune" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @77, i64 11 }, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteString", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteString" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @79, i64 7 }, ptr @"_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteTo", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteTo" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @83, i64 11 }, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.empty", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.empty" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @87, i64 10 }, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.grow", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.grow" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @90, i64 15 }, ptr @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.readSlice", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.readSlice" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @92, i64 22 }, ptr @"_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.tryGrowByReslice", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.tryGrowByReslice" }] }, align 8
+// CHECK: @"*_llgo_bytes.Buffer" = weak_odr constant { %"{{.*}}/runtime/abi.PtrType", %"{{.*}}/runtime/abi.UncommonType", [27 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 258663788, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @29, i64 12 }, ptr null }, ptr @_llgo_bytes.Buffer }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @30, i64 5 }, i16 27, i16 23, i32 24 }, [27 x %"{{.*}}/runtime/abi.Method"] [%"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @37, i64 9 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"bytes.(*Buffer).Available", ptr @"bytes.(*Buffer).Available" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @38, i64 15 }, ptr @"_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY", ptr @"bytes.(*Buffer).AvailableBuffer", ptr @"bytes.(*Buffer).AvailableBuffer" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @40, i64 5 }, ptr @"_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY", ptr @"bytes.(*Buffer).Bytes", ptr @"bytes.(*Buffer).Bytes" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @41, i64 3 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"bytes.(*Buffer).Cap", ptr @"bytes.(*Buffer).Cap" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @42, i64 4 }, ptr @"_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA", ptr @"bytes.(*Buffer).Grow", ptr @"bytes.(*Buffer).Grow" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @44, i64 3 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"bytes.(*Buffer).Len", ptr @"bytes.(*Buffer).Len" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @45, i64 4 }, ptr @"_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY", ptr @"bytes.(*Buffer).Next", ptr @"bytes.(*Buffer).Next" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @47, i64 4 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk", ptr @"bytes.(*Buffer).Read", ptr @"bytes.(*Buffer).Read" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @52, i64 8 }, ptr @"_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ", ptr @"bytes.(*Buffer).ReadByte", ptr @"bytes.(*Buffer).ReadByte" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @54, i64 9 }, ptr @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0", ptr @"bytes.(*Buffer).ReadBytes", ptr @"bytes.(*Buffer).ReadBytes" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @56, i64 8 }, ptr @"_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8", ptr @"bytes.(*Buffer).ReadFrom", ptr @"bytes.(*Buffer).ReadFrom" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @60, i64 8 }, ptr @"_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y", ptr @"bytes.(*Buffer).ReadRune", ptr @"bytes.(*Buffer).ReadRune" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @63, i64 10 }, ptr @"_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o", ptr @"bytes.(*Buffer).ReadString", ptr @"bytes.(*Buffer).ReadString" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @65, i64 5 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"bytes.(*Buffer).Reset", ptr @"bytes.(*Buffer).Reset" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @67, i64 6 }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", ptr @"bytes.(*Buffer).String", ptr @"bytes.(*Buffer).String" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @68, i64 8 }, ptr @"_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA", ptr @"bytes.(*Buffer).Truncate", ptr @"bytes.(*Buffer).Truncate" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @69, i64 10 }, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", ptr @"bytes.(*Buffer).UnreadByte", ptr @"bytes.(*Buffer).UnreadByte" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @71, i64 10 }, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", ptr @"bytes.(*Buffer).UnreadRune", ptr @"bytes.(*Buffer).UnreadRune" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @72, i64 5 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk", ptr @"bytes.(*Buffer).Write", ptr @"bytes.(*Buffer).Write" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @73, i64 9 }, ptr @"_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg", ptr @"bytes.(*Buffer).WriteByte", ptr @"bytes.(*Buffer).WriteByte" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @75, i64 9 }, ptr @"_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw", ptr @"bytes.(*Buffer).WriteRune", ptr @"bytes.(*Buffer).WriteRune" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @77, i64 11 }, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw", ptr @"bytes.(*Buffer).WriteString", ptr @"bytes.(*Buffer).WriteString" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @79, i64 7 }, ptr @"_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M", ptr @"bytes.(*Buffer).WriteTo", ptr @"bytes.(*Buffer).WriteTo" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @83, i64 11 }, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", ptr @"bytes.(*Buffer).empty", ptr @"bytes.(*Buffer).empty" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @87, i64 10 }, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU", ptr @"bytes.(*Buffer).grow", ptr @"bytes.(*Buffer).grow" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @90, i64 15 }, ptr @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0", ptr @"bytes.(*Buffer).readSlice", ptr @"bytes.(*Buffer).readSlice" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @92, i64 22 }, ptr @"_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M", ptr @"bytes.(*Buffer).tryGrowByReslice", ptr @"bytes.(*Buffer).tryGrowByReslice" }] }, align 8
+// CHECK: @_llgo_bytes.Buffer = weak_odr constant { %"{{.*}}/runtime/abi.StructType", %"{{.*}}/runtime/abi.UncommonType", [0 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.StructType" { %"{{.*}}/runtime/abi.Type" { i64 40, i64 0, i32 661676552, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @29, i64 12 }, ptr @"*_llgo_bytes.Buffer" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @30, i64 5 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"bytes.struct$8M6lRFZ7Fk2XCr2laNI9Y7uQtk2A8VDBrezMuq2Fkuo$fields", i64 3, i64 3 } }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @30, i64 5 }, i16 0, i16 0, i32 24 }, [0 x %"{{.*}}/runtime/abi.Method"] zeroinitializer }, align 8
+// CHECK: @"[]_llgo_uint8" = weak_odr constant %"{{.*}}/runtime/abi.SliceType" { %"{{.*}}/runtime/abi.Type" { i64 24, i64 8, i32 370346748, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @32, i64 7 }, ptr @"*[]_llgo_uint8" }, ptr @_llgo_uint8 }, align 8
+// CHECK: @"*[]_llgo_uint8" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -2143776929, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @32, i64 7 }, ptr null }, ptr @"[]_llgo_uint8" }, align 8
+// CHECK: @_llgo_uint8 = weak_odr constant %"{{.*}}/runtime/abi.Type" { i64 1, i64 0, i32 269156761, i8 12, i8 1, i8 1, i8 40, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequal8", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @33, i64 5 }, ptr @"*_llgo_uint8" }, align 8
+// CHECK: @"*_llgo_uint8" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1277858201, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @33, i64 5 }, ptr null }, ptr @_llgo_uint8 }, align 8
+// CHECK: @_llgo_bytes.readOp = weak_odr constant { %"{{.*}}/runtime/abi.Type", %"{{.*}}/runtime/abi.UncommonType", [0 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.Type" { i64 1, i64 0, i32 1507423333, i8 13, i8 1, i8 1, i8 35, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequal8", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @36, i64 12 }, ptr @"*_llgo_bytes.readOp" }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @30, i64 5 }, i16 0, i16 0, i32 24 }, [0 x %"{{.*}}/runtime/abi.Method"] zeroinitializer }, align 8
+// CHECK: @"*_llgo_bytes.readOp" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1082688598, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @36, i64 12 }, ptr null }, ptr @_llgo_bytes.readOp }, align 8
+// CHECK: @"bytes.struct$8M6lRFZ7Fk2XCr2laNI9Y7uQtk2A8VDBrezMuq2Fkuo$fields" = weak_odr constant [3 x %"{{.*}}/runtime/abi.StructField"] [%"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @31, i64 3 }, ptr @"[]_llgo_uint8", i64 0, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @34, i64 3 }, ptr @_llgo_int, i64 24, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @35, i64 8 }, ptr @_llgo_bytes.readOp, i64 32, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+// CHECK: @"_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -153447421, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @39, i64 14 }, ptr @"*_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY" }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY$out", i64 1, i64 1 } }, align 8
+// CHECK: @"*_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1574747178, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @39, i64 14 }, ptr null }, ptr @"_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY" }, align 8
+// CHECK: @"_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY$out" = weak_odr constant [1 x ptr] [ptr @"[]_llgo_uint8"], align 8
+// CHECK: @"_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -637187458, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @43, i64 9 }, ptr @"*_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer }, align 8
+// CHECK: @"*_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 735356155, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @43, i64 9 }, ptr null }, ptr @"_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA" }, align 8
+// CHECK: @"_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA$in" = weak_odr constant [1 x ptr] [ptr @_llgo_int], align 8
+// CHECK: @"_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -875118098, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @46, i64 17 }, ptr @"*_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY$out", i64 1, i64 1 } }, align 8
+// CHECK: @"*_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1809495648, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @46, i64 17 }, ptr null }, ptr @"_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY" }, align 8
+// CHECK: @"_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY$in" = weak_odr constant [1 x ptr] [ptr @_llgo_int], align 8
+// CHECK: @"_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY$out" = weak_odr constant [1 x ptr] [ptr @"[]_llgo_uint8"], align 8
+// CHECK: @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -58533757, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @48, i64 26 }, ptr @"*_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk$out", i64 2, i64 2 } }, align 8
+// CHECK: @"*_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1244675479, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @48, i64 26 }, ptr null }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk" }, align 8
+// CHECK: @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk$in" = weak_odr constant [1 x ptr] [ptr @"[]_llgo_uint8"], align 8
+// CHECK: @_llgo_error = weak_odr constant %"{{.*}}/runtime/abi.InterfaceType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 -1462738452, i8 4, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @49, i64 5 }, ptr @"*_llgo_error" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU$imethods", i64 1, i64 1 } }, align 8
+// CHECK: @"*_llgo_error" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1621558991, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @49, i64 5 }, ptr null }, ptr @_llgo_error }, align 8
+// CHECK: @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1419376263, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @51, i64 13 }, ptr @"*_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to$out", i64 1, i64 1 } }, align 8
+// CHECK: @"*_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1900367307, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @51, i64 13 }, ptr null }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" }, align 8
+// CHECK: @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to$out" = weak_odr constant [1 x ptr] [ptr @_llgo_string], align 8
+// CHECK: @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU$imethods" = weak_odr constant [1 x %"{{.*}}/runtime/abi.Imethod"] [%"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @50, i64 5 }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" }], align 8
+// CHECK: @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk$out" = weak_odr constant [2 x ptr] [ptr @_llgo_int, ptr @_llgo_error], align 8
+// CHECK: @"_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1499372428, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @53, i64 21 }, ptr @"*_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ" }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ$out", i64 2, i64 2 } }, align 8
+// CHECK: @"*_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1164205677, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @53, i64 21 }, ptr null }, ptr @"_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ" }, align 8
+// CHECK: @"_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ$out" = weak_odr constant [2 x ptr] [ptr @_llgo_uint8, ptr @_llgo_error], align 8
+// CHECK: @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1659702664, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @55, i64 28 }, ptr @"*_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0$out", i64 2, i64 2 } }, align 8
+// CHECK: @"*_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 2010891442, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @55, i64 28 }, ptr null }, ptr @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0" }, align 8
+// CHECK: @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0$in" = weak_odr constant [1 x ptr] [ptr @_llgo_uint8], align 8
+// CHECK: @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0$out" = weak_odr constant [2 x ptr] [ptr @"[]_llgo_uint8", ptr @_llgo_error], align 8
+// CHECK: @"_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1635781323, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @57, i64 30 }, ptr @"*_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8$out", i64 2, i64 2 } }, align 8
+// CHECK: @"*_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1930979199, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @57, i64 30 }, ptr null }, ptr @"_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8" }, align 8
+// CHECK: @_llgo_io.Reader = weak_odr constant %"{{.*}}/runtime/abi.InterfaceType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 -1885455791, i8 4, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @58, i64 9 }, ptr @"*_llgo_io.Reader" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw$imethods", i64 1, i64 1 } }, align 8
+// CHECK: @"*_llgo_io.Reader" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 760453616, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @58, i64 9 }, ptr null }, ptr @_llgo_io.Reader }, align 8
+// CHECK: @"_llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw$imethods" = weak_odr constant [1 x %"{{.*}}/runtime/abi.Imethod"] [%"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @47, i64 4 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk" }], align 8
+// CHECK: @"_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8$in" = weak_odr constant [1 x ptr] [ptr @_llgo_io.Reader], align 8
+// CHECK: @_llgo_int64 = weak_odr constant %"{{.*}}/runtime/abi.Type" { i64 8, i64 0, i32 394795202, i8 12, i8 8, i8 8, i8 38, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequal64", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @59, i64 5 }, ptr @"*_llgo_int64" }, align 8
+// CHECK: @"*_llgo_int64" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1901231210, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @59, i64 5 }, ptr null }, ptr @_llgo_int64 }, align 8
+// CHECK: @"_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8$out" = weak_odr constant [2 x ptr] [ptr @_llgo_int64, ptr @_llgo_error], align 8
+// CHECK: @"_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1043083527, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @61, i64 26 }, ptr @"*_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y" }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y$out", i64 3, i64 3 } }, align 8
+// CHECK: @"*_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 746645372, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @61, i64 26 }, ptr null }, ptr @"_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y" }, align 8
+// CHECK: @_llgo_int32 = weak_odr constant %"{{.*}}/runtime/abi.Type" { i64 4, i64 0, i32 1448558410, i8 12, i8 4, i8 4, i8 37, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequal32", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @62, i64 5 }, ptr @"*_llgo_int32" }, align 8
+// CHECK: @"*_llgo_int32" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -38689692, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @62, i64 5 }, ptr null }, ptr @_llgo_int32 }, align 8
+// CHECK: @"_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y$out" = weak_odr constant [3 x ptr] [ptr @_llgo_int32, ptr @_llgo_int, ptr @_llgo_error], align 8
+// CHECK: @"_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 2138446355, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @64, i64 27 }, ptr @"*_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o$out", i64 2, i64 2 } }, align 8
+// CHECK: @"*_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1932918037, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @64, i64 27 }, ptr null }, ptr @"_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o" }, align 8
+// CHECK: @"_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o$in" = weak_odr constant [1 x ptr] [ptr @_llgo_uint8], align 8
+// CHECK: @"_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o$out" = weak_odr constant [2 x ptr] [ptr @_llgo_string, ptr @_llgo_error], align 8
+// CHECK: @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1790696805, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @66, i64 6 }, ptr @"*_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac" }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer }, align 8
+// CHECK: @"*_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -130179135, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @66, i64 6 }, ptr null }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac" }, align 8
+// CHECK: @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1183719404, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @70, i64 12 }, ptr @"*_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w" }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w$out", i64 1, i64 1 } }, align 8
+// CHECK: @"*_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1571491799, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @70, i64 12 }, ptr null }, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w" }, align 8
+// CHECK: @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w$out" = weak_odr constant [1 x ptr] [ptr @_llgo_error], align 8
+// CHECK: @"_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1226479232, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @74, i64 17 }, ptr @"*_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg$out", i64 1, i64 1 } }, align 8
+// CHECK: @"*_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 513101056, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @74, i64 17 }, ptr null }, ptr @"_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg" }, align 8
+// CHECK: @"_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg$in" = weak_odr constant [1 x ptr] [ptr @_llgo_uint8], align 8
+// CHECK: @"_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg$out" = weak_odr constant [1 x ptr] [ptr @_llgo_error], align 8
+// CHECK: @"_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1027172853, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @76, i64 24 }, ptr @"*_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw$out", i64 2, i64 2 } }, align 8
+// CHECK: @"*_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -841225112, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @76, i64 24 }, ptr null }, ptr @"_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw" }, align 8
+// CHECK: @"_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw$in" = weak_odr constant [1 x ptr] [ptr @_llgo_int32], align 8
+// CHECK: @"_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw$out" = weak_odr constant [2 x ptr] [ptr @_llgo_int, ptr @_llgo_error], align 8
+// CHECK: @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -183202291, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @78, i64 25 }, ptr @"*_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw$out", i64 2, i64 2 } }, align 8
+// CHECK: @"*_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1229992101, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @78, i64 25 }, ptr null }, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw" }, align 8
+// CHECK: @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw$in" = weak_odr constant [1 x ptr] [ptr @_llgo_string], align 8
+// CHECK: @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw$out" = weak_odr constant [2 x ptr] [ptr @_llgo_int, ptr @_llgo_error], align 8
+// CHECK: @"_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1753174026, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @80, i64 30 }, ptr @"*_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M$out", i64 2, i64 2 } }, align 8
+// CHECK: @"*_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1055881531, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @80, i64 30 }, ptr null }, ptr @"_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M" }, align 8
+// CHECK: @_llgo_io.Writer = weak_odr constant %"{{.*}}/runtime/abi.InterfaceType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 1423852385, i8 4, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @81, i64 9 }, ptr @"*_llgo_io.Writer" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$kr1iSWwMezh0B9LdQN0MhEZUNZvBlHPhlst95jAyxE0$imethods", i64 1, i64 1 } }, align 8
+// CHECK: @"*_llgo_io.Writer" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1477879550, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @81, i64 9 }, ptr null }, ptr @_llgo_io.Writer }, align 8
+// CHECK: @"_llgo_iface$kr1iSWwMezh0B9LdQN0MhEZUNZvBlHPhlst95jAyxE0$imethods" = weak_odr constant [1 x %"{{.*}}/runtime/abi.Imethod"] [%"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @72, i64 5 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk" }], align 8
+// CHECK: @"_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M$in" = weak_odr constant [1 x ptr] [ptr @_llgo_io.Writer], align 8
+// CHECK: @"_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M$out" = weak_odr constant [2 x ptr] [ptr @_llgo_int64, ptr @_llgo_error], align 8
+// CHECK: @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -541022001, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @84, i64 11 }, ptr @"*_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk" }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk$out", i64 1, i64 1 } }, align 8
+// CHECK: @"*_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -367308996, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @84, i64 11 }, ptr null }, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk" }, align 8
+// CHECK: @_llgo_bool = weak_odr constant %"{{.*}}/runtime/abi.Type" { i64 1, i64 0, i32 554183389, i8 12, i8 1, i8 1, i8 33, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequal8", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @85, i64 4 }, ptr @"*_llgo_bool" }, align 8
+// CHECK: @"*_llgo_bool" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1896950390, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @85, i64 4 }, ptr null }, ptr @_llgo_bool }, align 8
+// CHECK: @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk$out" = weak_odr constant [1 x ptr] [ptr @_llgo_bool], align 8
+// CHECK: @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1134531106, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @88, i64 13 }, ptr @"*_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU$out", i64 1, i64 1 } }, align 8
+// CHECK: @"*_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1763581361, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @88, i64 13 }, ptr null }, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" }, align 8
+// CHECK: @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU$in" = weak_odr constant [1 x ptr] [ptr @_llgo_int], align 8
+// CHECK: @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU$out" = weak_odr constant [1 x ptr] [ptr @_llgo_int], align 8
+// CHECK: @"_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 559523889, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @93, i64 21 }, ptr @"*_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M$out", i64 2, i64 2 } }, align 8
+// CHECK: @"*_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1842714480, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @93, i64 21 }, ptr null }, ptr @"_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M" }, align 8
+// CHECK: @"_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M$in" = weak_odr constant [1 x ptr] [ptr @_llgo_int], align 8
+// CHECK: @"_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M$out" = weak_odr constant [2 x ptr] [ptr @_llgo_int, ptr @_llgo_bool], align 8
+// CHECK: @"{{.*}}/_testgo/abimethod.struct$RGW016k7zllXgGPm1CvD5-IBe-9lphOOTCFtYyDGLjY$fields" = weak_odr constant [2 x %"{{.*}}/runtime/abi.StructField"] [%"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 1 }, ptr @_llgo_int, i64 0, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @28, i64 6 }, ptr @"*_llgo_bytes.Buffer", i64 8, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 true }], align 8
+// CHECK: @"_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U" = weak_odr constant %"{{.*}}/runtime/abi.InterfaceType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 -195205541, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @94, i64 29 }, ptr @"*_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U$imethods", i64 1, i64 1 } }, align 8
+// CHECK: @"*_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 876051709, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @94, i64 29 }, ptr null }, ptr @"_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U" }, align 8
+// CHECK: @"_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U$imethods" = weak_odr constant [1 x %"{{.*}}/runtime/abi.Imethod"] [%"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @67, i64 6 }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" }], align 8
+// CHECK: @"*_llgo_{{.*}}/_testgo/abimethod.Pointer[any]" = weak_odr constant { %"{{.*}}/runtime/abi.PtrType", %"{{.*}}/runtime/abi.UncommonType", [2 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1798654480, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @96, i64 17 }, ptr null }, ptr @"_llgo_{{.*}}/_testgo/abimethod.Pointer[any]" }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, i16 2, i16 2, i32 24 }, [2 x %"{{.*}}/runtime/abi.Method"] [%"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @103, i64 4 }, ptr @"_llgo_func$oqZ09zjnrQRdlivNw60EomwRoboDQbCk5_Y4MGDpQMQ", ptr @"{{.*}}/_testgo/abimethod.(*Pointer[any]).Load", ptr @"{{.*}}/_testgo/abimethod.(*Pointer[any]).Load" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @105, i64 5 }, ptr @"_llgo_func$Y8Pl6IHgSDuynhMRTXPlqFo9zl71SSTuMe0Wi5m8eWw", ptr @"{{.*}}/_testgo/abimethod.(*Pointer[any]).Store", ptr @"{{.*}}/_testgo/abimethod.(*Pointer[any]).Store" }] }, align 8
+// CHECK: @"_llgo_{{.*}}/_testgo/abimethod.Pointer[any]" = weak_odr constant { %"{{.*}}/runtime/abi.StructType", %"{{.*}}/runtime/abi.UncommonType", [0 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.StructType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -858197093, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"{{.*}}/runtime/internal/runtime.structequal", ptr @"_llgo_{{.*}}/_testgo/abimethod.Pointer[any]" }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @96, i64 17 }, ptr @"*_llgo_{{.*}}/_testgo/abimethod.Pointer[any]" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"{{.*}}/_testgo/abimethod.struct$WF_Ikp6H-8IyobSlL849gp6AslXPTyT8oKnkzqHD2NA$fields", i64 2, i64 2 } }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, i16 0, i16 0, i32 24 }, [0 x %"{{.*}}/runtime/abi.Method"] zeroinitializer }, align 8
+// CHECK: @"[0]*_llgo_any" = weak_odr constant %"{{.*}}/runtime/abi.ArrayType" { %"{{.*}}/runtime/abi.Type" { i64 0, i64 0, i32 -1235244625, i8 8, i8 8, i8 8, i8 17, { ptr, ptr } { ptr @"{{.*}}/runtime/internal/runtime.arrayequal", ptr @"[0]*_llgo_any" }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @98, i64 16 }, ptr @"*[0]*_llgo_any" }, ptr @"*_llgo_any", ptr @"[]*_llgo_any", i64 0 }, align 8
+// CHECK: @"*[0]*_llgo_any" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1487017406, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @98, i64 16 }, ptr null }, ptr @"[0]*_llgo_any" }, align 8
+// CHECK: @"*_llgo_any" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1741196194, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @99, i64 12 }, ptr null }, ptr @_llgo_any }, align 8
+// CHECK: @_llgo_any = weak_odr constant %"{{.*}}/runtime/abi.InterfaceType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 1376530322, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.nilinterequal", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @99, i64 12 }, ptr @"*_llgo_any" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer }, align 8
+// CHECK: @"[]*_llgo_any" = weak_odr constant %"{{.*}}/runtime/abi.SliceType" { %"{{.*}}/runtime/abi.Type" { i64 24, i64 8, i32 1393026359, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @100, i64 15 }, ptr @"*[]*_llgo_any" }, ptr @"*_llgo_any" }, align 8
+// CHECK: @"*[]*_llgo_any" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1459791968, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @100, i64 15 }, ptr null }, ptr @"[]*_llgo_any" }, align 8
+// CHECK: @_llgo_Pointer = weak_odr constant %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 507576105, i8 12, i8 8, i8 8, i8 58, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @102, i64 14 }, ptr @"*_llgo_Pointer" }, align 8
+// CHECK: @"*_llgo_Pointer" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1134390089, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @102, i64 14 }, ptr null }, ptr @_llgo_Pointer }, align 8
+// CHECK: @"{{.*}}/_testgo/abimethod.struct$WF_Ikp6H-8IyobSlL849gp6AslXPTyT8oKnkzqHD2NA$fields" = weak_odr constant [2 x %"{{.*}}/runtime/abi.StructField"] [%"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @97, i64 1 }, ptr @"[0]*_llgo_any", i64 0, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @101, i64 1 }, ptr @_llgo_Pointer, i64 0, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+// CHECK: @"_llgo_func$oqZ09zjnrQRdlivNw60EomwRoboDQbCk5_Y4MGDpQMQ" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1908794164, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @104, i64 20 }, ptr @"*_llgo_func$oqZ09zjnrQRdlivNw60EomwRoboDQbCk5_Y4MGDpQMQ" }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$oqZ09zjnrQRdlivNw60EomwRoboDQbCk5_Y4MGDpQMQ$out", i64 1, i64 1 } }, align 8
+// CHECK: @"*_llgo_func$oqZ09zjnrQRdlivNw60EomwRoboDQbCk5_Y4MGDpQMQ" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 709309578, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @104, i64 20 }, ptr null }, ptr @"_llgo_func$oqZ09zjnrQRdlivNw60EomwRoboDQbCk5_Y4MGDpQMQ" }, align 8
+// CHECK: @"_llgo_func$oqZ09zjnrQRdlivNw60EomwRoboDQbCk5_Y4MGDpQMQ$out" = weak_odr constant [1 x ptr] [ptr @"*_llgo_any"], align 8
+// CHECK: @"_llgo_func$Y8Pl6IHgSDuynhMRTXPlqFo9zl71SSTuMe0Wi5m8eWw" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1005812159, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @106, i64 19 }, ptr @"*_llgo_func$Y8Pl6IHgSDuynhMRTXPlqFo9zl71SSTuMe0Wi5m8eWw" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$Y8Pl6IHgSDuynhMRTXPlqFo9zl71SSTuMe0Wi5m8eWw$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer }, align 8
+// CHECK: @"*_llgo_func$Y8Pl6IHgSDuynhMRTXPlqFo9zl71SSTuMe0Wi5m8eWw" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1778721426, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @106, i64 19 }, ptr null }, ptr @"_llgo_func$Y8Pl6IHgSDuynhMRTXPlqFo9zl71SSTuMe0Wi5m8eWw" }, align 8
+// CHECK: @"_llgo_func$Y8Pl6IHgSDuynhMRTXPlqFo9zl71SSTuMe0Wi5m8eWw$in" = weak_odr constant [1 x ptr] [ptr @"*_llgo_any"], align 8
+// CHECK: @"_llgo_iface$uinGjIxPTfzB5e5h5gH-0VIvLl5rQdJ_yx2UsrxQqds" = weak_odr constant %"{{.*}}/runtime/abi.InterfaceType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 414101712, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @107, i64 56 }, ptr @"*_llgo_iface$uinGjIxPTfzB5e5h5gH-0VIvLl5rQdJ_yx2UsrxQqds" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$uinGjIxPTfzB5e5h5gH-0VIvLl5rQdJ_yx2UsrxQqds$imethods", i64 2, i64 2 } }, align 8
+// CHECK: @"*_llgo_iface$uinGjIxPTfzB5e5h5gH-0VIvLl5rQdJ_yx2UsrxQqds" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -756921395, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @107, i64 56 }, ptr null }, ptr @"_llgo_iface$uinGjIxPTfzB5e5h5gH-0VIvLl5rQdJ_yx2UsrxQqds" }, align 8
+// CHECK: @"_llgo_iface$uinGjIxPTfzB5e5h5gH-0VIvLl5rQdJ_yx2UsrxQqds$imethods" = weak_odr constant [2 x %"{{.*}}/runtime/abi.Imethod"] [%"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @103, i64 4 }, ptr @"_llgo_func$oqZ09zjnrQRdlivNw60EomwRoboDQbCk5_Y4MGDpQMQ" }, %"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @105, i64 5 }, ptr @"_llgo_func$Y8Pl6IHgSDuynhMRTXPlqFo9zl71SSTuMe0Wi5m8eWw" }], align 8
+
 type T struct {
 	n int
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/abimethod.T.Demo1"{{.*}}
-// CHECK: ret i64
-//
-// CHECK-LABEL: define {{.*}} @"{{.*}}/abimethod.(*T).Demo1"{{.*}}
-// CHECK: T.Demo1
-// CHECK: ret i64
+// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.T.Demo1"(%"{{.*}}/_testgo/abimethod.T" %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca %"{{.*}}/_testgo/abimethod.T", align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   store %"{{.*}}/_testgo/abimethod.T" %0, ptr %1, align 4
+// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   %3 = load i64, ptr %2, align 4
+// CHECK-NEXT:   ret i64 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.(*T).Demo1"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = load %"{{.*}}/_testgo/abimethod.T", ptr %0, align 4
+// CHECK-NEXT:   %2 = call i64 @"{{.*}}/_testgo/abimethod.T.Demo1"(%"{{.*}}/_testgo/abimethod.T" %1)
+// CHECK-NEXT:   ret i64 %2
+// CHECK-NEXT: }
 func (t T) Demo1() int {
 	return t.n
 }
 
+// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.(*T).Demo2"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:  %1 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %0, i32 0, i32 0
+// CHECK-NEXT:  %2 = load i64, ptr %1, align 4
+// CHECK-NEXT:  ret i64 %2
+// CHECK-NEXT: }
 func (t *T) Demo2() int {
 	return t.n
 }
 
+// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.(*T).demo3"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:  %1 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %0, i32 0, i32 0
+// CHECK-NEXT:  %2 = load i64, ptr %1, align 4
+// CHECK-NEXT:  ret i64 %2
+// CHECK-NEXT: }
 func (t *T) demo3() int {
 	return t.n
 }
 
-type I interface {
-	Demo1() int
-}
-
-type I2 interface {
-	Demo2() int
-}
-
-// CHECK-LABEL: define {{.*}} @"{{.*}}/abimethod.main"{{.*}}
-// CHECK: testGeneric"
-// CHECK: testNamed1"
-// CHECK: testNamed2"
-// CHECK: testNamed3"
-// CHECK: testAnonymousBuffer"
-// CHECK: ret void
+// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.main"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testGeneric"()
+// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testNamed1"()
+// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testNamed2"()
+// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testNamed3"()
+// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testAnonymous1"()
+// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testAnonymous2"()
+// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testAnonymous3"()
+// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testAnonymous4"()
+// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testAnonymous5"()
+// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testAnonymous6"()
+// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testAnonymous7"()
+// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testAnonymous8"()
+// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testAnonymousBuffer"()
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 func main() {
 	testGeneric()
 	testNamed1()
@@ -61,6 +226,601 @@ func main() {
 	testAnonymousBuffer()
 }
 
+// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testAnonymous1"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %3, i32 0, i32 0
+// CHECK-NEXT:   store i64 100, ptr %4, align 4
+// CHECK-NEXT:   store i64 10, ptr %1, align 4
+// CHECK-NEXT:   store ptr %3, ptr %2, align 8
+// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"*{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8")
+// CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %5, 0
+// CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %6, ptr %0, 1
+// CHECK-NEXT:   %8 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %7)
+// CHECK-NEXT:   %9 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %7, 0
+// CHECK-NEXT:   %10 = getelementptr ptr, ptr %9, i64 3
+// CHECK-NEXT:   %11 = load ptr, ptr %10, align 8
+// CHECK-NEXT:   %12 = insertvalue { ptr, ptr } undef, ptr %11, 0
+// CHECK-NEXT:   %13 = insertvalue { ptr, ptr } %12, ptr %8, 1
+// CHECK-NEXT:   %14 = extractvalue { ptr, ptr } %13, 1
+// CHECK-NEXT:   %15 = extractvalue { ptr, ptr } %13, 0
+// CHECK-NEXT:   %16 = call i64 %15(ptr %14)
+// CHECK-NEXT:   %17 = icmp ne i64 %16, 100
+// CHECK-NEXT:   br i1 %17, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %18 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @13, i64 20 }, ptr %18, align 8
+// CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %18, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %19)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+func testAnonymous1() {
+	var s I = &struct {
+		m int
+		*T
+	}{10, &T{100}}
+	if s.Demo1() != 100 {
+		panic("testAnonymous1 error")
+	}
+}
+
+// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testAnonymous2"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %3, i32 0, i32 0
+// CHECK-NEXT:   store i64 100, ptr %4, align 4
+// CHECK-NEXT:   store i64 10, ptr %1, align 4
+// CHECK-NEXT:   store ptr %3, ptr %2, align 8
+// CHECK-NEXT:   %5 = load { i64, ptr }, ptr %0, align 8
+// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store { i64, ptr } %5, ptr %6, align 8
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8")
+// CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %7, 0
+// CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %8, ptr %6, 1
+// CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
+// CHECK-NEXT:   %11 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
+// CHECK-NEXT:   %12 = getelementptr ptr, ptr %11, i64 3
+// CHECK-NEXT:   %13 = load ptr, ptr %12, align 8
+// CHECK-NEXT:   %14 = insertvalue { ptr, ptr } undef, ptr %13, 0
+// CHECK-NEXT:   %15 = insertvalue { ptr, ptr } %14, ptr %10, 1
+// CHECK-NEXT:   %16 = extractvalue { ptr, ptr } %15, 1
+// CHECK-NEXT:   %17 = extractvalue { ptr, ptr } %15, 0
+// CHECK-NEXT:   %18 = call i64 %17(ptr %16)
+// CHECK-NEXT:   %19 = icmp ne i64 %18, 100
+// CHECK-NEXT:   br i1 %19, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @15, i64 20 }, ptr %20, align 8
+// CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %20, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %21)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+func testAnonymous2() {
+	var s I = struct {
+		m int
+		*T
+	}{10, &T{100}}
+	if s.Demo1() != 100 {
+		panic("testAnonymous2 error")
+	}
+}
+
+// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testAnonymous3"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = alloca { i64, %"{{.*}}/_testgo/abimethod.T" }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/_testgo/abimethod.T" }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, %"{{.*}}/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   store i64 10, ptr %1, align 4
+// CHECK-NEXT:   store i64 100, ptr %3, align 4
+// CHECK-NEXT:   %4 = load { i64, %"{{.*}}/_testgo/abimethod.T" }, ptr %0, align 4
+// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store { i64, %"{{.*}}/_testgo/abimethod.T" } %4, ptr %5, align 4
+// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"{{.*}}/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088")
+// CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %6, 0
+// CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %7, ptr %5, 1
+// CHECK-NEXT:   %9 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %8)
+// CHECK-NEXT:   %10 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %8, 0
+// CHECK-NEXT:   %11 = getelementptr ptr, ptr %10, i64 3
+// CHECK-NEXT:   %12 = load ptr, ptr %11, align 8
+// CHECK-NEXT:   %13 = insertvalue { ptr, ptr } undef, ptr %12, 0
+// CHECK-NEXT:   %14 = insertvalue { ptr, ptr } %13, ptr %9, 1
+// CHECK-NEXT:   %15 = extractvalue { ptr, ptr } %14, 1
+// CHECK-NEXT:   %16 = extractvalue { ptr, ptr } %14, 0
+// CHECK-NEXT:   %17 = call i64 %16(ptr %15)
+// CHECK-NEXT:   %18 = icmp ne i64 %17, 100
+// CHECK-NEXT:   br i1 %18, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %19 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @17, i64 20 }, ptr %19, align 8
+// CHECK-NEXT:   %20 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %19, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %20)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+func testAnonymous3() {
+	var s I = struct {
+		m int
+		T
+	}{10, T{100}}
+	if s.Demo1() != 100 {
+		panic("testAnonymous3 error")
+	}
+}
+
+// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testAnonymous4"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/_testgo/abimethod.T" }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, %"{{.*}}/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   store i64 10, ptr %1, align 4
+// CHECK-NEXT:   store i64 100, ptr %3, align 4
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"*{{.*}}/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088")
+// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %4, 0
+// CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %5, ptr %0, 1
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %6)
+// CHECK-NEXT:   %8 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %6, 0
+// CHECK-NEXT:   %9 = getelementptr ptr, ptr %8, i64 3
+// CHECK-NEXT:   %10 = load ptr, ptr %9, align 8
+// CHECK-NEXT:   %11 = insertvalue { ptr, ptr } undef, ptr %10, 0
+// CHECK-NEXT:   %12 = insertvalue { ptr, ptr } %11, ptr %7, 1
+// CHECK-NEXT:   %13 = extractvalue { ptr, ptr } %12, 1
+// CHECK-NEXT:   %14 = extractvalue { ptr, ptr } %12, 0
+// CHECK-NEXT:   %15 = call i64 %14(ptr %13)
+// CHECK-NEXT:   %16 = icmp ne i64 %15, 100
+// CHECK-NEXT:   br i1 %16, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %17 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @18, i64 20 }, ptr %17, align 8
+// CHECK-NEXT:   %18 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %17, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %18)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+func testAnonymous4() {
+	var s I = &struct {
+		m int
+		T
+	}{10, T{100}}
+	if s.Demo1() != 100 {
+		panic("testAnonymous4 error")
+	}
+}
+
+// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testAnonymous5"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/_testgo/abimethod.T" }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, %"{{.*}}/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   store i64 10, ptr %1, align 4
+// CHECK-NEXT:   store i64 100, ptr %3, align 4
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4", ptr @"*{{.*}}/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088")
+// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %4, 0
+// CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %5, ptr %0, 1
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %6)
+// CHECK-NEXT:   %8 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %6, 0
+// CHECK-NEXT:   %9 = getelementptr ptr, ptr %8, i64 3
+// CHECK-NEXT:   %10 = load ptr, ptr %9, align 8
+// CHECK-NEXT:   %11 = insertvalue { ptr, ptr } undef, ptr %10, 0
+// CHECK-NEXT:   %12 = insertvalue { ptr, ptr } %11, ptr %7, 1
+// CHECK-NEXT:   %13 = extractvalue { ptr, ptr } %12, 1
+// CHECK-NEXT:   %14 = extractvalue { ptr, ptr } %12, 0
+// CHECK-NEXT:   %15 = call i64 %14(ptr %13)
+// CHECK-NEXT:   %16 = icmp ne i64 %15, 100
+// CHECK-NEXT:   br i1 %16, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %17 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @20, i64 20 }, ptr %17, align 8
+// CHECK-NEXT:   %18 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %17, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %18)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+func testAnonymous5() {
+	var s I2 = &struct {
+		m int
+		T
+	}{10, T{100}}
+	if s.Demo2() != 100 {
+		panic("testAnonymous5 error")
+	}
+}
+
+// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testAnonymous6"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %3, i32 0, i32 0
+// CHECK-NEXT:   store i64 100, ptr %4, align 4
+// CHECK-NEXT:   store i64 10, ptr %1, align 4
+// CHECK-NEXT:   store ptr %3, ptr %2, align 8
+// CHECK-NEXT:   %5 = load { i64, ptr }, ptr %0, align 8
+// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store { i64, ptr } %5, ptr %6, align 8
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4", ptr @"{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8")
+// CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %7, 0
+// CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %8, ptr %6, 1
+// CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
+// CHECK-NEXT:   %11 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
+// CHECK-NEXT:   %12 = getelementptr ptr, ptr %11, i64 3
+// CHECK-NEXT:   %13 = load ptr, ptr %12, align 8
+// CHECK-NEXT:   %14 = insertvalue { ptr, ptr } undef, ptr %13, 0
+// CHECK-NEXT:   %15 = insertvalue { ptr, ptr } %14, ptr %10, 1
+// CHECK-NEXT:   %16 = extractvalue { ptr, ptr } %15, 1
+// CHECK-NEXT:   %17 = extractvalue { ptr, ptr } %15, 0
+// CHECK-NEXT:   %18 = call i64 %17(ptr %16)
+// CHECK-NEXT:   %19 = icmp ne i64 %18, 100
+// CHECK-NEXT:   br i1 %19, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @21, i64 20 }, ptr %20, align 8
+// CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %20, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %21)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+func testAnonymous6() {
+	var s I2 = struct {
+		m int
+		*T
+	}{10, &T{100}}
+	if s.Demo2() != 100 {
+		panic("testAnonymous6 error")
+	}
+}
+
+// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testAnonymous7"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %3, i32 0, i32 0
+// CHECK-NEXT:   store i64 100, ptr %4, align 4
+// CHECK-NEXT:   store i64 10, ptr %1, align 4
+// CHECK-NEXT:   store ptr %3, ptr %2, align 8
+// CHECK-NEXT:   %5 = load { i64, ptr }, ptr %0, align 8
+// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store { i64, ptr } %5, ptr %6, align 8
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$58AxoxqQ6sGUOM73FOqFrXsMlgxkU4HGd-S1Wl-ssYw", ptr @"{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8")
+// CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %7, 0
+// CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %8, ptr %6, 1
+// CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
+// CHECK-NEXT:   %11 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
+// CHECK-NEXT:   %12 = getelementptr ptr, ptr %11, i64 3
+// CHECK-NEXT:   %13 = load ptr, ptr %12, align 8
+// CHECK-NEXT:   %14 = insertvalue { ptr, ptr } undef, ptr %13, 0
+// CHECK-NEXT:   %15 = insertvalue { ptr, ptr } %14, ptr %10, 1
+// CHECK-NEXT:   %16 = extractvalue { ptr, ptr } %15, 1
+// CHECK-NEXT:   %17 = extractvalue { ptr, ptr } %15, 0
+// CHECK-NEXT:   %18 = call i64 %17(ptr %16)
+// CHECK-NEXT:   %19 = icmp ne i64 %18, 100
+// CHECK-NEXT:   br i1 %19, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @23, i64 20 }, ptr %20, align 8
+// CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %20, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %21)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %22 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
+// CHECK-NEXT:   %23 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
+// CHECK-NEXT:   %24 = getelementptr ptr, ptr %23, i64 4
+// CHECK-NEXT:   %25 = load ptr, ptr %24, align 8
+// CHECK-NEXT:   %26 = insertvalue { ptr, ptr } undef, ptr %25, 0
+// CHECK-NEXT:   %27 = insertvalue { ptr, ptr } %26, ptr %22, 1
+// CHECK-NEXT:   %28 = extractvalue { ptr, ptr } %27, 1
+// CHECK-NEXT:   %29 = extractvalue { ptr, ptr } %27, 0
+// CHECK-NEXT:   %30 = call i64 %29(ptr %28)
+// CHECK-NEXT:   %31 = icmp ne i64 %30, 100
+// CHECK-NEXT:   br i1 %31, label %_llgo_3, label %_llgo_4
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_2
+// CHECK-NEXT:   %32 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @23, i64 20 }, ptr %32, align 8
+// CHECK-NEXT:   %33 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %32, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %33)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+func testAnonymous7() {
+	var s interface {
+		Demo1() int
+		Demo2() int
+	} = struct {
+		m int
+		*T
+	}{10, &T{100}}
+	if s.Demo1() != 100 {
+		panic("testAnonymous7 error")
+	}
+	if s.Demo2() != 100 {
+		panic("testAnonymous7 error")
+	}
+}
+
+// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testAnonymous8"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %3, i32 0, i32 0
+// CHECK-NEXT:   store i64 100, ptr %4, align 4
+// CHECK-NEXT:   store i64 10, ptr %1, align 4
+// CHECK-NEXT:   store ptr %3, ptr %2, align 8
+// CHECK-NEXT:   %5 = load { i64, ptr }, ptr %0, align 8
+// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store { i64, ptr } %5, ptr %6, align 8
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/_testgo/abimethod.iface$kT5SIXt45Cspjl04Bof3DZVSOIltlDo-njpk6KqtZvA", ptr @"{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8")
+// CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %7, 0
+// CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %8, ptr %6, 1
+// CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
+// CHECK-NEXT:   %11 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
+// CHECK-NEXT:   %12 = getelementptr ptr, ptr %11, i64 3
+// CHECK-NEXT:   %13 = load ptr, ptr %12, align 8
+// CHECK-NEXT:   %14 = insertvalue { ptr, ptr } undef, ptr %13, 0
+// CHECK-NEXT:   %15 = insertvalue { ptr, ptr } %14, ptr %10, 1
+// CHECK-NEXT:   %16 = extractvalue { ptr, ptr } %15, 1
+// CHECK-NEXT:   %17 = extractvalue { ptr, ptr } %15, 0
+// CHECK-NEXT:   %18 = call i64 %17(ptr %16)
+// CHECK-NEXT:   %19 = icmp ne i64 %18, 100
+// CHECK-NEXT:   br i1 %19, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @25, i64 20 }, ptr %20, align 8
+// CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %20, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %21)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %22 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
+// CHECK-NEXT:   %23 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
+// CHECK-NEXT:   %24 = getelementptr ptr, ptr %23, i64 4
+// CHECK-NEXT:   %25 = load ptr, ptr %24, align 8
+// CHECK-NEXT:   %26 = insertvalue { ptr, ptr } undef, ptr %25, 0
+// CHECK-NEXT:   %27 = insertvalue { ptr, ptr } %26, ptr %22, 1
+// CHECK-NEXT:   %28 = extractvalue { ptr, ptr } %27, 1
+// CHECK-NEXT:   %29 = extractvalue { ptr, ptr } %27, 0
+// CHECK-NEXT:   %30 = call i64 %29(ptr %28)
+// CHECK-NEXT:   %31 = icmp ne i64 %30, 100
+// CHECK-NEXT:   br i1 %31, label %_llgo_3, label %_llgo_4
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_2
+// CHECK-NEXT:   %32 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @25, i64 20 }, ptr %32, align 8
+// CHECK-NEXT:   %33 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %32, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %33)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
+// CHECK-NEXT:   %34 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
+// CHECK-NEXT:   %35 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
+// CHECK-NEXT:   %36 = getelementptr ptr, ptr %35, i64 5
+// CHECK-NEXT:   %37 = load ptr, ptr %36, align 8
+// CHECK-NEXT:   %38 = insertvalue { ptr, ptr } undef, ptr %37, 0
+// CHECK-NEXT:   %39 = insertvalue { ptr, ptr } %38, ptr %34, 1
+// CHECK-NEXT:   %40 = extractvalue { ptr, ptr } %39, 1
+// CHECK-NEXT:   %41 = extractvalue { ptr, ptr } %39, 0
+// CHECK-NEXT:   %42 = call i64 %41(ptr %40)
+// CHECK-NEXT:   %43 = icmp ne i64 %42, 100
+// CHECK-NEXT:   br i1 %43, label %_llgo_5, label %_llgo_6
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_4
+// CHECK-NEXT:   %44 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @25, i64 20 }, ptr %44, align 8
+// CHECK-NEXT:   %45 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %44, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %45)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_4
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+func testAnonymous8() {
+	var s interface {
+		Demo1() int
+		Demo2() int
+		demo3() int
+	} = struct {
+		m int
+		*T
+	}{10, &T{100}}
+	if s.Demo1() != 100 {
+		panic("testAnonymous8 error")
+	}
+	if s.Demo2() != 100 {
+		panic("testAnonymous8 error")
+	}
+	if s.demo3() != 100 {
+		panic("testAnonymous8 error")
+	}
+}
+
+// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testAnonymousBuffer"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = call ptr @bytes.NewBufferString(%"{{.*}}/runtime/internal/runtime.String" { ptr @26, i64 5 })
+// CHECK-NEXT:   store i64 10, ptr %1, align 4
+// CHECK-NEXT:   store ptr %3, ptr %2, align 8
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U", ptr @"*{{.*}}/_testgo/abimethod.struct$RGW016k7zllXgGPm1CvD5-IBe-9lphOOTCFtYyDGLjY")
+// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %4, 0
+// CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %5, ptr %0, 1
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %6)
+// CHECK-NEXT:   %8 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %6, 0
+// CHECK-NEXT:   %9 = getelementptr ptr, ptr %8, i64 3
+// CHECK-NEXT:   %10 = load ptr, ptr %9, align 8
+// CHECK-NEXT:   %11 = insertvalue { ptr, ptr } undef, ptr %10, 0
+// CHECK-NEXT:   %12 = insertvalue { ptr, ptr } %11, ptr %7, 1
+// CHECK-NEXT:   %13 = extractvalue { ptr, ptr } %12, 1
+// CHECK-NEXT:   %14 = extractvalue { ptr, ptr } %12, 0
+// CHECK-NEXT:   %15 = call %"{{.*}}/runtime/internal/runtime.String" %14(ptr %13)
+// CHECK-NEXT:   %16 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %15, %"{{.*}}/runtime/internal/runtime.String" { ptr @26, i64 5 })
+// CHECK-NEXT:   %17 = xor i1 %16, true
+// CHECK-NEXT:   br i1 %17, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %18 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @95, i64 25 }, ptr %18, align 8
+// CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %18, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %19)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+func testAnonymousBuffer() {
+	var s fmt.Stringer = &struct {
+		m int
+		*bytes.Buffer
+	}{10, bytes.NewBufferString("hello")}
+	if s.String() != "hello" {
+		panic("testAnonymousBuffer error")
+	}
+}
+
+// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testGeneric"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uinGjIxPTfzB5e5h5gH-0VIvLl5rQdJ_yx2UsrxQqds", ptr @"*_llgo_{{.*}}/_testgo/abimethod.Pointer[any]")
+// CHECK-NEXT:   %2 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %1, 0
+// CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %2, ptr %0, 1
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/_testgo/abimethod.testGeneric$1"()
+// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %3)
+// CHECK-NEXT:   %6 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %3, 0
+// CHECK-NEXT:   %7 = getelementptr ptr, ptr %6, i64 4
+// CHECK-NEXT:   %8 = load ptr, ptr %7, align 8
+// CHECK-NEXT:   %9 = insertvalue { ptr, ptr } undef, ptr %8, 0
+// CHECK-NEXT:   %10 = insertvalue { ptr, ptr } %9, ptr %5, 1
+// CHECK-NEXT:   %11 = extractvalue { ptr, ptr } %10, 1
+// CHECK-NEXT:   %12 = extractvalue { ptr, ptr } %10, 0
+// CHECK-NEXT:   call void %12(ptr %11, ptr %4)
+// CHECK-NEXT:   %13 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %3)
+// CHECK-NEXT:   %14 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %3, 0
+// CHECK-NEXT:   %15 = getelementptr ptr, ptr %14, i64 3
+// CHECK-NEXT:   %16 = load ptr, ptr %15, align 8
+// CHECK-NEXT:   %17 = insertvalue { ptr, ptr } undef, ptr %16, 0
+// CHECK-NEXT:   %18 = insertvalue { ptr, ptr } %17, ptr %13, 1
+// CHECK-NEXT:   %19 = extractvalue { ptr, ptr } %18, 1
+// CHECK-NEXT:   %20 = extractvalue { ptr, ptr } %18, 0
+// CHECK-NEXT:   %21 = call ptr %20(ptr %19)
+// CHECK-NEXT:   %22 = load %"{{.*}}/runtime/internal/runtime.eface", ptr %21, align 8
+// CHECK-NEXT:   %23 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %22, 0
+// CHECK-NEXT:   %24 = icmp eq ptr %23, @_llgo_int
+// CHECK-NEXT:   br i1 %24, label %_llgo_3, label %_llgo_4
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_3
+// CHECK-NEXT:   %25 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @109, i64 17 }, ptr %25, align 8
+// CHECK-NEXT:   %26 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %25, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %26)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_3
+// CHECK-NEXT:   ret void
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %27 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %22, 1
+// CHECK-NEXT:   %28 = ptrtoint ptr %27 to i64
+// CHECK-NEXT:   %29 = icmp ne i64 %28, 100
+// CHECK-NEXT:   br i1 %29, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %30 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @108, i64 40 }, ptr %30, align 8
+// CHECK-NEXT:   %31 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %30, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %31)
+// CHECK-NEXT:   unreachable
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define ptr @"{{.*}}/_testgo/abimethod.testGeneric$1"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 100 to ptr) }, ptr %0, align 8
+// CHECK-NEXT:   ret ptr %0
+// CHECK-NEXT: }
+func testGeneric() {
+	var p IP = &Pointer[any]{}
+	p.Store(func() *any {
+		var a any = 100
+		return &a
+	}())
+	if (*p.Load()).(int) != 100 {
+		panic("testGeneric error")
+	}
+}
+
+// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testNamed1"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   store i64 100, ptr %1, align 4
+// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"*_llgo_{{.*}}/_testgo/abimethod.T")
+// CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %2, 0
+// CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %3, ptr %0, 1
+// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %4)
+// CHECK-NEXT:   %6 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %4, 0
+// CHECK-NEXT:   %7 = getelementptr ptr, ptr %6, i64 3
+// CHECK-NEXT:   %8 = load ptr, ptr %7, align 8
+// CHECK-NEXT:   %9 = insertvalue { ptr, ptr } undef, ptr %8, 0
+// CHECK-NEXT:   %10 = insertvalue { ptr, ptr } %9, ptr %5, 1
+// CHECK-NEXT:   %11 = extractvalue { ptr, ptr } %10, 1
+// CHECK-NEXT:   %12 = extractvalue { ptr, ptr } %10, 0
+// CHECK-NEXT:   %13 = call i64 %12(ptr %11)
+// CHECK-NEXT:   %14 = icmp ne i64 %13, 100
+// CHECK-NEXT:   br i1 %14, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %15 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @110, i64 16 }, ptr %15, align 8
+// CHECK-NEXT:   %16 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %15, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %16)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 func testNamed1() {
 	var a I = &T{100}
 	if a.Demo1() != 100 {
@@ -68,6 +828,40 @@ func testNamed1() {
 	}
 }
 
+// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testNamed2"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = alloca %"{{.*}}/_testgo/abimethod.T", align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   store i64 100, ptr %1, align 4
+// CHECK-NEXT:   %2 = load %"{{.*}}/_testgo/abimethod.T", ptr %0, align 4
+// CHECK-NEXT:   %3 = extractvalue %"{{.*}}/_testgo/abimethod.T" %2, 0
+// CHECK-NEXT:   %4 = inttoptr i64 %3 to ptr
+// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"_llgo_{{.*}}/_testgo/abimethod.T")
+// CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %5, 0
+// CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %6, ptr %4, 1
+// CHECK-NEXT:   %8 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %7)
+// CHECK-NEXT:   %9 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %7, 0
+// CHECK-NEXT:   %10 = getelementptr ptr, ptr %9, i64 3
+// CHECK-NEXT:   %11 = load ptr, ptr %10, align 8
+// CHECK-NEXT:   %12 = insertvalue { ptr, ptr } undef, ptr %11, 0
+// CHECK-NEXT:   %13 = insertvalue { ptr, ptr } %12, ptr %8, 1
+// CHECK-NEXT:   %14 = extractvalue { ptr, ptr } %13, 1
+// CHECK-NEXT:   %15 = extractvalue { ptr, ptr } %13, 0
+// CHECK-NEXT:   %16 = call i64 %15(ptr %14)
+// CHECK-NEXT:   %17 = icmp ne i64 %16, 100
+// CHECK-NEXT:   br i1 %17, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %18 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @111, i64 16 }, ptr %18, align 8
+// CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %18, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %19)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 func testNamed2() {
 	var a I = T{100}
 	if a.Demo1() != 100 {
@@ -75,6 +869,36 @@ func testNamed2() {
 	}
 }
 
+// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testNamed3"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   store i64 100, ptr %1, align 4
+// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4", ptr @"*_llgo_{{.*}}/_testgo/abimethod.T")
+// CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %2, 0
+// CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %3, ptr %0, 1
+// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %4)
+// CHECK-NEXT:   %6 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %4, 0
+// CHECK-NEXT:   %7 = getelementptr ptr, ptr %6, i64 3
+// CHECK-NEXT:   %8 = load ptr, ptr %7, align 8
+// CHECK-NEXT:   %9 = insertvalue { ptr, ptr } undef, ptr %8, 0
+// CHECK-NEXT:   %10 = insertvalue { ptr, ptr } %9, ptr %5, 1
+// CHECK-NEXT:   %11 = extractvalue { ptr, ptr } %10, 1
+// CHECK-NEXT:   %12 = extractvalue { ptr, ptr } %10, 0
+// CHECK-NEXT:   %13 = call i64 %12(ptr %11)
+// CHECK-NEXT:   %14 = icmp ne i64 %13, 100
+// CHECK-NEXT:   br i1 %14, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %15 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @112, i64 16 }, ptr %15, align 8
+// CHECK-NEXT:   %16 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %15, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %16)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 func testNamed3() {
 	var a I2 = &T{100}
 	if a.Demo2() != 100 {
@@ -101,123 +925,729 @@ type IP interface {
 	Load() *any
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/abimethod.testGeneric"{{.*}}
-// CHECK: NewItab
-// CHECK: IfacePtrData
-// CHECK: Panic
-func testGeneric() {
-	var p IP = &Pointer[any]{}
-	p.Store(func() *any {
-		var a any = 100
-		return &a
-	}())
-	if (*p.Load()).(int) != 100 {
-		panic("testGeneric error")
-	}
+type I interface {
+	Demo1() int
 }
 
-func testAnonymous1() {
-	var s I = &struct {
-		m int
-		*T
-	}{10, &T{100}}
-	if s.Demo1() != 100 {
-		panic("testAnonymous1 error")
-	}
+type I2 interface {
+	Demo2() int
 }
 
-func testAnonymous2() {
-	var s I = struct {
-		m int
-		*T
-	}{10, &T{100}}
-	if s.Demo1() != 100 {
-		panic("testAnonymous2 error")
-	}
-}
+// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo1"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
+// CHECK-NEXT:   %3 = load %"{{.*}}/_testgo/abimethod.T", ptr %2, align 4
+// CHECK-NEXT:   %4 = call i64 @"{{.*}}/_testgo/abimethod.T.Demo1"(%"{{.*}}/_testgo/abimethod.T" %3)
+// CHECK-NEXT:   ret i64 %4
+// CHECK-NEXT: }
 
-func testAnonymous3() {
-	var s I = struct {
-		m int
-		T
-	}{10, T{100}}
-	if s.Demo1() != 100 {
-		panic("testAnonymous3 error")
-	}
-}
+// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo2"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
+// CHECK-NEXT:   %3 = call i64 @"{{.*}}/_testgo/abimethod.(*T).Demo2"(ptr %2)
+// CHECK-NEXT:   ret i64 %3
+// CHECK-NEXT: }
 
-func testAnonymous4() {
-	var s I = &struct {
-		m int
-		T
-	}{10, T{100}}
-	if s.Demo1() != 100 {
-		panic("testAnonymous4 error")
-	}
-}
+// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.demo3"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
+// CHECK-NEXT:   %3 = call i64 @"{{.*}}/_testgo/abimethod.(*T).demo3"(ptr %2)
+// CHECK-NEXT:   ret i64 %3
+// CHECK-NEXT: }
 
-func testAnonymous5() {
-	var s I2 = &struct {
-		m int
-		T
-	}{10, T{100}}
-	if s.Demo2() != 100 {
-		panic("testAnonymous5 error")
-	}
-}
+// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo1"({ i64, ptr } %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = load %"{{.*}}/_testgo/abimethod.T", ptr %3, align 4
+// CHECK-NEXT:   %5 = call i64 @"{{.*}}/_testgo/abimethod.T.Demo1"(%"{{.*}}/_testgo/abimethod.T" %4)
+// CHECK-NEXT:   ret i64 %5
+// CHECK-NEXT: }
 
-func testAnonymous6() {
-	var s I2 = struct {
-		m int
-		*T
-	}{10, &T{100}}
-	if s.Demo2() != 100 {
-		panic("testAnonymous6 error")
-	}
-}
+// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo2"({ i64, ptr } %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call i64 @"{{.*}}/_testgo/abimethod.(*T).Demo2"(ptr %3)
+// CHECK-NEXT:   ret i64 %4
+// CHECK-NEXT: }
 
-func testAnonymous7() {
-	var s interface {
-		Demo1() int
-		Demo2() int
-	} = struct {
-		m int
-		*T
-	}{10, &T{100}}
-	if s.Demo1() != 100 {
-		panic("testAnonymous7 error")
-	}
-	if s.Demo2() != 100 {
-		panic("testAnonymous7 error")
-	}
-}
+// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.struct{m int; *{{.*}}/_testgo/abimethod.T}.demo3"({ i64, ptr } %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call i64 @"{{.*}}/_testgo/abimethod.(*T).demo3"(ptr %3)
+// CHECK-NEXT:   ret i64 %4
+// CHECK-NEXT: }
 
-func testAnonymous8() {
-	var s interface {
-		Demo1() int
-		Demo2() int
-		demo3() int
-	} = struct {
-		m int
-		*T
-	}{10, &T{100}}
-	if s.Demo1() != 100 {
-		panic("testAnonymous8 error")
-	}
-	if s.Demo2() != 100 {
-		panic("testAnonymous8 error")
-	}
-	if s.demo3() != 100 {
-		panic("testAnonymous8 error")
-	}
-}
+// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.struct{m int; {{.*}}/_testgo/abimethod.T}.Demo1"({ i64, %"{{.*}}/_testgo/abimethod.T" } %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca { i64, %"{{.*}}/_testgo/abimethod.T" }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, %"{{.*}}/_testgo/abimethod.T" } %0, ptr %1, align 4
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, %"{{.*}}/_testgo/abimethod.T" }, ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %3 = load %"{{.*}}/_testgo/abimethod.T", ptr %2, align 4
+// CHECK-NEXT:   %4 = call i64 @"{{.*}}/_testgo/abimethod.T.Demo1"(%"{{.*}}/_testgo/abimethod.T" %3)
+// CHECK-NEXT:   ret i64 %4
+// CHECK-NEXT: }
 
-func testAnonymousBuffer() {
-	var s fmt.Stringer = &struct {
-		m int
-		*bytes.Buffer
-	}{10, bytes.NewBufferString("hello")}
-	if s.String() != "hello" {
-		panic("testAnonymousBuffer error")
-	}
-}
+// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.*struct{m int; {{.*}}/_testgo/abimethod.T}.Demo1"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = load %"{{.*}}/_testgo/abimethod.T", ptr %1, align 4
+// CHECK-NEXT:   %3 = call i64 @"{{.*}}/_testgo/abimethod.T.Demo1"(%"{{.*}}/_testgo/abimethod.T" %2)
+// CHECK-NEXT:   ret i64 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.*struct{m int; {{.*}}/_testgo/abimethod.T}.Demo2"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = call i64 @"{{.*}}/_testgo/abimethod.(*T).Demo2"(ptr %1)
+// CHECK-NEXT:   ret i64 %2
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.*struct{m int; {{.*}}/_testgo/abimethod.T}.demo3"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = call i64 @"{{.*}}/_testgo/abimethod.(*T).demo3"(ptr %1)
+// CHECK-NEXT:   ret i64 %2
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Available"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
+// CHECK-NEXT:   %3 = call i64 @"bytes.(*Buffer).Available"(ptr %2)
+// CHECK-NEXT:   ret i64 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.AvailableBuffer"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
+// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.Slice" @"bytes.(*Buffer).AvailableBuffer"(ptr %2)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Bytes"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
+// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.Slice" @"bytes.(*Buffer).Bytes"(ptr %2)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Cap"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
+// CHECK-NEXT:   %3 = call i64 @"bytes.(*Buffer).Cap"(ptr %2)
+// CHECK-NEXT:   ret i64 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Grow"(ptr %0, i64 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   call void @"bytes.(*Buffer).Grow"(ptr %3, i64 %1)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Len"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
+// CHECK-NEXT:   %3 = call i64 @"bytes.(*Buffer).Len"(ptr %2)
+// CHECK-NEXT:   ret i64 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Next"(ptr %0, i64 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.Slice" @"bytes.(*Buffer).Next"(ptr %3, i64 %1)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %4
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Read"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"bytes.(*Buffer).Read"(ptr %3, %"{{.*}}/runtime/internal/runtime.Slice" %1)
+// CHECK-NEXT:   %5 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %4, 0
+// CHECK-NEXT:   %6 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %4, 1
+// CHECK-NEXT:   %7 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } undef, i64 %5, 0
+// CHECK-NEXT:   %8 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %7, %"{{.*}}/runtime/internal/runtime.iface" %6, 1
+// CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadByte"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
+// CHECK-NEXT:   %3 = call { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"bytes.(*Buffer).ReadByte"(ptr %2)
+// CHECK-NEXT:   %4 = extractvalue { i8, %"{{.*}}/runtime/internal/runtime.iface" } %3, 0
+// CHECK-NEXT:   %5 = extractvalue { i8, %"{{.*}}/runtime/internal/runtime.iface" } %3, 1
+// CHECK-NEXT:   %6 = insertvalue { i8, %"{{.*}}/runtime/internal/runtime.iface" } undef, i8 %4, 0
+// CHECK-NEXT:   %7 = insertvalue { i8, %"{{.*}}/runtime/internal/runtime.iface" } %6, %"{{.*}}/runtime/internal/runtime.iface" %5, 1
+// CHECK-NEXT:   ret { i8, %"{{.*}}/runtime/internal/runtime.iface" } %7
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadBytes"(ptr %0, i8 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"bytes.(*Buffer).ReadBytes"(ptr %3, i8 %1)
+// CHECK-NEXT:   %5 = extractvalue { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %4, 0
+// CHECK-NEXT:   %6 = extractvalue { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %4, 1
+// CHECK-NEXT:   %7 = insertvalue { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } undef, %"{{.*}}/runtime/internal/runtime.Slice" %5, 0
+// CHECK-NEXT:   %8 = insertvalue { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %7, %"{{.*}}/runtime/internal/runtime.iface" %6, 1
+// CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %8
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadFrom"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"bytes.(*Buffer).ReadFrom"(ptr %3, %"{{.*}}/runtime/internal/runtime.iface" %1)
+// CHECK-NEXT:   %5 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %4, 0
+// CHECK-NEXT:   %6 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %4, 1
+// CHECK-NEXT:   %7 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } undef, i64 %5, 0
+// CHECK-NEXT:   %8 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %7, %"{{.*}}/runtime/internal/runtime.iface" %6, 1
+// CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadRune"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
+// CHECK-NEXT:   %3 = call { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"bytes.(*Buffer).ReadRune"(ptr %2)
+// CHECK-NEXT:   %4 = extractvalue { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } %3, 0
+// CHECK-NEXT:   %5 = extractvalue { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } %3, 1
+// CHECK-NEXT:   %6 = extractvalue { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } %3, 2
+// CHECK-NEXT:   %7 = insertvalue { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } undef, i32 %4, 0
+// CHECK-NEXT:   %8 = insertvalue { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } %7, i64 %5, 1
+// CHECK-NEXT:   %9 = insertvalue { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } %8, %"{{.*}}/runtime/internal/runtime.iface" %6, 2
+// CHECK-NEXT:   ret { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadString"(ptr %0, i8 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } @"bytes.(*Buffer).ReadString"(ptr %3, i8 %1)
+// CHECK-NEXT:   %5 = extractvalue { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } %4, 0
+// CHECK-NEXT:   %6 = extractvalue { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } %4, 1
+// CHECK-NEXT:   %7 = insertvalue { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } undef, %"{{.*}}/runtime/internal/runtime.String" %5, 0
+// CHECK-NEXT:   %8 = insertvalue { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } %7, %"{{.*}}/runtime/internal/runtime.iface" %6, 1
+// CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } %8
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Reset"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
+// CHECK-NEXT:   call void @"bytes.(*Buffer).Reset"(ptr %2)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.String"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
+// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.String" @"bytes.(*Buffer).String"(ptr %2)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Truncate"(ptr %0, i64 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   call void @"bytes.(*Buffer).Truncate"(ptr %3, i64 %1)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadByte"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
+// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.iface" @"bytes.(*Buffer).UnreadByte"(ptr %2)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadRune"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
+// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.iface" @"bytes.(*Buffer).UnreadRune"(ptr %2)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Write"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"bytes.(*Buffer).Write"(ptr %3, %"{{.*}}/runtime/internal/runtime.Slice" %1)
+// CHECK-NEXT:   %5 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %4, 0
+// CHECK-NEXT:   %6 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %4, 1
+// CHECK-NEXT:   %7 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } undef, i64 %5, 0
+// CHECK-NEXT:   %8 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %7, %"{{.*}}/runtime/internal/runtime.iface" %6, 1
+// CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteByte"(ptr %0, i8 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.iface" @"bytes.(*Buffer).WriteByte"(ptr %3, i8 %1)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %4
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteRune"(ptr %0, i32 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"bytes.(*Buffer).WriteRune"(ptr %3, i32 %1)
+// CHECK-NEXT:   %5 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %4, 0
+// CHECK-NEXT:   %6 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %4, 1
+// CHECK-NEXT:   %7 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } undef, i64 %5, 0
+// CHECK-NEXT:   %8 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %7, %"{{.*}}/runtime/internal/runtime.iface" %6, 1
+// CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteString"(ptr %0, %"{{.*}}/runtime/internal/runtime.String" %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"bytes.(*Buffer).WriteString"(ptr %3, %"{{.*}}/runtime/internal/runtime.String" %1)
+// CHECK-NEXT:   %5 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %4, 0
+// CHECK-NEXT:   %6 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %4, 1
+// CHECK-NEXT:   %7 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } undef, i64 %5, 0
+// CHECK-NEXT:   %8 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %7, %"{{.*}}/runtime/internal/runtime.iface" %6, 1
+// CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteTo"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"bytes.(*Buffer).WriteTo"(ptr %3, %"{{.*}}/runtime/internal/runtime.iface" %1)
+// CHECK-NEXT:   %5 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %4, 0
+// CHECK-NEXT:   %6 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %4, 1
+// CHECK-NEXT:   %7 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } undef, i64 %5, 0
+// CHECK-NEXT:   %8 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %7, %"{{.*}}/runtime/internal/runtime.iface" %6, 1
+// CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i1 @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.empty"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
+// CHECK-NEXT:   %3 = call i1 @"bytes.(*Buffer).empty"(ptr %2)
+// CHECK-NEXT:   ret i1 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.grow"(ptr %0, i64 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call i64 @"bytes.(*Buffer).grow"(ptr %3, i64 %1)
+// CHECK-NEXT:   ret i64 %4
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.readSlice"(ptr %0, i8 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"bytes.(*Buffer).readSlice"(ptr %3, i8 %1)
+// CHECK-NEXT:   %5 = extractvalue { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %4, 0
+// CHECK-NEXT:   %6 = extractvalue { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %4, 1
+// CHECK-NEXT:   %7 = insertvalue { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } undef, %"{{.*}}/runtime/internal/runtime.Slice" %5, 0
+// CHECK-NEXT:   %8 = insertvalue { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %7, %"{{.*}}/runtime/internal/runtime.iface" %6, 1
+// CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %8
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { i64, i1 } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.tryGrowByReslice"(ptr %0, i64 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call { i64, i1 } @"bytes.(*Buffer).tryGrowByReslice"(ptr %3, i64 %1)
+// CHECK-NEXT:   %5 = extractvalue { i64, i1 } %4, 0
+// CHECK-NEXT:   %6 = extractvalue { i64, i1 } %4, 1
+// CHECK-NEXT:   %7 = insertvalue { i64, i1 } undef, i64 %5, 0
+// CHECK-NEXT:   %8 = insertvalue { i64, i1 } %7, i1 %6, 1
+// CHECK-NEXT:   ret { i64, i1 } %8
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Available"({ i64, ptr } %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call i64 @"bytes.(*Buffer).Available"(ptr %3)
+// CHECK-NEXT:   ret i64 %4
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.AvailableBuffer"({ i64, ptr } %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.Slice" @"bytes.(*Buffer).AvailableBuffer"(ptr %3)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %4
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Bytes"({ i64, ptr } %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.Slice" @"bytes.(*Buffer).Bytes"(ptr %3)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %4
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Cap"({ i64, ptr } %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call i64 @"bytes.(*Buffer).Cap"(ptr %3)
+// CHECK-NEXT:   ret i64 %4
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Grow"({ i64, ptr } %0, i64 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
+// CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
+// CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
+// CHECK-NEXT:   call void @"bytes.(*Buffer).Grow"(ptr %4, i64 %1)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Len"({ i64, ptr } %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call i64 @"bytes.(*Buffer).Len"(ptr %3)
+// CHECK-NEXT:   ret i64 %4
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Next"({ i64, ptr } %0, i64 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
+// CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
+// CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
+// CHECK-NEXT:   %5 = call %"{{.*}}/runtime/internal/runtime.Slice" @"bytes.(*Buffer).Next"(ptr %4, i64 %1)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %5
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Read"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.Slice" %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
+// CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
+// CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
+// CHECK-NEXT:   %5 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"bytes.(*Buffer).Read"(ptr %4, %"{{.*}}/runtime/internal/runtime.Slice" %1)
+// CHECK-NEXT:   %6 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %5, 0
+// CHECK-NEXT:   %7 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %5, 1
+// CHECK-NEXT:   %8 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } undef, i64 %6, 0
+// CHECK-NEXT:   %9 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8, %"{{.*}}/runtime/internal/runtime.iface" %7, 1
+// CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadByte"({ i64, ptr } %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"bytes.(*Buffer).ReadByte"(ptr %3)
+// CHECK-NEXT:   %5 = extractvalue { i8, %"{{.*}}/runtime/internal/runtime.iface" } %4, 0
+// CHECK-NEXT:   %6 = extractvalue { i8, %"{{.*}}/runtime/internal/runtime.iface" } %4, 1
+// CHECK-NEXT:   %7 = insertvalue { i8, %"{{.*}}/runtime/internal/runtime.iface" } undef, i8 %5, 0
+// CHECK-NEXT:   %8 = insertvalue { i8, %"{{.*}}/runtime/internal/runtime.iface" } %7, %"{{.*}}/runtime/internal/runtime.iface" %6, 1
+// CHECK-NEXT:   ret { i8, %"{{.*}}/runtime/internal/runtime.iface" } %8
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadBytes"({ i64, ptr } %0, i8 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
+// CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
+// CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
+// CHECK-NEXT:   %5 = call { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"bytes.(*Buffer).ReadBytes"(ptr %4, i8 %1)
+// CHECK-NEXT:   %6 = extractvalue { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %5, 0
+// CHECK-NEXT:   %7 = extractvalue { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %5, 1
+// CHECK-NEXT:   %8 = insertvalue { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } undef, %"{{.*}}/runtime/internal/runtime.Slice" %6, 0
+// CHECK-NEXT:   %9 = insertvalue { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %8, %"{{.*}}/runtime/internal/runtime.iface" %7, 1
+// CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %9
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadFrom"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.iface" %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
+// CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
+// CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
+// CHECK-NEXT:   %5 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"bytes.(*Buffer).ReadFrom"(ptr %4, %"{{.*}}/runtime/internal/runtime.iface" %1)
+// CHECK-NEXT:   %6 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %5, 0
+// CHECK-NEXT:   %7 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %5, 1
+// CHECK-NEXT:   %8 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } undef, i64 %6, 0
+// CHECK-NEXT:   %9 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8, %"{{.*}}/runtime/internal/runtime.iface" %7, 1
+// CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadRune"({ i64, ptr } %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"bytes.(*Buffer).ReadRune"(ptr %3)
+// CHECK-NEXT:   %5 = extractvalue { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } %4, 0
+// CHECK-NEXT:   %6 = extractvalue { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } %4, 1
+// CHECK-NEXT:   %7 = extractvalue { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } %4, 2
+// CHECK-NEXT:   %8 = insertvalue { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } undef, i32 %5, 0
+// CHECK-NEXT:   %9 = insertvalue { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } %8, i64 %6, 1
+// CHECK-NEXT:   %10 = insertvalue { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } %9, %"{{.*}}/runtime/internal/runtime.iface" %7, 2
+// CHECK-NEXT:   ret { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } %10
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadString"({ i64, ptr } %0, i8 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
+// CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
+// CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
+// CHECK-NEXT:   %5 = call { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } @"bytes.(*Buffer).ReadString"(ptr %4, i8 %1)
+// CHECK-NEXT:   %6 = extractvalue { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } %5, 0
+// CHECK-NEXT:   %7 = extractvalue { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } %5, 1
+// CHECK-NEXT:   %8 = insertvalue { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } undef, %"{{.*}}/runtime/internal/runtime.String" %6, 0
+// CHECK-NEXT:   %9 = insertvalue { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } %8, %"{{.*}}/runtime/internal/runtime.iface" %7, 1
+// CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } %9
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Reset"({ i64, ptr } %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   call void @"bytes.(*Buffer).Reset"(ptr %3)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.String"({ i64, ptr } %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.String" @"bytes.(*Buffer).String"(ptr %3)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %4
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Truncate"({ i64, ptr } %0, i64 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
+// CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
+// CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
+// CHECK-NEXT:   call void @"bytes.(*Buffer).Truncate"(ptr %4, i64 %1)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.UnreadByte"({ i64, ptr } %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.iface" @"bytes.(*Buffer).UnreadByte"(ptr %3)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %4
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.UnreadRune"({ i64, ptr } %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.iface" @"bytes.(*Buffer).UnreadRune"(ptr %3)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %4
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Write"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.Slice" %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
+// CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
+// CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
+// CHECK-NEXT:   %5 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"bytes.(*Buffer).Write"(ptr %4, %"{{.*}}/runtime/internal/runtime.Slice" %1)
+// CHECK-NEXT:   %6 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %5, 0
+// CHECK-NEXT:   %7 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %5, 1
+// CHECK-NEXT:   %8 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } undef, i64 %6, 0
+// CHECK-NEXT:   %9 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8, %"{{.*}}/runtime/internal/runtime.iface" %7, 1
+// CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteByte"({ i64, ptr } %0, i8 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
+// CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
+// CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
+// CHECK-NEXT:   %5 = call %"{{.*}}/runtime/internal/runtime.iface" @"bytes.(*Buffer).WriteByte"(ptr %4, i8 %1)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %5
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteRune"({ i64, ptr } %0, i32 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
+// CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
+// CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
+// CHECK-NEXT:   %5 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"bytes.(*Buffer).WriteRune"(ptr %4, i32 %1)
+// CHECK-NEXT:   %6 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %5, 0
+// CHECK-NEXT:   %7 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %5, 1
+// CHECK-NEXT:   %8 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } undef, i64 %6, 0
+// CHECK-NEXT:   %9 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8, %"{{.*}}/runtime/internal/runtime.iface" %7, 1
+// CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteString"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.String" %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
+// CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
+// CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
+// CHECK-NEXT:   %5 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"bytes.(*Buffer).WriteString"(ptr %4, %"{{.*}}/runtime/internal/runtime.String" %1)
+// CHECK-NEXT:   %6 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %5, 0
+// CHECK-NEXT:   %7 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %5, 1
+// CHECK-NEXT:   %8 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } undef, i64 %6, 0
+// CHECK-NEXT:   %9 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8, %"{{.*}}/runtime/internal/runtime.iface" %7, 1
+// CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteTo"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.iface" %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
+// CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
+// CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
+// CHECK-NEXT:   %5 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"bytes.(*Buffer).WriteTo"(ptr %4, %"{{.*}}/runtime/internal/runtime.iface" %1)
+// CHECK-NEXT:   %6 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %5, 0
+// CHECK-NEXT:   %7 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %5, 1
+// CHECK-NEXT:   %8 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } undef, i64 %6, 0
+// CHECK-NEXT:   %9 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8, %"{{.*}}/runtime/internal/runtime.iface" %7, 1
+// CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i1 @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.empty"({ i64, ptr } %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = call i1 @"bytes.(*Buffer).empty"(ptr %3)
+// CHECK-NEXT:   ret i1 %4
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.grow"({ i64, ptr } %0, i64 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
+// CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
+// CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
+// CHECK-NEXT:   %5 = call i64 @"bytes.(*Buffer).grow"(ptr %4, i64 %1)
+// CHECK-NEXT:   ret i64 %5
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.readSlice"({ i64, ptr } %0, i8 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
+// CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
+// CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
+// CHECK-NEXT:   %5 = call { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"bytes.(*Buffer).readSlice"(ptr %4, i8 %1)
+// CHECK-NEXT:   %6 = extractvalue { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %5, 0
+// CHECK-NEXT:   %7 = extractvalue { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %5, 1
+// CHECK-NEXT:   %8 = insertvalue { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } undef, %"{{.*}}/runtime/internal/runtime.Slice" %6, 0
+// CHECK-NEXT:   %9 = insertvalue { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %8, %"{{.*}}/runtime/internal/runtime.iface" %7, 1
+// CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %9
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define { i64, i1 } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.tryGrowByReslice"({ i64, ptr } %0, i64 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
+// CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
+// CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
+// CHECK-NEXT:   %5 = call { i64, i1 } @"bytes.(*Buffer).tryGrowByReslice"(ptr %4, i64 %1)
+// CHECK-NEXT:   %6 = extractvalue { i64, i1 } %5, 0
+// CHECK-NEXT:   %7 = extractvalue { i64, i1 } %5, 1
+// CHECK-NEXT:   %8 = insertvalue { i64, i1 } undef, i64 %6, 0
+// CHECK-NEXT:   %9 = insertvalue { i64, i1 } %8, i1 %7, 1
+// CHECK-NEXT:   ret { i64, i1 } %9
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce ptr @"{{.*}}/_testgo/abimethod.(*Pointer[any]).Load"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.Pointer[any]", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = load atomic ptr, ptr %1 seq_cst, align 8
+// CHECK-NEXT:   ret ptr %2
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce void @"{{.*}}/_testgo/abimethod.(*Pointer[any]).Store"(ptr %0, ptr %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.Pointer[any]", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   store atomic ptr %1, ptr %2 seq_cst, align 8
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }

--- a/cl/_testgo/closureall/in.go
+++ b/cl/_testgo/closureall/in.go
@@ -20,41 +20,105 @@ type S struct {
 	v int
 }
 
-func (s *S) Add(x int) int {
-	return s.v + x
-}
-
-// CHECK-LABEL: define {{.*}} @"{{.*}}/closureall.(*S).Inc"{{.*}}
-// CHECK: S.Inc
-// CHECK: ret i64
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/closureall.S.Inc"(%"{{.*}}/cl/_testgo/closureall.S" %0, i64 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = alloca %"{{.*}}/cl/_testgo/closureall.S", align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/closureall.S" %0, ptr %2, align 4
+// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/closureall.S", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %4 = load i64, ptr %3, align 4
+// CHECK-NEXT:   %5 = add i64 %4, %1
+// CHECK-NEXT:   ret i64 %5
+// CHECK-NEXT: }
 func (s S) Inc(x int) int {
 	return s.v + x
 }
 
-func globalAdd(x, y int) int {
-	return x + y
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/closureall.(*S).Add"(ptr %0, i64 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/closureall.S", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %3 = load i64, ptr %2, align 4
+// CHECK-NEXT:   %4 = add i64 %3, %1
+// CHECK-NEXT:   ret i64 %4
+// CHECK-NEXT: }
+func (s *S) Add(x int) int {
+	return s.v + x
 }
 
-func makeNoFree() Fn {
-	return func(x int) int { return x + 1 }
-}
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/closureall.(*S).Inc"(ptr %0, i64 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/closureall.S", ptr %0, align 4
+// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/closureall.S.Inc"(%"{{.*}}/cl/_testgo/closureall.S" %2, i64 %1)
+// CHECK-NEXT:   ret i64 %3
+// CHECK-NEXT: }
 
-func makeWithFree(base int) Fn {
-	return func(x int) int { return x + base }
-}
-
-// CHECK-LABEL: define {{.*}} @"{{.*}}/closureall.callCallback"{{.*}}
-// CHECK: ret i32
+// CHECK-LABEL: define i32 @"{{.*}}/cl/_testgo/closureall.callCallback"(ptr %0, i32 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = call i32 %0(i32 %1)
+// CHECK-NEXT:   ret i32 %2
+// CHECK-NEXT: }
 func callCallback(cb CCallback, v c.Int) c.Int {
 	return cb(v)
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/closureall.main"{{.*}}
-// CHECK: makeNoFree
-// CHECK: makeWithFree
-// CHECK: globalAdd
-// CHECK: callCallback
-// CHECK: NewItab
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/closureall.globalAdd"(i64 %0, i64 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = add i64 %0, %1
+// CHECK-NEXT:   ret i64 %2
+// CHECK-NEXT: }
+func globalAdd(x, y int) int {
+	return x + y
+}
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/closureall.main"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call %"{{.*}}/cl/_testgo/closureall.Fn" @"{{.*}}/cl/_testgo/closureall.makeNoFree"()
+// CHECK-NEXT:   %1 = call %"{{.*}}/cl/_testgo/closureall.Fn" @"{{.*}}/cl/_testgo/closureall.makeWithFree"(i64 3)
+// CHECK-NEXT:   %2 = extractvalue %"{{.*}}/cl/_testgo/closureall.Fn" %0, 1
+// CHECK-NEXT:   %3 = extractvalue %"{{.*}}/cl/_testgo/closureall.Fn" %0, 0
+// CHECK-NEXT:   %4 = call i64 %3(ptr %2, i64 1)
+// CHECK-NEXT:   %5 = extractvalue %"{{.*}}/cl/_testgo/closureall.Fn" %1, 1
+// CHECK-NEXT:   %6 = extractvalue %"{{.*}}/cl/_testgo/closureall.Fn" %1, 0
+// CHECK-NEXT:   %7 = call i64 %6(ptr %5, i64 2)
+// CHECK-NEXT:   %8 = call i64 @"{{.*}}/cl/_testgo/closureall.globalAdd"(i64 1, i64 2)
+// CHECK-NEXT:   %9 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/cl/_testgo/closureall.S", ptr %9, i32 0, i32 0
+// CHECK-NEXT:   store i64 5, ptr %10, align 4
+// CHECK-NEXT:   %11 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT:   %12 = getelementptr inbounds { ptr }, ptr %11, i32 0, i32 0
+// CHECK-NEXT:   store ptr %9, ptr %12, align 8
+// CHECK-NEXT:   %13 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/closureall.(*S).Add$bound", ptr undef }, ptr %11, 1
+// CHECK-NEXT:   %14 = extractvalue { ptr, ptr } %13, 1
+// CHECK-NEXT:   %15 = extractvalue { ptr, ptr } %13, 0
+// CHECK-NEXT:   %16 = call i64 %15(ptr %14, i64 7)
+// CHECK-NEXT:   %17 = call i64 @"{{.*}}/cl/_testgo/closureall.(*S).Add$thunk"(ptr %9, i64 8)
+// CHECK-NEXT:   %18 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A", ptr @"*_llgo_{{.*}}/cl/_testgo/closureall.S")
+// CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %18, 0
+// CHECK-NEXT:   %20 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %19, ptr %9, 1
+// CHECK-NEXT:   %21 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %20)
+// CHECK-NEXT:   %22 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %20, 1
+// CHECK-NEXT:   br i1 true, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %23 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   %24 = getelementptr inbounds { %"{{.*}}/runtime/internal/runtime.iface" }, ptr %23, i32 0, i32 0
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %20, ptr %24, align 8
+// CHECK-NEXT:   %25 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/closureall.interface{Add(int) int}.Add$bound", ptr undef }, ptr %23, 1
+// CHECK-NEXT:   %26 = extractvalue { ptr, ptr } %25, 1
+// CHECK-NEXT:   %27 = extractvalue { ptr, ptr } %25, 0
+// CHECK-NEXT:   %28 = call i64 %27(ptr %26, i64 9)
+// CHECK-NEXT:   %29 = call double @sqrt(double 4.000000e+00)
+// CHECK-NEXT:   %30 = call i32 @abs(i32 -3)
+// CHECK-NEXT:   %31 = call i32 @"{{.*}}/cl/_testgo/closureall.callCallback"(ptr @"{{.*}}/cl/_testgo/closureall.main$1", i32 7)
+// CHECK-NEXT:   ret void
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %32 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @8, i64 72 }, ptr %32, align 8
+// CHECK-NEXT:   %33 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %32, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %33)
+// CHECK-NEXT:   unreachable
+// CHECK-NEXT: }
 func main() {
 	nf := makeNoFree()
 	wf := makeWithFree(3)
@@ -82,3 +146,79 @@ func main() {
 	cb := CCallback(func(x c.Int) c.Int { return x + 1 })
 	_ = callCallback(cb, 7)
 }
+
+// CHECK-LABEL: define %"{{.*}}/cl/_testgo/closureall.Fn" @"{{.*}}/cl/_testgo/closureall.makeNoFree"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   ret %"{{.*}}/cl/_testgo/closureall.Fn" { ptr @"__llgo_stub.{{.*}}/cl/_testgo/closureall.makeNoFree$1", ptr null }
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/closureall.makeNoFree$1"(i64 %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = add i64 %0, 1
+// CHECK-NEXT:   ret i64 %1
+// CHECK-NEXT: }
+func makeNoFree() Fn {
+	return func(x int) int { return x + 1 }
+}
+
+// CHECK-LABEL: define %"{{.*}}/cl/_testgo/closureall.Fn" @"{{.*}}/cl/_testgo/closureall.makeWithFree"(i64 %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   store i64 %0, ptr %1, align 4
+// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT:   %3 = getelementptr inbounds { ptr }, ptr %2, i32 0, i32 0
+// CHECK-NEXT:   store ptr %1, ptr %3, align 8
+// CHECK-NEXT:   %4 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/closureall.makeWithFree$1", ptr undef }, ptr %2, 1
+// CHECK-NEXT:   %5 = alloca %"{{.*}}/cl/_testgo/closureall.Fn", align 8
+// CHECK-NEXT:   store { ptr, ptr } %4, ptr %5, align 8
+// CHECK-NEXT:   %6 = load %"{{.*}}/cl/_testgo/closureall.Fn", ptr %5, align 8
+// CHECK-NEXT:   ret %"{{.*}}/cl/_testgo/closureall.Fn" %6
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/closureall.makeWithFree$1"(ptr %0, i64 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = load { ptr }, ptr %0, align 8
+// CHECK-NEXT:   %3 = extractvalue { ptr } %2, 0
+// CHECK-NEXT:   %4 = load i64, ptr %3, align 4
+// CHECK-NEXT:   %5 = add i64 %1, %4
+// CHECK-NEXT:   ret i64 %5
+// CHECK-NEXT: }
+func makeWithFree(base int) Fn {
+	return func(x int) int { return x + base }
+}
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/closureall.(*S).Add$bound"(ptr %0, i64 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = load { ptr }, ptr %0, align 8
+// CHECK-NEXT:   %3 = extractvalue { ptr } %2, 0
+// CHECK-NEXT:   %4 = call i64 @"{{.*}}/cl/_testgo/closureall.(*S).Add"(ptr %3, i64 %1)
+// CHECK-NEXT:   ret i64 %4
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/closureall.(*S).Add$thunk"(ptr %0, i64 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = call i64 @"{{.*}}/cl/_testgo/closureall.(*S).Add"(ptr %0, i64 %1)
+// CHECK-NEXT:   ret i64 %2
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/closureall.interface{Add(int) int}.Add$bound"(ptr %0, i64 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = load { %"{{.*}}/runtime/internal/runtime.iface" }, ptr %0, align 8
+// CHECK-NEXT:   %3 = extractvalue { %"{{.*}}/runtime/internal/runtime.iface" } %2, 0
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %3)
+// CHECK-NEXT:   %5 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %3, 0
+// CHECK-NEXT:   %6 = getelementptr ptr, ptr %5, i64 3
+// CHECK-NEXT:   %7 = load ptr, ptr %6, align 8
+// CHECK-NEXT:   %8 = insertvalue { ptr, ptr } undef, ptr %7, 0
+// CHECK-NEXT:   %9 = insertvalue { ptr, ptr } %8, ptr %4, 1
+// CHECK-NEXT:   %10 = extractvalue { ptr, ptr } %9, 1
+// CHECK-NEXT:   %11 = extractvalue { ptr, ptr } %9, 0
+// CHECK-NEXT:   %12 = call i64 %11(ptr %10, i64 %1)
+// CHECK-NEXT:   ret i64 %12
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/closureall.makeNoFree$1"(ptr %0, i64 %1) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = tail call i64 @"{{.*}}/cl/_testgo/closureall.makeNoFree$1"(i64 %1)
+// CHECK-NEXT:   ret i64 %2
+// CHECK-NEXT: }

--- a/cl/_testgo/cursor/in.go
+++ b/cl/_testgo/cursor/in.go
@@ -1,4 +1,3 @@
-// LITTEST
 package main
 
 import (
@@ -17,13 +16,13 @@ type Cursor struct {
 	index int32 // index of push node; -1 for virtual root node
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/cursor.Cursor.FindNode"{{.*}}
-// CHECK: Cursor.Preorder
-// CHECK: maskOf
-// CHECK: Cursor.indices
-// CHECK: IfaceType
-// CHECK: EfaceEqual
-// CHECK: ret
+func (c Cursor) Node() ast.Node {
+	if c.index < 0 {
+		return nil
+	}
+	return c.in.events[c.index].node
+}
+
 func (c Cursor) FindNode(n ast.Node) (Cursor, bool) {
 
 	// FindNode is equivalent to this code,
@@ -60,16 +59,6 @@ func (c Cursor) FindNode(n ast.Node) (Cursor, bool) {
 	return Cursor{}, false
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/cursor.Cursor.Node"{{.*}}
-// CHECK: AssertIndexRange
-// CHECK: ret
-func (c Cursor) Node() ast.Node {
-	if c.index < 0 {
-		return nil
-	}
-	return c.in.events[c.index].node
-}
-
 type event struct {
 	node   ast.Node
 	typ    uint64 // typeOf(node) on push event, or union of typ strictly between push and pop events on pop events
@@ -101,10 +90,6 @@ func (c Cursor) indices() (int32, int32) {
 	}
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/cursor.Cursor.Preorder"{{.*}}
-// CHECK: maskOf
-// CHECK: AllocZ
-// CHECK: ret
 func (c Cursor) Preorder(types ...ast.Node) iter.Seq[Cursor] {
 	mask := maskOf(types)
 

--- a/cl/_testgo/cursor/out.ll
+++ b/cl/_testgo/cursor/out.ll
@@ -1,0 +1,2814 @@
+; ModuleID = 'github.com/goplus/llgo/cl/_testgo/cursor'
+source_filename = "github.com/goplus/llgo/cl/_testgo/cursor"
+
+%"github.com/goplus/llgo/runtime/abi.Type" = type { i64, i64, i32, i8, i8, i8, i8, { ptr, ptr }, ptr, %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr }
+%"github.com/goplus/llgo/runtime/internal/runtime.String" = type { ptr, i64 }
+%"github.com/goplus/llgo/runtime/abi.PtrType" = type { %"github.com/goplus/llgo/runtime/abi.Type", ptr }
+%"github.com/goplus/llgo/runtime/abi.UncommonType" = type { %"github.com/goplus/llgo/runtime/internal/runtime.String", i16, i16, i32 }
+%"github.com/goplus/llgo/runtime/abi.Method" = type { %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr, ptr, ptr }
+%"github.com/goplus/llgo/runtime/abi.StructType" = type { %"github.com/goplus/llgo/runtime/abi.Type", %"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.Slice" }
+%"github.com/goplus/llgo/runtime/internal/runtime.Slice" = type { ptr, i64, i64 }
+%"github.com/goplus/llgo/runtime/abi.FuncType" = type { %"github.com/goplus/llgo/runtime/abi.Type", %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.Slice" }
+%"github.com/goplus/llgo/runtime/abi.InterfaceType" = type { %"github.com/goplus/llgo/runtime/abi.Type", %"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.Slice" }
+%"github.com/goplus/llgo/runtime/abi.StructField" = type { %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr, i64, %"github.com/goplus/llgo/runtime/internal/runtime.String", i1 }
+%"github.com/goplus/llgo/runtime/abi.Imethod" = type { %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr }
+%"github.com/goplus/llgo/runtime/abi.SliceType" = type { %"github.com/goplus/llgo/runtime/abi.Type", ptr }
+%"github.com/goplus/llgo/runtime/abi.MapType" = type { %"github.com/goplus/llgo/runtime/abi.Type", ptr, ptr, ptr, { ptr, ptr }, i8, i8, i16, i32 }
+%"github.com/goplus/llgo/runtime/abi.ArrayType" = type { %"github.com/goplus/llgo/runtime/abi.Type", ptr, ptr, i64 }
+%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" = type { ptr, i32 }
+%"github.com/goplus/llgo/runtime/internal/runtime.iface" = type { ptr, ptr }
+%"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]" = type { ptr, ptr }
+%"github.com/goplus/llgo/cl/_testgo/cursor.Inspector" = type { %"github.com/goplus/llgo/runtime/internal/runtime.Slice" }
+%"github.com/goplus/llgo/runtime/internal/runtime.eface" = type { ptr, ptr }
+%"github.com/goplus/llgo/cl/_testgo/cursor.event" = type { %"github.com/goplus/llgo/runtime/internal/runtime.iface", i64, i32, i32 }
+
+@"github.com/goplus/llgo/cl/_testgo/cursor.init$guard" = global i1 false, align 1
+@0 = private unnamed_addr constant [36 x i8] c"iterator call did not preserve panic", align 1
+@_llgo_string = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 8, i32 1749264893, i8 4, i8 8, i8 8, i8 24, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 6 }, ptr @"*_llgo_string" }, align 8
+@1 = private unnamed_addr constant [6 x i8] c"string", align 1
+@"*_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1323879264, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 6 }, ptr null }, ptr @_llgo_string }, align 8
+@2 = private unnamed_addr constant [43 x i8] c"yield function called after range loop exit", align 1
+@"*_llgo_go/ast.Ident" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [5 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -2080842285, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @3, i64 9 }, ptr null }, ptr @"_llgo_go/ast.Ident" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 5, i16 4, i32 24 }, [5 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*Ident).End", ptr @"go/ast.(*Ident).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @26, i64 10 }, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", ptr @"go/ast.(*Ident).IsExported", ptr @"go/ast.(*Ident).IsExported" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*Ident).Pos", ptr @"go/ast.(*Ident).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @16, i64 6 }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", ptr @"go/ast.(*Ident).String", ptr @"go/ast.(*Ident).String" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*Ident).exprNode", ptr @"go/ast.(*Ident).exprNode" }] }, align 8
+@3 = private unnamed_addr constant [9 x i8] c"ast.Ident", align 1
+@"_llgo_go/ast.Ident" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 32, i64 32, i32 223651489, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.Ident" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @3, i64 9 }, ptr @"*_llgo_go/ast.Ident" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$ERhAAXQWPbqC1-_yiLvvpFhGaPd1HWshKDb-_H5Nm3M$fields", i64 3, i64 3 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@4 = private unnamed_addr constant [7 x i8] c"NamePos", align 1
+@"_llgo_go/token.Pos" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.Type", %"github.com/goplus/llgo/runtime/abi.UncommonType", [1 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 0, i32 1285526538, i8 13, i8 8, i8 8, i8 34, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @5, i64 9 }, ptr @"*_llgo_go/token.Pos" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @6, i64 8 }, i16 1, i16 1, i32 24 }, [1 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 7 }, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", ptr @"go/token.(*Pos).IsValid", ptr @"go/token.Pos.IsValid" }] }, align 8
+@5 = private unnamed_addr constant [9 x i8] c"token.Pos", align 1
+@"*_llgo_go/token.Pos" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [1 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1298747093, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @5, i64 9 }, ptr null }, ptr @"_llgo_go/token.Pos" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @6, i64 8 }, i16 1, i16 1, i32 24 }, [1 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 7 }, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", ptr @"go/token.(*Pos).IsValid", ptr @"go/token.(*Pos).IsValid" }] }, align 8
+@6 = private unnamed_addr constant [8 x i8] c"go/token", align 1
+@7 = private unnamed_addr constant [7 x i8] c"IsValid", align 1
+@"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -541022001, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 11 }, ptr @"*_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk$out", i64 1, i64 1 } }, align 8
+@8 = private unnamed_addr constant [11 x i8] c"func() bool", align 1
+@"*_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -367308996, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 11 }, ptr null }, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk" }, align 8
+@_llgo_bool = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 1, i64 0, i32 554183389, i8 12, i8 1, i8 1, i8 33, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @9, i64 4 }, ptr @"*_llgo_bool" }, align 8
+@9 = private unnamed_addr constant [4 x i8] c"bool", align 1
+@"*_llgo_bool" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1896950390, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @9, i64 4 }, ptr null }, ptr @_llgo_bool }, align 8
+@"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk$out" = weak_odr constant [1 x ptr] [ptr @_llgo_bool], align 8
+@10 = private unnamed_addr constant [4 x i8] c"Name", align 1
+@11 = private unnamed_addr constant [3 x i8] c"Obj", align 1
+@"*_llgo_go/ast.Object" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [1 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 398625873, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @12, i64 10 }, ptr null }, ptr @"_llgo_go/ast.Object" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 1, i16 1, i32 24 }, [1 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*Object).Pos", ptr @"go/ast.(*Object).Pos" }] }, align 8
+@12 = private unnamed_addr constant [10 x i8] c"ast.Object", align 1
+@"_llgo_go/ast.Object" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 72, i64 72, i32 -345899940, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.Object" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @12, i64 10 }, ptr @"*_llgo_go/ast.Object" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$PpBVodhNoYSyuTvVSvUg9Ezb8mKNNTWg_RwGYFq0KPA$fields", i64 5, i64 5 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@13 = private unnamed_addr constant [4 x i8] c"Kind", align 1
+@"_llgo_go/ast.ObjKind" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.Type", %"github.com/goplus/llgo/runtime/abi.UncommonType", [1 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 0, i32 118841177, i8 13, i8 8, i8 8, i8 34, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @14, i64 11 }, ptr @"*_llgo_go/ast.ObjKind" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 1, i16 1, i32 24 }, [1 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @16, i64 6 }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", ptr @"go/ast.(*ObjKind).String", ptr @"go/ast.ObjKind.String" }] }, align 8
+@14 = private unnamed_addr constant [11 x i8] c"ast.ObjKind", align 1
+@"*_llgo_go/ast.ObjKind" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [1 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1144452934, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @14, i64 11 }, ptr null }, ptr @"_llgo_go/ast.ObjKind" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 1, i16 1, i32 24 }, [1 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @16, i64 6 }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", ptr @"go/ast.(*ObjKind).String", ptr @"go/ast.(*ObjKind).String" }] }, align 8
+@15 = private unnamed_addr constant [6 x i8] c"go/ast", align 1
+@16 = private unnamed_addr constant [6 x i8] c"String", align 1
+@"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1419376263, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @17, i64 13 }, ptr @"*_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to$out", i64 1, i64 1 } }, align 8
+@17 = private unnamed_addr constant [13 x i8] c"func() string", align 1
+@"*_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1900367307, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @17, i64 13 }, ptr null }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" }, align 8
+@"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to$out" = weak_odr constant [1 x ptr] [ptr @_llgo_string], align 8
+@18 = private unnamed_addr constant [4 x i8] c"Decl", align 1
+@_llgo_any = weak_odr constant %"github.com/goplus/llgo/runtime/abi.InterfaceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 1376530322, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.nilinterequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @19, i64 12 }, ptr @"*_llgo_any" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @20, i64 40 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer }, align 8
+@19 = private unnamed_addr constant [12 x i8] c"interface {}", align 1
+@"*_llgo_any" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1741196194, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @19, i64 12 }, ptr null }, ptr @_llgo_any }, align 8
+@20 = private unnamed_addr constant [40 x i8] c"github.com/goplus/llgo/cl/_testgo/cursor", align 1
+@21 = private unnamed_addr constant [4 x i8] c"Data", align 1
+@22 = private unnamed_addr constant [4 x i8] c"Type", align 1
+@"_llgo_struct$PpBVodhNoYSyuTvVSvUg9Ezb8mKNNTWg_RwGYFq0KPA$fields" = weak_odr constant [5 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @13, i64 4 }, ptr @"_llgo_go/ast.ObjKind", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @10, i64 4 }, ptr @_llgo_string, i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @18, i64 4 }, ptr @_llgo_any, i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @21, i64 4 }, ptr @_llgo_any, i64 40, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @22, i64 4 }, ptr @_llgo_any, i64 56, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@23 = private unnamed_addr constant [3 x i8] c"Pos", align 1
+@"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -737142225, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @24, i64 16 }, ptr @"*_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU$out", i64 1, i64 1 } }, align 8
+@24 = private unnamed_addr constant [16 x i8] c"func() token.Pos", align 1
+@"*_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1791594852, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @24, i64 16 }, ptr null }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU" }, align 8
+@"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU$out" = weak_odr constant [1 x ptr] [ptr @"_llgo_go/token.Pos"], align 8
+@"_llgo_struct$ERhAAXQWPbqC1-_yiLvvpFhGaPd1HWshKDb-_H5Nm3M$fields" = weak_odr constant [3 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @4, i64 7 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @10, i64 4 }, ptr @_llgo_string, i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @11, i64 3 }, ptr @"*_llgo_go/ast.Object", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@25 = private unnamed_addr constant [3 x i8] c"End", align 1
+@26 = private unnamed_addr constant [10 x i8] c"IsExported", align 1
+@27 = private unnamed_addr constant [8 x i8] c"exprNode", align 1
+@28 = private unnamed_addr constant [15 x i8] c"go/ast.exprNode", align 1
+@"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1790696805, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @29, i64 6 }, ptr @"*_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer }, align 8
+@29 = private unnamed_addr constant [6 x i8] c"func()", align 1
+@"*_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -130179135, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @29, i64 6 }, ptr null }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac" }, align 8
+@"*_llgo_go/ast.ArrayType" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 244087908, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @30, i64 13 }, ptr null }, ptr @"_llgo_go/ast.ArrayType" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*ArrayType).End", ptr @"go/ast.(*ArrayType).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*ArrayType).Pos", ptr @"go/ast.(*ArrayType).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*ArrayType).exprNode", ptr @"go/ast.(*ArrayType).exprNode" }] }, align 8
+@30 = private unnamed_addr constant [13 x i8] c"ast.ArrayType", align 1
+@"_llgo_go/ast.ArrayType" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 40, i64 40, i32 11742203, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.ArrayType" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @30, i64 13 }, ptr @"*_llgo_go/ast.ArrayType" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$OFm4HePnTgUisOj7ADpESXwiDR--b7m5xa0AkQzVRu8$fields", i64 3, i64 3 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@31 = private unnamed_addr constant [6 x i8] c"Lbrack", align 1
+@32 = private unnamed_addr constant [3 x i8] c"Len", align 1
+@"_llgo_go/ast.Expr" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.InterfaceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 2005595146, i8 4, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @33, i64 8 }, ptr @"*_llgo_go/ast.Expr" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @20, i64 40 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"go/ast.iface$Sgj3BULO-Q00_yQXYnGpuhlgemISeswqTKF4CsM8fj4$imethods", i64 3, i64 3 } }, align 8
+@33 = private unnamed_addr constant [8 x i8] c"ast.Expr", align 1
+@"*_llgo_go/ast.Expr" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1862740788, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @33, i64 8 }, ptr null }, ptr @"_llgo_go/ast.Expr" }, align 8
+@"go/ast.iface$Sgj3BULO-Q00_yQXYnGpuhlgemISeswqTKF4CsM8fj4$imethods" = weak_odr constant [3 x %"github.com/goplus/llgo/runtime/abi.Imethod"] [%"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU" }, %"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU" }, %"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac" }], align 8
+@34 = private unnamed_addr constant [3 x i8] c"Elt", align 1
+@"_llgo_struct$OFm4HePnTgUisOj7ADpESXwiDR--b7m5xa0AkQzVRu8$fields" = weak_odr constant [3 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @31, i64 6 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @32, i64 3 }, ptr @"_llgo_go/ast.Expr", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @34, i64 3 }, ptr @"_llgo_go/ast.Expr", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.AssignStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 2086568871, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @35, i64 14 }, ptr null }, ptr @"_llgo_go/ast.AssignStmt" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*AssignStmt).End", ptr @"go/ast.(*AssignStmt).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*AssignStmt).Pos", ptr @"go/ast.(*AssignStmt).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @49, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*AssignStmt).stmtNode", ptr @"go/ast.(*AssignStmt).stmtNode" }] }, align 8
+@35 = private unnamed_addr constant [14 x i8] c"ast.AssignStmt", align 1
+@"_llgo_go/ast.AssignStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 64, i64 48, i32 -760628319, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @35, i64 14 }, ptr @"*_llgo_go/ast.AssignStmt" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$wsyF6kiIuFuywsMdyRhgzCeAvEWs50Iqjsb1NG8kod0$fields", i64 4, i64 4 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@36 = private unnamed_addr constant [3 x i8] c"Lhs", align 1
+@"[]_llgo_go/ast.Expr" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 -1155511237, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @37, i64 10 }, ptr @"*[]_llgo_go/ast.Expr" }, ptr @"_llgo_go/ast.Expr" }, align 8
+@37 = private unnamed_addr constant [10 x i8] c"[]ast.Expr", align 1
+@"*[]_llgo_go/ast.Expr" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 2140595147, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @37, i64 10 }, ptr null }, ptr @"[]_llgo_go/ast.Expr" }, align 8
+@38 = private unnamed_addr constant [6 x i8] c"TokPos", align 1
+@39 = private unnamed_addr constant [3 x i8] c"Tok", align 1
+@"_llgo_go/token.Token" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.Type", %"github.com/goplus/llgo/runtime/abi.UncommonType", [5 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 0, i32 -289315828, i8 13, i8 8, i8 8, i8 34, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @40, i64 11 }, ptr @"*_llgo_go/token.Token" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @6, i64 8 }, i16 5, i16 5, i32 24 }, [5 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @41, i64 9 }, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", ptr @"go/token.(*Token).IsKeyword", ptr @"go/token.Token.IsKeyword" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @42, i64 9 }, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", ptr @"go/token.(*Token).IsLiteral", ptr @"go/token.Token.IsLiteral" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @43, i64 10 }, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", ptr @"go/token.(*Token).IsOperator", ptr @"go/token.Token.IsOperator" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @44, i64 10 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"go/token.(*Token).Precedence", ptr @"go/token.Token.Precedence" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @16, i64 6 }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", ptr @"go/token.(*Token).String", ptr @"go/token.Token.String" }] }, align 8
+@40 = private unnamed_addr constant [11 x i8] c"token.Token", align 1
+@"*_llgo_go/token.Token" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [5 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -419138858, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @40, i64 11 }, ptr null }, ptr @"_llgo_go/token.Token" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @6, i64 8 }, i16 5, i16 5, i32 24 }, [5 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @41, i64 9 }, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", ptr @"go/token.(*Token).IsKeyword", ptr @"go/token.(*Token).IsKeyword" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @42, i64 9 }, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", ptr @"go/token.(*Token).IsLiteral", ptr @"go/token.(*Token).IsLiteral" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @43, i64 10 }, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", ptr @"go/token.(*Token).IsOperator", ptr @"go/token.(*Token).IsOperator" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @44, i64 10 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"go/token.(*Token).Precedence", ptr @"go/token.(*Token).Precedence" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @16, i64 6 }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", ptr @"go/token.(*Token).String", ptr @"go/token.(*Token).String" }] }, align 8
+@41 = private unnamed_addr constant [9 x i8] c"IsKeyword", align 1
+@42 = private unnamed_addr constant [9 x i8] c"IsLiteral", align 1
+@43 = private unnamed_addr constant [10 x i8] c"IsOperator", align 1
+@44 = private unnamed_addr constant [10 x i8] c"Precedence", align 1
+@"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 2131144854, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @45, i64 10 }, ptr @"*_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA$out", i64 1, i64 1 } }, align 8
+@45 = private unnamed_addr constant [10 x i8] c"func() int", align 1
+@"*_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1805835775, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @45, i64 10 }, ptr null }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" }, align 8
+@_llgo_int = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 0, i32 -25294021, i8 12, i8 8, i8 8, i8 34, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @46, i64 3 }, ptr @"*_llgo_int" }, align 8
+@46 = private unnamed_addr constant [3 x i8] c"int", align 1
+@"*_llgo_int" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -939606833, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @46, i64 3 }, ptr null }, ptr @_llgo_int }, align 8
+@"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA$out" = weak_odr constant [1 x ptr] [ptr @_llgo_int], align 8
+@47 = private unnamed_addr constant [3 x i8] c"Rhs", align 1
+@"_llgo_struct$wsyF6kiIuFuywsMdyRhgzCeAvEWs50Iqjsb1NG8kod0$fields" = weak_odr constant [4 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @36, i64 3 }, ptr @"[]_llgo_go/ast.Expr", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @38, i64 6 }, ptr @"_llgo_go/token.Pos", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @39, i64 3 }, ptr @"_llgo_go/token.Token", i64 32, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @47, i64 3 }, ptr @"[]_llgo_go/ast.Expr", i64 40, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@48 = private unnamed_addr constant [8 x i8] c"stmtNode", align 1
+@49 = private unnamed_addr constant [15 x i8] c"go/ast.stmtNode", align 1
+@"*_llgo_go/ast.BadDecl" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -2083812208, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @50, i64 11 }, ptr null }, ptr @"_llgo_go/ast.BadDecl" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*BadDecl).End", ptr @"go/ast.(*BadDecl).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*BadDecl).Pos", ptr @"go/ast.(*BadDecl).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @54, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*BadDecl).declNode", ptr @"go/ast.(*BadDecl).declNode" }] }, align 8
+@50 = private unnamed_addr constant [11 x i8] c"ast.BadDecl", align 1
+@"_llgo_go/ast.BadDecl" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 0, i32 -2072091450, i8 13, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.BadDecl" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @50, i64 11 }, ptr @"*_llgo_go/ast.BadDecl" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$gkeSKaIITwj2ufmiLzjRR5D0VShQKg6lFkjmKMIruzw$fields", i64 2, i64 2 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@51 = private unnamed_addr constant [4 x i8] c"From", align 1
+@52 = private unnamed_addr constant [2 x i8] c"To", align 1
+@"_llgo_struct$gkeSKaIITwj2ufmiLzjRR5D0VShQKg6lFkjmKMIruzw$fields" = weak_odr constant [2 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @51, i64 4 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @52, i64 2 }, ptr @"_llgo_go/token.Pos", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@53 = private unnamed_addr constant [8 x i8] c"declNode", align 1
+@54 = private unnamed_addr constant [15 x i8] c"go/ast.declNode", align 1
+@"*_llgo_go/ast.BadExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -153806428, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @55, i64 11 }, ptr null }, ptr @"_llgo_go/ast.BadExpr" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*BadExpr).End", ptr @"go/ast.(*BadExpr).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*BadExpr).Pos", ptr @"go/ast.(*BadExpr).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*BadExpr).exprNode", ptr @"go/ast.(*BadExpr).exprNode" }] }, align 8
+@55 = private unnamed_addr constant [11 x i8] c"ast.BadExpr", align 1
+@"_llgo_go/ast.BadExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 0, i32 2108480943, i8 13, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.BadExpr" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @55, i64 11 }, ptr @"*_llgo_go/ast.BadExpr" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$gkeSKaIITwj2ufmiLzjRR5D0VShQKg6lFkjmKMIruzw$fields", i64 2, i64 2 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@"*_llgo_go/ast.BadStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 799257336, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @56, i64 11 }, ptr null }, ptr @"_llgo_go/ast.BadStmt" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*BadStmt).End", ptr @"go/ast.(*BadStmt).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*BadStmt).Pos", ptr @"go/ast.(*BadStmt).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @49, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*BadStmt).stmtNode", ptr @"go/ast.(*BadStmt).stmtNode" }] }, align 8
+@56 = private unnamed_addr constant [11 x i8] c"ast.BadStmt", align 1
+@"_llgo_go/ast.BadStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 0, i32 1128289532, i8 13, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.BadStmt" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @56, i64 11 }, ptr @"*_llgo_go/ast.BadStmt" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$gkeSKaIITwj2ufmiLzjRR5D0VShQKg6lFkjmKMIruzw$fields", i64 2, i64 2 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@"*_llgo_go/ast.BasicLit" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1125097446, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @57, i64 12 }, ptr null }, ptr @"_llgo_go/ast.BasicLit" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*BasicLit).End", ptr @"go/ast.(*BasicLit).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*BasicLit).Pos", ptr @"go/ast.(*BasicLit).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*BasicLit).exprNode", ptr @"go/ast.(*BasicLit).exprNode" }] }, align 8
+@57 = private unnamed_addr constant [12 x i8] c"ast.BasicLit", align 1
+@"_llgo_go/ast.BasicLit" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 32, i64 24, i32 1327432624, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.BasicLit" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @57, i64 12 }, ptr @"*_llgo_go/ast.BasicLit" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$Z7ebo3g-cYjlxejcvNwrnpJyLE7Z6VnjYKW2DpiFDqg$fields", i64 3, i64 3 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@58 = private unnamed_addr constant [8 x i8] c"ValuePos", align 1
+@59 = private unnamed_addr constant [5 x i8] c"Value", align 1
+@"_llgo_struct$Z7ebo3g-cYjlxejcvNwrnpJyLE7Z6VnjYKW2DpiFDqg$fields" = weak_odr constant [3 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @58, i64 8 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @13, i64 4 }, ptr @"_llgo_go/token.Token", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @59, i64 5 }, ptr @_llgo_string, i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.BinaryExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -2024209925, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @60, i64 14 }, ptr null }, ptr @"_llgo_go/ast.BinaryExpr" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*BinaryExpr).End", ptr @"go/ast.(*BinaryExpr).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*BinaryExpr).Pos", ptr @"go/ast.(*BinaryExpr).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*BinaryExpr).exprNode", ptr @"go/ast.(*BinaryExpr).exprNode" }] }, align 8
+@60 = private unnamed_addr constant [14 x i8] c"ast.BinaryExpr", align 1
+@"_llgo_go/ast.BinaryExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 48, i64 48, i32 413701553, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.BinaryExpr" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @60, i64 14 }, ptr @"*_llgo_go/ast.BinaryExpr" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$aBJcr5FIITlEWIoN_uLLWcykBBxpGOnETSSSDciy4mY$fields", i64 4, i64 4 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@61 = private unnamed_addr constant [1 x i8] c"X", align 1
+@62 = private unnamed_addr constant [5 x i8] c"OpPos", align 1
+@63 = private unnamed_addr constant [2 x i8] c"Op", align 1
+@64 = private unnamed_addr constant [1 x i8] c"Y", align 1
+@"_llgo_struct$aBJcr5FIITlEWIoN_uLLWcykBBxpGOnETSSSDciy4mY$fields" = weak_odr constant [4 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @61, i64 1 }, ptr @"_llgo_go/ast.Expr", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @62, i64 5 }, ptr @"_llgo_go/token.Pos", i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @63, i64 2 }, ptr @"_llgo_go/token.Token", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @64, i64 1 }, ptr @"_llgo_go/ast.Expr", i64 32, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.BlockStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -272322005, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @65, i64 13 }, ptr null }, ptr @"_llgo_go/ast.BlockStmt" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*BlockStmt).End", ptr @"go/ast.(*BlockStmt).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*BlockStmt).Pos", ptr @"go/ast.(*BlockStmt).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @49, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*BlockStmt).stmtNode", ptr @"go/ast.(*BlockStmt).stmtNode" }] }, align 8
+@65 = private unnamed_addr constant [13 x i8] c"ast.BlockStmt", align 1
+@"_llgo_go/ast.BlockStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 40, i64 8, i32 -2111609664, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @65, i64 13 }, ptr @"*_llgo_go/ast.BlockStmt" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$6Oe5SqFaXSiOWR6kbH40io3wkZV1t6rBB1krEZj2K54$fields", i64 3, i64 3 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@66 = private unnamed_addr constant [6 x i8] c"Lbrace", align 1
+@67 = private unnamed_addr constant [4 x i8] c"List", align 1
+@"[]_llgo_go/ast.Stmt" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 -785311614, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @68, i64 10 }, ptr @"*[]_llgo_go/ast.Stmt" }, ptr @"_llgo_go/ast.Stmt" }, align 8
+@68 = private unnamed_addr constant [10 x i8] c"[]ast.Stmt", align 1
+@"*[]_llgo_go/ast.Stmt" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 913233737, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @68, i64 10 }, ptr null }, ptr @"[]_llgo_go/ast.Stmt" }, align 8
+@"_llgo_go/ast.Stmt" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.InterfaceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 120086185, i8 4, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @69, i64 8 }, ptr @"*_llgo_go/ast.Stmt" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @20, i64 40 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"go/ast.iface$aWT3Y-LS6IA7duoAic3XSpSKidbQ2k5eNPkDzno7gVM$imethods", i64 3, i64 3 } }, align 8
+@69 = private unnamed_addr constant [8 x i8] c"ast.Stmt", align 1
+@"*_llgo_go/ast.Stmt" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 556610737, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @69, i64 8 }, ptr null }, ptr @"_llgo_go/ast.Stmt" }, align 8
+@"go/ast.iface$aWT3Y-LS6IA7duoAic3XSpSKidbQ2k5eNPkDzno7gVM$imethods" = weak_odr constant [3 x %"github.com/goplus/llgo/runtime/abi.Imethod"] [%"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU" }, %"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU" }, %"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @49, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac" }], align 8
+@70 = private unnamed_addr constant [6 x i8] c"Rbrace", align 1
+@"_llgo_struct$6Oe5SqFaXSiOWR6kbH40io3wkZV1t6rBB1krEZj2K54$fields" = weak_odr constant [3 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @66, i64 6 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @67, i64 4 }, ptr @"[]_llgo_go/ast.Stmt", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @70, i64 6 }, ptr @"_llgo_go/token.Pos", i64 32, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.BranchStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -621596631, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @71, i64 14 }, ptr null }, ptr @"_llgo_go/ast.BranchStmt" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*BranchStmt).End", ptr @"go/ast.(*BranchStmt).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*BranchStmt).Pos", ptr @"go/ast.(*BranchStmt).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @49, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*BranchStmt).stmtNode", ptr @"go/ast.(*BranchStmt).stmtNode" }] }, align 8
+@71 = private unnamed_addr constant [14 x i8] c"ast.BranchStmt", align 1
+@"_llgo_go/ast.BranchStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 24, i32 -1725876318, i8 13, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.BranchStmt" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @71, i64 14 }, ptr @"*_llgo_go/ast.BranchStmt" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$sfihnGu4kE_OS6G3R1mLSCKiPWdor6lLJ7_TK9MgNBE$fields", i64 3, i64 3 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@72 = private unnamed_addr constant [5 x i8] c"Label", align 1
+@"_llgo_struct$sfihnGu4kE_OS6G3R1mLSCKiPWdor6lLJ7_TK9MgNBE$fields" = weak_odr constant [3 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @38, i64 6 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @39, i64 3 }, ptr @"_llgo_go/token.Token", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @72, i64 5 }, ptr @"*_llgo_go/ast.Ident", i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.CallExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -748651560, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @73, i64 12 }, ptr null }, ptr @"_llgo_go/ast.CallExpr" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*CallExpr).End", ptr @"go/ast.(*CallExpr).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*CallExpr).Pos", ptr @"go/ast.(*CallExpr).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*CallExpr).exprNode", ptr @"go/ast.(*CallExpr).exprNode" }] }, align 8
+@73 = private unnamed_addr constant [12 x i8] c"ast.CallExpr", align 1
+@"_llgo_go/ast.CallExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 64, i64 24, i32 1484530216, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @73, i64 12 }, ptr @"*_llgo_go/ast.CallExpr" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$blhZdb9fB5tVwkjY7RHO1GKkiX0pfRFPPyoXplJChHY$fields", i64 5, i64 5 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@74 = private unnamed_addr constant [3 x i8] c"Fun", align 1
+@75 = private unnamed_addr constant [6 x i8] c"Lparen", align 1
+@76 = private unnamed_addr constant [4 x i8] c"Args", align 1
+@77 = private unnamed_addr constant [8 x i8] c"Ellipsis", align 1
+@78 = private unnamed_addr constant [6 x i8] c"Rparen", align 1
+@"_llgo_struct$blhZdb9fB5tVwkjY7RHO1GKkiX0pfRFPPyoXplJChHY$fields" = weak_odr constant [5 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @74, i64 3 }, ptr @"_llgo_go/ast.Expr", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @75, i64 6 }, ptr @"_llgo_go/token.Pos", i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @76, i64 4 }, ptr @"[]_llgo_go/ast.Expr", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @77, i64 8 }, ptr @"_llgo_go/token.Pos", i64 48, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @78, i64 6 }, ptr @"_llgo_go/token.Pos", i64 56, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.CaseClause" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1914510687, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @79, i64 14 }, ptr null }, ptr @"_llgo_go/ast.CaseClause" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*CaseClause).End", ptr @"go/ast.(*CaseClause).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*CaseClause).Pos", ptr @"go/ast.(*CaseClause).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @49, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*CaseClause).stmtNode", ptr @"go/ast.(*CaseClause).stmtNode" }] }, align 8
+@79 = private unnamed_addr constant [14 x i8] c"ast.CaseClause", align 1
+@"_llgo_go/ast.CaseClause" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 64, i64 48, i32 898358260, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @79, i64 14 }, ptr @"*_llgo_go/ast.CaseClause" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$ag67E7f5LDTjuIDN-sKkxaxDuH0X5n4mnxZyCD7lHGs$fields", i64 4, i64 4 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@80 = private unnamed_addr constant [4 x i8] c"Case", align 1
+@81 = private unnamed_addr constant [5 x i8] c"Colon", align 1
+@82 = private unnamed_addr constant [4 x i8] c"Body", align 1
+@"_llgo_struct$ag67E7f5LDTjuIDN-sKkxaxDuH0X5n4mnxZyCD7lHGs$fields" = weak_odr constant [4 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @80, i64 4 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @67, i64 4 }, ptr @"[]_llgo_go/ast.Expr", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @81, i64 5 }, ptr @"_llgo_go/token.Pos", i64 32, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @82, i64 4 }, ptr @"[]_llgo_go/ast.Stmt", i64 40, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.ChanType" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1759169956, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @83, i64 12 }, ptr null }, ptr @"_llgo_go/ast.ChanType" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*ChanType).End", ptr @"go/ast.(*ChanType).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*ChanType).Pos", ptr @"go/ast.(*ChanType).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*ChanType).exprNode", ptr @"go/ast.(*ChanType).exprNode" }] }, align 8
+@83 = private unnamed_addr constant [12 x i8] c"ast.ChanType", align 1
+@"_llgo_go/ast.ChanType" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 40, i64 40, i32 -1804875866, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.ChanType" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @83, i64 12 }, ptr @"*_llgo_go/ast.ChanType" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$jNLpgFf8Fpzmg_7soMAPb94sUL7fIThqs7gJ1FySkcg$fields", i64 4, i64 4 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@84 = private unnamed_addr constant [5 x i8] c"Begin", align 1
+@85 = private unnamed_addr constant [5 x i8] c"Arrow", align 1
+@86 = private unnamed_addr constant [3 x i8] c"Dir", align 1
+@"_llgo_go/ast.ChanDir" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.Type", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 0, i32 -1370288072, i8 13, i8 8, i8 8, i8 34, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @87, i64 11 }, ptr @"*_llgo_go/ast.ChanDir" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@87 = private unnamed_addr constant [11 x i8] c"ast.ChanDir", align 1
+@"*_llgo_go/ast.ChanDir" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1839689125, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @87, i64 11 }, ptr null }, ptr @"_llgo_go/ast.ChanDir" }, align 8
+@"_llgo_struct$jNLpgFf8Fpzmg_7soMAPb94sUL7fIThqs7gJ1FySkcg$fields" = weak_odr constant [4 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @84, i64 5 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @85, i64 5 }, ptr @"_llgo_go/token.Pos", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @86, i64 3 }, ptr @"_llgo_go/ast.ChanDir", i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @59, i64 5 }, ptr @"_llgo_go/ast.Expr", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.CommClause" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1253709575, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @88, i64 14 }, ptr null }, ptr @"_llgo_go/ast.CommClause" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*CommClause).End", ptr @"go/ast.(*CommClause).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*CommClause).Pos", ptr @"go/ast.(*CommClause).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @49, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*CommClause).stmtNode", ptr @"go/ast.(*CommClause).stmtNode" }] }, align 8
+@88 = private unnamed_addr constant [14 x i8] c"ast.CommClause", align 1
+@"_llgo_go/ast.CommClause" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 56, i64 40, i32 420761253, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @88, i64 14 }, ptr @"*_llgo_go/ast.CommClause" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$juJMDy1Yel2c4JBmW70BnRAY6DO3qCmXG1jyqV0JI_4$fields", i64 4, i64 4 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@89 = private unnamed_addr constant [4 x i8] c"Comm", align 1
+@"_llgo_struct$juJMDy1Yel2c4JBmW70BnRAY6DO3qCmXG1jyqV0JI_4$fields" = weak_odr constant [4 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @80, i64 4 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @89, i64 4 }, ptr @"_llgo_go/ast.Stmt", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @81, i64 5 }, ptr @"_llgo_go/token.Pos", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @82, i64 4 }, ptr @"[]_llgo_go/ast.Stmt", i64 32, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.Comment" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [2 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 536854853, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @90, i64 11 }, ptr null }, ptr @"_llgo_go/ast.Comment" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 2, i16 2, i32 24 }, [2 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*Comment).End", ptr @"go/ast.(*Comment).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*Comment).Pos", ptr @"go/ast.(*Comment).Pos" }] }, align 8
+@90 = private unnamed_addr constant [11 x i8] c"ast.Comment", align 1
+@"_llgo_go/ast.Comment" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 16, i32 666294594, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.Comment" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @90, i64 11 }, ptr @"*_llgo_go/ast.Comment" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$JkUMn3AQRG0y9Ox2YvxcuB4dO1dz1mfUSkaHpLUHHI8$fields", i64 2, i64 2 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@91 = private unnamed_addr constant [5 x i8] c"Slash", align 1
+@92 = private unnamed_addr constant [4 x i8] c"Text", align 1
+@"_llgo_struct$JkUMn3AQRG0y9Ox2YvxcuB4dO1dz1mfUSkaHpLUHHI8$fields" = weak_odr constant [2 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @91, i64 5 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @92, i64 4 }, ptr @_llgo_string, i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.CommentGroup" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1541153512, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @93, i64 16 }, ptr null }, ptr @"_llgo_go/ast.CommentGroup" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 3, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*CommentGroup).End", ptr @"go/ast.(*CommentGroup).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*CommentGroup).Pos", ptr @"go/ast.(*CommentGroup).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @92, i64 4 }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", ptr @"go/ast.(*CommentGroup).Text", ptr @"go/ast.(*CommentGroup).Text" }] }, align 8
+@93 = private unnamed_addr constant [16 x i8] c"ast.CommentGroup", align 1
+@"_llgo_go/ast.CommentGroup" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 1742490746, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @93, i64 16 }, ptr @"*_llgo_go/ast.CommentGroup" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$FevbfthlCLUFksIacZ5wPxX7hbnBJ6mR7uPiei_IoKE$fields", i64 1, i64 1 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@"[]*_llgo_go/ast.Comment" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 363027565, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @94, i64 14 }, ptr @"*[]*_llgo_go/ast.Comment" }, ptr @"*_llgo_go/ast.Comment" }, align 8
+@94 = private unnamed_addr constant [14 x i8] c"[]*ast.Comment", align 1
+@"*[]*_llgo_go/ast.Comment" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 997666750, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @94, i64 14 }, ptr null }, ptr @"[]*_llgo_go/ast.Comment" }, align 8
+@"_llgo_struct$FevbfthlCLUFksIacZ5wPxX7hbnBJ6mR7uPiei_IoKE$fields" = weak_odr constant [1 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @67, i64 4 }, ptr @"[]*_llgo_go/ast.Comment", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.CompositeLit" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1766295072, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @95, i64 16 }, ptr null }, ptr @"_llgo_go/ast.CompositeLit" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*CompositeLit).End", ptr @"go/ast.(*CompositeLit).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*CompositeLit).Pos", ptr @"go/ast.(*CompositeLit).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*CompositeLit).exprNode", ptr @"go/ast.(*CompositeLit).exprNode" }] }, align 8
+@95 = private unnamed_addr constant [16 x i8] c"ast.CompositeLit", align 1
+@"_llgo_go/ast.CompositeLit" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 64, i64 24, i32 -1517563897, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @95, i64 16 }, ptr @"*_llgo_go/ast.CompositeLit" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$ajtdk_WxQXP_JaAayiU1aVAwFsdHz94E0_3qm09S3QM$fields", i64 5, i64 5 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@96 = private unnamed_addr constant [4 x i8] c"Elts", align 1
+@97 = private unnamed_addr constant [10 x i8] c"Incomplete", align 1
+@"_llgo_struct$ajtdk_WxQXP_JaAayiU1aVAwFsdHz94E0_3qm09S3QM$fields" = weak_odr constant [5 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @22, i64 4 }, ptr @"_llgo_go/ast.Expr", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @66, i64 6 }, ptr @"_llgo_go/token.Pos", i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @96, i64 4 }, ptr @"[]_llgo_go/ast.Expr", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @70, i64 6 }, ptr @"_llgo_go/token.Pos", i64 48, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @97, i64 10 }, ptr @_llgo_bool, i64 56, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.DeclStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -713342650, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @98, i64 12 }, ptr null }, ptr @"_llgo_go/ast.DeclStmt" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*DeclStmt).End", ptr @"go/ast.(*DeclStmt).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*DeclStmt).Pos", ptr @"go/ast.(*DeclStmt).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @49, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*DeclStmt).stmtNode", ptr @"go/ast.(*DeclStmt).stmtNode" }] }, align 8
+@98 = private unnamed_addr constant [12 x i8] c"ast.DeclStmt", align 1
+@"_llgo_go/ast.DeclStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 265143785, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.DeclStmt" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @98, i64 12 }, ptr @"*_llgo_go/ast.DeclStmt" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$6nuVnPrnvE8wLna7J0woqe2xk568yJXdXtmeDhT-ym4$fields", i64 1, i64 1 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@"_llgo_go/ast.Decl" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.InterfaceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 -1408863929, i8 4, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @99, i64 8 }, ptr @"*_llgo_go/ast.Decl" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @20, i64 40 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"go/ast.iface$lX4HMtTJnqhQ8pyXSaTH9ix6C26QiWLjzbxwpuX_Hhc$imethods", i64 3, i64 3 } }, align 8
+@99 = private unnamed_addr constant [8 x i8] c"ast.Decl", align 1
+@"*_llgo_go/ast.Decl" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1507437214, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @99, i64 8 }, ptr null }, ptr @"_llgo_go/ast.Decl" }, align 8
+@"go/ast.iface$lX4HMtTJnqhQ8pyXSaTH9ix6C26QiWLjzbxwpuX_Hhc$imethods" = weak_odr constant [3 x %"github.com/goplus/llgo/runtime/abi.Imethod"] [%"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU" }, %"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU" }, %"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @54, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac" }], align 8
+@"_llgo_struct$6nuVnPrnvE8wLna7J0woqe2xk568yJXdXtmeDhT-ym4$fields" = weak_odr constant [1 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @18, i64 4 }, ptr @"_llgo_go/ast.Decl", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.DeferStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 532452996, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @100, i64 13 }, ptr null }, ptr @"_llgo_go/ast.DeferStmt" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*DeferStmt).End", ptr @"go/ast.(*DeferStmt).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*DeferStmt).Pos", ptr @"go/ast.(*DeferStmt).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @49, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*DeferStmt).stmtNode", ptr @"go/ast.(*DeferStmt).stmtNode" }] }, align 8
+@100 = private unnamed_addr constant [13 x i8] c"ast.DeferStmt", align 1
+@"_llgo_go/ast.DeferStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 -424661139, i8 13, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.DeferStmt" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @100, i64 13 }, ptr @"*_llgo_go/ast.DeferStmt" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$ZRVKm-J4qpN6rd6CpMuwaykwh_Dq3DMiF_7dzTVEVdQ$fields", i64 2, i64 2 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@101 = private unnamed_addr constant [5 x i8] c"Defer", align 1
+@102 = private unnamed_addr constant [4 x i8] c"Call", align 1
+@"_llgo_struct$ZRVKm-J4qpN6rd6CpMuwaykwh_Dq3DMiF_7dzTVEVdQ$fields" = weak_odr constant [2 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @101, i64 5 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @102, i64 4 }, ptr @"*_llgo_go/ast.CallExpr", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.Ellipsis" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -132771931, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @103, i64 12 }, ptr null }, ptr @"_llgo_go/ast.Ellipsis" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*Ellipsis).End", ptr @"go/ast.(*Ellipsis).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*Ellipsis).Pos", ptr @"go/ast.(*Ellipsis).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*Ellipsis).exprNode", ptr @"go/ast.(*Ellipsis).exprNode" }] }, align 8
+@103 = private unnamed_addr constant [12 x i8] c"ast.Ellipsis", align 1
+@"_llgo_go/ast.Ellipsis" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 24, i32 1565756484, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.Ellipsis" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @103, i64 12 }, ptr @"*_llgo_go/ast.Ellipsis" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$5Gw78nw3D20fuWXX5topOtd2k-WW9Zvv08Vo4iETpgE$fields", i64 2, i64 2 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@"_llgo_struct$5Gw78nw3D20fuWXX5topOtd2k-WW9Zvv08Vo4iETpgE$fields" = weak_odr constant [2 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @77, i64 8 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @34, i64 3 }, ptr @"_llgo_go/ast.Expr", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.EmptyStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 436602520, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @104, i64 13 }, ptr null }, ptr @"_llgo_go/ast.EmptyStmt" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*EmptyStmt).End", ptr @"go/ast.(*EmptyStmt).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*EmptyStmt).Pos", ptr @"go/ast.(*EmptyStmt).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @49, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*EmptyStmt).stmtNode", ptr @"go/ast.(*EmptyStmt).stmtNode" }] }, align 8
+@104 = private unnamed_addr constant [13 x i8] c"ast.EmptyStmt", align 1
+@"_llgo_go/ast.EmptyStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 0, i32 -1567221368, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.EmptyStmt" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @104, i64 13 }, ptr @"*_llgo_go/ast.EmptyStmt" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$Sa6EsSkqIDwD_QwSOQAGJQQs4SEP6uI8169m_6YQY3E$fields", i64 2, i64 2 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@105 = private unnamed_addr constant [9 x i8] c"Semicolon", align 1
+@106 = private unnamed_addr constant [8 x i8] c"Implicit", align 1
+@"_llgo_struct$Sa6EsSkqIDwD_QwSOQAGJQQs4SEP6uI8169m_6YQY3E$fields" = weak_odr constant [2 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @105, i64 9 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @106, i64 8 }, ptr @_llgo_bool, i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.ExprStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1299324267, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @107, i64 12 }, ptr null }, ptr @"_llgo_go/ast.ExprStmt" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*ExprStmt).End", ptr @"go/ast.(*ExprStmt).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*ExprStmt).Pos", ptr @"go/ast.(*ExprStmt).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @49, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*ExprStmt).stmtNode", ptr @"go/ast.(*ExprStmt).stmtNode" }] }, align 8
+@107 = private unnamed_addr constant [12 x i8] c"ast.ExprStmt", align 1
+@"_llgo_go/ast.ExprStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 -1746325128, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.ExprStmt" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @107, i64 12 }, ptr @"*_llgo_go/ast.ExprStmt" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$rFSpiTBUIfW7V7bbgxwRR_uCaxOD9mgOzoCb9eWB9n4$fields", i64 1, i64 1 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@"_llgo_struct$rFSpiTBUIfW7V7bbgxwRR_uCaxOD9mgOzoCb9eWB9n4$fields" = weak_odr constant [1 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @61, i64 1 }, ptr @"_llgo_go/ast.Expr", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.Field" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [2 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1667370071, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @108, i64 9 }, ptr null }, ptr @"_llgo_go/ast.Field" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 2, i16 2, i32 24 }, [2 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*Field).End", ptr @"go/ast.(*Field).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*Field).Pos", ptr @"go/ast.(*Field).Pos" }] }, align 8
+@108 = private unnamed_addr constant [9 x i8] c"ast.Field", align 1
+@"_llgo_go/ast.Field" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 64, i64 64, i32 -1239207325, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @108, i64 9 }, ptr @"*_llgo_go/ast.Field" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$7biL8ZzhC-d58i2dwuVFgbbKaMC8NPWqFhljxncOqQg$fields", i64 5, i64 5 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@109 = private unnamed_addr constant [3 x i8] c"Doc", align 1
+@110 = private unnamed_addr constant [5 x i8] c"Names", align 1
+@"[]*_llgo_go/ast.Ident" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 -227307820, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @111, i64 12 }, ptr @"*[]*_llgo_go/ast.Ident" }, ptr @"*_llgo_go/ast.Ident" }, align 8
+@111 = private unnamed_addr constant [12 x i8] c"[]*ast.Ident", align 1
+@"*[]*_llgo_go/ast.Ident" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -690526116, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @111, i64 12 }, ptr null }, ptr @"[]*_llgo_go/ast.Ident" }, align 8
+@112 = private unnamed_addr constant [3 x i8] c"Tag", align 1
+@113 = private unnamed_addr constant [7 x i8] c"Comment", align 1
+@"_llgo_struct$7biL8ZzhC-d58i2dwuVFgbbKaMC8NPWqFhljxncOqQg$fields" = weak_odr constant [5 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @109, i64 3 }, ptr @"*_llgo_go/ast.CommentGroup", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @110, i64 5 }, ptr @"[]*_llgo_go/ast.Ident", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @22, i64 4 }, ptr @"_llgo_go/ast.Expr", i64 32, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @112, i64 3 }, ptr @"*_llgo_go/ast.BasicLit", i64 48, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @113, i64 7 }, ptr @"*_llgo_go/ast.CommentGroup", i64 56, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.FieldList" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -891825967, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @114, i64 13 }, ptr null }, ptr @"_llgo_go/ast.FieldList" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 3, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*FieldList).End", ptr @"go/ast.(*FieldList).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @118, i64 9 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"go/ast.(*FieldList).NumFields", ptr @"go/ast.(*FieldList).NumFields" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*FieldList).Pos", ptr @"go/ast.(*FieldList).Pos" }] }, align 8
+@114 = private unnamed_addr constant [13 x i8] c"ast.FieldList", align 1
+@"_llgo_go/ast.FieldList" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 40, i64 8, i32 1242140877, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @114, i64 13 }, ptr @"*_llgo_go/ast.FieldList" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$MuakH7pNsQahLQ0PZHsfMMdkq8wE3PbVMvFi23mLzQY$fields", i64 3, i64 3 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@115 = private unnamed_addr constant [7 x i8] c"Opening", align 1
+@"[]*_llgo_go/ast.Field" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 2086542688, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @116, i64 12 }, ptr @"*[]*_llgo_go/ast.Field" }, ptr @"*_llgo_go/ast.Field" }, align 8
+@116 = private unnamed_addr constant [12 x i8] c"[]*ast.Field", align 1
+@"*[]*_llgo_go/ast.Field" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1873828093, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @116, i64 12 }, ptr null }, ptr @"[]*_llgo_go/ast.Field" }, align 8
+@117 = private unnamed_addr constant [7 x i8] c"Closing", align 1
+@"_llgo_struct$MuakH7pNsQahLQ0PZHsfMMdkq8wE3PbVMvFi23mLzQY$fields" = weak_odr constant [3 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @115, i64 7 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @67, i64 4 }, ptr @"[]*_llgo_go/ast.Field", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @117, i64 7 }, ptr @"_llgo_go/token.Pos", i64 32, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@118 = private unnamed_addr constant [9 x i8] c"NumFields", align 1
+@"*_llgo_go/ast.File" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [2 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1267610958, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @119, i64 8 }, ptr null }, ptr @"_llgo_go/ast.File" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 2, i16 2, i32 24 }, [2 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*File).End", ptr @"go/ast.(*File).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*File).Pos", ptr @"go/ast.(*File).Pos" }] }, align 8
+@119 = private unnamed_addr constant [8 x i8] c"ast.File", align 1
+@"_llgo_go/ast.File" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 160, i64 152, i32 -1954135929, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @119, i64 8 }, ptr @"*_llgo_go/ast.File" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$enDlifvQmFbeCX0T4YY54AKXMJpi7m99H31E1Ch5x-0$fields", i64 11, i64 11 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@120 = private unnamed_addr constant [7 x i8] c"Package", align 1
+@121 = private unnamed_addr constant [5 x i8] c"Decls", align 1
+@"[]_llgo_go/ast.Decl" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 -1979764243, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @122, i64 10 }, ptr @"*[]_llgo_go/ast.Decl" }, ptr @"_llgo_go/ast.Decl" }, align 8
+@122 = private unnamed_addr constant [10 x i8] c"[]ast.Decl", align 1
+@"*[]_llgo_go/ast.Decl" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1192287419, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @122, i64 10 }, ptr null }, ptr @"[]_llgo_go/ast.Decl" }, align 8
+@123 = private unnamed_addr constant [9 x i8] c"FileStart", align 1
+@124 = private unnamed_addr constant [7 x i8] c"FileEnd", align 1
+@125 = private unnamed_addr constant [5 x i8] c"Scope", align 1
+@"*_llgo_go/ast.Scope" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1369367672, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @126, i64 9 }, ptr null }, ptr @"_llgo_go/ast.Scope" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 3, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @143, i64 6 }, ptr @"_llgo_func$6Bzrve4Ehr-C8uebix54ffuv5HX-Qd3V5Ir1RrkuIIQ", ptr @"go/ast.(*Scope).Insert", ptr @"go/ast.(*Scope).Insert" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @145, i64 6 }, ptr @"_llgo_func$DskKPFGJyA_zqt8KHhnaaEzc7yv07D3u6QVXgrOswcg", ptr @"go/ast.(*Scope).Lookup", ptr @"go/ast.(*Scope).Lookup" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @16, i64 6 }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", ptr @"go/ast.(*Scope).String", ptr @"go/ast.(*Scope).String" }] }, align 8
+@126 = private unnamed_addr constant [9 x i8] c"ast.Scope", align 1
+@"_llgo_go/ast.Scope" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 425962891, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @126, i64 9 }, ptr @"*_llgo_go/ast.Scope" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$DbV9X0343zhl-fmvHfVOywYbxZACxrpab-s9umtDEvw$fields", i64 2, i64 2 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@127 = private unnamed_addr constant [5 x i8] c"Outer", align 1
+@128 = private unnamed_addr constant [7 x i8] c"Objects", align 1
+@"map[_llgo_string]*_llgo_go/ast.Object" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.MapType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1468107150, i8 0, i8 8, i8 8, i8 53, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @129, i64 22 }, ptr @"*map[_llgo_string]*_llgo_go/ast.Object" }, ptr @_llgo_string, ptr @"*_llgo_go/ast.Object", ptr @"_llgo_struct$_LJkbIMwW5JFeoRylNj02F-pie0fRG5w_U6Ovfq2QjU", { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.typehash", ptr @_llgo_string }, i8 16, i8 8, i16 208, i32 12 }, align 8
+@129 = private unnamed_addr constant [22 x i8] c"map[string]*ast.Object", align 1
+@"*map[_llgo_string]*_llgo_go/ast.Object" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 385483539, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @129, i64 22 }, ptr null }, ptr @"map[_llgo_string]*_llgo_go/ast.Object" }, align 8
+@"_llgo_struct$_LJkbIMwW5JFeoRylNj02F-pie0fRG5w_U6Ovfq2QjU" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 208, i64 208, i32 902975473, i8 0, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_struct$_LJkbIMwW5JFeoRylNj02F-pie0fRG5w_U6Ovfq2QjU" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @130, i64 90 }, ptr @"*_llgo_struct$_LJkbIMwW5JFeoRylNj02F-pie0fRG5w_U6Ovfq2QjU" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$_LJkbIMwW5JFeoRylNj02F-pie0fRG5w_U6Ovfq2QjU$fields", i64 4, i64 4 } }, align 8
+@130 = private unnamed_addr constant [90 x i8] c"struct { topbits [8]uint8; keys [8]string; elems [8]*ast.Object; overflow unsafe.Pointer }", align 1
+@"*_llgo_struct$_LJkbIMwW5JFeoRylNj02F-pie0fRG5w_U6Ovfq2QjU" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1072037720, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @130, i64 90 }, ptr null }, ptr @"_llgo_struct$_LJkbIMwW5JFeoRylNj02F-pie0fRG5w_U6Ovfq2QjU" }, align 8
+@131 = private unnamed_addr constant [7 x i8] c"topbits", align 1
+@"[8]_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.ArrayType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 0, i32 307038632, i8 8, i8 1, i8 1, i8 17, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal", ptr @"[8]_llgo_uint8" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @132, i64 8 }, ptr @"*[8]_llgo_uint8" }, ptr @_llgo_uint8, ptr @"[]_llgo_uint8", i64 8 }, align 8
+@132 = private unnamed_addr constant [8 x i8] c"[8]uint8", align 1
+@"*[8]_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -566230779, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @132, i64 8 }, ptr null }, ptr @"[8]_llgo_uint8" }, align 8
+@_llgo_uint8 = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 1, i64 0, i32 269156761, i8 12, i8 1, i8 1, i8 40, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @133, i64 5 }, ptr @"*_llgo_uint8" }, align 8
+@133 = private unnamed_addr constant [5 x i8] c"uint8", align 1
+@"*_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1277858201, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @133, i64 5 }, ptr null }, ptr @_llgo_uint8 }, align 8
+@"[]_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 370346748, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @134, i64 7 }, ptr @"*[]_llgo_uint8" }, ptr @_llgo_uint8 }, align 8
+@134 = private unnamed_addr constant [7 x i8] c"[]uint8", align 1
+@"*[]_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -2143776929, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @134, i64 7 }, ptr null }, ptr @"[]_llgo_uint8" }, align 8
+@135 = private unnamed_addr constant [4 x i8] c"keys", align 1
+@"[8]_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.ArrayType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 128, i64 120, i32 460245566, i8 0, i8 8, i8 8, i8 17, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal", ptr @"[8]_llgo_string" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @136, i64 9 }, ptr @"*[8]_llgo_string" }, ptr @_llgo_string, ptr @"[]_llgo_string", i64 8 }, align 8
+@136 = private unnamed_addr constant [9 x i8] c"[8]string", align 1
+@"*[8]_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 368026044, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @136, i64 9 }, ptr null }, ptr @"[8]_llgo_string" }, align 8
+@"[]_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 608974920, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @137, i64 8 }, ptr @"*[]_llgo_string" }, ptr @_llgo_string }, align 8
+@137 = private unnamed_addr constant [8 x i8] c"[]string", align 1
+@"*[]_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -157880218, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @137, i64 8 }, ptr null }, ptr @"[]_llgo_string" }, align 8
+@138 = private unnamed_addr constant [5 x i8] c"elems", align 1
+@"[8]*_llgo_go/ast.Object" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.ArrayType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 64, i64 64, i32 -550036191, i8 8, i8 8, i8 8, i8 17, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal", ptr @"[8]*_llgo_go/ast.Object" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @139, i64 14 }, ptr @"*[8]*_llgo_go/ast.Object" }, ptr @"*_llgo_go/ast.Object", ptr @"[]*_llgo_go/ast.Object", i64 8 }, align 8
+@139 = private unnamed_addr constant [14 x i8] c"[8]*ast.Object", align 1
+@"*[8]*_llgo_go/ast.Object" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1872673345, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @139, i64 14 }, ptr null }, ptr @"[8]*_llgo_go/ast.Object" }, align 8
+@"[]*_llgo_go/ast.Object" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 -1660546995, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @140, i64 13 }, ptr @"*[]*_llgo_go/ast.Object" }, ptr @"*_llgo_go/ast.Object" }, align 8
+@140 = private unnamed_addr constant [13 x i8] c"[]*ast.Object", align 1
+@"*[]*_llgo_go/ast.Object" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -875554302, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @140, i64 13 }, ptr null }, ptr @"[]*_llgo_go/ast.Object" }, align 8
+@141 = private unnamed_addr constant [8 x i8] c"overflow", align 1
+@_llgo_Pointer = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 507576105, i8 12, i8 8, i8 8, i8 58, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @142, i64 14 }, ptr @"*_llgo_Pointer" }, align 8
+@142 = private unnamed_addr constant [14 x i8] c"unsafe.Pointer", align 1
+@"*_llgo_Pointer" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1134390089, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @142, i64 14 }, ptr null }, ptr @_llgo_Pointer }, align 8
+@"_llgo_struct$_LJkbIMwW5JFeoRylNj02F-pie0fRG5w_U6Ovfq2QjU$fields" = weak_odr constant [4 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @131, i64 7 }, ptr @"[8]_llgo_uint8", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @135, i64 4 }, ptr @"[8]_llgo_string", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @138, i64 5 }, ptr @"[8]*_llgo_go/ast.Object", i64 136, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @141, i64 8 }, ptr @_llgo_Pointer, i64 200, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"_llgo_struct$DbV9X0343zhl-fmvHfVOywYbxZACxrpab-s9umtDEvw$fields" = weak_odr constant [2 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @127, i64 5 }, ptr @"*_llgo_go/ast.Scope", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @128, i64 7 }, ptr @"map[_llgo_string]*_llgo_go/ast.Object", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@143 = private unnamed_addr constant [6 x i8] c"Insert", align 1
+@"_llgo_func$6Bzrve4Ehr-C8uebix54ffuv5HX-Qd3V5Ir1RrkuIIQ" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 83871217, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @144, i64 29 }, ptr @"*_llgo_func$6Bzrve4Ehr-C8uebix54ffuv5HX-Qd3V5Ir1RrkuIIQ" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$6Bzrve4Ehr-C8uebix54ffuv5HX-Qd3V5Ir1RrkuIIQ$in", i64 1, i64 1 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$6Bzrve4Ehr-C8uebix54ffuv5HX-Qd3V5Ir1RrkuIIQ$out", i64 1, i64 1 } }, align 8
+@144 = private unnamed_addr constant [29 x i8] c"func(*ast.Object) *ast.Object", align 1
+@"*_llgo_func$6Bzrve4Ehr-C8uebix54ffuv5HX-Qd3V5Ir1RrkuIIQ" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1990621660, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @144, i64 29 }, ptr null }, ptr @"_llgo_func$6Bzrve4Ehr-C8uebix54ffuv5HX-Qd3V5Ir1RrkuIIQ" }, align 8
+@"_llgo_func$6Bzrve4Ehr-C8uebix54ffuv5HX-Qd3V5Ir1RrkuIIQ$in" = weak_odr constant [1 x ptr] [ptr @"*_llgo_go/ast.Object"], align 8
+@"_llgo_func$6Bzrve4Ehr-C8uebix54ffuv5HX-Qd3V5Ir1RrkuIIQ$out" = weak_odr constant [1 x ptr] [ptr @"*_llgo_go/ast.Object"], align 8
+@145 = private unnamed_addr constant [6 x i8] c"Lookup", align 1
+@"_llgo_func$DskKPFGJyA_zqt8KHhnaaEzc7yv07D3u6QVXgrOswcg" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -914680838, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @146, i64 24 }, ptr @"*_llgo_func$DskKPFGJyA_zqt8KHhnaaEzc7yv07D3u6QVXgrOswcg" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$DskKPFGJyA_zqt8KHhnaaEzc7yv07D3u6QVXgrOswcg$in", i64 1, i64 1 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$DskKPFGJyA_zqt8KHhnaaEzc7yv07D3u6QVXgrOswcg$out", i64 1, i64 1 } }, align 8
+@146 = private unnamed_addr constant [24 x i8] c"func(string) *ast.Object", align 1
+@"*_llgo_func$DskKPFGJyA_zqt8KHhnaaEzc7yv07D3u6QVXgrOswcg" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 509475754, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @146, i64 24 }, ptr null }, ptr @"_llgo_func$DskKPFGJyA_zqt8KHhnaaEzc7yv07D3u6QVXgrOswcg" }, align 8
+@"_llgo_func$DskKPFGJyA_zqt8KHhnaaEzc7yv07D3u6QVXgrOswcg$in" = weak_odr constant [1 x ptr] [ptr @_llgo_string], align 8
+@"_llgo_func$DskKPFGJyA_zqt8KHhnaaEzc7yv07D3u6QVXgrOswcg$out" = weak_odr constant [1 x ptr] [ptr @"*_llgo_go/ast.Object"], align 8
+@147 = private unnamed_addr constant [7 x i8] c"Imports", align 1
+@"[]*_llgo_go/ast.ImportSpec" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 -972727512, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @148, i64 17 }, ptr @"*[]*_llgo_go/ast.ImportSpec" }, ptr @"*_llgo_go/ast.ImportSpec" }, align 8
+@148 = private unnamed_addr constant [17 x i8] c"[]*ast.ImportSpec", align 1
+@"*[]*_llgo_go/ast.ImportSpec" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -408900429, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @148, i64 17 }, ptr null }, ptr @"[]*_llgo_go/ast.ImportSpec" }, align 8
+@"*_llgo_go/ast.ImportSpec" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1022665386, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @149, i64 14 }, ptr null }, ptr @"_llgo_go/ast.ImportSpec" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*ImportSpec).End", ptr @"go/ast.(*ImportSpec).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*ImportSpec).Pos", ptr @"go/ast.(*ImportSpec).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @153, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*ImportSpec).specNode", ptr @"go/ast.(*ImportSpec).specNode" }] }, align 8
+@149 = private unnamed_addr constant [14 x i8] c"ast.ImportSpec", align 1
+@"_llgo_go/ast.ImportSpec" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 40, i64 24, i32 2041389939, i8 13, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.ImportSpec" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @149, i64 14 }, ptr @"*_llgo_go/ast.ImportSpec" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$yk5s5NR3y4bGX8scCimKUXY0lWXKm-0M7sIYRo9ehgc$fields", i64 5, i64 5 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@150 = private unnamed_addr constant [4 x i8] c"Path", align 1
+@151 = private unnamed_addr constant [6 x i8] c"EndPos", align 1
+@"_llgo_struct$yk5s5NR3y4bGX8scCimKUXY0lWXKm-0M7sIYRo9ehgc$fields" = weak_odr constant [5 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @109, i64 3 }, ptr @"*_llgo_go/ast.CommentGroup", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @10, i64 4 }, ptr @"*_llgo_go/ast.Ident", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @150, i64 4 }, ptr @"*_llgo_go/ast.BasicLit", i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @113, i64 7 }, ptr @"*_llgo_go/ast.CommentGroup", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @151, i64 6 }, ptr @"_llgo_go/token.Pos", i64 32, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@152 = private unnamed_addr constant [8 x i8] c"specNode", align 1
+@153 = private unnamed_addr constant [15 x i8] c"go/ast.specNode", align 1
+@154 = private unnamed_addr constant [10 x i8] c"Unresolved", align 1
+@155 = private unnamed_addr constant [8 x i8] c"Comments", align 1
+@"[]*_llgo_go/ast.CommentGroup" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 -1286201929, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @156, i64 19 }, ptr @"*[]*_llgo_go/ast.CommentGroup" }, ptr @"*_llgo_go/ast.CommentGroup" }, align 8
+@156 = private unnamed_addr constant [19 x i8] c"[]*ast.CommentGroup", align 1
+@"*[]*_llgo_go/ast.CommentGroup" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1812888669, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @156, i64 19 }, ptr null }, ptr @"[]*_llgo_go/ast.CommentGroup" }, align 8
+@157 = private unnamed_addr constant [9 x i8] c"GoVersion", align 1
+@"_llgo_struct$enDlifvQmFbeCX0T4YY54AKXMJpi7m99H31E1Ch5x-0$fields" = weak_odr constant [11 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @109, i64 3 }, ptr @"*_llgo_go/ast.CommentGroup", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @120, i64 7 }, ptr @"_llgo_go/token.Pos", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @10, i64 4 }, ptr @"*_llgo_go/ast.Ident", i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @121, i64 5 }, ptr @"[]_llgo_go/ast.Decl", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @123, i64 9 }, ptr @"_llgo_go/token.Pos", i64 48, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @124, i64 7 }, ptr @"_llgo_go/token.Pos", i64 56, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @125, i64 5 }, ptr @"*_llgo_go/ast.Scope", i64 64, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @147, i64 7 }, ptr @"[]*_llgo_go/ast.ImportSpec", i64 72, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @154, i64 10 }, ptr @"[]*_llgo_go/ast.Ident", i64 96, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @155, i64 8 }, ptr @"[]*_llgo_go/ast.CommentGroup", i64 120, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @157, i64 9 }, ptr @_llgo_string, i64 144, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.ForStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -737696344, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @158, i64 11 }, ptr null }, ptr @"_llgo_go/ast.ForStmt" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*ForStmt).End", ptr @"go/ast.(*ForStmt).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*ForStmt).Pos", ptr @"go/ast.(*ForStmt).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @49, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*ForStmt).stmtNode", ptr @"go/ast.(*ForStmt).stmtNode" }] }, align 8
+@158 = private unnamed_addr constant [11 x i8] c"ast.ForStmt", align 1
+@"_llgo_go/ast.ForStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 64, i64 64, i32 -2052080314, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.ForStmt" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @158, i64 11 }, ptr @"*_llgo_go/ast.ForStmt" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$u5l2PU2xGf51WHnf7B3sflAJVyqCexbTcHuV9YA0hHg$fields", i64 5, i64 5 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@159 = private unnamed_addr constant [3 x i8] c"For", align 1
+@160 = private unnamed_addr constant [4 x i8] c"Init", align 1
+@161 = private unnamed_addr constant [4 x i8] c"Cond", align 1
+@162 = private unnamed_addr constant [4 x i8] c"Post", align 1
+@"_llgo_struct$u5l2PU2xGf51WHnf7B3sflAJVyqCexbTcHuV9YA0hHg$fields" = weak_odr constant [5 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @159, i64 3 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @160, i64 4 }, ptr @"_llgo_go/ast.Stmt", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @161, i64 4 }, ptr @"_llgo_go/ast.Expr", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @162, i64 4 }, ptr @"_llgo_go/ast.Stmt", i64 40, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @82, i64 4 }, ptr @"*_llgo_go/ast.BlockStmt", i64 56, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.FuncDecl" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1287777460, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @163, i64 12 }, ptr null }, ptr @"_llgo_go/ast.FuncDecl" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*FuncDecl).End", ptr @"go/ast.(*FuncDecl).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*FuncDecl).Pos", ptr @"go/ast.(*FuncDecl).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @54, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*FuncDecl).declNode", ptr @"go/ast.(*FuncDecl).declNode" }] }, align 8
+@163 = private unnamed_addr constant [12 x i8] c"ast.FuncDecl", align 1
+@"_llgo_go/ast.FuncDecl" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 40, i64 40, i32 -162612344, i8 13, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.FuncDecl" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @163, i64 12 }, ptr @"*_llgo_go/ast.FuncDecl" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$dBL8AWu-MIlLMIB8mKOgzdGndFiGNM_lB_tksZtXO8g$fields", i64 5, i64 5 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@164 = private unnamed_addr constant [4 x i8] c"Recv", align 1
+@"*_llgo_go/ast.FuncType" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1894710989, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @165, i64 12 }, ptr null }, ptr @"_llgo_go/ast.FuncType" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*FuncType).End", ptr @"go/ast.(*FuncType).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*FuncType).Pos", ptr @"go/ast.(*FuncType).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*FuncType).exprNode", ptr @"go/ast.(*FuncType).exprNode" }] }, align 8
+@165 = private unnamed_addr constant [12 x i8] c"ast.FuncType", align 1
+@"_llgo_go/ast.FuncType" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 32, i64 32, i32 -1566549941, i8 13, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.FuncType" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @165, i64 12 }, ptr @"*_llgo_go/ast.FuncType" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$VSZKwV5L7crxBP32Z0Js4QfnZrBL6YokcEgFUJrnuno$fields", i64 4, i64 4 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@166 = private unnamed_addr constant [4 x i8] c"Func", align 1
+@167 = private unnamed_addr constant [10 x i8] c"TypeParams", align 1
+@168 = private unnamed_addr constant [6 x i8] c"Params", align 1
+@169 = private unnamed_addr constant [7 x i8] c"Results", align 1
+@"_llgo_struct$VSZKwV5L7crxBP32Z0Js4QfnZrBL6YokcEgFUJrnuno$fields" = weak_odr constant [4 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @166, i64 4 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @167, i64 10 }, ptr @"*_llgo_go/ast.FieldList", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @168, i64 6 }, ptr @"*_llgo_go/ast.FieldList", i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @169, i64 7 }, ptr @"*_llgo_go/ast.FieldList", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"_llgo_struct$dBL8AWu-MIlLMIB8mKOgzdGndFiGNM_lB_tksZtXO8g$fields" = weak_odr constant [5 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @109, i64 3 }, ptr @"*_llgo_go/ast.CommentGroup", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @164, i64 4 }, ptr @"*_llgo_go/ast.FieldList", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @10, i64 4 }, ptr @"*_llgo_go/ast.Ident", i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @22, i64 4 }, ptr @"*_llgo_go/ast.FuncType", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @82, i64 4 }, ptr @"*_llgo_go/ast.BlockStmt", i64 32, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.FuncLit" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 667496323, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @170, i64 11 }, ptr null }, ptr @"_llgo_go/ast.FuncLit" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*FuncLit).End", ptr @"go/ast.(*FuncLit).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*FuncLit).Pos", ptr @"go/ast.(*FuncLit).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*FuncLit).exprNode", ptr @"go/ast.(*FuncLit).exprNode" }] }, align 8
+@170 = private unnamed_addr constant [11 x i8] c"ast.FuncLit", align 1
+@"_llgo_go/ast.FuncLit" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 -1027459542, i8 13, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.FuncLit" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @170, i64 11 }, ptr @"*_llgo_go/ast.FuncLit" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$Vka1A-a1OD4rwWcUJAf5OGn041xUCo_lkrNUu7YBF8U$fields", i64 2, i64 2 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@"_llgo_struct$Vka1A-a1OD4rwWcUJAf5OGn041xUCo_lkrNUu7YBF8U$fields" = weak_odr constant [2 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @22, i64 4 }, ptr @"*_llgo_go/ast.FuncType", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @82, i64 4 }, ptr @"*_llgo_go/ast.BlockStmt", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.GenDecl" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -328553755, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @171, i64 11 }, ptr null }, ptr @"_llgo_go/ast.GenDecl" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*GenDecl).End", ptr @"go/ast.(*GenDecl).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*GenDecl).Pos", ptr @"go/ast.(*GenDecl).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @54, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*GenDecl).declNode", ptr @"go/ast.(*GenDecl).declNode" }] }, align 8
+@171 = private unnamed_addr constant [11 x i8] c"ast.GenDecl", align 1
+@"_llgo_go/ast.GenDecl" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 64, i64 32, i32 160314575, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @171, i64 11 }, ptr @"*_llgo_go/ast.GenDecl" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$lXSWTYHzmzKOu0GRHj7xoON1u9KBlrkbLYpS1txSMTU$fields", i64 6, i64 6 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@172 = private unnamed_addr constant [5 x i8] c"Specs", align 1
+@"[]_llgo_go/ast.Spec" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 1127389065, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @173, i64 10 }, ptr @"*[]_llgo_go/ast.Spec" }, ptr @"_llgo_go/ast.Spec" }, align 8
+@173 = private unnamed_addr constant [10 x i8] c"[]ast.Spec", align 1
+@"*[]_llgo_go/ast.Spec" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1966609582, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @173, i64 10 }, ptr null }, ptr @"[]_llgo_go/ast.Spec" }, align 8
+@"_llgo_go/ast.Spec" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.InterfaceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 -2026607612, i8 4, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @174, i64 8 }, ptr @"*_llgo_go/ast.Spec" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @20, i64 40 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"go/ast.iface$JkIs7q6riw3M4lQirjgYyFzfYBj4fN5Sf5vd96hOpAU$imethods", i64 3, i64 3 } }, align 8
+@174 = private unnamed_addr constant [8 x i8] c"ast.Spec", align 1
+@"*_llgo_go/ast.Spec" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 254211166, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @174, i64 8 }, ptr null }, ptr @"_llgo_go/ast.Spec" }, align 8
+@"go/ast.iface$JkIs7q6riw3M4lQirjgYyFzfYBj4fN5Sf5vd96hOpAU$imethods" = weak_odr constant [3 x %"github.com/goplus/llgo/runtime/abi.Imethod"] [%"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU" }, %"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU" }, %"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @153, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac" }], align 8
+@"_llgo_struct$lXSWTYHzmzKOu0GRHj7xoON1u9KBlrkbLYpS1txSMTU$fields" = weak_odr constant [6 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @109, i64 3 }, ptr @"*_llgo_go/ast.CommentGroup", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @38, i64 6 }, ptr @"_llgo_go/token.Pos", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @39, i64 3 }, ptr @"_llgo_go/token.Token", i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @75, i64 6 }, ptr @"_llgo_go/token.Pos", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @172, i64 5 }, ptr @"[]_llgo_go/ast.Spec", i64 32, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @78, i64 6 }, ptr @"_llgo_go/token.Pos", i64 56, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.GoStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -204577511, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @175, i64 10 }, ptr null }, ptr @"_llgo_go/ast.GoStmt" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*GoStmt).End", ptr @"go/ast.(*GoStmt).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*GoStmt).Pos", ptr @"go/ast.(*GoStmt).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @49, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*GoStmt).stmtNode", ptr @"go/ast.(*GoStmt).stmtNode" }] }, align 8
+@175 = private unnamed_addr constant [10 x i8] c"ast.GoStmt", align 1
+@"_llgo_go/ast.GoStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 -167601518, i8 13, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.GoStmt" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @175, i64 10 }, ptr @"*_llgo_go/ast.GoStmt" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$znWfNxZT-61b0LTWsOiGAMgSC8F9R-StamQOekqTEKo$fields", i64 2, i64 2 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@176 = private unnamed_addr constant [2 x i8] c"Go", align 1
+@"_llgo_struct$znWfNxZT-61b0LTWsOiGAMgSC8F9R-StamQOekqTEKo$fields" = weak_odr constant [2 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @176, i64 2 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @102, i64 4 }, ptr @"*_llgo_go/ast.CallExpr", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.IfStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1987080098, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @177, i64 10 }, ptr null }, ptr @"_llgo_go/ast.IfStmt" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*IfStmt).End", ptr @"go/ast.(*IfStmt).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*IfStmt).Pos", ptr @"go/ast.(*IfStmt).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @49, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*IfStmt).stmtNode", ptr @"go/ast.(*IfStmt).stmtNode" }] }, align 8
+@177 = private unnamed_addr constant [10 x i8] c"ast.IfStmt", align 1
+@"_llgo_go/ast.IfStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 64, i64 64, i32 1862235583, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.IfStmt" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @177, i64 10 }, ptr @"*_llgo_go/ast.IfStmt" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$9pAmM43oNNbjy4UhVZySTshJ-isdYdwJ04IZFVexdM4$fields", i64 5, i64 5 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@178 = private unnamed_addr constant [2 x i8] c"If", align 1
+@179 = private unnamed_addr constant [4 x i8] c"Else", align 1
+@"_llgo_struct$9pAmM43oNNbjy4UhVZySTshJ-isdYdwJ04IZFVexdM4$fields" = weak_odr constant [5 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @178, i64 2 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @160, i64 4 }, ptr @"_llgo_go/ast.Stmt", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @161, i64 4 }, ptr @"_llgo_go/ast.Expr", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @82, i64 4 }, ptr @"*_llgo_go/ast.BlockStmt", i64 40, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @179, i64 4 }, ptr @"_llgo_go/ast.Stmt", i64 48, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.IncDecStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1296823531, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @180, i64 14 }, ptr null }, ptr @"_llgo_go/ast.IncDecStmt" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*IncDecStmt).End", ptr @"go/ast.(*IncDecStmt).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*IncDecStmt).Pos", ptr @"go/ast.(*IncDecStmt).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @49, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*IncDecStmt).stmtNode", ptr @"go/ast.(*IncDecStmt).stmtNode" }] }, align 8
+@180 = private unnamed_addr constant [14 x i8] c"ast.IncDecStmt", align 1
+@"_llgo_go/ast.IncDecStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 32, i64 0, i32 1322432458, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.IncDecStmt" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @180, i64 14 }, ptr @"*_llgo_go/ast.IncDecStmt" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$AIGWuCQLxxdEHnya_AgqaGDFgFMR2ykItFYxxTzQNuM$fields", i64 3, i64 3 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@"_llgo_struct$AIGWuCQLxxdEHnya_AgqaGDFgFMR2ykItFYxxTzQNuM$fields" = weak_odr constant [3 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @61, i64 1 }, ptr @"_llgo_go/ast.Expr", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @38, i64 6 }, ptr @"_llgo_go/token.Pos", i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @39, i64 3 }, ptr @"_llgo_go/token.Token", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.IndexExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1782885371, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @181, i64 13 }, ptr null }, ptr @"_llgo_go/ast.IndexExpr" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*IndexExpr).End", ptr @"go/ast.(*IndexExpr).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*IndexExpr).Pos", ptr @"go/ast.(*IndexExpr).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*IndexExpr).exprNode", ptr @"go/ast.(*IndexExpr).exprNode" }] }, align 8
+@181 = private unnamed_addr constant [13 x i8] c"ast.IndexExpr", align 1
+@"_llgo_go/ast.IndexExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 48, i64 24, i32 1054923780, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.IndexExpr" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @181, i64 13 }, ptr @"*_llgo_go/ast.IndexExpr" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$jU-Kt7STcD13SNZ2kchpPHU9GZblFnD0D-W0CDKW7Bs$fields", i64 4, i64 4 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@182 = private unnamed_addr constant [5 x i8] c"Index", align 1
+@183 = private unnamed_addr constant [6 x i8] c"Rbrack", align 1
+@"_llgo_struct$jU-Kt7STcD13SNZ2kchpPHU9GZblFnD0D-W0CDKW7Bs$fields" = weak_odr constant [4 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @61, i64 1 }, ptr @"_llgo_go/ast.Expr", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @31, i64 6 }, ptr @"_llgo_go/token.Pos", i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @182, i64 5 }, ptr @"_llgo_go/ast.Expr", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @183, i64 6 }, ptr @"_llgo_go/token.Pos", i64 40, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.IndexListExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1460564778, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @184, i64 17 }, ptr null }, ptr @"_llgo_go/ast.IndexListExpr" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*IndexListExpr).End", ptr @"go/ast.(*IndexListExpr).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*IndexListExpr).Pos", ptr @"go/ast.(*IndexListExpr).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*IndexListExpr).exprNode", ptr @"go/ast.(*IndexListExpr).exprNode" }] }, align 8
+@184 = private unnamed_addr constant [17 x i8] c"ast.IndexListExpr", align 1
+@"_llgo_go/ast.IndexListExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 56, i64 24, i32 -596516190, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @184, i64 17 }, ptr @"*_llgo_go/ast.IndexListExpr" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$cq12iiQTQ4VelvVa9YG2rBvDEAU0AavEWhZtdJbpW-0$fields", i64 4, i64 4 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@185 = private unnamed_addr constant [7 x i8] c"Indices", align 1
+@"_llgo_struct$cq12iiQTQ4VelvVa9YG2rBvDEAU0AavEWhZtdJbpW-0$fields" = weak_odr constant [4 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @61, i64 1 }, ptr @"_llgo_go/ast.Expr", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @31, i64 6 }, ptr @"_llgo_go/token.Pos", i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @185, i64 7 }, ptr @"[]_llgo_go/ast.Expr", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @183, i64 6 }, ptr @"_llgo_go/token.Pos", i64 48, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.InterfaceType" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1615147479, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @186, i64 17 }, ptr null }, ptr @"_llgo_go/ast.InterfaceType" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*InterfaceType).End", ptr @"go/ast.(*InterfaceType).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*InterfaceType).Pos", ptr @"go/ast.(*InterfaceType).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*InterfaceType).exprNode", ptr @"go/ast.(*InterfaceType).exprNode" }] }, align 8
+@186 = private unnamed_addr constant [17 x i8] c"ast.InterfaceType", align 1
+@"_llgo_go/ast.InterfaceType" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 -505192302, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.InterfaceType" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @186, i64 17 }, ptr @"*_llgo_go/ast.InterfaceType" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$prq2Uf3mcUKYW8aGApUWMbDlZLfHIudFyc1VeH_dLA8$fields", i64 3, i64 3 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@187 = private unnamed_addr constant [9 x i8] c"Interface", align 1
+@188 = private unnamed_addr constant [7 x i8] c"Methods", align 1
+@"_llgo_struct$prq2Uf3mcUKYW8aGApUWMbDlZLfHIudFyc1VeH_dLA8$fields" = weak_odr constant [3 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @187, i64 9 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @188, i64 7 }, ptr @"*_llgo_go/ast.FieldList", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @97, i64 10 }, ptr @_llgo_bool, i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.KeyValueExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1913190403, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @189, i64 16 }, ptr null }, ptr @"_llgo_go/ast.KeyValueExpr" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*KeyValueExpr).End", ptr @"go/ast.(*KeyValueExpr).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*KeyValueExpr).Pos", ptr @"go/ast.(*KeyValueExpr).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*KeyValueExpr).exprNode", ptr @"go/ast.(*KeyValueExpr).exprNode" }] }, align 8
+@189 = private unnamed_addr constant [16 x i8] c"ast.KeyValueExpr", align 1
+@"_llgo_go/ast.KeyValueExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 40, i64 40, i32 243893140, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.KeyValueExpr" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @189, i64 16 }, ptr @"*_llgo_go/ast.KeyValueExpr" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$QsjogsoyaAlZr-cmidT7bfYzW1ycpMlTiIKXrh_672E$fields", i64 3, i64 3 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@190 = private unnamed_addr constant [3 x i8] c"Key", align 1
+@"_llgo_struct$QsjogsoyaAlZr-cmidT7bfYzW1ycpMlTiIKXrh_672E$fields" = weak_odr constant [3 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @190, i64 3 }, ptr @"_llgo_go/ast.Expr", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @81, i64 5 }, ptr @"_llgo_go/token.Pos", i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @59, i64 5 }, ptr @"_llgo_go/ast.Expr", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.LabeledStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1985683383, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @191, i64 15 }, ptr null }, ptr @"_llgo_go/ast.LabeledStmt" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*LabeledStmt).End", ptr @"go/ast.(*LabeledStmt).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*LabeledStmt).Pos", ptr @"go/ast.(*LabeledStmt).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @49, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*LabeledStmt).stmtNode", ptr @"go/ast.(*LabeledStmt).stmtNode" }] }, align 8
+@191 = private unnamed_addr constant [15 x i8] c"ast.LabeledStmt", align 1
+@"_llgo_go/ast.LabeledStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 32, i64 32, i32 -127155413, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.LabeledStmt" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @191, i64 15 }, ptr @"*_llgo_go/ast.LabeledStmt" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$5FVZr2a61etUKdz-wgg1auYtDfGpy5Q8XI4DUcf5lpY$fields", i64 3, i64 3 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@192 = private unnamed_addr constant [4 x i8] c"Stmt", align 1
+@"_llgo_struct$5FVZr2a61etUKdz-wgg1auYtDfGpy5Q8XI4DUcf5lpY$fields" = weak_odr constant [3 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @72, i64 5 }, ptr @"*_llgo_go/ast.Ident", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @81, i64 5 }, ptr @"_llgo_go/token.Pos", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @192, i64 4 }, ptr @"_llgo_go/ast.Stmt", i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.MapType" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 99637440, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @193, i64 11 }, ptr null }, ptr @"_llgo_go/ast.MapType" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*MapType).End", ptr @"go/ast.(*MapType).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*MapType).Pos", ptr @"go/ast.(*MapType).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*MapType).exprNode", ptr @"go/ast.(*MapType).exprNode" }] }, align 8
+@193 = private unnamed_addr constant [11 x i8] c"ast.MapType", align 1
+@"_llgo_go/ast.MapType" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 40, i64 40, i32 -699682364, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.MapType" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @193, i64 11 }, ptr @"*_llgo_go/ast.MapType" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$gXwQUZw1igPEurrdb1E04YLKkEeobfGRis6OKNulnqk$fields", i64 3, i64 3 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@194 = private unnamed_addr constant [3 x i8] c"Map", align 1
+@"_llgo_struct$gXwQUZw1igPEurrdb1E04YLKkEeobfGRis6OKNulnqk$fields" = weak_odr constant [3 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @194, i64 3 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @190, i64 3 }, ptr @"_llgo_go/ast.Expr", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @59, i64 5 }, ptr @"_llgo_go/ast.Expr", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.Package" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [2 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -969442699, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @195, i64 11 }, ptr null }, ptr @"_llgo_go/ast.Package" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 2, i16 2, i32 24 }, [2 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*Package).End", ptr @"go/ast.(*Package).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*Package).Pos", ptr @"go/ast.(*Package).Pos" }] }, align 8
+@195 = private unnamed_addr constant [11 x i8] c"ast.Package", align 1
+@"_llgo_go/ast.Package" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 40, i64 40, i32 1688492850, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @195, i64 11 }, ptr @"*_llgo_go/ast.Package" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$kPlcIVeU7JcZVCbMTZFOn949PrsiAjRZ5y56p4D7YoQ$fields", i64 4, i64 4 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@196 = private unnamed_addr constant [5 x i8] c"Files", align 1
+@"map[_llgo_string]*_llgo_go/ast.File" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.MapType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1400132735, i8 0, i8 8, i8 8, i8 53, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @197, i64 20 }, ptr @"*map[_llgo_string]*_llgo_go/ast.File" }, ptr @_llgo_string, ptr @"*_llgo_go/ast.File", ptr @"_llgo_struct$RCg4TciT45ITyoTg7qtuZl2-2ns4FSf9xntj8H5OmFg", { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.typehash", ptr @_llgo_string }, i8 16, i8 8, i16 208, i32 12 }, align 8
+@197 = private unnamed_addr constant [20 x i8] c"map[string]*ast.File", align 1
+@"*map[_llgo_string]*_llgo_go/ast.File" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 103152764, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @197, i64 20 }, ptr null }, ptr @"map[_llgo_string]*_llgo_go/ast.File" }, align 8
+@"_llgo_struct$RCg4TciT45ITyoTg7qtuZl2-2ns4FSf9xntj8H5OmFg" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 208, i64 208, i32 -1489928847, i8 0, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_struct$RCg4TciT45ITyoTg7qtuZl2-2ns4FSf9xntj8H5OmFg" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @198, i64 88 }, ptr @"*_llgo_struct$RCg4TciT45ITyoTg7qtuZl2-2ns4FSf9xntj8H5OmFg" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$RCg4TciT45ITyoTg7qtuZl2-2ns4FSf9xntj8H5OmFg$fields", i64 4, i64 4 } }, align 8
+@198 = private unnamed_addr constant [88 x i8] c"struct { topbits [8]uint8; keys [8]string; elems [8]*ast.File; overflow unsafe.Pointer }", align 1
+@"*_llgo_struct$RCg4TciT45ITyoTg7qtuZl2-2ns4FSf9xntj8H5OmFg" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1897877158, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @198, i64 88 }, ptr null }, ptr @"_llgo_struct$RCg4TciT45ITyoTg7qtuZl2-2ns4FSf9xntj8H5OmFg" }, align 8
+@"[8]*_llgo_go/ast.File" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.ArrayType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 64, i64 64, i32 -819632173, i8 8, i8 8, i8 8, i8 17, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal", ptr @"[8]*_llgo_go/ast.File" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @199, i64 12 }, ptr @"*[8]*_llgo_go/ast.File" }, ptr @"*_llgo_go/ast.File", ptr @"[]*_llgo_go/ast.File", i64 8 }, align 8
+@199 = private unnamed_addr constant [12 x i8] c"[8]*ast.File", align 1
+@"*[8]*_llgo_go/ast.File" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1879967793, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @199, i64 12 }, ptr null }, ptr @"[8]*_llgo_go/ast.File" }, align 8
+@"[]*_llgo_go/ast.File" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 -472289637, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @200, i64 11 }, ptr @"*[]*_llgo_go/ast.File" }, ptr @"*_llgo_go/ast.File" }, align 8
+@200 = private unnamed_addr constant [11 x i8] c"[]*ast.File", align 1
+@"*[]*_llgo_go/ast.File" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 403933123, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @200, i64 11 }, ptr null }, ptr @"[]*_llgo_go/ast.File" }, align 8
+@"_llgo_struct$RCg4TciT45ITyoTg7qtuZl2-2ns4FSf9xntj8H5OmFg$fields" = weak_odr constant [4 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @131, i64 7 }, ptr @"[8]_llgo_uint8", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @135, i64 4 }, ptr @"[8]_llgo_string", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @138, i64 5 }, ptr @"[8]*_llgo_go/ast.File", i64 136, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @141, i64 8 }, ptr @_llgo_Pointer, i64 200, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"_llgo_struct$kPlcIVeU7JcZVCbMTZFOn949PrsiAjRZ5y56p4D7YoQ$fields" = weak_odr constant [4 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @10, i64 4 }, ptr @_llgo_string, i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @125, i64 5 }, ptr @"*_llgo_go/ast.Scope", i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @147, i64 7 }, ptr @"map[_llgo_string]*_llgo_go/ast.Object", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @196, i64 5 }, ptr @"map[_llgo_string]*_llgo_go/ast.File", i64 32, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.ParenExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1531020989, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @201, i64 13 }, ptr null }, ptr @"_llgo_go/ast.ParenExpr" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*ParenExpr).End", ptr @"go/ast.(*ParenExpr).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*ParenExpr).Pos", ptr @"go/ast.(*ParenExpr).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*ParenExpr).exprNode", ptr @"go/ast.(*ParenExpr).exprNode" }] }, align 8
+@201 = private unnamed_addr constant [13 x i8] c"ast.ParenExpr", align 1
+@"_llgo_go/ast.ParenExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 32, i64 8, i32 1083458077, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.ParenExpr" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @201, i64 13 }, ptr @"*_llgo_go/ast.ParenExpr" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$8zlm3x964ReMZqGVglNWFILXnDBskBVunKpoLo8uJ8s$fields", i64 3, i64 3 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@"_llgo_struct$8zlm3x964ReMZqGVglNWFILXnDBskBVunKpoLo8uJ8s$fields" = weak_odr constant [3 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @75, i64 6 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @61, i64 1 }, ptr @"_llgo_go/ast.Expr", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @78, i64 6 }, ptr @"_llgo_go/token.Pos", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.RangeStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1931451638, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @202, i64 13 }, ptr null }, ptr @"_llgo_go/ast.RangeStmt" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*RangeStmt).End", ptr @"go/ast.(*RangeStmt).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*RangeStmt).Pos", ptr @"go/ast.(*RangeStmt).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @49, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*RangeStmt).stmtNode", ptr @"go/ast.(*RangeStmt).stmtNode" }] }, align 8
+@202 = private unnamed_addr constant [13 x i8] c"ast.RangeStmt", align 1
+@"_llgo_go/ast.RangeStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 88, i64 88, i32 1723080701, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.RangeStmt" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @202, i64 13 }, ptr @"*_llgo_go/ast.RangeStmt" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$2KQnmWjo6-7-fbb1nVxOQlqdhVihGCmPlrOJghI4WDU$fields", i64 8, i64 8 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@203 = private unnamed_addr constant [5 x i8] c"Range", align 1
+@"_llgo_struct$2KQnmWjo6-7-fbb1nVxOQlqdhVihGCmPlrOJghI4WDU$fields" = weak_odr constant [8 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @159, i64 3 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @190, i64 3 }, ptr @"_llgo_go/ast.Expr", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @59, i64 5 }, ptr @"_llgo_go/ast.Expr", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @38, i64 6 }, ptr @"_llgo_go/token.Pos", i64 40, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @39, i64 3 }, ptr @"_llgo_go/token.Token", i64 48, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @203, i64 5 }, ptr @"_llgo_go/token.Pos", i64 56, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @61, i64 1 }, ptr @"_llgo_go/ast.Expr", i64 64, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @82, i64 4 }, ptr @"*_llgo_go/ast.BlockStmt", i64 80, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.ReturnStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 330822980, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @204, i64 14 }, ptr null }, ptr @"_llgo_go/ast.ReturnStmt" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*ReturnStmt).End", ptr @"go/ast.(*ReturnStmt).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*ReturnStmt).Pos", ptr @"go/ast.(*ReturnStmt).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @49, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*ReturnStmt).stmtNode", ptr @"go/ast.(*ReturnStmt).stmtNode" }] }, align 8
+@204 = private unnamed_addr constant [14 x i8] c"ast.ReturnStmt", align 1
+@"_llgo_go/ast.ReturnStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 32, i64 16, i32 -308279916, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @204, i64 14 }, ptr @"*_llgo_go/ast.ReturnStmt" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$iX3lNHxFOYuz7YzsBUn73xPvy96z0srcLi30RqOWWrY$fields", i64 2, i64 2 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@205 = private unnamed_addr constant [6 x i8] c"Return", align 1
+@"_llgo_struct$iX3lNHxFOYuz7YzsBUn73xPvy96z0srcLi30RqOWWrY$fields" = weak_odr constant [2 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @205, i64 6 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @169, i64 7 }, ptr @"[]_llgo_go/ast.Expr", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.SelectStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 303492817, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @206, i64 14 }, ptr null }, ptr @"_llgo_go/ast.SelectStmt" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*SelectStmt).End", ptr @"go/ast.(*SelectStmt).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*SelectStmt).Pos", ptr @"go/ast.(*SelectStmt).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @49, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*SelectStmt).stmtNode", ptr @"go/ast.(*SelectStmt).stmtNode" }] }, align 8
+@206 = private unnamed_addr constant [14 x i8] c"ast.SelectStmt", align 1
+@"_llgo_go/ast.SelectStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 1685578866, i8 13, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.SelectStmt" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @206, i64 14 }, ptr @"*_llgo_go/ast.SelectStmt" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$HSiNfT7E4w16IxRIVWIEJyEyOXseRk4IKQKfJc8W-hc$fields", i64 2, i64 2 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@207 = private unnamed_addr constant [6 x i8] c"Select", align 1
+@"_llgo_struct$HSiNfT7E4w16IxRIVWIEJyEyOXseRk4IKQKfJc8W-hc$fields" = weak_odr constant [2 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @207, i64 6 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @82, i64 4 }, ptr @"*_llgo_go/ast.BlockStmt", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.SelectorExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -886691811, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @208, i64 16 }, ptr null }, ptr @"_llgo_go/ast.SelectorExpr" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*SelectorExpr).End", ptr @"go/ast.(*SelectorExpr).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*SelectorExpr).Pos", ptr @"go/ast.(*SelectorExpr).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*SelectorExpr).exprNode", ptr @"go/ast.(*SelectorExpr).exprNode" }] }, align 8
+@208 = private unnamed_addr constant [16 x i8] c"ast.SelectorExpr", align 1
+@"_llgo_go/ast.SelectorExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 24, i32 892270493, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.SelectorExpr" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @208, i64 16 }, ptr @"*_llgo_go/ast.SelectorExpr" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$JNfpTieVvt5lxbp6IF21sRM5Zh7Dt1LJgs47MlEXEqw$fields", i64 2, i64 2 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@209 = private unnamed_addr constant [3 x i8] c"Sel", align 1
+@"_llgo_struct$JNfpTieVvt5lxbp6IF21sRM5Zh7Dt1LJgs47MlEXEqw$fields" = weak_odr constant [2 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @61, i64 1 }, ptr @"_llgo_go/ast.Expr", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @209, i64 3 }, ptr @"*_llgo_go/ast.Ident", i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.SendStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 989652895, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @210, i64 12 }, ptr null }, ptr @"_llgo_go/ast.SendStmt" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*SendStmt).End", ptr @"go/ast.(*SendStmt).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*SendStmt).Pos", ptr @"go/ast.(*SendStmt).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @49, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*SendStmt).stmtNode", ptr @"go/ast.(*SendStmt).stmtNode" }] }, align 8
+@210 = private unnamed_addr constant [12 x i8] c"ast.SendStmt", align 1
+@"_llgo_go/ast.SendStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 40, i64 40, i32 780193081, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.SendStmt" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @210, i64 12 }, ptr @"*_llgo_go/ast.SendStmt" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$pVHVBFGq5ep5i6Rbl-vZ3HslWYu3kdDJXFGRoylKmzE$fields", i64 3, i64 3 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@211 = private unnamed_addr constant [4 x i8] c"Chan", align 1
+@"_llgo_struct$pVHVBFGq5ep5i6Rbl-vZ3HslWYu3kdDJXFGRoylKmzE$fields" = weak_odr constant [3 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @211, i64 4 }, ptr @"_llgo_go/ast.Expr", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @85, i64 5 }, ptr @"_llgo_go/token.Pos", i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @59, i64 5 }, ptr @"_llgo_go/ast.Expr", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.SliceExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1685321679, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @212, i64 13 }, ptr null }, ptr @"_llgo_go/ast.SliceExpr" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*SliceExpr).End", ptr @"go/ast.(*SliceExpr).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*SliceExpr).Pos", ptr @"go/ast.(*SliceExpr).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*SliceExpr).exprNode", ptr @"go/ast.(*SliceExpr).exprNode" }] }, align 8
+@212 = private unnamed_addr constant [13 x i8] c"ast.SliceExpr", align 1
+@"_llgo_go/ast.SliceExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 88, i64 56, i32 1882042726, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.SliceExpr" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @212, i64 13 }, ptr @"*_llgo_go/ast.SliceExpr" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$Bf5gwOJYbtOMFrmM04-BpZG3mcxaATd221yQqENNTKY$fields", i64 7, i64 7 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@213 = private unnamed_addr constant [3 x i8] c"Low", align 1
+@214 = private unnamed_addr constant [4 x i8] c"High", align 1
+@215 = private unnamed_addr constant [3 x i8] c"Max", align 1
+@216 = private unnamed_addr constant [6 x i8] c"Slice3", align 1
+@"_llgo_struct$Bf5gwOJYbtOMFrmM04-BpZG3mcxaATd221yQqENNTKY$fields" = weak_odr constant [7 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @61, i64 1 }, ptr @"_llgo_go/ast.Expr", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @31, i64 6 }, ptr @"_llgo_go/token.Pos", i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @213, i64 3 }, ptr @"_llgo_go/ast.Expr", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @214, i64 4 }, ptr @"_llgo_go/ast.Expr", i64 40, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @215, i64 3 }, ptr @"_llgo_go/ast.Expr", i64 56, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @216, i64 6 }, ptr @_llgo_bool, i64 72, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @183, i64 6 }, ptr @"_llgo_go/token.Pos", i64 80, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.StarExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1585692436, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @217, i64 12 }, ptr null }, ptr @"_llgo_go/ast.StarExpr" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*StarExpr).End", ptr @"go/ast.(*StarExpr).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*StarExpr).Pos", ptr @"go/ast.(*StarExpr).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*StarExpr).exprNode", ptr @"go/ast.(*StarExpr).exprNode" }] }, align 8
+@217 = private unnamed_addr constant [12 x i8] c"ast.StarExpr", align 1
+@"_llgo_go/ast.StarExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 24, i32 10434924, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.StarExpr" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @217, i64 12 }, ptr @"*_llgo_go/ast.StarExpr" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$s89Z8X8wUAn2GFpkjEnuBoDPb8bLrwYxdqemAlP12nM$fields", i64 2, i64 2 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@218 = private unnamed_addr constant [4 x i8] c"Star", align 1
+@"_llgo_struct$s89Z8X8wUAn2GFpkjEnuBoDPb8bLrwYxdqemAlP12nM$fields" = weak_odr constant [2 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @218, i64 4 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @61, i64 1 }, ptr @"_llgo_go/ast.Expr", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.StructType" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -901694354, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @219, i64 14 }, ptr null }, ptr @"_llgo_go/ast.StructType" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*StructType).End", ptr @"go/ast.(*StructType).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*StructType).Pos", ptr @"go/ast.(*StructType).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*StructType).exprNode", ptr @"go/ast.(*StructType).exprNode" }] }, align 8
+@219 = private unnamed_addr constant [14 x i8] c"ast.StructType", align 1
+@"_llgo_go/ast.StructType" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 385805719, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.StructType" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @219, i64 14 }, ptr @"*_llgo_go/ast.StructType" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$pYm8cqin1bpia1ZtqjgM67TopWGmN4CqSClgmf8fjtQ$fields", i64 3, i64 3 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@220 = private unnamed_addr constant [6 x i8] c"Struct", align 1
+@221 = private unnamed_addr constant [6 x i8] c"Fields", align 1
+@"_llgo_struct$pYm8cqin1bpia1ZtqjgM67TopWGmN4CqSClgmf8fjtQ$fields" = weak_odr constant [3 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @220, i64 6 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @221, i64 6 }, ptr @"*_llgo_go/ast.FieldList", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @97, i64 10 }, ptr @_llgo_bool, i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.SwitchStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -2103459330, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @222, i64 14 }, ptr null }, ptr @"_llgo_go/ast.SwitchStmt" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*SwitchStmt).End", ptr @"go/ast.(*SwitchStmt).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*SwitchStmt).Pos", ptr @"go/ast.(*SwitchStmt).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @49, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*SwitchStmt).stmtNode", ptr @"go/ast.(*SwitchStmt).stmtNode" }] }, align 8
+@222 = private unnamed_addr constant [14 x i8] c"ast.SwitchStmt", align 1
+@"_llgo_go/ast.SwitchStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 48, i64 48, i32 -1960068597, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.SwitchStmt" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @222, i64 14 }, ptr @"*_llgo_go/ast.SwitchStmt" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$RfJaIWtgHTQW1ZKi8blF02jtApmrthVXCi1mJ8c9768$fields", i64 4, i64 4 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@223 = private unnamed_addr constant [6 x i8] c"Switch", align 1
+@"_llgo_struct$RfJaIWtgHTQW1ZKi8blF02jtApmrthVXCi1mJ8c9768$fields" = weak_odr constant [4 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @223, i64 6 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @160, i64 4 }, ptr @"_llgo_go/ast.Stmt", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @112, i64 3 }, ptr @"_llgo_go/ast.Expr", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @82, i64 4 }, ptr @"*_llgo_go/ast.BlockStmt", i64 40, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.TypeAssertExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -488540242, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @224, i64 18 }, ptr null }, ptr @"_llgo_go/ast.TypeAssertExpr" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*TypeAssertExpr).End", ptr @"go/ast.(*TypeAssertExpr).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*TypeAssertExpr).Pos", ptr @"go/ast.(*TypeAssertExpr).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*TypeAssertExpr).exprNode", ptr @"go/ast.(*TypeAssertExpr).exprNode" }] }, align 8
+@224 = private unnamed_addr constant [18 x i8] c"ast.TypeAssertExpr", align 1
+@"_llgo_go/ast.TypeAssertExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 48, i64 24, i32 297889255, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.TypeAssertExpr" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @224, i64 18 }, ptr @"*_llgo_go/ast.TypeAssertExpr" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$GbTlN6LoD73HWDcPrP89qGNmJG9L6xCIr3mM5ynkUVk$fields", i64 4, i64 4 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@"_llgo_struct$GbTlN6LoD73HWDcPrP89qGNmJG9L6xCIr3mM5ynkUVk$fields" = weak_odr constant [4 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @61, i64 1 }, ptr @"_llgo_go/ast.Expr", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @75, i64 6 }, ptr @"_llgo_go/token.Pos", i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @22, i64 4 }, ptr @"_llgo_go/ast.Expr", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @78, i64 6 }, ptr @"_llgo_go/token.Pos", i64 40, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.TypeSpec" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -309190029, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @225, i64 12 }, ptr null }, ptr @"_llgo_go/ast.TypeSpec" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*TypeSpec).End", ptr @"go/ast.(*TypeSpec).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*TypeSpec).Pos", ptr @"go/ast.(*TypeSpec).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @153, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*TypeSpec).specNode", ptr @"go/ast.(*TypeSpec).specNode" }] }, align 8
+@225 = private unnamed_addr constant [12 x i8] c"ast.TypeSpec", align 1
+@"_llgo_go/ast.TypeSpec" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 56, i64 56, i32 -1371254115, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.TypeSpec" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @225, i64 12 }, ptr @"*_llgo_go/ast.TypeSpec" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$F-RLxRrFlPpQ-9dD-TUS3t9g2sYN_M8VIIal6nbsx4g$fields", i64 6, i64 6 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@226 = private unnamed_addr constant [6 x i8] c"Assign", align 1
+@"_llgo_struct$F-RLxRrFlPpQ-9dD-TUS3t9g2sYN_M8VIIal6nbsx4g$fields" = weak_odr constant [6 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @109, i64 3 }, ptr @"*_llgo_go/ast.CommentGroup", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @10, i64 4 }, ptr @"*_llgo_go/ast.Ident", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @167, i64 10 }, ptr @"*_llgo_go/ast.FieldList", i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @226, i64 6 }, ptr @"_llgo_go/token.Pos", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @22, i64 4 }, ptr @"_llgo_go/ast.Expr", i64 32, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @113, i64 7 }, ptr @"*_llgo_go/ast.CommentGroup", i64 48, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.TypeSwitchStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1749295401, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @227, i64 18 }, ptr null }, ptr @"_llgo_go/ast.TypeSwitchStmt" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*TypeSwitchStmt).End", ptr @"go/ast.(*TypeSwitchStmt).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*TypeSwitchStmt).Pos", ptr @"go/ast.(*TypeSwitchStmt).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @49, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*TypeSwitchStmt).stmtNode", ptr @"go/ast.(*TypeSwitchStmt).stmtNode" }] }, align 8
+@227 = private unnamed_addr constant [18 x i8] c"ast.TypeSwitchStmt", align 1
+@"_llgo_go/ast.TypeSwitchStmt" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 48, i64 48, i32 833431859, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.TypeSwitchStmt" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @227, i64 18 }, ptr @"*_llgo_go/ast.TypeSwitchStmt" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$T-5DZFbs511hNcHJcqwQu1gxvKx5rPLLAZXFdzBGEZ8$fields", i64 4, i64 4 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@"_llgo_struct$T-5DZFbs511hNcHJcqwQu1gxvKx5rPLLAZXFdzBGEZ8$fields" = weak_odr constant [4 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @223, i64 6 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @160, i64 4 }, ptr @"_llgo_go/ast.Stmt", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @226, i64 6 }, ptr @"_llgo_go/ast.Stmt", i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @82, i64 4 }, ptr @"*_llgo_go/ast.BlockStmt", i64 40, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.UnaryExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1857949224, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @228, i64 13 }, ptr null }, ptr @"_llgo_go/ast.UnaryExpr" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*UnaryExpr).End", ptr @"go/ast.(*UnaryExpr).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*UnaryExpr).Pos", ptr @"go/ast.(*UnaryExpr).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*UnaryExpr).exprNode", ptr @"go/ast.(*UnaryExpr).exprNode" }] }, align 8
+@228 = private unnamed_addr constant [13 x i8] c"ast.UnaryExpr", align 1
+@"_llgo_go/ast.UnaryExpr" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 32, i64 32, i32 -382478855, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_go/ast.UnaryExpr" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @228, i64 13 }, ptr @"*_llgo_go/ast.UnaryExpr" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$m5YCChGyUYh_c9KsJzXwHpBEkinMpksmQXyn1UwDyr8$fields", i64 3, i64 3 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@"_llgo_struct$m5YCChGyUYh_c9KsJzXwHpBEkinMpksmQXyn1UwDyr8$fields" = weak_odr constant [3 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @62, i64 5 }, ptr @"_llgo_go/token.Pos", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @63, i64 2 }, ptr @"_llgo_go/token.Token", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @61, i64 1 }, ptr @"_llgo_go/ast.Expr", i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"*_llgo_go/ast.ValueSpec" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 913999111, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @229, i64 13 }, ptr null }, ptr @"_llgo_go/ast.ValueSpec" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 3, i16 2, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*ValueSpec).End", ptr @"go/ast.(*ValueSpec).End" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 3 }, ptr @"_llgo_func$CJFKsfrtVsmWyEEPXCTr-THQYm4CSPEiO6h57SNQxKU", ptr @"go/ast.(*ValueSpec).Pos", ptr @"go/ast.(*ValueSpec).Pos" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @153, i64 15 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"go/ast.(*ValueSpec).specNode", ptr @"go/ast.(*ValueSpec).specNode" }] }, align 8
+@229 = private unnamed_addr constant [13 x i8] c"ast.ValueSpec", align 1
+@"_llgo_go/ast.ValueSpec" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 80, i64 80, i32 1801997620, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @229, i64 13 }, ptr @"*_llgo_go/ast.ValueSpec" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$sOcAC_ZOq0zUTjfUC4WQUDA-kMpBFrGHc6qNh-82d-Q$fields", i64 5, i64 5 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 6 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@230 = private unnamed_addr constant [6 x i8] c"Values", align 1
+@"_llgo_struct$sOcAC_ZOq0zUTjfUC4WQUDA-kMpBFrGHc6qNh-82d-Q$fields" = weak_odr constant [5 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @109, i64 3 }, ptr @"*_llgo_go/ast.CommentGroup", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @110, i64 5 }, ptr @"[]*_llgo_go/ast.Ident", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @22, i64 4 }, ptr @"_llgo_go/ast.Expr", i64 32, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @230, i64 6 }, ptr @"[]_llgo_go/ast.Expr", i64 48, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @113, i64 7 }, ptr @"*_llgo_go/ast.CommentGroup", i64 72, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+
+define { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.FindNode"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) {
+_llgo_0:
+  %2 = alloca %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", align 8
+  call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+  store %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %0, ptr %2, align 8
+  %3 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1, ptr %3, align 8
+  %4 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
+  %5 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 1)
+  br i1 false, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  %6 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %2, align 8
+  %7 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %3, align 8
+  %8 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
+  %9 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %8, i64 0
+  store %"github.com/goplus/llgo/runtime/internal/runtime.iface" %7, ptr %9, align 8
+  %10 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %8, 0
+  %11 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %10, i64 1, 1
+  %12 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %11, i64 1, 2
+  %13 = call %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]" @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.Preorder"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %6, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %12)
+  %14 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
+  %15 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 32)
+  %16 = getelementptr inbounds { ptr, ptr, ptr, ptr }, ptr %15, i32 0, i32 0
+  store ptr %14, ptr %16, align 8
+  %17 = getelementptr inbounds { ptr, ptr, ptr, ptr }, ptr %15, i32 0, i32 1
+  store ptr %3, ptr %17, align 8
+  %18 = getelementptr inbounds { ptr, ptr, ptr, ptr }, ptr %15, i32 0, i32 2
+  store ptr %4, ptr %18, align 8
+  %19 = getelementptr inbounds { ptr, ptr, ptr, ptr }, ptr %15, i32 0, i32 3
+  store ptr %5, ptr %19, align 8
+  %20 = insertvalue { ptr, ptr } { ptr @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.FindNode$1", ptr undef }, ptr %15, 1
+  %21 = extractvalue %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]" %13, 1
+  %22 = extractvalue %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]" %13, 0
+  call void %22(ptr %21, { ptr, ptr } %20)
+  %23 = load i64, ptr %14, align 4
+  %24 = icmp eq i64 %23, -1
+  br i1 %24, label %_llgo_4, label %_llgo_5
+
+_llgo_2:                                          ; preds = %_llgo_0
+  %25 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
+  %26 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %25, i64 0
+  %27 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %3, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.iface" %27, ptr %26, align 8
+  %28 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %25, 0
+  %29 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %28, i64 1, 1
+  %30 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %29, i64 1, 2
+  %31 = call i64 @"github.com/goplus/llgo/cl/_testgo/cursor.maskOf"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %30)
+  %32 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %2, i32 0, i32 0
+  %33 = load ptr, ptr %32, align 8
+  %34 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Inspector", ptr %33, i32 0, i32 0
+  %35 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %34, align 8
+  %36 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %2, align 8
+  %37 = call { i32, i32 } @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.indices"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %36)
+  %38 = extractvalue { i32, i32 } %37, 0
+  %39 = extractvalue { i32, i32 } %37, 1
+  br label %_llgo_9
+
+_llgo_3:                                          ; preds = %_llgo_7, %_llgo_6
+  store %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" zeroinitializer, ptr %4, align 8
+  store i1 false, ptr %5, align 1
+  %40 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %4, align 8
+  %41 = load i1, ptr %5, align 1
+  %42 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } undef, %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %40, 0
+  %43 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %42, i1 %41, 1
+  ret { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %43
+
+_llgo_4:                                          ; preds = %_llgo_1
+  %44 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 36 }, ptr %44, align 8
+  %45 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %44, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %45)
+  unreachable
+
+_llgo_5:                                          ; preds = %_llgo_1
+  %46 = icmp eq i64 %23, 0
+  br i1 %46, label %_llgo_6, label %_llgo_7
+
+_llgo_6:                                          ; preds = %_llgo_5
+  store i64 -2, ptr %14, align 4
+  br label %_llgo_3
+
+_llgo_7:                                          ; preds = %_llgo_5
+  %47 = icmp eq i64 %23, 1
+  br i1 %47, label %_llgo_8, label %_llgo_3
+
+_llgo_8:                                          ; preds = %_llgo_7
+  %48 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %4, align 8
+  %49 = load i1, ptr %5, align 1
+  %50 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } undef, %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %48, 0
+  %51 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %50, i1 %49, 1
+  ret { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %51
+
+_llgo_9:                                          ; preds = %_llgo_13, %_llgo_2
+  %52 = phi i32 [ %38, %_llgo_2 ], [ %75, %_llgo_13 ]
+  %53 = icmp slt i32 %52, %39
+  br i1 %53, label %_llgo_10, label %_llgo_11
+
+_llgo_10:                                         ; preds = %_llgo_9
+  %54 = alloca %"github.com/goplus/llgo/cl/_testgo/cursor.event", align 8
+  call void @llvm.memset(ptr %54, i8 0, i64 32, i1 false)
+  %55 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %35, 0
+  %56 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %35, 1
+  %57 = sext i32 %52 to i64
+  %58 = icmp slt i64 %57, 0
+  %59 = icmp sge i64 %57, %56
+  %60 = or i1 %59, %58
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %60)
+  %61 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %55, i64 %57
+  %62 = load %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %61, align 8
+  store %"github.com/goplus/llgo/cl/_testgo/cursor.event" %62, ptr %54, align 8
+  %63 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %54, i32 0, i32 2
+  %64 = load i32, ptr %63, align 4
+  %65 = icmp sgt i32 %64, %52
+  br i1 %65, label %_llgo_12, label %_llgo_13
+
+_llgo_11:                                         ; preds = %_llgo_9
+  store %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" zeroinitializer, ptr %4, align 8
+  store i1 false, ptr %5, align 1
+  %66 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %4, align 8
+  %67 = load i1, ptr %5, align 1
+  %68 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } undef, %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %66, 0
+  %69 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %68, i1 %67, 1
+  ret { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %69
+
+_llgo_12:                                         ; preds = %_llgo_10
+  %70 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %54, i32 0, i32 1
+  %71 = load i64, ptr %70, align 4
+  %72 = and i64 %71, %31
+  %73 = icmp ne i64 %72, 0
+  br i1 %73, label %_llgo_16, label %_llgo_15
+
+_llgo_13:                                         ; preds = %_llgo_17, %_llgo_15, %_llgo_10
+  %74 = phi i32 [ %52, %_llgo_10 ], [ %52, %_llgo_15 ], [ %87, %_llgo_17 ]
+  %75 = add i32 %74, 1
+  br label %_llgo_9
+
+_llgo_14:                                         ; preds = %_llgo_16
+  %76 = alloca %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", align 8
+  call void @llvm.memset(ptr %76, i8 0, i64 16, i1 false)
+  %77 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %76, i32 0, i32 0
+  %78 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %2, i32 0, i32 0
+  %79 = load ptr, ptr %78, align 8
+  %80 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %76, i32 0, i32 1
+  store ptr %79, ptr %77, align 8
+  store i32 %52, ptr %80, align 4
+  %81 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %76, align 8
+  store %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %81, ptr %4, align 8
+  store i1 true, ptr %5, align 1
+  %82 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %4, align 8
+  %83 = load i1, ptr %5, align 1
+  %84 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } undef, %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %82, 0
+  %85 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %84, i1 %83, 1
+  ret { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %85
+
+_llgo_15:                                         ; preds = %_llgo_16, %_llgo_12
+  %86 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %54, i32 0, i32 2
+  %87 = load i32, ptr %86, align 4
+  %88 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %35, 0
+  %89 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %35, 1
+  %90 = sext i32 %87 to i64
+  %91 = icmp slt i64 %90, 0
+  %92 = icmp sge i64 %90, %89
+  %93 = or i1 %92, %91
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %93)
+  %94 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %88, i64 %90
+  %95 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %94, i32 0, i32 1
+  %96 = load i64, ptr %95, align 4
+  %97 = and i64 %96, %31
+  %98 = icmp eq i64 %97, 0
+  br i1 %98, label %_llgo_17, label %_llgo_13
+
+_llgo_16:                                         ; preds = %_llgo_12
+  %99 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %54, i32 0, i32 0
+  %100 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %99, align 8
+  %101 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %3, align 8
+  %102 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %100)
+  %103 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %100, 1
+  %104 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %102, 0
+  %105 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %104, ptr %103, 1
+  %106 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %101)
+  %107 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %101, 1
+  %108 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %106, 0
+  %109 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %108, ptr %107, 1
+  %110 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %105, %"github.com/goplus/llgo/runtime/internal/runtime.eface" %109)
+  br i1 %110, label %_llgo_14, label %_llgo_15
+
+_llgo_17:                                         ; preds = %_llgo_15
+  br label %_llgo_13
+}
+
+define i1 @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.FindNode$1"(ptr %0, %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %1) {
+_llgo_0:
+  %2 = load { ptr, ptr, ptr, ptr }, ptr %0, align 8
+  %3 = extractvalue { ptr, ptr, ptr, ptr } %2, 0
+  %4 = load i64, ptr %3, align 4
+  %5 = icmp eq i64 %4, 0
+  br i1 %5, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  %6 = extractvalue { ptr, ptr, ptr, ptr } %2, 0
+  store i64 -1, ptr %6, align 4
+  %7 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.Node"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %1)
+  %8 = extractvalue { ptr, ptr, ptr, ptr } %2, 1
+  %9 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %8, align 8
+  %10 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %7)
+  %11 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %7, 1
+  %12 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %10, 0
+  %13 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %12, ptr %11, 1
+  %14 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %9)
+  %15 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %9, 1
+  %16 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %14, 0
+  %17 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %16, ptr %15, 1
+  %18 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %13, %"github.com/goplus/llgo/runtime/internal/runtime.eface" %17)
+  br i1 %18, label %_llgo_3, label %_llgo_4
+
+_llgo_2:                                          ; preds = %_llgo_0
+  %19 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @2, i64 43 }, ptr %19, align 8
+  %20 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %19, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %20)
+  unreachable
+
+_llgo_3:                                          ; preds = %_llgo_1
+  %21 = extractvalue { ptr, ptr, ptr, ptr } %2, 2
+  store %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %1, ptr %21, align 8
+  %22 = extractvalue { ptr, ptr, ptr, ptr } %2, 3
+  store i1 true, ptr %22, align 1
+  %23 = extractvalue { ptr, ptr, ptr, ptr } %2, 0
+  store i64 1, ptr %23, align 4
+  ret i1 false
+
+_llgo_4:                                          ; preds = %_llgo_1
+  %24 = extractvalue { ptr, ptr, ptr, ptr } %2, 0
+  store i64 0, ptr %24, align 4
+  ret i1 true
+}
+
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.Node"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %0) {
+_llgo_0:
+  %1 = alloca %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", align 8
+  call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+  store %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %0, ptr %1, align 8
+  %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %1, i32 0, i32 1
+  %3 = load i32, ptr %2, align 4
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" zeroinitializer
+
+_llgo_2:                                          ; preds = %_llgo_0
+  %5 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %1, i32 0, i32 0
+  %6 = load ptr, ptr %5, align 8
+  %7 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Inspector", ptr %6, i32 0, i32 0
+  %8 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %7, align 8
+  %9 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %1, i32 0, i32 1
+  %10 = load i32, ptr %9, align 4
+  %11 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %8, 0
+  %12 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %8, 1
+  %13 = sext i32 %10 to i64
+  %14 = icmp slt i64 %13, 0
+  %15 = icmp sge i64 %13, %12
+  %16 = or i1 %15, %14
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %16)
+  %17 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %11, i64 %13
+  %18 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %17, i32 0, i32 0
+  %19 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %18, align 8
+  ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %19
+}
+
+define %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]" @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.Preorder"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+_llgo_0:
+  %2 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
+  store %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %0, ptr %2, align 8
+  %3 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
+  %4 = call i64 @"github.com/goplus/llgo/cl/_testgo/cursor.maskOf"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1)
+  store i64 %4, ptr %3, align 4
+  %5 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  %6 = getelementptr inbounds { ptr, ptr }, ptr %5, i32 0, i32 0
+  store ptr %2, ptr %6, align 8
+  %7 = getelementptr inbounds { ptr, ptr }, ptr %5, i32 0, i32 1
+  store ptr %3, ptr %7, align 8
+  %8 = insertvalue { ptr, ptr } { ptr @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.Preorder$1", ptr undef }, ptr %5, 1
+  %9 = alloca %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]", align 8
+  store { ptr, ptr } %8, ptr %9, align 8
+  %10 = load %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]", ptr %9, align 8
+  ret %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]" %10
+}
+
+define void @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.Preorder$1"(ptr %0, { ptr, ptr } %1) {
+_llgo_0:
+  %2 = load { ptr, ptr }, ptr %0, align 8
+  %3 = extractvalue { ptr, ptr } %2, 0
+  %4 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %3, i32 0, i32 0
+  %5 = load ptr, ptr %4, align 8
+  %6 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Inspector", ptr %5, i32 0, i32 0
+  %7 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %6, align 8
+  %8 = extractvalue { ptr, ptr } %2, 0
+  %9 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %8, align 8
+  %10 = call { i32, i32 } @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.indices"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %9)
+  %11 = extractvalue { i32, i32 } %10, 0
+  %12 = extractvalue { i32, i32 } %10, 1
+  br label %_llgo_1
+
+_llgo_1:                                          ; preds = %_llgo_5, %_llgo_8, %_llgo_0
+  %13 = phi i32 [ %11, %_llgo_0 ], [ %59, %_llgo_8 ], [ %33, %_llgo_5 ]
+  %14 = icmp slt i32 %13, %12
+  br i1 %14, label %_llgo_2, label %_llgo_3
+
+_llgo_2:                                          ; preds = %_llgo_1
+  %15 = alloca %"github.com/goplus/llgo/cl/_testgo/cursor.event", align 8
+  call void @llvm.memset(ptr %15, i8 0, i64 32, i1 false)
+  %16 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %7, 0
+  %17 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %7, 1
+  %18 = sext i32 %13 to i64
+  %19 = icmp slt i64 %18, 0
+  %20 = icmp sge i64 %18, %17
+  %21 = or i1 %20, %19
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %21)
+  %22 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %16, i64 %18
+  %23 = load %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %22, align 8
+  store %"github.com/goplus/llgo/cl/_testgo/cursor.event" %23, ptr %15, align 8
+  %24 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %15, i32 0, i32 2
+  %25 = load i32, ptr %24, align 4
+  %26 = icmp sgt i32 %25, %13
+  br i1 %26, label %_llgo_4, label %_llgo_5
+
+_llgo_3:                                          ; preds = %_llgo_7, %_llgo_1
+  ret void
+
+_llgo_4:                                          ; preds = %_llgo_2
+  %27 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %15, i32 0, i32 1
+  %28 = load i64, ptr %27, align 4
+  %29 = extractvalue { ptr, ptr } %2, 1
+  %30 = load i64, ptr %29, align 4
+  %31 = and i64 %28, %30
+  %32 = icmp ne i64 %31, 0
+  br i1 %32, label %_llgo_7, label %_llgo_6
+
+_llgo_5:                                          ; preds = %_llgo_6, %_llgo_2
+  %33 = add i32 %13, 1
+  br label %_llgo_1
+
+_llgo_6:                                          ; preds = %_llgo_7, %_llgo_4
+  %34 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %15, i32 0, i32 2
+  %35 = load i32, ptr %34, align 4
+  %36 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %7, 0
+  %37 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %7, 1
+  %38 = sext i32 %35 to i64
+  %39 = icmp slt i64 %38, 0
+  %40 = icmp sge i64 %38, %37
+  %41 = or i1 %40, %39
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %41)
+  %42 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %36, i64 %38
+  %43 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %42, i32 0, i32 1
+  %44 = load i64, ptr %43, align 4
+  %45 = extractvalue { ptr, ptr } %2, 1
+  %46 = load i64, ptr %45, align 4
+  %47 = and i64 %44, %46
+  %48 = icmp eq i64 %47, 0
+  br i1 %48, label %_llgo_8, label %_llgo_5
+
+_llgo_7:                                          ; preds = %_llgo_4
+  %49 = alloca %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", align 8
+  call void @llvm.memset(ptr %49, i8 0, i64 16, i1 false)
+  %50 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %49, i32 0, i32 0
+  %51 = extractvalue { ptr, ptr } %2, 0
+  %52 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %51, i32 0, i32 0
+  %53 = load ptr, ptr %52, align 8
+  %54 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %49, i32 0, i32 1
+  store ptr %53, ptr %50, align 8
+  store i32 %13, ptr %54, align 4
+  %55 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %49, align 8
+  %56 = extractvalue { ptr, ptr } %1, 1
+  %57 = extractvalue { ptr, ptr } %1, 0
+  %58 = call i1 %57(ptr %56, %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %55)
+  br i1 %58, label %_llgo_6, label %_llgo_3
+
+_llgo_8:                                          ; preds = %_llgo_6
+  %59 = add i32 %35, 1
+  br label %_llgo_1
+}
+
+define { i32, i32 } @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.indices"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %0) {
+_llgo_0:
+  %1 = alloca %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", align 8
+  call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+  store %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %0, ptr %1, align 8
+  %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %1, i32 0, i32 1
+  %3 = load i32, ptr %2, align 4
+  %4 = icmp slt i32 %3, 0
+  br i1 %4, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  %5 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %1, i32 0, i32 0
+  %6 = load ptr, ptr %5, align 8
+  %7 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Inspector", ptr %6, i32 0, i32 0
+  %8 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %7, align 8
+  %9 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %8, 1
+  %10 = trunc i64 %9 to i32
+  %11 = insertvalue { i32, i32 } { i32 0, i32 undef }, i32 %10, 1
+  ret { i32, i32 } %11
+
+_llgo_2:                                          ; preds = %_llgo_0
+  %12 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %1, i32 0, i32 1
+  %13 = load i32, ptr %12, align 4
+  %14 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %1, i32 0, i32 0
+  %15 = load ptr, ptr %14, align 8
+  %16 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Inspector", ptr %15, i32 0, i32 0
+  %17 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %16, align 8
+  %18 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %1, i32 0, i32 1
+  %19 = load i32, ptr %18, align 4
+  %20 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %17, 0
+  %21 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %17, 1
+  %22 = sext i32 %19 to i64
+  %23 = icmp slt i64 %22, 0
+  %24 = icmp sge i64 %22, %21
+  %25 = or i1 %24, %23
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %25)
+  %26 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %20, i64 %22
+  %27 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %26, i32 0, i32 2
+  %28 = load i32, ptr %27, align 4
+  %29 = add i32 %28, 1
+  %30 = insertvalue { i32, i32 } undef, i32 %13, 0
+  %31 = insertvalue { i32, i32 } %30, i32 %29, 1
+  ret { i32, i32 } %31
+}
+
+define { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } @"github.com/goplus/llgo/cl/_testgo/cursor.(*Cursor).FindNode"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) {
+_llgo_0:
+  %2 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %0, align 8
+  %3 = call { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.FindNode"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %2, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1)
+  %4 = extractvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %3, 0
+  %5 = extractvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %3, 1
+  %6 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } undef, %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %4, 0
+  %7 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %6, i1 %5, 1
+  ret { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %7
+}
+
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/cursor.(*Cursor).Node"(ptr %0) {
+_llgo_0:
+  %1 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %0, align 8
+  %2 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.Node"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %1)
+  ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %2
+}
+
+define %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]" @"github.com/goplus/llgo/cl/_testgo/cursor.(*Cursor).Preorder"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+_llgo_0:
+  %2 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %0, align 8
+  %3 = call %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]" @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.Preorder"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %2, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1)
+  ret %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]" %3
+}
+
+define { i32, i32 } @"github.com/goplus/llgo/cl/_testgo/cursor.(*Cursor).indices"(ptr %0) {
+_llgo_0:
+  %1 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %0, align 8
+  %2 = call { i32, i32 } @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.indices"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %1)
+  %3 = extractvalue { i32, i32 } %2, 0
+  %4 = extractvalue { i32, i32 } %2, 1
+  %5 = insertvalue { i32, i32 } undef, i32 %3, 0
+  %6 = insertvalue { i32, i32 } %5, i32 %4, 1
+  ret { i32, i32 } %6
+}
+
+define void @"github.com/goplus/llgo/cl/_testgo/cursor.init"() {
+_llgo_0:
+  %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/cursor.init$guard", align 1
+  br i1 %0, label %_llgo_2, label %_llgo_1
+
+_llgo_1:                                          ; preds = %_llgo_0
+  store i1 true, ptr @"github.com/goplus/llgo/cl/_testgo/cursor.init$guard", align 1
+  call void @"go/ast.init"()
+  call void @iter.init()
+  call void @math.init()
+  br label %_llgo_2
+
+_llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+  ret void
+}
+
+define void @"github.com/goplus/llgo/cl/_testgo/cursor.main"() {
+_llgo_0:
+  %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
+  %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %0, i32 0, i32 0
+  %2 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 24)
+  store ptr %2, ptr %1, align 8
+  ret void
+}
+
+define i64 @"github.com/goplus/llgo/cl/_testgo/cursor.maskOf"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0) {
+_llgo_0:
+  %1 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0, 1
+  %2 = icmp eq i64 %1, 0
+  br i1 %2, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  ret i64 -1
+
+_llgo_2:                                          ; preds = %_llgo_0
+  %3 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0, 1
+  br label %_llgo_3
+
+_llgo_3:                                          ; preds = %_llgo_4, %_llgo_2
+  %4 = phi i64 [ 0, %_llgo_2 ], [ %16, %_llgo_4 ]
+  %5 = phi i64 [ -1, %_llgo_2 ], [ %6, %_llgo_4 ]
+  %6 = add i64 %5, 1
+  %7 = icmp slt i64 %6, %3
+  br i1 %7, label %_llgo_4, label %_llgo_5
+
+_llgo_4:                                          ; preds = %_llgo_3
+  %8 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0, 0
+  %9 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0, 1
+  %10 = icmp slt i64 %6, 0
+  %11 = icmp sge i64 %6, %9
+  %12 = or i1 %11, %10
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %12)
+  %13 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %8, i64 %6
+  %14 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %13, align 8
+  %15 = call i64 @"github.com/goplus/llgo/cl/_testgo/cursor.typeOf"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %14)
+  %16 = or i64 %4, %15
+  br label %_llgo_3
+
+_llgo_5:                                          ; preds = %_llgo_3
+  ret i64 %4
+}
+
+define i64 @"github.com/goplus/llgo/cl/_testgo/cursor.typeOf"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0) {
+_llgo_0:
+  %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %2 = icmp eq ptr %1, @"*_llgo_go/ast.Ident"
+  br i1 %2, label %_llgo_115, label %_llgo_116
+
+_llgo_1:                                          ; preds = %_llgo_117
+  ret i64 1073741824
+
+_llgo_2:                                          ; preds = %_llgo_117
+  %3 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %4 = icmp eq ptr %3, @"*_llgo_go/ast.ArrayType"
+  br i1 %4, label %_llgo_118, label %_llgo_119
+
+_llgo_3:                                          ; preds = %_llgo_120
+  ret i64 1
+
+_llgo_4:                                          ; preds = %_llgo_120
+  %5 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %6 = icmp eq ptr %5, @"*_llgo_go/ast.AssignStmt"
+  br i1 %6, label %_llgo_121, label %_llgo_122
+
+_llgo_5:                                          ; preds = %_llgo_123
+  ret i64 2
+
+_llgo_6:                                          ; preds = %_llgo_123
+  %7 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %8 = icmp eq ptr %7, @"*_llgo_go/ast.BadDecl"
+  br i1 %8, label %_llgo_124, label %_llgo_125
+
+_llgo_7:                                          ; preds = %_llgo_126
+  ret i64 4
+
+_llgo_8:                                          ; preds = %_llgo_126
+  %9 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %10 = icmp eq ptr %9, @"*_llgo_go/ast.BadExpr"
+  br i1 %10, label %_llgo_127, label %_llgo_128
+
+_llgo_9:                                          ; preds = %_llgo_129
+  ret i64 8
+
+_llgo_10:                                         ; preds = %_llgo_129
+  %11 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %12 = icmp eq ptr %11, @"*_llgo_go/ast.BadStmt"
+  br i1 %12, label %_llgo_130, label %_llgo_131
+
+_llgo_11:                                         ; preds = %_llgo_132
+  ret i64 16
+
+_llgo_12:                                         ; preds = %_llgo_132
+  %13 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %14 = icmp eq ptr %13, @"*_llgo_go/ast.BasicLit"
+  br i1 %14, label %_llgo_133, label %_llgo_134
+
+_llgo_13:                                         ; preds = %_llgo_135
+  ret i64 32
+
+_llgo_14:                                         ; preds = %_llgo_135
+  %15 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %16 = icmp eq ptr %15, @"*_llgo_go/ast.BinaryExpr"
+  br i1 %16, label %_llgo_136, label %_llgo_137
+
+_llgo_15:                                         ; preds = %_llgo_138
+  ret i64 64
+
+_llgo_16:                                         ; preds = %_llgo_138
+  %17 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %18 = icmp eq ptr %17, @"*_llgo_go/ast.BlockStmt"
+  br i1 %18, label %_llgo_139, label %_llgo_140
+
+_llgo_17:                                         ; preds = %_llgo_141
+  ret i64 128
+
+_llgo_18:                                         ; preds = %_llgo_141
+  %19 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %20 = icmp eq ptr %19, @"*_llgo_go/ast.BranchStmt"
+  br i1 %20, label %_llgo_142, label %_llgo_143
+
+_llgo_19:                                         ; preds = %_llgo_144
+  ret i64 256
+
+_llgo_20:                                         ; preds = %_llgo_144
+  %21 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %22 = icmp eq ptr %21, @"*_llgo_go/ast.CallExpr"
+  br i1 %22, label %_llgo_145, label %_llgo_146
+
+_llgo_21:                                         ; preds = %_llgo_147
+  ret i64 512
+
+_llgo_22:                                         ; preds = %_llgo_147
+  %23 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %24 = icmp eq ptr %23, @"*_llgo_go/ast.CaseClause"
+  br i1 %24, label %_llgo_148, label %_llgo_149
+
+_llgo_23:                                         ; preds = %_llgo_150
+  ret i64 1024
+
+_llgo_24:                                         ; preds = %_llgo_150
+  %25 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %26 = icmp eq ptr %25, @"*_llgo_go/ast.ChanType"
+  br i1 %26, label %_llgo_151, label %_llgo_152
+
+_llgo_25:                                         ; preds = %_llgo_153
+  ret i64 2048
+
+_llgo_26:                                         ; preds = %_llgo_153
+  %27 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %28 = icmp eq ptr %27, @"*_llgo_go/ast.CommClause"
+  br i1 %28, label %_llgo_154, label %_llgo_155
+
+_llgo_27:                                         ; preds = %_llgo_156
+  ret i64 4096
+
+_llgo_28:                                         ; preds = %_llgo_156
+  %29 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %30 = icmp eq ptr %29, @"*_llgo_go/ast.Comment"
+  br i1 %30, label %_llgo_157, label %_llgo_158
+
+_llgo_29:                                         ; preds = %_llgo_159
+  ret i64 8192
+
+_llgo_30:                                         ; preds = %_llgo_159
+  %31 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %32 = icmp eq ptr %31, @"*_llgo_go/ast.CommentGroup"
+  br i1 %32, label %_llgo_160, label %_llgo_161
+
+_llgo_31:                                         ; preds = %_llgo_162
+  ret i64 16384
+
+_llgo_32:                                         ; preds = %_llgo_162
+  %33 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %34 = icmp eq ptr %33, @"*_llgo_go/ast.CompositeLit"
+  br i1 %34, label %_llgo_163, label %_llgo_164
+
+_llgo_33:                                         ; preds = %_llgo_165
+  ret i64 32768
+
+_llgo_34:                                         ; preds = %_llgo_165
+  %35 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %36 = icmp eq ptr %35, @"*_llgo_go/ast.DeclStmt"
+  br i1 %36, label %_llgo_166, label %_llgo_167
+
+_llgo_35:                                         ; preds = %_llgo_168
+  ret i64 65536
+
+_llgo_36:                                         ; preds = %_llgo_168
+  %37 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %38 = icmp eq ptr %37, @"*_llgo_go/ast.DeferStmt"
+  br i1 %38, label %_llgo_169, label %_llgo_170
+
+_llgo_37:                                         ; preds = %_llgo_171
+  ret i64 131072
+
+_llgo_38:                                         ; preds = %_llgo_171
+  %39 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %40 = icmp eq ptr %39, @"*_llgo_go/ast.Ellipsis"
+  br i1 %40, label %_llgo_172, label %_llgo_173
+
+_llgo_39:                                         ; preds = %_llgo_174
+  ret i64 262144
+
+_llgo_40:                                         ; preds = %_llgo_174
+  %41 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %42 = icmp eq ptr %41, @"*_llgo_go/ast.EmptyStmt"
+  br i1 %42, label %_llgo_175, label %_llgo_176
+
+_llgo_41:                                         ; preds = %_llgo_177
+  ret i64 524288
+
+_llgo_42:                                         ; preds = %_llgo_177
+  %43 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %44 = icmp eq ptr %43, @"*_llgo_go/ast.ExprStmt"
+  br i1 %44, label %_llgo_178, label %_llgo_179
+
+_llgo_43:                                         ; preds = %_llgo_180
+  ret i64 1048576
+
+_llgo_44:                                         ; preds = %_llgo_180
+  %45 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %46 = icmp eq ptr %45, @"*_llgo_go/ast.Field"
+  br i1 %46, label %_llgo_181, label %_llgo_182
+
+_llgo_45:                                         ; preds = %_llgo_183
+  ret i64 2097152
+
+_llgo_46:                                         ; preds = %_llgo_183
+  %47 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %48 = icmp eq ptr %47, @"*_llgo_go/ast.FieldList"
+  br i1 %48, label %_llgo_184, label %_llgo_185
+
+_llgo_47:                                         ; preds = %_llgo_186
+  ret i64 4194304
+
+_llgo_48:                                         ; preds = %_llgo_186
+  %49 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %50 = icmp eq ptr %49, @"*_llgo_go/ast.File"
+  br i1 %50, label %_llgo_187, label %_llgo_188
+
+_llgo_49:                                         ; preds = %_llgo_189
+  ret i64 8388608
+
+_llgo_50:                                         ; preds = %_llgo_189
+  %51 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %52 = icmp eq ptr %51, @"*_llgo_go/ast.ForStmt"
+  br i1 %52, label %_llgo_190, label %_llgo_191
+
+_llgo_51:                                         ; preds = %_llgo_192
+  ret i64 16777216
+
+_llgo_52:                                         ; preds = %_llgo_192
+  %53 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %54 = icmp eq ptr %53, @"*_llgo_go/ast.FuncDecl"
+  br i1 %54, label %_llgo_193, label %_llgo_194
+
+_llgo_53:                                         ; preds = %_llgo_195
+  ret i64 33554432
+
+_llgo_54:                                         ; preds = %_llgo_195
+  %55 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %56 = icmp eq ptr %55, @"*_llgo_go/ast.FuncLit"
+  br i1 %56, label %_llgo_196, label %_llgo_197
+
+_llgo_55:                                         ; preds = %_llgo_198
+  ret i64 67108864
+
+_llgo_56:                                         ; preds = %_llgo_198
+  %57 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %58 = icmp eq ptr %57, @"*_llgo_go/ast.FuncType"
+  br i1 %58, label %_llgo_199, label %_llgo_200
+
+_llgo_57:                                         ; preds = %_llgo_201
+  ret i64 134217728
+
+_llgo_58:                                         ; preds = %_llgo_201
+  %59 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %60 = icmp eq ptr %59, @"*_llgo_go/ast.GenDecl"
+  br i1 %60, label %_llgo_202, label %_llgo_203
+
+_llgo_59:                                         ; preds = %_llgo_204
+  ret i64 268435456
+
+_llgo_60:                                         ; preds = %_llgo_204
+  %61 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %62 = icmp eq ptr %61, @"*_llgo_go/ast.GoStmt"
+  br i1 %62, label %_llgo_205, label %_llgo_206
+
+_llgo_61:                                         ; preds = %_llgo_207
+  ret i64 536870912
+
+_llgo_62:                                         ; preds = %_llgo_207
+  %63 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %64 = icmp eq ptr %63, @"*_llgo_go/ast.Ident"
+  br i1 %64, label %_llgo_208, label %_llgo_209
+
+_llgo_63:                                         ; preds = %_llgo_210
+  ret i64 1073741824
+
+_llgo_64:                                         ; preds = %_llgo_210
+  %65 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %66 = icmp eq ptr %65, @"*_llgo_go/ast.IfStmt"
+  br i1 %66, label %_llgo_211, label %_llgo_212
+
+_llgo_65:                                         ; preds = %_llgo_213
+  ret i64 2147483648
+
+_llgo_66:                                         ; preds = %_llgo_213
+  %67 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %68 = icmp eq ptr %67, @"*_llgo_go/ast.ImportSpec"
+  br i1 %68, label %_llgo_214, label %_llgo_215
+
+_llgo_67:                                         ; preds = %_llgo_216
+  ret i64 4294967296
+
+_llgo_68:                                         ; preds = %_llgo_216
+  %69 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %70 = icmp eq ptr %69, @"*_llgo_go/ast.IncDecStmt"
+  br i1 %70, label %_llgo_217, label %_llgo_218
+
+_llgo_69:                                         ; preds = %_llgo_219
+  ret i64 8589934592
+
+_llgo_70:                                         ; preds = %_llgo_219
+  %71 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %72 = icmp eq ptr %71, @"*_llgo_go/ast.IndexExpr"
+  br i1 %72, label %_llgo_220, label %_llgo_221
+
+_llgo_71:                                         ; preds = %_llgo_222
+  ret i64 17179869184
+
+_llgo_72:                                         ; preds = %_llgo_222
+  %73 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %74 = icmp eq ptr %73, @"*_llgo_go/ast.IndexListExpr"
+  br i1 %74, label %_llgo_223, label %_llgo_224
+
+_llgo_73:                                         ; preds = %_llgo_225
+  ret i64 34359738368
+
+_llgo_74:                                         ; preds = %_llgo_225
+  %75 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %76 = icmp eq ptr %75, @"*_llgo_go/ast.InterfaceType"
+  br i1 %76, label %_llgo_226, label %_llgo_227
+
+_llgo_75:                                         ; preds = %_llgo_228
+  ret i64 68719476736
+
+_llgo_76:                                         ; preds = %_llgo_228
+  %77 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %78 = icmp eq ptr %77, @"*_llgo_go/ast.KeyValueExpr"
+  br i1 %78, label %_llgo_229, label %_llgo_230
+
+_llgo_77:                                         ; preds = %_llgo_231
+  ret i64 137438953472
+
+_llgo_78:                                         ; preds = %_llgo_231
+  %79 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %80 = icmp eq ptr %79, @"*_llgo_go/ast.LabeledStmt"
+  br i1 %80, label %_llgo_232, label %_llgo_233
+
+_llgo_79:                                         ; preds = %_llgo_234
+  ret i64 274877906944
+
+_llgo_80:                                         ; preds = %_llgo_234
+  %81 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %82 = icmp eq ptr %81, @"*_llgo_go/ast.MapType"
+  br i1 %82, label %_llgo_235, label %_llgo_236
+
+_llgo_81:                                         ; preds = %_llgo_237
+  ret i64 549755813888
+
+_llgo_82:                                         ; preds = %_llgo_237
+  %83 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %84 = icmp eq ptr %83, @"*_llgo_go/ast.Package"
+  br i1 %84, label %_llgo_238, label %_llgo_239
+
+_llgo_83:                                         ; preds = %_llgo_240
+  ret i64 1099511627776
+
+_llgo_84:                                         ; preds = %_llgo_240
+  %85 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %86 = icmp eq ptr %85, @"*_llgo_go/ast.ParenExpr"
+  br i1 %86, label %_llgo_241, label %_llgo_242
+
+_llgo_85:                                         ; preds = %_llgo_243
+  ret i64 2199023255552
+
+_llgo_86:                                         ; preds = %_llgo_243
+  %87 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %88 = icmp eq ptr %87, @"*_llgo_go/ast.RangeStmt"
+  br i1 %88, label %_llgo_244, label %_llgo_245
+
+_llgo_87:                                         ; preds = %_llgo_246
+  ret i64 4398046511104
+
+_llgo_88:                                         ; preds = %_llgo_246
+  %89 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %90 = icmp eq ptr %89, @"*_llgo_go/ast.ReturnStmt"
+  br i1 %90, label %_llgo_247, label %_llgo_248
+
+_llgo_89:                                         ; preds = %_llgo_249
+  ret i64 8796093022208
+
+_llgo_90:                                         ; preds = %_llgo_249
+  %91 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %92 = icmp eq ptr %91, @"*_llgo_go/ast.SelectStmt"
+  br i1 %92, label %_llgo_250, label %_llgo_251
+
+_llgo_91:                                         ; preds = %_llgo_252
+  ret i64 17592186044416
+
+_llgo_92:                                         ; preds = %_llgo_252
+  %93 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %94 = icmp eq ptr %93, @"*_llgo_go/ast.SelectorExpr"
+  br i1 %94, label %_llgo_253, label %_llgo_254
+
+_llgo_93:                                         ; preds = %_llgo_255
+  ret i64 35184372088832
+
+_llgo_94:                                         ; preds = %_llgo_255
+  %95 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %96 = icmp eq ptr %95, @"*_llgo_go/ast.SendStmt"
+  br i1 %96, label %_llgo_256, label %_llgo_257
+
+_llgo_95:                                         ; preds = %_llgo_258
+  ret i64 70368744177664
+
+_llgo_96:                                         ; preds = %_llgo_258
+  %97 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %98 = icmp eq ptr %97, @"*_llgo_go/ast.SliceExpr"
+  br i1 %98, label %_llgo_259, label %_llgo_260
+
+_llgo_97:                                         ; preds = %_llgo_261
+  ret i64 140737488355328
+
+_llgo_98:                                         ; preds = %_llgo_261
+  %99 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %100 = icmp eq ptr %99, @"*_llgo_go/ast.StarExpr"
+  br i1 %100, label %_llgo_262, label %_llgo_263
+
+_llgo_99:                                         ; preds = %_llgo_264
+  ret i64 281474976710656
+
+_llgo_100:                                        ; preds = %_llgo_264
+  %101 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %102 = icmp eq ptr %101, @"*_llgo_go/ast.StructType"
+  br i1 %102, label %_llgo_265, label %_llgo_266
+
+_llgo_101:                                        ; preds = %_llgo_267
+  ret i64 562949953421312
+
+_llgo_102:                                        ; preds = %_llgo_267
+  %103 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %104 = icmp eq ptr %103, @"*_llgo_go/ast.SwitchStmt"
+  br i1 %104, label %_llgo_268, label %_llgo_269
+
+_llgo_103:                                        ; preds = %_llgo_270
+  ret i64 1125899906842624
+
+_llgo_104:                                        ; preds = %_llgo_270
+  %105 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %106 = icmp eq ptr %105, @"*_llgo_go/ast.TypeAssertExpr"
+  br i1 %106, label %_llgo_271, label %_llgo_272
+
+_llgo_105:                                        ; preds = %_llgo_273
+  ret i64 2251799813685248
+
+_llgo_106:                                        ; preds = %_llgo_273
+  %107 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %108 = icmp eq ptr %107, @"*_llgo_go/ast.TypeSpec"
+  br i1 %108, label %_llgo_274, label %_llgo_275
+
+_llgo_107:                                        ; preds = %_llgo_276
+  ret i64 4503599627370496
+
+_llgo_108:                                        ; preds = %_llgo_276
+  %109 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %110 = icmp eq ptr %109, @"*_llgo_go/ast.TypeSwitchStmt"
+  br i1 %110, label %_llgo_277, label %_llgo_278
+
+_llgo_109:                                        ; preds = %_llgo_279
+  ret i64 9007199254740992
+
+_llgo_110:                                        ; preds = %_llgo_279
+  %111 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %112 = icmp eq ptr %111, @"*_llgo_go/ast.UnaryExpr"
+  br i1 %112, label %_llgo_280, label %_llgo_281
+
+_llgo_111:                                        ; preds = %_llgo_282
+  ret i64 18014398509481984
+
+_llgo_112:                                        ; preds = %_llgo_282
+  %113 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %114 = icmp eq ptr %113, @"*_llgo_go/ast.ValueSpec"
+  br i1 %114, label %_llgo_283, label %_llgo_284
+
+_llgo_113:                                        ; preds = %_llgo_285
+  ret i64 36028797018963968
+
+_llgo_114:                                        ; preds = %_llgo_285
+  ret i64 0
+
+_llgo_115:                                        ; preds = %_llgo_0
+  %115 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %116 = insertvalue { ptr, i1 } undef, ptr %115, 0
+  %117 = insertvalue { ptr, i1 } %116, i1 true, 1
+  br label %_llgo_117
+
+_llgo_116:                                        ; preds = %_llgo_0
+  br label %_llgo_117
+
+_llgo_117:                                        ; preds = %_llgo_116, %_llgo_115
+  %118 = phi { ptr, i1 } [ %117, %_llgo_115 ], [ zeroinitializer, %_llgo_116 ]
+  %119 = extractvalue { ptr, i1 } %118, 0
+  %120 = extractvalue { ptr, i1 } %118, 1
+  br i1 %120, label %_llgo_1, label %_llgo_2
+
+_llgo_118:                                        ; preds = %_llgo_2
+  %121 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %122 = insertvalue { ptr, i1 } undef, ptr %121, 0
+  %123 = insertvalue { ptr, i1 } %122, i1 true, 1
+  br label %_llgo_120
+
+_llgo_119:                                        ; preds = %_llgo_2
+  br label %_llgo_120
+
+_llgo_120:                                        ; preds = %_llgo_119, %_llgo_118
+  %124 = phi { ptr, i1 } [ %123, %_llgo_118 ], [ zeroinitializer, %_llgo_119 ]
+  %125 = extractvalue { ptr, i1 } %124, 0
+  %126 = extractvalue { ptr, i1 } %124, 1
+  br i1 %126, label %_llgo_3, label %_llgo_4
+
+_llgo_121:                                        ; preds = %_llgo_4
+  %127 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %128 = insertvalue { ptr, i1 } undef, ptr %127, 0
+  %129 = insertvalue { ptr, i1 } %128, i1 true, 1
+  br label %_llgo_123
+
+_llgo_122:                                        ; preds = %_llgo_4
+  br label %_llgo_123
+
+_llgo_123:                                        ; preds = %_llgo_122, %_llgo_121
+  %130 = phi { ptr, i1 } [ %129, %_llgo_121 ], [ zeroinitializer, %_llgo_122 ]
+  %131 = extractvalue { ptr, i1 } %130, 0
+  %132 = extractvalue { ptr, i1 } %130, 1
+  br i1 %132, label %_llgo_5, label %_llgo_6
+
+_llgo_124:                                        ; preds = %_llgo_6
+  %133 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %134 = insertvalue { ptr, i1 } undef, ptr %133, 0
+  %135 = insertvalue { ptr, i1 } %134, i1 true, 1
+  br label %_llgo_126
+
+_llgo_125:                                        ; preds = %_llgo_6
+  br label %_llgo_126
+
+_llgo_126:                                        ; preds = %_llgo_125, %_llgo_124
+  %136 = phi { ptr, i1 } [ %135, %_llgo_124 ], [ zeroinitializer, %_llgo_125 ]
+  %137 = extractvalue { ptr, i1 } %136, 0
+  %138 = extractvalue { ptr, i1 } %136, 1
+  br i1 %138, label %_llgo_7, label %_llgo_8
+
+_llgo_127:                                        ; preds = %_llgo_8
+  %139 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %140 = insertvalue { ptr, i1 } undef, ptr %139, 0
+  %141 = insertvalue { ptr, i1 } %140, i1 true, 1
+  br label %_llgo_129
+
+_llgo_128:                                        ; preds = %_llgo_8
+  br label %_llgo_129
+
+_llgo_129:                                        ; preds = %_llgo_128, %_llgo_127
+  %142 = phi { ptr, i1 } [ %141, %_llgo_127 ], [ zeroinitializer, %_llgo_128 ]
+  %143 = extractvalue { ptr, i1 } %142, 0
+  %144 = extractvalue { ptr, i1 } %142, 1
+  br i1 %144, label %_llgo_9, label %_llgo_10
+
+_llgo_130:                                        ; preds = %_llgo_10
+  %145 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %146 = insertvalue { ptr, i1 } undef, ptr %145, 0
+  %147 = insertvalue { ptr, i1 } %146, i1 true, 1
+  br label %_llgo_132
+
+_llgo_131:                                        ; preds = %_llgo_10
+  br label %_llgo_132
+
+_llgo_132:                                        ; preds = %_llgo_131, %_llgo_130
+  %148 = phi { ptr, i1 } [ %147, %_llgo_130 ], [ zeroinitializer, %_llgo_131 ]
+  %149 = extractvalue { ptr, i1 } %148, 0
+  %150 = extractvalue { ptr, i1 } %148, 1
+  br i1 %150, label %_llgo_11, label %_llgo_12
+
+_llgo_133:                                        ; preds = %_llgo_12
+  %151 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %152 = insertvalue { ptr, i1 } undef, ptr %151, 0
+  %153 = insertvalue { ptr, i1 } %152, i1 true, 1
+  br label %_llgo_135
+
+_llgo_134:                                        ; preds = %_llgo_12
+  br label %_llgo_135
+
+_llgo_135:                                        ; preds = %_llgo_134, %_llgo_133
+  %154 = phi { ptr, i1 } [ %153, %_llgo_133 ], [ zeroinitializer, %_llgo_134 ]
+  %155 = extractvalue { ptr, i1 } %154, 0
+  %156 = extractvalue { ptr, i1 } %154, 1
+  br i1 %156, label %_llgo_13, label %_llgo_14
+
+_llgo_136:                                        ; preds = %_llgo_14
+  %157 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %158 = insertvalue { ptr, i1 } undef, ptr %157, 0
+  %159 = insertvalue { ptr, i1 } %158, i1 true, 1
+  br label %_llgo_138
+
+_llgo_137:                                        ; preds = %_llgo_14
+  br label %_llgo_138
+
+_llgo_138:                                        ; preds = %_llgo_137, %_llgo_136
+  %160 = phi { ptr, i1 } [ %159, %_llgo_136 ], [ zeroinitializer, %_llgo_137 ]
+  %161 = extractvalue { ptr, i1 } %160, 0
+  %162 = extractvalue { ptr, i1 } %160, 1
+  br i1 %162, label %_llgo_15, label %_llgo_16
+
+_llgo_139:                                        ; preds = %_llgo_16
+  %163 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %164 = insertvalue { ptr, i1 } undef, ptr %163, 0
+  %165 = insertvalue { ptr, i1 } %164, i1 true, 1
+  br label %_llgo_141
+
+_llgo_140:                                        ; preds = %_llgo_16
+  br label %_llgo_141
+
+_llgo_141:                                        ; preds = %_llgo_140, %_llgo_139
+  %166 = phi { ptr, i1 } [ %165, %_llgo_139 ], [ zeroinitializer, %_llgo_140 ]
+  %167 = extractvalue { ptr, i1 } %166, 0
+  %168 = extractvalue { ptr, i1 } %166, 1
+  br i1 %168, label %_llgo_17, label %_llgo_18
+
+_llgo_142:                                        ; preds = %_llgo_18
+  %169 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %170 = insertvalue { ptr, i1 } undef, ptr %169, 0
+  %171 = insertvalue { ptr, i1 } %170, i1 true, 1
+  br label %_llgo_144
+
+_llgo_143:                                        ; preds = %_llgo_18
+  br label %_llgo_144
+
+_llgo_144:                                        ; preds = %_llgo_143, %_llgo_142
+  %172 = phi { ptr, i1 } [ %171, %_llgo_142 ], [ zeroinitializer, %_llgo_143 ]
+  %173 = extractvalue { ptr, i1 } %172, 0
+  %174 = extractvalue { ptr, i1 } %172, 1
+  br i1 %174, label %_llgo_19, label %_llgo_20
+
+_llgo_145:                                        ; preds = %_llgo_20
+  %175 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %176 = insertvalue { ptr, i1 } undef, ptr %175, 0
+  %177 = insertvalue { ptr, i1 } %176, i1 true, 1
+  br label %_llgo_147
+
+_llgo_146:                                        ; preds = %_llgo_20
+  br label %_llgo_147
+
+_llgo_147:                                        ; preds = %_llgo_146, %_llgo_145
+  %178 = phi { ptr, i1 } [ %177, %_llgo_145 ], [ zeroinitializer, %_llgo_146 ]
+  %179 = extractvalue { ptr, i1 } %178, 0
+  %180 = extractvalue { ptr, i1 } %178, 1
+  br i1 %180, label %_llgo_21, label %_llgo_22
+
+_llgo_148:                                        ; preds = %_llgo_22
+  %181 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %182 = insertvalue { ptr, i1 } undef, ptr %181, 0
+  %183 = insertvalue { ptr, i1 } %182, i1 true, 1
+  br label %_llgo_150
+
+_llgo_149:                                        ; preds = %_llgo_22
+  br label %_llgo_150
+
+_llgo_150:                                        ; preds = %_llgo_149, %_llgo_148
+  %184 = phi { ptr, i1 } [ %183, %_llgo_148 ], [ zeroinitializer, %_llgo_149 ]
+  %185 = extractvalue { ptr, i1 } %184, 0
+  %186 = extractvalue { ptr, i1 } %184, 1
+  br i1 %186, label %_llgo_23, label %_llgo_24
+
+_llgo_151:                                        ; preds = %_llgo_24
+  %187 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %188 = insertvalue { ptr, i1 } undef, ptr %187, 0
+  %189 = insertvalue { ptr, i1 } %188, i1 true, 1
+  br label %_llgo_153
+
+_llgo_152:                                        ; preds = %_llgo_24
+  br label %_llgo_153
+
+_llgo_153:                                        ; preds = %_llgo_152, %_llgo_151
+  %190 = phi { ptr, i1 } [ %189, %_llgo_151 ], [ zeroinitializer, %_llgo_152 ]
+  %191 = extractvalue { ptr, i1 } %190, 0
+  %192 = extractvalue { ptr, i1 } %190, 1
+  br i1 %192, label %_llgo_25, label %_llgo_26
+
+_llgo_154:                                        ; preds = %_llgo_26
+  %193 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %194 = insertvalue { ptr, i1 } undef, ptr %193, 0
+  %195 = insertvalue { ptr, i1 } %194, i1 true, 1
+  br label %_llgo_156
+
+_llgo_155:                                        ; preds = %_llgo_26
+  br label %_llgo_156
+
+_llgo_156:                                        ; preds = %_llgo_155, %_llgo_154
+  %196 = phi { ptr, i1 } [ %195, %_llgo_154 ], [ zeroinitializer, %_llgo_155 ]
+  %197 = extractvalue { ptr, i1 } %196, 0
+  %198 = extractvalue { ptr, i1 } %196, 1
+  br i1 %198, label %_llgo_27, label %_llgo_28
+
+_llgo_157:                                        ; preds = %_llgo_28
+  %199 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %200 = insertvalue { ptr, i1 } undef, ptr %199, 0
+  %201 = insertvalue { ptr, i1 } %200, i1 true, 1
+  br label %_llgo_159
+
+_llgo_158:                                        ; preds = %_llgo_28
+  br label %_llgo_159
+
+_llgo_159:                                        ; preds = %_llgo_158, %_llgo_157
+  %202 = phi { ptr, i1 } [ %201, %_llgo_157 ], [ zeroinitializer, %_llgo_158 ]
+  %203 = extractvalue { ptr, i1 } %202, 0
+  %204 = extractvalue { ptr, i1 } %202, 1
+  br i1 %204, label %_llgo_29, label %_llgo_30
+
+_llgo_160:                                        ; preds = %_llgo_30
+  %205 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %206 = insertvalue { ptr, i1 } undef, ptr %205, 0
+  %207 = insertvalue { ptr, i1 } %206, i1 true, 1
+  br label %_llgo_162
+
+_llgo_161:                                        ; preds = %_llgo_30
+  br label %_llgo_162
+
+_llgo_162:                                        ; preds = %_llgo_161, %_llgo_160
+  %208 = phi { ptr, i1 } [ %207, %_llgo_160 ], [ zeroinitializer, %_llgo_161 ]
+  %209 = extractvalue { ptr, i1 } %208, 0
+  %210 = extractvalue { ptr, i1 } %208, 1
+  br i1 %210, label %_llgo_31, label %_llgo_32
+
+_llgo_163:                                        ; preds = %_llgo_32
+  %211 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %212 = insertvalue { ptr, i1 } undef, ptr %211, 0
+  %213 = insertvalue { ptr, i1 } %212, i1 true, 1
+  br label %_llgo_165
+
+_llgo_164:                                        ; preds = %_llgo_32
+  br label %_llgo_165
+
+_llgo_165:                                        ; preds = %_llgo_164, %_llgo_163
+  %214 = phi { ptr, i1 } [ %213, %_llgo_163 ], [ zeroinitializer, %_llgo_164 ]
+  %215 = extractvalue { ptr, i1 } %214, 0
+  %216 = extractvalue { ptr, i1 } %214, 1
+  br i1 %216, label %_llgo_33, label %_llgo_34
+
+_llgo_166:                                        ; preds = %_llgo_34
+  %217 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %218 = insertvalue { ptr, i1 } undef, ptr %217, 0
+  %219 = insertvalue { ptr, i1 } %218, i1 true, 1
+  br label %_llgo_168
+
+_llgo_167:                                        ; preds = %_llgo_34
+  br label %_llgo_168
+
+_llgo_168:                                        ; preds = %_llgo_167, %_llgo_166
+  %220 = phi { ptr, i1 } [ %219, %_llgo_166 ], [ zeroinitializer, %_llgo_167 ]
+  %221 = extractvalue { ptr, i1 } %220, 0
+  %222 = extractvalue { ptr, i1 } %220, 1
+  br i1 %222, label %_llgo_35, label %_llgo_36
+
+_llgo_169:                                        ; preds = %_llgo_36
+  %223 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %224 = insertvalue { ptr, i1 } undef, ptr %223, 0
+  %225 = insertvalue { ptr, i1 } %224, i1 true, 1
+  br label %_llgo_171
+
+_llgo_170:                                        ; preds = %_llgo_36
+  br label %_llgo_171
+
+_llgo_171:                                        ; preds = %_llgo_170, %_llgo_169
+  %226 = phi { ptr, i1 } [ %225, %_llgo_169 ], [ zeroinitializer, %_llgo_170 ]
+  %227 = extractvalue { ptr, i1 } %226, 0
+  %228 = extractvalue { ptr, i1 } %226, 1
+  br i1 %228, label %_llgo_37, label %_llgo_38
+
+_llgo_172:                                        ; preds = %_llgo_38
+  %229 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %230 = insertvalue { ptr, i1 } undef, ptr %229, 0
+  %231 = insertvalue { ptr, i1 } %230, i1 true, 1
+  br label %_llgo_174
+
+_llgo_173:                                        ; preds = %_llgo_38
+  br label %_llgo_174
+
+_llgo_174:                                        ; preds = %_llgo_173, %_llgo_172
+  %232 = phi { ptr, i1 } [ %231, %_llgo_172 ], [ zeroinitializer, %_llgo_173 ]
+  %233 = extractvalue { ptr, i1 } %232, 0
+  %234 = extractvalue { ptr, i1 } %232, 1
+  br i1 %234, label %_llgo_39, label %_llgo_40
+
+_llgo_175:                                        ; preds = %_llgo_40
+  %235 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %236 = insertvalue { ptr, i1 } undef, ptr %235, 0
+  %237 = insertvalue { ptr, i1 } %236, i1 true, 1
+  br label %_llgo_177
+
+_llgo_176:                                        ; preds = %_llgo_40
+  br label %_llgo_177
+
+_llgo_177:                                        ; preds = %_llgo_176, %_llgo_175
+  %238 = phi { ptr, i1 } [ %237, %_llgo_175 ], [ zeroinitializer, %_llgo_176 ]
+  %239 = extractvalue { ptr, i1 } %238, 0
+  %240 = extractvalue { ptr, i1 } %238, 1
+  br i1 %240, label %_llgo_41, label %_llgo_42
+
+_llgo_178:                                        ; preds = %_llgo_42
+  %241 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %242 = insertvalue { ptr, i1 } undef, ptr %241, 0
+  %243 = insertvalue { ptr, i1 } %242, i1 true, 1
+  br label %_llgo_180
+
+_llgo_179:                                        ; preds = %_llgo_42
+  br label %_llgo_180
+
+_llgo_180:                                        ; preds = %_llgo_179, %_llgo_178
+  %244 = phi { ptr, i1 } [ %243, %_llgo_178 ], [ zeroinitializer, %_llgo_179 ]
+  %245 = extractvalue { ptr, i1 } %244, 0
+  %246 = extractvalue { ptr, i1 } %244, 1
+  br i1 %246, label %_llgo_43, label %_llgo_44
+
+_llgo_181:                                        ; preds = %_llgo_44
+  %247 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %248 = insertvalue { ptr, i1 } undef, ptr %247, 0
+  %249 = insertvalue { ptr, i1 } %248, i1 true, 1
+  br label %_llgo_183
+
+_llgo_182:                                        ; preds = %_llgo_44
+  br label %_llgo_183
+
+_llgo_183:                                        ; preds = %_llgo_182, %_llgo_181
+  %250 = phi { ptr, i1 } [ %249, %_llgo_181 ], [ zeroinitializer, %_llgo_182 ]
+  %251 = extractvalue { ptr, i1 } %250, 0
+  %252 = extractvalue { ptr, i1 } %250, 1
+  br i1 %252, label %_llgo_45, label %_llgo_46
+
+_llgo_184:                                        ; preds = %_llgo_46
+  %253 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %254 = insertvalue { ptr, i1 } undef, ptr %253, 0
+  %255 = insertvalue { ptr, i1 } %254, i1 true, 1
+  br label %_llgo_186
+
+_llgo_185:                                        ; preds = %_llgo_46
+  br label %_llgo_186
+
+_llgo_186:                                        ; preds = %_llgo_185, %_llgo_184
+  %256 = phi { ptr, i1 } [ %255, %_llgo_184 ], [ zeroinitializer, %_llgo_185 ]
+  %257 = extractvalue { ptr, i1 } %256, 0
+  %258 = extractvalue { ptr, i1 } %256, 1
+  br i1 %258, label %_llgo_47, label %_llgo_48
+
+_llgo_187:                                        ; preds = %_llgo_48
+  %259 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %260 = insertvalue { ptr, i1 } undef, ptr %259, 0
+  %261 = insertvalue { ptr, i1 } %260, i1 true, 1
+  br label %_llgo_189
+
+_llgo_188:                                        ; preds = %_llgo_48
+  br label %_llgo_189
+
+_llgo_189:                                        ; preds = %_llgo_188, %_llgo_187
+  %262 = phi { ptr, i1 } [ %261, %_llgo_187 ], [ zeroinitializer, %_llgo_188 ]
+  %263 = extractvalue { ptr, i1 } %262, 0
+  %264 = extractvalue { ptr, i1 } %262, 1
+  br i1 %264, label %_llgo_49, label %_llgo_50
+
+_llgo_190:                                        ; preds = %_llgo_50
+  %265 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %266 = insertvalue { ptr, i1 } undef, ptr %265, 0
+  %267 = insertvalue { ptr, i1 } %266, i1 true, 1
+  br label %_llgo_192
+
+_llgo_191:                                        ; preds = %_llgo_50
+  br label %_llgo_192
+
+_llgo_192:                                        ; preds = %_llgo_191, %_llgo_190
+  %268 = phi { ptr, i1 } [ %267, %_llgo_190 ], [ zeroinitializer, %_llgo_191 ]
+  %269 = extractvalue { ptr, i1 } %268, 0
+  %270 = extractvalue { ptr, i1 } %268, 1
+  br i1 %270, label %_llgo_51, label %_llgo_52
+
+_llgo_193:                                        ; preds = %_llgo_52
+  %271 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %272 = insertvalue { ptr, i1 } undef, ptr %271, 0
+  %273 = insertvalue { ptr, i1 } %272, i1 true, 1
+  br label %_llgo_195
+
+_llgo_194:                                        ; preds = %_llgo_52
+  br label %_llgo_195
+
+_llgo_195:                                        ; preds = %_llgo_194, %_llgo_193
+  %274 = phi { ptr, i1 } [ %273, %_llgo_193 ], [ zeroinitializer, %_llgo_194 ]
+  %275 = extractvalue { ptr, i1 } %274, 0
+  %276 = extractvalue { ptr, i1 } %274, 1
+  br i1 %276, label %_llgo_53, label %_llgo_54
+
+_llgo_196:                                        ; preds = %_llgo_54
+  %277 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %278 = insertvalue { ptr, i1 } undef, ptr %277, 0
+  %279 = insertvalue { ptr, i1 } %278, i1 true, 1
+  br label %_llgo_198
+
+_llgo_197:                                        ; preds = %_llgo_54
+  br label %_llgo_198
+
+_llgo_198:                                        ; preds = %_llgo_197, %_llgo_196
+  %280 = phi { ptr, i1 } [ %279, %_llgo_196 ], [ zeroinitializer, %_llgo_197 ]
+  %281 = extractvalue { ptr, i1 } %280, 0
+  %282 = extractvalue { ptr, i1 } %280, 1
+  br i1 %282, label %_llgo_55, label %_llgo_56
+
+_llgo_199:                                        ; preds = %_llgo_56
+  %283 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %284 = insertvalue { ptr, i1 } undef, ptr %283, 0
+  %285 = insertvalue { ptr, i1 } %284, i1 true, 1
+  br label %_llgo_201
+
+_llgo_200:                                        ; preds = %_llgo_56
+  br label %_llgo_201
+
+_llgo_201:                                        ; preds = %_llgo_200, %_llgo_199
+  %286 = phi { ptr, i1 } [ %285, %_llgo_199 ], [ zeroinitializer, %_llgo_200 ]
+  %287 = extractvalue { ptr, i1 } %286, 0
+  %288 = extractvalue { ptr, i1 } %286, 1
+  br i1 %288, label %_llgo_57, label %_llgo_58
+
+_llgo_202:                                        ; preds = %_llgo_58
+  %289 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %290 = insertvalue { ptr, i1 } undef, ptr %289, 0
+  %291 = insertvalue { ptr, i1 } %290, i1 true, 1
+  br label %_llgo_204
+
+_llgo_203:                                        ; preds = %_llgo_58
+  br label %_llgo_204
+
+_llgo_204:                                        ; preds = %_llgo_203, %_llgo_202
+  %292 = phi { ptr, i1 } [ %291, %_llgo_202 ], [ zeroinitializer, %_llgo_203 ]
+  %293 = extractvalue { ptr, i1 } %292, 0
+  %294 = extractvalue { ptr, i1 } %292, 1
+  br i1 %294, label %_llgo_59, label %_llgo_60
+
+_llgo_205:                                        ; preds = %_llgo_60
+  %295 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %296 = insertvalue { ptr, i1 } undef, ptr %295, 0
+  %297 = insertvalue { ptr, i1 } %296, i1 true, 1
+  br label %_llgo_207
+
+_llgo_206:                                        ; preds = %_llgo_60
+  br label %_llgo_207
+
+_llgo_207:                                        ; preds = %_llgo_206, %_llgo_205
+  %298 = phi { ptr, i1 } [ %297, %_llgo_205 ], [ zeroinitializer, %_llgo_206 ]
+  %299 = extractvalue { ptr, i1 } %298, 0
+  %300 = extractvalue { ptr, i1 } %298, 1
+  br i1 %300, label %_llgo_61, label %_llgo_62
+
+_llgo_208:                                        ; preds = %_llgo_62
+  %301 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %302 = insertvalue { ptr, i1 } undef, ptr %301, 0
+  %303 = insertvalue { ptr, i1 } %302, i1 true, 1
+  br label %_llgo_210
+
+_llgo_209:                                        ; preds = %_llgo_62
+  br label %_llgo_210
+
+_llgo_210:                                        ; preds = %_llgo_209, %_llgo_208
+  %304 = phi { ptr, i1 } [ %303, %_llgo_208 ], [ zeroinitializer, %_llgo_209 ]
+  %305 = extractvalue { ptr, i1 } %304, 0
+  %306 = extractvalue { ptr, i1 } %304, 1
+  br i1 %306, label %_llgo_63, label %_llgo_64
+
+_llgo_211:                                        ; preds = %_llgo_64
+  %307 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %308 = insertvalue { ptr, i1 } undef, ptr %307, 0
+  %309 = insertvalue { ptr, i1 } %308, i1 true, 1
+  br label %_llgo_213
+
+_llgo_212:                                        ; preds = %_llgo_64
+  br label %_llgo_213
+
+_llgo_213:                                        ; preds = %_llgo_212, %_llgo_211
+  %310 = phi { ptr, i1 } [ %309, %_llgo_211 ], [ zeroinitializer, %_llgo_212 ]
+  %311 = extractvalue { ptr, i1 } %310, 0
+  %312 = extractvalue { ptr, i1 } %310, 1
+  br i1 %312, label %_llgo_65, label %_llgo_66
+
+_llgo_214:                                        ; preds = %_llgo_66
+  %313 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %314 = insertvalue { ptr, i1 } undef, ptr %313, 0
+  %315 = insertvalue { ptr, i1 } %314, i1 true, 1
+  br label %_llgo_216
+
+_llgo_215:                                        ; preds = %_llgo_66
+  br label %_llgo_216
+
+_llgo_216:                                        ; preds = %_llgo_215, %_llgo_214
+  %316 = phi { ptr, i1 } [ %315, %_llgo_214 ], [ zeroinitializer, %_llgo_215 ]
+  %317 = extractvalue { ptr, i1 } %316, 0
+  %318 = extractvalue { ptr, i1 } %316, 1
+  br i1 %318, label %_llgo_67, label %_llgo_68
+
+_llgo_217:                                        ; preds = %_llgo_68
+  %319 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %320 = insertvalue { ptr, i1 } undef, ptr %319, 0
+  %321 = insertvalue { ptr, i1 } %320, i1 true, 1
+  br label %_llgo_219
+
+_llgo_218:                                        ; preds = %_llgo_68
+  br label %_llgo_219
+
+_llgo_219:                                        ; preds = %_llgo_218, %_llgo_217
+  %322 = phi { ptr, i1 } [ %321, %_llgo_217 ], [ zeroinitializer, %_llgo_218 ]
+  %323 = extractvalue { ptr, i1 } %322, 0
+  %324 = extractvalue { ptr, i1 } %322, 1
+  br i1 %324, label %_llgo_69, label %_llgo_70
+
+_llgo_220:                                        ; preds = %_llgo_70
+  %325 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %326 = insertvalue { ptr, i1 } undef, ptr %325, 0
+  %327 = insertvalue { ptr, i1 } %326, i1 true, 1
+  br label %_llgo_222
+
+_llgo_221:                                        ; preds = %_llgo_70
+  br label %_llgo_222
+
+_llgo_222:                                        ; preds = %_llgo_221, %_llgo_220
+  %328 = phi { ptr, i1 } [ %327, %_llgo_220 ], [ zeroinitializer, %_llgo_221 ]
+  %329 = extractvalue { ptr, i1 } %328, 0
+  %330 = extractvalue { ptr, i1 } %328, 1
+  br i1 %330, label %_llgo_71, label %_llgo_72
+
+_llgo_223:                                        ; preds = %_llgo_72
+  %331 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %332 = insertvalue { ptr, i1 } undef, ptr %331, 0
+  %333 = insertvalue { ptr, i1 } %332, i1 true, 1
+  br label %_llgo_225
+
+_llgo_224:                                        ; preds = %_llgo_72
+  br label %_llgo_225
+
+_llgo_225:                                        ; preds = %_llgo_224, %_llgo_223
+  %334 = phi { ptr, i1 } [ %333, %_llgo_223 ], [ zeroinitializer, %_llgo_224 ]
+  %335 = extractvalue { ptr, i1 } %334, 0
+  %336 = extractvalue { ptr, i1 } %334, 1
+  br i1 %336, label %_llgo_73, label %_llgo_74
+
+_llgo_226:                                        ; preds = %_llgo_74
+  %337 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %338 = insertvalue { ptr, i1 } undef, ptr %337, 0
+  %339 = insertvalue { ptr, i1 } %338, i1 true, 1
+  br label %_llgo_228
+
+_llgo_227:                                        ; preds = %_llgo_74
+  br label %_llgo_228
+
+_llgo_228:                                        ; preds = %_llgo_227, %_llgo_226
+  %340 = phi { ptr, i1 } [ %339, %_llgo_226 ], [ zeroinitializer, %_llgo_227 ]
+  %341 = extractvalue { ptr, i1 } %340, 0
+  %342 = extractvalue { ptr, i1 } %340, 1
+  br i1 %342, label %_llgo_75, label %_llgo_76
+
+_llgo_229:                                        ; preds = %_llgo_76
+  %343 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %344 = insertvalue { ptr, i1 } undef, ptr %343, 0
+  %345 = insertvalue { ptr, i1 } %344, i1 true, 1
+  br label %_llgo_231
+
+_llgo_230:                                        ; preds = %_llgo_76
+  br label %_llgo_231
+
+_llgo_231:                                        ; preds = %_llgo_230, %_llgo_229
+  %346 = phi { ptr, i1 } [ %345, %_llgo_229 ], [ zeroinitializer, %_llgo_230 ]
+  %347 = extractvalue { ptr, i1 } %346, 0
+  %348 = extractvalue { ptr, i1 } %346, 1
+  br i1 %348, label %_llgo_77, label %_llgo_78
+
+_llgo_232:                                        ; preds = %_llgo_78
+  %349 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %350 = insertvalue { ptr, i1 } undef, ptr %349, 0
+  %351 = insertvalue { ptr, i1 } %350, i1 true, 1
+  br label %_llgo_234
+
+_llgo_233:                                        ; preds = %_llgo_78
+  br label %_llgo_234
+
+_llgo_234:                                        ; preds = %_llgo_233, %_llgo_232
+  %352 = phi { ptr, i1 } [ %351, %_llgo_232 ], [ zeroinitializer, %_llgo_233 ]
+  %353 = extractvalue { ptr, i1 } %352, 0
+  %354 = extractvalue { ptr, i1 } %352, 1
+  br i1 %354, label %_llgo_79, label %_llgo_80
+
+_llgo_235:                                        ; preds = %_llgo_80
+  %355 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %356 = insertvalue { ptr, i1 } undef, ptr %355, 0
+  %357 = insertvalue { ptr, i1 } %356, i1 true, 1
+  br label %_llgo_237
+
+_llgo_236:                                        ; preds = %_llgo_80
+  br label %_llgo_237
+
+_llgo_237:                                        ; preds = %_llgo_236, %_llgo_235
+  %358 = phi { ptr, i1 } [ %357, %_llgo_235 ], [ zeroinitializer, %_llgo_236 ]
+  %359 = extractvalue { ptr, i1 } %358, 0
+  %360 = extractvalue { ptr, i1 } %358, 1
+  br i1 %360, label %_llgo_81, label %_llgo_82
+
+_llgo_238:                                        ; preds = %_llgo_82
+  %361 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %362 = insertvalue { ptr, i1 } undef, ptr %361, 0
+  %363 = insertvalue { ptr, i1 } %362, i1 true, 1
+  br label %_llgo_240
+
+_llgo_239:                                        ; preds = %_llgo_82
+  br label %_llgo_240
+
+_llgo_240:                                        ; preds = %_llgo_239, %_llgo_238
+  %364 = phi { ptr, i1 } [ %363, %_llgo_238 ], [ zeroinitializer, %_llgo_239 ]
+  %365 = extractvalue { ptr, i1 } %364, 0
+  %366 = extractvalue { ptr, i1 } %364, 1
+  br i1 %366, label %_llgo_83, label %_llgo_84
+
+_llgo_241:                                        ; preds = %_llgo_84
+  %367 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %368 = insertvalue { ptr, i1 } undef, ptr %367, 0
+  %369 = insertvalue { ptr, i1 } %368, i1 true, 1
+  br label %_llgo_243
+
+_llgo_242:                                        ; preds = %_llgo_84
+  br label %_llgo_243
+
+_llgo_243:                                        ; preds = %_llgo_242, %_llgo_241
+  %370 = phi { ptr, i1 } [ %369, %_llgo_241 ], [ zeroinitializer, %_llgo_242 ]
+  %371 = extractvalue { ptr, i1 } %370, 0
+  %372 = extractvalue { ptr, i1 } %370, 1
+  br i1 %372, label %_llgo_85, label %_llgo_86
+
+_llgo_244:                                        ; preds = %_llgo_86
+  %373 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %374 = insertvalue { ptr, i1 } undef, ptr %373, 0
+  %375 = insertvalue { ptr, i1 } %374, i1 true, 1
+  br label %_llgo_246
+
+_llgo_245:                                        ; preds = %_llgo_86
+  br label %_llgo_246
+
+_llgo_246:                                        ; preds = %_llgo_245, %_llgo_244
+  %376 = phi { ptr, i1 } [ %375, %_llgo_244 ], [ zeroinitializer, %_llgo_245 ]
+  %377 = extractvalue { ptr, i1 } %376, 0
+  %378 = extractvalue { ptr, i1 } %376, 1
+  br i1 %378, label %_llgo_87, label %_llgo_88
+
+_llgo_247:                                        ; preds = %_llgo_88
+  %379 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %380 = insertvalue { ptr, i1 } undef, ptr %379, 0
+  %381 = insertvalue { ptr, i1 } %380, i1 true, 1
+  br label %_llgo_249
+
+_llgo_248:                                        ; preds = %_llgo_88
+  br label %_llgo_249
+
+_llgo_249:                                        ; preds = %_llgo_248, %_llgo_247
+  %382 = phi { ptr, i1 } [ %381, %_llgo_247 ], [ zeroinitializer, %_llgo_248 ]
+  %383 = extractvalue { ptr, i1 } %382, 0
+  %384 = extractvalue { ptr, i1 } %382, 1
+  br i1 %384, label %_llgo_89, label %_llgo_90
+
+_llgo_250:                                        ; preds = %_llgo_90
+  %385 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %386 = insertvalue { ptr, i1 } undef, ptr %385, 0
+  %387 = insertvalue { ptr, i1 } %386, i1 true, 1
+  br label %_llgo_252
+
+_llgo_251:                                        ; preds = %_llgo_90
+  br label %_llgo_252
+
+_llgo_252:                                        ; preds = %_llgo_251, %_llgo_250
+  %388 = phi { ptr, i1 } [ %387, %_llgo_250 ], [ zeroinitializer, %_llgo_251 ]
+  %389 = extractvalue { ptr, i1 } %388, 0
+  %390 = extractvalue { ptr, i1 } %388, 1
+  br i1 %390, label %_llgo_91, label %_llgo_92
+
+_llgo_253:                                        ; preds = %_llgo_92
+  %391 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %392 = insertvalue { ptr, i1 } undef, ptr %391, 0
+  %393 = insertvalue { ptr, i1 } %392, i1 true, 1
+  br label %_llgo_255
+
+_llgo_254:                                        ; preds = %_llgo_92
+  br label %_llgo_255
+
+_llgo_255:                                        ; preds = %_llgo_254, %_llgo_253
+  %394 = phi { ptr, i1 } [ %393, %_llgo_253 ], [ zeroinitializer, %_llgo_254 ]
+  %395 = extractvalue { ptr, i1 } %394, 0
+  %396 = extractvalue { ptr, i1 } %394, 1
+  br i1 %396, label %_llgo_93, label %_llgo_94
+
+_llgo_256:                                        ; preds = %_llgo_94
+  %397 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %398 = insertvalue { ptr, i1 } undef, ptr %397, 0
+  %399 = insertvalue { ptr, i1 } %398, i1 true, 1
+  br label %_llgo_258
+
+_llgo_257:                                        ; preds = %_llgo_94
+  br label %_llgo_258
+
+_llgo_258:                                        ; preds = %_llgo_257, %_llgo_256
+  %400 = phi { ptr, i1 } [ %399, %_llgo_256 ], [ zeroinitializer, %_llgo_257 ]
+  %401 = extractvalue { ptr, i1 } %400, 0
+  %402 = extractvalue { ptr, i1 } %400, 1
+  br i1 %402, label %_llgo_95, label %_llgo_96
+
+_llgo_259:                                        ; preds = %_llgo_96
+  %403 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %404 = insertvalue { ptr, i1 } undef, ptr %403, 0
+  %405 = insertvalue { ptr, i1 } %404, i1 true, 1
+  br label %_llgo_261
+
+_llgo_260:                                        ; preds = %_llgo_96
+  br label %_llgo_261
+
+_llgo_261:                                        ; preds = %_llgo_260, %_llgo_259
+  %406 = phi { ptr, i1 } [ %405, %_llgo_259 ], [ zeroinitializer, %_llgo_260 ]
+  %407 = extractvalue { ptr, i1 } %406, 0
+  %408 = extractvalue { ptr, i1 } %406, 1
+  br i1 %408, label %_llgo_97, label %_llgo_98
+
+_llgo_262:                                        ; preds = %_llgo_98
+  %409 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %410 = insertvalue { ptr, i1 } undef, ptr %409, 0
+  %411 = insertvalue { ptr, i1 } %410, i1 true, 1
+  br label %_llgo_264
+
+_llgo_263:                                        ; preds = %_llgo_98
+  br label %_llgo_264
+
+_llgo_264:                                        ; preds = %_llgo_263, %_llgo_262
+  %412 = phi { ptr, i1 } [ %411, %_llgo_262 ], [ zeroinitializer, %_llgo_263 ]
+  %413 = extractvalue { ptr, i1 } %412, 0
+  %414 = extractvalue { ptr, i1 } %412, 1
+  br i1 %414, label %_llgo_99, label %_llgo_100
+
+_llgo_265:                                        ; preds = %_llgo_100
+  %415 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %416 = insertvalue { ptr, i1 } undef, ptr %415, 0
+  %417 = insertvalue { ptr, i1 } %416, i1 true, 1
+  br label %_llgo_267
+
+_llgo_266:                                        ; preds = %_llgo_100
+  br label %_llgo_267
+
+_llgo_267:                                        ; preds = %_llgo_266, %_llgo_265
+  %418 = phi { ptr, i1 } [ %417, %_llgo_265 ], [ zeroinitializer, %_llgo_266 ]
+  %419 = extractvalue { ptr, i1 } %418, 0
+  %420 = extractvalue { ptr, i1 } %418, 1
+  br i1 %420, label %_llgo_101, label %_llgo_102
+
+_llgo_268:                                        ; preds = %_llgo_102
+  %421 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %422 = insertvalue { ptr, i1 } undef, ptr %421, 0
+  %423 = insertvalue { ptr, i1 } %422, i1 true, 1
+  br label %_llgo_270
+
+_llgo_269:                                        ; preds = %_llgo_102
+  br label %_llgo_270
+
+_llgo_270:                                        ; preds = %_llgo_269, %_llgo_268
+  %424 = phi { ptr, i1 } [ %423, %_llgo_268 ], [ zeroinitializer, %_llgo_269 ]
+  %425 = extractvalue { ptr, i1 } %424, 0
+  %426 = extractvalue { ptr, i1 } %424, 1
+  br i1 %426, label %_llgo_103, label %_llgo_104
+
+_llgo_271:                                        ; preds = %_llgo_104
+  %427 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %428 = insertvalue { ptr, i1 } undef, ptr %427, 0
+  %429 = insertvalue { ptr, i1 } %428, i1 true, 1
+  br label %_llgo_273
+
+_llgo_272:                                        ; preds = %_llgo_104
+  br label %_llgo_273
+
+_llgo_273:                                        ; preds = %_llgo_272, %_llgo_271
+  %430 = phi { ptr, i1 } [ %429, %_llgo_271 ], [ zeroinitializer, %_llgo_272 ]
+  %431 = extractvalue { ptr, i1 } %430, 0
+  %432 = extractvalue { ptr, i1 } %430, 1
+  br i1 %432, label %_llgo_105, label %_llgo_106
+
+_llgo_274:                                        ; preds = %_llgo_106
+  %433 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %434 = insertvalue { ptr, i1 } undef, ptr %433, 0
+  %435 = insertvalue { ptr, i1 } %434, i1 true, 1
+  br label %_llgo_276
+
+_llgo_275:                                        ; preds = %_llgo_106
+  br label %_llgo_276
+
+_llgo_276:                                        ; preds = %_llgo_275, %_llgo_274
+  %436 = phi { ptr, i1 } [ %435, %_llgo_274 ], [ zeroinitializer, %_llgo_275 ]
+  %437 = extractvalue { ptr, i1 } %436, 0
+  %438 = extractvalue { ptr, i1 } %436, 1
+  br i1 %438, label %_llgo_107, label %_llgo_108
+
+_llgo_277:                                        ; preds = %_llgo_108
+  %439 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %440 = insertvalue { ptr, i1 } undef, ptr %439, 0
+  %441 = insertvalue { ptr, i1 } %440, i1 true, 1
+  br label %_llgo_279
+
+_llgo_278:                                        ; preds = %_llgo_108
+  br label %_llgo_279
+
+_llgo_279:                                        ; preds = %_llgo_278, %_llgo_277
+  %442 = phi { ptr, i1 } [ %441, %_llgo_277 ], [ zeroinitializer, %_llgo_278 ]
+  %443 = extractvalue { ptr, i1 } %442, 0
+  %444 = extractvalue { ptr, i1 } %442, 1
+  br i1 %444, label %_llgo_109, label %_llgo_110
+
+_llgo_280:                                        ; preds = %_llgo_110
+  %445 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %446 = insertvalue { ptr, i1 } undef, ptr %445, 0
+  %447 = insertvalue { ptr, i1 } %446, i1 true, 1
+  br label %_llgo_282
+
+_llgo_281:                                        ; preds = %_llgo_110
+  br label %_llgo_282
+
+_llgo_282:                                        ; preds = %_llgo_281, %_llgo_280
+  %448 = phi { ptr, i1 } [ %447, %_llgo_280 ], [ zeroinitializer, %_llgo_281 ]
+  %449 = extractvalue { ptr, i1 } %448, 0
+  %450 = extractvalue { ptr, i1 } %448, 1
+  br i1 %450, label %_llgo_111, label %_llgo_112
+
+_llgo_283:                                        ; preds = %_llgo_112
+  %451 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %452 = insertvalue { ptr, i1 } undef, ptr %451, 0
+  %453 = insertvalue { ptr, i1 } %452, i1 true, 1
+  br label %_llgo_285
+
+_llgo_284:                                        ; preds = %_llgo_112
+  br label %_llgo_285
+
+_llgo_285:                                        ; preds = %_llgo_284, %_llgo_283
+  %454 = phi { ptr, i1 } [ %453, %_llgo_283 ], [ zeroinitializer, %_llgo_284 ]
+  %455 = extractvalue { ptr, i1 } %454, 0
+  %456 = extractvalue { ptr, i1 } %454, 1
+  br i1 %456, label %_llgo_113, label %_llgo_114
+}
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+
+define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
+_llgo_0:
+  %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %1, ptr %2)
+  ret i1 %3
+}
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+
+define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
+_llgo_0:
+  %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %1, ptr %2)
+  ret i1 %3
+}
+
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface", %"github.com/goplus/llgo/runtime/internal/runtime.eface")
+
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+
+declare void @"go/ast.init"()
+
+declare void @iter.init()
+
+declare void @math.init()
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+
+define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
+_llgo_0:
+  %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %1, ptr %2)
+  ret i1 %3
+}
+
+declare i1 @"go/token.(*Pos).IsValid"(ptr)
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+
+define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
+_llgo_0:
+  %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %1, ptr %2)
+  ret i1 %3
+}
+
+declare i1 @"go/token.Pos.IsValid"(i64)
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"go/ast.(*ObjKind).String"(ptr)
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"go/ast.ObjKind.String"(i64)
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr, ptr)
+
+define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr %0, ptr %1, ptr %2) {
+_llgo_0:
+  %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr %1, ptr %2)
+  ret i1 %3
+}
+
+declare i64 @"go/ast.(*Object).Pos"(ptr)
+
+declare i64 @"go/ast.(*Ident).End"(ptr)
+
+declare i1 @"go/ast.(*Ident).IsExported"(ptr)
+
+declare i64 @"go/ast.(*Ident).Pos"(ptr)
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"go/ast.(*Ident).String"(ptr)
+
+declare void @"go/ast.(*Ident).exprNode"(ptr)
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr)
+
+define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2) {
+_llgo_0:
+  %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %1, ptr %2)
+  ret i1 %3
+}
+
+declare i64 @"go/ast.(*ArrayType).End"(ptr)
+
+declare i64 @"go/ast.(*ArrayType).Pos"(ptr)
+
+declare void @"go/ast.(*ArrayType).exprNode"(ptr)
+
+declare i1 @"go/token.(*Token).IsKeyword"(ptr)
+
+declare i1 @"go/token.(*Token).IsLiteral"(ptr)
+
+declare i1 @"go/token.(*Token).IsOperator"(ptr)
+
+declare i64 @"go/token.(*Token).Precedence"(ptr)
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"go/token.(*Token).String"(ptr)
+
+declare i1 @"go/token.Token.IsKeyword"(i64)
+
+declare i1 @"go/token.Token.IsLiteral"(i64)
+
+declare i1 @"go/token.Token.IsOperator"(i64)
+
+declare i64 @"go/token.Token.Precedence"(i64)
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"go/token.Token.String"(i64)
+
+declare i64 @"go/ast.(*AssignStmt).End"(ptr)
+
+declare i64 @"go/ast.(*AssignStmt).Pos"(ptr)
+
+declare void @"go/ast.(*AssignStmt).stmtNode"(ptr)
+
+declare i64 @"go/ast.(*BadDecl).End"(ptr)
+
+declare i64 @"go/ast.(*BadDecl).Pos"(ptr)
+
+declare void @"go/ast.(*BadDecl).declNode"(ptr)
+
+declare i64 @"go/ast.(*BadExpr).End"(ptr)
+
+declare i64 @"go/ast.(*BadExpr).Pos"(ptr)
+
+declare void @"go/ast.(*BadExpr).exprNode"(ptr)
+
+declare i64 @"go/ast.(*BadStmt).End"(ptr)
+
+declare i64 @"go/ast.(*BadStmt).Pos"(ptr)
+
+declare void @"go/ast.(*BadStmt).stmtNode"(ptr)
+
+declare i64 @"go/ast.(*BasicLit).End"(ptr)
+
+declare i64 @"go/ast.(*BasicLit).Pos"(ptr)
+
+declare void @"go/ast.(*BasicLit).exprNode"(ptr)
+
+declare i64 @"go/ast.(*BinaryExpr).End"(ptr)
+
+declare i64 @"go/ast.(*BinaryExpr).Pos"(ptr)
+
+declare void @"go/ast.(*BinaryExpr).exprNode"(ptr)
+
+declare i64 @"go/ast.(*BlockStmt).End"(ptr)
+
+declare i64 @"go/ast.(*BlockStmt).Pos"(ptr)
+
+declare void @"go/ast.(*BlockStmt).stmtNode"(ptr)
+
+declare i64 @"go/ast.(*BranchStmt).End"(ptr)
+
+declare i64 @"go/ast.(*BranchStmt).Pos"(ptr)
+
+declare void @"go/ast.(*BranchStmt).stmtNode"(ptr)
+
+declare i64 @"go/ast.(*CallExpr).End"(ptr)
+
+declare i64 @"go/ast.(*CallExpr).Pos"(ptr)
+
+declare void @"go/ast.(*CallExpr).exprNode"(ptr)
+
+declare i64 @"go/ast.(*CaseClause).End"(ptr)
+
+declare i64 @"go/ast.(*CaseClause).Pos"(ptr)
+
+declare void @"go/ast.(*CaseClause).stmtNode"(ptr)
+
+declare i64 @"go/ast.(*ChanType).End"(ptr)
+
+declare i64 @"go/ast.(*ChanType).Pos"(ptr)
+
+declare void @"go/ast.(*ChanType).exprNode"(ptr)
+
+declare i64 @"go/ast.(*CommClause).End"(ptr)
+
+declare i64 @"go/ast.(*CommClause).Pos"(ptr)
+
+declare void @"go/ast.(*CommClause).stmtNode"(ptr)
+
+declare i64 @"go/ast.(*Comment).End"(ptr)
+
+declare i64 @"go/ast.(*Comment).Pos"(ptr)
+
+declare i64 @"go/ast.(*CommentGroup).End"(ptr)
+
+declare i64 @"go/ast.(*CommentGroup).Pos"(ptr)
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"go/ast.(*CommentGroup).Text"(ptr)
+
+declare i64 @"go/ast.(*CompositeLit).End"(ptr)
+
+declare i64 @"go/ast.(*CompositeLit).Pos"(ptr)
+
+declare void @"go/ast.(*CompositeLit).exprNode"(ptr)
+
+declare i64 @"go/ast.(*DeclStmt).End"(ptr)
+
+declare i64 @"go/ast.(*DeclStmt).Pos"(ptr)
+
+declare void @"go/ast.(*DeclStmt).stmtNode"(ptr)
+
+declare i64 @"go/ast.(*DeferStmt).End"(ptr)
+
+declare i64 @"go/ast.(*DeferStmt).Pos"(ptr)
+
+declare void @"go/ast.(*DeferStmt).stmtNode"(ptr)
+
+declare i64 @"go/ast.(*Ellipsis).End"(ptr)
+
+declare i64 @"go/ast.(*Ellipsis).Pos"(ptr)
+
+declare void @"go/ast.(*Ellipsis).exprNode"(ptr)
+
+declare i64 @"go/ast.(*EmptyStmt).End"(ptr)
+
+declare i64 @"go/ast.(*EmptyStmt).Pos"(ptr)
+
+declare void @"go/ast.(*EmptyStmt).stmtNode"(ptr)
+
+declare i64 @"go/ast.(*ExprStmt).End"(ptr)
+
+declare i64 @"go/ast.(*ExprStmt).Pos"(ptr)
+
+declare void @"go/ast.(*ExprStmt).stmtNode"(ptr)
+
+declare i64 @"go/ast.(*Field).End"(ptr)
+
+declare i64 @"go/ast.(*Field).Pos"(ptr)
+
+declare i64 @"go/ast.(*FieldList).End"(ptr)
+
+declare i64 @"go/ast.(*FieldList).NumFields"(ptr)
+
+declare i64 @"go/ast.(*FieldList).Pos"(ptr)
+
+declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.typehash"(ptr, ptr, i64)
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr)
+
+declare ptr @"go/ast.(*Scope).Insert"(ptr, ptr)
+
+declare ptr @"go/ast.(*Scope).Lookup"(ptr, %"github.com/goplus/llgo/runtime/internal/runtime.String")
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"go/ast.(*Scope).String"(ptr)
+
+declare i64 @"go/ast.(*ImportSpec).End"(ptr)
+
+declare i64 @"go/ast.(*ImportSpec).Pos"(ptr)
+
+declare void @"go/ast.(*ImportSpec).specNode"(ptr)
+
+declare i64 @"go/ast.(*File).End"(ptr)
+
+declare i64 @"go/ast.(*File).Pos"(ptr)
+
+declare i64 @"go/ast.(*ForStmt).End"(ptr)
+
+declare i64 @"go/ast.(*ForStmt).Pos"(ptr)
+
+declare void @"go/ast.(*ForStmt).stmtNode"(ptr)
+
+declare i64 @"go/ast.(*FuncType).End"(ptr)
+
+declare i64 @"go/ast.(*FuncType).Pos"(ptr)
+
+declare void @"go/ast.(*FuncType).exprNode"(ptr)
+
+declare i64 @"go/ast.(*FuncDecl).End"(ptr)
+
+declare i64 @"go/ast.(*FuncDecl).Pos"(ptr)
+
+declare void @"go/ast.(*FuncDecl).declNode"(ptr)
+
+declare i64 @"go/ast.(*FuncLit).End"(ptr)
+
+declare i64 @"go/ast.(*FuncLit).Pos"(ptr)
+
+declare void @"go/ast.(*FuncLit).exprNode"(ptr)
+
+declare i64 @"go/ast.(*GenDecl).End"(ptr)
+
+declare i64 @"go/ast.(*GenDecl).Pos"(ptr)
+
+declare void @"go/ast.(*GenDecl).declNode"(ptr)
+
+declare i64 @"go/ast.(*GoStmt).End"(ptr)
+
+declare i64 @"go/ast.(*GoStmt).Pos"(ptr)
+
+declare void @"go/ast.(*GoStmt).stmtNode"(ptr)
+
+declare i64 @"go/ast.(*IfStmt).End"(ptr)
+
+declare i64 @"go/ast.(*IfStmt).Pos"(ptr)
+
+declare void @"go/ast.(*IfStmt).stmtNode"(ptr)
+
+declare i64 @"go/ast.(*IncDecStmt).End"(ptr)
+
+declare i64 @"go/ast.(*IncDecStmt).Pos"(ptr)
+
+declare void @"go/ast.(*IncDecStmt).stmtNode"(ptr)
+
+declare i64 @"go/ast.(*IndexExpr).End"(ptr)
+
+declare i64 @"go/ast.(*IndexExpr).Pos"(ptr)
+
+declare void @"go/ast.(*IndexExpr).exprNode"(ptr)
+
+declare i64 @"go/ast.(*IndexListExpr).End"(ptr)
+
+declare i64 @"go/ast.(*IndexListExpr).Pos"(ptr)
+
+declare void @"go/ast.(*IndexListExpr).exprNode"(ptr)
+
+declare i64 @"go/ast.(*InterfaceType).End"(ptr)
+
+declare i64 @"go/ast.(*InterfaceType).Pos"(ptr)
+
+declare void @"go/ast.(*InterfaceType).exprNode"(ptr)
+
+declare i64 @"go/ast.(*KeyValueExpr).End"(ptr)
+
+declare i64 @"go/ast.(*KeyValueExpr).Pos"(ptr)
+
+declare void @"go/ast.(*KeyValueExpr).exprNode"(ptr)
+
+declare i64 @"go/ast.(*LabeledStmt).End"(ptr)
+
+declare i64 @"go/ast.(*LabeledStmt).Pos"(ptr)
+
+declare void @"go/ast.(*LabeledStmt).stmtNode"(ptr)
+
+declare i64 @"go/ast.(*MapType).End"(ptr)
+
+declare i64 @"go/ast.(*MapType).Pos"(ptr)
+
+declare void @"go/ast.(*MapType).exprNode"(ptr)
+
+declare i64 @"go/ast.(*Package).End"(ptr)
+
+declare i64 @"go/ast.(*Package).Pos"(ptr)
+
+declare i64 @"go/ast.(*ParenExpr).End"(ptr)
+
+declare i64 @"go/ast.(*ParenExpr).Pos"(ptr)
+
+declare void @"go/ast.(*ParenExpr).exprNode"(ptr)
+
+declare i64 @"go/ast.(*RangeStmt).End"(ptr)
+
+declare i64 @"go/ast.(*RangeStmt).Pos"(ptr)
+
+declare void @"go/ast.(*RangeStmt).stmtNode"(ptr)
+
+declare i64 @"go/ast.(*ReturnStmt).End"(ptr)
+
+declare i64 @"go/ast.(*ReturnStmt).Pos"(ptr)
+
+declare void @"go/ast.(*ReturnStmt).stmtNode"(ptr)
+
+declare i64 @"go/ast.(*SelectStmt).End"(ptr)
+
+declare i64 @"go/ast.(*SelectStmt).Pos"(ptr)
+
+declare void @"go/ast.(*SelectStmt).stmtNode"(ptr)
+
+declare i64 @"go/ast.(*SelectorExpr).End"(ptr)
+
+declare i64 @"go/ast.(*SelectorExpr).Pos"(ptr)
+
+declare void @"go/ast.(*SelectorExpr).exprNode"(ptr)
+
+declare i64 @"go/ast.(*SendStmt).End"(ptr)
+
+declare i64 @"go/ast.(*SendStmt).Pos"(ptr)
+
+declare void @"go/ast.(*SendStmt).stmtNode"(ptr)
+
+declare i64 @"go/ast.(*SliceExpr).End"(ptr)
+
+declare i64 @"go/ast.(*SliceExpr).Pos"(ptr)
+
+declare void @"go/ast.(*SliceExpr).exprNode"(ptr)
+
+declare i64 @"go/ast.(*StarExpr).End"(ptr)
+
+declare i64 @"go/ast.(*StarExpr).Pos"(ptr)
+
+declare void @"go/ast.(*StarExpr).exprNode"(ptr)
+
+declare i64 @"go/ast.(*StructType).End"(ptr)
+
+declare i64 @"go/ast.(*StructType).Pos"(ptr)
+
+declare void @"go/ast.(*StructType).exprNode"(ptr)
+
+declare i64 @"go/ast.(*SwitchStmt).End"(ptr)
+
+declare i64 @"go/ast.(*SwitchStmt).Pos"(ptr)
+
+declare void @"go/ast.(*SwitchStmt).stmtNode"(ptr)
+
+declare i64 @"go/ast.(*TypeAssertExpr).End"(ptr)
+
+declare i64 @"go/ast.(*TypeAssertExpr).Pos"(ptr)
+
+declare void @"go/ast.(*TypeAssertExpr).exprNode"(ptr)
+
+declare i64 @"go/ast.(*TypeSpec).End"(ptr)
+
+declare i64 @"go/ast.(*TypeSpec).Pos"(ptr)
+
+declare void @"go/ast.(*TypeSpec).specNode"(ptr)
+
+declare i64 @"go/ast.(*TypeSwitchStmt).End"(ptr)
+
+declare i64 @"go/ast.(*TypeSwitchStmt).Pos"(ptr)
+
+declare void @"go/ast.(*TypeSwitchStmt).stmtNode"(ptr)
+
+declare i64 @"go/ast.(*UnaryExpr).End"(ptr)
+
+declare i64 @"go/ast.(*UnaryExpr).Pos"(ptr)
+
+declare void @"go/ast.(*UnaryExpr).exprNode"(ptr)
+
+declare i64 @"go/ast.(*ValueSpec).End"(ptr)
+
+declare i64 @"go/ast.(*ValueSpec).Pos"(ptr)
+
+declare void @"go/ast.(*ValueSpec).specNode"(ptr)
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/embedunexport-1598/in.go
+++ b/cl/_testgo/embedunexport-1598/in.go
@@ -17,6 +17,7 @@ type Wrapped struct {
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
 // CHECK-NEXT:   %4 = call %"{{.*}}String" @"{{.*}}embedunexport.(*Base).Name"(ptr %3)
 // CHECK-NEXT:   ret %"{{.*}}String" %4
+
 // CHECK-LABEL: define void @"{{.*}}embedunexport-1598.Wrapped.setName"(%"{{.*}}embedunexport-1598.Wrapped" %0, %"{{.*}}String" %1) {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca %"{{.*}}embedunexport-1598.Wrapped", align 8
@@ -26,12 +27,14 @@ type Wrapped struct {
 // CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
 // CHECK-NEXT:   call void @"{{.*}}embedunexport.(*Base).setName"(ptr %4, %"{{.*}}String" %1)
 // CHECK-NEXT:   ret void
+
 // CHECK-LABEL: define %"{{.*}}String" @"{{.*}}embedunexport-1598.(*Wrapped).Name"(ptr %0) {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}embedunexport-1598.Wrapped", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
 // CHECK-NEXT:   %3 = call %"{{.*}}String" @"{{.*}}embedunexport.(*Base).Name"(ptr %2)
 // CHECK-NEXT:   ret %"{{.*}}String" %3
+
 // CHECK-LABEL: define void @"{{.*}}embedunexport-1598.(*Wrapped).setName"(ptr %0, %"{{.*}}String" %1) {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}embedunexport-1598.Wrapped", ptr %0, i32 0, i32 0

--- a/cl/_testgo/equal/in.go
+++ b/cl/_testgo/equal/in.go
@@ -3,25 +3,89 @@ package main
 
 func test() {}
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/equal.assert"{{.*}}
-// CHECK: Panic
-// CHECK: ret void
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/equal.assert"(i1 %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 6 }, ptr %1, align 8
+// CHECK-NEXT:   %2 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %1, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %2)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 func assert(cond bool) {
 	if !cond {
 		panic("failed")
 	}
 }
 
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/equal.init"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/equal.init$guard", align 1
+// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/equal.init$guard", align 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.init#1"()
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.init#2"()
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.init#3"()
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.init#4"()
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.init#5"()
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.init#6"()
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.init#7"()
+// CHECK-NEXT:   br label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/equal.init#1"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT:   %2 = getelementptr inbounds { ptr }, ptr %1, i32 0, i32 0
+// CHECK-NEXT:   store ptr %0, ptr %2, align 8
+// CHECK-NEXT:   %3 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/equal.init#1$2", ptr undef }, ptr %1, 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
+// CHECK-NEXT:   %4 = extractvalue { ptr, ptr } %3, 0
+// CHECK-NEXT:   %5 = icmp ne ptr %4, null
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %5)
+// CHECK-NEXT:   %6 = extractvalue { ptr, ptr } %3, 0
+// CHECK-NEXT:   %7 = icmp ne ptr null, %6
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %7)
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 // func
-// CHECK-LABEL: define {{.*}} @"{{.*}}/equal.init#1"{{.*}}
-// CHECK: assert
-// CHECK: AllocZ
-// CHECK: ret void
 func init() {
 	fn1 := test
 	fn2 := func(i, j int) int { return i + j }
+	// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/equal.init#1$1"(i64 %0, i64 %1) {
+	// CHECK-NEXT: _llgo_0:
+	// CHECK-NEXT:   %2 = add i64 %0, %1
+	// CHECK-NEXT:   ret i64 %2
+	// CHECK-NEXT: }
 	var n int
 	fn3 := func() { println(n) }
+	// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/equal.init#1$2"(ptr %0) {
+	// CHECK-NEXT: _llgo_0:
+	// CHECK-NEXT:   %1 = load { ptr }, ptr %0, align 8
+	// CHECK-NEXT:   %2 = extractvalue { ptr } %1, 0
+	// CHECK-NEXT:   %3 = load i64, ptr %2, align 4
+	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %3)
+	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+	// CHECK-NEXT:   ret void
+	// CHECK-NEXT: }
 	var fn4 func() int
 	assert(test != nil)
 	assert(nil != test)
@@ -35,6 +99,60 @@ func init() {
 	assert(nil == fn4)
 }
 
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/equal.init#2"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
+// CHECK-NEXT:   %0 = alloca [3 x i64], align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 24, i1 false)
+// CHECK-NEXT:   %1 = getelementptr inbounds i64, ptr %0, i64 0
+// CHECK-NEXT:   %2 = getelementptr inbounds i64, ptr %0, i64 1
+// CHECK-NEXT:   %3 = getelementptr inbounds i64, ptr %0, i64 2
+// CHECK-NEXT:   store i64 1, ptr %1, align 4
+// CHECK-NEXT:   store i64 2, ptr %2, align 4
+// CHECK-NEXT:   store i64 3, ptr %3, align 4
+// CHECK-NEXT:   %4 = alloca [3 x i64], align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %4, i8 0, i64 24, i1 false)
+// CHECK-NEXT:   %5 = getelementptr inbounds i64, ptr %4, i64 0
+// CHECK-NEXT:   %6 = getelementptr inbounds i64, ptr %4, i64 1
+// CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %4, i64 2
+// CHECK-NEXT:   store i64 1, ptr %5, align 4
+// CHECK-NEXT:   store i64 2, ptr %6, align 4
+// CHECK-NEXT:   store i64 3, ptr %7, align 4
+// CHECK-NEXT:   %8 = load [3 x i64], ptr %0, align 4
+// CHECK-NEXT:   %9 = load [3 x i64], ptr %4, align 4
+// CHECK-NEXT:   %10 = extractvalue [3 x i64] %8, 0
+// CHECK-NEXT:   %11 = extractvalue [3 x i64] %9, 0
+// CHECK-NEXT:   %12 = icmp eq i64 %10, %11
+// CHECK-NEXT:   %13 = and i1 true, %12
+// CHECK-NEXT:   %14 = extractvalue [3 x i64] %8, 1
+// CHECK-NEXT:   %15 = extractvalue [3 x i64] %9, 1
+// CHECK-NEXT:   %16 = icmp eq i64 %14, %15
+// CHECK-NEXT:   %17 = and i1 %13, %16
+// CHECK-NEXT:   %18 = extractvalue [3 x i64] %8, 2
+// CHECK-NEXT:   %19 = extractvalue [3 x i64] %9, 2
+// CHECK-NEXT:   %20 = icmp eq i64 %18, %19
+// CHECK-NEXT:   %21 = and i1 %17, %20
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %21)
+// CHECK-NEXT:   %22 = getelementptr inbounds i64, ptr %4, i64 1
+// CHECK-NEXT:   store i64 1, ptr %22, align 4
+// CHECK-NEXT:   %23 = load [3 x i64], ptr %0, align 4
+// CHECK-NEXT:   %24 = load [3 x i64], ptr %4, align 4
+// CHECK-NEXT:   %25 = extractvalue [3 x i64] %23, 0
+// CHECK-NEXT:   %26 = extractvalue [3 x i64] %24, 0
+// CHECK-NEXT:   %27 = icmp eq i64 %25, %26
+// CHECK-NEXT:   %28 = and i1 true, %27
+// CHECK-NEXT:   %29 = extractvalue [3 x i64] %23, 1
+// CHECK-NEXT:   %30 = extractvalue [3 x i64] %24, 1
+// CHECK-NEXT:   %31 = icmp eq i64 %29, %30
+// CHECK-NEXT:   %32 = and i1 %28, %31
+// CHECK-NEXT:   %33 = extractvalue [3 x i64] %23, 2
+// CHECK-NEXT:   %34 = extractvalue [3 x i64] %24, 2
+// CHECK-NEXT:   %35 = icmp eq i64 %33, %34
+// CHECK-NEXT:   %36 = and i1 %32, %35
+// CHECK-NEXT:   %37 = xor i1 %36, true
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %37)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 // array
 func init() {
 	assert([0]float64{} == [0]float64{})
@@ -54,6 +172,108 @@ type T struct {
 
 type N struct{}
 
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/equal.init#3"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = alloca %"{{.*}}/cl/_testgo/equal.T", align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 48, i1 false)
+// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %0, i32 0, i32 2
+// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %0, i32 0, i32 3
+// CHECK-NEXT:   store i64 10, ptr %1, align 4
+// CHECK-NEXT:   store i64 20, ptr %2, align 4
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 5 }, ptr %3, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 1 to ptr) }, ptr %4, align 8
+// CHECK-NEXT:   %5 = alloca %"{{.*}}/cl/_testgo/equal.T", align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %5, i8 0, i64 48, i1 false)
+// CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %5, i32 0, i32 0
+// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %5, i32 0, i32 1
+// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %5, i32 0, i32 2
+// CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %5, i32 0, i32 3
+// CHECK-NEXT:   store i64 10, ptr %6, align 4
+// CHECK-NEXT:   store i64 20, ptr %7, align 4
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 5 }, ptr %8, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 1 to ptr) }, ptr %9, align 8
+// CHECK-NEXT:   %10 = alloca %"{{.*}}/cl/_testgo/equal.T", align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %10, i8 0, i64 48, i1 false)
+// CHECK-NEXT:   %11 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %10, i32 0, i32 0
+// CHECK-NEXT:   %12 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %10, i32 0, i32 1
+// CHECK-NEXT:   %13 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %10, i32 0, i32 2
+// CHECK-NEXT:   %14 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %10, i32 0, i32 3
+// CHECK-NEXT:   store i64 10, ptr %11, align 4
+// CHECK-NEXT:   store i64 20, ptr %12, align 4
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 5 }, ptr %13, align 8
+// CHECK-NEXT:   %15 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @4, i64 2 }, ptr %15, align 8
+// CHECK-NEXT:   %16 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %15, 1
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %16, ptr %14, align 8
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
+// CHECK-NEXT:   %17 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" zeroinitializer, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer)
+// CHECK-NEXT:   %18 = and i1 true, %17
+// CHECK-NEXT:   %19 = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"(%"{{.*}}/runtime/internal/runtime.eface" zeroinitializer, %"{{.*}}/runtime/internal/runtime.eface" zeroinitializer)
+// CHECK-NEXT:   %20 = and i1 %18, %19
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %20)
+// CHECK-NEXT:   %21 = load %"{{.*}}/cl/_testgo/equal.T", ptr %0, align 8
+// CHECK-NEXT:   %22 = load %"{{.*}}/cl/_testgo/equal.T", ptr %5, align 8
+// CHECK-NEXT:   %23 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %21, 0
+// CHECK-NEXT:   %24 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %22, 0
+// CHECK-NEXT:   %25 = icmp eq i64 %23, %24
+// CHECK-NEXT:   %26 = and i1 true, %25
+// CHECK-NEXT:   %27 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %21, 1
+// CHECK-NEXT:   %28 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %22, 1
+// CHECK-NEXT:   %29 = icmp eq i64 %27, %28
+// CHECK-NEXT:   %30 = and i1 %26, %29
+// CHECK-NEXT:   %31 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %21, 2
+// CHECK-NEXT:   %32 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %22, 2
+// CHECK-NEXT:   %33 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %31, %"{{.*}}/runtime/internal/runtime.String" %32)
+// CHECK-NEXT:   %34 = and i1 %30, %33
+// CHECK-NEXT:   %35 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %21, 3
+// CHECK-NEXT:   %36 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %22, 3
+// CHECK-NEXT:   %37 = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"(%"{{.*}}/runtime/internal/runtime.eface" %35, %"{{.*}}/runtime/internal/runtime.eface" %36)
+// CHECK-NEXT:   %38 = and i1 %34, %37
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %38)
+// CHECK-NEXT:   %39 = load %"{{.*}}/cl/_testgo/equal.T", ptr %0, align 8
+// CHECK-NEXT:   %40 = load %"{{.*}}/cl/_testgo/equal.T", ptr %10, align 8
+// CHECK-NEXT:   %41 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %39, 0
+// CHECK-NEXT:   %42 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %40, 0
+// CHECK-NEXT:   %43 = icmp eq i64 %41, %42
+// CHECK-NEXT:   %44 = and i1 true, %43
+// CHECK-NEXT:   %45 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %39, 1
+// CHECK-NEXT:   %46 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %40, 1
+// CHECK-NEXT:   %47 = icmp eq i64 %45, %46
+// CHECK-NEXT:   %48 = and i1 %44, %47
+// CHECK-NEXT:   %49 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %39, 2
+// CHECK-NEXT:   %50 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %40, 2
+// CHECK-NEXT:   %51 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %49, %"{{.*}}/runtime/internal/runtime.String" %50)
+// CHECK-NEXT:   %52 = and i1 %48, %51
+// CHECK-NEXT:   %53 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %39, 3
+// CHECK-NEXT:   %54 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %40, 3
+// CHECK-NEXT:   %55 = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"(%"{{.*}}/runtime/internal/runtime.eface" %53, %"{{.*}}/runtime/internal/runtime.eface" %54)
+// CHECK-NEXT:   %56 = and i1 %52, %55
+// CHECK-NEXT:   %57 = xor i1 %56, true
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %57)
+// CHECK-NEXT:   %58 = load %"{{.*}}/cl/_testgo/equal.T", ptr %5, align 8
+// CHECK-NEXT:   %59 = load %"{{.*}}/cl/_testgo/equal.T", ptr %10, align 8
+// CHECK-NEXT:   %60 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %58, 0
+// CHECK-NEXT:   %61 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %59, 0
+// CHECK-NEXT:   %62 = icmp eq i64 %60, %61
+// CHECK-NEXT:   %63 = and i1 true, %62
+// CHECK-NEXT:   %64 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %58, 1
+// CHECK-NEXT:   %65 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %59, 1
+// CHECK-NEXT:   %66 = icmp eq i64 %64, %65
+// CHECK-NEXT:   %67 = and i1 %63, %66
+// CHECK-NEXT:   %68 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %58, 2
+// CHECK-NEXT:   %69 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %59, 2
+// CHECK-NEXT:   %70 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %68, %"{{.*}}/runtime/internal/runtime.String" %69)
+// CHECK-NEXT:   %71 = and i1 %67, %70
+// CHECK-NEXT:   %72 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %58, 3
+// CHECK-NEXT:   %73 = extractvalue %"{{.*}}/cl/_testgo/equal.T" %59, 3
+// CHECK-NEXT:   %74 = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"(%"{{.*}}/runtime/internal/runtime.eface" %72, %"{{.*}}/runtime/internal/runtime.eface" %73)
+// CHECK-NEXT:   %75 = and i1 %71, %74
+// CHECK-NEXT:   %76 = xor i1 %75, true
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %76)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 // struct
 func init() {
 	var n1, n2 N
@@ -68,6 +288,35 @@ func init() {
 	assert(y != z)
 }
 
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/equal.init#4"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
+// CHECK-NEXT:   %1 = getelementptr inbounds i64, ptr %0, i64 0
+// CHECK-NEXT:   store i64 1, ptr %1, align 4
+// CHECK-NEXT:   %2 = getelementptr inbounds i64, ptr %0, i64 1
+// CHECK-NEXT:   store i64 2, ptr %2, align 4
+// CHECK-NEXT:   %3 = getelementptr inbounds i64, ptr %0, i64 2
+// CHECK-NEXT:   store i64 3, ptr %3, align 4
+// CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %0, 0
+// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %4, i64 3, 1
+// CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %5, i64 3, 2
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT:   %8 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice3"(ptr %7, i64 8, i64 2, i64 0, i64 2, i64 2)
+// CHECK-NEXT:   %9 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT:   %10 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.NewSlice3"(ptr %9, i64 8, i64 2, i64 0, i64 0, i64 2)
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
+// CHECK-NEXT:   %11 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %6, 0
+// CHECK-NEXT:   %12 = icmp ne ptr %11, null
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %12)
+// CHECK-NEXT:   %13 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %8, 0
+// CHECK-NEXT:   %14 = icmp ne ptr %13, null
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %14)
+// CHECK-NEXT:   %15 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %10, 0
+// CHECK-NEXT:   %16 = icmp ne ptr %15, null
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %16)
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 // slice
 func init() {
 	var a []int
@@ -82,6 +331,76 @@ func init() {
 	assert(b == nil)
 }
 
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/equal.init#5"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 0)
+// CHECK-NEXT:   store {} zeroinitializer, ptr %0, align 1
+// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", ptr undef }, ptr %0, 1
+// CHECK-NEXT:   %2 = alloca %"{{.*}}/cl/_testgo/equal.T", align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 48, i1 false)
+// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %2, i32 0, i32 1
+// CHECK-NEXT:   %5 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %2, i32 0, i32 2
+// CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %2, i32 0, i32 3
+// CHECK-NEXT:   store i64 10, ptr %3, align 4
+// CHECK-NEXT:   store i64 20, ptr %4, align 4
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 5 }, ptr %5, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 1 to ptr) }, ptr %6, align 8
+// CHECK-NEXT:   %7 = load %"{{.*}}/cl/_testgo/equal.T", ptr %2, align 8
+// CHECK-NEXT:   %8 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 48)
+// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/equal.T" %7, ptr %8, align 8
+// CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testgo/equal.T", ptr undef }, ptr %8, 1
+// CHECK-NEXT:   %10 = alloca %"{{.*}}/cl/_testgo/equal.T", align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %10, i8 0, i64 48, i1 false)
+// CHECK-NEXT:   %11 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %10, i32 0, i32 0
+// CHECK-NEXT:   %12 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %10, i32 0, i32 1
+// CHECK-NEXT:   %13 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %10, i32 0, i32 2
+// CHECK-NEXT:   %14 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %10, i32 0, i32 3
+// CHECK-NEXT:   store i64 10, ptr %11, align 4
+// CHECK-NEXT:   store i64 20, ptr %12, align 4
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 5 }, ptr %13, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 1 to ptr) }, ptr %14, align 8
+// CHECK-NEXT:   %15 = alloca %"{{.*}}/cl/_testgo/equal.T", align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %15, i8 0, i64 48, i1 false)
+// CHECK-NEXT:   %16 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %15, i32 0, i32 0
+// CHECK-NEXT:   %17 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %15, i32 0, i32 1
+// CHECK-NEXT:   %18 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %15, i32 0, i32 2
+// CHECK-NEXT:   %19 = getelementptr inbounds %"{{.*}}/cl/_testgo/equal.T", ptr %15, i32 0, i32 3
+// CHECK-NEXT:   store i64 10, ptr %16, align 4
+// CHECK-NEXT:   store i64 20, ptr %17, align 4
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 5 }, ptr %18, align 8
+// CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @4, i64 2 }, ptr %20, align 8
+// CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %20, 1
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %21, ptr %19, align 8
+// CHECK-NEXT:   %22 = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"(%"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 100 to ptr) }, %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 100 to ptr) })
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %22)
+// CHECK-NEXT:   %23 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 0)
+// CHECK-NEXT:   store {} zeroinitializer, ptr %23, align 1
+// CHECK-NEXT:   %24 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_struct$n1H8J_3prDN3firMwPxBLVTkE5hJ9Di-AqNvaC9jczw", ptr undef }, ptr %23, 1
+// CHECK-NEXT:   %25 = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"(%"{{.*}}/runtime/internal/runtime.eface" %1, %"{{.*}}/runtime/internal/runtime.eface" %24)
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %25)
+// CHECK-NEXT:   %26 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 0)
+// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/equal.N" zeroinitializer, ptr %26, align 1
+// CHECK-NEXT:   %27 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testgo/equal.N", ptr undef }, ptr %26, 1
+// CHECK-NEXT:   %28 = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"(%"{{.*}}/runtime/internal/runtime.eface" %1, %"{{.*}}/runtime/internal/runtime.eface" %27)
+// CHECK-NEXT:   %29 = xor i1 %28, true
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %29)
+// CHECK-NEXT:   %30 = load %"{{.*}}/cl/_testgo/equal.T", ptr %10, align 8
+// CHECK-NEXT:   %31 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 48)
+// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/equal.T" %30, ptr %31, align 8
+// CHECK-NEXT:   %32 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testgo/equal.T", ptr undef }, ptr %31, 1
+// CHECK-NEXT:   %33 = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"(%"{{.*}}/runtime/internal/runtime.eface" %9, %"{{.*}}/runtime/internal/runtime.eface" %32)
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %33)
+// CHECK-NEXT:   %34 = load %"{{.*}}/cl/_testgo/equal.T", ptr %15, align 8
+// CHECK-NEXT:   %35 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 48)
+// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/equal.T" %34, ptr %35, align 8
+// CHECK-NEXT:   %36 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testgo/equal.T", ptr undef }, ptr %35, 1
+// CHECK-NEXT:   %37 = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"(%"{{.*}}/runtime/internal/runtime.eface" %9, %"{{.*}}/runtime/internal/runtime.eface" %36)
+// CHECK-NEXT:   %38 = xor i1 %37, true
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %38)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 // iface
 func init() {
 	var a any = 100
@@ -96,6 +415,18 @@ func init() {
 	assert(c != y)
 }
 
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/equal.init#6"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.NewChan"(i64 8, i64 0)
+// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.NewChan"(i64 8, i64 0)
+// CHECK-NEXT:   %2 = icmp eq ptr %0, %0
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %2)
+// CHECK-NEXT:   %3 = icmp ne ptr %0, %1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %3)
+// CHECK-NEXT:   %4 = icmp ne ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %4)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 // chan
 func init() {
 	a := make(chan int)
@@ -105,10 +436,15 @@ func init() {
 	assert(a != nil)
 }
 
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/equal.init#7"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_string", i64 0)
+// CHECK-NEXT:   %1 = icmp ne ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 %1)
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 // map
-// CHECK-LABEL: define {{.*}} @"{{.*}}/equal.init#6"{{.*}}
-// CHECK: assert
-// CHECK: ret void
 func init() {
 	m1 := make(map[int]string)
 	var m2 map[int]string

--- a/cl/_testgo/ifaceconv/in.go
+++ b/cl/_testgo/ifaceconv/in.go
@@ -16,26 +16,349 @@ type I2 interface {
 type C0 struct{}
 type C1 struct{}
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/ifaceconv.(*C1).f"{{.*}}
-// CHECK: C1.f
-// CHECK: ret void
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceconv.C1.f"(%"{{.*}}/cl/_testgo/ifaceconv.C1" %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceconv.(*C1).f"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = load %"{{.*}}/cl/_testgo/ifaceconv.C1", ptr %0, align 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/ifaceconv.C1.f"(%"{{.*}}/cl/_testgo/ifaceconv.C1" %1)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 func (C1) f() {}
 
 type C2 struct{}
 
-func (C2) f() {}
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceconv.C2.f"(%"{{.*}}/cl/_testgo/ifaceconv.C2" %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/ifaceconv.(*C2).g"{{.*}}
-// CHECK: C2.g
-// CHECK: ret void
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceconv.C2.g"(%"{{.*}}/cl/_testgo/ifaceconv.C2" %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceconv.(*C2).f"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = load %"{{.*}}/cl/_testgo/ifaceconv.C2", ptr %0, align 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/ifaceconv.C2.f"(%"{{.*}}/cl/_testgo/ifaceconv.C2" %1)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceconv.(*C2).g"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = load %"{{.*}}/cl/_testgo/ifaceconv.C2", ptr %0, align 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/ifaceconv.C2.g"(%"{{.*}}/cl/_testgo/ifaceconv.C2" %1)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+func (C2) f() {}
 func (C2) g() {}
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/ifaceconv.main"{{.*}}
-// CHECK: NewItab
-// CHECK: Implements
-// CHECK: IfaceType
-// CHECK: Panic
-// CHECK: ret void
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceconv.main"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   br i1 false, label %_llgo_23, label %_llgo_24
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_25
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 21 }, ptr %0, align 8
+// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %0, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %1)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_25
+// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" zeroinitializer)
+// CHECK-NEXT:   br i1 false, label %_llgo_26, label %_llgo_27
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_28
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 21 }, ptr %3, align 8
+// CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %3, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %4)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_28
+// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" zeroinitializer)
+// CHECK-NEXT:   br i1 false, label %_llgo_29, label %_llgo_30
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_31
+// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @10, i64 21 }, ptr %6, align 8
+// CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %6, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %7)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_31
+// CHECK-NEXT:   %8 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" zeroinitializer)
+// CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" undef, ptr %8, 0
+// CHECK-NEXT:   %10 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" %9, ptr null, 1
+// CHECK-NEXT:   %11 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" zeroinitializer)
+// CHECK-NEXT:   %12 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" undef, ptr %11, 0
+// CHECK-NEXT:   %13 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" %12, ptr null, 1
+// CHECK-NEXT:   %14 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" zeroinitializer)
+// CHECK-NEXT:   %15 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/ifaceconv.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", ptr %14)
+// CHECK-NEXT:   %16 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %15, 0
+// CHECK-NEXT:   %17 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %16, ptr null, 1
+// CHECK-NEXT:   %18 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 0)
+// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/ifaceconv.C1" zeroinitializer, ptr %18, align 1
+// CHECK-NEXT:   %19 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/ifaceconv.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", ptr @"_llgo_{{.*}}/cl/_testgo/ifaceconv.C1")
+// CHECK-NEXT:   %20 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %19, 0
+// CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %20, ptr %18, 1
+// CHECK-NEXT:   %22 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %21)
+// CHECK-NEXT:   %23 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @"_llgo_{{.*}}/cl/_testgo/ifaceconv.I0", ptr %22)
+// CHECK-NEXT:   br i1 %23, label %_llgo_32, label %_llgo_33
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_34
+// CHECK-NEXT:   %24 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @14, i64 17 }, ptr %24, align 8
+// CHECK-NEXT:   %25 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %24, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %25)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_34
+// CHECK-NEXT:   %26 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %21)
+// CHECK-NEXT:   %27 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %21, 1
+// CHECK-NEXT:   br i1 true, label %_llgo_35, label %_llgo_36
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_9:                                          ; preds = %_llgo_37
+// CHECK-NEXT:   %28 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @16, i64 17 }, ptr %28, align 8
+// CHECK-NEXT:   %29 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %28, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %29)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_10:                                         ; preds = %_llgo_37
+// CHECK-NEXT:   %30 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %21)
+// CHECK-NEXT:   %31 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @"_llgo_{{.*}}/cl/_testgo/ifaceconv.I2", ptr %30)
+// CHECK-NEXT:   br i1 %31, label %_llgo_38, label %_llgo_39
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_11:                                         ; preds = %_llgo_40
+// CHECK-NEXT:   %32 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @17, i64 20 }, ptr %32, align 8
+// CHECK-NEXT:   %33 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %32, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %33)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_12:                                         ; preds = %_llgo_40
+// CHECK-NEXT:   %34 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 0)
+// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/ifaceconv.C2" zeroinitializer, ptr %34, align 1
+// CHECK-NEXT:   %35 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/ifaceconv.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", ptr @"_llgo_{{.*}}/cl/_testgo/ifaceconv.C2")
+// CHECK-NEXT:   %36 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %35, 0
+// CHECK-NEXT:   %37 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %36, ptr %34, 1
+// CHECK-NEXT:   %38 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %37)
+// CHECK-NEXT:   %39 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @"_llgo_{{.*}}/cl/_testgo/ifaceconv.I0", ptr %38)
+// CHECK-NEXT:   br i1 %39, label %_llgo_41, label %_llgo_42
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_13:                                         ; preds = %_llgo_43
+// CHECK-NEXT:   %40 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @20, i64 17 }, ptr %40, align 8
+// CHECK-NEXT:   %41 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %40, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %41)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_14:                                         ; preds = %_llgo_43
+// CHECK-NEXT:   %42 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %37)
+// CHECK-NEXT:   %43 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %37, 1
+// CHECK-NEXT:   br i1 true, label %_llgo_44, label %_llgo_45
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_15:                                         ; preds = %_llgo_46
+// CHECK-NEXT:   %44 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @21, i64 17 }, ptr %44, align 8
+// CHECK-NEXT:   %45 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %44, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %45)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_16:                                         ; preds = %_llgo_46
+// CHECK-NEXT:   %46 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %37)
+// CHECK-NEXT:   %47 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @"_llgo_{{.*}}/cl/_testgo/ifaceconv.I2", ptr %46)
+// CHECK-NEXT:   br i1 %47, label %_llgo_47, label %_llgo_48
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_17:                                         ; preds = %_llgo_49
+// CHECK-NEXT:   %48 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 17 }, ptr %48, align 8
+// CHECK-NEXT:   %49 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %48, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %49)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_18:                                         ; preds = %_llgo_49
+// CHECK-NEXT:   %50 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 0)
+// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/ifaceconv.C1" zeroinitializer, ptr %50, align 1
+// CHECK-NEXT:   %51 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/ifaceconv.iface$brpgdLtIeRlPi8QUoTgPCXzlehUkncg7v9aITo-GsF4", ptr @"_llgo_{{.*}}/cl/_testgo/ifaceconv.C1")
+// CHECK-NEXT:   %52 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %51, 0
+// CHECK-NEXT:   %53 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %52, ptr %50, 1
+// CHECK-NEXT:   %54 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %53)
+// CHECK-NEXT:   %55 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %53, 1
+// CHECK-NEXT:   %56 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" undef, ptr %54, 0
+// CHECK-NEXT:   %57 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" %56, ptr %55, 1
+// CHECK-NEXT:   %58 = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"(%"{{.*}}/runtime/internal/runtime.eface" %57, %"{{.*}}/runtime/internal/runtime.eface" zeroinitializer)
+// CHECK-NEXT:   br i1 %58, label %_llgo_19, label %_llgo_20
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_19:                                         ; preds = %_llgo_18
+// CHECK-NEXT:   %59 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @23, i64 17 }, ptr %59, align 8
+// CHECK-NEXT:   %60 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %59, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %60)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_20:                                         ; preds = %_llgo_18
+// CHECK-NEXT:   %61 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %53)
+// CHECK-NEXT:   %62 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %53, 1
+// CHECK-NEXT:   %63 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" undef, ptr %61, 0
+// CHECK-NEXT:   %64 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" %63, ptr %62, 1
+// CHECK-NEXT:   %65 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" zeroinitializer)
+// CHECK-NEXT:   %66 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" undef, ptr %65, 0
+// CHECK-NEXT:   %67 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" %66, ptr null, 1
+// CHECK-NEXT:   %68 = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"(%"{{.*}}/runtime/internal/runtime.eface" %64, %"{{.*}}/runtime/internal/runtime.eface" %67)
+// CHECK-NEXT:   br i1 %68, label %_llgo_21, label %_llgo_22
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_21:                                         ; preds = %_llgo_20
+// CHECK-NEXT:   %69 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @24, i64 17 }, ptr %69, align 8
+// CHECK-NEXT:   %70 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %69, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %70)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_22:                                         ; preds = %_llgo_20
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @25, i64 4 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   ret void
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_23:                                         ; preds = %_llgo_0
+// CHECK-NEXT:   br label %_llgo_25
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_24:                                         ; preds = %_llgo_0
+// CHECK-NEXT:   br label %_llgo_25
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_25:                                         ; preds = %_llgo_24, %_llgo_23
+// CHECK-NEXT:   %71 = phi { %"{{.*}}/runtime/internal/runtime.eface", i1 } [ { %"{{.*}}/runtime/internal/runtime.eface" zeroinitializer, i1 true }, %_llgo_23 ], [ zeroinitializer, %_llgo_24 ]
+// CHECK-NEXT:   %72 = extractvalue { %"{{.*}}/runtime/internal/runtime.eface", i1 } %71, 0
+// CHECK-NEXT:   %73 = extractvalue { %"{{.*}}/runtime/internal/runtime.eface", i1 } %71, 1
+// CHECK-NEXT:   br i1 %73, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_26:                                         ; preds = %_llgo_2
+// CHECK-NEXT:   br label %_llgo_28
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_27:                                         ; preds = %_llgo_2
+// CHECK-NEXT:   br label %_llgo_28
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_28:                                         ; preds = %_llgo_27, %_llgo_26
+// CHECK-NEXT:   %74 = phi { %"{{.*}}/runtime/internal/runtime.iface", i1 } [ { %"{{.*}}/runtime/internal/runtime.iface" zeroinitializer, i1 true }, %_llgo_26 ], [ zeroinitializer, %_llgo_27 ]
+// CHECK-NEXT:   %75 = extractvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } %74, 0
+// CHECK-NEXT:   %76 = extractvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } %74, 1
+// CHECK-NEXT:   br i1 %76, label %_llgo_3, label %_llgo_4
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_29:                                         ; preds = %_llgo_4
+// CHECK-NEXT:   br label %_llgo_31
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_30:                                         ; preds = %_llgo_4
+// CHECK-NEXT:   br label %_llgo_31
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_31:                                         ; preds = %_llgo_30, %_llgo_29
+// CHECK-NEXT:   %77 = phi { %"{{.*}}/runtime/internal/runtime.iface", i1 } [ { %"{{.*}}/runtime/internal/runtime.iface" zeroinitializer, i1 true }, %_llgo_29 ], [ zeroinitializer, %_llgo_30 ]
+// CHECK-NEXT:   %78 = extractvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } %77, 0
+// CHECK-NEXT:   %79 = extractvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } %77, 1
+// CHECK-NEXT:   br i1 %79, label %_llgo_5, label %_llgo_6
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_32:                                         ; preds = %_llgo_6
+// CHECK-NEXT:   %80 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %21, 1
+// CHECK-NEXT:   %81 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" undef, ptr %22, 0
+// CHECK-NEXT:   %82 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" %81, ptr %80, 1
+// CHECK-NEXT:   %83 = insertvalue { %"{{.*}}/runtime/internal/runtime.eface", i1 } undef, %"{{.*}}/runtime/internal/runtime.eface" %82, 0
+// CHECK-NEXT:   %84 = insertvalue { %"{{.*}}/runtime/internal/runtime.eface", i1 } %83, i1 true, 1
+// CHECK-NEXT:   br label %_llgo_34
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_33:                                         ; preds = %_llgo_6
+// CHECK-NEXT:   br label %_llgo_34
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_34:                                         ; preds = %_llgo_33, %_llgo_32
+// CHECK-NEXT:   %85 = phi { %"{{.*}}/runtime/internal/runtime.eface", i1 } [ %84, %_llgo_32 ], [ zeroinitializer, %_llgo_33 ]
+// CHECK-NEXT:   %86 = extractvalue { %"{{.*}}/runtime/internal/runtime.eface", i1 } %85, 0
+// CHECK-NEXT:   %87 = extractvalue { %"{{.*}}/runtime/internal/runtime.eface", i1 } %85, 1
+// CHECK-NEXT:   br i1 %87, label %_llgo_8, label %_llgo_7
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_35:                                         ; preds = %_llgo_8
+// CHECK-NEXT:   %88 = insertvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } undef, %"{{.*}}/runtime/internal/runtime.iface" %21, 0
+// CHECK-NEXT:   %89 = insertvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } %88, i1 true, 1
+// CHECK-NEXT:   br label %_llgo_37
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_36:                                         ; preds = %_llgo_8
+// CHECK-NEXT:   br label %_llgo_37
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_37:                                         ; preds = %_llgo_36, %_llgo_35
+// CHECK-NEXT:   %90 = phi { %"{{.*}}/runtime/internal/runtime.iface", i1 } [ %89, %_llgo_35 ], [ zeroinitializer, %_llgo_36 ]
+// CHECK-NEXT:   %91 = extractvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } %90, 0
+// CHECK-NEXT:   %92 = extractvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } %90, 1
+// CHECK-NEXT:   br i1 %92, label %_llgo_10, label %_llgo_9
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_38:                                         ; preds = %_llgo_10
+// CHECK-NEXT:   %93 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %21, 1
+// CHECK-NEXT:   %94 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/ifaceconv.iface$gZBF8fFlqIMZ9M6lT2VWPyc3eu5Co6j0WoKGIEgDPAw", ptr %30)
+// CHECK-NEXT:   %95 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %94, 0
+// CHECK-NEXT:   %96 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %95, ptr %93, 1
+// CHECK-NEXT:   %97 = insertvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } undef, %"{{.*}}/runtime/internal/runtime.iface" %96, 0
+// CHECK-NEXT:   %98 = insertvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } %97, i1 true, 1
+// CHECK-NEXT:   br label %_llgo_40
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_39:                                         ; preds = %_llgo_10
+// CHECK-NEXT:   br label %_llgo_40
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_40:                                         ; preds = %_llgo_39, %_llgo_38
+// CHECK-NEXT:   %99 = phi { %"{{.*}}/runtime/internal/runtime.iface", i1 } [ %98, %_llgo_38 ], [ zeroinitializer, %_llgo_39 ]
+// CHECK-NEXT:   %100 = extractvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } %99, 0
+// CHECK-NEXT:   %101 = extractvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } %99, 1
+// CHECK-NEXT:   br i1 %101, label %_llgo_11, label %_llgo_12
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_41:                                         ; preds = %_llgo_12
+// CHECK-NEXT:   %102 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %37, 1
+// CHECK-NEXT:   %103 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" undef, ptr %38, 0
+// CHECK-NEXT:   %104 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" %103, ptr %102, 1
+// CHECK-NEXT:   %105 = insertvalue { %"{{.*}}/runtime/internal/runtime.eface", i1 } undef, %"{{.*}}/runtime/internal/runtime.eface" %104, 0
+// CHECK-NEXT:   %106 = insertvalue { %"{{.*}}/runtime/internal/runtime.eface", i1 } %105, i1 true, 1
+// CHECK-NEXT:   br label %_llgo_43
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_42:                                         ; preds = %_llgo_12
+// CHECK-NEXT:   br label %_llgo_43
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_43:                                         ; preds = %_llgo_42, %_llgo_41
+// CHECK-NEXT:   %107 = phi { %"{{.*}}/runtime/internal/runtime.eface", i1 } [ %106, %_llgo_41 ], [ zeroinitializer, %_llgo_42 ]
+// CHECK-NEXT:   %108 = extractvalue { %"{{.*}}/runtime/internal/runtime.eface", i1 } %107, 0
+// CHECK-NEXT:   %109 = extractvalue { %"{{.*}}/runtime/internal/runtime.eface", i1 } %107, 1
+// CHECK-NEXT:   br i1 %109, label %_llgo_14, label %_llgo_13
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_44:                                         ; preds = %_llgo_14
+// CHECK-NEXT:   %110 = insertvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } undef, %"{{.*}}/runtime/internal/runtime.iface" %37, 0
+// CHECK-NEXT:   %111 = insertvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } %110, i1 true, 1
+// CHECK-NEXT:   br label %_llgo_46
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_45:                                         ; preds = %_llgo_14
+// CHECK-NEXT:   br label %_llgo_46
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_46:                                         ; preds = %_llgo_45, %_llgo_44
+// CHECK-NEXT:   %112 = phi { %"{{.*}}/runtime/internal/runtime.iface", i1 } [ %111, %_llgo_44 ], [ zeroinitializer, %_llgo_45 ]
+// CHECK-NEXT:   %113 = extractvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } %112, 0
+// CHECK-NEXT:   %114 = extractvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } %112, 1
+// CHECK-NEXT:   br i1 %114, label %_llgo_16, label %_llgo_15
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_47:                                         ; preds = %_llgo_16
+// CHECK-NEXT:   %115 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %37, 1
+// CHECK-NEXT:   %116 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/ifaceconv.iface$gZBF8fFlqIMZ9M6lT2VWPyc3eu5Co6j0WoKGIEgDPAw", ptr %46)
+// CHECK-NEXT:   %117 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %116, 0
+// CHECK-NEXT:   %118 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %117, ptr %115, 1
+// CHECK-NEXT:   %119 = insertvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } undef, %"{{.*}}/runtime/internal/runtime.iface" %118, 0
+// CHECK-NEXT:   %120 = insertvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } %119, i1 true, 1
+// CHECK-NEXT:   br label %_llgo_49
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_48:                                         ; preds = %_llgo_16
+// CHECK-NEXT:   br label %_llgo_49
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_49:                                         ; preds = %_llgo_48, %_llgo_47
+// CHECK-NEXT:   %121 = phi { %"{{.*}}/runtime/internal/runtime.iface", i1 } [ %120, %_llgo_47 ], [ zeroinitializer, %_llgo_48 ]
+// CHECK-NEXT:   %122 = extractvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } %121, 0
+// CHECK-NEXT:   %123 = extractvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } %121, 1
+// CHECK-NEXT:   br i1 %123, label %_llgo_18, label %_llgo_17
+// CHECK-NEXT: }
 func main() {
 	var i0 I0
 	var i1 I1

--- a/cl/_testgo/ifaceprom/in.go
+++ b/cl/_testgo/ifaceprom/in.go
@@ -10,32 +10,296 @@ type I interface {
 	two() string
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/ifaceprom.S.one"{{.*}}
-// CHECK: IfacePtrData
-// CHECK: ret i64
-//
-// CHECK-LABEL: define {{.*}} @"{{.*}}/ifaceprom.S.two"{{.*}}
-// CHECK: IfacePtrData
-// CHECK: ret
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/ifaceprom.S.one"(%"{{.*}}/cl/_testgo/ifaceprom.S" %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/ifaceprom.S", align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/ifaceprom.S" %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %2, align 8
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %3)
+// CHECK-NEXT:   %5 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %3, 0
+// CHECK-NEXT:   %6 = getelementptr ptr, ptr %5, i64 3
+// CHECK-NEXT:   %7 = load ptr, ptr %6, align 8
+// CHECK-NEXT:   %8 = insertvalue { ptr, ptr } undef, ptr %7, 0
+// CHECK-NEXT:   %9 = insertvalue { ptr, ptr } %8, ptr %4, 1
+// CHECK-NEXT:   %10 = extractvalue { ptr, ptr } %9, 1
+// CHECK-NEXT:   %11 = extractvalue { ptr, ptr } %9, 0
+// CHECK-NEXT:   %12 = call i64 %11(ptr %10)
+// CHECK-NEXT:   ret i64 %12
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/ifaceprom.S.two"(%"{{.*}}/cl/_testgo/ifaceprom.S" %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/ifaceprom.S", align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/ifaceprom.S" %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %2, align 8
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %3)
+// CHECK-NEXT:   %5 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %3, 0
+// CHECK-NEXT:   %6 = getelementptr ptr, ptr %5, i64 4
+// CHECK-NEXT:   %7 = load ptr, ptr %6, align 8
+// CHECK-NEXT:   %8 = insertvalue { ptr, ptr } undef, ptr %7, 0
+// CHECK-NEXT:   %9 = insertvalue { ptr, ptr } %8, ptr %4, 1
+// CHECK-NEXT:   %10 = extractvalue { ptr, ptr } %9, 1
+// CHECK-NEXT:   %11 = extractvalue { ptr, ptr } %9, 0
+// CHECK-NEXT:   %12 = call %"{{.*}}/runtime/internal/runtime.String" %11(ptr %10)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %12
+// CHECK-NEXT: }
 type S struct {
 	I
 }
 
 type impl struct{}
 
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/ifaceprom.impl.one"(%"{{.*}}/cl/_testgo/ifaceprom.impl" %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   ret i64 1
+// CHECK-NEXT: }
 func (impl) one() int {
 	return 1
 }
 
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/ifaceprom.impl.two"(%"{{.*}}/cl/_testgo/ifaceprom.impl" %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 3 }
+// CHECK-NEXT: }
 func (impl) two() string {
 	return "two"
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/ifaceprom.main"{{.*}}
-// CHECK: NewItab
-// CHECK: IfacePtrData
-// CHECK: PrintString
-// CHECK: ret void
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceprom.main"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = alloca %"{{.*}}/cl/_testgo/ifaceprom.S", align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 0)
+// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/ifaceprom.impl" zeroinitializer, ptr %2, align 1
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/ifaceprom.iface$zZ89tENb5h_KNjvpxf1TXPfaWFYn0IZrZwyVf42lRtA", ptr @"_llgo_{{.*}}/cl/_testgo/ifaceprom.impl")
+// CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %3, 0
+// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %4, ptr %2, 1
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %5, ptr %1, align 8
+// CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %7 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %6, align 8
+// CHECK-NEXT:   %8 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %7)
+// CHECK-NEXT:   %9 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %7, 0
+// CHECK-NEXT:   %10 = getelementptr ptr, ptr %9, i64 3
+// CHECK-NEXT:   %11 = load ptr, ptr %10, align 8
+// CHECK-NEXT:   %12 = insertvalue { ptr, ptr } undef, ptr %11, 0
+// CHECK-NEXT:   %13 = insertvalue { ptr, ptr } %12, ptr %8, 1
+// CHECK-NEXT:   %14 = extractvalue { ptr, ptr } %13, 1
+// CHECK-NEXT:   %15 = extractvalue { ptr, ptr } %13, 0
+// CHECK-NEXT:   %16 = call i64 %15(ptr %14)
+// CHECK-NEXT:   %17 = icmp ne i64 %16, 1
+// CHECK-NEXT:   br i1 %17, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %18 = inttoptr i64 %16 to ptr
+// CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %18, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %19)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %20 = load %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %0, align 8
+// CHECK-NEXT:   %21 = extractvalue %"{{.*}}/cl/_testgo/ifaceprom.S" %20, 0
+// CHECK-NEXT:   %22 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %21)
+// CHECK-NEXT:   %23 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %21, 0
+// CHECK-NEXT:   %24 = getelementptr ptr, ptr %23, i64 3
+// CHECK-NEXT:   %25 = load ptr, ptr %24, align 8
+// CHECK-NEXT:   %26 = insertvalue { ptr, ptr } undef, ptr %25, 0
+// CHECK-NEXT:   %27 = insertvalue { ptr, ptr } %26, ptr %22, 1
+// CHECK-NEXT:   %28 = extractvalue { ptr, ptr } %27, 1
+// CHECK-NEXT:   %29 = extractvalue { ptr, ptr } %27, 0
+// CHECK-NEXT:   %30 = call i64 %29(ptr %28)
+// CHECK-NEXT:   %31 = icmp ne i64 %30, 1
+// CHECK-NEXT:   br i1 %31, label %_llgo_3, label %_llgo_4
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_2
+// CHECK-NEXT:   %32 = inttoptr i64 %30 to ptr
+// CHECK-NEXT:   %33 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %32, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %33)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
+// CHECK-NEXT:   %34 = getelementptr inbounds %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %35 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %34, align 8
+// CHECK-NEXT:   %36 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %35)
+// CHECK-NEXT:   %37 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %35, 1
+// CHECK-NEXT:   br i1 true, label %_llgo_17, label %_llgo_18
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_17
+// CHECK-NEXT:   %38 = inttoptr i64 %93 to ptr
+// CHECK-NEXT:   %39 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %38, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %39)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_17
+// CHECK-NEXT:   %40 = load %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %0, align 8
+// CHECK-NEXT:   %41 = extractvalue %"{{.*}}/cl/_testgo/ifaceprom.S" %40, 0
+// CHECK-NEXT:   %42 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %41)
+// CHECK-NEXT:   %43 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %41, 1
+// CHECK-NEXT:   br i1 true, label %_llgo_19, label %_llgo_20
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_19
+// CHECK-NEXT:   %44 = inttoptr i64 %102 to ptr
+// CHECK-NEXT:   %45 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %44, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %45)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_19
+// CHECK-NEXT:   %46 = getelementptr inbounds %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %47 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %46, align 8
+// CHECK-NEXT:   %48 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %47)
+// CHECK-NEXT:   %49 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %47, 0
+// CHECK-NEXT:   %50 = getelementptr ptr, ptr %49, i64 4
+// CHECK-NEXT:   %51 = load ptr, ptr %50, align 8
+// CHECK-NEXT:   %52 = insertvalue { ptr, ptr } undef, ptr %51, 0
+// CHECK-NEXT:   %53 = insertvalue { ptr, ptr } %52, ptr %48, 1
+// CHECK-NEXT:   %54 = extractvalue { ptr, ptr } %53, 1
+// CHECK-NEXT:   %55 = extractvalue { ptr, ptr } %53, 0
+// CHECK-NEXT:   %56 = call %"{{.*}}/runtime/internal/runtime.String" %55(ptr %54)
+// CHECK-NEXT:   %57 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %56, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 3 })
+// CHECK-NEXT:   %58 = xor i1 %57, true
+// CHECK-NEXT:   br i1 %58, label %_llgo_9, label %_llgo_10
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_9:                                          ; preds = %_llgo_8
+// CHECK-NEXT:   %59 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" %56, ptr %59, align 8
+// CHECK-NEXT:   %60 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %59, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %60)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_10:                                         ; preds = %_llgo_8
+// CHECK-NEXT:   %61 = load %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %0, align 8
+// CHECK-NEXT:   %62 = extractvalue %"{{.*}}/cl/_testgo/ifaceprom.S" %61, 0
+// CHECK-NEXT:   %63 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %62)
+// CHECK-NEXT:   %64 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %62, 0
+// CHECK-NEXT:   %65 = getelementptr ptr, ptr %64, i64 4
+// CHECK-NEXT:   %66 = load ptr, ptr %65, align 8
+// CHECK-NEXT:   %67 = insertvalue { ptr, ptr } undef, ptr %66, 0
+// CHECK-NEXT:   %68 = insertvalue { ptr, ptr } %67, ptr %63, 1
+// CHECK-NEXT:   %69 = extractvalue { ptr, ptr } %68, 1
+// CHECK-NEXT:   %70 = extractvalue { ptr, ptr } %68, 0
+// CHECK-NEXT:   %71 = call %"{{.*}}/runtime/internal/runtime.String" %70(ptr %69)
+// CHECK-NEXT:   %72 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %71, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 3 })
+// CHECK-NEXT:   %73 = xor i1 %72, true
+// CHECK-NEXT:   br i1 %73, label %_llgo_11, label %_llgo_12
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_11:                                         ; preds = %_llgo_10
+// CHECK-NEXT:   %74 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" %71, ptr %74, align 8
+// CHECK-NEXT:   %75 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %74, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %75)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_12:                                         ; preds = %_llgo_10
+// CHECK-NEXT:   %76 = getelementptr inbounds %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %77 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %76, align 8
+// CHECK-NEXT:   %78 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %77)
+// CHECK-NEXT:   %79 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %77, 1
+// CHECK-NEXT:   br i1 true, label %_llgo_21, label %_llgo_22
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_13:                                         ; preds = %_llgo_21
+// CHECK-NEXT:   %80 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" %111, ptr %80, align 8
+// CHECK-NEXT:   %81 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %80, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %81)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_14:                                         ; preds = %_llgo_21
+// CHECK-NEXT:   %82 = load %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %0, align 8
+// CHECK-NEXT:   %83 = extractvalue %"{{.*}}/cl/_testgo/ifaceprom.S" %82, 0
+// CHECK-NEXT:   %84 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %83)
+// CHECK-NEXT:   %85 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %83, 1
+// CHECK-NEXT:   br i1 true, label %_llgo_23, label %_llgo_24
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_15:                                         ; preds = %_llgo_23
+// CHECK-NEXT:   %86 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" %121, ptr %86, align 8
+// CHECK-NEXT:   %87 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %86, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %87)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_16:                                         ; preds = %_llgo_23
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @13, i64 4 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   ret void
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_17:                                         ; preds = %_llgo_4
+// CHECK-NEXT:   %88 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   %89 = getelementptr inbounds { %"{{.*}}/runtime/internal/runtime.iface" }, ptr %88, i32 0, i32 0
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %35, ptr %89, align 8
+// CHECK-NEXT:   %90 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/ifaceprom.I.one$bound", ptr undef }, ptr %88, 1
+// CHECK-NEXT:   %91 = extractvalue { ptr, ptr } %90, 1
+// CHECK-NEXT:   %92 = extractvalue { ptr, ptr } %90, 0
+// CHECK-NEXT:   %93 = call i64 %92(ptr %91)
+// CHECK-NEXT:   %94 = icmp ne i64 %93, 1
+// CHECK-NEXT:   br i1 %94, label %_llgo_5, label %_llgo_6
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_18:                                         ; preds = %_llgo_4
+// CHECK-NEXT:   %95 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @12, i64 116 }, ptr %95, align 8
+// CHECK-NEXT:   %96 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %95, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %96)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_19:                                         ; preds = %_llgo_6
+// CHECK-NEXT:   %97 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   %98 = getelementptr inbounds { %"{{.*}}/runtime/internal/runtime.iface" }, ptr %97, i32 0, i32 0
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %41, ptr %98, align 8
+// CHECK-NEXT:   %99 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/ifaceprom.I.one$bound", ptr undef }, ptr %97, 1
+// CHECK-NEXT:   %100 = extractvalue { ptr, ptr } %99, 1
+// CHECK-NEXT:   %101 = extractvalue { ptr, ptr } %99, 0
+// CHECK-NEXT:   %102 = call i64 %101(ptr %100)
+// CHECK-NEXT:   %103 = icmp ne i64 %102, 1
+// CHECK-NEXT:   br i1 %103, label %_llgo_7, label %_llgo_8
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_20:                                         ; preds = %_llgo_6
+// CHECK-NEXT:   %104 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @12, i64 116 }, ptr %104, align 8
+// CHECK-NEXT:   %105 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %104, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %105)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_21:                                         ; preds = %_llgo_12
+// CHECK-NEXT:   %106 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   %107 = getelementptr inbounds { %"{{.*}}/runtime/internal/runtime.iface" }, ptr %106, i32 0, i32 0
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %77, ptr %107, align 8
+// CHECK-NEXT:   %108 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/ifaceprom.I.two$bound", ptr undef }, ptr %106, 1
+// CHECK-NEXT:   %109 = extractvalue { ptr, ptr } %108, 1
+// CHECK-NEXT:   %110 = extractvalue { ptr, ptr } %108, 0
+// CHECK-NEXT:   %111 = call %"{{.*}}/runtime/internal/runtime.String" %110(ptr %109)
+// CHECK-NEXT:   %112 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %111, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 3 })
+// CHECK-NEXT:   %113 = xor i1 %112, true
+// CHECK-NEXT:   br i1 %113, label %_llgo_13, label %_llgo_14
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_22:                                         ; preds = %_llgo_12
+// CHECK-NEXT:   %114 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @12, i64 116 }, ptr %114, align 8
+// CHECK-NEXT:   %115 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %114, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %115)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_23:                                         ; preds = %_llgo_14
+// CHECK-NEXT:   %116 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   %117 = getelementptr inbounds { %"{{.*}}/runtime/internal/runtime.iface" }, ptr %116, i32 0, i32 0
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %83, ptr %117, align 8
+// CHECK-NEXT:   %118 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/ifaceprom.I.two$bound", ptr undef }, ptr %116, 1
+// CHECK-NEXT:   %119 = extractvalue { ptr, ptr } %118, 1
+// CHECK-NEXT:   %120 = extractvalue { ptr, ptr } %118, 0
+// CHECK-NEXT:   %121 = call %"{{.*}}/runtime/internal/runtime.String" %120(ptr %119)
+// CHECK-NEXT:   %122 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %121, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 3 })
+// CHECK-NEXT:   %123 = xor i1 %122, true
+// CHECK-NEXT:   br i1 %123, label %_llgo_15, label %_llgo_16
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_24:                                         ; preds = %_llgo_14
+// CHECK-NEXT:   %124 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @12, i64 116 }, ptr %124, align 8
+// CHECK-NEXT:   %125 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %124, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %125)
+// CHECK-NEXT:   unreachable
+// CHECK-NEXT: }
 func main() {
 	var s S
 	s.I = impl{}

--- a/cl/_testgo/interface/in.go
+++ b/cl/_testgo/interface/in.go
@@ -18,31 +18,91 @@ type Game2 struct {
 func (p *Game2) initGame() {
 }
 
-// CHECK-LABEL: define void @"{{.*}}interface.main"() {
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/interface.main"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/interface.Game1", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 0)
+// CHECK-NEXT:   store ptr %2, ptr %1, align 8
+// CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_{{.*}}/cl/_testgo/interface.Game1", ptr undef }, ptr %0, 1
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 0)
+// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"*_llgo_{{.*}}/cl/_testgo/interface.Game2", ptr undef }, ptr %4, 1
+// CHECK-NEXT:   %6 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %3, 0
+// CHECK-NEXT:   %7 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @"_llgo_{{.*}}/cl/_testdata/foo.Gamer", ptr %6)
+// CHECK-NEXT:   br i1 %7, label %_llgo_3, label %_llgo_4
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_5
+// CHECK-NEXT:   %8 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %25)
+// CHECK-NEXT:   %9 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %25, 0
+// CHECK-NEXT:   %10 = getelementptr ptr, ptr %9, i64 3
+// CHECK-NEXT:   %11 = load ptr, ptr %10, align 8
+// CHECK-NEXT:   %12 = insertvalue { ptr, ptr } undef, ptr %11, 0
+// CHECK-NEXT:   %13 = insertvalue { ptr, ptr } %12, ptr %8, 1
+// CHECK-NEXT:   %14 = extractvalue { ptr, ptr } %13, 1
+// CHECK-NEXT:   %15 = extractvalue { ptr, ptr } %13, 0
+// CHECK-NEXT:   call void %15(ptr %14)
+// CHECK-NEXT:   br label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_5
+// CHECK-NEXT:   %16 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %5, 0
+// CHECK-NEXT:   %17 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @"_llgo_{{.*}}/cl/_testdata/foo.Gamer", ptr %16)
+// CHECK-NEXT:   br i1 %17, label %_llgo_6, label %_llgo_7
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %18 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %3, 1
+// CHECK-NEXT:   %19 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testdata/foo.iface$sO8a1LvuUsjXwiwaC6sR9-L4DiYgiOnZi7iosyShJXg", ptr %6)
+// CHECK-NEXT:   %20 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %19, 0
+// CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %20, ptr %18, 1
+// CHECK-NEXT:   %22 = insertvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } undef, %"{{.*}}/runtime/internal/runtime.iface" %21, 0
+// CHECK-NEXT:   %23 = insertvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } %22, i1 true, 1
+// CHECK-NEXT:   br label %_llgo_5
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   br label %_llgo_5
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
+// CHECK-NEXT:   %24 = phi { %"{{.*}}/runtime/internal/runtime.iface", i1 } [ %23, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
+// CHECK-NEXT:   %25 = extractvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } %24, 0
+// CHECK-NEXT:   %26 = extractvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } %24, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @13, i64 2 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintIface"(%"{{.*}}/runtime/internal/runtime.iface" %25)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %26)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   br i1 %26, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_2
+// CHECK-NEXT:   %27 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %5, 1
+// CHECK-NEXT:   %28 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testdata/foo.iface$sO8a1LvuUsjXwiwaC6sR9-L4DiYgiOnZi7iosyShJXg", ptr %16)
+// CHECK-NEXT:   %29 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %28, 0
+// CHECK-NEXT:   %30 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %29, ptr %27, 1
+// CHECK-NEXT:   %31 = insertvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } undef, %"{{.*}}/runtime/internal/runtime.iface" %30, 0
+// CHECK-NEXT:   %32 = insertvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } %31, i1 true, 1
+// CHECK-NEXT:   br label %_llgo_8
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_2
+// CHECK-NEXT:   br label %_llgo_8
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_7, %_llgo_6
+// CHECK-NEXT:   %33 = phi { %"{{.*}}/runtime/internal/runtime.iface", i1 } [ %32, %_llgo_6 ], [ zeroinitializer, %_llgo_7 ]
+// CHECK-NEXT:   %34 = extractvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } %33, 0
+// CHECK-NEXT:   %35 = extractvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } %33, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @14, i64 4 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintIface"(%"{{.*}}/runtime/internal/runtime.iface" %34)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %35)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 func main() {
-	// CHECK: call ptr @"{{.*}}AllocZ"(i64 8)
-	// CHECK: getelementptr inbounds %"{{.*}}interface.Game1", ptr %0, i32 0, i32 0
-	// CHECK: call ptr @"{{.*}}AllocZ"(i64 0)
-	// CHECK: store ptr %{{[0-9]+}}, ptr %{{[0-9]+}}, align 8
-	// CHECK: insertvalue %"{{.*}}eface" { ptr @"{{.*}}interface.Game1", ptr undef }, ptr %0, 1
 	var g1 any = &Game1{&foo.Game{}}
 
-	// CHECK: call ptr @"{{.*}}AllocZ"(i64 0)
-	// CHECK: insertvalue %"{{.*}}eface" { ptr @"{{.*}}interface.Game2", ptr undef }, ptr %{{[0-9]+}}, 1
 	var g2 any = &Game2{}
 
-	// CHECK: call i1 @"{{.*}}Implements"(ptr @"{{.*}}foo.Gamer", ptr %{{[0-9]+}})
-	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}foo.iface{{.*}}", ptr %{{[0-9]+}})
-	// CHECK: insertvalue %"{{.*}}iface" undef, ptr %{{[0-9]+}}, 0
-	// CHECK: insertvalue { %"{{.*}}iface", i1 } %{{[0-9]+}}, i1 true, 1
 	v1, ok := g1.(foo.Gamer)
 
-	// CHECK: call void @"{{.*}}PrintString"(%"{{.*}}String" { ptr @{{[0-9]+}}, i64 2 })
-	// CHECK-NEXT: call void @"{{.*}}PrintByte"(i8 32)
-	// CHECK-NEXT: call void @"{{.*}}PrintIface"(%"{{.*}}iface" %{{[0-9]+}})
-	// CHECK-NEXT: call void @"{{.*}}PrintByte"(i8 32)
-	// CHECK-NEXT: call void @"{{.*}}PrintBool"(i1 %{{[0-9]+}})
-	// CHECK-NEXT: call void @"{{.*}}PrintByte"(i8 10)
 	println("OK", v1, ok)
 
 	if ok {
@@ -51,12 +111,5 @@ func main() {
 
 	v2, ok := g2.(foo.Gamer)
 
-	// CHECK: call void @"{{.*}}PrintString"(%"{{.*}}String" { ptr @{{[0-9]+}}, i64 4 })
-	// CHECK-NEXT: call void @"{{.*}}PrintByte"(i8 32)
-	// CHECK-NEXT: call void @"{{.*}}PrintIface"(%"{{.*}}iface" %{{[0-9]+}})
-	// CHECK-NEXT: call void @"{{.*}}PrintByte"(i8 32)
-	// CHECK-NEXT: call void @"{{.*}}PrintBool"(i1 %{{[0-9]+}})
-	// CHECK-NEXT: call void @"{{.*}}PrintByte"(i8 10)
-	// CHECK-NEXT: ret void
 	println("FAIL", v2, ok)
 }

--- a/cl/_testgo/invoke/in.go
+++ b/cl/_testgo/invoke/in.go
@@ -79,6 +79,19 @@ func (t *T3) Invoke() int {
 
 type T4 [1]int
 
+// CHECK-LABEL: define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.T4.Invoke"([1 x i64] %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca [1 x i64], align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   store [1 x i64] %0, ptr %1, align 4
+// CHECK-NEXT:   %2 = getelementptr inbounds i64, ptr %1, i64 0
+// CHECK-NEXT:   %3 = load i64, ptr %2, align 4
+// CHECK-NEXT:   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @4, i64 7 })
+// CHECK-NEXT:   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
+// CHECK-NEXT:   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %3)
+// CHECK-NEXT:   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   ret i64 4
+// CHECK-NEXT: }
 func (t T4) Invoke() int {
 	println("invoke4", t[0])
 	return 4
@@ -88,6 +101,19 @@ type T5 struct {
 	n int
 }
 
+// CHECK-LABEL: define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.T5.Invoke"(%"github.com/goplus/llgo/cl/_testgo/invoke.T5" %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca %"github.com/goplus/llgo/cl/_testgo/invoke.T5", align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   store %"github.com/goplus/llgo/cl/_testgo/invoke.T5" %0, ptr %1, align 4
+// CHECK-NEXT:   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/invoke.T5", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   %3 = load i64, ptr %2, align 4
+// CHECK-NEXT:   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @5, i64 7 })
+// CHECK-NEXT:   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
+// CHECK-NEXT:   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %3)
+// CHECK-NEXT:   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   ret i64 5
+// CHECK-NEXT: }
 func (t T5) Invoke() int {
 	println("invoke5", t.n)
 	return 5
@@ -112,6 +138,10 @@ func (t T6) Invoke() int {
 
 type I interface {
 	Invoke() int
+}
+
+func invoke(i I) {
+	println(i.Invoke())
 }
 
 // CHECK-LABEL: define void @"{{.*}}invoke.invoke"(%"{{.*}}iface" %0) {
@@ -169,9 +199,20 @@ func main() {
 	// CHECK: call void @"{{.*}}invoke.invoke"(%"{{.*}}iface" %{{[0-9]+}})
 	invoke(&t3)
 
+	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr @"_llgo_{{.*}}invoke.T4")
+	// CHECK: call void @"{{.*}}invoke.invoke"(%"{{.*}}iface" %{{[0-9]+}})
 	invoke(t4)
+
+	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr @"*_llgo_{{.*}}invoke.T4")
+	// CHECK: call void @"{{.*}}invoke.invoke"(%"{{.*}}iface" %{{[0-9]+}})
 	invoke(&t4)
+
+	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr @"_llgo_{{.*}}invoke.T5")
+	// CHECK: call void @"{{.*}}invoke.invoke"(%"{{.*}}iface" %{{[0-9]+}})
 	invoke(t5)
+
+	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr @"*_llgo_{{.*}}invoke.T5")
+	// CHECK: call void @"{{.*}}invoke.invoke"(%"{{.*}}iface" %{{[0-9]+}})
 	invoke(&t5)
 
 	// CHECK: call ptr @"{{.*}}AllocU"(i64 16)
@@ -218,10 +259,6 @@ func main() {
 
 	//panic
 	//invoke(nil)
-}
-
-func invoke(i I) {
-	println(i.Invoke())
 }
 
 type M interface {

--- a/cl/_testgo/reader/in.go
+++ b/cl/_testgo/reader/in.go
@@ -1,4 +1,3 @@
-// LITTEST
 package main
 
 import (
@@ -106,10 +105,13 @@ type StringWriter interface {
 	WriteString(s string) (n int, err error)
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/reader.NopCloser"{{.*}}
-// CHECK: IfaceType
-// CHECK: Implements
-// CHECK: NewItab
+func WriteString(w Writer, s string) (n int, err error) {
+	if sw, ok := w.(StringWriter); ok {
+		return sw.WriteString(s)
+	}
+	return w.Write([]byte(s))
+}
+
 func NopCloser(r Reader) ReadCloser {
 	if _, ok := r.(WriterTo); ok {
 		return nopCloserWriterTo{r}
@@ -133,9 +135,6 @@ func (c nopCloserWriterTo) WriteTo(w Writer) (n int64, err error) {
 	return c.Reader.(WriterTo).WriteTo(w)
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/reader.ReadAll"{{.*}}
-// CHECK: NewSlice3
-// CHECK: SliceAppend
 func ReadAll(r Reader) ([]byte, error) {
 	b := make([]byte, 0, 512)
 	for {
@@ -153,15 +152,6 @@ func ReadAll(r Reader) ([]byte, error) {
 			b = append(b, 0)[:len(b)]
 		}
 	}
-}
-
-// CHECK-LABEL: define {{.*}} @"{{.*}}/reader.WriteString"{{.*}}
-// CHECK: StringToBytes
-func WriteString(w Writer, s string) (n int, err error) {
-	if sw, ok := w.(StringWriter); ok {
-		return sw.WriteString(s)
-	}
-	return w.Write([]byte(s))
 }
 
 type stringReader struct {
@@ -310,12 +300,6 @@ var (
 	ErrShortWrite = newError("short write")
 )
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/reader.main"{{.*}}
-// CHECK: ReadAll
-// CHECK: StringFromBytes
-// CHECK: PrintString
-// CHECK: PrintIface
-// CHECK: ret void
 func main() {
 	r := &stringReader{s: "hello world"}
 	data, err := ReadAll(r)

--- a/cl/_testgo/reader/out.ll
+++ b/cl/_testgo/reader/out.ll
@@ -1,0 +1,1075 @@
+; ModuleID = 'github.com/goplus/llgo/cl/_testgo/reader'
+source_filename = "github.com/goplus/llgo/cl/_testgo/reader"
+
+%"github.com/goplus/llgo/runtime/internal/runtime.iface" = type { ptr, ptr }
+%"github.com/goplus/llgo/runtime/abi.InterfaceType" = type { %"github.com/goplus/llgo/runtime/abi.Type", %"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.Slice" }
+%"github.com/goplus/llgo/runtime/abi.Type" = type { i64, i64, i32, i8, i8, i8, i8, { ptr, ptr }, ptr, %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr }
+%"github.com/goplus/llgo/runtime/internal/runtime.String" = type { ptr, i64 }
+%"github.com/goplus/llgo/runtime/internal/runtime.Slice" = type { ptr, i64, i64 }
+%"github.com/goplus/llgo/runtime/abi.PtrType" = type { %"github.com/goplus/llgo/runtime/abi.Type", ptr }
+%"github.com/goplus/llgo/runtime/abi.FuncType" = type { %"github.com/goplus/llgo/runtime/abi.Type", %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.Slice" }
+%"github.com/goplus/llgo/runtime/abi.SliceType" = type { %"github.com/goplus/llgo/runtime/abi.Type", ptr }
+%"github.com/goplus/llgo/runtime/abi.Imethod" = type { %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr }
+%"github.com/goplus/llgo/runtime/abi.StructType" = type { %"github.com/goplus/llgo/runtime/abi.Type", %"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.Slice" }
+%"github.com/goplus/llgo/runtime/abi.UncommonType" = type { %"github.com/goplus/llgo/runtime/internal/runtime.String", i16, i16, i32 }
+%"github.com/goplus/llgo/runtime/abi.Method" = type { %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr, ptr, ptr }
+%"github.com/goplus/llgo/runtime/abi.StructField" = type { %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr, i64, %"github.com/goplus/llgo/runtime/internal/runtime.String", i1 }
+%"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo" = type { %"github.com/goplus/llgo/runtime/internal/runtime.iface" }
+%"github.com/goplus/llgo/cl/_testgo/reader.nopCloser" = type { %"github.com/goplus/llgo/runtime/internal/runtime.iface" }
+%"github.com/goplus/llgo/runtime/internal/runtime.eface" = type { ptr, ptr }
+%"github.com/goplus/llgo/cl/_testgo/reader.errorString" = type { %"github.com/goplus/llgo/runtime/internal/runtime.String" }
+%"github.com/goplus/llgo/cl/_testgo/reader.stringReader" = type { %"github.com/goplus/llgo/runtime/internal/runtime.String", i64, i64 }
+
+@"github.com/goplus/llgo/cl/_testgo/reader.EOF" = global %"github.com/goplus/llgo/runtime/internal/runtime.iface" zeroinitializer, align 8
+@"github.com/goplus/llgo/cl/_testgo/reader.ErrShortWrite" = global %"github.com/goplus/llgo/runtime/internal/runtime.iface" zeroinitializer, align 8
+@"github.com/goplus/llgo/cl/_testgo/reader.init$guard" = global i1 false, align 1
+@"_llgo_github.com/goplus/llgo/cl/_testgo/reader.WriterTo" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.InterfaceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 1496804321, i8 4, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 13 }, ptr @"*_llgo_github.com/goplus/llgo/cl/_testgo/reader.WriterTo" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 40 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$p5Bo_emI1h8acs1rFbUxZTrpeDbIQ34gFcsbwK9YIgs$imethods", i64 1, i64 1 } }, align 8
+@0 = private unnamed_addr constant [13 x i8] c"main.WriterTo", align 1
+@"*_llgo_github.com/goplus/llgo/cl/_testgo/reader.WriterTo" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -2025713268, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 13 }, ptr null }, ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reader.WriterTo" }, align 8
+@1 = private unnamed_addr constant [40 x i8] c"github.com/goplus/llgo/cl/_testgo/reader", align 1
+@2 = private unnamed_addr constant [7 x i8] c"WriteTo", align 1
+@"_llgo_func$V_kP-r1nn8Ij-G2jGIm9ROLn4CjtLBch-g3Ha7pGJo4" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 306543811, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @3, i64 32 }, ptr @"*_llgo_func$V_kP-r1nn8Ij-G2jGIm9ROLn4CjtLBch-g3Ha7pGJo4" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$V_kP-r1nn8Ij-G2jGIm9ROLn4CjtLBch-g3Ha7pGJo4$in", i64 1, i64 1 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$V_kP-r1nn8Ij-G2jGIm9ROLn4CjtLBch-g3Ha7pGJo4$out", i64 2, i64 2 } }, align 8
+@3 = private unnamed_addr constant [32 x i8] c"func(main.Writer) (int64, error)", align 1
+@"*_llgo_func$V_kP-r1nn8Ij-G2jGIm9ROLn4CjtLBch-g3Ha7pGJo4" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1170995737, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @3, i64 32 }, ptr null }, ptr @"_llgo_func$V_kP-r1nn8Ij-G2jGIm9ROLn4CjtLBch-g3Ha7pGJo4" }, align 8
+@"_llgo_github.com/goplus/llgo/cl/_testgo/reader.Writer" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.InterfaceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 2135553712, i8 4, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @4, i64 11 }, ptr @"*_llgo_github.com/goplus/llgo/cl/_testgo/reader.Writer" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 40 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$kr1iSWwMezh0B9LdQN0MhEZUNZvBlHPhlst95jAyxE0$imethods", i64 1, i64 1 } }, align 8
+@4 = private unnamed_addr constant [11 x i8] c"main.Writer", align 1
+@"*_llgo_github.com/goplus/llgo/cl/_testgo/reader.Writer" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 466144066, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @4, i64 11 }, ptr null }, ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reader.Writer" }, align 8
+@5 = private unnamed_addr constant [5 x i8] c"Write", align 1
+@"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -58533757, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @6, i64 26 }, ptr @"*_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk$in", i64 1, i64 1 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk$out", i64 2, i64 2 } }, align 8
+@6 = private unnamed_addr constant [26 x i8] c"func([]uint8) (int, error)", align 1
+@"*_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1244675479, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @6, i64 26 }, ptr null }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk" }, align 8
+@"[]_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 370346748, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 7 }, ptr @"*[]_llgo_uint8" }, ptr @_llgo_uint8 }, align 8
+@7 = private unnamed_addr constant [7 x i8] c"[]uint8", align 1
+@"*[]_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -2143776929, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 7 }, ptr null }, ptr @"[]_llgo_uint8" }, align 8
+@_llgo_uint8 = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 1, i64 0, i32 269156761, i8 12, i8 1, i8 1, i8 40, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 5 }, ptr @"*_llgo_uint8" }, align 8
+@8 = private unnamed_addr constant [5 x i8] c"uint8", align 1
+@"*_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1277858201, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 5 }, ptr null }, ptr @_llgo_uint8 }, align 8
+@"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk$in" = weak_odr constant [1 x ptr] [ptr @"[]_llgo_uint8"], align 8
+@_llgo_int = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 0, i32 -25294021, i8 12, i8 8, i8 8, i8 34, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @9, i64 3 }, ptr @"*_llgo_int" }, align 8
+@9 = private unnamed_addr constant [3 x i8] c"int", align 1
+@"*_llgo_int" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -939606833, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @9, i64 3 }, ptr null }, ptr @_llgo_int }, align 8
+@_llgo_error = weak_odr constant %"github.com/goplus/llgo/runtime/abi.InterfaceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 -1462738452, i8 4, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @10, i64 5 }, ptr @"*_llgo_error" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 40 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU$imethods", i64 1, i64 1 } }, align 8
+@10 = private unnamed_addr constant [5 x i8] c"error", align 1
+@"*_llgo_error" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1621558991, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @10, i64 5 }, ptr null }, ptr @_llgo_error }, align 8
+@11 = private unnamed_addr constant [5 x i8] c"Error", align 1
+@"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1419376263, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @12, i64 13 }, ptr @"*_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to$out", i64 1, i64 1 } }, align 8
+@12 = private unnamed_addr constant [13 x i8] c"func() string", align 1
+@"*_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1900367307, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @12, i64 13 }, ptr null }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" }, align 8
+@_llgo_string = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 8, i32 1749264893, i8 4, i8 8, i8 8, i8 24, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @13, i64 6 }, ptr @"*_llgo_string" }, align 8
+@13 = private unnamed_addr constant [6 x i8] c"string", align 1
+@"*_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1323879264, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @13, i64 6 }, ptr null }, ptr @_llgo_string }, align 8
+@"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to$out" = weak_odr constant [1 x ptr] [ptr @_llgo_string], align 8
+@"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU$imethods" = weak_odr constant [1 x %"github.com/goplus/llgo/runtime/abi.Imethod"] [%"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @11, i64 5 }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" }], align 8
+@"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk$out" = weak_odr constant [2 x ptr] [ptr @_llgo_int, ptr @_llgo_error], align 8
+@"_llgo_iface$kr1iSWwMezh0B9LdQN0MhEZUNZvBlHPhlst95jAyxE0$imethods" = weak_odr constant [1 x %"github.com/goplus/llgo/runtime/abi.Imethod"] [%"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @5, i64 5 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk" }], align 8
+@"_llgo_func$V_kP-r1nn8Ij-G2jGIm9ROLn4CjtLBch-g3Ha7pGJo4$in" = weak_odr constant [1 x ptr] [ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reader.Writer"], align 8
+@_llgo_int64 = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 0, i32 394795202, i8 12, i8 8, i8 8, i8 38, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @14, i64 5 }, ptr @"*_llgo_int64" }, align 8
+@14 = private unnamed_addr constant [5 x i8] c"int64", align 1
+@"*_llgo_int64" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1901231210, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @14, i64 5 }, ptr null }, ptr @_llgo_int64 }, align 8
+@"_llgo_func$V_kP-r1nn8Ij-G2jGIm9ROLn4CjtLBch-g3Ha7pGJo4$out" = weak_odr constant [2 x ptr] [ptr @_llgo_int64, ptr @_llgo_error], align 8
+@"_llgo_iface$p5Bo_emI1h8acs1rFbUxZTrpeDbIQ34gFcsbwK9YIgs$imethods" = weak_odr constant [1 x %"github.com/goplus/llgo/runtime/abi.Imethod"] [%"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @2, i64 7 }, ptr @"_llgo_func$V_kP-r1nn8Ij-G2jGIm9ROLn4CjtLBch-g3Ha7pGJo4" }], align 8
+@"_llgo_iface$p5Bo_emI1h8acs1rFbUxZTrpeDbIQ34gFcsbwK9YIgs" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.InterfaceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 999934762, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 49 }, ptr @"*_llgo_iface$p5Bo_emI1h8acs1rFbUxZTrpeDbIQ34gFcsbwK9YIgs" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 40 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$p5Bo_emI1h8acs1rFbUxZTrpeDbIQ34gFcsbwK9YIgs$imethods", i64 1, i64 1 } }, align 8
+@15 = private unnamed_addr constant [49 x i8] c"interface { WriteTo(main.Writer) (int64, error) }", align 1
+@"*_llgo_iface$p5Bo_emI1h8acs1rFbUxZTrpeDbIQ34gFcsbwK9YIgs" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1324065545, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 49 }, ptr null }, ptr @"_llgo_iface$p5Bo_emI1h8acs1rFbUxZTrpeDbIQ34gFcsbwK9YIgs" }, align 8
+@"_llgo_github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 -2131804033, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @16, i64 22 }, ptr @"*_llgo_github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$aF5tOq8uFNwjAKwq7XzhGO-4YESPiFwZOQDpqkTBqL8$fields", i64 1, i64 1 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 40 }, i16 3, i16 3, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @17, i64 5 }, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloserWriterTo).Close", ptr @"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo.Close" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @19, i64 4 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloserWriterTo).Read", ptr @"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo.Read" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @2, i64 7 }, ptr @"_llgo_func$V_kP-r1nn8Ij-G2jGIm9ROLn4CjtLBch-g3Ha7pGJo4", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloserWriterTo).WriteTo", ptr @"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo.WriteTo" }] }, align 8
+@16 = private unnamed_addr constant [22 x i8] c"main.nopCloserWriterTo", align 1
+@"*_llgo_github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [3 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 2074015848, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @16, i64 22 }, ptr null }, ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 40 }, i16 3, i16 3, i32 24 }, [3 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @17, i64 5 }, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloserWriterTo).Close", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloserWriterTo).Close" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @19, i64 4 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloserWriterTo).Read", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloserWriterTo).Read" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @2, i64 7 }, ptr @"_llgo_func$V_kP-r1nn8Ij-G2jGIm9ROLn4CjtLBch-g3Ha7pGJo4", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloserWriterTo).WriteTo", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloserWriterTo).WriteTo" }] }, align 8
+@17 = private unnamed_addr constant [5 x i8] c"Close", align 1
+@"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1183719404, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @18, i64 12 }, ptr @"*_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w$out", i64 1, i64 1 } }, align 8
+@18 = private unnamed_addr constant [12 x i8] c"func() error", align 1
+@"*_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1571491799, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @18, i64 12 }, ptr null }, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w" }, align 8
+@"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w$out" = weak_odr constant [1 x ptr] [ptr @_llgo_error], align 8
+@19 = private unnamed_addr constant [4 x i8] c"Read", align 1
+@20 = private unnamed_addr constant [6 x i8] c"Reader", align 1
+@"_llgo_github.com/goplus/llgo/cl/_testgo/reader.Reader" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.InterfaceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 1318060398, i8 4, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @21, i64 11 }, ptr @"*_llgo_github.com/goplus/llgo/cl/_testgo/reader.Reader" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 40 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw$imethods", i64 1, i64 1 } }, align 8
+@21 = private unnamed_addr constant [11 x i8] c"main.Reader", align 1
+@"*_llgo_github.com/goplus/llgo/cl/_testgo/reader.Reader" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 688483744, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @21, i64 11 }, ptr null }, ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reader.Reader" }, align 8
+@"_llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw$imethods" = weak_odr constant [1 x %"github.com/goplus/llgo/runtime/abi.Imethod"] [%"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @19, i64 4 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk" }], align 8
+@"_llgo_struct$aF5tOq8uFNwjAKwq7XzhGO-4YESPiFwZOQDpqkTBqL8$fields" = weak_odr constant [1 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @20, i64 6 }, ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reader.Reader", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 true }], align 8
+@"_llgo_iface$2bmbYDBStAIdmbXPPn7qIaCcpVcj2I5k6AqgqwAfh84" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.InterfaceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 -330631760, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @22, i64 55 }, ptr @"*_llgo_iface$2bmbYDBStAIdmbXPPn7qIaCcpVcj2I5k6AqgqwAfh84" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 40 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$2bmbYDBStAIdmbXPPn7qIaCcpVcj2I5k6AqgqwAfh84$imethods", i64 2, i64 2 } }, align 8
+@22 = private unnamed_addr constant [55 x i8] c"interface { Close() error; Read([]uint8) (int, error) }", align 1
+@"*_llgo_iface$2bmbYDBStAIdmbXPPn7qIaCcpVcj2I5k6AqgqwAfh84" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -322135592, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @22, i64 55 }, ptr null }, ptr @"_llgo_iface$2bmbYDBStAIdmbXPPn7qIaCcpVcj2I5k6AqgqwAfh84" }, align 8
+@"_llgo_iface$2bmbYDBStAIdmbXPPn7qIaCcpVcj2I5k6AqgqwAfh84$imethods" = weak_odr constant [2 x %"github.com/goplus/llgo/runtime/abi.Imethod"] [%"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @17, i64 5 }, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w" }, %"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @19, i64 4 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk" }], align 8
+@"_llgo_github.com/goplus/llgo/cl/_testgo/reader.nopCloser" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [2 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 -1105494488, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reader.nopCloser" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 14 }, ptr @"*_llgo_github.com/goplus/llgo/cl/_testgo/reader.nopCloser" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$aF5tOq8uFNwjAKwq7XzhGO-4YESPiFwZOQDpqkTBqL8$fields", i64 1, i64 1 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 40 }, i16 2, i16 2, i32 24 }, [2 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @17, i64 5 }, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloser).Close", ptr @"github.com/goplus/llgo/cl/_testgo/reader.nopCloser.Close" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @19, i64 4 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloser).Read", ptr @"github.com/goplus/llgo/cl/_testgo/reader.nopCloser.Read" }] }, align 8
+@23 = private unnamed_addr constant [14 x i8] c"main.nopCloser", align 1
+@"*_llgo_github.com/goplus/llgo/cl/_testgo/reader.nopCloser" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [2 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1379326590, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 14 }, ptr null }, ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reader.nopCloser" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 40 }, i16 2, i16 2, i32 24 }, [2 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @17, i64 5 }, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloser).Close", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloser).Close" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @19, i64 4 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloser).Read", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloser).Read" }] }, align 8
+@"_llgo_github.com/goplus/llgo/cl/_testgo/reader.StringWriter" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.InterfaceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 907110884, i8 4, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @24, i64 17 }, ptr @"*_llgo_github.com/goplus/llgo/cl/_testgo/reader.StringWriter" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 40 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$Ly4zXiUMEac-hYAMw6b6miJ1JEhGfLyBWyBOhpsRZcU$imethods", i64 1, i64 1 } }, align 8
+@24 = private unnamed_addr constant [17 x i8] c"main.StringWriter", align 1
+@"*_llgo_github.com/goplus/llgo/cl/_testgo/reader.StringWriter" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 128707447, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @24, i64 17 }, ptr null }, ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reader.StringWriter" }, align 8
+@25 = private unnamed_addr constant [11 x i8] c"WriteString", align 1
+@"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -183202291, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @26, i64 25 }, ptr @"*_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw$in", i64 1, i64 1 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw$out", i64 2, i64 2 } }, align 8
+@26 = private unnamed_addr constant [25 x i8] c"func(string) (int, error)", align 1
+@"*_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1229992101, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @26, i64 25 }, ptr null }, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw" }, align 8
+@"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw$in" = weak_odr constant [1 x ptr] [ptr @_llgo_string], align 8
+@"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw$out" = weak_odr constant [2 x ptr] [ptr @_llgo_int, ptr @_llgo_error], align 8
+@"_llgo_iface$Ly4zXiUMEac-hYAMw6b6miJ1JEhGfLyBWyBOhpsRZcU$imethods" = weak_odr constant [1 x %"github.com/goplus/llgo/runtime/abi.Imethod"] [%"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 11 }, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw" }], align 8
+@"_llgo_iface$Ly4zXiUMEac-hYAMw6b6miJ1JEhGfLyBWyBOhpsRZcU" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.InterfaceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 1973521222, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @27, i64 46 }, ptr @"*_llgo_iface$Ly4zXiUMEac-hYAMw6b6miJ1JEhGfLyBWyBOhpsRZcU" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 40 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$Ly4zXiUMEac-hYAMw6b6miJ1JEhGfLyBWyBOhpsRZcU$imethods", i64 1, i64 1 } }, align 8
+@27 = private unnamed_addr constant [46 x i8] c"interface { WriteString(string) (int, error) }", align 1
+@"*_llgo_iface$Ly4zXiUMEac-hYAMw6b6miJ1JEhGfLyBWyBOhpsRZcU" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1598946471, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @27, i64 46 }, ptr null }, ptr @"_llgo_iface$Ly4zXiUMEac-hYAMw6b6miJ1JEhGfLyBWyBOhpsRZcU" }, align 8
+@28 = private unnamed_addr constant [3 x i8] c"EOF", align 1
+@29 = private unnamed_addr constant [11 x i8] c"short write", align 1
+@30 = private unnamed_addr constant [11 x i8] c"hello world", align 1
+@"*_llgo_github.com/goplus/llgo/cl/_testgo/reader.stringReader" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [10 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1218063015, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @31, i64 17 }, ptr null }, ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reader.stringReader" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 40 }, i16 10, i16 10, i32 24 }, [10 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @35, i64 3 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).Len", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).Len" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @19, i64 4 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).Read", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).Read" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @37, i64 6 }, ptr @"_llgo_func$QoHVzMQ4PMXOd5kbZvdARJn-o_00R6hNyf6LoVk3X_4", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).ReadAt", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).ReadAt" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @39, i64 8 }, ptr @"_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).ReadByte", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).ReadByte" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @41, i64 8 }, ptr @"_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).ReadRune", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).ReadRune" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @44, i64 4 }, ptr @"_llgo_func$HE7H49xPa1uXmrkMDpqB3RCRGf3qzhLGrxKCEXOYjms", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).Seek", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).Seek" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @46, i64 4 }, ptr @"_llgo_func$Eoig9xhJM5GShHH5aNPxTZZXp1IZxprRl4zPuv2hkug", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).Size", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).Size" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @48, i64 10 }, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).UnreadByte", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).UnreadByte" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @49, i64 10 }, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).UnreadRune", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).UnreadRune" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @2, i64 7 }, ptr @"_llgo_func$V_kP-r1nn8Ij-G2jGIm9ROLn4CjtLBch-g3Ha7pGJo4", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).WriteTo", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).WriteTo" }] }, align 8
+@31 = private unnamed_addr constant [17 x i8] c"main.stringReader", align 1
+@"_llgo_github.com/goplus/llgo/cl/_testgo/reader.stringReader" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 32, i64 0, i32 -2042302092, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reader.stringReader" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @31, i64 17 }, ptr @"*_llgo_github.com/goplus/llgo/cl/_testgo/reader.stringReader" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 40 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"github.com/goplus/llgo/cl/_testgo/reader.struct$Mdt84yjYYwxF9D2i4cRmpEPiWaO6tsjtrbGUjyESypk$fields", i64 3, i64 3 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 40 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@32 = private unnamed_addr constant [1 x i8] c"s", align 1
+@33 = private unnamed_addr constant [1 x i8] c"i", align 1
+@34 = private unnamed_addr constant [8 x i8] c"prevRune", align 1
+@"github.com/goplus/llgo/cl/_testgo/reader.struct$Mdt84yjYYwxF9D2i4cRmpEPiWaO6tsjtrbGUjyESypk$fields" = weak_odr constant [3 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @32, i64 1 }, ptr @_llgo_string, i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @33, i64 1 }, ptr @_llgo_int64, i64 16, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @34, i64 8 }, ptr @_llgo_int, i64 24, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@35 = private unnamed_addr constant [3 x i8] c"Len", align 1
+@"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 2131144854, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @36, i64 10 }, ptr @"*_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA$out", i64 1, i64 1 } }, align 8
+@36 = private unnamed_addr constant [10 x i8] c"func() int", align 1
+@"*_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1805835775, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @36, i64 10 }, ptr null }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" }, align 8
+@"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA$out" = weak_odr constant [1 x ptr] [ptr @_llgo_int], align 8
+@37 = private unnamed_addr constant [6 x i8] c"ReadAt", align 1
+@"_llgo_func$QoHVzMQ4PMXOd5kbZvdARJn-o_00R6hNyf6LoVk3X_4" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 475784095, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @38, i64 33 }, ptr @"*_llgo_func$QoHVzMQ4PMXOd5kbZvdARJn-o_00R6hNyf6LoVk3X_4" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$QoHVzMQ4PMXOd5kbZvdARJn-o_00R6hNyf6LoVk3X_4$in", i64 2, i64 2 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$QoHVzMQ4PMXOd5kbZvdARJn-o_00R6hNyf6LoVk3X_4$out", i64 2, i64 2 } }, align 8
+@38 = private unnamed_addr constant [33 x i8] c"func([]uint8, int64) (int, error)", align 1
+@"*_llgo_func$QoHVzMQ4PMXOd5kbZvdARJn-o_00R6hNyf6LoVk3X_4" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -943934209, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @38, i64 33 }, ptr null }, ptr @"_llgo_func$QoHVzMQ4PMXOd5kbZvdARJn-o_00R6hNyf6LoVk3X_4" }, align 8
+@"_llgo_func$QoHVzMQ4PMXOd5kbZvdARJn-o_00R6hNyf6LoVk3X_4$in" = weak_odr constant [2 x ptr] [ptr @"[]_llgo_uint8", ptr @_llgo_int64], align 8
+@"_llgo_func$QoHVzMQ4PMXOd5kbZvdARJn-o_00R6hNyf6LoVk3X_4$out" = weak_odr constant [2 x ptr] [ptr @_llgo_int, ptr @_llgo_error], align 8
+@39 = private unnamed_addr constant [8 x i8] c"ReadByte", align 1
+@"_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1499372428, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @40, i64 21 }, ptr @"*_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ$out", i64 2, i64 2 } }, align 8
+@40 = private unnamed_addr constant [21 x i8] c"func() (uint8, error)", align 1
+@"*_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1164205677, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @40, i64 21 }, ptr null }, ptr @"_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ" }, align 8
+@"_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ$out" = weak_odr constant [2 x ptr] [ptr @_llgo_uint8, ptr @_llgo_error], align 8
+@41 = private unnamed_addr constant [8 x i8] c"ReadRune", align 1
+@"_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1043083527, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @42, i64 26 }, ptr @"*_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y$out", i64 3, i64 3 } }, align 8
+@42 = private unnamed_addr constant [26 x i8] c"func() (int32, int, error)", align 1
+@"*_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 746645372, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @42, i64 26 }, ptr null }, ptr @"_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y" }, align 8
+@_llgo_int32 = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 4, i64 0, i32 1448558410, i8 12, i8 4, i8 4, i8 37, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal32", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @43, i64 5 }, ptr @"*_llgo_int32" }, align 8
+@43 = private unnamed_addr constant [5 x i8] c"int32", align 1
+@"*_llgo_int32" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -38689692, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @43, i64 5 }, ptr null }, ptr @_llgo_int32 }, align 8
+@"_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y$out" = weak_odr constant [3 x ptr] [ptr @_llgo_int32, ptr @_llgo_int, ptr @_llgo_error], align 8
+@44 = private unnamed_addr constant [4 x i8] c"Seek", align 1
+@"_llgo_func$HE7H49xPa1uXmrkMDpqB3RCRGf3qzhLGrxKCEXOYjms" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -367037366, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @45, i64 31 }, ptr @"*_llgo_func$HE7H49xPa1uXmrkMDpqB3RCRGf3qzhLGrxKCEXOYjms" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$HE7H49xPa1uXmrkMDpqB3RCRGf3qzhLGrxKCEXOYjms$in", i64 2, i64 2 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$HE7H49xPa1uXmrkMDpqB3RCRGf3qzhLGrxKCEXOYjms$out", i64 2, i64 2 } }, align 8
+@45 = private unnamed_addr constant [31 x i8] c"func(int64, int) (int64, error)", align 1
+@"*_llgo_func$HE7H49xPa1uXmrkMDpqB3RCRGf3qzhLGrxKCEXOYjms" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1356075299, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @45, i64 31 }, ptr null }, ptr @"_llgo_func$HE7H49xPa1uXmrkMDpqB3RCRGf3qzhLGrxKCEXOYjms" }, align 8
+@"_llgo_func$HE7H49xPa1uXmrkMDpqB3RCRGf3qzhLGrxKCEXOYjms$in" = weak_odr constant [2 x ptr] [ptr @_llgo_int64, ptr @_llgo_int], align 8
+@"_llgo_func$HE7H49xPa1uXmrkMDpqB3RCRGf3qzhLGrxKCEXOYjms$out" = weak_odr constant [2 x ptr] [ptr @_llgo_int64, ptr @_llgo_error], align 8
+@46 = private unnamed_addr constant [4 x i8] c"Size", align 1
+@"_llgo_func$Eoig9xhJM5GShHH5aNPxTZZXp1IZxprRl4zPuv2hkug" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1236366245, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @47, i64 12 }, ptr @"*_llgo_func$Eoig9xhJM5GShHH5aNPxTZZXp1IZxprRl4zPuv2hkug" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$Eoig9xhJM5GShHH5aNPxTZZXp1IZxprRl4zPuv2hkug$out", i64 1, i64 1 } }, align 8
+@47 = private unnamed_addr constant [12 x i8] c"func() int64", align 1
+@"*_llgo_func$Eoig9xhJM5GShHH5aNPxTZZXp1IZxprRl4zPuv2hkug" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 137110153, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @47, i64 12 }, ptr null }, ptr @"_llgo_func$Eoig9xhJM5GShHH5aNPxTZZXp1IZxprRl4zPuv2hkug" }, align 8
+@"_llgo_func$Eoig9xhJM5GShHH5aNPxTZZXp1IZxprRl4zPuv2hkug$out" = weak_odr constant [1 x ptr] [ptr @_llgo_int64], align 8
+@48 = private unnamed_addr constant [10 x i8] c"UnreadByte", align 1
+@49 = private unnamed_addr constant [10 x i8] c"UnreadRune", align 1
+@"_llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.InterfaceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 -2028598289, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @50, i64 40 }, ptr @"*_llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 40 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw$imethods", i64 1, i64 1 } }, align 8
+@50 = private unnamed_addr constant [40 x i8] c"interface { Read([]uint8) (int, error) }", align 1
+@"*_llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1109399972, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @50, i64 40 }, ptr null }, ptr @"_llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw" }, align 8
+@"*_llgo_github.com/goplus/llgo/cl/_testgo/reader.errorString" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [1 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 881334858, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @51, i64 16 }, ptr null }, ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reader.errorString" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 40 }, i16 1, i16 1, i32 24 }, [1 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @11, i64 5 }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*errorString).Error", ptr @"github.com/goplus/llgo/cl/_testgo/reader.(*errorString).Error" }] }, align 8
+@51 = private unnamed_addr constant [16 x i8] c"main.errorString", align 1
+@"_llgo_github.com/goplus/llgo/cl/_testgo/reader.errorString" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 8, i32 -690024693, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reader.errorString" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @51, i64 16 }, ptr @"*_llgo_github.com/goplus/llgo/cl/_testgo/reader.errorString" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 40 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"github.com/goplus/llgo/cl/_testgo/reader.struct$QTufDJA9wEDzuzgkA-ZSrLqW-B6lWN8O25mTSglAoLQ$fields", i64 1, i64 1 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 40 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@"github.com/goplus/llgo/cl/_testgo/reader.struct$QTufDJA9wEDzuzgkA-ZSrLqW-B6lWN8O25mTSglAoLQ$fields" = weak_odr constant [1 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @32, i64 1 }, ptr @_llgo_string, i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.InterfaceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 -1583200459, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @52, i64 28 }, ptr @"*_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 40 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU$imethods", i64 1, i64 1 } }, align 8
+@52 = private unnamed_addr constant [28 x i8] c"interface { Error() string }", align 1
+@"*_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 722800013, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @52, i64 28 }, ptr null }, ptr @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU" }, align 8
+@53 = private unnamed_addr constant [122 x i8] c"type assertion github.com/goplus/llgo/cl/_testgo/reader.Reader -> github.com/goplus/llgo/cl/_testgo/reader.WriterTo failed", align 1
+@54 = private unnamed_addr constant [37 x i8] c"stringsReader.ReadAt: negative offset", align 1
+@55 = private unnamed_addr constant [34 x i8] c"stringsReader.Seek: invalid whence", align 1
+@56 = private unnamed_addr constant [37 x i8] c"stringsReader.Seek: negative position", align 1
+@57 = private unnamed_addr constant [48 x i8] c"stringsReader.UnreadByte: at beginning of string", align 1
+@58 = private unnamed_addr constant [49 x i8] c"strings.Reader.UnreadRune: at beginning of string", align 1
+@59 = private unnamed_addr constant [62 x i8] c"strings.Reader.UnreadRune: previous operation was not ReadRune", align 1
+@60 = private unnamed_addr constant [48 x i8] c"stringsReader.WriteTo: invalid WriteString count", align 1
+
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.NopCloser"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0) {
+_llgo_0:
+  %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %2 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.Implements"(ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reader.WriterTo", ptr %1)
+  br i1 %2, label %_llgo_3, label %_llgo_4
+
+_llgo_1:                                          ; preds = %_llgo_5
+  %3 = alloca %"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo", align 8
+  call void @llvm.memset(ptr %3, i8 0, i64 16, i1 false)
+  %4 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo", ptr %3, i32 0, i32 0
+  store %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, ptr %4, align 8
+  %5 = load %"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo", ptr %3, align 8
+  %6 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo" %5, ptr %6, align 8
+  %7 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$2bmbYDBStAIdmbXPPn7qIaCcpVcj2I5k6AqgqwAfh84", ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo")
+  %8 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" undef, ptr %7, 0
+  %9 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %8, ptr %6, 1
+  ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %9
+
+_llgo_2:                                          ; preds = %_llgo_5
+  %10 = alloca %"github.com/goplus/llgo/cl/_testgo/reader.nopCloser", align 8
+  call void @llvm.memset(ptr %10, i8 0, i64 16, i1 false)
+  %11 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.nopCloser", ptr %10, i32 0, i32 0
+  store %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, ptr %11, align 8
+  %12 = load %"github.com/goplus/llgo/cl/_testgo/reader.nopCloser", ptr %10, align 8
+  %13 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/cl/_testgo/reader.nopCloser" %12, ptr %13, align 8
+  %14 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$2bmbYDBStAIdmbXPPn7qIaCcpVcj2I5k6AqgqwAfh84", ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reader.nopCloser")
+  %15 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" undef, ptr %14, 0
+  %16 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %15, ptr %13, 1
+  ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %16
+
+_llgo_3:                                          ; preds = %_llgo_0
+  %17 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %18 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$p5Bo_emI1h8acs1rFbUxZTrpeDbIQ34gFcsbwK9YIgs", ptr %1)
+  %19 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" undef, ptr %18, 0
+  %20 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %19, ptr %17, 1
+  %21 = insertvalue { %"github.com/goplus/llgo/runtime/internal/runtime.iface", i1 } undef, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %20, 0
+  %22 = insertvalue { %"github.com/goplus/llgo/runtime/internal/runtime.iface", i1 } %21, i1 true, 1
+  br label %_llgo_5
+
+_llgo_4:                                          ; preds = %_llgo_0
+  br label %_llgo_5
+
+_llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
+  %23 = phi { %"github.com/goplus/llgo/runtime/internal/runtime.iface", i1 } [ %22, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
+  %24 = extractvalue { %"github.com/goplus/llgo/runtime/internal/runtime.iface", i1 } %23, 0
+  %25 = extractvalue { %"github.com/goplus/llgo/runtime/internal/runtime.iface", i1 } %23, 1
+  br i1 %25, label %_llgo_1, label %_llgo_2
+}
+
+define { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.ReadAll"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0) {
+_llgo_0:
+  %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 512)
+  %2 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.NewSlice3"(ptr %1, i64 1, i64 512, i64 0, i64 0, i64 512)
+  br label %_llgo_1
+
+_llgo_1:                                          ; preds = %_llgo_6, %_llgo_3, %_llgo_0
+  %3 = phi %"github.com/goplus/llgo/runtime/internal/runtime.Slice" [ %2, %_llgo_0 ], [ %24, %_llgo_3 ], [ %61, %_llgo_6 ]
+  %4 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %3, 1
+  %5 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %3, 2
+  %6 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %3, 2
+  %7 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %3, 0
+  %8 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.NewSlice3"(ptr %7, i64 1, i64 %6, i64 %4, i64 %5, i64 %6)
+  %9 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %10 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 0
+  %11 = getelementptr ptr, ptr %10, i64 3
+  %12 = load ptr, ptr %11, align 8
+  %13 = insertvalue { ptr, ptr } undef, ptr %12, 0
+  %14 = insertvalue { ptr, ptr } %13, ptr %9, 1
+  %15 = extractvalue { ptr, ptr } %14, 1
+  %16 = extractvalue { ptr, ptr } %14, 0
+  %17 = call { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %16(ptr %15, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %8)
+  %18 = extractvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %17, 0
+  %19 = extractvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %17, 1
+  %20 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %3, 1
+  %21 = add i64 %20, %18
+  %22 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %3, 2
+  %23 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %3, 0
+  %24 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.NewSlice3"(ptr %23, i64 1, i64 %22, i64 0, i64 %21, i64 %22)
+  %25 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %19)
+  %26 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %19, 1
+  %27 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %25, 0
+  %28 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %27, ptr %26, 1
+  %29 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" zeroinitializer)
+  %30 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %29, 0
+  %31 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %30, ptr null, 1
+  %32 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %28, %"github.com/goplus/llgo/runtime/internal/runtime.eface" %31)
+  %33 = xor i1 %32, true
+  br i1 %33, label %_llgo_2, label %_llgo_3
+
+_llgo_2:                                          ; preds = %_llgo_1
+  %34 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr @"github.com/goplus/llgo/cl/_testgo/reader.EOF", align 8
+  %35 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %19)
+  %36 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %19, 1
+  %37 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %35, 0
+  %38 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %37, ptr %36, 1
+  %39 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %34)
+  %40 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %34, 1
+  %41 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %39, 0
+  %42 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %41, ptr %40, 1
+  %43 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %38, %"github.com/goplus/llgo/runtime/internal/runtime.eface" %42)
+  br i1 %43, label %_llgo_4, label %_llgo_5
+
+_llgo_3:                                          ; preds = %_llgo_1
+  %44 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %24, 1
+  %45 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %24, 2
+  %46 = icmp eq i64 %44, %45
+  br i1 %46, label %_llgo_6, label %_llgo_1
+
+_llgo_4:                                          ; preds = %_llgo_2
+  br label %_llgo_5
+
+_llgo_5:                                          ; preds = %_llgo_4, %_llgo_2
+  %47 = phi %"github.com/goplus/llgo/runtime/internal/runtime.iface" [ %19, %_llgo_2 ], [ zeroinitializer, %_llgo_4 ]
+  %48 = insertvalue { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } undef, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %24, 0
+  %49 = insertvalue { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %48, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %47, 1
+  ret { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %49
+
+_llgo_6:                                          ; preds = %_llgo_3
+  %50 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 1)
+  %51 = getelementptr inbounds i8, ptr %50, i64 0
+  store i8 0, ptr %51, align 1
+  %52 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %50, 0
+  %53 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %52, i64 1, 1
+  %54 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %53, i64 1, 2
+  %55 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %54, 0
+  %56 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %54, 1
+  %57 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.SliceAppend"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %24, ptr %55, i64 %56, i64 1)
+  %58 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %24, 1
+  %59 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %57, 2
+  %60 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %57, 0
+  %61 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.NewSlice3"(ptr %60, i64 1, i64 %59, i64 0, i64 %58, i64 %59)
+  br label %_llgo_1
+}
+
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.WriteString"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, %"github.com/goplus/llgo/runtime/internal/runtime.String" %1) {
+_llgo_0:
+  %2 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %3 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.Implements"(ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reader.StringWriter", ptr %2)
+  br i1 %3, label %_llgo_3, label %_llgo_4
+
+_llgo_1:                                          ; preds = %_llgo_5
+  %4 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %38)
+  %5 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %38, 0
+  %6 = getelementptr ptr, ptr %5, i64 3
+  %7 = load ptr, ptr %6, align 8
+  %8 = insertvalue { ptr, ptr } undef, ptr %7, 0
+  %9 = insertvalue { ptr, ptr } %8, ptr %4, 1
+  %10 = extractvalue { ptr, ptr } %9, 1
+  %11 = extractvalue { ptr, ptr } %9, 0
+  %12 = call { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %11(ptr %10, %"github.com/goplus/llgo/runtime/internal/runtime.String" %1)
+  %13 = extractvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %12, 0
+  %14 = extractvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %12, 1
+  %15 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } undef, i64 %13, 0
+  %16 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %15, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %14, 1
+  ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %16
+
+_llgo_2:                                          ; preds = %_llgo_5
+  %17 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %1)
+  %18 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %19 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 0
+  %20 = getelementptr ptr, ptr %19, i64 3
+  %21 = load ptr, ptr %20, align 8
+  %22 = insertvalue { ptr, ptr } undef, ptr %21, 0
+  %23 = insertvalue { ptr, ptr } %22, ptr %18, 1
+  %24 = extractvalue { ptr, ptr } %23, 1
+  %25 = extractvalue { ptr, ptr } %23, 0
+  %26 = call { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %25(ptr %24, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %17)
+  %27 = extractvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %26, 0
+  %28 = extractvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %26, 1
+  %29 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } undef, i64 %27, 0
+  %30 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %29, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %28, 1
+  ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %30
+
+_llgo_3:                                          ; preds = %_llgo_0
+  %31 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 1
+  %32 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$Ly4zXiUMEac-hYAMw6b6miJ1JEhGfLyBWyBOhpsRZcU", ptr %2)
+  %33 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" undef, ptr %32, 0
+  %34 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %33, ptr %31, 1
+  %35 = insertvalue { %"github.com/goplus/llgo/runtime/internal/runtime.iface", i1 } undef, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %34, 0
+  %36 = insertvalue { %"github.com/goplus/llgo/runtime/internal/runtime.iface", i1 } %35, i1 true, 1
+  br label %_llgo_5
+
+_llgo_4:                                          ; preds = %_llgo_0
+  br label %_llgo_5
+
+_llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
+  %37 = phi { %"github.com/goplus/llgo/runtime/internal/runtime.iface", i1 } [ %36, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
+  %38 = extractvalue { %"github.com/goplus/llgo/runtime/internal/runtime.iface", i1 } %37, 0
+  %39 = extractvalue { %"github.com/goplus/llgo/runtime/internal/runtime.iface", i1 } %37, 1
+  br i1 %39, label %_llgo_1, label %_llgo_2
+}
+
+define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/reader.(*errorString).Error"(ptr %0) {
+_llgo_0:
+  %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.errorString", ptr %0, i32 0, i32 0
+  %2 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %1, align 8
+  ret %"github.com/goplus/llgo/runtime/internal/runtime.String" %2
+}
+
+define void @"github.com/goplus/llgo/cl/_testgo/reader.init"() {
+_llgo_0:
+  %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/reader.init$guard", align 1
+  br i1 %0, label %_llgo_2, label %_llgo_1
+
+_llgo_1:                                          ; preds = %_llgo_0
+  store i1 true, ptr @"github.com/goplus/llgo/cl/_testgo/reader.init$guard", align 1
+  call void @"unicode/utf8.init"()
+  %1 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.newError"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 3 })
+  store %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1, ptr @"github.com/goplus/llgo/cl/_testgo/reader.EOF", align 8
+  %2 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.newError"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @29, i64 11 })
+  store %"github.com/goplus/llgo/runtime/internal/runtime.iface" %2, ptr @"github.com/goplus/llgo/cl/_testgo/reader.ErrShortWrite", align 8
+  br label %_llgo_2
+
+_llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+  ret void
+}
+
+define void @"github.com/goplus/llgo/cl/_testgo/reader.main"() {
+_llgo_0:
+  %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 32)
+  %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @30, i64 11 }, ptr %1, align 8
+  %2 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw", ptr @"*_llgo_github.com/goplus/llgo/cl/_testgo/reader.stringReader")
+  %3 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" undef, ptr %2, 0
+  %4 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %3, ptr %0, 1
+  %5 = call { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.ReadAll"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %4)
+  %6 = extractvalue { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %5, 0
+  %7 = extractvalue { %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %5, 1
+  %8 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringFromBytes"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %6)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %8)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintIface"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %7)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  ret void
+}
+
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.newError"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0) {
+_llgo_0:
+  %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
+  %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.errorString", ptr %1, i32 0, i32 0
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" %0, ptr %2, align 8
+  %3 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU", ptr @"*_llgo_github.com/goplus/llgo/cl/_testgo/reader.errorString")
+  %4 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" undef, ptr %3, 0
+  %5 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %4, ptr %1, 1
+  ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %5
+}
+
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.nopCloser.Close"(%"github.com/goplus/llgo/cl/_testgo/reader.nopCloser" %0) {
+_llgo_0:
+  ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" zeroinitializer
+}
+
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.nopCloser.Read"(%"github.com/goplus/llgo/cl/_testgo/reader.nopCloser" %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+_llgo_0:
+  %2 = alloca %"github.com/goplus/llgo/cl/_testgo/reader.nopCloser", align 8
+  call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+  store %"github.com/goplus/llgo/cl/_testgo/reader.nopCloser" %0, ptr %2, align 8
+  %3 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.nopCloser", ptr %2, i32 0, i32 0
+  %4 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %3, align 8
+  %5 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %4)
+  %6 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %4, 0
+  %7 = getelementptr ptr, ptr %6, i64 3
+  %8 = load ptr, ptr %7, align 8
+  %9 = insertvalue { ptr, ptr } undef, ptr %8, 0
+  %10 = insertvalue { ptr, ptr } %9, ptr %5, 1
+  %11 = extractvalue { ptr, ptr } %10, 1
+  %12 = extractvalue { ptr, ptr } %10, 0
+  %13 = call { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %12(ptr %11, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1)
+  %14 = extractvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %13, 0
+  %15 = extractvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %13, 1
+  %16 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } undef, i64 %14, 0
+  %17 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %16, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %15, 1
+  ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %17
+}
+
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloser).Close"(ptr %0) {
+_llgo_0:
+  %1 = load %"github.com/goplus/llgo/cl/_testgo/reader.nopCloser", ptr %0, align 8
+  %2 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.nopCloser.Close"(%"github.com/goplus/llgo/cl/_testgo/reader.nopCloser" %1)
+  ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %2
+}
+
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloser).Read"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+_llgo_0:
+  %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.nopCloser", ptr %0, i32 0, i32 0
+  %3 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %2, align 8
+  %4 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %3)
+  %5 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %3, 0
+  %6 = getelementptr ptr, ptr %5, i64 3
+  %7 = load ptr, ptr %6, align 8
+  %8 = insertvalue { ptr, ptr } undef, ptr %7, 0
+  %9 = insertvalue { ptr, ptr } %8, ptr %4, 1
+  %10 = extractvalue { ptr, ptr } %9, 1
+  %11 = extractvalue { ptr, ptr } %9, 0
+  %12 = call { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %11(ptr %10, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1)
+  %13 = extractvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %12, 0
+  %14 = extractvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %12, 1
+  %15 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } undef, i64 %13, 0
+  %16 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %15, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %14, 1
+  ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %16
+}
+
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo.Close"(%"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo" %0) {
+_llgo_0:
+  ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" zeroinitializer
+}
+
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo.Read"(%"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo" %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+_llgo_0:
+  %2 = alloca %"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo", align 8
+  call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+  store %"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo" %0, ptr %2, align 8
+  %3 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo", ptr %2, i32 0, i32 0
+  %4 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %3, align 8
+  %5 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %4)
+  %6 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %4, 0
+  %7 = getelementptr ptr, ptr %6, i64 3
+  %8 = load ptr, ptr %7, align 8
+  %9 = insertvalue { ptr, ptr } undef, ptr %8, 0
+  %10 = insertvalue { ptr, ptr } %9, ptr %5, 1
+  %11 = extractvalue { ptr, ptr } %10, 1
+  %12 = extractvalue { ptr, ptr } %10, 0
+  %13 = call { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %12(ptr %11, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1)
+  %14 = extractvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %13, 0
+  %15 = extractvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %13, 1
+  %16 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } undef, i64 %14, 0
+  %17 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %16, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %15, 1
+  ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %17
+}
+
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo.WriteTo"(%"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo" %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) {
+_llgo_0:
+  %2 = alloca %"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo", align 8
+  call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+  store %"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo" %0, ptr %2, align 8
+  %3 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo", ptr %2, i32 0, i32 0
+  %4 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %3, align 8
+  %5 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %4)
+  %6 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.Implements"(ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reader.WriterTo", ptr %5)
+  br i1 %6, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  %7 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %4, 1
+  %8 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$p5Bo_emI1h8acs1rFbUxZTrpeDbIQ34gFcsbwK9YIgs", ptr %5)
+  %9 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" undef, ptr %8, 0
+  %10 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %9, ptr %7, 1
+  %11 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %10)
+  %12 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %10, 0
+  %13 = getelementptr ptr, ptr %12, i64 3
+  %14 = load ptr, ptr %13, align 8
+  %15 = insertvalue { ptr, ptr } undef, ptr %14, 0
+  %16 = insertvalue { ptr, ptr } %15, ptr %11, 1
+  %17 = extractvalue { ptr, ptr } %16, 1
+  %18 = extractvalue { ptr, ptr } %16, 0
+  %19 = call { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %18(ptr %17, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1)
+  %20 = extractvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %19, 0
+  %21 = extractvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %19, 1
+  %22 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } undef, i64 %20, 0
+  %23 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %22, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %21, 1
+  ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %23
+
+_llgo_2:                                          ; preds = %_llgo_0
+  %24 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @53, i64 122 }, ptr %24, align 8
+  %25 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %24, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %25)
+  unreachable
+}
+
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloserWriterTo).Close"(ptr %0) {
+_llgo_0:
+  %1 = load %"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo", ptr %0, align 8
+  %2 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo.Close"(%"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo" %1)
+  ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %2
+}
+
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloserWriterTo).Read"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+_llgo_0:
+  %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo", ptr %0, i32 0, i32 0
+  %3 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %2, align 8
+  %4 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %3)
+  %5 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %3, 0
+  %6 = getelementptr ptr, ptr %5, i64 3
+  %7 = load ptr, ptr %6, align 8
+  %8 = insertvalue { ptr, ptr } undef, ptr %7, 0
+  %9 = insertvalue { ptr, ptr } %8, ptr %4, 1
+  %10 = extractvalue { ptr, ptr } %9, 1
+  %11 = extractvalue { ptr, ptr } %9, 0
+  %12 = call { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %11(ptr %10, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1)
+  %13 = extractvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %12, 0
+  %14 = extractvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %12, 1
+  %15 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } undef, i64 %13, 0
+  %16 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %15, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %14, 1
+  ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %16
+}
+
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*nopCloserWriterTo).WriteTo"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) {
+_llgo_0:
+  %2 = load %"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo", ptr %0, align 8
+  %3 = call { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo.WriteTo"(%"github.com/goplus/llgo/cl/_testgo/reader.nopCloserWriterTo" %2, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1)
+  %4 = extractvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %3, 0
+  %5 = extractvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %3, 1
+  %6 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } undef, i64 %4, 0
+  %7 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %6, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %5, 1
+  ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %7
+}
+
+define i64 @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).Len"(ptr %0) {
+_llgo_0:
+  %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  %2 = load i64, ptr %1, align 4
+  %3 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+  %4 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %3, align 8
+  %5 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %4, 1
+  %6 = icmp sge i64 %2, %5
+  br i1 %6, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  ret i64 0
+
+_llgo_2:                                          ; preds = %_llgo_0
+  %7 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+  %8 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %7, align 8
+  %9 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %8, 1
+  %10 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  %11 = load i64, ptr %10, align 4
+  %12 = sub i64 %9, %11
+  ret i64 %12
+}
+
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).Read"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+_llgo_0:
+  %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  %3 = load i64, ptr %2, align 4
+  %4 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+  %5 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %4, align 8
+  %6 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %5, 1
+  %7 = icmp sge i64 %3, %6
+  br i1 %7, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  %8 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr @"github.com/goplus/llgo/cl/_testgo/reader.EOF", align 8
+  %9 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } { i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" undef }, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %8, 1
+  ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %9
+
+_llgo_2:                                          ; preds = %_llgo_0
+  %10 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 2
+  store i64 -1, ptr %10, align 4
+  %11 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+  %12 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %11, align 8
+  %13 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  %14 = load i64, ptr %13, align 4
+  %15 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %12, 1
+  %16 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringSlice"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %12, i64 %14, i64 %15)
+  %17 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %16, 0
+  %18 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %16, 1
+  %19 = call i64 @"github.com/goplus/llgo/runtime/internal/runtime.SliceCopy"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1, ptr %17, i64 %18, i64 1)
+  %20 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  %21 = load i64, ptr %20, align 4
+  %22 = add i64 %21, %19
+  %23 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  store i64 %22, ptr %23, align 4
+  %24 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } undef, i64 %19, 0
+  %25 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %24, %"github.com/goplus/llgo/runtime/internal/runtime.iface" zeroinitializer, 1
+  ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %25
+}
+
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).ReadAt"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1, i64 %2) {
+_llgo_0:
+  %3 = icmp slt i64 %2, 0
+  br i1 %3, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  %4 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.newError"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @54, i64 37 })
+  %5 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } { i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" undef }, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %4, 1
+  ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %5
+
+_llgo_2:                                          ; preds = %_llgo_0
+  %6 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+  %7 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %6, align 8
+  %8 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %7, 1
+  %9 = icmp sge i64 %2, %8
+  br i1 %9, label %_llgo_3, label %_llgo_4
+
+_llgo_3:                                          ; preds = %_llgo_2
+  %10 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr @"github.com/goplus/llgo/cl/_testgo/reader.EOF", align 8
+  %11 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } { i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" undef }, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %10, 1
+  ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %11
+
+_llgo_4:                                          ; preds = %_llgo_2
+  %12 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+  %13 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %12, align 8
+  %14 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %13, 1
+  %15 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringSlice"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %13, i64 %2, i64 %14)
+  %16 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %15, 0
+  %17 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %15, 1
+  %18 = call i64 @"github.com/goplus/llgo/runtime/internal/runtime.SliceCopy"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1, ptr %16, i64 %17, i64 1)
+  %19 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1, 1
+  %20 = icmp slt i64 %18, %19
+  br i1 %20, label %_llgo_5, label %_llgo_6
+
+_llgo_5:                                          ; preds = %_llgo_4
+  %21 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr @"github.com/goplus/llgo/cl/_testgo/reader.EOF", align 8
+  br label %_llgo_6
+
+_llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
+  %22 = phi %"github.com/goplus/llgo/runtime/internal/runtime.iface" [ zeroinitializer, %_llgo_4 ], [ %21, %_llgo_5 ]
+  %23 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } undef, i64 %18, 0
+  %24 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %23, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %22, 1
+  ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %24
+}
+
+define { i8, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).ReadByte"(ptr %0) {
+_llgo_0:
+  %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 2
+  store i64 -1, ptr %1, align 4
+  %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  %3 = load i64, ptr %2, align 4
+  %4 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+  %5 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %4, align 8
+  %6 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %5, 1
+  %7 = icmp sge i64 %3, %6
+  br i1 %7, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  %8 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr @"github.com/goplus/llgo/cl/_testgo/reader.EOF", align 8
+  %9 = insertvalue { i8, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } { i8 0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" undef }, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %8, 1
+  ret { i8, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %9
+
+_llgo_2:                                          ; preds = %_llgo_0
+  %10 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  %11 = load i64, ptr %10, align 4
+  %12 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+  %13 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %12, align 8
+  %14 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %13, 0
+  %15 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %13, 1
+  %16 = icmp slt i64 %11, 0
+  %17 = icmp sge i64 %11, %15
+  %18 = or i1 %17, %16
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %18)
+  %19 = getelementptr inbounds i8, ptr %14, i64 %11
+  %20 = load i8, ptr %19, align 1
+  %21 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  %22 = load i64, ptr %21, align 4
+  %23 = add i64 %22, 1
+  %24 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  store i64 %23, ptr %24, align 4
+  %25 = insertvalue { i8, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } undef, i8 %20, 0
+  %26 = insertvalue { i8, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %25, %"github.com/goplus/llgo/runtime/internal/runtime.iface" zeroinitializer, 1
+  ret { i8, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %26
+}
+
+define { i32, i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).ReadRune"(ptr %0) {
+_llgo_0:
+  %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  %2 = load i64, ptr %1, align 4
+  %3 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+  %4 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %3, align 8
+  %5 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %4, 1
+  %6 = icmp sge i64 %2, %5
+  br i1 %6, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  %7 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 2
+  store i64 -1, ptr %7, align 4
+  %8 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr @"github.com/goplus/llgo/cl/_testgo/reader.EOF", align 8
+  %9 = insertvalue { i32, i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } { i32 0, i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" undef }, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %8, 2
+  ret { i32, i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %9
+
+_llgo_2:                                          ; preds = %_llgo_0
+  %10 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  %11 = load i64, ptr %10, align 4
+  %12 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 2
+  store i64 %11, ptr %12, align 4
+  %13 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  %14 = load i64, ptr %13, align 4
+  %15 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+  %16 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %15, align 8
+  %17 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %16, 0
+  %18 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %16, 1
+  %19 = icmp slt i64 %14, 0
+  %20 = icmp sge i64 %14, %18
+  %21 = or i1 %20, %19
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %21)
+  %22 = getelementptr inbounds i8, ptr %17, i64 %14
+  %23 = load i8, ptr %22, align 1
+  %24 = icmp ult i8 %23, -128
+  br i1 %24, label %_llgo_3, label %_llgo_4
+
+_llgo_3:                                          ; preds = %_llgo_2
+  %25 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  %26 = load i64, ptr %25, align 4
+  %27 = add i64 %26, 1
+  %28 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  store i64 %27, ptr %28, align 4
+  %29 = zext i8 %23 to i32
+  %30 = insertvalue { i32, i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } undef, i32 %29, 0
+  %31 = insertvalue { i32, i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %30, i64 1, 1
+  %32 = insertvalue { i32, i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %31, %"github.com/goplus/llgo/runtime/internal/runtime.iface" zeroinitializer, 2
+  ret { i32, i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %32
+
+_llgo_4:                                          ; preds = %_llgo_2
+  %33 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+  %34 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %33, align 8
+  %35 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  %36 = load i64, ptr %35, align 4
+  %37 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %34, 1
+  %38 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringSlice"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %34, i64 %36, i64 %37)
+  %39 = call { i32, i64 } @"unicode/utf8.DecodeRuneInString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %38)
+  %40 = extractvalue { i32, i64 } %39, 0
+  %41 = extractvalue { i32, i64 } %39, 1
+  %42 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  %43 = load i64, ptr %42, align 4
+  %44 = add i64 %43, %41
+  %45 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  store i64 %44, ptr %45, align 4
+  %46 = insertvalue { i32, i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } undef, i32 %40, 0
+  %47 = insertvalue { i32, i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %46, i64 %41, 1
+  %48 = insertvalue { i32, i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %47, %"github.com/goplus/llgo/runtime/internal/runtime.iface" zeroinitializer, 2
+  ret { i32, i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %48
+}
+
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).Seek"(ptr %0, i64 %1, i64 %2) {
+_llgo_0:
+  %3 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 2
+  store i64 -1, ptr %3, align 4
+  %4 = icmp eq i64 %2, 0
+  br i1 %4, label %_llgo_2, label %_llgo_4
+
+_llgo_1:                                          ; preds = %_llgo_5, %_llgo_3, %_llgo_2
+  %5 = phi i64 [ %1, %_llgo_2 ], [ %9, %_llgo_3 ], [ %14, %_llgo_5 ]
+  %6 = icmp slt i64 %5, 0
+  br i1 %6, label %_llgo_8, label %_llgo_9
+
+_llgo_2:                                          ; preds = %_llgo_0
+  br label %_llgo_1
+
+_llgo_3:                                          ; preds = %_llgo_4
+  %7 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  %8 = load i64, ptr %7, align 4
+  %9 = add i64 %8, %1
+  br label %_llgo_1
+
+_llgo_4:                                          ; preds = %_llgo_0
+  %10 = icmp eq i64 %2, 1
+  br i1 %10, label %_llgo_3, label %_llgo_6
+
+_llgo_5:                                          ; preds = %_llgo_6
+  %11 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+  %12 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %11, align 8
+  %13 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %12, 1
+  %14 = add i64 %13, %1
+  br label %_llgo_1
+
+_llgo_6:                                          ; preds = %_llgo_4
+  %15 = icmp eq i64 %2, 2
+  br i1 %15, label %_llgo_5, label %_llgo_7
+
+_llgo_7:                                          ; preds = %_llgo_6
+  %16 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.newError"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @55, i64 34 })
+  %17 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } { i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" undef }, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %16, 1
+  ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %17
+
+_llgo_8:                                          ; preds = %_llgo_1
+  %18 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.newError"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @56, i64 37 })
+  %19 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } { i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" undef }, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %18, 1
+  ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %19
+
+_llgo_9:                                          ; preds = %_llgo_1
+  %20 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  store i64 %5, ptr %20, align 4
+  %21 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } undef, i64 %5, 0
+  %22 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %21, %"github.com/goplus/llgo/runtime/internal/runtime.iface" zeroinitializer, 1
+  ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %22
+}
+
+define i64 @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).Size"(ptr %0) {
+_llgo_0:
+  %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+  %2 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %1, align 8
+  %3 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %2, 1
+  ret i64 %3
+}
+
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).UnreadByte"(ptr %0) {
+_llgo_0:
+  %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  %2 = load i64, ptr %1, align 4
+  %3 = icmp sle i64 %2, 0
+  br i1 %3, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  %4 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.newError"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @57, i64 48 })
+  ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %4
+
+_llgo_2:                                          ; preds = %_llgo_0
+  %5 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 2
+  store i64 -1, ptr %5, align 4
+  %6 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  %7 = load i64, ptr %6, align 4
+  %8 = sub i64 %7, 1
+  %9 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  store i64 %8, ptr %9, align 4
+  ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" zeroinitializer
+}
+
+define %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).UnreadRune"(ptr %0) {
+_llgo_0:
+  %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  %2 = load i64, ptr %1, align 4
+  %3 = icmp sle i64 %2, 0
+  br i1 %3, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  %4 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.newError"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @58, i64 49 })
+  ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %4
+
+_llgo_2:                                          ; preds = %_llgo_0
+  %5 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 2
+  %6 = load i64, ptr %5, align 4
+  %7 = icmp slt i64 %6, 0
+  br i1 %7, label %_llgo_3, label %_llgo_4
+
+_llgo_3:                                          ; preds = %_llgo_2
+  %8 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @"github.com/goplus/llgo/cl/_testgo/reader.newError"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @59, i64 62 })
+  ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" %8
+
+_llgo_4:                                          ; preds = %_llgo_2
+  %9 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 2
+  %10 = load i64, ptr %9, align 4
+  %11 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  store i64 %10, ptr %11, align 4
+  %12 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 2
+  store i64 -1, ptr %12, align 4
+  ret %"github.com/goplus/llgo/runtime/internal/runtime.iface" zeroinitializer
+}
+
+define { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.(*stringReader).WriteTo"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) {
+_llgo_0:
+  %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 2
+  store i64 -1, ptr %2, align 4
+  %3 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  %4 = load i64, ptr %3, align 4
+  %5 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+  %6 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %5, align 8
+  %7 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %6, 1
+  %8 = icmp sge i64 %4, %7
+  br i1 %8, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } zeroinitializer
+
+_llgo_2:                                          ; preds = %_llgo_0
+  %9 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 0
+  %10 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %9, align 8
+  %11 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  %12 = load i64, ptr %11, align 4
+  %13 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %10, 1
+  %14 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringSlice"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %10, i64 %12, i64 %13)
+  %15 = call { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } @"github.com/goplus/llgo/cl/_testgo/reader.WriteString"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %1, %"github.com/goplus/llgo/runtime/internal/runtime.String" %14)
+  %16 = extractvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %15, 0
+  %17 = extractvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %15, 1
+  %18 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %14, 1
+  %19 = icmp sgt i64 %16, %18
+  br i1 %19, label %_llgo_3, label %_llgo_4
+
+_llgo_3:                                          ; preds = %_llgo_2
+  %20 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @60, i64 48 }, ptr %20, align 8
+  %21 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %20, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %21)
+  unreachable
+
+_llgo_4:                                          ; preds = %_llgo_2
+  %22 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  %23 = load i64, ptr %22, align 4
+  %24 = add i64 %23, %16
+  %25 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reader.stringReader", ptr %0, i32 0, i32 1
+  store i64 %24, ptr %25, align 4
+  %26 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %14, 1
+  %27 = icmp ne i64 %16, %26
+  br i1 %27, label %_llgo_7, label %_llgo_6
+
+_llgo_5:                                          ; preds = %_llgo_7
+  %28 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr @"github.com/goplus/llgo/cl/_testgo/reader.ErrShortWrite", align 8
+  br label %_llgo_6
+
+_llgo_6:                                          ; preds = %_llgo_5, %_llgo_7, %_llgo_4
+  %29 = phi %"github.com/goplus/llgo/runtime/internal/runtime.iface" [ %17, %_llgo_4 ], [ %17, %_llgo_7 ], [ %28, %_llgo_5 ]
+  %30 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } undef, i64 %16, 0
+  %31 = insertvalue { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %30, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %29, 1
+  ret { i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface" } %31
+
+_llgo_7:                                          ; preds = %_llgo_4
+  %32 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %17)
+  %33 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %17, 1
+  %34 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %32, 0
+  %35 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %34, ptr %33, 1
+  %36 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" zeroinitializer)
+  %37 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %36, 0
+  %38 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %37, ptr null, 1
+  %39 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %35, %"github.com/goplus/llgo/runtime/internal/runtime.eface" %38)
+  br i1 %39, label %_llgo_5, label %_llgo_6
+}
+
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr)
+
+define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2) {
+_llgo_0:
+  %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %1, ptr %2)
+  ret i1 %3
+}
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+
+define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
+_llgo_0:
+  %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %1, ptr %2)
+  ret i1 %3
+}
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+
+define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
+_llgo_0:
+  %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %1, ptr %2)
+  ret i1 %3
+}
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+
+define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
+_llgo_0:
+  %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %1, ptr %2)
+  ret i1 %3
+}
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+
+define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
+_llgo_0:
+  %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %1, ptr %2)
+  ret i1 %3
+}
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.Implements"(ptr, ptr)
+
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr)
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.NewSlice3"(ptr, i64, i64, i64, i64, i64)
+
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface", %"github.com/goplus/llgo/runtime/internal/runtime.eface")
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.SliceAppend"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr, i64, i64)
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.StringToBytes"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+
+declare void @"unicode/utf8.init"()
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr, ptr)
+
+define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr %0, ptr %1, ptr %2) {
+_llgo_0:
+  %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal32"(ptr %1, ptr %2)
+  ret i1 %3
+}
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringFromBytes"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintIface"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringSlice"(%"github.com/goplus/llgo/runtime/internal/runtime.String", i64, i64)
+
+declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.SliceCopy"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr, i64, i64)
+
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+
+declare { i32, i64 } @"unicode/utf8.DecodeRuneInString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/reflect/in.go
+++ b/cl/_testgo/reflect/in.go
@@ -1,10 +1,19 @@
-// LITTEST
 package main
 
 import (
 	"reflect"
 	"unsafe"
 )
+
+func main() {
+	callSlice()
+	callFunc()
+	callClosure()
+	callMethod()
+	callIMethod()
+	mapDemo1()
+	mapDemo2()
+}
 
 func demo(n1, n2, n3, n4, n5, n6, n7, n8, n9 int, a ...interface{}) (int, int) {
 	var sum int
@@ -14,17 +23,24 @@ func demo(n1, n2, n3, n4, n5, n6, n7, n8, n9 int, a ...interface{}) (int, int) {
 	return n1 + n2 + n3 + n4 + n5 + n6 + n7 + n8 + n9, sum
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/reflect.callClosure"{{.*}}
-// CHECK: reflect.Value.Call
-// CHECK: MatchesClosure
-func callClosure() {
-	m := 100
+func callSlice() {
+	v := reflect.ValueOf(demo)
+	n := reflect.ValueOf(1)
+	r := v.Call([]reflect.Value{n, n, n, n, n, n, n, n, n,
+		reflect.ValueOf(1), reflect.ValueOf(2), reflect.ValueOf(3)})
+	println("call.slice", r[0].Int(), r[1].Int())
+	r = v.CallSlice([]reflect.Value{n, n, n, n, n, n, n, n, n,
+		reflect.ValueOf([]interface{}{1, 2, 3})})
+	println("call.slice", r[0].Int(), r[1].Int())
+}
+
+func callFunc() {
 	var f any = func(n int) int {
-		println("call.closure")
-		return m + n + 1
+		println("call.func")
+		return n + 1
 	}
 	fn := reflect.ValueOf(f)
-	println("closure", fn.Kind(), fn.Type().String())
+	println("func", fn.Kind(), fn.Type().String())
 	r := fn.Call([]reflect.Value{reflect.ValueOf(100)})
 	println(r[0].Int())
 	ifn, ok := fn.Interface().(func(int) int)
@@ -34,17 +50,14 @@ func callClosure() {
 	ifn(100)
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/reflect.callFunc"{{.*}}
-// CHECK: PrintUint
-// CHECK: reflect.Value.Call
-// CHECK: MatchesClosure
-func callFunc() {
+func callClosure() {
+	m := 100
 	var f any = func(n int) int {
-		println("call.func")
-		return n + 1
+		println("call.closure")
+		return m + n + 1
 	}
 	fn := reflect.ValueOf(f)
-	println("func", fn.Kind(), fn.Type().String())
+	println("closure", fn.Kind(), fn.Type().String())
 	r := fn.Call([]reflect.Value{reflect.ValueOf(100)})
 	println(r[0].Int())
 	ifn, ok := fn.Interface().(func(int) int)
@@ -73,29 +86,6 @@ type abi struct {
 	data unsafe.Pointer
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/reflect.callIMethod"{{.*}}
-// CHECK: reflect.Value.Call
-// CHECK: MatchesClosure
-func callIMethod() {
-	var i I = &T{1}
-	v := reflect.ValueOf(i)
-	fn := v.Method(0)
-	println("imethod", fn.Kind(), fn.Type().String())
-	r := fn.Call([]reflect.Value{reflect.ValueOf(100)})
-	println(r[0].Int())
-	ifn, ok := fn.Interface().(func(int) int)
-	if !ok {
-		panic("error")
-	}
-	ifn(1)
-	v2 := reflect.ValueOf(fn.Interface())
-	r2 := v2.Call([]reflect.Value{reflect.ValueOf(100)})
-	println(r2[0].Int())
-}
-
-// CHECK-LABEL: define {{.*}} @"{{.*}}/reflect.callMethod"{{.*}}
-// CHECK: reflect.Value.Call
-// CHECK: MatchesClosure
 func callMethod() {
 	t := &T{1}
 	v := reflect.ValueOf(t)
@@ -113,43 +103,23 @@ func callMethod() {
 	println(r2[0].Int())
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/reflect.callSlice"{{.*}}
-// CHECK: reflect.Value.Call
-// CHECK: reflect.Value.CallSlice
-// CHECK: PrintString
-// CHECK: PrintInt
-func callSlice() {
-	v := reflect.ValueOf(demo)
-	n := reflect.ValueOf(1)
-	r := v.Call([]reflect.Value{n, n, n, n, n, n, n, n, n,
-		reflect.ValueOf(1), reflect.ValueOf(2), reflect.ValueOf(3)})
-	println("call.slice", r[0].Int(), r[1].Int())
-	r = v.CallSlice([]reflect.Value{n, n, n, n, n, n, n, n, n,
-		reflect.ValueOf([]interface{}{1, 2, 3})})
-	println("call.slice", r[0].Int(), r[1].Int())
+func callIMethod() {
+	var i I = &T{1}
+	v := reflect.ValueOf(i)
+	fn := v.Method(0)
+	println("imethod", fn.Kind(), fn.Type().String())
+	r := fn.Call([]reflect.Value{reflect.ValueOf(100)})
+	println(r[0].Int())
+	ifn, ok := fn.Interface().(func(int) int)
+	if !ok {
+		panic("error")
+	}
+	ifn(1)
+	v2 := reflect.ValueOf(fn.Interface())
+	r2 := v2.Call([]reflect.Value{reflect.ValueOf(100)})
+	println(r2[0].Int())
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/reflect.main"{{.*}}
-// CHECK: callSlice
-// CHECK: callFunc
-// CHECK: callClosure
-// CHECK: callMethod
-// CHECK: callIMethod
-// CHECK: mapDemo1
-// CHECK: mapDemo2
-func main() {
-	callSlice()
-	callFunc()
-	callClosure()
-	callMethod()
-	callIMethod()
-	mapDemo1()
-	mapDemo2()
-}
-
-// CHECK-LABEL: define {{.*}} @"{{.*}}/reflect.mapDemo1"{{.*}}
-// CHECK: MakeMap
-// CHECK: MapRange
 func mapDemo1() {
 	m := map[int]string{
 		1: "hello",
@@ -181,9 +151,6 @@ func mapDemo1() {
 	}
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/reflect.mapDemo2"{{.*}}
-// CHECK: reflect.MakeMap
-// CHECK: MapRange
 func mapDemo2() {
 	v := reflect.MakeMap(reflect.MapOf(reflect.TypeOf(0), reflect.TypeOf("")))
 	v.SetMapIndex(reflect.ValueOf(1), reflect.ValueOf("hello"))

--- a/cl/_testgo/reflect/out.ll
+++ b/cl/_testgo/reflect/out.ll
@@ -1,0 +1,1134 @@
+; ModuleID = 'github.com/goplus/llgo/cl/_testgo/reflect'
+source_filename = "github.com/goplus/llgo/cl/_testgo/reflect"
+
+%"github.com/goplus/llgo/runtime/abi.StructType" = type { %"github.com/goplus/llgo/runtime/abi.Type", %"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.Slice" }
+%"github.com/goplus/llgo/runtime/abi.Type" = type { i64, i64, i32, i8, i8, i8, i8, { ptr, ptr }, ptr, %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr }
+%"github.com/goplus/llgo/runtime/internal/runtime.String" = type { ptr, i64 }
+%"github.com/goplus/llgo/runtime/internal/runtime.Slice" = type { ptr, i64, i64 }
+%"github.com/goplus/llgo/runtime/abi.PtrType" = type { %"github.com/goplus/llgo/runtime/abi.Type", ptr }
+%"github.com/goplus/llgo/runtime/abi.FuncType" = type { %"github.com/goplus/llgo/runtime/abi.Type", %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.Slice" }
+%"github.com/goplus/llgo/runtime/abi.StructField" = type { %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr, i64, %"github.com/goplus/llgo/runtime/internal/runtime.String", i1 }
+%"github.com/goplus/llgo/runtime/abi.UncommonType" = type { %"github.com/goplus/llgo/runtime/internal/runtime.String", i16, i16, i32 }
+%"github.com/goplus/llgo/runtime/abi.Method" = type { %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr, ptr, ptr }
+%"github.com/goplus/llgo/runtime/abi.InterfaceType" = type { %"github.com/goplus/llgo/runtime/abi.Type", %"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.Slice" }
+%"github.com/goplus/llgo/runtime/abi.Imethod" = type { %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr }
+%"github.com/goplus/llgo/runtime/abi.SliceType" = type { %"github.com/goplus/llgo/runtime/abi.Type", ptr }
+%"github.com/goplus/llgo/runtime/abi.MapType" = type { %"github.com/goplus/llgo/runtime/abi.Type", ptr, ptr, ptr, { ptr, ptr }, i8, i8, i16, i32 }
+%"github.com/goplus/llgo/runtime/abi.ArrayType" = type { %"github.com/goplus/llgo/runtime/abi.Type", ptr, ptr, i64 }
+%"github.com/goplus/llgo/cl/_testgo/reflect.T" = type { i64 }
+%"github.com/goplus/llgo/runtime/internal/runtime.eface" = type { ptr, ptr }
+%reflect.Value = type { ptr, ptr, i64 }
+%"github.com/goplus/llgo/runtime/internal/runtime.iface" = type { ptr, ptr }
+
+@"github.com/goplus/llgo/cl/_testgo/reflect.init$guard" = global i1 false, align 1
+@0 = private unnamed_addr constant [11 x i8] c"call.method", align 1
+@"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 -459742120, i8 32, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 49 }, ptr @"*_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk$fields", i64 2, i64 2 } }, align 8
+@1 = private unnamed_addr constant [49 x i8] c"struct { $f func(int) int; $data unsafe.Pointer }", align 1
+@"*_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -299237839, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 49 }, ptr null }, ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk" }, align 8
+@2 = private unnamed_addr constant [2 x i8] c"$f", align 1
+@"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1134531106, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @3, i64 13 }, ptr @"*_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU$in", i64 1, i64 1 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU$out", i64 1, i64 1 } }, align 8
+@3 = private unnamed_addr constant [13 x i8] c"func(int) int", align 1
+@"*_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1763581361, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @3, i64 13 }, ptr null }, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" }, align 8
+@_llgo_int = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 0, i32 -25294021, i8 12, i8 8, i8 8, i8 34, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @4, i64 3 }, ptr @"*_llgo_int" }, align 8
+@4 = private unnamed_addr constant [3 x i8] c"int", align 1
+@"*_llgo_int" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -939606833, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @4, i64 3 }, ptr null }, ptr @_llgo_int }, align 8
+@"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU$in" = weak_odr constant [1 x ptr] [ptr @_llgo_int], align 8
+@"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU$out" = weak_odr constant [1 x ptr] [ptr @_llgo_int], align 8
+@5 = private unnamed_addr constant [5 x i8] c"$data", align 1
+@_llgo_Pointer = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 507576105, i8 12, i8 8, i8 8, i8 58, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @6, i64 14 }, ptr @"*_llgo_Pointer" }, align 8
+@6 = private unnamed_addr constant [14 x i8] c"unsafe.Pointer", align 1
+@"*_llgo_Pointer" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1134390089, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @6, i64 14 }, ptr null }, ptr @_llgo_Pointer }, align 8
+@"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk$fields" = weak_odr constant [2 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @2, i64 2 }, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @5, i64 5 }, ptr @_llgo_Pointer, i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@7 = private unnamed_addr constant [7 x i8] c"closure", align 1
+@8 = private unnamed_addr constant [5 x i8] c"error", align 1
+@_llgo_string = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 8, i32 1749264893, i8 4, i8 8, i8 8, i8 24, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @9, i64 6 }, ptr @"*_llgo_string" }, align 8
+@9 = private unnamed_addr constant [6 x i8] c"string", align 1
+@"*_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1323879264, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @9, i64 6 }, ptr null }, ptr @_llgo_string }, align 8
+@10 = private unnamed_addr constant [12 x i8] c"call.closure", align 1
+@11 = private unnamed_addr constant [4 x i8] c"func", align 1
+@12 = private unnamed_addr constant [9 x i8] c"call.func", align 1
+@"*_llgo_github.com/goplus/llgo/cl/_testgo/reflect.T" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [1 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1206070585, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @13, i64 6 }, ptr null }, ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reflect.T" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @14, i64 41 }, i16 1, i16 1, i32 24 }, [1 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @16, i64 3 }, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU", ptr @"github.com/goplus/llgo/cl/_testgo/reflect.(*T).Add", ptr @"github.com/goplus/llgo/cl/_testgo/reflect.(*T).Add" }] }, align 8
+@13 = private unnamed_addr constant [6 x i8] c"main.T", align 1
+@"_llgo_github.com/goplus/llgo/cl/_testgo/reflect.T" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 0, i32 -325780477, i8 13, i8 8, i8 8, i8 57, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reflect.T" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @13, i64 6 }, ptr @"*_llgo_github.com/goplus/llgo/cl/_testgo/reflect.T" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @14, i64 41 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"github.com/goplus/llgo/cl/_testgo/reflect.struct$eovYmOhZg4X0zMSsuscSshndnbbAGvB2E3cyG8E7Y4U$fields", i64 1, i64 1 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @14, i64 41 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@14 = private unnamed_addr constant [41 x i8] c"github.com/goplus/llgo/cl/_testgo/reflect", align 1
+@15 = private unnamed_addr constant [1 x i8] c"n", align 1
+@"github.com/goplus/llgo/cl/_testgo/reflect.struct$eovYmOhZg4X0zMSsuscSshndnbbAGvB2E3cyG8E7Y4U$fields" = weak_odr constant [1 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 1 }, ptr @_llgo_int, i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@16 = private unnamed_addr constant [3 x i8] c"Add", align 1
+@"_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.InterfaceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 1704177746, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @17, i64 26 }, ptr @"*_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @14, i64 41 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A$imethods", i64 1, i64 1 } }, align 8
+@17 = private unnamed_addr constant [26 x i8] c"interface { Add(int) int }", align 1
+@"*_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -721103048, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @17, i64 26 }, ptr null }, ptr @"_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A" }, align 8
+@"_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A$imethods" = weak_odr constant [1 x %"github.com/goplus/llgo/runtime/abi.Imethod"] [%"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @16, i64 3 }, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" }], align 8
+@18 = private unnamed_addr constant [7 x i8] c"imethod", align 1
+@19 = private unnamed_addr constant [6 x i8] c"method", align 1
+@"_llgo_closure$FjMjjQr3-2iTiWyZP1IIQFOz0hUCa0OS6pEm5uVV6Pk" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 1002059468, i8 32, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @20, i64 113 }, ptr @"*_llgo_closure$FjMjjQr3-2iTiWyZP1IIQFOz0hUCa0OS6pEm5uVV6Pk" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_closure$FjMjjQr3-2iTiWyZP1IIQFOz0hUCa0OS6pEm5uVV6Pk$fields", i64 2, i64 2 } }, align 8
+@20 = private unnamed_addr constant [113 x i8] c"struct { $f func(int, int, int, int, int, int, int, int, int, ...interface {}) (int, int); $data unsafe.Pointer }", align 1
+@"*_llgo_closure$FjMjjQr3-2iTiWyZP1IIQFOz0hUCa0OS6pEm5uVV6Pk" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -2059600842, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @20, i64 113 }, ptr null }, ptr @"_llgo_closure$FjMjjQr3-2iTiWyZP1IIQFOz0hUCa0OS6pEm5uVV6Pk" }, align 8
+@"_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -767802053, i8 16, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @21, i64 77 }, ptr @"*_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU$in", i64 10, i64 10 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU$out", i64 2, i64 2 } }, align 8
+@21 = private unnamed_addr constant [77 x i8] c"func(int, int, int, int, int, int, int, int, int, ...interface {}) (int, int)", align 1
+@"*_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1012808481, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @21, i64 77 }, ptr null }, ptr @"_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU" }, align 8
+@"[]_llgo_any" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 -396233978, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @22, i64 14 }, ptr @"*[]_llgo_any" }, ptr @_llgo_any }, align 8
+@22 = private unnamed_addr constant [14 x i8] c"[]interface {}", align 1
+@"*[]_llgo_any" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1171476965, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @22, i64 14 }, ptr null }, ptr @"[]_llgo_any" }, align 8
+@_llgo_any = weak_odr constant %"github.com/goplus/llgo/runtime/abi.InterfaceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 1376530322, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.nilinterequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 12 }, ptr @"*_llgo_any" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @14, i64 41 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer }, align 8
+@23 = private unnamed_addr constant [12 x i8] c"interface {}", align 1
+@"*_llgo_any" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1741196194, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 12 }, ptr null }, ptr @_llgo_any }, align 8
+@"_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU$in" = weak_odr constant [10 x ptr] [ptr @_llgo_int, ptr @_llgo_int, ptr @_llgo_int, ptr @_llgo_int, ptr @_llgo_int, ptr @_llgo_int, ptr @_llgo_int, ptr @_llgo_int, ptr @_llgo_int, ptr @"[]_llgo_any"], align 8
+@"_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU$out" = weak_odr constant [2 x ptr] [ptr @_llgo_int, ptr @_llgo_int], align 8
+@"_llgo_closure$FjMjjQr3-2iTiWyZP1IIQFOz0hUCa0OS6pEm5uVV6Pk$fields" = weak_odr constant [2 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @2, i64 2 }, ptr @"_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @5, i64 5 }, ptr @_llgo_Pointer, i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@24 = private unnamed_addr constant [10 x i8] c"call.slice", align 1
+@25 = private unnamed_addr constant [40 x i8] c"type assertion interface{} -> int failed", align 1
+@"map[_llgo_int]_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.MapType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -2084636366, i8 0, i8 8, i8 8, i8 53, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @26, i64 14 }, ptr @"*map[_llgo_int]_llgo_string" }, ptr @_llgo_int, ptr @_llgo_string, ptr @"_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ", { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.typehash", ptr @_llgo_int }, i8 8, i8 16, i16 208, i32 4 }, align 8
+@26 = private unnamed_addr constant [14 x i8] c"map[int]string", align 1
+@"*map[_llgo_int]_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 668541983, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @26, i64 14 }, ptr null }, ptr @"map[_llgo_int]_llgo_string" }, align 8
+@"_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 208, i64 208, i32 1935989513, i8 0, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @27, i64 82 }, ptr @"*_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ$fields", i64 4, i64 4 } }, align 8
+@27 = private unnamed_addr constant [82 x i8] c"struct { topbits [8]uint8; keys [8]int; elems [8]string; overflow unsafe.Pointer }", align 1
+@"*_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 597085808, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @27, i64 82 }, ptr null }, ptr @"_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ" }, align 8
+@28 = private unnamed_addr constant [7 x i8] c"topbits", align 1
+@"[8]_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.ArrayType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 0, i32 307038632, i8 8, i8 1, i8 1, i8 17, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal", ptr @"[8]_llgo_uint8" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @29, i64 8 }, ptr @"*[8]_llgo_uint8" }, ptr @_llgo_uint8, ptr @"[]_llgo_uint8", i64 8 }, align 8
+@29 = private unnamed_addr constant [8 x i8] c"[8]uint8", align 1
+@"*[8]_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -566230779, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @29, i64 8 }, ptr null }, ptr @"[8]_llgo_uint8" }, align 8
+@_llgo_uint8 = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 1, i64 0, i32 269156761, i8 12, i8 1, i8 1, i8 40, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @30, i64 5 }, ptr @"*_llgo_uint8" }, align 8
+@30 = private unnamed_addr constant [5 x i8] c"uint8", align 1
+@"*_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1277858201, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @30, i64 5 }, ptr null }, ptr @_llgo_uint8 }, align 8
+@"[]_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 370346748, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @31, i64 7 }, ptr @"*[]_llgo_uint8" }, ptr @_llgo_uint8 }, align 8
+@31 = private unnamed_addr constant [7 x i8] c"[]uint8", align 1
+@"*[]_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -2143776929, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @31, i64 7 }, ptr null }, ptr @"[]_llgo_uint8" }, align 8
+@32 = private unnamed_addr constant [4 x i8] c"keys", align 1
+@"[8]_llgo_int" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.ArrayType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 64, i64 0, i32 -1310855284, i8 8, i8 8, i8 8, i8 17, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal", ptr @"[8]_llgo_int" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @33, i64 6 }, ptr @"*[8]_llgo_int" }, ptr @_llgo_int, ptr @"[]_llgo_int", i64 8 }, align 8
+@33 = private unnamed_addr constant [6 x i8] c"[8]int", align 1
+@"*[8]_llgo_int" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1841254256, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @33, i64 6 }, ptr null }, ptr @"[8]_llgo_int" }, align 8
+@"[]_llgo_int" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 -1129561019, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @34, i64 5 }, ptr @"*[]_llgo_int" }, ptr @_llgo_int }, align 8
+@34 = private unnamed_addr constant [5 x i8] c"[]int", align 1
+@"*[]_llgo_int" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1428175521, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @34, i64 5 }, ptr null }, ptr @"[]_llgo_int" }, align 8
+@35 = private unnamed_addr constant [5 x i8] c"elems", align 1
+@"[8]_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.ArrayType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 128, i64 120, i32 460245566, i8 0, i8 8, i8 8, i8 17, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal", ptr @"[8]_llgo_string" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @36, i64 9 }, ptr @"*[8]_llgo_string" }, ptr @_llgo_string, ptr @"[]_llgo_string", i64 8 }, align 8
+@36 = private unnamed_addr constant [9 x i8] c"[8]string", align 1
+@"*[8]_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 368026044, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @36, i64 9 }, ptr null }, ptr @"[8]_llgo_string" }, align 8
+@"[]_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 608974920, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @37, i64 8 }, ptr @"*[]_llgo_string" }, ptr @_llgo_string }, align 8
+@37 = private unnamed_addr constant [8 x i8] c"[]string", align 1
+@"*[]_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -157880218, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @37, i64 8 }, ptr null }, ptr @"[]_llgo_string" }, align 8
+@38 = private unnamed_addr constant [8 x i8] c"overflow", align 1
+@"_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ$fields" = weak_odr constant [4 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 7 }, ptr @"[8]_llgo_uint8", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @32, i64 4 }, ptr @"[8]_llgo_int", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @35, i64 5 }, ptr @"[8]_llgo_string", i64 72, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @38, i64 8 }, ptr @_llgo_Pointer, i64 200, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@39 = private unnamed_addr constant [5 x i8] c"hello", align 1
+@40 = private unnamed_addr constant [5 x i8] c"world", align 1
+@41 = private unnamed_addr constant [14 x i8] c"MapIndex error", align 1
+@42 = private unnamed_addr constant [4 x i8] c"todo", align 1
+@43 = private unnamed_addr constant [12 x i8] c"must invalid", align 1
+@44 = private unnamed_addr constant [13 x i8] c"MapIter error", align 1
+
+define i64 @"github.com/goplus/llgo/cl/_testgo/reflect.(*T).Add"(ptr %0, i64 %1) {
+_llgo_0:
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 11 })
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reflect.T", ptr %0, i32 0, i32 0
+  %3 = load i64, ptr %2, align 4
+  %4 = add i64 %3, %1
+  %5 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reflect.T", ptr %0, i32 0, i32 0
+  store i64 %4, ptr %5, align 4
+  %6 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reflect.T", ptr %0, i32 0, i32 0
+  %7 = load i64, ptr %6, align 4
+  ret i64 %7
+}
+
+define void @"github.com/goplus/llgo/cl/_testgo/reflect.callClosure"() {
+_llgo_0:
+  %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
+  store i64 100, ptr %0, align 4
+  %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 8)
+  %2 = getelementptr inbounds { ptr }, ptr %1, i32 0, i32 0
+  store ptr %0, ptr %2, align 8
+  %3 = insertvalue { ptr, ptr } { ptr @"github.com/goplus/llgo/cl/_testgo/reflect.callClosure$1", ptr undef }, ptr %1, 1
+  %4 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store { ptr, ptr } %3, ptr %4, align 8
+  %5 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", ptr undef }, ptr %4, 1
+  %6 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %5)
+  %7 = call i64 @reflect.Value.Kind(%reflect.Value %6)
+  %8 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %6)
+  %9 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %8)
+  %10 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %8, 0
+  %11 = getelementptr ptr, ptr %10, i64 37
+  %12 = load ptr, ptr %11, align 8
+  %13 = insertvalue { ptr, ptr } undef, ptr %12, 0
+  %14 = insertvalue { ptr, ptr } %13, ptr %9, 1
+  %15 = extractvalue { ptr, ptr } %14, 1
+  %16 = extractvalue { ptr, ptr } %14, 0
+  %17 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" %16(ptr %15)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 7 })
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64 %7)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %17)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  %18 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 24)
+  %19 = getelementptr inbounds %reflect.Value, ptr %18, i64 0
+  %20 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 100 to ptr) })
+  store %reflect.Value %20, ptr %19, align 8
+  %21 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %18, 0
+  %22 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %21, i64 1, 1
+  %23 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %22, i64 1, 2
+  %24 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %6, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %23)
+  %25 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %24, 0
+  %26 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %24, 1
+  %27 = icmp sge i64 0, %26
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %27)
+  %28 = getelementptr inbounds %reflect.Value, ptr %25, i64 0
+  %29 = load %reflect.Value, ptr %28, align 8
+  %30 = call i64 @reflect.Value.Int(%reflect.Value %29)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %30)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  %31 = call %"github.com/goplus/llgo/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %6)
+  %32 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %31, 0
+  %33 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", ptr %32)
+  br i1 %33, label %_llgo_3, label %_llgo_4
+
+_llgo_1:                                          ; preds = %_llgo_5
+  %34 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 5 }, ptr %34, align 8
+  %35 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %34, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %35)
+  unreachable
+
+_llgo_2:                                          ; preds = %_llgo_5
+  %36 = extractvalue { ptr, ptr } %44, 1
+  %37 = extractvalue { ptr, ptr } %44, 0
+  %38 = call i64 %37(ptr %36, i64 100)
+  ret void
+
+_llgo_3:                                          ; preds = %_llgo_0
+  %39 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %31, 1
+  %40 = load { ptr, ptr }, ptr %39, align 8
+  %41 = insertvalue { { ptr, ptr }, i1 } undef, { ptr, ptr } %40, 0
+  %42 = insertvalue { { ptr, ptr }, i1 } %41, i1 true, 1
+  br label %_llgo_5
+
+_llgo_4:                                          ; preds = %_llgo_0
+  br label %_llgo_5
+
+_llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
+  %43 = phi { { ptr, ptr }, i1 } [ %42, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
+  %44 = extractvalue { { ptr, ptr }, i1 } %43, 0
+  %45 = extractvalue { { ptr, ptr }, i1 } %43, 1
+  br i1 %45, label %_llgo_2, label %_llgo_1
+}
+
+define i64 @"github.com/goplus/llgo/cl/_testgo/reflect.callClosure$1"(ptr %0, i64 %1) {
+_llgo_0:
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @10, i64 12 })
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  %2 = load { ptr }, ptr %0, align 8
+  %3 = extractvalue { ptr } %2, 0
+  %4 = load i64, ptr %3, align 4
+  %5 = add i64 %4, %1
+  %6 = add i64 %5, 1
+  ret i64 %6
+}
+
+define void @"github.com/goplus/llgo/cl/_testgo/reflect.callFunc"() {
+_llgo_0:
+  %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testgo/reflect.callFunc$1", ptr null }, ptr %0, align 8
+  %1 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", ptr undef }, ptr %0, 1
+  %2 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %1)
+  %3 = call i64 @reflect.Value.Kind(%reflect.Value %2)
+  %4 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %2)
+  %5 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %4)
+  %6 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %4, 0
+  %7 = getelementptr ptr, ptr %6, i64 37
+  %8 = load ptr, ptr %7, align 8
+  %9 = insertvalue { ptr, ptr } undef, ptr %8, 0
+  %10 = insertvalue { ptr, ptr } %9, ptr %5, 1
+  %11 = extractvalue { ptr, ptr } %10, 1
+  %12 = extractvalue { ptr, ptr } %10, 0
+  %13 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" %12(ptr %11)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @11, i64 4 })
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64 %3)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %13)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  %14 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 24)
+  %15 = getelementptr inbounds %reflect.Value, ptr %14, i64 0
+  %16 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 100 to ptr) })
+  store %reflect.Value %16, ptr %15, align 8
+  %17 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %14, 0
+  %18 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %17, i64 1, 1
+  %19 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %18, i64 1, 2
+  %20 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %2, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %19)
+  %21 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %20, 0
+  %22 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %20, 1
+  %23 = icmp sge i64 0, %22
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %23)
+  %24 = getelementptr inbounds %reflect.Value, ptr %21, i64 0
+  %25 = load %reflect.Value, ptr %24, align 8
+  %26 = call i64 @reflect.Value.Int(%reflect.Value %25)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %26)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  %27 = call %"github.com/goplus/llgo/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %2)
+  %28 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %27, 0
+  %29 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", ptr %28)
+  br i1 %29, label %_llgo_3, label %_llgo_4
+
+_llgo_1:                                          ; preds = %_llgo_5
+  %30 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 5 }, ptr %30, align 8
+  %31 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %30, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %31)
+  unreachable
+
+_llgo_2:                                          ; preds = %_llgo_5
+  %32 = extractvalue { ptr, ptr } %40, 1
+  %33 = extractvalue { ptr, ptr } %40, 0
+  %34 = call i64 %33(ptr %32, i64 100)
+  ret void
+
+_llgo_3:                                          ; preds = %_llgo_0
+  %35 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %27, 1
+  %36 = load { ptr, ptr }, ptr %35, align 8
+  %37 = insertvalue { { ptr, ptr }, i1 } undef, { ptr, ptr } %36, 0
+  %38 = insertvalue { { ptr, ptr }, i1 } %37, i1 true, 1
+  br label %_llgo_5
+
+_llgo_4:                                          ; preds = %_llgo_0
+  br label %_llgo_5
+
+_llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
+  %39 = phi { { ptr, ptr }, i1 } [ %38, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
+  %40 = extractvalue { { ptr, ptr }, i1 } %39, 0
+  %41 = extractvalue { { ptr, ptr }, i1 } %39, 1
+  br i1 %41, label %_llgo_2, label %_llgo_1
+}
+
+define i64 @"github.com/goplus/llgo/cl/_testgo/reflect.callFunc$1"(i64 %0) {
+_llgo_0:
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @12, i64 9 })
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  %1 = add i64 %0, 1
+  ret i64 %1
+}
+
+define void @"github.com/goplus/llgo/cl/_testgo/reflect.callIMethod"() {
+_llgo_0:
+  %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
+  %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reflect.T", ptr %0, i32 0, i32 0
+  store i64 1, ptr %1, align 4
+  %2 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A", ptr @"*_llgo_github.com/goplus/llgo/cl/_testgo/reflect.T")
+  %3 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" undef, ptr %2, 0
+  %4 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %3, ptr %0, 1
+  %5 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %4)
+  %6 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %4, 1
+  %7 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %5, 0
+  %8 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %7, ptr %6, 1
+  %9 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %8)
+  %10 = call %reflect.Value @reflect.Value.Method(%reflect.Value %9, i64 0)
+  %11 = call i64 @reflect.Value.Kind(%reflect.Value %10)
+  %12 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %10)
+  %13 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %12)
+  %14 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %12, 0
+  %15 = getelementptr ptr, ptr %14, i64 37
+  %16 = load ptr, ptr %15, align 8
+  %17 = insertvalue { ptr, ptr } undef, ptr %16, 0
+  %18 = insertvalue { ptr, ptr } %17, ptr %13, 1
+  %19 = extractvalue { ptr, ptr } %18, 1
+  %20 = extractvalue { ptr, ptr } %18, 0
+  %21 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" %20(ptr %19)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @18, i64 7 })
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64 %11)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %21)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  %22 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 24)
+  %23 = getelementptr inbounds %reflect.Value, ptr %22, i64 0
+  %24 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 100 to ptr) })
+  store %reflect.Value %24, ptr %23, align 8
+  %25 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %22, 0
+  %26 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %25, i64 1, 1
+  %27 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %26, i64 1, 2
+  %28 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %10, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %27)
+  %29 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %28, 0
+  %30 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %28, 1
+  %31 = icmp sge i64 0, %30
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %31)
+  %32 = getelementptr inbounds %reflect.Value, ptr %29, i64 0
+  %33 = load %reflect.Value, ptr %32, align 8
+  %34 = call i64 @reflect.Value.Int(%reflect.Value %33)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %34)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  %35 = call %"github.com/goplus/llgo/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %10)
+  %36 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %35, 0
+  %37 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", ptr %36)
+  br i1 %37, label %_llgo_3, label %_llgo_4
+
+_llgo_1:                                          ; preds = %_llgo_5
+  %38 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 5 }, ptr %38, align 8
+  %39 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %38, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %39)
+  unreachable
+
+_llgo_2:                                          ; preds = %_llgo_5
+  %40 = extractvalue { ptr, ptr } %63, 1
+  %41 = extractvalue { ptr, ptr } %63, 0
+  %42 = call i64 %41(ptr %40, i64 1)
+  %43 = call %"github.com/goplus/llgo/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %10)
+  %44 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %43)
+  %45 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 24)
+  %46 = getelementptr inbounds %reflect.Value, ptr %45, i64 0
+  %47 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 100 to ptr) })
+  store %reflect.Value %47, ptr %46, align 8
+  %48 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %45, 0
+  %49 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %48, i64 1, 1
+  %50 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %49, i64 1, 2
+  %51 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %44, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %50)
+  %52 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %51, 0
+  %53 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %51, 1
+  %54 = icmp sge i64 0, %53
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %54)
+  %55 = getelementptr inbounds %reflect.Value, ptr %52, i64 0
+  %56 = load %reflect.Value, ptr %55, align 8
+  %57 = call i64 @reflect.Value.Int(%reflect.Value %56)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %57)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  ret void
+
+_llgo_3:                                          ; preds = %_llgo_0
+  %58 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %35, 1
+  %59 = load { ptr, ptr }, ptr %58, align 8
+  %60 = insertvalue { { ptr, ptr }, i1 } undef, { ptr, ptr } %59, 0
+  %61 = insertvalue { { ptr, ptr }, i1 } %60, i1 true, 1
+  br label %_llgo_5
+
+_llgo_4:                                          ; preds = %_llgo_0
+  br label %_llgo_5
+
+_llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
+  %62 = phi { { ptr, ptr }, i1 } [ %61, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
+  %63 = extractvalue { { ptr, ptr }, i1 } %62, 0
+  %64 = extractvalue { { ptr, ptr }, i1 } %62, 1
+  br i1 %64, label %_llgo_2, label %_llgo_1
+}
+
+define void @"github.com/goplus/llgo/cl/_testgo/reflect.callMethod"() {
+_llgo_0:
+  %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
+  %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reflect.T", ptr %0, i32 0, i32 0
+  store i64 1, ptr %1, align 4
+  %2 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @"*_llgo_github.com/goplus/llgo/cl/_testgo/reflect.T", ptr undef }, ptr %0, 1
+  %3 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %2)
+  %4 = call %reflect.Value @reflect.Value.Method(%reflect.Value %3, i64 0)
+  %5 = call i64 @reflect.Value.Kind(%reflect.Value %4)
+  %6 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %4)
+  %7 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %6)
+  %8 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %6, 0
+  %9 = getelementptr ptr, ptr %8, i64 37
+  %10 = load ptr, ptr %9, align 8
+  %11 = insertvalue { ptr, ptr } undef, ptr %10, 0
+  %12 = insertvalue { ptr, ptr } %11, ptr %7, 1
+  %13 = extractvalue { ptr, ptr } %12, 1
+  %14 = extractvalue { ptr, ptr } %12, 0
+  %15 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" %14(ptr %13)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @19, i64 6 })
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64 %5)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %15)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  %16 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 24)
+  %17 = getelementptr inbounds %reflect.Value, ptr %16, i64 0
+  %18 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 100 to ptr) })
+  store %reflect.Value %18, ptr %17, align 8
+  %19 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %16, 0
+  %20 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %19, i64 1, 1
+  %21 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %20, i64 1, 2
+  %22 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %4, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %21)
+  %23 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %22, 0
+  %24 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %22, 1
+  %25 = icmp sge i64 0, %24
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %25)
+  %26 = getelementptr inbounds %reflect.Value, ptr %23, i64 0
+  %27 = load %reflect.Value, ptr %26, align 8
+  %28 = call i64 @reflect.Value.Int(%reflect.Value %27)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %28)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  %29 = call %"github.com/goplus/llgo/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %4)
+  %30 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %29, 0
+  %31 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", ptr %30)
+  br i1 %31, label %_llgo_3, label %_llgo_4
+
+_llgo_1:                                          ; preds = %_llgo_5
+  %32 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 5 }, ptr %32, align 8
+  %33 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %32, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %33)
+  unreachable
+
+_llgo_2:                                          ; preds = %_llgo_5
+  %34 = extractvalue { ptr, ptr } %57, 1
+  %35 = extractvalue { ptr, ptr } %57, 0
+  %36 = call i64 %35(ptr %34, i64 1)
+  %37 = call %"github.com/goplus/llgo/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %4)
+  %38 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %37)
+  %39 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 24)
+  %40 = getelementptr inbounds %reflect.Value, ptr %39, i64 0
+  %41 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 100 to ptr) })
+  store %reflect.Value %41, ptr %40, align 8
+  %42 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %39, 0
+  %43 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %42, i64 1, 1
+  %44 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %43, i64 1, 2
+  %45 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %38, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %44)
+  %46 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %45, 0
+  %47 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %45, 1
+  %48 = icmp sge i64 0, %47
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %48)
+  %49 = getelementptr inbounds %reflect.Value, ptr %46, i64 0
+  %50 = load %reflect.Value, ptr %49, align 8
+  %51 = call i64 @reflect.Value.Int(%reflect.Value %50)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %51)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  ret void
+
+_llgo_3:                                          ; preds = %_llgo_0
+  %52 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %29, 1
+  %53 = load { ptr, ptr }, ptr %52, align 8
+  %54 = insertvalue { { ptr, ptr }, i1 } undef, { ptr, ptr } %53, 0
+  %55 = insertvalue { { ptr, ptr }, i1 } %54, i1 true, 1
+  br label %_llgo_5
+
+_llgo_4:                                          ; preds = %_llgo_0
+  br label %_llgo_5
+
+_llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
+  %56 = phi { { ptr, ptr }, i1 } [ %55, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
+  %57 = extractvalue { { ptr, ptr }, i1 } %56, 0
+  %58 = extractvalue { { ptr, ptr }, i1 } %56, 1
+  br i1 %58, label %_llgo_2, label %_llgo_1
+}
+
+define void @"github.com/goplus/llgo/cl/_testgo/reflect.callSlice"() {
+_llgo_0:
+  %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testgo/reflect.demo", ptr null }, ptr %0, align 8
+  %1 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @"_llgo_closure$FjMjjQr3-2iTiWyZP1IIQFOz0hUCa0OS6pEm5uVV6Pk", ptr undef }, ptr %0, 1
+  %2 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %1)
+  %3 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 1 to ptr) })
+  %4 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 288)
+  %5 = getelementptr inbounds %reflect.Value, ptr %4, i64 0
+  store %reflect.Value %3, ptr %5, align 8
+  %6 = getelementptr inbounds %reflect.Value, ptr %4, i64 1
+  store %reflect.Value %3, ptr %6, align 8
+  %7 = getelementptr inbounds %reflect.Value, ptr %4, i64 2
+  store %reflect.Value %3, ptr %7, align 8
+  %8 = getelementptr inbounds %reflect.Value, ptr %4, i64 3
+  store %reflect.Value %3, ptr %8, align 8
+  %9 = getelementptr inbounds %reflect.Value, ptr %4, i64 4
+  store %reflect.Value %3, ptr %9, align 8
+  %10 = getelementptr inbounds %reflect.Value, ptr %4, i64 5
+  store %reflect.Value %3, ptr %10, align 8
+  %11 = getelementptr inbounds %reflect.Value, ptr %4, i64 6
+  store %reflect.Value %3, ptr %11, align 8
+  %12 = getelementptr inbounds %reflect.Value, ptr %4, i64 7
+  store %reflect.Value %3, ptr %12, align 8
+  %13 = getelementptr inbounds %reflect.Value, ptr %4, i64 8
+  store %reflect.Value %3, ptr %13, align 8
+  %14 = getelementptr inbounds %reflect.Value, ptr %4, i64 9
+  %15 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 1 to ptr) })
+  store %reflect.Value %15, ptr %14, align 8
+  %16 = getelementptr inbounds %reflect.Value, ptr %4, i64 10
+  %17 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 2 to ptr) })
+  store %reflect.Value %17, ptr %16, align 8
+  %18 = getelementptr inbounds %reflect.Value, ptr %4, i64 11
+  %19 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 3 to ptr) })
+  store %reflect.Value %19, ptr %18, align 8
+  %20 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %4, 0
+  %21 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %20, i64 12, 1
+  %22 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %21, i64 12, 2
+  %23 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %2, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %22)
+  %24 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %23, 0
+  %25 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %23, 1
+  %26 = icmp sge i64 0, %25
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %26)
+  %27 = getelementptr inbounds %reflect.Value, ptr %24, i64 0
+  %28 = load %reflect.Value, ptr %27, align 8
+  %29 = call i64 @reflect.Value.Int(%reflect.Value %28)
+  %30 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %23, 0
+  %31 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %23, 1
+  %32 = icmp sge i64 1, %31
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %32)
+  %33 = getelementptr inbounds %reflect.Value, ptr %30, i64 1
+  %34 = load %reflect.Value, ptr %33, align 8
+  %35 = call i64 @reflect.Value.Int(%reflect.Value %34)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @24, i64 10 })
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %29)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %35)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  %36 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 240)
+  %37 = getelementptr inbounds %reflect.Value, ptr %36, i64 0
+  store %reflect.Value %3, ptr %37, align 8
+  %38 = getelementptr inbounds %reflect.Value, ptr %36, i64 1
+  store %reflect.Value %3, ptr %38, align 8
+  %39 = getelementptr inbounds %reflect.Value, ptr %36, i64 2
+  store %reflect.Value %3, ptr %39, align 8
+  %40 = getelementptr inbounds %reflect.Value, ptr %36, i64 3
+  store %reflect.Value %3, ptr %40, align 8
+  %41 = getelementptr inbounds %reflect.Value, ptr %36, i64 4
+  store %reflect.Value %3, ptr %41, align 8
+  %42 = getelementptr inbounds %reflect.Value, ptr %36, i64 5
+  store %reflect.Value %3, ptr %42, align 8
+  %43 = getelementptr inbounds %reflect.Value, ptr %36, i64 6
+  store %reflect.Value %3, ptr %43, align 8
+  %44 = getelementptr inbounds %reflect.Value, ptr %36, i64 7
+  store %reflect.Value %3, ptr %44, align 8
+  %45 = getelementptr inbounds %reflect.Value, ptr %36, i64 8
+  store %reflect.Value %3, ptr %45, align 8
+  %46 = getelementptr inbounds %reflect.Value, ptr %36, i64 9
+  %47 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 48)
+  %48 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.eface", ptr %47, i64 0
+  store %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 1 to ptr) }, ptr %48, align 8
+  %49 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.eface", ptr %47, i64 1
+  store %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 2 to ptr) }, ptr %49, align 8
+  %50 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.eface", ptr %47, i64 2
+  store %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 3 to ptr) }, ptr %50, align 8
+  %51 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %47, 0
+  %52 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %51, i64 3, 1
+  %53 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %52, i64 3, 2
+  %54 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 24)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %53, ptr %54, align 8
+  %55 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @"[]_llgo_any", ptr undef }, ptr %54, 1
+  %56 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %55)
+  store %reflect.Value %56, ptr %46, align 8
+  %57 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %36, 0
+  %58 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %57, i64 10, 1
+  %59 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %58, i64 10, 2
+  %60 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.CallSlice(%reflect.Value %2, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %59)
+  %61 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %60, 0
+  %62 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %60, 1
+  %63 = icmp sge i64 0, %62
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %63)
+  %64 = getelementptr inbounds %reflect.Value, ptr %61, i64 0
+  %65 = load %reflect.Value, ptr %64, align 8
+  %66 = call i64 @reflect.Value.Int(%reflect.Value %65)
+  %67 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %60, 0
+  %68 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %60, 1
+  %69 = icmp sge i64 1, %68
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %69)
+  %70 = getelementptr inbounds %reflect.Value, ptr %67, i64 1
+  %71 = load %reflect.Value, ptr %70, align 8
+  %72 = call i64 @reflect.Value.Int(%reflect.Value %71)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @24, i64 10 })
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %66)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %72)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  ret void
+}
+
+define { i64, i64 } @"github.com/goplus/llgo/cl/_testgo/reflect.demo"(i64 %0, i64 %1, i64 %2, i64 %3, i64 %4, i64 %5, i64 %6, i64 %7, i64 %8, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %9) {
+_llgo_0:
+  %10 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %9, 1
+  br label %_llgo_1
+
+_llgo_1:                                          ; preds = %_llgo_4, %_llgo_0
+  %11 = phi i64 [ 0, %_llgo_0 ], [ %36, %_llgo_4 ]
+  %12 = phi i64 [ -1, %_llgo_0 ], [ %13, %_llgo_4 ]
+  %13 = add i64 %12, 1
+  %14 = icmp slt i64 %13, %10
+  br i1 %14, label %_llgo_2, label %_llgo_3
+
+_llgo_2:                                          ; preds = %_llgo_1
+  %15 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %9, 0
+  %16 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %9, 1
+  %17 = icmp slt i64 %13, 0
+  %18 = icmp sge i64 %13, %16
+  %19 = or i1 %18, %17
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %19)
+  %20 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.eface", ptr %15, i64 %13
+  %21 = load %"github.com/goplus/llgo/runtime/internal/runtime.eface", ptr %20, align 8
+  %22 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %21, 0
+  %23 = icmp eq ptr %22, @_llgo_int
+  br i1 %23, label %_llgo_4, label %_llgo_5
+
+_llgo_3:                                          ; preds = %_llgo_1
+  %24 = add i64 %0, %1
+  %25 = add i64 %24, %2
+  %26 = add i64 %25, %3
+  %27 = add i64 %26, %4
+  %28 = add i64 %27, %5
+  %29 = add i64 %28, %6
+  %30 = add i64 %29, %7
+  %31 = add i64 %30, %8
+  %32 = insertvalue { i64, i64 } undef, i64 %31, 0
+  %33 = insertvalue { i64, i64 } %32, i64 %11, 1
+  ret { i64, i64 } %33
+
+_llgo_4:                                          ; preds = %_llgo_2
+  %34 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %21, 1
+  %35 = ptrtoint ptr %34 to i64
+  %36 = add i64 %11, %35
+  br label %_llgo_1
+
+_llgo_5:                                          ; preds = %_llgo_2
+  %37 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 40 }, ptr %37, align 8
+  %38 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %37, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %38)
+  unreachable
+}
+
+define void @"github.com/goplus/llgo/cl/_testgo/reflect.init"() {
+_llgo_0:
+  %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/reflect.init$guard", align 1
+  br i1 %0, label %_llgo_2, label %_llgo_1
+
+_llgo_1:                                          ; preds = %_llgo_0
+  store i1 true, ptr @"github.com/goplus/llgo/cl/_testgo/reflect.init$guard", align 1
+  call void @reflect.init()
+  br label %_llgo_2
+
+_llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+  ret void
+}
+
+define void @"github.com/goplus/llgo/cl/_testgo/reflect.main"() {
+_llgo_0:
+  call void @"github.com/goplus/llgo/cl/_testgo/reflect.callSlice"()
+  call void @"github.com/goplus/llgo/cl/_testgo/reflect.callFunc"()
+  call void @"github.com/goplus/llgo/cl/_testgo/reflect.callClosure"()
+  call void @"github.com/goplus/llgo/cl/_testgo/reflect.callMethod"()
+  call void @"github.com/goplus/llgo/cl/_testgo/reflect.callIMethod"()
+  call void @"github.com/goplus/llgo/cl/_testgo/reflect.mapDemo1"()
+  call void @"github.com/goplus/llgo/cl/_testgo/reflect.mapDemo2"()
+  ret void
+}
+
+define void @"github.com/goplus/llgo/cl/_testgo/reflect.mapDemo1"() {
+_llgo_0:
+  %0 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_string", i64 2)
+  %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 8)
+  store i64 1, ptr %1, align 4
+  %2 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_int]_llgo_string", ptr %0, ptr %1)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @39, i64 5 }, ptr %2, align 8
+  %3 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 8)
+  store i64 2, ptr %3, align 4
+  %4 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_int]_llgo_string", ptr %0, ptr %3)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @40, i64 5 }, ptr %4, align 8
+  %5 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @"map[_llgo_int]_llgo_string", ptr undef }, ptr %0, 1
+  %6 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %5)
+  %7 = call i64 @reflect.Value.Len(%reflect.Value %6)
+  %8 = icmp ne i64 %7, 2
+  br i1 %8, label %_llgo_1, label %_llgo_3
+
+_llgo_1:                                          ; preds = %_llgo_3, %_llgo_0
+  %9 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 5 }, ptr %9, align 8
+  %10 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %9, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %10)
+  unreachable
+
+_llgo_2:                                          ; preds = %_llgo_3
+  %11 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 2 to ptr) })
+  %12 = call %reflect.Value @reflect.Value.MapIndex(%reflect.Value %6, %reflect.Value %11)
+  %13 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %12)
+  %14 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %13, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @40, i64 5 })
+  %15 = xor i1 %14, true
+  br i1 %15, label %_llgo_4, label %_llgo_5
+
+_llgo_3:                                          ; preds = %_llgo_0
+  %16 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.MapKeys(%reflect.Value %6)
+  %17 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %16, 1
+  %18 = icmp ne i64 %17, 2
+  br i1 %18, label %_llgo_1, label %_llgo_2
+
+_llgo_4:                                          ; preds = %_llgo_2
+  %19 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @41, i64 14 }, ptr %19, align 8
+  %20 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %19, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %20)
+  unreachable
+
+_llgo_5:                                          ; preds = %_llgo_2
+  %21 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 2 to ptr) })
+  %22 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @42, i64 4 }, ptr %22, align 8
+  %23 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %22, 1
+  %24 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %23)
+  call void @reflect.Value.SetMapIndex(%reflect.Value %6, %reflect.Value %21, %reflect.Value %24)
+  %25 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 2 to ptr) })
+  %26 = call %reflect.Value @reflect.Value.MapIndex(%reflect.Value %6, %reflect.Value %25)
+  %27 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %26)
+  %28 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %27, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @42, i64 4 })
+  %29 = xor i1 %28, true
+  br i1 %29, label %_llgo_6, label %_llgo_7
+
+_llgo_6:                                          ; preds = %_llgo_5
+  %30 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @41, i64 14 }, ptr %30, align 8
+  %31 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %30, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %31)
+  unreachable
+
+_llgo_7:                                          ; preds = %_llgo_5
+  %32 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr null })
+  %33 = call %reflect.Value @reflect.Value.MapIndex(%reflect.Value %6, %reflect.Value %32)
+  %34 = call i1 @reflect.Value.IsValid(%reflect.Value %33)
+  br i1 %34, label %_llgo_8, label %_llgo_9
+
+_llgo_8:                                          ; preds = %_llgo_7
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @43, i64 12 })
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  br label %_llgo_9
+
+_llgo_9:                                          ; preds = %_llgo_8, %_llgo_7
+  %35 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %6)
+  %36 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %35)
+  %37 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %35, 0
+  %38 = getelementptr ptr, ptr %37, i64 20
+  %39 = load ptr, ptr %38, align 8
+  %40 = insertvalue { ptr, ptr } undef, ptr %39, 0
+  %41 = insertvalue { ptr, ptr } %40, ptr %36, 1
+  %42 = extractvalue { ptr, ptr } %41, 1
+  %43 = extractvalue { ptr, ptr } %41, 0
+  %44 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" %43(ptr %42)
+  %45 = call %reflect.Value @reflect.New(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %44)
+  %46 = call %reflect.Value @reflect.Value.Elem(%reflect.Value %45)
+  %47 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %6)
+  %48 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %47)
+  %49 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %47, 0
+  %50 = getelementptr ptr, ptr %49, i64 11
+  %51 = load ptr, ptr %50, align 8
+  %52 = insertvalue { ptr, ptr } undef, ptr %51, 0
+  %53 = insertvalue { ptr, ptr } %52, ptr %48, 1
+  %54 = extractvalue { ptr, ptr } %53, 1
+  %55 = extractvalue { ptr, ptr } %53, 0
+  %56 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" %55(ptr %54)
+  %57 = call %reflect.Value @reflect.New(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %56)
+  %58 = call %reflect.Value @reflect.Value.Elem(%reflect.Value %57)
+  %59 = call ptr @reflect.Value.MapRange(%reflect.Value %6)
+  br label %_llgo_12
+
+_llgo_10:                                         ; preds = %_llgo_12
+  call void @reflect.Value.SetIterKey(%reflect.Value %46, ptr %59)
+  call void @reflect.Value.SetIterValue(%reflect.Value %58, ptr %59)
+  %60 = call i64 @reflect.Value.Int(%reflect.Value %46)
+  %61 = call %reflect.Value @"reflect.(*MapIter).Key"(ptr %59)
+  %62 = call i64 @reflect.Value.Int(%reflect.Value %61)
+  %63 = icmp ne i64 %60, %62
+  br i1 %63, label %_llgo_13, label %_llgo_14
+
+_llgo_11:                                         ; preds = %_llgo_12
+  ret void
+
+_llgo_12:                                         ; preds = %_llgo_14, %_llgo_9
+  %64 = call i1 @"reflect.(*MapIter).Next"(ptr %59)
+  br i1 %64, label %_llgo_10, label %_llgo_11
+
+_llgo_13:                                         ; preds = %_llgo_14, %_llgo_10
+  %65 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @44, i64 13 }, ptr %65, align 8
+  %66 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %65, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %66)
+  unreachable
+
+_llgo_14:                                         ; preds = %_llgo_10
+  %67 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %58)
+  %68 = call %reflect.Value @"reflect.(*MapIter).Value"(ptr %59)
+  %69 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %68)
+  %70 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %67, %"github.com/goplus/llgo/runtime/internal/runtime.String" %69)
+  %71 = xor i1 %70, true
+  br i1 %71, label %_llgo_13, label %_llgo_12
+}
+
+define void @"github.com/goplus/llgo/cl/_testgo/reflect.mapDemo2"() {
+_llgo_0:
+  %0 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.TypeOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr null })
+  %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, ptr %1, align 8
+  %2 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %1, 1
+  %3 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.TypeOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %2)
+  %4 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.MapOf(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %3)
+  %5 = call %reflect.Value @reflect.MakeMap(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %4)
+  %6 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 1 to ptr) })
+  %7 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @39, i64 5 }, ptr %7, align 8
+  %8 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %7, 1
+  %9 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %8)
+  call void @reflect.Value.SetMapIndex(%reflect.Value %5, %reflect.Value %6, %reflect.Value %9)
+  %10 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 2 to ptr) })
+  %11 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @40, i64 5 }, ptr %11, align 8
+  %12 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %11, 1
+  %13 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %12)
+  call void @reflect.Value.SetMapIndex(%reflect.Value %5, %reflect.Value %10, %reflect.Value %13)
+  %14 = call i64 @reflect.Value.Len(%reflect.Value %5)
+  %15 = icmp ne i64 %14, 2
+  br i1 %15, label %_llgo_1, label %_llgo_3
+
+_llgo_1:                                          ; preds = %_llgo_3, %_llgo_0
+  %16 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 5 }, ptr %16, align 8
+  %17 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %16, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %17)
+  unreachable
+
+_llgo_2:                                          ; preds = %_llgo_3
+  %18 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 2 to ptr) })
+  %19 = call %reflect.Value @reflect.Value.MapIndex(%reflect.Value %5, %reflect.Value %18)
+  %20 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %19)
+  %21 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %20, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @40, i64 5 })
+  %22 = xor i1 %21, true
+  br i1 %22, label %_llgo_4, label %_llgo_5
+
+_llgo_3:                                          ; preds = %_llgo_0
+  %23 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.MapKeys(%reflect.Value %5)
+  %24 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %23, 1
+  %25 = icmp ne i64 %24, 2
+  br i1 %25, label %_llgo_1, label %_llgo_2
+
+_llgo_4:                                          ; preds = %_llgo_2
+  %26 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @41, i64 14 }, ptr %26, align 8
+  %27 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %26, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %27)
+  unreachable
+
+_llgo_5:                                          ; preds = %_llgo_2
+  %28 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 2 to ptr) })
+  %29 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @42, i64 4 }, ptr %29, align 8
+  %30 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %29, 1
+  %31 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %30)
+  call void @reflect.Value.SetMapIndex(%reflect.Value %5, %reflect.Value %28, %reflect.Value %31)
+  %32 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr inttoptr (i64 2 to ptr) })
+  %33 = call %reflect.Value @reflect.Value.MapIndex(%reflect.Value %5, %reflect.Value %32)
+  %34 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %33)
+  %35 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %34, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @42, i64 4 })
+  %36 = xor i1 %35, true
+  br i1 %36, label %_llgo_6, label %_llgo_7
+
+_llgo_6:                                          ; preds = %_llgo_5
+  %37 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @41, i64 14 }, ptr %37, align 8
+  %38 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %37, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %38)
+  unreachable
+
+_llgo_7:                                          ; preds = %_llgo_5
+  %39 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr null })
+  %40 = call %reflect.Value @reflect.Value.MapIndex(%reflect.Value %5, %reflect.Value %39)
+  %41 = call i1 @reflect.Value.IsValid(%reflect.Value %40)
+  br i1 %41, label %_llgo_8, label %_llgo_9
+
+_llgo_8:                                          ; preds = %_llgo_7
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @43, i64 12 })
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  br label %_llgo_9
+
+_llgo_9:                                          ; preds = %_llgo_8, %_llgo_7
+  %42 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %5)
+  %43 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %42)
+  %44 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %42, 0
+  %45 = getelementptr ptr, ptr %44, i64 20
+  %46 = load ptr, ptr %45, align 8
+  %47 = insertvalue { ptr, ptr } undef, ptr %46, 0
+  %48 = insertvalue { ptr, ptr } %47, ptr %43, 1
+  %49 = extractvalue { ptr, ptr } %48, 1
+  %50 = extractvalue { ptr, ptr } %48, 0
+  %51 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" %50(ptr %49)
+  %52 = call %reflect.Value @reflect.New(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %51)
+  %53 = call %reflect.Value @reflect.Value.Elem(%reflect.Value %52)
+  %54 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %5)
+  %55 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %54)
+  %56 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %54, 0
+  %57 = getelementptr ptr, ptr %56, i64 11
+  %58 = load ptr, ptr %57, align 8
+  %59 = insertvalue { ptr, ptr } undef, ptr %58, 0
+  %60 = insertvalue { ptr, ptr } %59, ptr %55, 1
+  %61 = extractvalue { ptr, ptr } %60, 1
+  %62 = extractvalue { ptr, ptr } %60, 0
+  %63 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" %62(ptr %61)
+  %64 = call %reflect.Value @reflect.New(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %63)
+  %65 = call %reflect.Value @reflect.Value.Elem(%reflect.Value %64)
+  %66 = call ptr @reflect.Value.MapRange(%reflect.Value %5)
+  br label %_llgo_12
+
+_llgo_10:                                         ; preds = %_llgo_12
+  call void @reflect.Value.SetIterKey(%reflect.Value %53, ptr %66)
+  call void @reflect.Value.SetIterValue(%reflect.Value %65, ptr %66)
+  %67 = call i64 @reflect.Value.Int(%reflect.Value %53)
+  %68 = call %reflect.Value @"reflect.(*MapIter).Key"(ptr %66)
+  %69 = call i64 @reflect.Value.Int(%reflect.Value %68)
+  %70 = icmp ne i64 %67, %69
+  br i1 %70, label %_llgo_13, label %_llgo_14
+
+_llgo_11:                                         ; preds = %_llgo_12
+  ret void
+
+_llgo_12:                                         ; preds = %_llgo_14, %_llgo_9
+  %71 = call i1 @"reflect.(*MapIter).Next"(ptr %66)
+  br i1 %71, label %_llgo_10, label %_llgo_11
+
+_llgo_13:                                         ; preds = %_llgo_14, %_llgo_10
+  %72 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @44, i64 13 }, ptr %72, align 8
+  %73 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %72, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %73)
+  unreachable
+
+_llgo_14:                                         ; preds = %_llgo_10
+  %74 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %65)
+  %75 = call %reflect.Value @"reflect.(*MapIter).Value"(ptr %66)
+  %76 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %75)
+  %77 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %74, %"github.com/goplus/llgo/runtime/internal/runtime.String" %76)
+  %78 = xor i1 %77, true
+  br i1 %78, label %_llgo_13, label %_llgo_12
+}
+
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+
+declare %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+
+define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
+_llgo_0:
+  %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %1, ptr %2)
+  ret i1 %3
+}
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+
+define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
+_llgo_0:
+  %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %1, ptr %2)
+  ret i1 %3
+}
+
+declare i64 @reflect.Value.Kind(%reflect.Value)
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.Value.Type(%reflect.Value)
+
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64)
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value, %"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+
+declare i64 @reflect.Value.Int(%reflect.Value)
+
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value)
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.MatchesClosure"(ptr, ptr)
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+
+define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
+_llgo_0:
+  %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %1, ptr %2)
+  ret i1 %3
+}
+
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+
+define linkonce i64 @"__llgo_stub.github.com/goplus/llgo/cl/_testgo/reflect.callFunc$1"(ptr %0, i64 %1) {
+_llgo_0:
+  %2 = tail call i64 @"github.com/goplus/llgo/cl/_testgo/reflect.callFunc$1"(i64 %1)
+  ret i64 %2
+}
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr, ptr)
+
+define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2) {
+_llgo_0:
+  %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %1, ptr %2)
+  ret i1 %3
+}
+
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.NewItab"(ptr, ptr)
+
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+
+declare %reflect.Value @reflect.Value.Method(%reflect.Value, i64)
+
+define linkonce { i64, i64 } @"__llgo_stub.github.com/goplus/llgo/cl/_testgo/reflect.demo"(ptr %0, i64 %1, i64 %2, i64 %3, i64 %4, i64 %5, i64 %6, i64 %7, i64 %8, i64 %9, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %10) {
+_llgo_0:
+  %11 = tail call { i64, i64 } @"github.com/goplus/llgo/cl/_testgo/reflect.demo"(i64 %1, i64 %2, i64 %3, i64 %4, i64 %5, i64 %6, i64 %7, i64 %8, i64 %9, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %10)
+  ret { i64, i64 } %11
+}
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr, ptr)
+
+define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr %0, ptr %1, ptr %2) {
+_llgo_0:
+  %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.nilinterequal"(ptr %1, ptr %2)
+  ret i1 %3
+}
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.CallSlice(%reflect.Value, %"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+
+declare void @reflect.init()
+
+declare i64 @"github.com/goplus/llgo/runtime/internal/runtime.typehash"(ptr, ptr, i64)
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal"(ptr, ptr, ptr)
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr, ptr)
+
+define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2) {
+_llgo_0:
+  %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal8"(ptr %1, ptr %2)
+  ret i1 %3
+}
+
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MakeMap"(ptr, i64)
+
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAssign"(ptr, ptr, ptr)
+
+declare i64 @reflect.Value.Len(%reflect.Value)
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.MapKeys(%reflect.Value)
+
+declare %reflect.Value @reflect.Value.MapIndex(%reflect.Value, %reflect.Value)
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value)
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String")
+
+declare void @reflect.Value.SetMapIndex(%reflect.Value, %reflect.Value, %reflect.Value)
+
+declare i1 @reflect.Value.IsValid(%reflect.Value)
+
+declare %reflect.Value @reflect.New(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+
+declare %reflect.Value @reflect.Value.Elem(%reflect.Value)
+
+declare ptr @reflect.Value.MapRange(%reflect.Value)
+
+declare i1 @"reflect.(*MapIter).Next"(ptr)
+
+declare void @reflect.Value.SetIterKey(%reflect.Value, ptr)
+
+declare void @reflect.Value.SetIterValue(%reflect.Value, ptr)
+
+declare %reflect.Value @"reflect.(*MapIter).Key"(ptr)
+
+declare %reflect.Value @"reflect.(*MapIter).Value"(ptr)
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.TypeOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.MapOf(%"github.com/goplus/llgo/runtime/internal/runtime.iface", %"github.com/goplus/llgo/runtime/internal/runtime.iface")
+
+declare %reflect.Value @reflect.MakeMap(%"github.com/goplus/llgo/runtime/internal/runtime.iface")

--- a/cl/_testgo/reflectfn/in.go
+++ b/cl/_testgo/reflectfn/in.go
@@ -6,23 +6,97 @@ import (
 	"reflect"
 )
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/reflectfn.demo"{{.*}}
-// CHECK: PrintString
-// CHECK: ret void
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/reflectfn.demo"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 4 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 func demo() {
 	println("demo")
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/reflectfn.main"{{.*}}
-// CHECK: fmt.Println
-// CHECK: reflect.ValueOf
-// CHECK: UnsafePointer
-// CHECK: ret void
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/reflectfn.main"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   store i64 100, ptr %0, align 4
+// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT:   %2 = getelementptr inbounds { ptr }, ptr %1, i32 0, i32 0
+// CHECK-NEXT:   store ptr %0, ptr %2, align 8
+// CHECK-NEXT:   %3 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/reflectfn.main$1", ptr undef }, ptr %1, 1
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT:   %5 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.eface", ptr %4, i64 0
+// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store { ptr, ptr } %3, ptr %6, align 8
+// CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", ptr undef }, ptr %6, 1
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %7, ptr %5, align 8
+// CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %4, 0
+// CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %8, i64 1, 1
+// CHECK-NEXT:   %10 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %9, i64 1, 2
+// CHECK-NEXT:   %11 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @fmt.Println(%"{{.*}}/runtime/internal/runtime.Slice" %10)
+// CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT:   %13 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.eface", ptr %12, i64 0
+// CHECK-NEXT:   %14 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/cl/_testgo/reflectfn.demo", ptr null }, ptr %14, align 8
+// CHECK-NEXT:   %15 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", ptr undef }, ptr %14, 1
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %15, ptr %13, align 8
+// CHECK-NEXT:   %16 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %12, 0
+// CHECK-NEXT:   %17 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %16, i64 1, 1
+// CHECK-NEXT:   %18 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %17, i64 1, 2
+// CHECK-NEXT:   %19 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @fmt.Println(%"{{.*}}/runtime/internal/runtime.Slice" %18)
+// CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT:   %21 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.eface", ptr %20, i64 0
+// CHECK-NEXT:   %22 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/cl/_testgo/reflectfn.demo", ptr null }, ptr %22, align 8
+// CHECK-NEXT:   %23 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", ptr undef }, ptr %22, 1
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %23, ptr %21, align 8
+// CHECK-NEXT:   %24 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %20, 0
+// CHECK-NEXT:   %25 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %24, i64 1, 1
+// CHECK-NEXT:   %26 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %25, i64 1, 2
+// CHECK-NEXT:   %27 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @fmt.Println(%"{{.*}}/runtime/internal/runtime.Slice" %26)
+// CHECK-NEXT:   %28 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store { ptr, ptr } %3, ptr %28, align 8
+// CHECK-NEXT:   %29 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", ptr undef }, ptr %28, 1
+// CHECK-NEXT:   %30 = call %reflect.Value @reflect.ValueOf(%"{{.*}}/runtime/internal/runtime.eface" %29)
+// CHECK-NEXT:   %31 = call ptr @reflect.Value.UnsafePointer(%reflect.Value %30)
+// CHECK-NEXT:   %32 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT:   %33 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.eface", ptr %32, i64 0
+// CHECK-NEXT:   %34 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_Pointer, ptr undef }, ptr %31, 1
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %34, ptr %33, align 8
+// CHECK-NEXT:   %35 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %32, 0
+// CHECK-NEXT:   %36 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %35, i64 1, 1
+// CHECK-NEXT:   %37 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %36, i64 1, 2
+// CHECK-NEXT:   %38 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @fmt.Println(%"{{.*}}/runtime/internal/runtime.Slice" %37)
+// CHECK-NEXT:   %39 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/cl/_testgo/reflectfn.demo", ptr null }, ptr %39, align 8
+// CHECK-NEXT:   %40 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", ptr undef }, ptr %39, 1
+// CHECK-NEXT:   %41 = call %reflect.Value @reflect.ValueOf(%"{{.*}}/runtime/internal/runtime.eface" %40)
+// CHECK-NEXT:   %42 = call ptr @reflect.Value.UnsafePointer(%reflect.Value %41)
+// CHECK-NEXT:   %43 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT:   %44 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.eface", ptr %43, i64 0
+// CHECK-NEXT:   %45 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_Pointer, ptr undef }, ptr %42, 1
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %45, ptr %44, align 8
+// CHECK-NEXT:   %46 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %43, 0
+// CHECK-NEXT:   %47 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %46, i64 1, 1
+// CHECK-NEXT:   %48 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %47, i64 1, 2
+// CHECK-NEXT:   %49 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @fmt.Println(%"{{.*}}/runtime/internal/runtime.Slice" %48)
+// CHECK-NEXT:   %50 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/cl/_testgo/reflectfn.demo", ptr null }, ptr %50, align 8
+// CHECK-NEXT:   %51 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure$b7Su1hWaFih-M0M9hMk6nO_RD1K_GQu5WjIXQp6Q2e8", ptr undef }, ptr %50, 1
+// CHECK-NEXT:   %52 = call %reflect.Value @reflect.ValueOf(%"{{.*}}/runtime/internal/runtime.eface" %51)
+// CHECK-NEXT:   %53 = call ptr @reflect.Value.UnsafePointer(%reflect.Value %52)
+// CHECK-NEXT:   %54 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT:   %55 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.eface", ptr %54, i64 0
+// CHECK-NEXT:   %56 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_Pointer, ptr undef }, ptr %53, 1
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %56, ptr %55, align 8
+// CHECK-NEXT:   %57 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %54, 0
+// CHECK-NEXT:   %58 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %57, i64 1, 1
+// CHECK-NEXT:   %59 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %58, i64 1, 2
+// CHECK-NEXT:   %60 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @fmt.Println(%"{{.*}}/runtime/internal/runtime.Slice" %59)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 func main() {
 	v := 100
-	// CHECK-LABEL: define {{.*}} @"{{.*}}/reflectfn.main$1"{{.*}}
-	// CHECK: PrintInt
-	// CHECK: ret void
 	fn := func() {
 		println(v)
 	}

--- a/cl/_testgo/reflectmk/in.go
+++ b/cl/_testgo/reflectmk/in.go
@@ -1,4 +1,3 @@
-// LITTEST
 package main
 
 import (
@@ -16,21 +15,10 @@ func (p *Point) Set(x int, y int) {
 	p.y = y
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/reflectmk.Point.String"{{.*}}
-// CHECK: AllocZ
-// CHECK: ret
-//
-// CHECK-LABEL: define {{.*}} @"{{.*}}/reflectmk.(*Point).String"{{.*}}
-// CHECK: Point.String
-// CHECK: ret
 func (p Point) String() string {
 	return fmt.Sprintf("(%v,%v)", p.x, p.y)
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/reflectmk.main"{{.*}}
-// CHECK: StringEqual
-// CHECK: Panic
-// CHECK: ret void
 func main() {
 	rt := reflect.TypeOf((*Point)(nil)).Elem()
 	if t := reflect.ArrayOf(1, rt); t.Elem() != rt {
@@ -73,11 +61,6 @@ func main() {
 	methodByName("String")
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/reflectmk.method"{{.*}}
-// CHECK: AssertIndexRange
-// CHECK: StringEqual
-// CHECK: Panic
-// CHECK: ret void
 func method(n int) {
 	v := reflect.ValueOf(&Point{1, 2})
 	if r := v.Method(n).Call(nil); r[0].String() != "(1,2)" {
@@ -85,11 +68,6 @@ func method(n int) {
 	}
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/reflectmk.methodByName"{{.*}}
-// CHECK: AssertIndexRange
-// CHECK: StringEqual
-// CHECK: Panic
-// CHECK: ret void
 func methodByName(name string) {
 	v := reflect.ValueOf(&Point{1, 2})
 	if r := v.MethodByName(name).Call(nil); r[0].String() != "(1,2)" {

--- a/cl/_testgo/reflectmk/out.ll
+++ b/cl/_testgo/reflectmk/out.ll
@@ -1,0 +1,657 @@
+; ModuleID = 'github.com/goplus/llgo/cl/_testgo/reflectmk'
+source_filename = "github.com/goplus/llgo/cl/_testgo/reflectmk"
+
+%"github.com/goplus/llgo/runtime/abi.Type" = type { i64, i64, i32, i8, i8, i8, i8, { ptr, ptr }, ptr, %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr }
+%"github.com/goplus/llgo/runtime/internal/runtime.String" = type { ptr, i64 }
+%"github.com/goplus/llgo/runtime/abi.PtrType" = type { %"github.com/goplus/llgo/runtime/abi.Type", ptr }
+%"github.com/goplus/llgo/runtime/abi.UncommonType" = type { %"github.com/goplus/llgo/runtime/internal/runtime.String", i16, i16, i32 }
+%"github.com/goplus/llgo/runtime/abi.Method" = type { %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr, ptr, ptr }
+%"github.com/goplus/llgo/runtime/abi.StructType" = type { %"github.com/goplus/llgo/runtime/abi.Type", %"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.Slice" }
+%"github.com/goplus/llgo/runtime/internal/runtime.Slice" = type { ptr, i64, i64 }
+%"github.com/goplus/llgo/runtime/abi.StructField" = type { %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr, i64, %"github.com/goplus/llgo/runtime/internal/runtime.String", i1 }
+%"github.com/goplus/llgo/runtime/abi.FuncType" = type { %"github.com/goplus/llgo/runtime/abi.Type", %"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.Slice" }
+%"github.com/goplus/llgo/cl/_testgo/reflectmk.Point" = type { i64, i64 }
+%"github.com/goplus/llgo/runtime/internal/runtime.eface" = type { ptr, ptr }
+%"github.com/goplus/llgo/runtime/internal/runtime.iface" = type { ptr, ptr }
+%reflect.StructField = type { %"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.iface", %"github.com/goplus/llgo/runtime/internal/runtime.String", i64, %"github.com/goplus/llgo/runtime/internal/runtime.Slice", i1 }
+%reflect.Method = type { %"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.iface", %reflect.Value, i64 }
+%reflect.Value = type { ptr, ptr, i64 }
+
+@"github.com/goplus/llgo/cl/_testgo/reflectmk.init$guard" = global i1 false, align 1
+@_llgo_int = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 0, i32 -25294021, i8 12, i8 8, i8 8, i8 34, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 3 }, ptr @"*_llgo_int" }, align 8
+@0 = private unnamed_addr constant [3 x i8] c"int", align 1
+@"*_llgo_int" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -939606833, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 3 }, ptr null }, ptr @_llgo_int }, align 8
+@1 = private unnamed_addr constant [7 x i8] c"(%v,%v)", align 1
+@"*_llgo_github.com/goplus/llgo/cl/_testgo/reflectmk.Point" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [2 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 945670493, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @2, i64 10 }, ptr null }, ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reflectmk.Point" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @3, i64 43 }, i16 2, i16 2, i32 24 }, [2 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @9, i64 3 }, ptr @"_llgo_func$1H6zMZ_cfMoleeOtJ_eCCBwy0eczea5_BZyjKcZr1wQ", ptr @"github.com/goplus/llgo/cl/_testgo/reflectmk.(*Point).Set", ptr @"github.com/goplus/llgo/cl/_testgo/reflectmk.(*Point).Set" }, %"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @6, i64 6 }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", ptr @"github.com/goplus/llgo/cl/_testgo/reflectmk.(*Point).String", ptr @"github.com/goplus/llgo/cl/_testgo/reflectmk.(*Point).String" }] }, align 8
+@2 = private unnamed_addr constant [10 x i8] c"main.Point", align 1
+@"_llgo_github.com/goplus/llgo/cl/_testgo/reflectmk.Point" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [1 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 0, i32 1133814495, i8 13, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reflectmk.Point" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @2, i64 10 }, ptr @"*_llgo_github.com/goplus/llgo/cl/_testgo/reflectmk.Point" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @3, i64 43 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"github.com/goplus/llgo/cl/_testgo/reflectmk.struct$0tuJ6xZuR-AC1wllPwRckyWv72rpKBksbx5z7eh2qaI$fields", i64 2, i64 2 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @3, i64 43 }, i16 1, i16 1, i32 24 }, [1 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @6, i64 6 }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", ptr @"github.com/goplus/llgo/cl/_testgo/reflectmk.(*Point).String", ptr @"github.com/goplus/llgo/cl/_testgo/reflectmk.Point.String" }] }, align 8
+@3 = private unnamed_addr constant [43 x i8] c"github.com/goplus/llgo/cl/_testgo/reflectmk", align 1
+@4 = private unnamed_addr constant [1 x i8] c"x", align 1
+@5 = private unnamed_addr constant [1 x i8] c"y", align 1
+@"github.com/goplus/llgo/cl/_testgo/reflectmk.struct$0tuJ6xZuR-AC1wllPwRckyWv72rpKBksbx5z7eh2qaI$fields" = weak_odr constant [2 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @4, i64 1 }, ptr @_llgo_int, i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @5, i64 1 }, ptr @_llgo_int, i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@6 = private unnamed_addr constant [6 x i8] c"String", align 1
+@"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1419376263, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 13 }, ptr @"*_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to$out", i64 1, i64 1 } }, align 8
+@7 = private unnamed_addr constant [13 x i8] c"func() string", align 1
+@"*_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1900367307, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 13 }, ptr null }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" }, align 8
+@_llgo_string = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 8, i32 1749264893, i8 4, i8 8, i8 8, i8 24, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 6 }, ptr @"*_llgo_string" }, align 8
+@8 = private unnamed_addr constant [6 x i8] c"string", align 1
+@"*_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1323879264, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 6 }, ptr null }, ptr @_llgo_string }, align 8
+@"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to$out" = weak_odr constant [1 x ptr] [ptr @_llgo_string], align 8
+@9 = private unnamed_addr constant [3 x i8] c"Set", align 1
+@"_llgo_func$1H6zMZ_cfMoleeOtJ_eCCBwy0eczea5_BZyjKcZr1wQ" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -2021994584, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @10, i64 14 }, ptr @"*_llgo_func$1H6zMZ_cfMoleeOtJ_eCCBwy0eczea5_BZyjKcZr1wQ" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$1H6zMZ_cfMoleeOtJ_eCCBwy0eczea5_BZyjKcZr1wQ$in", i64 2, i64 2 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer }, align 8
+@10 = private unnamed_addr constant [14 x i8] c"func(int, int)", align 1
+@"*_llgo_func$1H6zMZ_cfMoleeOtJ_eCCBwy0eczea5_BZyjKcZr1wQ" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 699874857, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @10, i64 14 }, ptr null }, ptr @"_llgo_func$1H6zMZ_cfMoleeOtJ_eCCBwy0eczea5_BZyjKcZr1wQ" }, align 8
+@"_llgo_func$1H6zMZ_cfMoleeOtJ_eCCBwy0eczea5_BZyjKcZr1wQ$in" = weak_odr constant [2 x ptr] [ptr @_llgo_int, ptr @_llgo_int], align 8
+@11 = private unnamed_addr constant [13 x i8] c"arrayOf error", align 1
+@12 = private unnamed_addr constant [12 x i8] c"chanOf error", align 1
+@13 = private unnamed_addr constant [12 x i8] c"funcOf error", align 1
+@14 = private unnamed_addr constant [11 x i8] c"mapOf error", align 1
+@15 = private unnamed_addr constant [15 x i8] c"pointerTo error", align 1
+@16 = private unnamed_addr constant [13 x i8] c"sliceOf error", align 1
+@17 = private unnamed_addr constant [1 x i8] c"T", align 1
+@18 = private unnamed_addr constant [14 x i8] c"structOf error", align 1
+@19 = private unnamed_addr constant [12 x i8] c"method error", align 1
+@20 = private unnamed_addr constant [18 x i8] c"methodByName error", align 1
+@21 = private unnamed_addr constant [5 x i8] c"(1,2)", align 1
+@22 = private unnamed_addr constant [18 x i8] c"value.Method error", align 1
+@23 = private unnamed_addr constant [24 x i8] c"value.MethodByName error", align 1
+
+define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/reflectmk.Point.String"(%"github.com/goplus/llgo/cl/_testgo/reflectmk.Point" %0) {
+_llgo_0:
+  %1 = alloca %"github.com/goplus/llgo/cl/_testgo/reflectmk.Point", align 8
+  call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+  store %"github.com/goplus/llgo/cl/_testgo/reflectmk.Point" %0, ptr %1, align 4
+  %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reflectmk.Point", ptr %1, i32 0, i32 0
+  %3 = load i64, ptr %2, align 4
+  %4 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reflectmk.Point", ptr %1, i32 0, i32 1
+  %5 = load i64, ptr %4, align 4
+  %6 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 32)
+  %7 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.eface", ptr %6, i64 0
+  %8 = inttoptr i64 %3 to ptr
+  %9 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %8, 1
+  store %"github.com/goplus/llgo/runtime/internal/runtime.eface" %9, ptr %7, align 8
+  %10 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.eface", ptr %6, i64 1
+  %11 = inttoptr i64 %5 to ptr
+  %12 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %11, 1
+  store %"github.com/goplus/llgo/runtime/internal/runtime.eface" %12, ptr %10, align 8
+  %13 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %6, 0
+  %14 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %13, i64 2, 1
+  %15 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %14, i64 2, 2
+  %16 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @fmt.Sprintf(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 7 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %15)
+  ret %"github.com/goplus/llgo/runtime/internal/runtime.String" %16
+}
+
+define void @"github.com/goplus/llgo/cl/_testgo/reflectmk.(*Point).Set"(ptr %0, i64 %1, i64 %2) {
+_llgo_0:
+  %3 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reflectmk.Point", ptr %0, i32 0, i32 0
+  store i64 %1, ptr %3, align 4
+  %4 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reflectmk.Point", ptr %0, i32 0, i32 1
+  store i64 %2, ptr %4, align 4
+  ret void
+}
+
+define %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/reflectmk.(*Point).String"(ptr %0) {
+_llgo_0:
+  %1 = load %"github.com/goplus/llgo/cl/_testgo/reflectmk.Point", ptr %0, align 4
+  %2 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/cl/_testgo/reflectmk.Point.String"(%"github.com/goplus/llgo/cl/_testgo/reflectmk.Point" %1)
+  ret %"github.com/goplus/llgo/runtime/internal/runtime.String" %2
+}
+
+define void @"github.com/goplus/llgo/cl/_testgo/reflectmk.init"() {
+_llgo_0:
+  %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/reflectmk.init$guard", align 1
+  br i1 %0, label %_llgo_2, label %_llgo_1
+
+_llgo_1:                                          ; preds = %_llgo_0
+  store i1 true, ptr @"github.com/goplus/llgo/cl/_testgo/reflectmk.init$guard", align 1
+  call void @fmt.init()
+  call void @reflect.init()
+  br label %_llgo_2
+
+_llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+  ret void
+}
+
+define void @"github.com/goplus/llgo/cl/_testgo/reflectmk.main"() {
+_llgo_0:
+  %0 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.TypeOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @"*_llgo_github.com/goplus/llgo/cl/_testgo/reflectmk.Point", ptr null })
+  %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %0)
+  %2 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %0, 0
+  %3 = getelementptr ptr, ptr %2, i64 11
+  %4 = load ptr, ptr %3, align 8
+  %5 = insertvalue { ptr, ptr } undef, ptr %4, 0
+  %6 = insertvalue { ptr, ptr } %5, ptr %1, 1
+  %7 = extractvalue { ptr, ptr } %6, 1
+  %8 = extractvalue { ptr, ptr } %6, 0
+  %9 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" %8(ptr %7)
+  %10 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.ArrayOf(i64 1, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %9)
+  %11 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %10)
+  %12 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %10, 0
+  %13 = getelementptr ptr, ptr %12, i64 11
+  %14 = load ptr, ptr %13, align 8
+  %15 = insertvalue { ptr, ptr } undef, ptr %14, 0
+  %16 = insertvalue { ptr, ptr } %15, ptr %11, 1
+  %17 = extractvalue { ptr, ptr } %16, 1
+  %18 = extractvalue { ptr, ptr } %16, 0
+  %19 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" %18(ptr %17)
+  %20 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %19)
+  %21 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %19, 1
+  %22 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %20, 0
+  %23 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %22, ptr %21, 1
+  %24 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %9)
+  %25 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %9, 1
+  %26 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %24, 0
+  %27 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %26, ptr %25, 1
+  %28 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %23, %"github.com/goplus/llgo/runtime/internal/runtime.eface" %27)
+  %29 = xor i1 %28, true
+  br i1 %29, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  %30 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @11, i64 13 }, ptr %30, align 8
+  %31 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %30, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %31)
+  unreachable
+
+_llgo_2:                                          ; preds = %_llgo_0
+  %32 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.ChanOf(i64 2, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %9)
+  %33 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %32)
+  %34 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %32, 0
+  %35 = getelementptr ptr, ptr %34, i64 11
+  %36 = load ptr, ptr %35, align 8
+  %37 = insertvalue { ptr, ptr } undef, ptr %36, 0
+  %38 = insertvalue { ptr, ptr } %37, ptr %33, 1
+  %39 = extractvalue { ptr, ptr } %38, 1
+  %40 = extractvalue { ptr, ptr } %38, 0
+  %41 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" %40(ptr %39)
+  %42 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %41)
+  %43 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %41, 1
+  %44 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %42, 0
+  %45 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %44, ptr %43, 1
+  %46 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %9)
+  %47 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %9, 1
+  %48 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %46, 0
+  %49 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %48, ptr %47, 1
+  %50 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %45, %"github.com/goplus/llgo/runtime/internal/runtime.eface" %49)
+  %51 = xor i1 %50, true
+  br i1 %51, label %_llgo_3, label %_llgo_4
+
+_llgo_3:                                          ; preds = %_llgo_2
+  %52 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @12, i64 12 }, ptr %52, align 8
+  %53 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %52, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %53)
+  unreachable
+
+_llgo_4:                                          ; preds = %_llgo_2
+  %54 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
+  %55 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %54, i64 0
+  store %"github.com/goplus/llgo/runtime/internal/runtime.iface" %9, ptr %55, align 8
+  %56 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %54, 0
+  %57 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %56, i64 1, 1
+  %58 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %57, i64 1, 2
+  %59 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
+  %60 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %59, i64 0
+  store %"github.com/goplus/llgo/runtime/internal/runtime.iface" %9, ptr %60, align 8
+  %61 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %59, 0
+  %62 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %61, i64 1, 1
+  %63 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %62, i64 1, 2
+  %64 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.FuncOf(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %58, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %63, i1 false)
+  %65 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %64)
+  %66 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %64, 0
+  %67 = getelementptr ptr, ptr %66, i64 18
+  %68 = load ptr, ptr %67, align 8
+  %69 = insertvalue { ptr, ptr } undef, ptr %68, 0
+  %70 = insertvalue { ptr, ptr } %69, ptr %65, 1
+  %71 = extractvalue { ptr, ptr } %70, 1
+  %72 = extractvalue { ptr, ptr } %70, 0
+  %73 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" %72(ptr %71, i64 0)
+  %74 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %73)
+  %75 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %73, 1
+  %76 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %74, 0
+  %77 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %76, ptr %75, 1
+  %78 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %9)
+  %79 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %9, 1
+  %80 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %78, 0
+  %81 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %80, ptr %79, 1
+  %82 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %77, %"github.com/goplus/llgo/runtime/internal/runtime.eface" %81)
+  %83 = xor i1 %82, true
+  br i1 %83, label %_llgo_5, label %_llgo_7
+
+_llgo_5:                                          ; preds = %_llgo_7, %_llgo_4
+  %84 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @13, i64 12 }, ptr %84, align 8
+  %85 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %84, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %85)
+  unreachable
+
+_llgo_6:                                          ; preds = %_llgo_7
+  %86 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.MapOf(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %9, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %9)
+  %87 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %86)
+  %88 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %86, 0
+  %89 = getelementptr ptr, ptr %88, i64 20
+  %90 = load ptr, ptr %89, align 8
+  %91 = insertvalue { ptr, ptr } undef, ptr %90, 0
+  %92 = insertvalue { ptr, ptr } %91, ptr %87, 1
+  %93 = extractvalue { ptr, ptr } %92, 1
+  %94 = extractvalue { ptr, ptr } %92, 0
+  %95 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" %94(ptr %93)
+  %96 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %95)
+  %97 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %95, 1
+  %98 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %96, 0
+  %99 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %98, ptr %97, 1
+  %100 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %9)
+  %101 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %9, 1
+  %102 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %100, 0
+  %103 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %102, ptr %101, 1
+  %104 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %99, %"github.com/goplus/llgo/runtime/internal/runtime.eface" %103)
+  %105 = xor i1 %104, true
+  br i1 %105, label %_llgo_8, label %_llgo_10
+
+_llgo_7:                                          ; preds = %_llgo_4
+  %106 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %64)
+  %107 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %64, 0
+  %108 = getelementptr ptr, ptr %107, i64 30
+  %109 = load ptr, ptr %108, align 8
+  %110 = insertvalue { ptr, ptr } undef, ptr %109, 0
+  %111 = insertvalue { ptr, ptr } %110, ptr %106, 1
+  %112 = extractvalue { ptr, ptr } %111, 1
+  %113 = extractvalue { ptr, ptr } %111, 0
+  %114 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" %113(ptr %112, i64 0)
+  %115 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %114)
+  %116 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %114, 1
+  %117 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %115, 0
+  %118 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %117, ptr %116, 1
+  %119 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %9)
+  %120 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %9, 1
+  %121 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %119, 0
+  %122 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %121, ptr %120, 1
+  %123 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %118, %"github.com/goplus/llgo/runtime/internal/runtime.eface" %122)
+  %124 = xor i1 %123, true
+  br i1 %124, label %_llgo_5, label %_llgo_6
+
+_llgo_8:                                          ; preds = %_llgo_10, %_llgo_6
+  %125 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @14, i64 11 }, ptr %125, align 8
+  %126 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %125, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %126)
+  unreachable
+
+_llgo_9:                                          ; preds = %_llgo_10
+  %127 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.PointerTo(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %9)
+  %128 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %127)
+  %129 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %127, 0
+  %130 = getelementptr ptr, ptr %129, i64 11
+  %131 = load ptr, ptr %130, align 8
+  %132 = insertvalue { ptr, ptr } undef, ptr %131, 0
+  %133 = insertvalue { ptr, ptr } %132, ptr %128, 1
+  %134 = extractvalue { ptr, ptr } %133, 1
+  %135 = extractvalue { ptr, ptr } %133, 0
+  %136 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" %135(ptr %134)
+  %137 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %136)
+  %138 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %136, 1
+  %139 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %137, 0
+  %140 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %139, ptr %138, 1
+  %141 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %9)
+  %142 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %9, 1
+  %143 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %141, 0
+  %144 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %143, ptr %142, 1
+  %145 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %140, %"github.com/goplus/llgo/runtime/internal/runtime.eface" %144)
+  %146 = xor i1 %145, true
+  br i1 %146, label %_llgo_11, label %_llgo_12
+
+_llgo_10:                                         ; preds = %_llgo_6
+  %147 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %86)
+  %148 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %86, 0
+  %149 = getelementptr ptr, ptr %148, i64 11
+  %150 = load ptr, ptr %149, align 8
+  %151 = insertvalue { ptr, ptr } undef, ptr %150, 0
+  %152 = insertvalue { ptr, ptr } %151, ptr %147, 1
+  %153 = extractvalue { ptr, ptr } %152, 1
+  %154 = extractvalue { ptr, ptr } %152, 0
+  %155 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" %154(ptr %153)
+  %156 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %155)
+  %157 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %155, 1
+  %158 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %156, 0
+  %159 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %158, ptr %157, 1
+  %160 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %9)
+  %161 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %9, 1
+  %162 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %160, 0
+  %163 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %162, ptr %161, 1
+  %164 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %159, %"github.com/goplus/llgo/runtime/internal/runtime.eface" %163)
+  %165 = xor i1 %164, true
+  br i1 %165, label %_llgo_8, label %_llgo_9
+
+_llgo_11:                                         ; preds = %_llgo_9
+  %166 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 15 }, ptr %166, align 8
+  %167 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %166, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %167)
+  unreachable
+
+_llgo_12:                                         ; preds = %_llgo_9
+  %168 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.SliceOf(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %9)
+  %169 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %168)
+  %170 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %168, 0
+  %171 = getelementptr ptr, ptr %170, i64 11
+  %172 = load ptr, ptr %171, align 8
+  %173 = insertvalue { ptr, ptr } undef, ptr %172, 0
+  %174 = insertvalue { ptr, ptr } %173, ptr %169, 1
+  %175 = extractvalue { ptr, ptr } %174, 1
+  %176 = extractvalue { ptr, ptr } %174, 0
+  %177 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" %176(ptr %175)
+  %178 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %177)
+  %179 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %177, 1
+  %180 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %178, 0
+  %181 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %180, ptr %179, 1
+  %182 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %9)
+  %183 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %9, 1
+  %184 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %182, 0
+  %185 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %184, ptr %183, 1
+  %186 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %181, %"github.com/goplus/llgo/runtime/internal/runtime.eface" %185)
+  %187 = xor i1 %186, true
+  br i1 %187, label %_llgo_13, label %_llgo_14
+
+_llgo_13:                                         ; preds = %_llgo_12
+  %188 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @16, i64 13 }, ptr %188, align 8
+  %189 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %188, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %189)
+  unreachable
+
+_llgo_14:                                         ; preds = %_llgo_12
+  %190 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 104)
+  %191 = getelementptr inbounds %reflect.StructField, ptr %190, i64 0
+  %192 = getelementptr inbounds %reflect.StructField, ptr %191, i32 0, i32 0
+  %193 = getelementptr inbounds %reflect.StructField, ptr %191, i32 0, i32 2
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @17, i64 1 }, ptr %192, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.iface" %9, ptr %193, align 8
+  %194 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %190, 0
+  %195 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %194, i64 1, 1
+  %196 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %195, i64 1, 2
+  %197 = call %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.StructOf(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %196)
+  %198 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %197)
+  %199 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %197, 0
+  %200 = getelementptr ptr, ptr %199, i64 12
+  %201 = load ptr, ptr %200, align 8
+  %202 = insertvalue { ptr, ptr } undef, ptr %201, 0
+  %203 = insertvalue { ptr, ptr } %202, ptr %198, 1
+  %204 = extractvalue { ptr, ptr } %203, 1
+  %205 = extractvalue { ptr, ptr } %203, 0
+  %206 = call %reflect.StructField %205(ptr %204, i64 0)
+  %207 = extractvalue %reflect.StructField %206, 2
+  %208 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %207)
+  %209 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %207, 1
+  %210 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %208, 0
+  %211 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %210, ptr %209, 1
+  %212 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %9)
+  %213 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %9, 1
+  %214 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %212, 0
+  %215 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" %214, ptr %213, 1
+  %216 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %211, %"github.com/goplus/llgo/runtime/internal/runtime.eface" %215)
+  %217 = xor i1 %216, true
+  br i1 %217, label %_llgo_15, label %_llgo_16
+
+_llgo_15:                                         ; preds = %_llgo_14
+  %218 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @18, i64 14 }, ptr %218, align 8
+  %219 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %218, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %219)
+  unreachable
+
+_llgo_16:                                         ; preds = %_llgo_14
+  %220 = alloca %reflect.Method, align 8
+  call void @llvm.memset(ptr %220, i8 0, i64 80, i1 false)
+  %221 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %9)
+  %222 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %9, 0
+  %223 = getelementptr ptr, ptr %222, i64 23
+  %224 = load ptr, ptr %223, align 8
+  %225 = insertvalue { ptr, ptr } undef, ptr %224, 0
+  %226 = insertvalue { ptr, ptr } %225, ptr %221, 1
+  %227 = extractvalue { ptr, ptr } %226, 1
+  %228 = extractvalue { ptr, ptr } %226, 0
+  %229 = call %reflect.Method %228(ptr %227, i64 0)
+  store %reflect.Method %229, ptr %220, align 8
+  %230 = getelementptr inbounds %reflect.Method, ptr %220, i32 0, i32 0
+  %231 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %230, align 8
+  %232 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %231, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @6, i64 6 })
+  %233 = xor i1 %232, true
+  br i1 %233, label %_llgo_17, label %_llgo_18
+
+_llgo_17:                                         ; preds = %_llgo_16
+  %234 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @19, i64 12 }, ptr %234, align 8
+  %235 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %234, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %235)
+  unreachable
+
+_llgo_18:                                         ; preds = %_llgo_16
+  %236 = alloca %reflect.Method, align 8
+  call void @llvm.memset(ptr %236, i8 0, i64 80, i1 false)
+  %237 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %9)
+  %238 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %9, 0
+  %239 = getelementptr ptr, ptr %238, i64 24
+  %240 = load ptr, ptr %239, align 8
+  %241 = insertvalue { ptr, ptr } undef, ptr %240, 0
+  %242 = insertvalue { ptr, ptr } %241, ptr %237, 1
+  %243 = extractvalue { ptr, ptr } %242, 1
+  %244 = extractvalue { ptr, ptr } %242, 0
+  %245 = call { %reflect.Method, i1 } %244(ptr %243, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @6, i64 6 })
+  %246 = extractvalue { %reflect.Method, i1 } %245, 0
+  store %reflect.Method %246, ptr %236, align 8
+  %247 = extractvalue { %reflect.Method, i1 } %245, 1
+  br i1 %247, label %_llgo_21, label %_llgo_19
+
+_llgo_19:                                         ; preds = %_llgo_21, %_llgo_18
+  %248 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @20, i64 18 }, ptr %248, align 8
+  %249 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %248, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %249)
+  unreachable
+
+_llgo_20:                                         ; preds = %_llgo_21
+  %250 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
+  %251 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reflectmk.Point", ptr %250, i32 0, i32 0
+  %252 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reflectmk.Point", ptr %250, i32 0, i32 1
+  store i64 1, ptr %251, align 4
+  store i64 2, ptr %252, align 4
+  %253 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @"*_llgo_github.com/goplus/llgo/cl/_testgo/reflectmk.Point", ptr undef }, ptr %250, 1
+  %254 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %253)
+  %255 = call %reflect.Value @reflect.Value.Method(%reflect.Value %254, i64 1)
+  %256 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %255, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer)
+  %257 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %256, 0
+  %258 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %256, 1
+  %259 = icmp sge i64 0, %258
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %259)
+  %260 = getelementptr inbounds %reflect.Value, ptr %257, i64 0
+  %261 = load %reflect.Value, ptr %260, align 8
+  %262 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %261)
+  %263 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %262, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @21, i64 5 })
+  %264 = xor i1 %263, true
+  br i1 %264, label %_llgo_22, label %_llgo_23
+
+_llgo_21:                                         ; preds = %_llgo_18
+  %265 = getelementptr inbounds %reflect.Method, ptr %236, i32 0, i32 0
+  %266 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %265, align 8
+  %267 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %266, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @6, i64 6 })
+  %268 = xor i1 %267, true
+  br i1 %268, label %_llgo_19, label %_llgo_20
+
+_llgo_22:                                         ; preds = %_llgo_20
+  %269 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @22, i64 18 }, ptr %269, align 8
+  %270 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %269, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %270)
+  unreachable
+
+_llgo_23:                                         ; preds = %_llgo_20
+  %271 = call %reflect.Value @reflect.Value.MethodByName(%reflect.Value %254, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @6, i64 6 })
+  %272 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %271, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer)
+  %273 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %272, 0
+  %274 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %272, 1
+  %275 = icmp sge i64 0, %274
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %275)
+  %276 = getelementptr inbounds %reflect.Value, ptr %273, i64 0
+  %277 = load %reflect.Value, ptr %276, align 8
+  %278 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %277)
+  %279 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %278, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @21, i64 5 })
+  %280 = xor i1 %279, true
+  br i1 %280, label %_llgo_24, label %_llgo_25
+
+_llgo_24:                                         ; preds = %_llgo_23
+  %281 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 24 }, ptr %281, align 8
+  %282 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %281, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %282)
+  unreachable
+
+_llgo_25:                                         ; preds = %_llgo_23
+  call void @"github.com/goplus/llgo/cl/_testgo/reflectmk.method"(i64 1)
+  call void @"github.com/goplus/llgo/cl/_testgo/reflectmk.methodByName"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @6, i64 6 })
+  ret void
+}
+
+define void @"github.com/goplus/llgo/cl/_testgo/reflectmk.method"(i64 %0) {
+_llgo_0:
+  %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
+  %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reflectmk.Point", ptr %1, i32 0, i32 0
+  %3 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reflectmk.Point", ptr %1, i32 0, i32 1
+  store i64 1, ptr %2, align 4
+  store i64 2, ptr %3, align 4
+  %4 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @"*_llgo_github.com/goplus/llgo/cl/_testgo/reflectmk.Point", ptr undef }, ptr %1, 1
+  %5 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %4)
+  %6 = call %reflect.Value @reflect.Value.Method(%reflect.Value %5, i64 %0)
+  %7 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %6, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer)
+  %8 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %7, 0
+  %9 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %7, 1
+  %10 = icmp sge i64 0, %9
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %10)
+  %11 = getelementptr inbounds %reflect.Value, ptr %8, i64 0
+  %12 = load %reflect.Value, ptr %11, align 8
+  %13 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %12)
+  %14 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %13, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @21, i64 5 })
+  %15 = xor i1 %14, true
+  br i1 %15, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  %16 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @22, i64 18 }, ptr %16, align 8
+  %17 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %16, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %17)
+  unreachable
+
+_llgo_2:                                          ; preds = %_llgo_0
+  ret void
+}
+
+define void @"github.com/goplus/llgo/cl/_testgo/reflectmk.methodByName"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %0) {
+_llgo_0:
+  %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
+  %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reflectmk.Point", ptr %1, i32 0, i32 0
+  %3 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/reflectmk.Point", ptr %1, i32 0, i32 1
+  store i64 1, ptr %2, align 4
+  store i64 2, ptr %3, align 4
+  %4 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @"*_llgo_github.com/goplus/llgo/cl/_testgo/reflectmk.Point", ptr undef }, ptr %1, 1
+  %5 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %4)
+  %6 = call %reflect.Value @reflect.Value.MethodByName(%reflect.Value %5, %"github.com/goplus/llgo/runtime/internal/runtime.String" %0)
+  %7 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %6, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer)
+  %8 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %7, 0
+  %9 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %7, 1
+  %10 = icmp sge i64 0, %9
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %10)
+  %11 = getelementptr inbounds %reflect.Value, ptr %8, i64 0
+  %12 = load %reflect.Value, ptr %11, align 8
+  %13 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %12)
+  %14 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %13, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @21, i64 5 })
+  %15 = xor i1 %14, true
+  br i1 %15, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  %16 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 24 }, ptr %16, align 8
+  %17 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %16, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %17)
+  unreachable
+
+_llgo_2:                                          ; preds = %_llgo_0
+  ret void
+}
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr, ptr)
+
+define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2) {
+_llgo_0:
+  %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequal64"(ptr %1, ptr %2)
+  ret i1 %3
+}
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+
+define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
+_llgo_0:
+  %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %1, ptr %2)
+  ret i1 %3
+}
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @fmt.Sprintf(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+
+declare void @fmt.init()
+
+declare void @reflect.init()
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.TypeOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.structequal"(ptr, ptr, ptr)
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+
+define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
+_llgo_0:
+  %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %1, ptr %2)
+  ret i1 %3
+}
+
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.ArrayOf(i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface")
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.EfaceEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.eface", %"github.com/goplus/llgo/runtime/internal/runtime.eface")
+
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.ChanOf(i64, %"github.com/goplus/llgo/runtime/internal/runtime.iface")
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.FuncOf(%"github.com/goplus/llgo/runtime/internal/runtime.Slice", %"github.com/goplus/llgo/runtime/internal/runtime.Slice", i1)
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.MapOf(%"github.com/goplus/llgo/runtime/internal/runtime.iface", %"github.com/goplus/llgo/runtime/internal/runtime.iface")
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.PointerTo(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.SliceOf(%"github.com/goplus/llgo/runtime/internal/runtime.iface")
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.iface" @reflect.StructOf(%"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String", %"github.com/goplus/llgo/runtime/internal/runtime.String")
+
+declare %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+
+declare %reflect.Value @reflect.Value.Method(%reflect.Value, i64)
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value, %"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value)
+
+declare %reflect.Value @reflect.Value.MethodByName(%reflect.Value, %"github.com/goplus/llgo/runtime/internal/runtime.String")
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }

--- a/cl/_testgo/reflectmkfn/in.go
+++ b/cl/_testgo/reflectmkfn/in.go
@@ -6,14 +6,67 @@ import (
 	"strings"
 )
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/reflectmkfn.main"{{.*}}
-// CHECK: MatchesClosure
-// CHECK: StringEqual
+// CHECK-LABEL: define void @"g{{.*}}/cl/_testgo/reflectmkfn.main"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"g{{.*}}/runtime/internal/runtime.AllocZ"(i64 32)
+// CHECK-NEXT:   %1 = getelementptr inbounds %"g{{.*}}/runtime/internal/runtime.iface", ptr %0, i64 0
+// CHECK-NEXT:   %2 = call ptr @"g{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"g{{.*}}/runtime/internal/runtime.String" zeroinitializer, ptr %2, align 8
+// CHECK-NEXT:   %3 = insertvalue %"g{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %2, 1
+// CHECK-NEXT:   %4 = call %"g{{.*}}/runtime/internal/runtime.iface" @reflect.TypeOf(%"g{{.*}}/runtime/internal/runtime.eface" %3)
+// CHECK-NEXT:   store %"g{{.*}}/runtime/internal/runtime.iface" %4, ptr %1, align 8
+// CHECK-NEXT:   %5 = getelementptr inbounds %"g{{.*}}/runtime/internal/runtime.iface", ptr %0, i64 1
+// CHECK-NEXT:   %6 = call %"g{{.*}}/runtime/internal/runtime.iface" @reflect.TypeOf(%"g{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr null })
+// CHECK-NEXT:   store %"g{{.*}}/runtime/internal/runtime.iface" %6, ptr %5, align 8
+// CHECK-NEXT:   %7 = insertvalue %"g{{.*}}/runtime/internal/runtime.Slice" undef, ptr %0, 0
+// CHECK-NEXT:   %8 = insertvalue %"g{{.*}}/runtime/internal/runtime.Slice" %7, i64 2, 1
+// CHECK-NEXT:   %9 = insertvalue %"g{{.*}}/runtime/internal/runtime.Slice" %8, i64 2, 2
+// CHECK-NEXT:   %10 = call ptr @"g{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT:   %11 = getelementptr inbounds %"g{{.*}}/runtime/internal/runtime.iface", ptr %10, i64 0
+// CHECK-NEXT:   %12 = call ptr @"g{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"g{{.*}}/runtime/internal/runtime.String" zeroinitializer, ptr %12, align 8
+// CHECK-NEXT:   %13 = insertvalue %"g{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %12, 1
+// CHECK-NEXT:   %14 = call %"g{{.*}}/runtime/internal/runtime.iface" @reflect.TypeOf(%"g{{.*}}/runtime/internal/runtime.eface" %13)
+// CHECK-NEXT:   store %"g{{.*}}/runtime/internal/runtime.iface" %14, ptr %11, align 8
+// CHECK-NEXT:   %15 = insertvalue %"g{{.*}}/runtime/internal/runtime.Slice" undef, ptr %10, 0
+// CHECK-NEXT:   %16 = insertvalue %"g{{.*}}/runtime/internal/runtime.Slice" %15, i64 1, 1
+// CHECK-NEXT:   %17 = insertvalue %"g{{.*}}/runtime/internal/runtime.Slice" %16, i64 1, 2
+// CHECK-NEXT:   %18 = call %"g{{.*}}/runtime/internal/runtime.iface" @reflect.FuncOf(%"g{{.*}}/runtime/internal/runtime.Slice" %9, %"g{{.*}}/runtime/internal/runtime.Slice" %17, i1 false)
+// CHECK-NEXT:   %19 = call %reflect.Value @reflect.MakeFunc(%"g{{.*}}/runtime/internal/runtime.iface" %18, { ptr, ptr } { ptr @"__llgo_stub.g{{.*}}/cl/_testgo/reflectmkfn.main$1", ptr null })
+// CHECK-NEXT:   %20 = call %"g{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %19)
+// CHECK-NEXT:   %21 = extractvalue %"g{{.*}}/runtime/internal/runtime.eface" %20, 0
+// CHECK-NEXT:   %22 = call i1 @"g{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure$XBbb2Vd9fa-WWUcWFPjreitD8Eex4qtMIsPbz__3VQU", ptr %21)
+// CHECK-NEXT:   br i1 %22, label %_llgo_3, label %_llgo_4
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_3
+// CHECK-NEXT:   %23 = call ptr @"g{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"g{{.*}}/runtime/internal/runtime.String" { ptr @10, i64 5 }, ptr %23, align 8
+// CHECK-NEXT:   %24 = insertvalue %"g{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %23, 1
+// CHECK-NEXT:   call void @"g{{.*}}/runtime/internal/runtime.Panic"(%"g{{.*}}/runtime/internal/runtime.eface" %24)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_3
+// CHECK-NEXT:   ret void
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %25 = extractvalue %"g{{.*}}/runtime/internal/runtime.eface" %20, 1
+// CHECK-NEXT:   %26 = load { ptr, ptr }, ptr %25, align 8
+// CHECK-NEXT:   %27 = extractvalue { ptr, ptr } %26, 1
+// CHECK-NEXT:   %28 = extractvalue { ptr, ptr } %26, 0
+// CHECK-NEXT:   %29 = call %"g{{.*}}/runtime/internal/runtime.String" %28(ptr %27, %"g{{.*}}/runtime/internal/runtime.String" { ptr @8, i64 3 }, i64 2)
+// CHECK-NEXT:   %30 = call i1 @"g{{.*}}/runtime/internal/runtime.StringEqual"(%"g{{.*}}/runtime/internal/runtime.String" %29, %"g{{.*}}/runtime/internal/runtime.String" { ptr @9, i64 6 })
+// CHECK-NEXT:   %31 = xor i1 %30, true
+// CHECK-NEXT:   br i1 %31, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %32 = call ptr @"g{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"g{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 94 }, ptr %32, align 8
+// CHECK-NEXT:   %33 = insertvalue %"g{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %32, 1
+// CHECK-NEXT:   call void @"g{{.*}}/runtime/internal/runtime.Panic"(%"g{{.*}}/runtime/internal/runtime.eface" %33)
+// CHECK-NEXT:   unreachable
+// CHECK-NEXT: }
 func main() {
 	typ := reflect.FuncOf([]reflect.Type{reflect.TypeOf(""), reflect.TypeOf(0)}, []reflect.Type{reflect.TypeOf("")}, false)
-	// CHECK-LABEL: define {{.*}} @"{{.*}}/reflectmkfn.main$1"{{.*}}
-	// CHECK: AssertIndexRange
-	// CHECK: AllocZ
 	fn := reflect.MakeFunc(typ, func(args []reflect.Value) []reflect.Value {
 		r := strings.Repeat(args[0].String(), int(args[1].Int()))
 		return []reflect.Value{reflect.ValueOf(r)}
@@ -23,3 +76,33 @@ func main() {
 		panic("error")
 	}
 }
+
+// CHECK-LABEL: define %"g{{.*}}/runtime/internal/runtime.Slice" @"g{{.*}}/cl/_testgo/reflectmkfn.main$1"(%"g{{.*}}/runtime/internal/runtime.Slice" %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = extractvalue %"g{{.*}}/runtime/internal/runtime.Slice" %0, 0
+// CHECK-NEXT:   %2 = extractvalue %"g{{.*}}/runtime/internal/runtime.Slice" %0, 1
+// CHECK-NEXT:   %3 = icmp sge i64 0, %2
+// CHECK-NEXT:   call void @"g{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %3)
+// CHECK-NEXT:   %4 = getelementptr inbounds %reflect.Value, ptr %1, i64 0
+// CHECK-NEXT:   %5 = load %reflect.Value, ptr %4, align 8
+// CHECK-NEXT:   %6 = call %"g{{.*}}/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %5)
+// CHECK-NEXT:   %7 = extractvalue %"g{{.*}}/runtime/internal/runtime.Slice" %0, 0
+// CHECK-NEXT:   %8 = extractvalue %"g{{.*}}/runtime/internal/runtime.Slice" %0, 1
+// CHECK-NEXT:   %9 = icmp sge i64 1, %8
+// CHECK-NEXT:   call void @"g{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %9)
+// CHECK-NEXT:   %10 = getelementptr inbounds %reflect.Value, ptr %7, i64 1
+// CHECK-NEXT:   %11 = load %reflect.Value, ptr %10, align 8
+// CHECK-NEXT:   %12 = call i64 @reflect.Value.Int(%reflect.Value %11)
+// CHECK-NEXT:   %13 = call %"g{{.*}}/runtime/internal/runtime.String" @strings.Repeat(%"g{{.*}}/runtime/internal/runtime.String" %6, i64 %12)
+// CHECK-NEXT:   %14 = call ptr @"g{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
+// CHECK-NEXT:   %15 = getelementptr inbounds %reflect.Value, ptr %14, i64 0
+// CHECK-NEXT:   %16 = call ptr @"g{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"g{{.*}}/runtime/internal/runtime.String" %13, ptr %16, align 8
+// CHECK-NEXT:   %17 = insertvalue %"g{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %16, 1
+// CHECK-NEXT:   %18 = call %reflect.Value @reflect.ValueOf(%"g{{.*}}/runtime/internal/runtime.eface" %17)
+// CHECK-NEXT:   store %reflect.Value %18, ptr %15, align 8
+// CHECK-NEXT:   %19 = insertvalue %"g{{.*}}/runtime/internal/runtime.Slice" undef, ptr %14, 0
+// CHECK-NEXT:   %20 = insertvalue %"g{{.*}}/runtime/internal/runtime.Slice" %19, i64 1, 1
+// CHECK-NEXT:   %21 = insertvalue %"g{{.*}}/runtime/internal/runtime.Slice" %20, i64 1, 2
+// CHECK-NEXT:   ret %"g{{.*}}/runtime/internal/runtime.Slice" %21
+// CHECK-NEXT: }

--- a/cl/_testgo/selects/in.go
+++ b/cl/_testgo/selects/in.go
@@ -1,22 +1,104 @@
 // LITTEST
 package main
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/selects.main"{{.*}}
-// CHECK: NewChan
-// CHECK: CreateThread
-// CHECK: ChanSend
-// CHECK: Select
-// CHECK: PrintString
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/selects.main"() {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.NewChan"(i64 0, i64 1)
+// CHECK-NEXT:   store ptr %1, ptr %0, align 8
+// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.NewChan"(i64 0, i64 1)
+// CHECK-NEXT:   store ptr %3, ptr %2, align 8
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.NewChan"(i64 0, i64 1)
+// CHECK-NEXT:   store ptr %5, ptr %4, align 8
+// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.NewChan"(i64 0, i64 1)
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 24)
+// CHECK-NEXT:   %8 = getelementptr inbounds { ptr, ptr, ptr }, ptr %7, i32 0, i32 0
+// CHECK-NEXT:   store ptr %0, ptr %8, align 8
+// CHECK-NEXT:   %9 = getelementptr inbounds { ptr, ptr, ptr }, ptr %7, i32 0, i32 1
+// CHECK-NEXT:   store ptr %2, ptr %9, align 8
+// CHECK-NEXT:   %10 = getelementptr inbounds { ptr, ptr, ptr }, ptr %7, i32 0, i32 2
+// CHECK-NEXT:   store ptr %4, ptr %10, align 8
+// CHECK-NEXT:   %11 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/selects.main$1", ptr undef }, ptr %7, 1
+// CHECK-NEXT:   %12 = call ptr @malloc(i64 16)
+// CHECK-NEXT:   %13 = getelementptr inbounds { { ptr, ptr } }, ptr %12, i32 0, i32 0
+// CHECK-NEXT:   store { ptr, ptr } %11, ptr %13, align 8
+// CHECK-NEXT:   %14 = alloca i8, i64 8, align 1
+// CHECK-NEXT:   %15 = call i32 @"{{.*}}/runtime/internal/runtime.CreateThread"(ptr %14, ptr null, ptr @"{{.*}}/cl/_testgo/selects._llgo_routine$1", ptr %12)
+// CHECK-NEXT:   %16 = load ptr, ptr %0, align 8
+// CHECK-NEXT:   %17 = alloca {}, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %17, i8 0, i64 0, i1 false)
+// CHECK-NEXT:   store {} zeroinitializer, ptr %17, align 1
+// CHECK-NEXT:   %18 = call i1 @"{{.*}}/runtime/internal/runtime.ChanSend"(ptr %16, ptr %17, i64 0)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 4 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   %19 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %20 = alloca {}, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %20, i8 0, i64 0, i1 false)
+// CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" undef, ptr %19, 0
+// CHECK-NEXT:   %22 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %21, ptr %20, 1
+// CHECK-NEXT:   %23 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %22, i32 0, 2
+// CHECK-NEXT:   %24 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %23, i1 false, 3
+// CHECK-NEXT:   %25 = alloca {}, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %25, i8 0, i64 0, i1 false)
+// CHECK-NEXT:   %26 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" undef, ptr %6, 0
+// CHECK-NEXT:   %27 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %26, ptr %25, 1
+// CHECK-NEXT:   %28 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %27, i32 0, 2
+// CHECK-NEXT:   %29 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %28, i1 false, 3
+// CHECK-NEXT:   %30 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 48)
+// CHECK-NEXT:   %31 = getelementptr %"{{.*}}/runtime/internal/runtime.ChanOp", ptr %30, i64 0
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.ChanOp" %24, ptr %31, align 8
+// CHECK-NEXT:   %32 = getelementptr %"{{.*}}/runtime/internal/runtime.ChanOp", ptr %30, i64 1
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.ChanOp" %29, ptr %32, align 8
+// CHECK-NEXT:   %33 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %30, 0
+// CHECK-NEXT:   %34 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %33, i64 2, 1
+// CHECK-NEXT:   %35 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %34, i64 2, 2
+// CHECK-NEXT:   %36 = call { i64, i1 } @"{{.*}}/runtime/internal/runtime.Select"(%"{{.*}}/runtime/internal/runtime.Slice" %35)
+// CHECK-NEXT:   %37 = extractvalue { i64, i1 } %36, 0
+// CHECK-NEXT:   %38 = extractvalue { i64, i1 } %36, 1
+// CHECK-NEXT:   %39 = extractvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %24, 1
+// CHECK-NEXT:   %40 = load {}, ptr %39, align 1
+// CHECK-NEXT:   %41 = extractvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %29, 1
+// CHECK-NEXT:   %42 = load {}, ptr %41, align 1
+// CHECK-NEXT:   %43 = insertvalue { i64, i1, {}, {} } undef, i64 %37, 0
+// CHECK-NEXT:   %44 = insertvalue { i64, i1, {}, {} } %43, i1 %38, 1
+// CHECK-NEXT:   %45 = insertvalue { i64, i1, {}, {} } %44, {} %40, 2
+// CHECK-NEXT:   %46 = insertvalue { i64, i1, {}, {} } %45, {} %42, 3
+// CHECK-NEXT:   %47 = extractvalue { i64, i1, {}, {} } %46, 0
+// CHECK-NEXT:   %48 = icmp eq i64 %47, 0
+// CHECK-NEXT:   br i1 %48, label %_llgo_2, label %_llgo_3
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_4, %_llgo_2
+// CHECK-NEXT:   ret void
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 4 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   br label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %49 = icmp eq i64 %47, 1
+// CHECK-NEXT:   br i1 %49, label %_llgo_4, label %_llgo_5
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_3
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 4 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   br label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_3
+// CHECK-NEXT:   %50 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 31 }, ptr %50, align 8
+// CHECK-NEXT:   %51 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %50, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %51)
+// CHECK-NEXT:   unreachable
+// CHECK-NEXT: }
 func main() {
 	c1 := make(chan struct{}, 1)
 	c2 := make(chan struct{}, 1)
 	c3 := make(chan struct{}, 1)
 	c4 := make(chan struct{}, 1)
 
-	// CHECK-LABEL: define {{.*}} @"{{.*}}/selects.main$1"{{.*}}
-	// CHECK: ChanRecv
-	// CHECK: Select
-	// CHECK: Panic
 	go func() {
 		<-c1
 		println("<-c1")
@@ -39,3 +121,76 @@ func main() {
 		println("<-c4")
 	}
 }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/selects.main$1"(ptr %0) {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = load { ptr, ptr, ptr }, ptr %0, align 8
+// CHECK-NEXT:   %2 = extractvalue { ptr, ptr, ptr } %1, 0
+// CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %4 = alloca {}, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %4, i8 0, i64 0, i1 false)
+// CHECK-NEXT:   %5 = call i1 @"{{.*}}/runtime/internal/runtime.ChanRecv"(ptr %3, ptr %4, i64 0)
+// CHECK-NEXT:   %6 = load {}, ptr %4, align 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 4 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   %7 = extractvalue { ptr, ptr, ptr } %1, 1
+// CHECK-NEXT:   %8 = load ptr, ptr %7, align 8
+// CHECK-NEXT:   %9 = extractvalue { ptr, ptr, ptr } %1, 2
+// CHECK-NEXT:   %10 = load ptr, ptr %9, align 8
+// CHECK-NEXT:   %11 = alloca {}, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %11, i8 0, i64 0, i1 false)
+// CHECK-NEXT:   store {} zeroinitializer, ptr %11, align 1
+// CHECK-NEXT:   %12 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" undef, ptr %8, 0
+// CHECK-NEXT:   %13 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %12, ptr %11, 1
+// CHECK-NEXT:   %14 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %13, i32 0, 2
+// CHECK-NEXT:   %15 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %14, i1 true, 3
+// CHECK-NEXT:   %16 = alloca {}, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %16, i8 0, i64 0, i1 false)
+// CHECK-NEXT:   %17 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" undef, ptr %10, 0
+// CHECK-NEXT:   %18 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %17, ptr %16, 1
+// CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %18, i32 0, 2
+// CHECK-NEXT:   %20 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %19, i1 false, 3
+// CHECK-NEXT:   %21 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 48)
+// CHECK-NEXT:   %22 = getelementptr %"{{.*}}/runtime/internal/runtime.ChanOp", ptr %21, i64 0
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.ChanOp" %15, ptr %22, align 8
+// CHECK-NEXT:   %23 = getelementptr %"{{.*}}/runtime/internal/runtime.ChanOp", ptr %21, i64 1
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.ChanOp" %20, ptr %23, align 8
+// CHECK-NEXT:   %24 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %21, 0
+// CHECK-NEXT:   %25 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %24, i64 2, 1
+// CHECK-NEXT:   %26 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %25, i64 2, 2
+// CHECK-NEXT:   %27 = call { i64, i1 } @"{{.*}}/runtime/internal/runtime.Select"(%"{{.*}}/runtime/internal/runtime.Slice" %26)
+// CHECK-NEXT:   %28 = extractvalue { i64, i1 } %27, 0
+// CHECK-NEXT:   %29 = extractvalue { i64, i1 } %27, 1
+// CHECK-NEXT:   %30 = extractvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %20, 1
+// CHECK-NEXT:   %31 = load {}, ptr %30, align 1
+// CHECK-NEXT:   %32 = insertvalue { i64, i1, {} } undef, i64 %28, 0
+// CHECK-NEXT:   %33 = insertvalue { i64, i1, {} } %32, i1 %29, 1
+// CHECK-NEXT:   %34 = insertvalue { i64, i1, {} } %33, {} %31, 2
+// CHECK-NEXT:   %35 = extractvalue { i64, i1, {} } %34, 0
+// CHECK-NEXT:   %36 = icmp eq i64 %35, 0
+// CHECK-NEXT:   br i1 %36, label %_llgo_2, label %_llgo_3
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_4, %_llgo_2
+// CHECK-NEXT:   ret void
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 4 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   br label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %37 = icmp eq i64 %35, 1
+// CHECK-NEXT:   br i1 %37, label %_llgo_4, label %_llgo_5
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_3
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 4 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   br label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_3
+// CHECK-NEXT:   %38 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 31 }, ptr %38, align 8
+// CHECK-NEXT:   %39 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %38, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %39)
+// CHECK-NEXT:   unreachable
+// CHECK-NEXT: }

--- a/cl/_testgo/tprecur/in.go
+++ b/cl/_testgo/tprecur/in.go
@@ -1,17 +1,9 @@
-// LITTEST
 package main
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/tprecur.main"{{.*}}
-// CHECK: recursive"
-// CHECK: ret void
 func main() {
 	recursive()
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/tprecur.recursive"{{.*}}
-// CHECK: recur1[
-// CHECK: Panic
-// CHECK: ret void
 func recursive() {
 	type T int
 	if got, want := recur1[T](5), T(110); got != want {
@@ -23,9 +15,6 @@ type Integer interface {
 	~int | ~int32 | ~int64
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/tprecur.recur1[github.com/goplus/llgo/cl/_testgo/tprecur.T.1.0]"{{.*}}
-// CHECK: recur2[
-// CHECK: ret i64
 func recur1[T Integer](n T) T {
 	if n == 0 || n == 1 {
 		return T(1)
@@ -34,8 +23,6 @@ func recur1[T Integer](n T) T {
 	}
 }
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/tprecur.recur2[github.com/goplus/llgo/cl/_testgo/tprecur.T.1.0]"{{.*}}
-// CHECK: ret i64
 func recur2[T Integer](n T) T {
 	list := make([]T, n)
 	for i, _ := range list {

--- a/cl/_testgo/tprecur/out.ll
+++ b/cl/_testgo/tprecur/out.ll
@@ -1,0 +1,147 @@
+; ModuleID = 'github.com/goplus/llgo/cl/_testgo/tprecur'
+source_filename = "github.com/goplus/llgo/cl/_testgo/tprecur"
+
+%"github.com/goplus/llgo/runtime/abi.Type" = type { i64, i64, i32, i8, i8, i8, i8, { ptr, ptr }, ptr, %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr }
+%"github.com/goplus/llgo/runtime/internal/runtime.String" = type { ptr, i64 }
+%"github.com/goplus/llgo/runtime/abi.PtrType" = type { %"github.com/goplus/llgo/runtime/abi.Type", ptr }
+%"github.com/goplus/llgo/runtime/internal/runtime.eface" = type { ptr, ptr }
+%"github.com/goplus/llgo/runtime/internal/runtime.Slice" = type { ptr, i64, i64 }
+
+@"github.com/goplus/llgo/cl/_testgo/tprecur.init$guard" = global i1 false, align 1
+@0 = private unnamed_addr constant [5 x i8] c"error", align 1
+@_llgo_string = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 8, i32 1749264893, i8 4, i8 8, i8 8, i8 24, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 6 }, ptr @"*_llgo_string" }, align 8
+@1 = private unnamed_addr constant [6 x i8] c"string", align 1
+@"*_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1323879264, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 6 }, ptr null }, ptr @_llgo_string }, align 8
+
+define void @"github.com/goplus/llgo/cl/_testgo/tprecur.init"() {
+_llgo_0:
+  %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/tprecur.init$guard", align 1
+  br i1 %0, label %_llgo_2, label %_llgo_1
+
+_llgo_1:                                          ; preds = %_llgo_0
+  store i1 true, ptr @"github.com/goplus/llgo/cl/_testgo/tprecur.init$guard", align 1
+  br label %_llgo_2
+
+_llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+  ret void
+}
+
+define void @"github.com/goplus/llgo/cl/_testgo/tprecur.main"() {
+_llgo_0:
+  call void @"github.com/goplus/llgo/cl/_testgo/tprecur.recursive"()
+  ret void
+}
+
+define void @"github.com/goplus/llgo/cl/_testgo/tprecur.recursive"() {
+_llgo_0:
+  %0 = call i64 @"github.com/goplus/llgo/cl/_testgo/tprecur.recur1[github.com/goplus/llgo/cl/_testgo/tprecur.T.1.0]"(i64 5)
+  %1 = icmp ne i64 %0, 110
+  br i1 %1, label %_llgo_1, label %_llgo_2
+
+_llgo_1:                                          ; preds = %_llgo_0
+  %2 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %2, align 8
+  %3 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %2, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %3)
+  unreachable
+
+_llgo_2:                                          ; preds = %_llgo_0
+  ret void
+}
+
+define linkonce i64 @"github.com/goplus/llgo/cl/_testgo/tprecur.recur1[github.com/goplus/llgo/cl/_testgo/tprecur.T.1.0]"(i64 %0) {
+_llgo_0:
+  %1 = icmp eq i64 %0, 0
+  br i1 %1, label %_llgo_1, label %_llgo_3
+
+_llgo_1:                                          ; preds = %_llgo_3, %_llgo_0
+  ret i64 1
+
+_llgo_2:                                          ; preds = %_llgo_3
+  %2 = sub i64 %0, 1
+  %3 = call i64 @"github.com/goplus/llgo/cl/_testgo/tprecur.recur2[github.com/goplus/llgo/cl/_testgo/tprecur.T.1.0]"(i64 %2)
+  %4 = mul i64 %0, %3
+  ret i64 %4
+
+_llgo_3:                                          ; preds = %_llgo_0
+  %5 = icmp eq i64 %0, 1
+  br i1 %5, label %_llgo_1, label %_llgo_2
+}
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr, ptr)
+
+define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %0, ptr %1, ptr %2) {
+_llgo_0:
+  %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.strequal"(ptr %1, ptr %2)
+  ret i1 %3
+}
+
+declare i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr, ptr)
+
+define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %0, ptr %1, ptr %2) {
+_llgo_0:
+  %3 = tail call i1 @"github.com/goplus/llgo/runtime/internal/runtime.memequalptr"(ptr %1, ptr %2)
+  ret i1 %3
+}
+
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64)
+
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface")
+
+define linkonce i64 @"github.com/goplus/llgo/cl/_testgo/tprecur.recur2[github.com/goplus/llgo/cl/_testgo/tprecur.T.1.0]"(i64 %0) {
+_llgo_0:
+  %1 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.MakeSlice"(i64 %0, i64 %0, i64 8)
+  %2 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1, 1
+  br label %_llgo_1
+
+_llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
+  %3 = phi i64 [ -1, %_llgo_0 ], [ %4, %_llgo_2 ]
+  %4 = add i64 %3, 1
+  %5 = icmp slt i64 %4, %2
+  br i1 %5, label %_llgo_2, label %_llgo_3
+
+_llgo_2:                                          ; preds = %_llgo_1
+  %6 = add i64 %4, 1
+  %7 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1, 0
+  %8 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1, 1
+  %9 = icmp slt i64 %4, 0
+  %10 = icmp sge i64 %4, %8
+  %11 = or i1 %10, %9
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %11)
+  %12 = getelementptr inbounds i64, ptr %7, i64 %4
+  store i64 %6, ptr %12, align 4
+  br label %_llgo_1
+
+_llgo_3:                                          ; preds = %_llgo_1
+  %13 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1, 1
+  br label %_llgo_4
+
+_llgo_4:                                          ; preds = %_llgo_5, %_llgo_3
+  %14 = phi i64 [ 0, %_llgo_3 ], [ %25, %_llgo_5 ]
+  %15 = phi i64 [ -1, %_llgo_3 ], [ %16, %_llgo_5 ]
+  %16 = add i64 %15, 1
+  %17 = icmp slt i64 %16, %13
+  br i1 %17, label %_llgo_5, label %_llgo_6
+
+_llgo_5:                                          ; preds = %_llgo_4
+  %18 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1, 0
+  %19 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1, 1
+  %20 = icmp slt i64 %16, 0
+  %21 = icmp sge i64 %16, %19
+  %22 = or i1 %21, %20
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %22)
+  %23 = getelementptr inbounds i64, ptr %18, i64 %16
+  %24 = load i64, ptr %23, align 4
+  %25 = add i64 %14, %24
+  br label %_llgo_4
+
+_llgo_6:                                          ; preds = %_llgo_4
+  %26 = sub i64 %0, 1
+  %27 = call i64 @"github.com/goplus/llgo/cl/_testgo/tprecur.recur1[github.com/goplus/llgo/cl/_testgo/tprecur.T.1.0]"(i64 %26)
+  %28 = add i64 %14, %27
+  ret i64 %28
+}
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.MakeSlice"(i64, i64, i64)
+
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)

--- a/cl/_testgo/tprecurfn/in.go
+++ b/cl/_testgo/tprecurfn/in.go
@@ -8,11 +8,21 @@ type My[T any] struct {
 
 // CHECK-LABEL: define void @"{{.*}}tprecurfn.main"() {
 func main() {
-	// CHECK: call ptr @"{{.*}}AllocZ"(i64 24)
-	// CHECK: call ptr @"{{.*}}AllocZ"(i64 24)
-	// CHECK: store { ptr, ptr } { ptr @"__llgo_stub.{{.*}}tprecurfn.main$1", ptr null }, ptr %3, align 8
-	// CHECK: call void %9(ptr %8, i64 100)
-	// CHECK: ret void
+	// CHECK:  %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
+	// CHECK-NEXT:  %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/tprecurfn.My[int]", ptr %0, i32 0, i32 1
+	// CHECK-NEXT:  %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
+	// CHECK-NEXT:  %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/tprecurfn.My[int]", ptr %2, i32 0, i32 0
+	// CHECK-NEXT:  store { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/cl/_testgo/tprecurfn.main$1", ptr null }, ptr %3, align 8
+	// CHECK-NEXT:  store ptr %2, ptr %1, align 8
+	// CHECK-NEXT:  %4 = getelementptr inbounds %"{{.*}}/cl/_testgo/tprecurfn.My[int]", ptr %0, i32 0, i32 1
+	// CHECK-NEXT:  %5 = load ptr, ptr %4, align 8
+	// CHECK-NEXT:  %6 = getelementptr inbounds %"{{.*}}/cl/_testgo/tprecurfn.My[int]", ptr %5, i32 0, i32 0
+	// CHECK-NEXT:  %7 = load { ptr, ptr }, ptr %6, align 8
+	// CHECK-NEXT:  %8 = extractvalue { ptr, ptr } %7, 1
+	// CHECK-NEXT:  %9 = extractvalue { ptr, ptr } %7, 0
+	// CHECK-NEXT:  call void %9(ptr %8, i64 100)
+	// CHECK-NEXT:  ret void
+	// CHECK-NEXT:}
 	m := &My[int]{next: &My[int]{fn: func(n int) { println(n) }}}
 	m.next.fn(100)
 }

--- a/cl/_testgo/tptypes/in.go
+++ b/cl/_testgo/tptypes/in.go
@@ -1,13 +1,42 @@
-// LITTEST
 package main
 
-// CHECK-LABEL: define {{.*}} @"{{.*}}/tptypes.main"{{.*}}
-// CHECK: PrintInt
-// CHECK: PrintString
-// CHECK: Append
-// CHECK: Append2
-// CHECK: AssertIndexRange
-// CHECK: ret void
+type Data[T any] struct {
+	v T
+}
+
+func (p *Data[T]) Set(v T) {
+	p.v = v
+}
+
+func (p *(Data[T1])) Set2(v T1) {
+	p.v = v
+}
+
+type sliceOf[E any] interface {
+	~[]E
+}
+
+type Slice[S sliceOf[T], T any] struct {
+	Data S
+}
+
+func (p *Slice[S, T]) Append(t ...T) S {
+	p.Data = append(p.Data, t...)
+	return p.Data
+}
+
+func (p *Slice[S1, T1]) Append2(t ...T1) S1 {
+	p.Data = append(p.Data, t...)
+	return p.Data
+}
+
+type (
+	DataInt     = Data[int]
+	SliceInt    = Slice[[]int, int]
+	DataString  = Data[string]
+	SliceString = Slice[[]string, string]
+)
+
 func main() {
 	println(DataInt{1}.v)
 	println(DataString{"hello"}.v)
@@ -32,50 +61,3 @@ func main() {
 	println(v2.Data, v2.Data[0])
 	println(v3.Data, v3.Data[0])
 }
-
-type Data[T any] struct {
-	v T
-}
-
-func (p *Data[T]) Set(v T) {
-	p.v = v
-}
-
-func (p *(Data[T1])) Set2(v T1) {
-	p.v = v
-}
-
-type sliceOf[E any] interface {
-	~[]E
-}
-
-type Slice[S sliceOf[T], T any] struct {
-	Data S
-}
-
-// CHECK-LABEL: define {{.*}} @"{{.*}}/tptypes.(*Slice[[]int,int]).Append"{{.*}}
-// CHECK: SliceAppend
-// CHECK: ret
-//
-// CHECK-LABEL: define {{.*}} @"{{.*}}/tptypes.(*Slice[[]string,string]).Append"{{.*}}
-// CHECK: SliceAppend
-// CHECK: ret
-func (p *Slice[S, T]) Append(t ...T) S {
-	p.Data = append(p.Data, t...)
-	return p.Data
-}
-
-// CHECK-LABEL: define {{.*}} @"{{.*}}/tptypes.(*Slice[[]int,int]).Append2"{{.*}}
-// CHECK: SliceAppend
-// CHECK: ret
-func (p *Slice[S1, T1]) Append2(t ...T1) S1 {
-	p.Data = append(p.Data, t...)
-	return p.Data
-}
-
-type (
-	DataInt     = Data[int]
-	SliceInt    = Slice[[]int, int]
-	DataString  = Data[string]
-	SliceString = Slice[[]string, string]
-)

--- a/cl/_testgo/tptypes/out.ll
+++ b/cl/_testgo/tptypes/out.ll
@@ -1,0 +1,210 @@
+; ModuleID = 'github.com/goplus/llgo/cl/_testgo/tptypes'
+source_filename = "github.com/goplus/llgo/cl/_testgo/tptypes"
+
+%"github.com/goplus/llgo/cl/_testgo/tptypes.Data[int]" = type { i64 }
+%"github.com/goplus/llgo/cl/_testgo/tptypes.Data[string]" = type { %"github.com/goplus/llgo/runtime/internal/runtime.String" }
+%"github.com/goplus/llgo/runtime/internal/runtime.String" = type { ptr, i64 }
+%"github.com/goplus/llgo/runtime/internal/runtime.Slice" = type { ptr, i64, i64 }
+%"github.com/goplus/llgo/cl/_testgo/tptypes.Slice[[]int,int]" = type { %"github.com/goplus/llgo/runtime/internal/runtime.Slice" }
+%"github.com/goplus/llgo/cl/_testgo/tptypes.Slice[[]string,string]" = type { %"github.com/goplus/llgo/runtime/internal/runtime.Slice" }
+
+@"github.com/goplus/llgo/cl/_testgo/tptypes.init$guard" = global i1 false, align 1
+@0 = private unnamed_addr constant [5 x i8] c"hello", align 1
+
+define void @"github.com/goplus/llgo/cl/_testgo/tptypes.init"() {
+_llgo_0:
+  %0 = load i1, ptr @"github.com/goplus/llgo/cl/_testgo/tptypes.init$guard", align 1
+  br i1 %0, label %_llgo_2, label %_llgo_1
+
+_llgo_1:                                          ; preds = %_llgo_0
+  store i1 true, ptr @"github.com/goplus/llgo/cl/_testgo/tptypes.init$guard", align 1
+  br label %_llgo_2
+
+_llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+  ret void
+}
+
+define void @"github.com/goplus/llgo/cl/_testgo/tptypes.main"() {
+_llgo_0:
+  %0 = alloca %"github.com/goplus/llgo/cl/_testgo/tptypes.Data[int]", align 8
+  call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
+  %1 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tptypes.Data[int]", ptr %0, i32 0, i32 0
+  store i64 1, ptr %1, align 4
+  %2 = load %"github.com/goplus/llgo/cl/_testgo/tptypes.Data[int]", ptr %0, align 4
+  %3 = extractvalue %"github.com/goplus/llgo/cl/_testgo/tptypes.Data[int]" %2, 0
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %3)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  %4 = alloca %"github.com/goplus/llgo/cl/_testgo/tptypes.Data[string]", align 8
+  call void @llvm.memset(ptr %4, i8 0, i64 16, i1 false)
+  %5 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tptypes.Data[string]", ptr %4, i32 0, i32 0
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %5, align 8
+  %6 = load %"github.com/goplus/llgo/cl/_testgo/tptypes.Data[string]", ptr %4, align 8
+  %7 = extractvalue %"github.com/goplus/llgo/cl/_testgo/tptypes.Data[string]" %6, 0
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %7)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  %8 = alloca %"github.com/goplus/llgo/cl/_testgo/tptypes.Data[int]", align 8
+  call void @llvm.memset(ptr %8, i8 0, i64 8, i1 false)
+  %9 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tptypes.Data[int]", ptr %8, i32 0, i32 0
+  store i64 100, ptr %9, align 4
+  %10 = load %"github.com/goplus/llgo/cl/_testgo/tptypes.Data[int]", ptr %8, align 4
+  %11 = extractvalue %"github.com/goplus/llgo/cl/_testgo/tptypes.Data[int]" %10, 0
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %11)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  %12 = alloca %"github.com/goplus/llgo/cl/_testgo/tptypes.Data[string]", align 8
+  call void @llvm.memset(ptr %12, i8 0, i64 16, i1 false)
+  %13 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tptypes.Data[string]", ptr %12, i32 0, i32 0
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %13, align 8
+  %14 = load %"github.com/goplus/llgo/cl/_testgo/tptypes.Data[string]", ptr %12, align 8
+  %15 = extractvalue %"github.com/goplus/llgo/cl/_testgo/tptypes.Data[string]" %14, 0
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %15)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 0)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  %16 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 24)
+  %17 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
+  %18 = getelementptr inbounds i64, ptr %17, i64 0
+  store i64 100, ptr %18, align 4
+  %19 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %17, 0
+  %20 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %19, i64 1, 1
+  %21 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %20, i64 1, 2
+  %22 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/tptypes.(*Slice[[]int,int]).Append"(ptr %16, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %21)
+  %23 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 24)
+  %24 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
+  %25 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %24, i64 0
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %25, align 8
+  %26 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %24, 0
+  %27 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %26, i64 1, 1
+  %28 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %27, i64 1, 2
+  %29 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/tptypes.(*Slice[[]string,string]).Append"(ptr %23, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %28)
+  %30 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 24)
+  %31 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 32)
+  %32 = getelementptr inbounds i64, ptr %31, i64 0
+  store i64 1, ptr %32, align 4
+  %33 = getelementptr inbounds i64, ptr %31, i64 1
+  store i64 2, ptr %33, align 4
+  %34 = getelementptr inbounds i64, ptr %31, i64 2
+  store i64 3, ptr %34, align 4
+  %35 = getelementptr inbounds i64, ptr %31, i64 3
+  store i64 4, ptr %35, align 4
+  %36 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %31, 0
+  %37 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %36, i64 4, 1
+  %38 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %37, i64 4, 2
+  %39 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/tptypes.(*Slice[[]int,int]).Append"(ptr %30, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %38)
+  %40 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 32)
+  %41 = getelementptr inbounds i64, ptr %40, i64 0
+  store i64 1, ptr %41, align 4
+  %42 = getelementptr inbounds i64, ptr %40, i64 1
+  store i64 2, ptr %42, align 4
+  %43 = getelementptr inbounds i64, ptr %40, i64 2
+  store i64 3, ptr %43, align 4
+  %44 = getelementptr inbounds i64, ptr %40, i64 3
+  store i64 4, ptr %44, align 4
+  %45 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %40, 0
+  %46 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %45, i64 4, 1
+  %47 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %46, i64 4, 2
+  %48 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/tptypes.(*Slice[[]int,int]).Append2"(ptr %30, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %47)
+  %49 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tptypes.Slice[[]int,int]", ptr %16, i32 0, i32 0
+  %50 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %49, align 8
+  %51 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tptypes.Slice[[]int,int]", ptr %16, i32 0, i32 0
+  %52 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %51, align 8
+  %53 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %52, 0
+  %54 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %52, 1
+  %55 = icmp sge i64 0, %54
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %55)
+  %56 = getelementptr inbounds i64, ptr %53, i64 0
+  %57 = load i64, ptr %56, align 4
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %50)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %57)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  %58 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tptypes.Slice[[]string,string]", ptr %23, i32 0, i32 0
+  %59 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %58, align 8
+  %60 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tptypes.Slice[[]string,string]", ptr %23, i32 0, i32 0
+  %61 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %60, align 8
+  %62 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %61, 0
+  %63 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %61, 1
+  %64 = icmp sge i64 0, %63
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %64)
+  %65 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %62, i64 0
+  %66 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %65, align 8
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %59)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %66)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  %67 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tptypes.Slice[[]int,int]", ptr %30, i32 0, i32 0
+  %68 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %67, align 8
+  %69 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tptypes.Slice[[]int,int]", ptr %30, i32 0, i32 0
+  %70 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %69, align 8
+  %71 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %70, 0
+  %72 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %70, 1
+  %73 = icmp sge i64 0, %72
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %73)
+  %74 = getelementptr inbounds i64, ptr %71, i64 0
+  %75 = load i64, ptr %74, align 4
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %68)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %75)
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
+  ret void
+}
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset(ptr nocapture writeonly, i8, i64, i1 immarg) #0
+
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64)
+
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8)
+
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String")
+
+declare ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64)
+
+define linkonce %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/tptypes.(*Slice[[]int,int]).Append"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+_llgo_0:
+  %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tptypes.Slice[[]int,int]", ptr %0, i32 0, i32 0
+  %3 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %2, align 8
+  %4 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1, 0
+  %5 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1, 1
+  %6 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.SliceAppend"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %3, ptr %4, i64 %5, i64 8)
+  %7 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tptypes.Slice[[]int,int]", ptr %0, i32 0, i32 0
+  store %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %6, ptr %7, align 8
+  %8 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tptypes.Slice[[]int,int]", ptr %0, i32 0, i32 0
+  %9 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %8, align 8
+  ret %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %9
+}
+
+define linkonce %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/tptypes.(*Slice[[]string,string]).Append"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+_llgo_0:
+  %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tptypes.Slice[[]string,string]", ptr %0, i32 0, i32 0
+  %3 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %2, align 8
+  %4 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1, 0
+  %5 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1, 1
+  %6 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.SliceAppend"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %3, ptr %4, i64 %5, i64 16)
+  %7 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tptypes.Slice[[]string,string]", ptr %0, i32 0, i32 0
+  store %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %6, ptr %7, align 8
+  %8 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tptypes.Slice[[]string,string]", ptr %0, i32 0, i32 0
+  %9 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %8, align 8
+  ret %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %9
+}
+
+define linkonce %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/cl/_testgo/tptypes.(*Slice[[]int,int]).Append2"(ptr %0, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1) {
+_llgo_0:
+  %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tptypes.Slice[[]int,int]", ptr %0, i32 0, i32 0
+  %3 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %2, align 8
+  %4 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1, 0
+  %5 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1, 1
+  %6 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.SliceAppend"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %3, ptr %4, i64 %5, i64 8)
+  %7 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tptypes.Slice[[]int,int]", ptr %0, i32 0, i32 0
+  store %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %6, ptr %7, align 8
+  %8 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/tptypes.Slice[[]int,int]", ptr %0, i32 0, i32 0
+  %9 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %8, align 8
+  ret %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %9
+}
+
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1)
+
+declare void @"github.com/goplus/llgo/runtime/internal/runtime.PrintSlice"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice")
+
+declare %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @"github.com/goplus/llgo/runtime/internal/runtime.SliceAppend"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr, i64, i64)
+
+attributes #0 = { nocallback nofree nounwind willreturn memory(argmem: write) }


### PR DESCRIPTION
## Summary
- follow up on #1782 to make `_testgo` source checks more reasonable and maintainable
- tighten source-embedded `LITTEST`/`CHECK` coverage for stable cases such as `abimethod`, `closureall`, `equal`, `ifaceconv`, `ifaceprom`, `interface`, `invoke`, `reflectfn`, `reflectmkfn`, `selects`, and `tprecurfn`
- restore `out.ll` baselines for cases whose inline checks became too large or noisy: `cursor`, `reader`, `reflect`, `reflectmk`, `strucintf`, `tprecur`, and `tptypes`

## Notes
- keep inline checks where the lowering points are stable and reviewer-facing intent is still clear
- fall back to file-based IR baselines where source-embedded checks are no longer a reasonable fit
- includes a small source-check adjustment for `embedunexport-1598`