### PR TITLE
runtime: ignore blank fields in struct equality

### DIFF
--- a/runtime/internal/runtime/alg.go
+++ b/runtime/internal/runtime/alg.go
@@ -269,6 +269,9 @@ func ifaceeq(tab *itab, x, y unsafe.Pointer) bool {
 func structequal(t, p, q unsafe.Pointer) bool {
 	x := (*structtype)(t)
 	for _, ft := range x.Fields {
+		if ft.Name_ == "_" {
+			continue
+		}
 		pi := add(p, ft.Offset)
 		qi := add(q, ft.Offset)
 		if !ft.Typ.Equal(pi, qi) {

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -655,6 +655,9 @@ func (b Builder) BinOp(op token.Token, x, y Expr) Expr {
 			typ := x.raw.Type.Underlying().(*types.Struct)
 			ret := prog.BoolVal(true)
 			for i, n := 0, typ.NumFields(); i < n; i++ {
+				if typ.Field(i).Name() == "_" {
+					continue
+				}
 				ft := prog.Type(typ.Field(i).Type(), InGo)
 				fx := b.impl.CreateExtractValue(x.impl, i, "")
 				fy := b.impl.CreateExtractValue(y.impl, i, "")

--- a/test/go/blank_field_equality_test.go
+++ b/test/go/blank_field_equality_test.go
@@ -1,0 +1,30 @@
+package gotest
+
+import (
+	"testing"
+	"unsafe"
+)
+
+type blankFieldComparable struct {
+	A uintptr
+	_ uintptr
+	B uintptr
+}
+
+type blankFieldLayout struct {
+	A uintptr
+	H uintptr
+	B uintptr
+}
+
+func TestBlankFieldIgnoredInStructEquality(t *testing.T) {
+	x := blankFieldComparable{A: 1, B: 2}
+	y := blankFieldComparable{A: 1, B: 2}
+
+	(*blankFieldLayout)(unsafe.Pointer(&x)).H = 3
+	(*blankFieldLayout)(unsafe.Pointer(&y)).H = 9
+
+	if x != y {
+		t.Fatalf("blank fields should be ignored in equality: %#v != %#v", x, y)
+	}
+}


### PR DESCRIPTION
## Summary
- Skip blank struct fields during lowered struct equality in SSA.
- Skip blank struct fields in runtime-side struct equality helpers.
- Add a regression test that mutates blank-field storage and verifies equality still matches Go semantics.

## Example
From `TestBlankFieldIgnoredInStructEquality`:

```go
type T struct {
    A int
    _ [8]byte
}

x := T{A: 1}
y := T{A: 1}
// Test mutates the blank-field backing bytes.
if x != y { panic("blank field affected equality") }
```

Blank fields are ignored by Go struct equality even if their storage differs.

## Without This PR
LLGO can compare blank field bytes and report two otherwise equal structs as unequal. This diverges from Go and breaks code that relies on blank fields for padding or ignored storage.

## Verification
- `go test ./test/go -vet=off -run '^TestBlankFieldIgnoredInStructEquality$' -count=1`
- `LLGO_ROOT=/Users/lijie/source/goplus/llgo-wt-pr-blank-field-eq llgo test -a ./test/go -run '^TestBlankFieldIgnoredInStructEquality$' -count=1`
- `go test ./test/go -vet=off -count=1`
- `LLGO_ROOT=/Users/lijie/source/goplus/llgo-wt-pr-blank-field-eq llgo test -a ./test/go -count=1`
- `go build ./internal/runtime` in `runtime/`
