### PR TITLE
ssa: handle recursive named function types

### DIFF
--- a/ssa/type.go
+++ b/ssa/type.go
@@ -489,10 +489,10 @@ func (p Program) toLLVMFunc(sig *types.Signature) llvm.Type {
 	return llvm.FunctionType(ret, params, hasVArg)
 }
 
-func (p Program) toLLVMFuncPtr(sig *types.Signature) llvm.Type {
+func (p Program) toLLVMFuncPtr(_ *types.Signature) llvm.Type {
 	// LLVM opaque pointers don't retain the pointee function type. Avoid
 	// recursively expanding named function types such as F func(F) F.
-	return llvm.PointerType(p.tyInt8(), 0)
+	return p.tyVoidPtr()
 }
 
 func (p Program) retType(raw *types.Signature) Type {
@@ -580,12 +580,9 @@ func namedTypeEquivalent(a, b types.Type) bool {
 	if NameOf(na) != NameOf(nb) {
 		return false
 	}
-	switch na.Underlying().(type) {
-	case *types.Signature:
-		return false
-	}
-	switch nb.Underlying().(type) {
-	case *types.Signature:
+	_, sigA := na.Underlying().(*types.Signature)
+	_, sigB := nb.Underlying().(*types.Signature)
+	if sigA || sigB {
 		return false
 	}
 	// go/types may materialize the same package/type in distinct instances

--- a/ssa/type.go
+++ b/ssa/type.go
@@ -490,8 +490,9 @@ func (p Program) toLLVMFunc(sig *types.Signature) llvm.Type {
 }
 
 func (p Program) toLLVMFuncPtr(sig *types.Signature) llvm.Type {
-	ft := p.toLLVMFunc(sig)
-	return llvm.PointerType(ft, 0)
+	// LLVM opaque pointers don't retain the pointee function type. Avoid
+	// recursively expanding named function types such as F func(F) F.
+	return llvm.PointerType(p.tyInt8(), 0)
 }
 
 func (p Program) retType(raw *types.Signature) Type {
@@ -577,6 +578,14 @@ func namedTypeEquivalent(a, b types.Type) bool {
 		return true
 	}
 	if NameOf(na) != NameOf(nb) {
+		return false
+	}
+	switch na.Underlying().(type) {
+	case *types.Signature:
+		return false
+	}
+	switch nb.Underlying().(type) {
+	case *types.Signature:
 		return false
 	}
 	// go/types may materialize the same package/type in distinct instances

--- a/ssa/type_patch_test.go
+++ b/ssa/type_patch_test.go
@@ -70,6 +70,24 @@ func TestNamedTypeEquivalent(t *testing.T) {
 	}
 }
 
+func TestNamedTypeEquivalentRecursiveSignature(t *testing.T) {
+	pkg1 := types.NewPackage("example.com/p", "p")
+	pkg2 := types.NewPackage("example.com/p", "p")
+	a := types.NewNamed(types.NewTypeName(token.NoPos, pkg1, "F", nil), nil, nil)
+	b := types.NewNamed(types.NewTypeName(token.NoPos, pkg2, "F", nil), nil, nil)
+	a.SetUnderlying(types.NewSignatureType(nil, nil, nil,
+		types.NewTuple(types.NewParam(token.NoPos, nil, "", a)),
+		types.NewTuple(types.NewParam(token.NoPos, nil, "", a)),
+		false))
+	b.SetUnderlying(types.NewSignatureType(nil, nil, nil,
+		types.NewTuple(types.NewParam(token.NoPos, nil, "", b)),
+		types.NewTuple(types.NewParam(token.NoPos, nil, "", b)),
+		false))
+	if namedTypeEquivalent(a, b) {
+		t.Fatalf("namedTypeEquivalent should be false for recursive function signatures")
+	}
+}
+
 func TestNamedStructLayoutEquivalent(t *testing.T) {
 	prog := NewProgram(nil)
 	prog.TypeSizes(types.SizesFor("gc", runtime.GOARCH))

--- a/ssa/type_patch_test.go
+++ b/ssa/type_patch_test.go
@@ -88,6 +88,31 @@ func TestNamedTypeEquivalentRecursiveSignature(t *testing.T) {
 	}
 }
 
+func TestNamedTypeEquivalentRejectsAnySignature(t *testing.T) {
+	pkg1 := types.NewPackage("example.com/p", "p")
+	pkg2 := types.NewPackage("example.com/p", "p")
+	sigNamed := types.NewNamed(types.NewTypeName(token.NoPos, pkg1, "F", nil),
+		types.NewSignatureType(nil, nil, nil, nil, nil, false), nil)
+	structNamed := types.NewNamed(types.NewTypeName(token.NoPos, pkg2, "F", nil),
+		types.NewStruct([]*types.Var{
+			types.NewField(token.NoPos, nil, "A", types.Typ[types.Int], false),
+		}, nil), nil)
+	if namedTypeEquivalent(sigNamed, structNamed) {
+		t.Fatalf("namedTypeEquivalent should be false when only one side is a signature")
+	}
+	if namedTypeEquivalent(structNamed, sigNamed) {
+		t.Fatalf("namedTypeEquivalent should be false when only one side is a signature")
+	}
+}
+
+func TestToLLVMFuncPtrUsesVoidPtr(t *testing.T) {
+	prog := NewProgram(nil)
+	sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+	if got, want := prog.toLLVMFuncPtr(sig).String(), prog.tyVoidPtr().String(); got != want {
+		t.Fatalf("toLLVMFuncPtr() = %q, want %q", got, want)
+	}
+}
+
 func TestNamedStructLayoutEquivalent(t *testing.T) {
 	prog := NewProgram(nil)
 	prog.TypeSizes(types.SizesFor("gc", runtime.GOARCH))


### PR DESCRIPTION
## Summary
- Avoid recursively expanding named function types when lowering LLVM function pointers under opaque pointers.
- Treat named recursive function signatures as non-equivalent to avoid reusing incompatible LLVM named types.
- Add a unit test covering recursive named function signatures.

## Example
From `TestNamedTypeEquivalentRecursiveSignature`:

```go
type F func(F)
```

A named function type can reference itself through its signature. Type equivalence checks must not infinitely expand or incorrectly merge it with another function type.

## Without This PR
Recursive named function signatures can recurse indefinitely or reuse an incompatible LLVM type. That risks compiler crashes or invalid type metadata for recursive callback/function declarations.

## Verification
- `go test ./ssa -run 'TestNamedTypeEquivalentRecursiveSignature|TestNamedTypeEquivalent|TestNamedStructLayoutEquivalent' -count=1`
