### PR TITLE
build: generate cgo malloc wrapper symbols

### DIFF
--- a/cl/cgo_test.go
+++ b/cl/cgo_test.go
@@ -109,6 +109,26 @@ func _Cfunc_add(a int32, b int32) int32 {
 	}
 }
 
+func TestIsCgoVar(t *testing.T) {
+	for _, name := range []string{
+		"_cgo_96608f8de8c8_Cfunc__Cmalloc",
+		"__cgo_callback",
+	} {
+		if !isCgoVar(name) {
+			t.Fatalf("isCgoVar(%q) = false, want true", name)
+		}
+	}
+	if isCgoVar("_Cfunc_malloc") {
+		t.Fatal("isCgoVar should not match cgo wrapper functions")
+	}
+	if isCgoFuncPtrVar("_cgo_96608f8de8c8_Cfunc__Cmalloc") {
+		t.Fatal("isCgoFuncPtrVar should not match package cgo globals")
+	}
+	if !isCgoFuncPtrVar("__cgo_callback") {
+		t.Fatal("isCgoFuncPtrVar should match __cgo function pointer vars")
+	}
+}
+
 func TestCgoInstr_C2func(t *testing.T) {
 	_, m := mustCompileLLPkgFromSrc(t, `
 package foo

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -320,6 +320,10 @@ func isCgoCmacro(name string) bool {
 }
 
 func isCgoVar(name string) bool {
+	return strings.HasPrefix(name, "_cgo_") || isCgoFuncPtrVar(name)
+}
+
+func isCgoFuncPtrVar(name string) bool {
 	return strings.HasPrefix(name, "__cgo_")
 }
 
@@ -1307,7 +1311,7 @@ func processPkg(ctx *context, ret llssa.Package, pkg *ssa.Package) {
 		case *ssa.Type:
 			ctx.compileType(ret, member)
 		case *ssa.Global:
-			if !isCgoVar(member.Name()) {
+			if !isCgoFuncPtrVar(member.Name()) {
 				ctx.compileGlobal(ret, member)
 			}
 		}

--- a/internal/build/cgo.go
+++ b/internal/build/cgo.go
@@ -53,6 +53,8 @@ static void* _Cmalloc(size_t size) {
 `
 )
 
+var cgoExternRE = regexp.MustCompile(`^(_cgo_[^_]+_(C2func|Cfunc|Cmacro)_)(.*)$`)
+
 func buildCgo(ctx *context, pkg *aPackage, files []*ast.File, externs []string, verbose bool) (llfiles, cgoLdflags []string, err error) {
 	cfiles, preambles, cdecls, err := parseCgo_(pkg, files)
 	if err != nil {
@@ -90,30 +92,7 @@ func buildCgo(ctx *context, pkg *aPackage, files []*ast.File, externs []string, 
 			llfiles = append(llfiles, linkFile)
 		}, verbose)
 	}
-	re := regexp.MustCompile(`^(_cgo_[^_]+_(C2func|Cfunc|Cmacro)_)(.*)$`)
-	cgoSymbols := make(map[string]string)
-	mallocFix := false
-	for _, symbolName := range externs {
-		lastPart := symbolName
-		lastDot := strings.LastIndex(symbolName, ".")
-		if lastDot != -1 {
-			lastPart = symbolName[lastDot+1:]
-		}
-		if strings.HasPrefix(lastPart, "__cgo_") {
-			// func ptr var: main.__cgo_func_name
-			cgoSymbols[symbolName] = lastPart
-		} else if m := re.FindStringSubmatch(symbolName); len(m) > 0 {
-			prefix := m[1] // _cgo_hash_(Cfunc|Cmacro)_
-			name := m[3]   // remaining part
-			cgoSymbols[symbolName] = name
-			// fix missing _cgo_9113e32b6599_Cfunc__Cmalloc
-			if !mallocFix && m[2] == "Cfunc" {
-				mallocName := prefix + "_Cmalloc"
-				cgoSymbols[mallocName] = "_Cmalloc"
-				mallocFix = true
-			}
-		}
-	}
+	cgoSymbols := collectCgoSymbols(externs)
 	for _, preamble := range preambles {
 		tmpFile, err := os.CreateTemp("", "-cgo-*.c")
 		if err != nil {
@@ -137,6 +116,33 @@ func buildCgo(ctx *context, pkg *aPackage, files []*ast.File, externs []string, 
 		cgoLdflags = append(cgoLdflags, safesplit.SplitPkgConfigFlags(ldflag)...)
 	}
 	return
+}
+
+func collectCgoSymbols(externs []string) map[string]string {
+	cgoSymbols := make(map[string]string)
+	mallocFix := false
+	for _, symbolName := range externs {
+		lastPart := symbolName
+		lastDot := strings.LastIndex(symbolName, ".")
+		if lastDot != -1 {
+			lastPart = symbolName[lastDot+1:]
+		}
+		if strings.HasPrefix(lastPart, "__cgo_") {
+			// func ptr var: main.__cgo_func_name
+			cgoSymbols[symbolName] = lastPart
+		} else if m := cgoExternRE.FindStringSubmatch(lastPart); len(m) > 0 {
+			prefix := m[1] // _cgo_hash_(Cfunc|Cmacro)_
+			name := m[3]   // remaining part
+			cgoSymbols[lastPart] = name
+			// fix missing _cgo_9113e32b6599_Cfunc__Cmalloc
+			if !mallocFix && m[2] == "Cfunc" {
+				mallocName := prefix + "_Cmalloc"
+				cgoSymbols[mallocName] = "_Cmalloc"
+				mallocFix = true
+			}
+		}
+	}
+	return cgoSymbols
 }
 
 // clangASTNode represents a node in clang's AST

--- a/internal/build/cgo.go
+++ b/internal/build/cgo.go
@@ -119,7 +119,7 @@ func buildCgo(ctx *context, pkg *aPackage, files []*ast.File, externs []string, 
 }
 
 func collectCgoSymbols(externs []string) map[string]string {
-	cgoSymbols := make(map[string]string)
+	cgoSymbols := make(map[string]string, len(externs))
 	mallocFix := false
 	for _, symbolName := range externs {
 		lastPart := symbolName
@@ -128,7 +128,8 @@ func collectCgoSymbols(externs []string) map[string]string {
 			lastPart = symbolName[lastDot+1:]
 		}
 		if strings.HasPrefix(lastPart, "__cgo_") {
-			// func ptr var: main.__cgo_func_name
+			// Func pointer vars are looked up in the Go package by their
+			// qualified names, but emitted C globals must use bare _cgo_* names.
 			cgoSymbols[symbolName] = lastPart
 		} else if m := cgoExternRE.FindStringSubmatch(lastPart); len(m) > 0 {
 			prefix := m[1] // _cgo_hash_(Cfunc|Cmacro)_

--- a/internal/build/cgo_test.go
+++ b/internal/build/cgo_test.go
@@ -63,3 +63,22 @@ func TestParseCgoDeclFlags(t *testing.T) {
 		})
 	}
 }
+
+func TestCollectCgoSymbolsStripsPackagePrefix(t *testing.T) {
+	externs := []string{
+		"command-line-arguments._cgo_96608f8de8c8_Cfunc_fputs",
+		"demo._cgo_123456789abc_C2func_errno",
+		"demo.__cgo_callback",
+	}
+
+	got := collectCgoSymbols(externs)
+	want := map[string]string{
+		"_cgo_96608f8de8c8_Cfunc__Cmalloc": "_Cmalloc",
+		"_cgo_96608f8de8c8_Cfunc_fputs":    "fputs",
+		"_cgo_123456789abc_C2func_errno":   "errno",
+		"demo.__cgo_callback":              "__cgo_callback",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("collectCgoSymbols = %#v, want %#v", got, want)
+	}
+}

--- a/internal/build/cgo_test.go
+++ b/internal/build/cgo_test.go
@@ -67,6 +67,7 @@ func TestParseCgoDeclFlags(t *testing.T) {
 func TestCollectCgoSymbolsStripsPackagePrefix(t *testing.T) {
 	externs := []string{
 		"command-line-arguments._cgo_96608f8de8c8_Cfunc_fputs",
+		"_cgo_96608f8de8c8_Cfunc_puts",
 		"demo._cgo_123456789abc_C2func_errno",
 		"demo.__cgo_callback",
 	}
@@ -75,6 +76,7 @@ func TestCollectCgoSymbolsStripsPackagePrefix(t *testing.T) {
 	want := map[string]string{
 		"_cgo_96608f8de8c8_Cfunc__Cmalloc": "_Cmalloc",
 		"_cgo_96608f8de8c8_Cfunc_fputs":    "fputs",
+		"_cgo_96608f8de8c8_Cfunc_puts":     "puts",
 		"_cgo_123456789abc_C2func_errno":   "errno",
 		"demo.__cgo_callback":              "__cgo_callback",
 	}

--- a/test/go/cgo_malloc_test.go
+++ b/test/go/cgo_malloc_test.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gotest
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCgoMallocWrapperSymbols(t *testing.T) {
+	if strings.TrimSpace(runGoCmd(t, "", "env", "CGO_ENABLED")) != "1" {
+		t.Skip("cgo is disabled")
+	}
+
+	dir := t.TempDir()
+	src := `package main
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+import "unsafe"
+
+func main() {
+	p := C.malloc(8)
+	if p == nil {
+		panic("C.malloc returned nil")
+	}
+	C.free(unsafe.Pointer(p))
+}
+`
+	mainFile := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(mainFile, []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	runGoCmd(t, dir, "run", mainFile)
+
+	root := findLLGoRoot(t)
+	runGoCmd(t, root, "run", "./cmd/llgo", "run", mainFile)
+}
+
+func runGoCmd(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("go", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.Env = os.Environ()
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("go %s failed: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), err, stdout.String(), stderr.String())
+	}
+	return stdout.String()
+}
+
+func findLLGoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		data, err := os.ReadFile(filepath.Join(dir, "go.mod"))
+		if err == nil && strings.Contains(string(data), "module github.com/goplus/llgo") {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("cannot find llgo repository root")
+		}
+		dir = parent
+	}
+}

--- a/test/go/cgo_malloc_test.go
+++ b/test/go/cgo_malloc_test.go
@@ -29,6 +29,9 @@ func TestCgoMallocWrapperSymbols(t *testing.T) {
 	if strings.TrimSpace(runGoCmd(t, "", "env", "CGO_ENABLED")) != "1" {
 		t.Skip("cgo is disabled")
 	}
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang is unavailable")
+	}
 
 	dir := t.TempDir()
 	src := `package main


### PR DESCRIPTION
## Summary
- Collect cgo externs after stripping package prefixes so `_cgo_*` globals match clang-generated symbol names.
- Keep `__cgo_*` callback pointer globals out of normal global emission while allowing `_cgo_*` data globals to be emitted.
- Synthesize the `_Cmalloc` wrapper symbol needed by cgo-generated `C.malloc` calls.

## Example
From `TestCgoMallocWrapperSymbols`:

```go
// #include <stdlib.h>
import "C"

p := C.malloc(16)
C.free(p)
```

The generated Go side refers to cgo wrapper symbols such as `_Cmalloc`; LLGO must emit/link the wrapper symbols expected by cgo output.

## Without This PR
Programs using `C.malloc` can fail to link because `_Cmalloc` or related cgo symbols are missing or emitted under the wrong package-qualified name.

## Verification
- `go test ./internal/build -run 'TestCollectCgoSymbolsStripsPackagePrefix|TestParseCgoDeclFlags' -count=1`
- `go test ./cl -run 'TestIsCgoVar|TestCgoInstr_Cfunc|TestCgoInstr_C2func' -count=1`
- `go test ./test/go -run '^TestCgoMallocWrapperSymbols$' -count=1`
- `go test ./internal/build -count=1`
- `go test ./test/go -count=1`
- `go run ./cmd/llgo test ./test/go -run '^TestCgoMallocWrapperSymbols$' -count=1`
- `go test ./cl -count=1`
