### PR TITLE
ssa: use unsigned upper-bound checks

### DIFF
--- a/cl/_testdata/print/out.ll
+++ b/cl/_testdata/print/out.ll
@@ -123,7 +123,7 @@ _llgo_4:                                          ; preds = %_llgo_3
   %7 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0, 0
   %8 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0, 1
   %9 = icmp slt i64 %5, 0
-  %10 = icmp sge i64 %5, %8
+  %10 = icmp uge i64 %5, %8
   %11 = or i1 %10, %9
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %11)
   %12 = getelementptr inbounds i8, ptr %7, i64 %5
@@ -929,7 +929,7 @@ _llgo_26:                                         ; preds = %_llgo_25
   %45 = add i64 %43, 48
   %46 = trunc i64 %45 to i8
   %47 = icmp slt i64 %44, 0
-  %48 = icmp sge i64 %44, 14
+  %48 = icmp uge i64 %44, 14
   %49 = or i1 %48, %47
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %49)
   %50 = getelementptr inbounds i8, ptr %8, i64 %44
@@ -992,12 +992,12 @@ _llgo_0:
 
 _llgo_1:                                          ; preds = %_llgo_3
   %2 = urem i64 %22, 16
-  %3 = icmp sge i64 %2, 16
+  %3 = icmp uge i64 %2, 16
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %3)
   %4 = getelementptr inbounds i8, ptr @28, i64 %2
   %5 = load i8, ptr %4, align 1
   %6 = icmp slt i64 %23, 0
-  %7 = icmp sge i64 %23, 100
+  %7 = icmp uge i64 %23, 100
   %8 = or i1 %7, %6
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %8)
   %9 = getelementptr inbounds i8, ptr %1, i64 %23
@@ -1008,14 +1008,14 @@ _llgo_1:                                          ; preds = %_llgo_3
 _llgo_2:                                          ; preds = %_llgo_5, %_llgo_3
   %11 = sub i64 %23, 1
   %12 = icmp slt i64 %11, 0
-  %13 = icmp sge i64 %11, 100
+  %13 = icmp uge i64 %11, 100
   %14 = or i1 %13, %12
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %14)
   %15 = getelementptr inbounds i8, ptr %1, i64 %11
   store i8 120, ptr %15, align 1
   %16 = sub i64 %11, 1
   %17 = icmp slt i64 %16, 0
-  %18 = icmp sge i64 %16, 100
+  %18 = icmp uge i64 %16, 100
   %19 = or i1 %18, %17
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %19)
   %20 = getelementptr inbounds i8, ptr %1, i64 %16
@@ -1073,7 +1073,7 @@ _llgo_2:                                          ; preds = %_llgo_1
   %5 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0, 0
   %6 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0, 1
   %7 = icmp slt i64 %3, 0
-  %8 = icmp sge i64 %3, %6
+  %8 = icmp uge i64 %3, %6
   %9 = or i1 %8, %7
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %9)
   %10 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.eface", ptr %5, i64 %3
@@ -1123,7 +1123,7 @@ _llgo_1:                                          ; preds = %_llgo_3
   %3 = add i64 %2, 48
   %4 = trunc i64 %3 to i8
   %5 = icmp slt i64 %12, 0
-  %6 = icmp sge i64 %12, 100
+  %6 = icmp uge i64 %12, 100
   %7 = or i1 %6, %5
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %7)
   %8 = getelementptr inbounds i8, ptr %1, i64 %12

--- a/cl/_testdata/utf8/in.go
+++ b/cl/_testdata/utf8/in.go
@@ -9,7 +9,7 @@ import (
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = sext i8 %0 to i64
 // CHECK-NEXT:   %2 = icmp slt i64 %1, 0
-// CHECK-NEXT:   %3 = icmp sge i64 %1, 8
+// CHECK-NEXT:   %3 = icmp uge i64 %1, 8
 // CHECK-NEXT:   %4 = or i1 %3, %2
 // CHECK-NEXT:   call void @"{{.*}}.AssertIndexRange"(i1 %4)
 // CHECK-NEXT:   %5 = getelementptr inbounds i8, ptr @"{{.*}}.array", i64 %1

--- a/cl/_testdata/vargs/in.go
+++ b/cl/_testdata/vargs/in.go
@@ -15,6 +15,7 @@ func main() {
 // CHECK-LABEL: define void @"{{.*}}cl/_testdata/vargs.test"(%"{{.*}}runtime/internal/runtime.Slice" %0) {
 // CHECK:   %{{.*}} = getelementptr inbounds %"{{.*}}runtime/internal/runtime.eface", ptr %{{.*}}, i64 %{{.*}}
 // CHECK:   %{{.*}} = load %"{{.*}}runtime/internal/runtime.eface", ptr %{{.*}}, align 8
+// CHECK:   %{{.*}} = icmp uge i64 %{{.*}}, %{{.*}}
 // CHECK:   %{{.*}} = icmp eq ptr %{{.*}}, @_llgo_int
 // CHECK:   %{{.*}} = load i64, ptr %{{.*}}, align 4
 // CHECK:   %{{.*}} = call i32 (ptr, ...) @printf(ptr @{{.*}}, i64 %{{.*}})

--- a/cl/_testdata/vargs/in.go
+++ b/cl/_testdata/vargs/in.go
@@ -15,7 +15,6 @@ func main() {
 // CHECK-LABEL: define void @"{{.*}}cl/_testdata/vargs.test"(%"{{.*}}runtime/internal/runtime.Slice" %0) {
 // CHECK:   %{{.*}} = getelementptr inbounds %"{{.*}}runtime/internal/runtime.eface", ptr %{{.*}}, i64 %{{.*}}
 // CHECK:   %{{.*}} = load %"{{.*}}runtime/internal/runtime.eface", ptr %{{.*}}, align 8
-// CHECK:   %{{.*}} = icmp uge i64 %{{.*}}, %{{.*}}
 // CHECK:   %{{.*}} = icmp eq ptr %{{.*}}, @_llgo_int
 // CHECK:   %{{.*}} = load i64, ptr %{{.*}}, align 4
 // CHECK:   %{{.*}} = call i32 (ptr, ...) @printf(ptr @{{.*}}, i64 %{{.*}})

--- a/cl/_testgo/cursor/out.ll
+++ b/cl/_testgo/cursor/out.ll
@@ -630,7 +630,7 @@ _llgo_10:                                         ; preds = %_llgo_9
   %56 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %35, 1
   %57 = sext i32 %52 to i64
   %58 = icmp slt i64 %57, 0
-  %59 = icmp sge i64 %57, %56
+  %59 = icmp uge i64 %57, %56
   %60 = or i1 %59, %58
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %60)
   %61 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %55, i64 %57
@@ -687,7 +687,7 @@ _llgo_15:                                         ; preds = %_llgo_16, %_llgo_12
   %89 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %35, 1
   %90 = sext i32 %87 to i64
   %91 = icmp slt i64 %90, 0
-  %92 = icmp sge i64 %90, %89
+  %92 = icmp uge i64 %90, %89
   %93 = or i1 %92, %91
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %93)
   %94 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %88, i64 %90
@@ -787,7 +787,7 @@ _llgo_2:                                          ; preds = %_llgo_0
   %12 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %8, 1
   %13 = sext i32 %10 to i64
   %14 = icmp slt i64 %13, 0
-  %15 = icmp sge i64 %13, %12
+  %15 = icmp uge i64 %13, %12
   %16 = or i1 %15, %14
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %16)
   %17 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %11, i64 %13
@@ -842,7 +842,7 @@ _llgo_2:                                          ; preds = %_llgo_1
   %17 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %7, 1
   %18 = sext i32 %13 to i64
   %19 = icmp slt i64 %18, 0
-  %20 = icmp sge i64 %18, %17
+  %20 = icmp uge i64 %18, %17
   %21 = or i1 %20, %19
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %21)
   %22 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %16, i64 %18
@@ -876,7 +876,7 @@ _llgo_6:                                          ; preds = %_llgo_7, %_llgo_4
   %37 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %7, 1
   %38 = sext i32 %35 to i64
   %39 = icmp slt i64 %38, 0
-  %40 = icmp sge i64 %38, %37
+  %40 = icmp uge i64 %38, %37
   %41 = or i1 %40, %39
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %41)
   %42 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %36, i64 %38
@@ -942,7 +942,7 @@ _llgo_2:                                          ; preds = %_llgo_0
   %21 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %17, 1
   %22 = sext i32 %19 to i64
   %23 = icmp slt i64 %22, 0
-  %24 = icmp sge i64 %22, %21
+  %24 = icmp uge i64 %22, %21
   %25 = or i1 %24, %23
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %25)
   %26 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %20, i64 %22
@@ -1039,7 +1039,7 @@ _llgo_4:                                          ; preds = %_llgo_3
   %8 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0, 0
   %9 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %0, 1
   %10 = icmp slt i64 %6, 0
-  %11 = icmp sge i64 %6, %9
+  %11 = icmp uge i64 %6, %9
   %12 = or i1 %11, %10
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %12)
   %13 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %8, i64 %6

--- a/cl/_testgo/reader/out.ll
+++ b/cl/_testgo/reader/out.ll
@@ -711,7 +711,7 @@ _llgo_2:                                          ; preds = %_llgo_0
   %14 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %13, 0
   %15 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %13, 1
   %16 = icmp slt i64 %11, 0
-  %17 = icmp sge i64 %11, %15
+  %17 = icmp uge i64 %11, %15
   %18 = or i1 %17, %16
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %18)
   %19 = getelementptr inbounds i8, ptr %14, i64 %11
@@ -755,7 +755,7 @@ _llgo_2:                                          ; preds = %_llgo_0
   %17 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %16, 0
   %18 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.String" %16, 1
   %19 = icmp slt i64 %14, 0
-  %20 = icmp sge i64 %14, %18
+  %20 = icmp uge i64 %14, %18
   %21 = or i1 %20, %19
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %21)
   %22 = getelementptr inbounds i8, ptr %17, i64 %14

--- a/cl/_testgo/reflect/out.ll
+++ b/cl/_testgo/reflect/out.ll
@@ -172,7 +172,7 @@ _llgo_0:
   %26 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %6, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %25)
   %27 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %26, 0
   %28 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %26, 1
-  %29 = icmp sge i64 0, %28
+  %29 = icmp uge i64 0, %28
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %29)
   %30 = getelementptr inbounds %reflect.Value, ptr %27, i64 0
   %31 = load %reflect.Value, ptr %30, align 8
@@ -262,7 +262,7 @@ _llgo_0:
   %22 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %2, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %21)
   %23 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %22, 0
   %24 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %22, 1
-  %25 = icmp sge i64 0, %24
+  %25 = icmp uge i64 0, %24
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %25)
   %26 = getelementptr inbounds %reflect.Value, ptr %23, i64 0
   %27 = load %reflect.Value, ptr %26, align 8
@@ -356,7 +356,7 @@ _llgo_0:
   %30 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %10, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %29)
   %31 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %30, 0
   %32 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %30, 1
-  %33 = icmp sge i64 0, %32
+  %33 = icmp uge i64 0, %32
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %33)
   %34 = getelementptr inbounds %reflect.Value, ptr %31, i64 0
   %35 = load %reflect.Value, ptr %34, align 8
@@ -394,7 +394,7 @@ _llgo_2:                                          ; preds = %_llgo_5
   %55 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %46, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %54)
   %56 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %55, 0
   %57 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %55, 1
-  %58 = icmp sge i64 0, %57
+  %58 = icmp uge i64 0, %57
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %58)
   %59 = getelementptr inbounds %reflect.Value, ptr %56, i64 0
   %60 = load %reflect.Value, ptr %59, align 8
@@ -458,7 +458,7 @@ _llgo_0:
   %24 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %4, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %23)
   %25 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %24, 0
   %26 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %24, 1
-  %27 = icmp sge i64 0, %26
+  %27 = icmp uge i64 0, %26
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %27)
   %28 = getelementptr inbounds %reflect.Value, ptr %25, i64 0
   %29 = load %reflect.Value, ptr %28, align 8
@@ -496,7 +496,7 @@ _llgo_2:                                          ; preds = %_llgo_5
   %49 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %40, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %48)
   %50 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %49, 0
   %51 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %49, 1
-  %52 = icmp sge i64 0, %51
+  %52 = icmp uge i64 0, %51
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %52)
   %53 = getelementptr inbounds %reflect.Value, ptr %50, i64 0
   %54 = load %reflect.Value, ptr %53, align 8
@@ -575,14 +575,14 @@ _llgo_0:
   %31 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %2, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %30)
   %32 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %31, 0
   %33 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %31, 1
-  %34 = icmp sge i64 0, %33
+  %34 = icmp uge i64 0, %33
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %34)
   %35 = getelementptr inbounds %reflect.Value, ptr %32, i64 0
   %36 = load %reflect.Value, ptr %35, align 8
   %37 = call i64 @reflect.Value.Int(%reflect.Value %36)
   %38 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %31, 0
   %39 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %31, 1
-  %40 = icmp sge i64 1, %39
+  %40 = icmp uge i64 1, %39
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %40)
   %41 = getelementptr inbounds %reflect.Value, ptr %38, i64 1
   %42 = load %reflect.Value, ptr %41, align 8
@@ -643,14 +643,14 @@ _llgo_0:
   %74 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.CallSlice(%reflect.Value %2, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %73)
   %75 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %74, 0
   %76 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %74, 1
-  %77 = icmp sge i64 0, %76
+  %77 = icmp uge i64 0, %76
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %77)
   %78 = getelementptr inbounds %reflect.Value, ptr %75, i64 0
   %79 = load %reflect.Value, ptr %78, align 8
   %80 = call i64 @reflect.Value.Int(%reflect.Value %79)
   %81 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %74, 0
   %82 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %74, 1
-  %83 = icmp sge i64 1, %82
+  %83 = icmp uge i64 1, %82
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %83)
   %84 = getelementptr inbounds %reflect.Value, ptr %81, i64 1
   %85 = load %reflect.Value, ptr %84, align 8
@@ -680,7 +680,7 @@ _llgo_2:                                          ; preds = %_llgo_1
   %15 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %9, 0
   %16 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %9, 1
   %17 = icmp slt i64 %13, 0
-  %18 = icmp sge i64 %13, %16
+  %18 = icmp uge i64 %13, %16
   %19 = or i1 %18, %17
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %19)
   %20 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.eface", ptr %15, i64 %13

--- a/cl/_testgo/reflect/out.ll
+++ b/cl/_testgo/reflect/out.ll
@@ -22,99 +22,97 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/reflect"
 
 @"github.com/goplus/llgo/cl/_testgo/reflect.init$guard" = global i1 false, align 1
 @0 = private unnamed_addr constant [11 x i8] c"call.method", align 1
-@"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 -459742120, i8 32, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 49 }, ptr @"*_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk$fields", i64 2, i64 2 } }, align 8
-@1 = private unnamed_addr constant [49 x i8] c"struct { $f func(int) int; $data unsafe.Pointer }", align 1
-@"*_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -299237839, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 49 }, ptr null }, ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk" }, align 8
-@2 = private unnamed_addr constant [2 x i8] c"$f", align 1
-@"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1134531106, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @3, i64 13 }, ptr @"*_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU$in", i64 1, i64 1 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU$out", i64 1, i64 1 } }, align 8
-@3 = private unnamed_addr constant [13 x i8] c"func(int) int", align 1
-@"*_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1763581361, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @3, i64 13 }, ptr null }, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" }, align 8
-@_llgo_int = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 0, i32 -25294021, i8 12, i8 8, i8 8, i8 2, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @4, i64 3 }, ptr @"*_llgo_int" }, align 8
-@4 = private unnamed_addr constant [3 x i8] c"int", align 1
-@"*_llgo_int" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -939606833, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @4, i64 3 }, ptr null }, ptr @_llgo_int }, align 8
+@"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 -459742120, i8 32, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 13 }, ptr @"*_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk$fields", i64 2, i64 2 } }, align 8
+@1 = private unnamed_addr constant [13 x i8] c"func(int) int", align 1
+@"*_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -299237839, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 13 }, ptr null }, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" }, align 8
+@"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1134531106, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 13 }, ptr @"*_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU$in", i64 1, i64 1 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU$out", i64 1, i64 1 } }, align 8
+@"*_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1763581361, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @1, i64 13 }, ptr null }, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" }, align 8
+@_llgo_int = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 0, i32 -25294021, i8 12, i8 8, i8 8, i8 2, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @2, i64 3 }, ptr @"*_llgo_int" }, align 8
+@2 = private unnamed_addr constant [3 x i8] c"int", align 1
+@"*_llgo_int" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -939606833, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @2, i64 3 }, ptr null }, ptr @_llgo_int }, align 8
 @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU$in" = weak_odr constant [1 x ptr] [ptr @_llgo_int], align 8
 @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU$out" = weak_odr constant [1 x ptr] [ptr @_llgo_int], align 8
-@5 = private unnamed_addr constant [5 x i8] c"$data", align 1
-@_llgo_Pointer = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 507576105, i8 12, i8 8, i8 8, i8 58, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @6, i64 14 }, ptr @"*_llgo_Pointer" }, align 8
-@6 = private unnamed_addr constant [14 x i8] c"unsafe.Pointer", align 1
-@"*_llgo_Pointer" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1134390089, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @6, i64 14 }, ptr null }, ptr @_llgo_Pointer }, align 8
-@"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk$fields" = weak_odr constant [2 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @2, i64 2 }, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @5, i64 5 }, ptr @_llgo_Pointer, i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
-@7 = private unnamed_addr constant [7 x i8] c"closure", align 1
-@8 = private unnamed_addr constant [5 x i8] c"error", align 1
-@_llgo_string = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 8, i32 1749264893, i8 4, i8 8, i8 8, i8 24, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @9, i64 6 }, ptr @"*_llgo_string" }, align 8
-@9 = private unnamed_addr constant [6 x i8] c"string", align 1
-@"*_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1323879264, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @9, i64 6 }, ptr null }, ptr @_llgo_string }, align 8
-@10 = private unnamed_addr constant [12 x i8] c"call.closure", align 1
-@11 = private unnamed_addr constant [4 x i8] c"func", align 1
-@12 = private unnamed_addr constant [9 x i8] c"call.func", align 1
-@"*_llgo_github.com/goplus/llgo/cl/_testgo/reflect.T" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [1 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1206070585, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @13, i64 6 }, ptr null }, ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reflect.T" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @14, i64 41 }, i16 1, i16 1, i32 24 }, [1 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @16, i64 3 }, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU", ptr @"github.com/goplus/llgo/cl/_testgo/reflect.(*T).Add", ptr @"github.com/goplus/llgo/cl/_testgo/reflect.(*T).Add" }] }, align 8
-@13 = private unnamed_addr constant [6 x i8] c"main.T", align 1
-@"_llgo_github.com/goplus/llgo/cl/_testgo/reflect.T" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 0, i32 -325780477, i8 13, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reflect.T" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @13, i64 6 }, ptr @"*_llgo_github.com/goplus/llgo/cl/_testgo/reflect.T" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @14, i64 41 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"github.com/goplus/llgo/cl/_testgo/reflect.struct$eovYmOhZg4X0zMSsuscSshndnbbAGvB2E3cyG8E7Y4U$fields", i64 1, i64 1 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @14, i64 41 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
-@14 = private unnamed_addr constant [41 x i8] c"github.com/goplus/llgo/cl/_testgo/reflect", align 1
-@15 = private unnamed_addr constant [1 x i8] c"n", align 1
-@"github.com/goplus/llgo/cl/_testgo/reflect.struct$eovYmOhZg4X0zMSsuscSshndnbbAGvB2E3cyG8E7Y4U$fields" = weak_odr constant [1 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 1 }, ptr @_llgo_int, i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
-@16 = private unnamed_addr constant [3 x i8] c"Add", align 1
-@"_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.InterfaceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 1704177746, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @17, i64 26 }, ptr @"*_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @14, i64 41 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A$imethods", i64 1, i64 1 } }, align 8
-@17 = private unnamed_addr constant [26 x i8] c"interface { Add(int) int }", align 1
-@"*_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -721103048, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @17, i64 26 }, ptr null }, ptr @"_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A" }, align 8
-@"_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A$imethods" = weak_odr constant [1 x %"github.com/goplus/llgo/runtime/abi.Imethod"] [%"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @16, i64 3 }, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" }], align 8
-@18 = private unnamed_addr constant [7 x i8] c"imethod", align 1
-@19 = private unnamed_addr constant [6 x i8] c"method", align 1
-@"_llgo_closure$FjMjjQr3-2iTiWyZP1IIQFOz0hUCa0OS6pEm5uVV6Pk" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 1002059468, i8 32, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @20, i64 113 }, ptr @"*_llgo_closure$FjMjjQr3-2iTiWyZP1IIQFOz0hUCa0OS6pEm5uVV6Pk" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_closure$FjMjjQr3-2iTiWyZP1IIQFOz0hUCa0OS6pEm5uVV6Pk$fields", i64 2, i64 2 } }, align 8
-@20 = private unnamed_addr constant [113 x i8] c"struct { $f func(int, int, int, int, int, int, int, int, int, ...interface {}) (int, int); $data unsafe.Pointer }", align 1
-@"*_llgo_closure$FjMjjQr3-2iTiWyZP1IIQFOz0hUCa0OS6pEm5uVV6Pk" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -2059600842, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @20, i64 113 }, ptr null }, ptr @"_llgo_closure$FjMjjQr3-2iTiWyZP1IIQFOz0hUCa0OS6pEm5uVV6Pk" }, align 8
-@"_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -767802053, i8 16, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @21, i64 77 }, ptr @"*_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU$in", i64 10, i64 10 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU$out", i64 2, i64 2 } }, align 8
-@21 = private unnamed_addr constant [77 x i8] c"func(int, int, int, int, int, int, int, int, int, ...interface {}) (int, int)", align 1
-@"*_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1012808481, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @21, i64 77 }, ptr null }, ptr @"_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU" }, align 8
-@"[]_llgo_any" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 -396233978, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @22, i64 14 }, ptr @"*[]_llgo_any" }, ptr @_llgo_any }, align 8
-@22 = private unnamed_addr constant [14 x i8] c"[]interface {}", align 1
-@"*[]_llgo_any" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1171476965, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @22, i64 14 }, ptr null }, ptr @"[]_llgo_any" }, align 8
-@_llgo_any = weak_odr constant %"github.com/goplus/llgo/runtime/abi.InterfaceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 1376530322, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.nilinterequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 12 }, ptr @"*_llgo_any" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @14, i64 41 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer }, align 8
-@23 = private unnamed_addr constant [12 x i8] c"interface {}", align 1
-@"*_llgo_any" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1741196194, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 12 }, ptr null }, ptr @_llgo_any }, align 8
+@3 = private unnamed_addr constant [2 x i8] c"$f", align 1
+@4 = private unnamed_addr constant [5 x i8] c"$data", align 1
+@_llgo_Pointer = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 507576105, i8 12, i8 8, i8 8, i8 58, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @5, i64 14 }, ptr @"*_llgo_Pointer" }, align 8
+@5 = private unnamed_addr constant [14 x i8] c"unsafe.Pointer", align 1
+@"*_llgo_Pointer" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1134390089, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @5, i64 14 }, ptr null }, ptr @_llgo_Pointer }, align 8
+@"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk$fields" = weak_odr constant [2 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @3, i64 2 }, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @4, i64 5 }, ptr @_llgo_Pointer, i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@6 = private unnamed_addr constant [7 x i8] c"closure", align 1
+@7 = private unnamed_addr constant [5 x i8] c"error", align 1
+@_llgo_string = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 8, i32 1749264893, i8 4, i8 8, i8 8, i8 24, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 6 }, ptr @"*_llgo_string" }, align 8
+@8 = private unnamed_addr constant [6 x i8] c"string", align 1
+@"*_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1323879264, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 6 }, ptr null }, ptr @_llgo_string }, align 8
+@9 = private unnamed_addr constant [12 x i8] c"call.closure", align 1
+@10 = private unnamed_addr constant [4 x i8] c"func", align 1
+@11 = private unnamed_addr constant [9 x i8] c"call.func", align 1
+@"*_llgo_github.com/goplus/llgo/cl/_testgo/reflect.T" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.PtrType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [1 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1206070585, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @12, i64 6 }, ptr null }, ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reflect.T" }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @13, i64 41 }, i16 1, i16 1, i32 24 }, [1 x %"github.com/goplus/llgo/runtime/abi.Method"] [%"github.com/goplus/llgo/runtime/abi.Method" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 3 }, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU", ptr @"github.com/goplus/llgo/cl/_testgo/reflect.(*T).Add", ptr @"github.com/goplus/llgo/cl/_testgo/reflect.(*T).Add" }] }, align 8
+@12 = private unnamed_addr constant [6 x i8] c"main.T", align 1
+@"_llgo_github.com/goplus/llgo/cl/_testgo/reflect.T" = weak_odr constant { %"github.com/goplus/llgo/runtime/abi.StructType", %"github.com/goplus/llgo/runtime/abi.UncommonType", [0 x %"github.com/goplus/llgo/runtime/abi.Method"] } { %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 0, i32 -325780477, i8 13, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_github.com/goplus/llgo/cl/_testgo/reflect.T" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @12, i64 6 }, ptr @"*_llgo_github.com/goplus/llgo/cl/_testgo/reflect.T" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @13, i64 41 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"github.com/goplus/llgo/cl/_testgo/reflect.struct$eovYmOhZg4X0zMSsuscSshndnbbAGvB2E3cyG8E7Y4U$fields", i64 1, i64 1 } }, %"github.com/goplus/llgo/runtime/abi.UncommonType" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @13, i64 41 }, i16 0, i16 0, i32 24 }, [0 x %"github.com/goplus/llgo/runtime/abi.Method"] zeroinitializer }, align 8
+@13 = private unnamed_addr constant [41 x i8] c"github.com/goplus/llgo/cl/_testgo/reflect", align 1
+@14 = private unnamed_addr constant [1 x i8] c"n", align 1
+@"github.com/goplus/llgo/cl/_testgo/reflect.struct$eovYmOhZg4X0zMSsuscSshndnbbAGvB2E3cyG8E7Y4U$fields" = weak_odr constant [1 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @14, i64 1 }, ptr @_llgo_int, i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@15 = private unnamed_addr constant [3 x i8] c"Add", align 1
+@"_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.InterfaceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 1704177746, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @16, i64 26 }, ptr @"*_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @13, i64 41 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A$imethods", i64 1, i64 1 } }, align 8
+@16 = private unnamed_addr constant [26 x i8] c"interface { Add(int) int }", align 1
+@"*_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -721103048, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @16, i64 26 }, ptr null }, ptr @"_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A" }, align 8
+@"_llgo_iface$VdBKYV8-gcMjZtZfcf-u2oKoj9Lu3VXwuG8TGCW2S4A$imethods" = weak_odr constant [1 x %"github.com/goplus/llgo/runtime/abi.Imethod"] [%"github.com/goplus/llgo/runtime/abi.Imethod" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @15, i64 3 }, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" }], align 8
+@17 = private unnamed_addr constant [7 x i8] c"imethod", align 1
+@18 = private unnamed_addr constant [6 x i8] c"method", align 1
+@"_llgo_closure$FjMjjQr3-2iTiWyZP1IIQFOz0hUCa0OS6pEm5uVV6Pk" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 1002059468, i8 32, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @19, i64 77 }, ptr @"*_llgo_closure$FjMjjQr3-2iTiWyZP1IIQFOz0hUCa0OS6pEm5uVV6Pk" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_closure$FjMjjQr3-2iTiWyZP1IIQFOz0hUCa0OS6pEm5uVV6Pk$fields", i64 2, i64 2 } }, align 8
+@19 = private unnamed_addr constant [77 x i8] c"func(int, int, int, int, int, int, int, int, int, ...interface {}) (int, int)", align 1
+@"*_llgo_closure$FjMjjQr3-2iTiWyZP1IIQFOz0hUCa0OS6pEm5uVV6Pk" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -2059600842, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @19, i64 77 }, ptr null }, ptr @"_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU" }, align 8
+@"_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.FuncType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -767802053, i8 16, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @19, i64 77 }, ptr @"*_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU" }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU$in", i64 10, i64 10 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU$out", i64 2, i64 2 } }, align 8
+@"*_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1012808481, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @19, i64 77 }, ptr null }, ptr @"_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU" }, align 8
+@"[]_llgo_any" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 -396233978, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @20, i64 14 }, ptr @"*[]_llgo_any" }, ptr @_llgo_any }, align 8
+@20 = private unnamed_addr constant [14 x i8] c"[]interface {}", align 1
+@"*[]_llgo_any" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1171476965, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @20, i64 14 }, ptr null }, ptr @"[]_llgo_any" }, align 8
+@_llgo_any = weak_odr constant %"github.com/goplus/llgo/runtime/abi.InterfaceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 16, i64 16, i32 1376530322, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.nilinterequal", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @21, i64 12 }, ptr @"*_llgo_any" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @13, i64 41 }, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer }, align 8
+@21 = private unnamed_addr constant [12 x i8] c"interface {}", align 1
+@"*_llgo_any" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1741196194, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @21, i64 12 }, ptr null }, ptr @_llgo_any }, align 8
 @"_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU$in" = weak_odr constant [10 x ptr] [ptr @_llgo_int, ptr @_llgo_int, ptr @_llgo_int, ptr @_llgo_int, ptr @_llgo_int, ptr @_llgo_int, ptr @_llgo_int, ptr @_llgo_int, ptr @_llgo_int, ptr @"[]_llgo_any"], align 8
 @"_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU$out" = weak_odr constant [2 x ptr] [ptr @_llgo_int, ptr @_llgo_int], align 8
-@"_llgo_closure$FjMjjQr3-2iTiWyZP1IIQFOz0hUCa0OS6pEm5uVV6Pk$fields" = weak_odr constant [2 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @2, i64 2 }, ptr @"_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @5, i64 5 }, ptr @_llgo_Pointer, i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
-@24 = private unnamed_addr constant [10 x i8] c"call.slice", align 1
-@25 = private unnamed_addr constant [40 x i8] c"type assertion interface{} -> int failed", align 1
-@"map[_llgo_int]_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.MapType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -2084636366, i8 0, i8 8, i8 8, i8 53, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @26, i64 14 }, ptr @"*map[_llgo_int]_llgo_string" }, ptr @_llgo_int, ptr @_llgo_string, ptr @"_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ", { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.typehash", ptr @_llgo_int }, i8 8, i8 16, i16 208, i32 4 }, align 8
-@26 = private unnamed_addr constant [14 x i8] c"map[int]string", align 1
-@"*map[_llgo_int]_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 668541983, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @26, i64 14 }, ptr null }, ptr @"map[_llgo_int]_llgo_string" }, align 8
-@"_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 208, i64 208, i32 1935989513, i8 0, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @27, i64 82 }, ptr @"*_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ$fields", i64 4, i64 4 } }, align 8
-@27 = private unnamed_addr constant [82 x i8] c"struct { topbits [8]uint8; keys [8]int; elems [8]string; overflow unsafe.Pointer }", align 1
-@"*_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 597085808, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @27, i64 82 }, ptr null }, ptr @"_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ" }, align 8
-@28 = private unnamed_addr constant [7 x i8] c"topbits", align 1
-@"[8]_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.ArrayType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 0, i32 307038632, i8 8, i8 1, i8 1, i8 17, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal", ptr @"[8]_llgo_uint8" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @29, i64 8 }, ptr @"*[8]_llgo_uint8" }, ptr @_llgo_uint8, ptr @"[]_llgo_uint8", i64 8 }, align 8
-@29 = private unnamed_addr constant [8 x i8] c"[8]uint8", align 1
-@"*[8]_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -566230779, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @29, i64 8 }, ptr null }, ptr @"[8]_llgo_uint8" }, align 8
-@_llgo_uint8 = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 1, i64 0, i32 269156761, i8 12, i8 1, i8 1, i8 8, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @30, i64 5 }, ptr @"*_llgo_uint8" }, align 8
-@30 = private unnamed_addr constant [5 x i8] c"uint8", align 1
-@"*_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1277858201, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @30, i64 5 }, ptr null }, ptr @_llgo_uint8 }, align 8
-@"[]_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 370346748, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @31, i64 7 }, ptr @"*[]_llgo_uint8" }, ptr @_llgo_uint8 }, align 8
-@31 = private unnamed_addr constant [7 x i8] c"[]uint8", align 1
-@"*[]_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -2143776929, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @31, i64 7 }, ptr null }, ptr @"[]_llgo_uint8" }, align 8
-@32 = private unnamed_addr constant [4 x i8] c"keys", align 1
-@"[8]_llgo_int" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.ArrayType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 64, i64 0, i32 -1310855284, i8 8, i8 8, i8 8, i8 17, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal", ptr @"[8]_llgo_int" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @33, i64 6 }, ptr @"*[8]_llgo_int" }, ptr @_llgo_int, ptr @"[]_llgo_int", i64 8 }, align 8
-@33 = private unnamed_addr constant [6 x i8] c"[8]int", align 1
-@"*[8]_llgo_int" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1841254256, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @33, i64 6 }, ptr null }, ptr @"[8]_llgo_int" }, align 8
-@"[]_llgo_int" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 -1129561019, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @34, i64 5 }, ptr @"*[]_llgo_int" }, ptr @_llgo_int }, align 8
-@34 = private unnamed_addr constant [5 x i8] c"[]int", align 1
-@"*[]_llgo_int" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1428175521, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @34, i64 5 }, ptr null }, ptr @"[]_llgo_int" }, align 8
-@35 = private unnamed_addr constant [5 x i8] c"elems", align 1
-@"[8]_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.ArrayType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 128, i64 120, i32 460245566, i8 0, i8 8, i8 8, i8 17, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal", ptr @"[8]_llgo_string" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @36, i64 9 }, ptr @"*[8]_llgo_string" }, ptr @_llgo_string, ptr @"[]_llgo_string", i64 8 }, align 8
-@36 = private unnamed_addr constant [9 x i8] c"[8]string", align 1
-@"*[8]_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 368026044, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @36, i64 9 }, ptr null }, ptr @"[8]_llgo_string" }, align 8
-@"[]_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 608974920, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @37, i64 8 }, ptr @"*[]_llgo_string" }, ptr @_llgo_string }, align 8
-@37 = private unnamed_addr constant [8 x i8] c"[]string", align 1
-@"*[]_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -157880218, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @37, i64 8 }, ptr null }, ptr @"[]_llgo_string" }, align 8
-@38 = private unnamed_addr constant [8 x i8] c"overflow", align 1
-@"_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ$fields" = weak_odr constant [4 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 7 }, ptr @"[8]_llgo_uint8", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @32, i64 4 }, ptr @"[8]_llgo_int", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @35, i64 5 }, ptr @"[8]_llgo_string", i64 72, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @38, i64 8 }, ptr @_llgo_Pointer, i64 200, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
-@39 = private unnamed_addr constant [5 x i8] c"hello", align 1
-@40 = private unnamed_addr constant [5 x i8] c"world", align 1
-@41 = private unnamed_addr constant [14 x i8] c"MapIndex error", align 1
-@42 = private unnamed_addr constant [4 x i8] c"todo", align 1
-@43 = private unnamed_addr constant [12 x i8] c"must invalid", align 1
-@44 = private unnamed_addr constant [13 x i8] c"MapIter error", align 1
+@"_llgo_closure$FjMjjQr3-2iTiWyZP1IIQFOz0hUCa0OS6pEm5uVV6Pk$fields" = weak_odr constant [2 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @3, i64 2 }, ptr @"_llgo_func$KK0iU4Wpi3BdRqssvycXqtgNe2Dq1riBlM61Rds1QsU", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @4, i64 5 }, ptr @_llgo_Pointer, i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@22 = private unnamed_addr constant [10 x i8] c"call.slice", align 1
+@23 = private unnamed_addr constant [40 x i8] c"type assertion interface{} -> int failed", align 1
+@"map[_llgo_int]_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.MapType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -2084636366, i8 0, i8 8, i8 8, i8 53, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @24, i64 14 }, ptr @"*map[_llgo_int]_llgo_string" }, ptr @_llgo_int, ptr @_llgo_string, ptr @"_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ", { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.typehash", ptr @_llgo_int }, i8 8, i8 16, i16 208, i32 4 }, align 8
+@24 = private unnamed_addr constant [14 x i8] c"map[int]string", align 1
+@"*map[_llgo_int]_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 668541983, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @24, i64 14 }, ptr null }, ptr @"map[_llgo_int]_llgo_string" }, align 8
+@"_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.StructType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 208, i64 208, i32 1935989513, i8 0, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.structequal", ptr @"_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 82 }, ptr @"*_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ" }, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ$fields", i64 4, i64 4 } }, align 8
+@25 = private unnamed_addr constant [82 x i8] c"struct { topbits [8]uint8; keys [8]int; elems [8]string; overflow unsafe.Pointer }", align 1
+@"*_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 597085808, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 82 }, ptr null }, ptr @"_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ" }, align 8
+@26 = private unnamed_addr constant [7 x i8] c"topbits", align 1
+@"[8]_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.ArrayType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 0, i32 307038632, i8 8, i8 1, i8 1, i8 17, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal", ptr @"[8]_llgo_uint8" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @27, i64 8 }, ptr @"*[8]_llgo_uint8" }, ptr @_llgo_uint8, ptr @"[]_llgo_uint8", i64 8 }, align 8
+@27 = private unnamed_addr constant [8 x i8] c"[8]uint8", align 1
+@"*[8]_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -566230779, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @27, i64 8 }, ptr null }, ptr @"[8]_llgo_uint8" }, align 8
+@_llgo_uint8 = weak_odr constant %"github.com/goplus/llgo/runtime/abi.Type" { i64 1, i64 0, i32 269156761, i8 12, i8 1, i8 1, i8 8, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 5 }, ptr @"*_llgo_uint8" }, align 8
+@28 = private unnamed_addr constant [5 x i8] c"uint8", align 1
+@"*_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 1277858201, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @28, i64 5 }, ptr null }, ptr @_llgo_uint8 }, align 8
+@"[]_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 370346748, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @29, i64 7 }, ptr @"*[]_llgo_uint8" }, ptr @_llgo_uint8 }, align 8
+@29 = private unnamed_addr constant [7 x i8] c"[]uint8", align 1
+@"*[]_llgo_uint8" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -2143776929, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @29, i64 7 }, ptr null }, ptr @"[]_llgo_uint8" }, align 8
+@30 = private unnamed_addr constant [4 x i8] c"keys", align 1
+@"[8]_llgo_int" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.ArrayType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 64, i64 0, i32 -1310855284, i8 8, i8 8, i8 8, i8 17, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal", ptr @"[8]_llgo_int" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @31, i64 6 }, ptr @"*[8]_llgo_int" }, ptr @_llgo_int, ptr @"[]_llgo_int", i64 8 }, align 8
+@31 = private unnamed_addr constant [6 x i8] c"[8]int", align 1
+@"*[8]_llgo_int" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1841254256, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @31, i64 6 }, ptr null }, ptr @"[8]_llgo_int" }, align 8
+@"[]_llgo_int" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 -1129561019, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @32, i64 5 }, ptr @"*[]_llgo_int" }, ptr @_llgo_int }, align 8
+@32 = private unnamed_addr constant [5 x i8] c"[]int", align 1
+@"*[]_llgo_int" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -1428175521, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @32, i64 5 }, ptr null }, ptr @"[]_llgo_int" }, align 8
+@33 = private unnamed_addr constant [5 x i8] c"elems", align 1
+@"[8]_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.ArrayType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 128, i64 120, i32 460245566, i8 0, i8 8, i8 8, i8 17, { ptr, ptr } { ptr @"github.com/goplus/llgo/runtime/internal/runtime.arrayequal", ptr @"[8]_llgo_string" }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @34, i64 9 }, ptr @"*[8]_llgo_string" }, ptr @_llgo_string, ptr @"[]_llgo_string", i64 8 }, align 8
+@34 = private unnamed_addr constant [9 x i8] c"[8]string", align 1
+@"*[8]_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 368026044, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @34, i64 9 }, ptr null }, ptr @"[8]_llgo_string" }, align 8
+@"[]_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.SliceType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 24, i64 8, i32 608974920, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @35, i64 8 }, ptr @"*[]_llgo_string" }, ptr @_llgo_string }, align 8
+@35 = private unnamed_addr constant [8 x i8] c"[]string", align 1
+@"*[]_llgo_string" = weak_odr constant %"github.com/goplus/llgo/runtime/abi.PtrType" { %"github.com/goplus/llgo/runtime/abi.Type" { i64 8, i64 8, i32 -157880218, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @35, i64 8 }, ptr null }, ptr @"[]_llgo_string" }, align 8
+@36 = private unnamed_addr constant [8 x i8] c"overflow", align 1
+@"_llgo_struct$-d5W1oQEguzs9p8l76MbO7RbmjtJYi8DH1vVvnKnZqQ$fields" = weak_odr constant [4 x %"github.com/goplus/llgo/runtime/abi.StructField"] [%"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @26, i64 7 }, ptr @"[8]_llgo_uint8", i64 0, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @30, i64 4 }, ptr @"[8]_llgo_int", i64 8, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @33, i64 5 }, ptr @"[8]_llgo_string", i64 72, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"github.com/goplus/llgo/runtime/abi.StructField" { %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @36, i64 8 }, ptr @_llgo_Pointer, i64 200, %"github.com/goplus/llgo/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
+@37 = private unnamed_addr constant [5 x i8] c"hello", align 1
+@38 = private unnamed_addr constant [5 x i8] c"world", align 1
+@39 = private unnamed_addr constant [14 x i8] c"MapIndex error", align 1
+@40 = private unnamed_addr constant [4 x i8] c"todo", align 1
+@41 = private unnamed_addr constant [12 x i8] c"must invalid", align 1
+@42 = private unnamed_addr constant [13 x i8] c"MapIter error", align 1
 
 define i64 @"github.com/goplus/llgo/cl/_testgo/reflect.(*T).Add"(ptr %0, i64 %1) {
 _llgo_0:
@@ -153,7 +151,7 @@ _llgo_0:
   %15 = extractvalue { ptr, ptr } %14, 1
   %16 = extractvalue { ptr, ptr } %14, 0
   %17 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" %16(ptr %15)
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 7 })
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @6, i64 7 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64 %7)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
@@ -186,7 +184,7 @@ _llgo_0:
 
 _llgo_1:                                          ; preds = %_llgo_5
   %36 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 5 }, ptr %36, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr %36, align 8
   %37 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %36, 1
   call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %37)
   unreachable
@@ -216,7 +214,7 @@ _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
 
 define i64 @"github.com/goplus/llgo/cl/_testgo/reflect.callClosure$1"(ptr %0, i64 %1) {
 _llgo_0:
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @10, i64 12 })
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @9, i64 12 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
   %2 = load { ptr }, ptr %0, align 8
   %3 = extractvalue { ptr } %2, 0
@@ -243,7 +241,7 @@ _llgo_0:
   %11 = extractvalue { ptr, ptr } %10, 1
   %12 = extractvalue { ptr, ptr } %10, 0
   %13 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" %12(ptr %11)
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @11, i64 4 })
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @10, i64 4 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64 %3)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
@@ -276,7 +274,7 @@ _llgo_0:
 
 _llgo_1:                                          ; preds = %_llgo_5
   %32 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 5 }, ptr %32, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr %32, align 8
   %33 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %32, 1
   call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %33)
   unreachable
@@ -306,7 +304,7 @@ _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
 
 define i64 @"github.com/goplus/llgo/cl/_testgo/reflect.callFunc$1"(i64 %0) {
 _llgo_0:
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @12, i64 9 })
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @11, i64 9 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
   %1 = add i64 %0, 1
   ret i64 %1
@@ -337,7 +335,7 @@ _llgo_0:
   %19 = extractvalue { ptr, ptr } %18, 1
   %20 = extractvalue { ptr, ptr } %18, 0
   %21 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" %20(ptr %19)
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @18, i64 7 })
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @17, i64 7 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64 %11)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
@@ -370,7 +368,7 @@ _llgo_0:
 
 _llgo_1:                                          ; preds = %_llgo_5
   %40 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 5 }, ptr %40, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr %40, align 8
   %41 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %40, 1
   call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %41)
   unreachable
@@ -439,7 +437,7 @@ _llgo_0:
   %13 = extractvalue { ptr, ptr } %12, 1
   %14 = extractvalue { ptr, ptr } %12, 0
   %15 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" %14(ptr %13)
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @19, i64 6 })
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @18, i64 6 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintUint"(i64 %5)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
@@ -472,7 +470,7 @@ _llgo_0:
 
 _llgo_1:                                          ; preds = %_llgo_5
   %34 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 5 }, ptr %34, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr %34, align 8
   %35 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %34, 1
   call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %35)
   unreachable
@@ -587,7 +585,7 @@ _llgo_0:
   %41 = getelementptr inbounds %reflect.Value, ptr %38, i64 1
   %42 = load %reflect.Value, ptr %41, align 8
   %43 = call i64 @reflect.Value.Int(%reflect.Value %42)
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @24, i64 10 })
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @22, i64 10 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %37)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
@@ -655,7 +653,7 @@ _llgo_0:
   %84 = getelementptr inbounds %reflect.Value, ptr %81, i64 1
   %85 = load %reflect.Value, ptr %84, align 8
   %86 = call i64 @reflect.Value.Int(%reflect.Value %85)
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @24, i64 10 })
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @22, i64 10 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %80)
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
@@ -710,7 +708,7 @@ _llgo_4:                                          ; preds = %_llgo_2
 
 _llgo_5:                                          ; preds = %_llgo_2
   %37 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @25, i64 40 }, ptr %37, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @23, i64 40 }, ptr %37, align 8
   %38 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %37, 1
   call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %38)
   unreachable
@@ -748,11 +746,11 @@ _llgo_0:
   %1 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 8)
   store i64 1, ptr %1, align 4
   %2 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_int]_llgo_string", ptr %0, ptr %1)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @39, i64 5 }, ptr %2, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @37, i64 5 }, ptr %2, align 8
   %3 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 8)
   store i64 2, ptr %3, align 4
   %4 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_int]_llgo_string", ptr %0, ptr %3)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @40, i64 5 }, ptr %4, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @38, i64 5 }, ptr %4, align 8
   %5 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @"map[_llgo_int]_llgo_string", ptr undef }, ptr %0, 1
   %6 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %5)
   %7 = call i64 @reflect.Value.Len(%reflect.Value %6)
@@ -761,7 +759,7 @@ _llgo_0:
 
 _llgo_1:                                          ; preds = %_llgo_3, %_llgo_0
   %9 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 5 }, ptr %9, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr %9, align 8
   %10 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %9, 1
   call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %10)
   unreachable
@@ -773,7 +771,7 @@ _llgo_2:                                          ; preds = %_llgo_3
   %13 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %12)
   %14 = call %reflect.Value @reflect.Value.MapIndex(%reflect.Value %6, %reflect.Value %13)
   %15 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %14)
-  %16 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %15, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @40, i64 5 })
+  %16 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %15, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @38, i64 5 })
   %17 = xor i1 %16, true
   br i1 %17, label %_llgo_4, label %_llgo_5
 
@@ -785,7 +783,7 @@ _llgo_3:                                          ; preds = %_llgo_0
 
 _llgo_4:                                          ; preds = %_llgo_2
   %21 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @41, i64 14 }, ptr %21, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @39, i64 14 }, ptr %21, align 8
   %22 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %21, 1
   call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %22)
   unreachable
@@ -796,7 +794,7 @@ _llgo_5:                                          ; preds = %_llgo_2
   %24 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %23, 1
   %25 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %24)
   %26 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @42, i64 4 }, ptr %26, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @40, i64 4 }, ptr %26, align 8
   %27 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %26, 1
   %28 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %27)
   call void @reflect.Value.SetMapIndex(%reflect.Value %6, %reflect.Value %25, %reflect.Value %28)
@@ -806,13 +804,13 @@ _llgo_5:                                          ; preds = %_llgo_2
   %31 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %30)
   %32 = call %reflect.Value @reflect.Value.MapIndex(%reflect.Value %6, %reflect.Value %31)
   %33 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %32)
-  %34 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %33, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @42, i64 4 })
+  %34 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %33, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @40, i64 4 })
   %35 = xor i1 %34, true
   br i1 %35, label %_llgo_6, label %_llgo_7
 
 _llgo_6:                                          ; preds = %_llgo_5
   %36 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @41, i64 14 }, ptr %36, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @39, i64 14 }, ptr %36, align 8
   %37 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %36, 1
   call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %37)
   unreachable
@@ -827,7 +825,7 @@ _llgo_7:                                          ; preds = %_llgo_5
   br i1 %42, label %_llgo_8, label %_llgo_9
 
 _llgo_8:                                          ; preds = %_llgo_7
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @43, i64 12 })
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @41, i64 12 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_9
 
@@ -877,7 +875,7 @@ _llgo_12:                                         ; preds = %_llgo_14, %_llgo_9
 
 _llgo_13:                                         ; preds = %_llgo_14, %_llgo_10
   %73 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @44, i64 13 }, ptr %73, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @42, i64 13 }, ptr %73, align 8
   %74 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %73, 1
   call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %74)
   unreachable
@@ -908,7 +906,7 @@ _llgo_0:
   %9 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %8, 1
   %10 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %9)
   %11 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @39, i64 5 }, ptr %11, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @37, i64 5 }, ptr %11, align 8
   %12 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %11, 1
   %13 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %12)
   call void @reflect.Value.SetMapIndex(%reflect.Value %7, %reflect.Value %10, %reflect.Value %13)
@@ -917,7 +915,7 @@ _llgo_0:
   %15 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %14, 1
   %16 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %15)
   %17 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @40, i64 5 }, ptr %17, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @38, i64 5 }, ptr %17, align 8
   %18 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %17, 1
   %19 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %18)
   call void @reflect.Value.SetMapIndex(%reflect.Value %7, %reflect.Value %16, %reflect.Value %19)
@@ -927,7 +925,7 @@ _llgo_0:
 
 _llgo_1:                                          ; preds = %_llgo_3, %_llgo_0
   %22 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @8, i64 5 }, ptr %22, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr %22, align 8
   %23 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %22, 1
   call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %23)
   unreachable
@@ -939,7 +937,7 @@ _llgo_2:                                          ; preds = %_llgo_3
   %26 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %25)
   %27 = call %reflect.Value @reflect.Value.MapIndex(%reflect.Value %7, %reflect.Value %26)
   %28 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %27)
-  %29 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %28, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @40, i64 5 })
+  %29 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %28, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @38, i64 5 })
   %30 = xor i1 %29, true
   br i1 %30, label %_llgo_4, label %_llgo_5
 
@@ -951,7 +949,7 @@ _llgo_3:                                          ; preds = %_llgo_0
 
 _llgo_4:                                          ; preds = %_llgo_2
   %34 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @41, i64 14 }, ptr %34, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @39, i64 14 }, ptr %34, align 8
   %35 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %34, 1
   call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %35)
   unreachable
@@ -962,7 +960,7 @@ _llgo_5:                                          ; preds = %_llgo_2
   %37 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %36, 1
   %38 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %37)
   %39 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @42, i64 4 }, ptr %39, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @40, i64 4 }, ptr %39, align 8
   %40 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %39, 1
   %41 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %40)
   call void @reflect.Value.SetMapIndex(%reflect.Value %7, %reflect.Value %38, %reflect.Value %41)
@@ -972,13 +970,13 @@ _llgo_5:                                          ; preds = %_llgo_2
   %44 = call %reflect.Value @reflect.ValueOf(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %43)
   %45 = call %reflect.Value @reflect.Value.MapIndex(%reflect.Value %7, %reflect.Value %44)
   %46 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %45)
-  %47 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %46, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @42, i64 4 })
+  %47 = call i1 @"github.com/goplus/llgo/runtime/internal/runtime.StringEqual"(%"github.com/goplus/llgo/runtime/internal/runtime.String" %46, %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @40, i64 4 })
   %48 = xor i1 %47, true
   br i1 %48, label %_llgo_6, label %_llgo_7
 
 _llgo_6:                                          ; preds = %_llgo_5
   %49 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @41, i64 14 }, ptr %49, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @39, i64 14 }, ptr %49, align 8
   %50 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %49, 1
   call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %50)
   unreachable
@@ -993,7 +991,7 @@ _llgo_7:                                          ; preds = %_llgo_5
   br i1 %55, label %_llgo_8, label %_llgo_9
 
 _llgo_8:                                          ; preds = %_llgo_7
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @43, i64 12 })
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @41, i64 12 })
   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
   br label %_llgo_9
 
@@ -1043,7 +1041,7 @@ _llgo_12:                                         ; preds = %_llgo_14, %_llgo_9
 
 _llgo_13:                                         ; preds = %_llgo_14, %_llgo_10
   %86 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @44, i64 13 }, ptr %86, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @42, i64 13 }, ptr %86, align 8
   %87 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %86, 1
   call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %87)
   unreachable

--- a/cl/_testgo/reflectmk/out.ll
+++ b/cl/_testgo/reflectmk/out.ll
@@ -463,7 +463,7 @@ _llgo_20:                                         ; preds = %_llgo_21
   %256 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %255, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer)
   %257 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %256, 0
   %258 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %256, 1
-  %259 = icmp sge i64 0, %258
+  %259 = icmp uge i64 0, %258
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %259)
   %260 = getelementptr inbounds %reflect.Value, ptr %257, i64 0
   %261 = load %reflect.Value, ptr %260, align 8
@@ -491,7 +491,7 @@ _llgo_23:                                         ; preds = %_llgo_20
   %272 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %271, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer)
   %273 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %272, 0
   %274 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %272, 1
-  %275 = icmp sge i64 0, %274
+  %275 = icmp uge i64 0, %274
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %275)
   %276 = getelementptr inbounds %reflect.Value, ptr %273, i64 0
   %277 = load %reflect.Value, ptr %276, align 8
@@ -526,7 +526,7 @@ _llgo_0:
   %7 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %6, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer)
   %8 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %7, 0
   %9 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %7, 1
-  %10 = icmp sge i64 0, %9
+  %10 = icmp uge i64 0, %9
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %10)
   %11 = getelementptr inbounds %reflect.Value, ptr %8, i64 0
   %12 = load %reflect.Value, ptr %11, align 8
@@ -559,7 +559,7 @@ _llgo_0:
   %7 = call %"github.com/goplus/llgo/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %6, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" zeroinitializer)
   %8 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %7, 0
   %9 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %7, 1
-  %10 = icmp sge i64 0, %9
+  %10 = icmp uge i64 0, %9
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %10)
   %11 = getelementptr inbounds %reflect.Value, ptr %8, i64 0
   %12 = load %reflect.Value, ptr %11, align 8

--- a/cl/_testgo/tpindex/in.go
+++ b/cl/_testgo/tpindex/in.go
@@ -36,7 +36,7 @@ func main() {
 // CHECK-NEXT:   %6 = extractvalue %"{{.*}}Slice" %0, 0
 // CHECK-NEXT:   %7 = extractvalue %"{{.*}}Slice" %0, 1
 // CHECK-NEXT:   %8 = icmp slt i64 %4, 0
-// CHECK-NEXT:   %9 = icmp sge i64 %4, %7
+// CHECK-NEXT:   %9 = icmp uge i64 %4, %7
 // CHECK-NEXT:   %10 = or i1 %9, %8
 // CHECK-NEXT:   call void @"{{.*}}AssertIndexRange"(i1 %10)
 // CHECK-NEXT:   %11 = getelementptr inbounds i64, ptr %6, i64 %4

--- a/cl/_testgo/tprecur/out.ll
+++ b/cl/_testgo/tprecur/out.ll
@@ -105,7 +105,7 @@ _llgo_2:                                          ; preds = %_llgo_1
   %7 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1, 0
   %8 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1, 1
   %9 = icmp slt i64 %4, 0
-  %10 = icmp sge i64 %4, %8
+  %10 = icmp uge i64 %4, %8
   %11 = or i1 %10, %9
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %11)
   %12 = getelementptr inbounds i64, ptr %7, i64 %4
@@ -127,7 +127,7 @@ _llgo_5:                                          ; preds = %_llgo_4
   %18 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1, 0
   %19 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %1, 1
   %20 = icmp slt i64 %16, 0
-  %21 = icmp sge i64 %16, %19
+  %21 = icmp uge i64 %16, %19
   %22 = or i1 %21, %20
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %22)
   %23 = getelementptr inbounds i64, ptr %18, i64 %16

--- a/cl/_testgo/tptypes/out.ll
+++ b/cl/_testgo/tptypes/out.ll
@@ -109,7 +109,7 @@ _llgo_0:
   %52 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %51, align 8
   %53 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %52, 0
   %54 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %52, 1
-  %55 = icmp sge i64 0, %54
+  %55 = icmp uge i64 0, %54
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %55)
   %56 = getelementptr inbounds i64, ptr %53, i64 0
   %57 = load i64, ptr %56, align 4
@@ -123,7 +123,7 @@ _llgo_0:
   %61 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %60, align 8
   %62 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %61, 0
   %63 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %61, 1
-  %64 = icmp sge i64 0, %63
+  %64 = icmp uge i64 0, %63
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %64)
   %65 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %62, i64 0
   %66 = load %"github.com/goplus/llgo/runtime/internal/runtime.String", ptr %65, align 8
@@ -137,7 +137,7 @@ _llgo_0:
   %70 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %69, align 8
   %71 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %70, 0
   %72 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %70, 1
-  %73 = icmp sge i64 0, %72
+  %73 = icmp uge i64 0, %72
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %73)
   %74 = getelementptr inbounds i64, ptr %71, i64 0
   %75 = load i64, ptr %74, align 4

--- a/cl/_testlibc/allocacstrs/in.go
+++ b/cl/_testlibc/allocacstrs/in.go
@@ -45,7 +45,7 @@ func main() {
 	// CHECK-NEXT:   %18 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %6, 0
 	// CHECK-NEXT:   %19 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %6, 1
 	// CHECK-NEXT:   %20 = icmp slt i64 %16, 0
-	// CHECK-NEXT:   %21 = icmp sge i64 %16, %19
+	// CHECK-NEXT:   %21 = icmp uge i64 %16, %19
 	// CHECK-NEXT:   %22 = or i1 %21, %20
 	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %22)
 	// CHECK-NEXT:   %23 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.String", ptr %18, i64 %16

--- a/cl/_testrt/abinamed/in.go
+++ b/cl/_testrt/abinamed/in.go
@@ -46,7 +46,7 @@ import (
 // CHECK-NEXT:   %23 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %22, align 8
 // CHECK-NEXT:   %24 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %23, 0
 // CHECK-NEXT:   %25 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %23, 1
-// CHECK-NEXT:   %26 = icmp sge i64 0, %25
+// CHECK-NEXT:   %26 = icmp uge i64 0, %25
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %26)
 // CHECK-NEXT:   %27 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %24, i64 0
 // CHECK-NEXT:   %28 = load %"{{.*}}/runtime/abi.StructField", ptr %27, align 8
@@ -93,7 +93,7 @@ import (
 // CHECK-NEXT:   %51 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %50, align 8
 // CHECK-NEXT:   %52 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %51, 0
 // CHECK-NEXT:   %53 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %51, 1
-// CHECK-NEXT:   %54 = icmp sge i64 1, %53
+// CHECK-NEXT:   %54 = icmp uge i64 1, %53
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %54)
 // CHECK-NEXT:   %55 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %52, i64 1
 // CHECK-NEXT:   %56 = load %"{{.*}}/runtime/abi.StructField", ptr %55, align 8
@@ -140,7 +140,7 @@ import (
 // CHECK-NEXT:   %79 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %78, align 8
 // CHECK-NEXT:   %80 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %79, 0
 // CHECK-NEXT:   %81 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %79, 1
-// CHECK-NEXT:   %82 = icmp sge i64 2, %81
+// CHECK-NEXT:   %82 = icmp uge i64 2, %81
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %82)
 // CHECK-NEXT:   %83 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %80, i64 2
 // CHECK-NEXT:   %84 = load %"{{.*}}/runtime/abi.StructField", ptr %83, align 8
@@ -154,7 +154,7 @@ import (
 // CHECK-NEXT:   %91 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %90, align 8
 // CHECK-NEXT:   %92 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %91, 0
 // CHECK-NEXT:   %93 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %91, 1
-// CHECK-NEXT:   %94 = icmp sge i64 0, %93
+// CHECK-NEXT:   %94 = icmp uge i64 0, %93
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %94)
 // CHECK-NEXT:   %95 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %92, i64 0
 // CHECK-NEXT:   %96 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %95, i32 0, i32 1
@@ -179,7 +179,7 @@ import (
 // CHECK-NEXT:   %106 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %105, align 8
 // CHECK-NEXT:   %107 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %106, 0
 // CHECK-NEXT:   %108 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %106, 1
-// CHECK-NEXT:   %109 = icmp sge i64 3, %108
+// CHECK-NEXT:   %109 = icmp uge i64 3, %108
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %109)
 // CHECK-NEXT:   %110 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %107, i64 3
 // CHECK-NEXT:   %111 = load %"{{.*}}/runtime/abi.StructField", ptr %110, align 8

--- a/cl/_testrt/builtin/out.ll
+++ b/cl/_testrt/builtin/out.ll
@@ -397,7 +397,7 @@ _llgo_3:                                          ; preds = %_llgo_1
   %151 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringFromRunes"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %149)
   %152 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %148, 0
   %153 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %148, 1
-  %154 = icmp sge i64 3, %153
+  %154 = icmp uge i64 3, %153
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %154)
   %155 = getelementptr inbounds i8, ptr %152, i64 3
   %156 = load i8, ptr %155, align 1
@@ -405,7 +405,7 @@ _llgo_3:                                          ; preds = %_llgo_1
   %158 = call %"github.com/goplus/llgo/runtime/internal/runtime.String" @"github.com/goplus/llgo/runtime/internal/runtime.StringFromRune"(i32 %157)
   %159 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %149, 0
   %160 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %149, 1
-  %161 = icmp sge i64 0, %160
+  %161 = icmp uge i64 0, %160
   call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %161)
   %162 = getelementptr inbounds i32, ptr %159, i64 0
   %163 = load i32, ptr %162, align 4

--- a/cl/_testrt/concat/in.go
+++ b/cl/_testrt/concat/in.go
@@ -17,7 +17,7 @@ package main
 // CHECK-NEXT:   %6 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %0, 0
 // CHECK-NEXT:   %7 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %0, 1
 // CHECK-NEXT:   %8 = icmp slt i64 %4, 0
-// CHECK-NEXT:   %9 = icmp sge i64 %4, %7
+// CHECK-NEXT:   %9 = icmp uge i64 %4, %7
 // CHECK-NEXT:   %10 = or i1 %9, %8
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %10)
 // CHECK-NEXT:   %11 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.String", ptr %6, i64 %4

--- a/cl/_testrt/gblarray/in.go
+++ b/cl/_testrt/gblarray/in.go
@@ -8,7 +8,7 @@ import (
 
 // CHECK-LABEL: define ptr @"{{.*}}/cl/_testrt/gblarray.Basic"(i64 %0) {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = icmp sge i64 %0, 25
+// CHECK-NEXT:   %1 = icmp uge i64 %0, 25
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %1)
 // CHECK-NEXT:   %2 = getelementptr inbounds ptr, ptr @"{{.*}}/cl/_testrt/gblarray.basicTypes", i64 %0
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -22,7 +22,7 @@ func Basic(kind abi.Kind) *abi.Type {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 72)
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %1, i32 0, i32 0
-// CHECK-NEXT:   %3 = icmp sge i64 %0, 25
+// CHECK-NEXT:   %3 = icmp uge i64 %0, 25
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %3)
 // CHECK-NEXT:   %4 = getelementptr inbounds i64, ptr @"{{.*}}/cl/_testrt/gblarray.sizeBasicTypes", i64 %0
 // CHECK-NEXT:   %5 = load i64, ptr %4, align 4

--- a/cl/_testrt/index/in.go
+++ b/cl/_testrt/index/in.go
@@ -122,7 +122,7 @@ type S []int
 // CHECK-NEXT:   %60 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %59, i64 4, 2
 // CHECK-NEXT:   %61 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %60, 0
 // CHECK-NEXT:   %62 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %60, 1
-// CHECK-NEXT:   %63 = icmp sge i64 1, %62
+// CHECK-NEXT:   %63 = icmp uge i64 1, %62
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %63)
 // CHECK-NEXT:   %64 = getelementptr inbounds i64, ptr %61, i64 1
 // CHECK-NEXT:   %65 = load i64, ptr %64, align 4

--- a/cl/_testrt/intgen/in.go
+++ b/cl/_testrt/intgen/in.go
@@ -24,7 +24,7 @@ import (
 // CHECK-NEXT:   %10 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %2, 0
 // CHECK-NEXT:   %11 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %2, 1
 // CHECK-NEXT:   %12 = icmp slt i64 %5, 0
-// CHECK-NEXT:   %13 = icmp sge i64 %5, %11
+// CHECK-NEXT:   %13 = icmp uge i64 %5, %11
 // CHECK-NEXT:   %14 = or i1 %13, %12
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %14)
 // CHECK-NEXT:   %15 = getelementptr inbounds i32, ptr %10, i64 %5
@@ -78,7 +78,7 @@ type generator struct {
 // CHECK-NEXT:   %5 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %0, 0
 // CHECK-NEXT:   %6 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %0, 1
 // CHECK-NEXT:   %7 = icmp slt i64 %3, 0
-// CHECK-NEXT:   %8 = icmp sge i64 %3, %6
+// CHECK-NEXT:   %8 = icmp uge i64 %3, %6
 // CHECK-NEXT:   %9 = or i1 %8, %7
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %9)
 // CHECK-NEXT:   %10 = getelementptr inbounds i32, ptr %5, i64 %3
@@ -107,7 +107,7 @@ type generator struct {
 // CHECK-NEXT:   %22 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %17, 0
 // CHECK-NEXT:   %23 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %17, 1
 // CHECK-NEXT:   %24 = icmp slt i64 %20, 0
-// CHECK-NEXT:   %25 = icmp sge i64 %20, %23
+// CHECK-NEXT:   %25 = icmp uge i64 %20, %23
 // CHECK-NEXT:   %26 = or i1 %25, %24
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %26)
 // CHECK-NEXT:   %27 = getelementptr inbounds i32, ptr %22, i64 %20
@@ -137,7 +137,7 @@ type generator struct {
 // CHECK-NEXT:   %40 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %35, 0
 // CHECK-NEXT:   %41 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %35, 1
 // CHECK-NEXT:   %42 = icmp slt i64 %38, 0
-// CHECK-NEXT:   %43 = icmp sge i64 %38, %41
+// CHECK-NEXT:   %43 = icmp uge i64 %38, %41
 // CHECK-NEXT:   %44 = or i1 %43, %42
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %44)
 // CHECK-NEXT:   %45 = getelementptr inbounds i32, ptr %40, i64 %38

--- a/cl/_testrt/mapclosure/in.go
+++ b/cl/_testrt/mapclosure/in.go
@@ -46,7 +46,7 @@ var (
 // CHECK-NEXT:   %6 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr @"{{.*}}/cl/_testrt/mapclosure.list", align 8
 // CHECK-NEXT:   %7 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %6, 0
 // CHECK-NEXT:   %8 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %6, 1
-// CHECK-NEXT:   %9 = icmp sge i64 0, %8
+// CHECK-NEXT:   %9 = icmp uge i64 0, %8
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %9)
 // CHECK-NEXT:   %10 = getelementptr inbounds { ptr, ptr }, ptr %7, i64 0
 // CHECK-NEXT:   %11 = load { ptr, ptr }, ptr %10, align 8

--- a/cl/_testrt/qsort/in.go
+++ b/cl/_testrt/qsort/in.go
@@ -36,7 +36,7 @@ func qsort(base c.Pointer, count, elem uintptr, compar func(a, b c.Pointer) c.In
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
 // CHECK-NEXT:   %11 = icmp slt i64 %9, 0
-// CHECK-NEXT:   %12 = icmp sge i64 %9, 5
+// CHECK-NEXT:   %12 = icmp uge i64 %9, 5
 // CHECK-NEXT:   %13 = or i1 %12, %11
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %13)
 // CHECK-NEXT:   %14 = getelementptr inbounds i64, ptr %0, i64 %9

--- a/cl/_testrt/qsortfn/in.go
+++ b/cl/_testrt/qsortfn/in.go
@@ -62,7 +62,7 @@ func main() {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
 // CHECK-NEXT:   %12 = icmp slt i64 %10, 0
-// CHECK-NEXT:   %13 = icmp sge i64 %10, 5
+// CHECK-NEXT:   %13 = icmp uge i64 %10, 5
 // CHECK-NEXT:   %14 = or i1 %13, %12
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %14)
 // CHECK-NEXT:   %15 = getelementptr inbounds i64, ptr %1, i64 %10
@@ -120,7 +120,7 @@ func sort1a() {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
 // CHECK-NEXT:   %12 = icmp slt i64 %10, 0
-// CHECK-NEXT:   %13 = icmp sge i64 %10, 5
+// CHECK-NEXT:   %13 = icmp uge i64 %10, 5
 // CHECK-NEXT:   %14 = or i1 %13, %12
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %14)
 // CHECK-NEXT:   %15 = getelementptr inbounds i64, ptr %1, i64 %10
@@ -178,7 +178,7 @@ func sort1b() {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
 // CHECK-NEXT:   %12 = icmp slt i64 %10, 0
-// CHECK-NEXT:   %13 = icmp sge i64 %10, 5
+// CHECK-NEXT:   %13 = icmp uge i64 %10, 5
 // CHECK-NEXT:   %14 = or i1 %13, %12
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %14)
 // CHECK-NEXT:   %15 = getelementptr inbounds i64, ptr %1, i64 %10
@@ -236,7 +236,7 @@ func sort2a() {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
 // CHECK-NEXT:   %12 = icmp slt i64 %10, 0
-// CHECK-NEXT:   %13 = icmp sge i64 %10, 5
+// CHECK-NEXT:   %13 = icmp uge i64 %10, 5
 // CHECK-NEXT:   %14 = or i1 %13, %12
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %14)
 // CHECK-NEXT:   %15 = getelementptr inbounds i64, ptr %1, i64 %10
@@ -294,7 +294,7 @@ func sort2b() {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
 // CHECK-NEXT:   %12 = icmp slt i64 %10, 0
-// CHECK-NEXT:   %13 = icmp sge i64 %10, 5
+// CHECK-NEXT:   %13 = icmp uge i64 %10, 5
 // CHECK-NEXT:   %14 = or i1 %13, %12
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %14)
 // CHECK-NEXT:   %15 = getelementptr inbounds i64, ptr %1, i64 %10
@@ -352,7 +352,7 @@ func sort3a() {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
 // CHECK-NEXT:   %12 = icmp slt i64 %10, 0
-// CHECK-NEXT:   %13 = icmp sge i64 %10, 5
+// CHECK-NEXT:   %13 = icmp uge i64 %10, 5
 // CHECK-NEXT:   %14 = or i1 %13, %12
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %14)
 // CHECK-NEXT:   %15 = getelementptr inbounds i64, ptr %1, i64 %10
@@ -410,7 +410,7 @@ func sort3b() {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
 // CHECK-NEXT:   %12 = icmp slt i64 %10, 0
-// CHECK-NEXT:   %13 = icmp sge i64 %10, 5
+// CHECK-NEXT:   %13 = icmp uge i64 %10, 5
 // CHECK-NEXT:   %14 = or i1 %13, %12
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %14)
 // CHECK-NEXT:   %15 = getelementptr inbounds i64, ptr %1, i64 %10
@@ -468,7 +468,7 @@ func sort4a() {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
 // CHECK-NEXT:   %12 = icmp slt i64 %10, 0
-// CHECK-NEXT:   %13 = icmp sge i64 %10, 5
+// CHECK-NEXT:   %13 = icmp uge i64 %10, 5
 // CHECK-NEXT:   %14 = or i1 %13, %12
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %14)
 // CHECK-NEXT:   %15 = getelementptr inbounds i64, ptr %1, i64 %10
@@ -526,7 +526,7 @@ func sort4b() {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
 // CHECK-NEXT:   %12 = icmp slt i64 %10, 0
-// CHECK-NEXT:   %13 = icmp sge i64 %10, 5
+// CHECK-NEXT:   %13 = icmp uge i64 %10, 5
 // CHECK-NEXT:   %14 = or i1 %13, %12
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %14)
 // CHECK-NEXT:   %15 = getelementptr inbounds i64, ptr %1, i64 %10
@@ -584,7 +584,7 @@ func sort5a() {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
 // CHECK-NEXT:   %12 = icmp slt i64 %10, 0
-// CHECK-NEXT:   %13 = icmp sge i64 %10, 5
+// CHECK-NEXT:   %13 = icmp uge i64 %10, 5
 // CHECK-NEXT:   %14 = or i1 %13, %12
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %14)
 // CHECK-NEXT:   %15 = getelementptr inbounds i64, ptr %1, i64 %10

--- a/cl/_testrt/sum/in.go
+++ b/cl/_testrt/sum/in.go
@@ -43,7 +43,7 @@ func main() {
 // CHECK-NEXT:   %6 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %0, 0
 // CHECK-NEXT:   %7 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %0, 1
 // CHECK-NEXT:   %8 = icmp slt i64 %4, 0
-// CHECK-NEXT:   %9 = icmp sge i64 %4, %7
+// CHECK-NEXT:   %9 = icmp uge i64 %4, %7
 // CHECK-NEXT:   %10 = or i1 %9, %8
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %10)
 // CHECK-NEXT:   %11 = getelementptr inbounds i64, ptr %6, i64 %4

--- a/cl/_testrt/unsafe/in.go
+++ b/cl/_testrt/unsafe/in.go
@@ -157,7 +157,7 @@ type N struct {
 // CHECK-NEXT:   %34 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %33, i64 2, 2
 // CHECK-NEXT:   %35 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %34, 0
 // CHECK-NEXT:   %36 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %34, 1
-// CHECK-NEXT:   %37 = icmp sge i64 0, %36
+// CHECK-NEXT:   %37 = icmp uge i64 0, %36
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %37)
 // CHECK-NEXT:   %38 = getelementptr inbounds i64, ptr %35, i64 0
 // CHECK-NEXT:   %39 = load i64, ptr %38, align 4
@@ -190,7 +190,7 @@ type N struct {
 // CHECK-NEXT: _llgo_29:                                         ; preds = %_llgo_24
 // CHECK-NEXT:   %50 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %34, 0
 // CHECK-NEXT:   %51 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %34, 1
-// CHECK-NEXT:   %52 = icmp sge i64 1, %51
+// CHECK-NEXT:   %52 = icmp uge i64 1, %51
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %52)
 // CHECK-NEXT:   %53 = getelementptr inbounds i64, ptr %50, i64 1
 // CHECK-NEXT:   %54 = load i64, ptr %53, align 4

--- a/ssa/datastruct.go
+++ b/ssa/datastruct.go
@@ -236,11 +236,10 @@ func (b Builder) checkIndex(idx Expr, max Expr) Expr {
 		check = Expr{llvm.CreateICmp(b.impl, llvm.IntSLT, idx.impl, zero), prog.Bool()}
 	}
 	if checkMax {
-		pred := llvm.IntSGE
-		if idx.kind != vkSigned {
-			pred = llvm.IntUGE
-		}
-		r := Expr{llvm.CreateICmp(b.impl, pred, idx.impl, max.impl), prog.Bool()}
+		// max is a non-negative len/cap value. Unsigned comparison is valid for
+		// both signed and unsigned indexes, and signed negatives fail as large
+		// unsigned values.
+		r := Expr{llvm.CreateICmp(b.impl, llvm.IntUGE, idx.impl, max.impl), prog.Bool()}
 		if check.IsNil() {
 			check = r
 		} else {

--- a/ssa/datastruct.go
+++ b/ssa/datastruct.go
@@ -236,7 +236,11 @@ func (b Builder) checkIndex(idx Expr, max Expr) Expr {
 		check = Expr{llvm.CreateICmp(b.impl, llvm.IntSLT, idx.impl, zero), prog.Bool()}
 	}
 	if checkMax {
-		r := Expr{llvm.CreateICmp(b.impl, llvm.IntSGE, idx.impl, max.impl), prog.Bool()}
+		pred := llvm.IntSGE
+		if idx.kind != vkSigned {
+			pred = llvm.IntUGE
+		}
+		r := Expr{llvm.CreateICmp(b.impl, pred, idx.impl, max.impl), prog.Bool()}
 		if check.IsNil() {
 			check = r
 		} else {

--- a/test/go/unsigned_index_bounds_test.go
+++ b/test/go/unsigned_index_bounds_test.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gotest
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestUnsignedIndexBoundsCheck(t *testing.T) {
+	expectPanicContaining(t, "out of range", func() {
+		s := []int{1}
+		var idx uint64 = 1 << 63
+		_ = s[idx]
+	})
+}
+
+func expectPanicContaining(t *testing.T, want string, f func()) {
+	t.Helper()
+	defer func() {
+		err := recover()
+		if err == nil {
+			t.Fatalf("expected panic containing %q", want)
+		}
+		if got := panicString(err); !strings.Contains(got, want) {
+			t.Fatalf("panic = %q, want contains %q", got, want)
+		}
+	}()
+	f()
+}
+
+func panicString(v any) string {
+	if err, ok := v.(interface{ Error() string }); ok {
+		return err.Error()
+	}
+	return fmt.Sprint(v)
+}

--- a/test/go/unsigned_index_bounds_test.go
+++ b/test/go/unsigned_index_bounds_test.go
@@ -72,12 +72,12 @@ func TestUnsignedIndexBoundsCheck(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			expectPanicContaining(t, "out of range", tt.f)
+			expectUnsignedIndexPanicContaining(t, "out of range", tt.f)
 		})
 	}
 }
 
-func expectPanicContaining(t *testing.T, want string, f func()) {
+func expectUnsignedIndexPanicContaining(t *testing.T, want string, f func()) {
 	t.Helper()
 	defer func() {
 		err := recover()

--- a/test/go/unsigned_index_bounds_test.go
+++ b/test/go/unsigned_index_bounds_test.go
@@ -23,11 +23,58 @@ import (
 )
 
 func TestUnsignedIndexBoundsCheck(t *testing.T) {
-	expectPanicContaining(t, "out of range", func() {
-		s := []int{1}
-		var idx uint64 = 1 << 63
-		_ = s[idx]
-	})
+	tests := []struct {
+		name string
+		f    func()
+	}{
+		{
+			name: "uint64 sign bit slice",
+			f: func() {
+				s := []int{1}
+				// Set the sign bit so a signed upper-bound compare would miss it.
+				var idx uint64 = 1 << 63
+				_ = s[idx]
+			},
+		},
+		{
+			name: "uint slice",
+			f: func() {
+				s := []int{1}
+				var idx uint = ^uint(0)
+				_ = s[idx]
+			},
+		},
+		{
+			name: "uint8 slice",
+			f: func() {
+				s := []int{1}
+				var idx uint8 = 255
+				_ = s[idx]
+			},
+		},
+		{
+			name: "uintptr slice",
+			f: func() {
+				s := []int{1}
+				var idx uintptr = ^uintptr(0)
+				_ = s[idx]
+			},
+		},
+		{
+			name: "uint64 sign bit array",
+			f: func() {
+				a := [1]int{1}
+				// Array indexing uses a separate IndexAddr path from slices.
+				var idx uint64 = 1 << 63
+				_ = a[idx]
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expectPanicContaining(t, "out of range", tt.f)
+		})
+	}
 }
 
 func expectPanicContaining(t *testing.T, want string, f func()) {


### PR DESCRIPTION
## Summary
- Use unsigned upper-bound checks for index bounds checks.
- Keep signed negative checks where needed, while making large unsigned indexes fail correctly.
- Add regression coverage for `uint64`, `uint`, `uint8`, `uintptr`, and array indexing.

## Example
From `TestUnsignedIndexBoundsCheck`:

```go
s := []int{1}
var idx uint64 = 1 << 63
_ = s[idx]
```

The index is far larger than the slice length and must panic.

## Without This PR
The upper-bound check used a signed comparison. A value such as `uint64(1<<63)` can look negative in a signed compare and bypass the `idx >= len` check instead of panicking as out-of-range.

## Verification
- `go test ./test/go -run TestUnsignedIndexBoundsCheck -count=1`
- `go run ./cmd/llgo test ./test/go -run TestUnsignedIndexBoundsCheck -count=1`
- `go test ./cl -run 'TestCompile|TestRuntime' -count=1`
- `go test ./ssa -count=1`
