### PR TITLE
runtime: match full slice bounds panic text

### DIFF
--- a/runtime/internal/runtime/z_slice.go
+++ b/runtime/internal/runtime/z_slice.go
@@ -34,8 +34,14 @@ type Slice struct {
 }
 
 func NewSlice3(base unsafe.Pointer, eltSize, cap, i, j, k int) (s Slice) {
-	if i < 0 || j < i || k < j || k > cap {
-		panic(errorString("slice bounds out of range"))
+	if k < 0 || k > cap {
+		panic(boundsError{x: int64(k), signed: true, y: cap, code: boundsSlice3Acap})
+	}
+	if j < 0 || j > k {
+		panic(boundsError{x: int64(j), signed: true, y: k, code: boundsSlice3B})
+	}
+	if i < 0 || i > j {
+		panic(boundsError{x: int64(i), signed: true, y: j, code: boundsSlice3C})
 	}
 	s.len = j - i
 	s.cap = k - i

--- a/runtime/internal/runtime/z_slice.go
+++ b/runtime/internal/runtime/z_slice.go
@@ -35,7 +35,7 @@ type Slice struct {
 
 func NewSlice3(base unsafe.Pointer, eltSize, cap, i, j, k int) (s Slice) {
 	if i < 0 || j < i || k < j || k > cap {
-		panic("slice index out of bounds")
+		panic(errorString("slice bounds out of range"))
 	}
 	s.len = j - i
 	s.cap = k - i

--- a/test/go/full_slice_panic_test.go
+++ b/test/go/full_slice_panic_test.go
@@ -18,26 +18,86 @@ package gotest
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 )
 
 func TestFullSliceBoundsPanicText(t *testing.T) {
-	expectFullSlicePanicContaining(t, "slice bounds out of range", func() {
-		s := []int{1}
-		_ = s[:1:2]
-	})
+	tests := []struct {
+		name string
+		want string
+		f    func()
+	}{
+		{
+			name: "max exceeds cap",
+			want: "runtime error: slice bounds out of range [::2] with capacity 1",
+			f: func() {
+				s := []int{1}
+				k := 2
+				_ = s[:1:k]
+			},
+		},
+		{
+			name: "high exceeds max",
+			want: "runtime error: slice bounds out of range [:2:1]",
+			f: func() {
+				s := []int{1, 2}
+				j, k := 2, 1
+				_ = s[:j:k]
+			},
+		},
+		{
+			name: "low exceeds high",
+			want: "runtime error: slice bounds out of range [1:0:]",
+			f: func() {
+				s := []int{1, 2}
+				i, j := 1, 0
+				_ = s[i:j:1]
+			},
+		},
+		{
+			name: "negative low",
+			want: "runtime error: slice bounds out of range [-1::]",
+			f: func() {
+				s := []int{1, 2}
+				i := -1
+				_ = s[i:0:1]
+			},
+		},
+		{
+			name: "negative high",
+			want: "runtime error: slice bounds out of range [:-1:]",
+			f: func() {
+				s := []int{1, 2}
+				j := -1
+				_ = s[0:j:1]
+			},
+		},
+		{
+			name: "negative max",
+			want: "runtime error: slice bounds out of range [::-1]",
+			f: func() {
+				s := []int{1, 2}
+				k := -1
+				_ = s[0:0:k]
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expectFullSlicePanic(t, tt.want, tt.f)
+		})
+	}
 }
 
-func expectFullSlicePanicContaining(t *testing.T, want string, f func()) {
+func expectFullSlicePanic(t *testing.T, want string, f func()) {
 	t.Helper()
 	defer func() {
 		err := recover()
 		if err == nil {
-			t.Fatalf("expected panic containing %q", want)
+			t.Fatalf("expected panic %q", want)
 		}
-		if got := fullSlicePanicString(err); !strings.Contains(got, want) {
-			t.Fatalf("panic = %q, want contains %q", got, want)
+		if got := fullSlicePanicString(err); got != want {
+			t.Fatalf("panic = %q, want %q", got, want)
 		}
 	}()
 	f()

--- a/test/go/full_slice_panic_test.go
+++ b/test/go/full_slice_panic_test.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gotest
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestFullSliceBoundsPanicText(t *testing.T) {
+	expectFullSlicePanicContaining(t, "slice bounds out of range", func() {
+		s := []int{1}
+		_ = s[:1:2]
+	})
+}
+
+func expectFullSlicePanicContaining(t *testing.T, want string, f func()) {
+	t.Helper()
+	defer func() {
+		err := recover()
+		if err == nil {
+			t.Fatalf("expected panic containing %q", want)
+		}
+		if got := fullSlicePanicString(err); !strings.Contains(got, want) {
+			t.Fatalf("panic = %q, want contains %q", got, want)
+		}
+	}()
+	f()
+}
+
+func fullSlicePanicString(v any) string {
+	if err, ok := v.(interface{ Error() string }); ok {
+		return err.Error()
+	}
+	return fmt.Sprint(v)
+}


### PR DESCRIPTION
## Summary
- Use `boundsError` for full-slice expression panics.
- Match Go's detailed panic text for `s[i:j:k]` failures.
- Add table-driven coverage for `k > cap`, `j > k`, `i > j`, and negative bounds.

## Example
From `TestFullSliceBoundsPanicText`:

```go
s := []int{1}
k := 2
_ = s[:1:k]
```

Go reports `runtime error: slice bounds out of range [::2] with capacity 1`.

## Without This PR
LLGO only panics with a generic `slice bounds out of range` string. Code/tests that compare Go's detailed bounds panic text fail, and recover sees less precise runtime error information.

## Verification
- `go test ./test/go -run TestFullSliceBoundsPanicText -count=1`
- `go run ./cmd/llgo test ./test/go -run TestFullSliceBoundsPanicText -count=1`
