### PR TITLE
runtime: delay map iterator advance

### DIFF
--- a/runtime/internal/runtime/z_map.go
+++ b/runtime/internal/runtime/z_map.go
@@ -67,19 +67,34 @@ func MapClear(t *maptype, h *hmap) {
 	mapclear(t, h)
 }
 
-func NewMapIter(t *maptype, h *hmap) *hiter {
-	var it hiter
-	mapiterinit(t, h, &it)
+type llgoMapIter struct {
+	hiter
+	ready bool
+}
+
+func NewMapIter(t *maptype, h *hmap) *llgoMapIter {
+	var it llgoMapIter
+	mapiterinit(t, h, &it.hiter)
+	it.ready = true
 	return &it
 }
 
-func MapIterNext(it *hiter) (ok bool, k unsafe.Pointer, v unsafe.Pointer) {
+func MapIterNext(it *llgoMapIter) (ok bool, k unsafe.Pointer, v unsafe.Pointer) {
+	if !it.ready {
+		mapiternext(&it.hiter)
+		it.ready = true
+	}
+	if it.h == nil || it.h.count == 0 {
+		it.key = nil
+		it.elem = nil
+		return
+	}
 	if it.key == nil {
 		return
 	}
 	ok = true
 	k, v = it.key, it.elem
-	mapiternext(it)
+	it.ready = false
 	return
 }
 

--- a/runtime/internal/runtime/z_map.go
+++ b/runtime/internal/runtime/z_map.go
@@ -69,6 +69,9 @@ func MapClear(t *maptype, h *hmap) {
 
 type llgoMapIter struct {
 	hiter
+	// ready reports whether hiter.key/elem is still waiting to be yielded.
+	// Advancing is delayed until the next call so mutation after yield can stop
+	// iteration before mapiternext touches cleared map state.
 	ready bool
 }
 
@@ -80,14 +83,14 @@ func NewMapIter(t *maptype, h *hmap) *llgoMapIter {
 }
 
 func MapIterNext(it *llgoMapIter) (ok bool, k unsafe.Pointer, v unsafe.Pointer) {
-	if !it.ready {
-		mapiternext(&it.hiter)
-		it.ready = true
-	}
 	if it.h == nil || it.h.count == 0 {
 		it.key = nil
 		it.elem = nil
 		return
+	}
+	if !it.ready {
+		mapiternext(&it.hiter)
+		it.ready = true
 	}
 	if it.key == nil {
 		return

--- a/test/go/map_iter_clear_test.go
+++ b/test/go/map_iter_clear_test.go
@@ -1,0 +1,28 @@
+package gotest
+
+import "testing"
+
+func mapIterClearNaN() float64 {
+	var x, y float64
+	return x / y
+}
+
+func TestMapIterClearAfterGrowStops(t *testing.T) {
+	m := map[float64]int{}
+	for i := 0; i < 8; i++ {
+		m[mapIterClearNaN()] = i
+	}
+
+	start := true
+	for _, v := range m {
+		if start {
+			for i := 0; i < 10; i++ {
+				m[float64(i)] = i
+			}
+			clear(m)
+			start = false
+			continue
+		}
+		t.Fatalf("map iteration continued after clear; unexpected value %d", v)
+	}
+}

--- a/test/go/map_iter_clear_test.go
+++ b/test/go/map_iter_clear_test.go
@@ -26,3 +26,19 @@ func TestMapIterClearAfterGrowStops(t *testing.T) {
 		t.Fatalf("map iteration continued after clear; unexpected value %d", v)
 	}
 }
+
+func TestMapIterClearStops(t *testing.T) {
+	m := map[int]int{1: 1, 2: 2, 3: 3}
+	sawFirst := false
+	for _, v := range m {
+		if !sawFirst {
+			clear(m)
+			sawFirst = true
+			continue
+		}
+		t.Fatalf("map iteration continued after clear; unexpected value %d", v)
+	}
+	if !sawFirst {
+		t.Fatal("map iteration did not start")
+	}
+}


### PR DESCRIPTION
## Summary
- Delay map iterator advancement until the next `MapIterNext` call.
- Stop iteration before advancing when the loop body clears the map.
- Add `./test/go` coverage for clear-after-grow and ordinary map clear cases.

## Example
From `TestMapIterClearAfterGrowStops`:

```go
for _, v := range m {
    clear(m)
    continue
    _ = v
}
```

After `clear(m)`, iteration should stop; it must not yield stale entries from old buckets.

## Without This PR
LLGO advances the runtime map iterator too early. If the loop body mutates or clears the map, the already-prefetched next entry can make iteration continue after clear, causing extra values or stale map state access.

## Verification
- `go test ./test/go -run TestMapIterClear -count=1`
- `go run ./cmd/llgo test ./test/go -run TestMapIterClear -count=1`
- `go test ./test/go -count=1`
