### PR TITLE
build: add no-pie for linux host executables

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1124,8 +1124,10 @@ func needsLinuxNoPIE(ctx *context, linkArgs []string) bool {
 	if ctx.buildConf.Target != "" || ctx.buildConf.Goos != "linux" {
 		return false
 	}
+	// Host Linux toolchains commonly default to PIE executables, which can
+	// break runtime assumptions unless the user explicitly requested a PIE mode.
 	for _, arg := range linkArgs {
-		if arg == "-pie" || arg == "-no-pie" || arg == "-nopie" {
+		if arg == "-pie" || arg == "-static-pie" || arg == "-no-pie" || arg == "-nopie" {
 			return false
 		}
 	}

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1083,7 +1083,9 @@ func linkObjFiles(ctx *context, app string, objFiles, linkArgs []string, verbose
 	case BuildModeCShared:
 		buildArgs = append(buildArgs, "-shared", "-fPIC")
 	case BuildModeExe:
-		// Default executable mode, no additional flags needed
+		if needsLinuxNoPIE(ctx, linkArgs) {
+			buildArgs = append(buildArgs, "-no-pie")
+		}
 	}
 
 	// Add common linker arguments based on target OS and architecture
@@ -1116,6 +1118,18 @@ func linkObjFiles(ctx *context, app string, objFiles, linkArgs []string, verbose
 	cmd := ctx.linker()
 	cmd.Verbose = printCmds
 	return cmd.Link(buildArgs...)
+}
+
+func needsLinuxNoPIE(ctx *context, linkArgs []string) bool {
+	if ctx.buildConf.Target != "" || ctx.buildConf.Goos != "linux" {
+		return false
+	}
+	for _, arg := range linkArgs {
+		if arg == "-pie" || arg == "-no-pie" || arg == "-nopie" {
+			return false
+		}
+	}
+	return true
 }
 
 // archiver returns the archiving tool to use for the current context.

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -32,6 +32,28 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+func TestNeedsLinuxNoPIE(t *testing.T) {
+	ctx := &context{buildConf: &Config{Goos: "linux"}}
+	if !needsLinuxNoPIE(ctx, nil) {
+		t.Fatal("linux executable link should default to -no-pie")
+	}
+	if needsLinuxNoPIE(ctx, []string{"-pie"}) {
+		t.Fatal("explicit -pie should not be overridden")
+	}
+	if needsLinuxNoPIE(ctx, []string{"-no-pie"}) {
+		t.Fatal("existing -no-pie should not be duplicated")
+	}
+	ctx.buildConf.Goos = "darwin"
+	if needsLinuxNoPIE(ctx, nil) {
+		t.Fatal("non-linux executable link should not force -no-pie")
+	}
+	ctx.buildConf.Goos = "linux"
+	ctx.buildConf.Target = "wasi"
+	if needsLinuxNoPIE(ctx, nil) {
+		t.Fatal("named targets should not force host linux -no-pie")
+	}
+}
+
 func mockRun(args []string, cfg *Config) {
 	defer mockable.DisableMock()
 	mockable.EnableMock()

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -37,11 +37,10 @@ func TestNeedsLinuxNoPIE(t *testing.T) {
 	if !needsLinuxNoPIE(ctx, nil) {
 		t.Fatal("linux executable link should default to -no-pie")
 	}
-	if needsLinuxNoPIE(ctx, []string{"-pie"}) {
-		t.Fatal("explicit -pie should not be overridden")
-	}
-	if needsLinuxNoPIE(ctx, []string{"-no-pie"}) {
-		t.Fatal("existing -no-pie should not be duplicated")
+	for _, flag := range []string{"-pie", "-static-pie", "-no-pie", "-nopie"} {
+		if needsLinuxNoPIE(ctx, []string{flag}) {
+			t.Fatalf("explicit %s should not be overridden", flag)
+		}
 	}
 	ctx.buildConf.Goos = "darwin"
 	if needsLinuxNoPIE(ctx, nil) {


### PR DESCRIPTION
## Summary
- Add `-no-pie` when linking Linux host executables by default.
- Do not inject `-no-pie` when the user explicitly requests PIE/no-PIE, including `-static-pie`.
- Keep named cross targets unchanged.

## Example
From `TestNeedsLinuxNoPIE`:

```go
ctx := &context{buildConf: &Config{Goos: "linux"}}
needsLinuxNoPIE(ctx, nil)                 // true
needsLinuxNoPIE(ctx, []string{"-pie"})    // false
needsLinuxNoPIE(ctx, []string{"-static-pie"}) // false
```

Linux host executable builds need a stable default, but explicit linker intent must be respected.

## Without This PR
Host Linux builds may inherit toolchain PIE defaults and break runtime assumptions. Conversely, without the explicit flag checks LLGO could add `-no-pie` on top of user-requested `-pie`/`-static-pie`.

## Verification
- `go test ./internal/build -run TestNeedsLinuxNoPIE -count=1`
- `go test ./internal/build -count=1`
