### PR TITLE
build: preserve single-case select receive order

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1603,7 +1603,7 @@ func createSSAPkg(ctx *context, prog *ssa.Program, p *packages.Package, verbose 
 		pkgSSA = prog.CreatePackage(p.Types, p.Syntax, p.TypesInfo, true)
 		pkgSSA.Build() // TODO(xsw): build concurrently
 		// Apply local SSA fixups once when package SSA is first built.
-		fixSSAOrder(pkgSSA)
+		fixSSAOrder(pkgSSA, p.Syntax)
 	}
 	return pkgSSA
 }

--- a/internal/build/ssa_order_fix.go
+++ b/internal/build/ssa_order_fix.go
@@ -112,6 +112,13 @@ func fixSingleCaseSelectRecvAssignBlock(b *ssa.BasicBlock, recvAssigns map[token
 	}
 	for {
 		changed := false
+		instrIndex := make(map[ssa.Instruction]int, len(b.Instrs))
+		for i, ins := range b.Instrs {
+			instrIndex[ins] = i
+		}
+		// Restart after a move because instruction indexes change. Each move
+		// removes at least one root dependency from before its receive, so the
+		// loop converges once no safely movable dependencies remain.
 		for assignIdx, ins := range b.Instrs {
 			var roots []ssa.Value
 			var val ssa.Value
@@ -133,8 +140,8 @@ func fixSingleCaseSelectRecvAssignBlock(b *ssa.BasicBlock, recvAssigns map[token
 			if !ok {
 				continue
 			}
-			recvIdx := indexOfInstr(b.Instrs, recvInstr)
-			if recvIdx < 0 || recvIdx >= assignIdx {
+			recvIdx, found := instrIndex[recvInstr]
+			if !found || recvIdx >= assignIdx {
 				continue
 			}
 			if moveAssignDepsAfterRecv(b, roots, recv, recvIdx, assignIdx) {
@@ -157,8 +164,8 @@ func selectRecvRoot(v ssa.Value, recvAssigns map[token.Pos]struct{}) (ssa.Value,
 		}
 	case *ssa.Extract:
 		if u, ok := v.Tuple.(*ssa.UnOp); ok && u.Op == token.ARROW {
-			_, ok := recvAssigns[u.Pos()]
-			return u, ok
+			_, found := recvAssigns[u.Pos()]
+			return u, found
 		}
 	}
 	return nil, false
@@ -166,16 +173,20 @@ func selectRecvRoot(v ssa.Value, recvAssigns map[token.Pos]struct{}) (ssa.Value,
 
 func moveAssignDepsAfterRecv(b *ssa.BasicBlock, roots []ssa.Value, recv ssa.Value, recvIdx, assignIdx int) bool {
 	move := make(map[int]struct{})
+	seen := make(map[ssa.Value]struct{})
 	for i := 0; i < recvIdx; i++ {
 		v, ok := b.Instrs[i].(ssa.Value)
 		if !ok || v == nil {
 			continue
 		}
-		if valueDependsOnAny(roots, v) && !valueDependsOn(recv, v, map[ssa.Value]struct{}{}) {
+		if valueDependsOnAny(roots, v, seen) && !valueDependsOnReusing(recv, v, seen) {
 			move[i] = struct{}{}
 		}
 	}
 	if len(move) == 0 {
+		return false
+	}
+	if moveWouldBreakSSA(b.Instrs, move, recvIdx) {
 		return false
 	}
 	deps := make([]ssa.Instruction, 0, len(move))
@@ -194,13 +205,38 @@ func moveAssignDepsAfterRecv(b *ssa.BasicBlock, roots []ssa.Value, recv ssa.Valu
 	return true
 }
 
-func valueDependsOnAny(values []ssa.Value, target ssa.Value) bool {
+func moveWouldBreakSSA(instrs []ssa.Instruction, move map[int]struct{}, recvIdx int) bool {
+	moved := make(map[ssa.Value]struct{}, len(move))
+	for i := range move {
+		if v, ok := instrs[i].(ssa.Value); ok && v != nil {
+			moved[v] = struct{}{}
+		}
+	}
+	for i := 0; i <= recvIdx && i < len(instrs); i++ {
+		if _, moving := move[i]; moving {
+			continue
+		}
+		for v := range moved {
+			if instrUsesValue(instrs[i], v) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func valueDependsOnAny(values []ssa.Value, target ssa.Value, seen map[ssa.Value]struct{}) bool {
 	for _, v := range values {
-		if valueDependsOn(v, target, map[ssa.Value]struct{}{}) {
+		if valueDependsOnReusing(v, target, seen) {
 			return true
 		}
 	}
 	return false
+}
+
+func valueDependsOnReusing(v, target ssa.Value, seen map[ssa.Value]struct{}) bool {
+	clear(seen)
+	return valueDependsOn(v, target, seen)
 }
 
 func fixSSAOrderBlock(b *ssa.BasicBlock) {

--- a/internal/build/ssa_order_fix.go
+++ b/internal/build/ssa_order_fix.go
@@ -1,6 +1,7 @@
 package build
 
 import (
+	"go/ast"
 	"go/token"
 	"go/types"
 
@@ -23,10 +24,11 @@ import (
 // This pass moves loads of local allocs used only for the final Return results
 // to after any intervening calls that use the same alloc pointer, matching the
 // behavior of the Go compiler for the stdlib cases we rely on (e.g. crypto/x509.ParseOID).
-func fixSSAOrder(pkg *ssa.Package) {
+func fixSSAOrder(pkg *ssa.Package, files []*ast.File) {
 	if pkg == nil {
 		return
 	}
+	selectRecvAssigns := collectSingleCaseSelectRecvAssigns(files)
 	visited := make(map[*ssa.Function]struct{})
 	visitFn := func(fn *ssa.Function) {
 		if fn == nil {
@@ -36,7 +38,7 @@ func fixSSAOrder(pkg *ssa.Package) {
 			return
 		}
 		visited[fn] = struct{}{}
-		fixSSAOrderFunc(fn)
+		fixSSAOrderFunc(fn, selectRecvAssigns)
 	}
 
 	for _, mem := range pkg.Members {
@@ -64,16 +66,141 @@ func fixSSAOrderMethods(pkg *ssa.Package, typ types.Type, visitFn func(*ssa.Func
 	}
 }
 
-func fixSSAOrderFunc(fn *ssa.Function) {
+func fixSSAOrderFunc(fn *ssa.Function, selectRecvAssigns map[token.Pos]struct{}) {
 	if fn == nil || len(fn.Blocks) == 0 {
 		return
 	}
 	for _, b := range fn.Blocks {
 		fixSSAOrderBlock(b)
+		fixSingleCaseSelectRecvAssignBlock(b, selectRecvAssigns)
 	}
 	for _, anon := range fn.AnonFuncs {
-		fixSSAOrderFunc(anon)
+		fixSSAOrderFunc(anon, selectRecvAssigns)
 	}
+}
+
+func collectSingleCaseSelectRecvAssigns(files []*ast.File) map[token.Pos]struct{} {
+	ret := make(map[token.Pos]struct{})
+	for _, file := range files {
+		ast.Inspect(file, func(node ast.Node) bool {
+			sel, ok := node.(*ast.SelectStmt)
+			if !ok || sel.Body == nil || len(sel.Body.List) != 1 {
+				return true
+			}
+			clause, ok := sel.Body.List[0].(*ast.CommClause)
+			if !ok {
+				return true
+			}
+			assign, ok := clause.Comm.(*ast.AssignStmt)
+			if !ok || len(assign.Rhs) != 1 {
+				return true
+			}
+			recv, ok := ast.Unparen(assign.Rhs[0]).(*ast.UnaryExpr)
+			if !ok || recv.Op != token.ARROW {
+				return true
+			}
+			ret[recv.OpPos] = struct{}{}
+			return true
+		})
+	}
+	return ret
+}
+
+func fixSingleCaseSelectRecvAssignBlock(b *ssa.BasicBlock, recvAssigns map[token.Pos]struct{}) {
+	if b == nil || len(b.Instrs) == 0 || len(recvAssigns) == 0 {
+		return
+	}
+	for {
+		changed := false
+		for assignIdx, ins := range b.Instrs {
+			var roots []ssa.Value
+			var val ssa.Value
+			switch instr := ins.(type) {
+			case *ssa.Store:
+				roots = []ssa.Value{instr.Addr}
+				val = instr.Val
+			case *ssa.MapUpdate:
+				roots = []ssa.Value{instr.Map, instr.Key}
+				val = instr.Value
+			default:
+				continue
+			}
+			recv, ok := selectRecvRoot(val, recvAssigns)
+			if !ok {
+				continue
+			}
+			recvInstr, ok := recv.(ssa.Instruction)
+			if !ok {
+				continue
+			}
+			recvIdx := indexOfInstr(b.Instrs, recvInstr)
+			if recvIdx < 0 || recvIdx >= assignIdx {
+				continue
+			}
+			if moveAssignDepsAfterRecv(b, roots, recv, recvIdx, assignIdx) {
+				changed = true
+				break
+			}
+		}
+		if !changed {
+			return
+		}
+	}
+}
+
+func selectRecvRoot(v ssa.Value, recvAssigns map[token.Pos]struct{}) (ssa.Value, bool) {
+	switch v := v.(type) {
+	case *ssa.UnOp:
+		if v.Op == token.ARROW {
+			_, ok := recvAssigns[v.Pos()]
+			return v, ok
+		}
+	case *ssa.Extract:
+		if u, ok := v.Tuple.(*ssa.UnOp); ok && u.Op == token.ARROW {
+			_, ok := recvAssigns[u.Pos()]
+			return u, ok
+		}
+	}
+	return nil, false
+}
+
+func moveAssignDepsAfterRecv(b *ssa.BasicBlock, roots []ssa.Value, recv ssa.Value, recvIdx, assignIdx int) bool {
+	move := make(map[int]struct{})
+	for i := 0; i < recvIdx; i++ {
+		v, ok := b.Instrs[i].(ssa.Value)
+		if !ok || v == nil {
+			continue
+		}
+		if valueDependsOnAny(roots, v) && !valueDependsOn(recv, v, map[ssa.Value]struct{}{}) {
+			move[i] = struct{}{}
+		}
+	}
+	if len(move) == 0 {
+		return false
+	}
+	deps := make([]ssa.Instruction, 0, len(move))
+	next := make([]ssa.Instruction, 0, len(b.Instrs))
+	for i, ins := range b.Instrs {
+		if _, ok := move[i]; ok {
+			deps = append(deps, ins)
+			continue
+		}
+		next = append(next, ins)
+		if i == recvIdx {
+			next = append(next, deps...)
+		}
+	}
+	b.Instrs = next
+	return true
+}
+
+func valueDependsOnAny(values []ssa.Value, target ssa.Value) bool {
+	for _, v := range values {
+		if valueDependsOn(v, target, map[ssa.Value]struct{}{}) {
+			return true
+		}
+	}
+	return false
 }
 
 func fixSSAOrderBlock(b *ssa.BasicBlock) {

--- a/internal/build/ssa_order_fix_test.go
+++ b/internal/build/ssa_order_fix_test.go
@@ -1,0 +1,127 @@
+//go:build !llgo
+
+package build
+
+import (
+	"go/ast"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/ssa/ssautil"
+)
+
+func TestFixSSAOrderSingleCaseSelectRecvAssign(t *testing.T) {
+	const src = `package p
+var c = make(chan int, 1)
+var x int
+func checkorder(o int) {}
+func fc(c chan int, o int) chan int { checkorder(o); return c }
+func fp(p *int, o int) *int { checkorder(o); return p }
+func f() {
+	c <- 1
+	select {
+	case *fp(&x, 100) = <-fc(c, 1):
+	}
+}`
+	fn := buildSSAOrderTestPackage(t, src)
+	got := instrOrder(fn, "fc(", "<-", "fp(", "*t")
+	if !inOrder(got, "fc(", "<-", "fp(") {
+		t.Fatalf("single-case select receive assignment order = %v, want fc/receive before fp", got)
+	}
+}
+
+func TestFixSSAOrderPlainRecvAssignKeepsLeftToRight(t *testing.T) {
+	const src = `package p
+var c = make(chan int, 1)
+var x int
+func checkorder(o int) {}
+func fc(c chan int, o int) chan int { checkorder(o); return c }
+func fp(p *int, o int) *int { checkorder(o); return p }
+func f() {
+	c <- 1
+	*fp(&x, 100) = <-fc(c, 1)
+}`
+	fn := buildSSAOrderTestPackage(t, src)
+	got := instrOrder(fn, "fp(", "fc(", "<-")
+	if !inOrder(got, "fp(", "fc(", "<-") {
+		t.Fatalf("plain receive assignment order = %v, want fp before fc/receive", got)
+	}
+}
+
+func TestFixSSAOrderSingleCaseSelectMapAssign(t *testing.T) {
+	const src = `package p
+var c = make(chan int, 1)
+var m = make(map[int]int)
+func checkorder(o int) {}
+func fc(c chan int, o int) chan int { checkorder(o); return c }
+func fn(n, o int) int { checkorder(o); return n }
+func f() {
+	c <- 1
+	select {
+	case m[fn(13, 100)] = <-fc(c, 1):
+	}
+}`
+	fn := buildSSAOrderTestPackage(t, src)
+	got := instrOrder(fn, "fc(", "<-", "fn(")
+	if !inOrder(got, "fc(", "<-", "fn(") {
+		t.Fatalf("single-case select map receive assignment order = %v, want fc/receive before fn", got)
+	}
+}
+
+func buildSSAOrderTestPackage(t *testing.T, src string) *ssa.Function {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "p.go", src, 0)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	files := []*ast.File{file}
+	pkg := types.NewPackage("p", "p")
+	ssapkg, _, err := ssautil.BuildPackage(
+		&types.Config{Importer: importer.Default()},
+		fset,
+		pkg,
+		files,
+		ssa.SanityCheckFunctions|ssa.InstantiateGenerics,
+	)
+	if err != nil {
+		t.Fatalf("BuildPackage: %v", err)
+	}
+	fixSSAOrder(ssapkg, files)
+	fn, ok := ssapkg.Members["f"].(*ssa.Function)
+	if !ok {
+		t.Fatalf("missing function f")
+	}
+	return fn
+}
+
+func instrOrder(fn *ssa.Function, needles ...string) []string {
+	var ret []string
+	for _, block := range fn.Blocks {
+		for _, instr := range block.Instrs {
+			s := instr.String()
+			for _, needle := range needles {
+				if strings.Contains(s, needle) {
+					ret = append(ret, s)
+					break
+				}
+			}
+		}
+	}
+	return ret
+}
+
+func inOrder(instrs []string, needles ...string) bool {
+	pos := 0
+	for _, instr := range instrs {
+		if pos < len(needles) && strings.Contains(instr, needles[pos]) {
+			pos++
+		}
+	}
+	return pos == len(needles)
+}

--- a/internal/build/ssa_order_fix_test.go
+++ b/internal/build/ssa_order_fix_test.go
@@ -73,6 +73,48 @@ func f() {
 	}
 }
 
+func TestFixSSAOrderSingleCaseSelectTwoValueRecv(t *testing.T) {
+	const src = `package p
+var c = make(chan int, 1)
+var x int
+var ok bool
+func checkorder(o int) {}
+func fc(c chan int, o int) chan int { checkorder(o); return c }
+func fp(p *int, o int) *int { checkorder(o); return p }
+func f() {
+	c <- 1
+	select {
+	case *fp(&x, 100), ok = <-fc(c, 1):
+	}
+}`
+	fn := buildSSAOrderTestPackage(t, src)
+	got := instrOrder(fn, "fc(", "<-", "fp(", "*t")
+	if !inOrder(got, "fc(", "<-", "fp(") {
+		t.Fatalf("single-case select two-value receive assignment order = %v, want fc/receive before fp", got)
+	}
+}
+
+func TestFixSSAOrderMultiCaseSelectKeepsLeftToRight(t *testing.T) {
+	const src = `package p
+var c = make(chan int, 1)
+var x int
+func checkorder(o int) {}
+func fc(c chan int, o int) chan int { checkorder(o); return c }
+func fp(p *int, o int) *int { checkorder(o); return p }
+func f() {
+	c <- 1
+	select {
+	case *fp(&x, 100) = <-fc(c, 1):
+	case <-c:
+	}
+}`
+	fn := buildSSAOrderTestPackage(t, src)
+	got := instrOrder(fn, "fc(", "select", "fp(")
+	if !inOrder(got, "fc(", "select", "fp(") {
+		t.Fatalf("multi-case select receive assignment order = %v, want fp after select", got)
+	}
+}
+
 func buildSSAOrderTestPackage(t *testing.T, src string) *ssa.Function {
 	t.Helper()
 	fset := token.NewFileSet()

--- a/test/go/select_recv_order_test.go
+++ b/test/go/select_recv_order_test.go
@@ -1,0 +1,32 @@
+package gotest
+
+import "testing"
+
+var selectRecvOrderTarget int
+
+func TestSingleCaseSelectReceiveAssignOrder(t *testing.T) {
+	order := make([]int, 0, 2)
+	c := make(chan int, 1)
+	selectRecvOrderTarget = 0
+
+	chanArg := func(ch chan int, marker int) chan int {
+		order = append(order, marker)
+		return ch
+	}
+	ptrArg := func(p *int, marker int) *int {
+		order = append(order, marker)
+		return p
+	}
+
+	c <- 42
+	select {
+	case *ptrArg(&selectRecvOrderTarget, 100) = <-chanArg(c, 1):
+	}
+
+	if selectRecvOrderTarget != 42 {
+		t.Fatalf("select receive assignment stored %d, want 42", selectRecvOrderTarget)
+	}
+	if len(order) != 2 || order[0] != 1 || order[1] != 100 {
+		t.Fatalf("single-case select receive assignment order = %v, want [1 100]", order)
+	}
+}


### PR DESCRIPTION
## Summary
- Preserve Go compiler-compatible evaluation order for receive assignments in single-case select statements.
- Apply the reorder only to single-case select receive assignments.
- Add SSA-order unit tests and `./test/go` runtime coverage.

## Example
From `TestSingleCaseSelectReceiveAssignOrder`:

```go
select {
case *fp(&x, 100) = <-fc(c, 1):
}
```

For this single-case select form, the receive side must be evaluated before the assignment destination side.

## Without This PR
LLGO evaluates the assignment destination first. The regression records order `[100 1]` on main, but Go-compatible order is `[1 100]`. This can change side effects and break programs relying on select receive assignment semantics.

## Verification
- `go test ./internal/build -run 'TestFixSSAOrderSingleCaseSelect|TestFixSSAOrderPlainRecv' -count=1`
- `go test ./test/go -run TestSingleCaseSelectReceiveAssignOrder -count=1`
- `go run ./cmd/llgo test ./test/go -run TestSingleCaseSelectReceiveAssignOrder -count=1`
- `go test ./internal/build -count=1`
