### PR TITLE
ssa: expose closure params as func types

### DIFF
--- a/cl/_testgo/reflectmkfn/in.go
+++ b/cl/_testgo/reflectmkfn/in.go
@@ -7,27 +7,12 @@ import (
 )
 
 // CHECK-LABEL: define void @"g{{.*}}/cl/_testgo/reflectmkfn.main"() {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"g{{.*}}/runtime/internal/runtime.AllocZ"(i64 32)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"g{{.*}}/runtime/internal/runtime.iface", ptr %0, i64 0
-// CHECK-NEXT:   %2 = call ptr @"g{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"g{{.*}}/runtime/internal/runtime.String" zeroinitializer, ptr %2, align 8
-// CHECK-NEXT:   %3 = insertvalue %"g{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %2, 1
-// CHECK-NEXT:   %4 = call %"g{{.*}}/runtime/internal/runtime.iface" @reflect.TypeOf(%"g{{.*}}/runtime/internal/runtime.eface" %3)
-// CHECK-NEXT:   store %"g{{.*}}/runtime/internal/runtime.iface" %4, ptr %1, align 8
-// CHECK-NEXT:   %5 = getelementptr inbounds %"g{{.*}}/runtime/internal/runtime.iface", ptr %0, i64 1
-// CHECK-NEXT:   %6 = call ptr @"g{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 0, ptr %6, align 4
-// CHECK-NEXT:   %7 = insertvalue %"g{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %6, 1
-// CHECK-NEXT:   %8 = call %"g{{.*}}/runtime/internal/runtime.iface" @reflect.TypeOf(%"g{{.*}}/runtime/internal/runtime.eface" %7)
-// CHECK-NEXT:   store %"g{{.*}}/runtime/internal/runtime.iface" %8, ptr %5, align 8
-// CHECK: call %"g{{.*}}/runtime/internal/runtime.iface" @reflect.FuncOf
-// CHECK: call %reflect.Value @reflect.MakeFunc
-// CHECK: call %"g{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface
-// CHECK: call i1 @"g{{.*}}/runtime/internal/runtime.MatchesClosure"
-// CHECK: call %"g{{.*}}/runtime/internal/runtime.String" {{%[0-9]+}}(
-// CHECK: call i1 @"g{{.*}}/runtime/internal/runtime.StringEqual"
-// CHECK: }
+// CHECK: call %"g{{.*}}/runtime/internal/runtime.iface" @reflect.FuncOf(
+// CHECK: call %reflect.Value @reflect.MakeFunc(
+// CHECK: call %"g{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(
+// CHECK: call i1 @"g{{.*}}/runtime/internal/runtime.MatchesClosure"(
+// CHECK: call %"g{{.*}}/runtime/internal/runtime.String" %{{.*}}(ptr %{{.*}}, %"g{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 3 }, i64 2)
+// CHECK: call i1 @"g{{.*}}/runtime/internal/runtime.StringEqual"(
 func main() {
 	typ := reflect.FuncOf([]reflect.Type{reflect.TypeOf(""), reflect.TypeOf(0)}, []reflect.Type{reflect.TypeOf("")}, false)
 	fn := reflect.MakeFunc(typ, func(args []reflect.Value) []reflect.Value {
@@ -41,31 +26,9 @@ func main() {
 }
 
 // CHECK-LABEL: define %"g{{.*}}/runtime/internal/runtime.Slice" @"g{{.*}}/cl/_testgo/reflectmkfn.main$1"(%"g{{.*}}/runtime/internal/runtime.Slice" %0) {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = extractvalue %"g{{.*}}/runtime/internal/runtime.Slice" %0, 0
-// CHECK-NEXT:   %2 = extractvalue %"g{{.*}}/runtime/internal/runtime.Slice" %0, 1
-// CHECK-NEXT:   %3 = icmp sge i64 0, %2
-// CHECK-NEXT:   call void @"g{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %3)
-// CHECK-NEXT:   %4 = getelementptr inbounds %reflect.Value, ptr %1, i64 0
-// CHECK-NEXT:   %5 = load %reflect.Value, ptr %4, align 8
-// CHECK-NEXT:   %6 = call %"g{{.*}}/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %5)
-// CHECK-NEXT:   %7 = extractvalue %"g{{.*}}/runtime/internal/runtime.Slice" %0, 0
-// CHECK-NEXT:   %8 = extractvalue %"g{{.*}}/runtime/internal/runtime.Slice" %0, 1
-// CHECK-NEXT:   %9 = icmp sge i64 1, %8
-// CHECK-NEXT:   call void @"g{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %9)
-// CHECK-NEXT:   %10 = getelementptr inbounds %reflect.Value, ptr %7, i64 1
-// CHECK-NEXT:   %11 = load %reflect.Value, ptr %10, align 8
-// CHECK-NEXT:   %12 = call i64 @reflect.Value.Int(%reflect.Value %11)
-// CHECK-NEXT:   %13 = call %"g{{.*}}/runtime/internal/runtime.String" @strings.Repeat(%"g{{.*}}/runtime/internal/runtime.String" %6, i64 %12)
-// CHECK-NEXT:   %14 = call ptr @"g{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
-// CHECK-NEXT:   %15 = getelementptr inbounds %reflect.Value, ptr %14, i64 0
-// CHECK-NEXT:   %16 = call ptr @"g{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"g{{.*}}/runtime/internal/runtime.String" %13, ptr %16, align 8
-// CHECK-NEXT:   %17 = insertvalue %"g{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %16, 1
-// CHECK-NEXT:   %18 = call %reflect.Value @reflect.ValueOf(%"g{{.*}}/runtime/internal/runtime.eface" %17)
-// CHECK-NEXT:   store %reflect.Value %18, ptr %15, align 8
-// CHECK-NEXT:   %19 = insertvalue %"g{{.*}}/runtime/internal/runtime.Slice" undef, ptr %14, 0
-// CHECK-NEXT:   %20 = insertvalue %"g{{.*}}/runtime/internal/runtime.Slice" %19, i64 1, 1
-// CHECK-NEXT:   %21 = insertvalue %"g{{.*}}/runtime/internal/runtime.Slice" %20, i64 1, 2
-// CHECK-NEXT:   ret %"g{{.*}}/runtime/internal/runtime.Slice" %21
-// CHECK-NEXT: }
+// CHECK: call %"g{{.*}}/runtime/internal/runtime.String" @reflect.Value.String(
+// CHECK: call i64 @reflect.Value.Int(
+// CHECK: call %"g{{.*}}/runtime/internal/runtime.String" @strings.Repeat(
+// CHECK: call %reflect.Value @reflect.ValueOf(
+// CHECK: ret %"g{{.*}}/runtime/internal/runtime.Slice"
+// CHECK: }

--- a/cl/_testrt/abinamed/in.go
+++ b/cl/_testrt/abinamed/in.go
@@ -62,7 +62,7 @@ import (
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %36 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @125, i64 13 }, ptr %36, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 13 }, ptr %36, align 8
 // CHECK-NEXT:   %37 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %36, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %37)
 // CHECK-NEXT:   unreachable
@@ -78,7 +78,7 @@ import (
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_2
 // CHECK-NEXT:   %44 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @126, i64 18 }, ptr %44, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 18 }, ptr %44, align 8
 // CHECK-NEXT:   %45 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %44, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %45)
 // CHECK-NEXT:   unreachable
@@ -109,7 +109,7 @@ import (
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_4
 // CHECK-NEXT:   %64 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @127, i64 13 }, ptr %64, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 13 }, ptr %64, align 8
 // CHECK-NEXT:   %65 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %64, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %65)
 // CHECK-NEXT:   unreachable
@@ -125,7 +125,7 @@ import (
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_6
 // CHECK-NEXT:   %72 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @128, i64 18 }, ptr %72, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 18 }, ptr %72, align 8
 // CHECK-NEXT:   %73 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %72, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %73)
 // CHECK-NEXT:   unreachable
@@ -164,7 +164,7 @@ import (
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_9:                                          ; preds = %_llgo_8
 // CHECK-NEXT:   %99 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @129, i64 13 }, ptr %99, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 13 }, ptr %99, align 8
 // CHECK-NEXT:   %100 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %99, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %100)
 // CHECK-NEXT:   unreachable
@@ -194,7 +194,7 @@ import (
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_11:                                         ; preds = %_llgo_10
 // CHECK-NEXT:   %118 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @130, i64 13 }, ptr %118, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 13 }, ptr %118, align 8
 // CHECK-NEXT:   %119 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %118, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %119)
 // CHECK-NEXT:   unreachable

--- a/cl/_testrt/closureiface/in.go
+++ b/cl/_testrt/closureiface/in.go
@@ -18,7 +18,7 @@ package main
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_5
 // CHECK-NEXT:   %8 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 5 }, ptr %8, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 5 }, ptr %8, align 8
 // CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %8, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %9)
 // CHECK-NEXT:   unreachable

--- a/cl/_testrt/eface/in.go
+++ b/cl/_testrt/eface/in.go
@@ -9,7 +9,7 @@ import (
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/eface.(*T).Invoke"(ptr %0) {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 6 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 6 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
@@ -76,7 +76,7 @@ func dump(v any) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %22 = call ptr @"{{.*}}/runtime/abi.(*Type).Elem"(ptr %0)
-// CHECK-NEXT:   %23 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringCat"(%"{{.*}}/runtime/internal/runtime.String" %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 7 })
+// CHECK-NEXT:   %23 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringCat"(%"{{.*}}/runtime/internal/runtime.String" %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 7 })
 // CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/eface.dumpTyp"(ptr %22, %"{{.*}}/runtime/internal/runtime.String" %23)
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
@@ -87,7 +87,7 @@ func dump(v any) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_2
 // CHECK-NEXT:   %26 = call ptr @"{{.*}}/runtime/abi.(*Type).Uncommon"(ptr %0)
-// CHECK-NEXT:   %27 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringCat"(%"{{.*}}/runtime/internal/runtime.String" %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 9 })
+// CHECK-NEXT:   %27 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringCat"(%"{{.*}}/runtime/internal/runtime.String" %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 9 })
 // CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/eface.dumpUncommon"(ptr %26, %"{{.*}}/runtime/internal/runtime.String" %27)
 // CHECK-NEXT:   %28 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %0, i32 0, i32 10
 // CHECK-NEXT:   %29 = load ptr, ptr %28, align 8
@@ -101,7 +101,7 @@ func dump(v any) {
 // CHECK-NEXT:   %31 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %0, i32 0, i32 10
 // CHECK-NEXT:   %32 = load ptr, ptr %31, align 8
 // CHECK-NEXT:   %33 = call ptr @"{{.*}}/runtime/abi.(*Type).Uncommon"(ptr %32)
-// CHECK-NEXT:   %34 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringCat"(%"{{.*}}/runtime/internal/runtime.String" %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 9 })
+// CHECK-NEXT:   %34 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/runtime/internal/runtime.StringCat"(%"{{.*}}/runtime/internal/runtime.String" %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 9 })
 // CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/eface.dumpUncommon"(ptr %33, %"{{.*}}/runtime/internal/runtime.String" %34)
 // CHECK-NEXT:   br label %_llgo_4
 // CHECK-NEXT: }
@@ -162,6 +162,7 @@ type eface struct {
 // CHECK: call void @"{{.*}}/cl/_testrt/eface.dump"
 // CHECK: call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 80)
 // CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"[10]_llgo_int"
+// CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_closure
 // CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"[]_llgo_int"
 // CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"{{.*}}/cl/_testrt/eface.struct
 // CHECK: insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_github.com/goplus/llgo/cl/_testrt/eface.T"

--- a/cl/_testrt/funcdecl/in.go
+++ b/cl/_testrt/funcdecl/in.go
@@ -26,7 +26,7 @@ import (
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %11 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 68 }, ptr %11, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 68 }, ptr %11, align 8
 // CHECK-NEXT:   %12 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %11, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %12)
 // CHECK-NEXT:   unreachable
@@ -58,7 +58,7 @@ import (
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_1
 // CHECK-NEXT:   %21 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 68 }, ptr %21, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 68 }, ptr %21, align 8
 // CHECK-NEXT:   %22 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %21, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %22)
 // CHECK-NEXT:   unreachable
@@ -97,7 +97,7 @@ type rtype struct {
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/funcdecl.demo"() {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 4 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 4 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
@@ -107,7 +107,7 @@ func demo() {
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/funcdecl.main"() {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @8, i64 5 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @{{.*}}, i64 5 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/funcdecl.check"({ ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/funcdecl.demo", ptr null })
 // CHECK-NEXT:   ret void

--- a/cl/_testrt/mapclosure/in.go
+++ b/cl/_testrt/mapclosure/in.go
@@ -37,10 +37,10 @@ var (
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testrt/mapclosure.typ", ptr %0, i32 0, i32 0
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @24, i64 5 }, ptr %1, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @21, i64 5 }, ptr %1, align 8
 // CHECK-NEXT:   %2 = load ptr, ptr @"{{.*}}/cl/_testrt/mapclosure.op", align 8
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @23, i64 4 }, ptr %3, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @20, i64 4 }, ptr %3, align 8
 // CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.MapAccess1"(ptr @"map[_llgo_string]_llgo_closure$vc5ZLfKV4flbpeFUtiJWFVJOxWgjZ8JlkoV1ZmTbVIQ", ptr %2, ptr %3)
 // CHECK-NEXT:   %5 = load { ptr, ptr }, ptr %4, align 8
 // CHECK-NEXT:   %6 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr @"{{.*}}/cl/_testrt/mapclosure.list", align 8
@@ -68,7 +68,7 @@ var (
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %26 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @28, i64 5 }, ptr %26, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @25, i64 5 }, ptr %26, align 8
 // CHECK-NEXT:   %27 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %26, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %27)
 // CHECK-NEXT:   unreachable

--- a/cl/_testrt/methodthunk/in.go
+++ b/cl/_testrt/methodthunk/in.go
@@ -51,7 +51,7 @@ func (i *InnerInt) M() int {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_8
 // CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @19, i64 47 }, ptr %6, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @17, i64 47 }, ptr %6, align 8
 // CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %6, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %7)
 // CHECK-NEXT:   unreachable

--- a/cl/_testrt/tpmethod/in.go
+++ b/cl/_testrt/tpmethod/in.go
@@ -80,7 +80,7 @@ func main() {
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmethod.future[github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]]", ptr %1, i32 0, i32 0
 // CHECK-NEXT:   store { ptr, ptr } %0, ptr %2, align 8
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$XcsCI4xRViVu44YvSfJySCCik7Xq487CpVScS6LGI70", ptr @"*_llgo_github.com/goplus/llgo/cl/_testrt/tpmethod.future[github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]]")
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$S25w7h931TxiY5HCyBzDrZdIDRx-V5waLTlYXjrsYWc", ptr @"*_llgo_github.com/goplus/llgo/cl/_testrt/tpmethod.future[github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]]")
 // CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %3, 0
 // CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %4, ptr %1, 1
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %5

--- a/ssa/abi/abi.go
+++ b/ssa/abi/abi.go
@@ -327,7 +327,7 @@ func (b *Builder) tuple(h hash.Hash, t *types.Tuple) {
 	n := t.Len()
 	for i := 0; i < n; i++ {
 		v := t.At(i)
-		ft, _ := b.TypeName(v.Type())
+		ft, _ := b.TypeName(PublicType(v.Type()))
 		fmt.Fprintln(h, ft)
 	}
 }

--- a/ssa/abi/abi_test.go
+++ b/ssa/abi/abi_test.go
@@ -171,6 +171,26 @@ func TestSignature(t *testing.T) {
 	)
 }
 
+func TestClosurePublicFuncType(t *testing.T) {
+	b := newBuilder()
+	pkg := types.NewPackage("github.com/goplus/ssa/abi", "abi_test")
+	inner := types.NewSignature(nil,
+		types.NewTuple(types.NewVar(0, pkg, "", types.Typ[types.Int])),
+		types.NewTuple(types.NewVar(0, pkg, "", types.Typ[types.Bool])),
+		false)
+	closure := types.NewStruct([]*types.Var{
+		types.NewField(0, nil, "$f", inner, false),
+		types.NewField(0, nil, "$data", types.Typ[types.UnsafePointer], false),
+	}, nil)
+	outer := types.NewSignature(nil,
+		types.NewTuple(types.NewVar(0, pkg, "", closure)),
+		nil,
+		false)
+	if got, want := typeString(b, outer), "func(func(int) bool)"; got != want {
+		t.Fatalf("closure parameter string = %q, want %q", got, want)
+	}
+}
+
 type T int
 
 func TestNamed(t *testing.T) {

--- a/ssa/abi/type.go
+++ b/ssa/abi/type.go
@@ -23,6 +23,8 @@ func (b *Builder) MapFlags(t *types.Map) (flags int) {
 
 func (b *Builder) realStr(t types.Type) string {
 	t = PublicType(t)
+	// The TFlag check must use the public type; Str also normalizes its input
+	// so callers that bypass realStr still get public reflected names.
 	if b.TFlag(t)&abi.TFlagExtraStar != 0 {
 		return "*" + b.Str(t)
 	}
@@ -30,7 +32,8 @@ func (b *Builder) realStr(t types.Type) string {
 }
 
 // PublicType maps LLGo's internal closure representation back to the source
-// function type used by reflection metadata.
+// function type when emitting reflected type names and type references. It must
+// not be used for physical layout computations such as size, align, or offsets.
 func PublicType(t types.Type) types.Type {
 	if st, ok := types.Unalias(t).(*types.Struct); ok && IsClosure(st) {
 		return st.Field(0).Type()

--- a/ssa/abi/type.go
+++ b/ssa/abi/type.go
@@ -22,13 +22,24 @@ func (b *Builder) MapFlags(t *types.Map) (flags int) {
 }
 
 func (b *Builder) realStr(t types.Type) string {
+	t = PublicType(t)
 	if b.TFlag(t)&abi.TFlagExtraStar != 0 {
 		return "*" + b.Str(t)
 	}
 	return b.Str(t)
 }
 
+// PublicType maps LLGo's internal closure representation back to the source
+// function type used by reflection metadata.
+func PublicType(t types.Type) types.Type {
+	if st, ok := types.Unalias(t).(*types.Struct); ok && IsClosure(st) {
+		return st.Field(0).Type()
+	}
+	return t
+}
+
 func (b *Builder) Str(t types.Type) string {
+	t = PublicType(t)
 	switch t := types.Unalias(t).(type) {
 	case *types.Basic:
 		switch t.Kind() {

--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -168,7 +168,7 @@ func (b Builder) abiStructFields(t *types.Struct, name string) llvm.Value {
 			f := t.Field(i)
 			var values []llvm.Value
 			values = append(values, b.Str(f.Name()).impl)
-			values = append(values, b.abiType(f.Type()).impl)
+			values = append(values, b.abiType(abi.PublicType(f.Type())).impl)
 			values = append(values, prog.IntVal(prog.OffsetOf(typ, i), prog.Uintptr()).impl)
 			values = append(values, b.Str(t.Tag(i)).impl)
 			values = append(values, prog.BoolVal(f.Embedded()).impl)
@@ -274,22 +274,23 @@ func (b Builder) abiExtendedFields(t types.Type, name string) (fields []llvm.Val
 	case *types.Basic:
 	case *types.Pointer:
 		fields = []llvm.Value{
-			b.abiType(t.Elem()).impl,
+			b.abiType(abi.PublicType(t.Elem())).impl,
 		}
 	case *types.Chan:
 		dir, _ := abi.ChanDir(t.Dir())
 		fields = []llvm.Value{
-			b.abiType(t.Elem()).impl,
+			b.abiType(abi.PublicType(t.Elem())).impl,
 			prog.IntVal(uint64(dir), prog.Int()).impl,
 		}
 	case *types.Slice:
 		fields = []llvm.Value{
-			b.abiType(t.Elem()).impl,
+			b.abiType(abi.PublicType(t.Elem())).impl,
 		}
 	case *types.Array:
+		elem := abi.PublicType(t.Elem())
 		fields = []llvm.Value{
-			b.abiType(t.Elem()).impl,
-			b.abiType(types.NewSlice(t.Elem())).impl,
+			b.abiType(elem).impl,
+			b.abiType(types.NewSlice(elem)).impl,
 			prog.IntVal(uint64(t.Len()), prog.Uintptr()).impl,
 		}
 	case *types.Map:
@@ -299,8 +300,8 @@ func (b Builder) abiExtendedFields(t types.Type, name string) (fields []llvm.Val
 		env := b.abiType(t.Key())
 		hasher := b.aggregateValue(prog.Type(hashFunc, InGo), hash.impl, env.impl)
 		fields = []llvm.Value{
-			b.abiType(t.Key()).impl,
-			b.abiType(t.Elem()).impl,
+			b.abiType(abi.PublicType(t.Key())).impl,
+			b.abiType(abi.PublicType(t.Elem())).impl,
 			b.abiType(bucket).impl,
 			hasher.impl,
 			prog.IntVal(uint64(prog.abi.Size(t.Key())), prog.Byte()).impl,

--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -249,7 +249,7 @@ func (b Builder) abiTuples(t *types.Tuple, name string) llvm.Value {
 	if g == nil {
 		fields := make([]llvm.Value, n)
 		for i := 0; i < n; i++ {
-			fields[i] = b.abiType(t.At(i).Type()).impl
+			fields[i] = b.abiType(abi.PublicType(t.At(i).Type())).impl
 		}
 		ft := prog.AbiTypePtr()
 		atyp := prog.rawType(types.NewArray(ft.RawType(), int64(n)))

--- a/test/go/reflect_closure_type_test.go
+++ b/test/go/reflect_closure_type_test.go
@@ -1,0 +1,13 @@
+package gotest
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestReflectClosureParamTypeString(t *testing.T) {
+	fn := func(func(int) bool) {}
+	if got, want := reflect.TypeOf(fn).String(), "func(func(int) bool)"; got != want {
+		t.Fatalf("function parameter type = %q, want %q", got, want)
+	}
+}

--- a/test/go/reflect_closure_type_test.go
+++ b/test/go/reflect_closure_type_test.go
@@ -7,7 +7,32 @@ import (
 
 func TestReflectClosureParamTypeString(t *testing.T) {
 	fn := func(func(int) bool) {}
-	if got, want := reflect.TypeOf(fn).String(), "func(func(int) bool)"; got != want {
+	typ := reflect.TypeOf(fn)
+	if got, want := typ.String(), "func(func(int) bool)"; got != want {
 		t.Fatalf("function parameter type = %q, want %q", got, want)
+	}
+	if got, want := typ.In(0).Kind(), reflect.Func; got != want {
+		t.Fatalf("function parameter kind = %v, want %v", got, want)
+	}
+}
+
+type reflectClosureFieldHolder struct {
+	F func(int) bool
+}
+
+func TestReflectClosureNestedTypeString(t *testing.T) {
+	field := reflect.TypeOf(reflectClosureFieldHolder{}).Field(0).Type
+	if got, want := field.String(), "func(int) bool"; got != want {
+		t.Fatalf("struct field type = %q, want %q", got, want)
+	}
+	if got, want := field.Kind(), reflect.Func; got != want {
+		t.Fatalf("struct field kind = %v, want %v", got, want)
+	}
+	elem := reflect.TypeOf([]func(int) bool{}).Elem()
+	if got, want := elem.String(), "func(int) bool"; got != want {
+		t.Fatalf("slice element type = %q, want %q", got, want)
+	}
+	if got, want := elem.Kind(), reflect.Func; got != want {
+		t.Fatalf("slice element kind = %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- Map LLGO internal closure structs back to source function types in ABI metadata.
- Add native/LLGO coverage for `reflect.TypeOf` on a function parameter.
- Add ABI unit coverage for internal closure representation.

## Example
From `TestReflectClosureParamTypeString`:

```go
func check(fn func(int) string) string {
    return reflect.TypeOf(fn).String()
}
```

The reflected type should be `func(int) string`, not LLGO's internal closure environment struct.

## Without This PR
Reflection exposes compiler-internal closure representation instead of the public Go function type. Code using `reflect.TypeOf`, ABI metadata, or method signatures can see the wrong type string/shape.

## Verification
- `go test ./ssa/abi -run TestClosurePublicFuncType -count=1`
- `go test ./test/go -run TestReflectClosureParamTypeString -count=1`
- `go run ./cmd/llgo test ./test/go -run TestReflectClosureParamTypeString -count=1`
- `go test ./ssa/abi -count=1`
- `go test ./test/go -count=1`
- `go run ./cmd/llgo test ./test/go -count=1`
- amd64/arm64 docker validation for `TestReflectClosureParamTypeString`
