### PR TITLE
ssa: apply assignment conversions in value checks

### DIFF
--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -1537,7 +1537,17 @@ func checkExpr(v Expr, t types.Type, b Builder) Expr {
 		}
 		return b.aggregateValue(tclosure, v.impl, data.impl)
 	}
-	return v
+	if types.Identical(v.raw.Type, t) || !types.AssignableTo(v.raw.Type, t) {
+		return v
+	}
+	dst := b.Prog.Type(t, InGo)
+	if _, ok := t.Underlying().(*types.Interface); ok {
+		if _, srcIsInterface := v.raw.Type.Underlying().(*types.Interface); srcIsInterface {
+			return b.ChangeInterface(dst, v)
+		}
+		return b.MakeInterface(dst, v)
+	}
+	return b.ChangeType(dst, v)
 }
 
 func needsNegativeCheck(x Expr) bool {

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -1541,6 +1541,9 @@ func checkExpr(v Expr, t types.Type, b Builder) Expr {
 		return v
 	}
 	dst := b.Prog.Type(t, InGo)
+	// Range and assignment lowering can produce a value whose source type is
+	// assignable but not identical to the destination, so preserve the value
+	// while retagging it with the destination runtime type.
 	if _, ok := t.Underlying().(*types.Interface); ok {
 		if _, srcIsInterface := v.raw.Type.Underlying().(*types.Interface); srcIsInterface {
 			return b.ChangeInterface(dst, v)

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -601,6 +601,45 @@ func TestMakeInterfaceKinds(t *testing.T) {
 	bNE.Return(bNE.MakeInterface(nonEmptyType, prog.Val(7)))
 }
 
+func TestCheckExprAssignmentConversions(t *testing.T) {
+	prog := NewProgram(nil)
+	prog.sizes = types.SizesFor("gc", runtime.GOARCH)
+	prog.SetRuntime(func() *types.Package {
+		pkg, err := importer.For("source", nil).Import(PkgRuntime)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return pkg
+	})
+	pkg := prog.NewPackage("bar", "foo/bar")
+	fn := pkg.NewFunc("checkExprAssignmentConversions", NoArgsNoRet, InGo)
+	b := fn.MakeBody(1)
+
+	pkgTypes := types.NewPackage("foo/bar", "bar")
+	intSlice := types.NewSlice(types.Typ[types.Int])
+	namedSlice := types.NewNamed(types.NewTypeName(token.NoPos, pkgTypes, "checkExprSlice", nil), intSlice, nil)
+	concrete := checkExpr(prog.Zero(prog.Type(namedSlice, InGo)), intSlice, b)
+	if !types.Identical(concrete.RawType(), intSlice) {
+		t.Fatalf("concrete retag type = %v, want %v", concrete.RawType(), intSlice)
+	}
+
+	emptyIface := types.NewInterfaceType(nil, nil)
+	emptyIface.Complete()
+	toIface := checkExpr(prog.Val(7), emptyIface, b)
+	if !types.Identical(toIface.RawType(), emptyIface) {
+		t.Fatalf("concrete-to-interface type = %v, want %v", toIface.RawType(), emptyIface)
+	}
+
+	namedIface := types.NewNamed(types.NewTypeName(token.NoPos, pkgTypes, "checkExprIface", nil), emptyIface, nil)
+	fromIface := b.MakeInterface(prog.Type(namedIface, InGo), prog.Val(7))
+	changedIface := checkExpr(fromIface, emptyIface, b)
+	if !types.Identical(changedIface.RawType(), emptyIface) {
+		t.Fatalf("interface-to-interface type = %v, want %v", changedIface.RawType(), emptyIface)
+	}
+
+	b.Return()
+}
+
 func TestInterfaceHelpers(t *testing.T) {
 	rawSig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
 	rawMeth := types.NewFunc(0, nil, "M", rawSig)

--- a/test/go/range_assignment_conversion_test.go
+++ b/test/go/range_assignment_conversion_test.go
@@ -1,0 +1,110 @@
+package gotest
+
+import (
+	"reflect"
+	"testing"
+)
+
+type rangeAssignmentIface interface{ rangeAssignmentM() int }
+
+type rangeAssignmentKey int
+type rangeAssignmentValue int
+
+func (rangeAssignmentKey) rangeAssignmentM() int   { return 0 }
+func (rangeAssignmentValue) rangeAssignmentM() int { return 0 }
+
+func TestRangeAssignmentConversions(t *testing.T) {
+	k, v := rangeArrayAny[rangeAssignmentValue]()
+	rangeAssignmentMatch2(t, "int", "rangeAssignmentValue", k, v)
+	k, v = rangeArrayIface[rangeAssignmentValue]()
+	rangeAssignmentMatch2(t, "int", "rangeAssignmentValue", k, v)
+	rangeAssignmentMatch1(t, "rangeAssignmentValue", rangeChanAny[rangeAssignmentValue]())
+	rangeAssignmentMatch1(t, "rangeAssignmentValue", rangeChanIface[rangeAssignmentValue]())
+	k, v = rangeMapAny[rangeAssignmentKey, rangeAssignmentValue]()
+	rangeAssignmentMatch2(t, "rangeAssignmentKey", "rangeAssignmentValue", k, v)
+	k, v = rangeMapIface[rangeAssignmentKey, rangeAssignmentValue]()
+	rangeAssignmentMatch2(t, "rangeAssignmentKey", "rangeAssignmentValue", k, v)
+	k, v = rangeSliceAny[rangeAssignmentValue]()
+	rangeAssignmentMatch2(t, "int", "rangeAssignmentValue", k, v)
+	k, v = rangeSliceIface[rangeAssignmentValue]()
+	rangeAssignmentMatch2(t, "int", "rangeAssignmentValue", k, v)
+}
+
+func rangeAssignmentMatch1(t *testing.T, want string, arg any) {
+	t.Helper()
+	if got := reflect.TypeOf(arg).Name(); got != want {
+		t.Fatalf("arg type = %q, want %q", got, want)
+	}
+}
+
+func rangeAssignmentMatch2(t *testing.T, want0, want1 string, arg0, arg1 any) {
+	t.Helper()
+	if got := reflect.TypeOf(arg0).Name(); got != want0 {
+		t.Fatalf("arg 0 type = %q, want %q", got, want0)
+	}
+	if got := reflect.TypeOf(arg1).Name(); got != want1 {
+		t.Fatalf("arg 1 type = %q, want %q", got, want1)
+	}
+}
+
+func rangeArrayAny[V any]() (k, v any) {
+	for k, v = range [...]V{rangeAssignmentZero[V]()} {
+	}
+	return
+}
+
+func rangeArrayIface[V rangeAssignmentIface]() (k any, v rangeAssignmentIface) {
+	for k, v = range [...]V{rangeAssignmentZero[V]()} {
+	}
+	return
+}
+
+func rangeChanAny[V any]() (v any) {
+	for v = range rangeAssignmentChanOf(rangeAssignmentZero[V]()) {
+	}
+	return
+}
+
+func rangeChanIface[V rangeAssignmentIface]() (v rangeAssignmentIface) {
+	for v = range rangeAssignmentChanOf(rangeAssignmentZero[V]()) {
+	}
+	return
+}
+
+func rangeMapAny[K comparable, V any]() (k, v any) {
+	for k, v = range map[K]V{rangeAssignmentZero[K](): rangeAssignmentZero[V]()} {
+	}
+	return
+}
+
+func rangeMapIface[K interface {
+	rangeAssignmentIface
+	comparable
+}, V rangeAssignmentIface]() (k, v rangeAssignmentIface) {
+	for k, v = range map[K]V{rangeAssignmentZero[K](): rangeAssignmentZero[V]()} {
+	}
+	return
+}
+
+func rangeSliceAny[V any]() (k, v any) {
+	for k, v = range []V{rangeAssignmentZero[V]()} {
+	}
+	return
+}
+
+func rangeSliceIface[V rangeAssignmentIface]() (k any, v rangeAssignmentIface) {
+	for k, v = range []V{rangeAssignmentZero[V]()} {
+	}
+	return
+}
+
+func rangeAssignmentChanOf[T any](elems ...T) chan T {
+	c := make(chan T, len(elems))
+	for _, elem := range elems {
+		c <- elem
+	}
+	close(c)
+	return c
+}
+
+func rangeAssignmentZero[T any]() (_ T) { return }

--- a/test/go/range_assignment_conversion_test.go
+++ b/test/go/range_assignment_conversion_test.go
@@ -9,6 +9,7 @@ type rangeAssignmentIface interface{ rangeAssignmentM() int }
 
 type rangeAssignmentKey int
 type rangeAssignmentValue int
+type rangeAssignmentSlice []int
 
 func (rangeAssignmentKey) rangeAssignmentM() int   { return 0 }
 func (rangeAssignmentValue) rangeAssignmentM() int { return 0 }
@@ -28,6 +29,9 @@ func TestRangeAssignmentConversions(t *testing.T) {
 	rangeAssignmentMatch2(t, "int", "rangeAssignmentValue", k, v)
 	k, v = rangeSliceIface[rangeAssignmentValue]()
 	rangeAssignmentMatch2(t, "int", "rangeAssignmentValue", k, v)
+	if got := rangeSliceChangeType(); len(got) != 2 || got[0] != 1 || got[1] != 2 {
+		t.Fatalf("range assignment ChangeType result = %v, want [1 2]", got)
+	}
 }
 
 func rangeAssignmentMatch1(t *testing.T, want string, arg any) {
@@ -94,6 +98,12 @@ func rangeSliceAny[V any]() (k, v any) {
 
 func rangeSliceIface[V rangeAssignmentIface]() (k any, v rangeAssignmentIface) {
 	for k, v = range []V{rangeAssignmentZero[V]()} {
+	}
+	return
+}
+
+func rangeSliceChangeType() (v []int) {
+	for _, v = range []rangeAssignmentSlice{{1, 2}} {
 	}
 	return
 }


### PR DESCRIPTION
## Summary
- Apply assignment conversions when lowering checked values to destination types.
- Fix generic range assignments into `any` and interface destinations.
- Add native/LLGO range conversion coverage plus direct `checkExpr` unit coverage.

## Example
From `TestRangeAssignmentConversions`:

```go
type V int
var out any
for _, out = range []V{1} {
}
if reflect.TypeOf(out).Name() != "V" { panic("lost assignment conversion") }
```

Range assignment can assign a source value to a destination with an assignable but non-identical type. LLGO must retag/convert the lowered value to the destination runtime type.

## Without This PR
Generic range assignments into `any` or interface variables can keep the wrong runtime type. Reflect/type checks see the source lowering type instead of the assignment destination type, causing Go typeparam range cases to fail.

## Verification
- `go test ./test/go -run TestRangeAssignmentConversions -count=1`
- `go run ./cmd/llgo test ./test/go -run TestRangeAssignmentConversions -count=1`
- `go test ./ssa -run TestCheckExprAssignmentConversions -count=1`
- `go test ./ssa -count=1`
- `go test ./test/go -count=1`
- `go run ./cmd/llgo test ./test/go -count=1`
