### PR TITLE
cabi: materialize aggregate call arguments

### DIFF
--- a/internal/cabi/cabi.go
+++ b/internal/cabi/cabi.go
@@ -553,19 +553,8 @@ func (p *Transformer) transformCallInstr(m llvm.Module, ctx llvm.Context, call l
 		case AttrVoid:
 			// none
 		case AttrPointer:
-			if p.optimize {
-				if rv := param.IsALoadInst(); !rv.IsNil() {
-					ptr := rv.Operand(0)
-					if p.sys.SupportByVal() {
-						nparams = append(nparams, ptr)
-					} else {
-						nptr := createAlloca(ti.Type)
-						p.callMemcpy(m, ctx, b, nptr, ptr, ti.Size)
-						nparams = append(nparams, nptr)
-					}
-					break
-				}
-			}
+			// Do not pass a load's source pointer directly. The source memory may
+			// be modified between the load and this call; pass the loaded value.
 			ptr := createAlloca(ti.Type)
 			b.CreateStore(param, ptr)
 			nparams = append(nparams, ptr)

--- a/internal/cabi/cabi_test.go
+++ b/internal/cabi/cabi_test.go
@@ -374,6 +374,14 @@ entry:
 }
 
 func TestAttrPointerCallParamNoLoadSourceReuse(t *testing.T) {
+	for _, arch := range []string{"arm64", "amd64"} {
+		t.Run(arch, func(t *testing.T) {
+			testAttrPointerCallParamNoLoadSourceReuse(t, arch)
+		})
+	}
+}
+
+func testAttrPointerCallParamNoLoadSourceReuse(t *testing.T, arch string) {
 	testIR := `; ModuleID = 'test'
 source_filename = "test"
 
@@ -413,7 +421,7 @@ entry:
 	}
 	defer mod.Dispose()
 
-	conf, _ := buildConf(cabi.ModeAllFunc, "arm64")
+	conf, _ := buildConf(cabi.ModeAllFunc, arch)
 	pkgs, err := build.Do([]string{"./_testdata/demo/demo.go"}, conf)
 	if err != nil {
 		t.Fatalf("Failed to build demo: %v", err)
@@ -429,10 +437,13 @@ entry:
 	if strings.Contains(ir, "call void @sink(ptr byval(%Slice) %src)") {
 		t.Fatalf("call reused load source that is later cleared:\n%s", ir)
 	}
+	if strings.Contains(ir, "call void @sink(ptr %src)") {
+		t.Fatalf("call reused load source that is later cleared:\n%s", ir)
+	}
 	if !strings.Contains(ir, "store %Slice %val, ptr") {
 		t.Fatalf("call argument should be materialized from loaded value:\n%s", ir)
 	}
-	if !strings.Contains(ir, "call void @sink(ptr %") {
+	if !strings.Contains(ir, "call void @sink(ptr") {
 		t.Fatalf("sink call was not rewritten to pointer argument:\n%s", ir)
 	}
 }

--- a/internal/cabi/cabi_test.go
+++ b/internal/cabi/cabi_test.go
@@ -373,6 +373,70 @@ entry:
 	}
 }
 
+func TestAttrPointerCallParamNoLoadSourceReuse(t *testing.T) {
+	testIR := `; ModuleID = 'test'
+source_filename = "test"
+
+%Slice = type { ptr, i64, i64 }
+
+declare void @sink(%Slice)
+declare void @llvm.memset(ptr, i8, i64, i1)
+
+define void @caller() {
+entry:
+  %src = alloca %Slice, align 8
+  %first0 = insertvalue %Slice undef, ptr null, 0
+  %first1 = insertvalue %Slice %first0, i64 3, 1
+  %first2 = insertvalue %Slice %first1, i64 3, 2
+  store %Slice %first2, ptr %src, align 8
+  %val = load %Slice, ptr %src, align 8
+  call void @llvm.memset(ptr %src, i8 0, i64 24, i1 false)
+  call void @sink(%Slice %val)
+  ret void
+}
+`
+
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+
+	tmpfile := filepath.Join(t.TempDir(), "test.ll")
+	if err := os.WriteFile(tmpfile, []byte(testIR), 0644); err != nil {
+		t.Fatalf("Failed to write test IR: %v", err)
+	}
+	buf, err := llvm.NewMemoryBufferFromFile(tmpfile)
+	if err != nil {
+		t.Fatalf("Failed to read test IR: %v", err)
+	}
+	mod, err := ctx.ParseIR(buf)
+	if err != nil {
+		t.Fatalf("Failed to parse test IR: %v", err)
+	}
+	defer mod.Dispose()
+
+	conf, _ := buildConf(cabi.ModeAllFunc, "arm64")
+	pkgs, err := build.Do([]string{"./_testdata/demo/demo.go"}, conf)
+	if err != nil {
+		t.Fatalf("Failed to build demo: %v", err)
+	}
+	tr := cabi.NewTransformer(pkgs[0].LPkg.Prog, "", "", cabi.ModeAllFunc, true)
+	tr.TransformModule("test", mod)
+
+	caller := mod.NamedFunction("caller")
+	if caller.IsNil() {
+		t.Fatal("caller not found")
+	}
+	ir := caller.String()
+	if strings.Contains(ir, "call void @sink(ptr byval(%Slice) %src)") {
+		t.Fatalf("call reused load source that is later cleared:\n%s", ir)
+	}
+	if !strings.Contains(ir, "store %Slice %val, ptr") {
+		t.Fatalf("call argument should be materialized from loaded value:\n%s", ir)
+	}
+	if !strings.Contains(ir, "call void @sink(ptr %") {
+		t.Fatalf("sink call was not rewritten to pointer argument:\n%s", ir)
+	}
+}
+
 // TestModeCFunc_SkipIndirectCallWrapping verifies that ModeCFunc does not
 // rewrite indirect calls. In opaque-pointer IR, indirect callees have empty
 // names and must not be treated as C symbol calls.


### PR DESCRIPTION
## Summary
- Materialize aggregate call arguments loaded from memory before C ABI call rewriting.
- Avoid reusing mutable source memory for byval-style lowered calls.
- Add an `internal/cabi` IR regression test for the transform.

## Example
From `TestAttrPointerCallParamNoLoadSourceReuse`:

```llvm
%v = load %struct.S, ptr %src
store %struct.S zeroinitializer, ptr %src
call void @callee(%struct.S %v)
```

The rewritten call must pass the loaded aggregate value, not a pointer to `%src` after `%src` has been cleared or modified.

## Without This PR
The C ABI transformer can reuse the original load source pointer for aggregate arguments. If that memory is changed before the call, the callee observes the modified data instead of the value that was loaded at the call site.

## Verification
- `go test ./internal/cabi -run TestAttrPointerCallParamNoLoadSourceReuse -count=1`
- `go test ./internal/cabi -count=1`
- `./dev/docker.sh amd64 bash -lc 'go test ./internal/cabi -run TestAttrPointerCallParamNoLoadSourceReuse -count=1'`
- `./dev/docker.sh arm64 bash -lc 'go test ./internal/cabi -run TestAttrPointerCallParamNoLoadSourceReuse -count=1'`
