### PR TITLE
runtime: panic with runtime error for interface equality

### DIFF
--- a/runtime/internal/runtime/z_face.go
+++ b/runtime/internal/runtime/z_face.go
@@ -287,13 +287,14 @@ func EfaceEqual(v, u eface) bool {
 	if v._type != u._type {
 		return false
 	}
+	equal := v._type.Equal
+	if equal == nil {
+		panic(errorString("comparing uncomparable type " + v._type.String()))
+	}
 	if isDirectIface(v._type) {
 		return v.data == u.data
 	}
-	if equal := v._type.Equal; equal != nil {
-		return equal(v.data, u.data)
-	}
-	panic(errorString("comparing uncomparable type " + v._type.String()).Error())
+	return equal(v.data, u.data)
 }
 
 func (v eface) Kind() abi.Kind {

--- a/test/go/interface_uncomparable_panic_test.go
+++ b/test/go/interface_uncomparable_panic_test.go
@@ -1,0 +1,34 @@
+package gotest
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestInterfaceCompareUncomparableDirectValuePanics(t *testing.T) {
+	type uncomparableDirect struct {
+		f func()
+	}
+	v := uncomparableDirect{f: func() {}}
+	expectPanicContaining(t, "comparing uncomparable type gotest.uncomparableDirect", func() {
+		_ = any(v) == any(v)
+	})
+}
+
+func expectPanicContaining(t *testing.T, want string, f func()) {
+	t.Helper()
+	defer func() {
+		err := recover()
+		if err == nil {
+			t.Fatalf("expected panic containing %q", want)
+		}
+		if _, ok := err.(interface{ RuntimeError() }); !ok {
+			t.Fatalf("panic type = %T, want runtime.Error", err)
+		}
+		if got := fmt.Sprint(err); !strings.Contains(got, want) {
+			t.Fatalf("panic = %q, want contains %q", got, want)
+		}
+	}()
+	f()
+}


### PR DESCRIPTION
## Summary
- Make interface equality on uncomparable dynamic values panic with a runtime error value instead of a plain string.
- Check the dynamic type `Equal` function before direct-interface data comparison.
- Add native/LLGO coverage for panic message and recovered panic type.

## Example
From `TestInterfaceCompareUncomparableDirectValuePanics`:

```go
type uncomparableDirect struct { f func() }
v := uncomparableDirect{f: func() {}}
_ = any(v) == any(v)
```

Go panics with a `runtime.Error` value whose message contains `comparing uncomparable type ...`.

## Without This PR
LLGO panics with a plain `string` for this path. Code using `recover()` sees the wrong panic type, and tests that assert Go-compatible `runtime.Error` semantics fail.

## Verification
- `go test ./test/go -run TestInterfaceCompareUncomparableDirectValuePanics -count=1`
- `go run ./cmd/llgo test ./test/go -run TestInterfaceCompareUncomparableDirectValuePanics -count=1`
