### PR TITLE
runtime: keep string base for empty suffix slices

### DIFF
--- a/runtime/internal/runtime/z_string.go
+++ b/runtime/internal/runtime/z_string.go
@@ -66,8 +66,8 @@ func StringSlice(base String, i, j int) String {
 	if i < base.len {
 		return String{c.Advance(base.data, i), j - i}
 	}
-	// Keep the source base for empty suffix slices so repeated slicing
-	// continues to report a stable base pointer like the standard runtime.
+	// Keep the source base for empty suffix slices to avoid advancing past
+	// the underlying allocation while still preserving a stable non-nil base.
 	return String{base.data, 0}
 }
 

--- a/runtime/internal/runtime/z_string.go
+++ b/runtime/internal/runtime/z_string.go
@@ -66,7 +66,9 @@ func StringSlice(base String, i, j int) String {
 	if i < base.len {
 		return String{c.Advance(base.data, i), j - i}
 	}
-	return String{nil, 0}
+	// Keep the source base for empty suffix slices so repeated slicing
+	// continues to report a stable base pointer like the standard runtime.
+	return String{base.data, 0}
 }
 
 type StringIter struct {

--- a/test/go/string_slice_base_test.go
+++ b/test/go/string_slice_base_test.go
@@ -1,0 +1,29 @@
+package gotest
+
+import (
+	"testing"
+	"unsafe"
+)
+
+func TestStringEmptySuffixKeepsBase(t *testing.T) {
+	const s = "hello"
+	base := stringDataBase(s)
+
+	for name, got := range map[string]string{
+		"s[5:]":           s[5:],
+		"s[len(s):]":      s[len(s):],
+		"s[5:5]":          s[5:5],
+		"s[1:][2:][2:]":   s[1:][2:][2:],
+		"s[4:][1:]":       s[4:][1:],
+		"s[4:][1:len(s)]": s[4:][1:len(s[4:])],
+	} {
+		gotBase := stringDataBase(got)
+		if gotBase-base >= uintptr(len(s)) {
+			t.Fatalf("%s data base = %#x, want within original string [%#x, %#x)", name, gotBase, base, base+uintptr(len(s)))
+		}
+	}
+}
+
+func stringDataBase(s string) uintptr {
+	return *(*uintptr)(unsafe.Pointer(&s))
+}

--- a/test/go/string_slice_base_test.go
+++ b/test/go/string_slice_base_test.go
@@ -6,22 +6,31 @@ import (
 )
 
 func TestStringEmptySuffixKeepsBase(t *testing.T) {
-	const s = "hello"
+	s := stringSliceBaseValue()
 	base := stringDataBase(s)
+	n := len(s)
 
-	for name, got := range map[string]string{
-		"s[5:]":           s[5:],
-		"s[len(s):]":      s[len(s):],
-		"s[5:5]":          s[5:5],
-		"s[1:][2:][2:]":   s[1:][2:][2:],
-		"s[4:][1:]":       s[4:][1:],
-		"s[4:][1:len(s)]": s[4:][1:len(s[4:])],
-	} {
-		gotBase := stringDataBase(got)
+	tail := s[n-1:]
+	cases := []struct {
+		name string
+		got  string
+	}{
+		{"s[n:]", s[n:]},
+		{"s[n:n]", s[n:n]},
+		{"s[1:][2:][2:]", s[1:][2:][2:]},
+		{"s[n-1:][1:]", tail[1:]},
+		{"s[n-1:][1:len(s[n-1:])]", tail[1:len(tail)]},
+	}
+	for _, tc := range cases {
+		gotBase := stringDataBase(tc.got)
 		if gotBase-base >= uintptr(len(s)) {
-			t.Fatalf("%s data base = %#x, want within original string [%#x, %#x)", name, gotBase, base, base+uintptr(len(s)))
+			t.Errorf("%s data base = %#x, want within original string [%#x, %#x)", tc.name, gotBase, base, base+uintptr(len(s)))
 		}
 	}
+}
+
+func stringSliceBaseValue() string {
+	return string([]byte{'h', 'e', 'l', 'l', 'o'})
 }
 
 func stringDataBase(s string) uintptr {


### PR DESCRIPTION
## Problem

LLGO lost the string data base when slicing a non-empty string to an empty suffix. Go keeps the empty suffix base within the original string range, and code that depends on string slice bases can observe the difference.

```go
const s = "hello"
base := *(*uintptr)(unsafe.Pointer(&s))
tail := s[len(s):]
tailBase := *(*uintptr)(unsafe.Pointer(&tail))
if tailBase-base >= uintptr(len(s)) {
    panic("empty suffix lost string base")
}
```

Without this PR, LLGO returns a `0x0` data base for `s[5:]` / `s[len(s):]`, so the new `./test/go` case fails.

## Fix

Keep the advanced data pointer in `runtime.StringSlice` when the result is an empty suffix. Only return a nil base when the source string itself has a nil data pointer.

## Tests

- `go test ./test/go -run '^TestStringEmptySuffixKeepsBase$'`
- `LLGO_ROOT=$PWD ./dev/llgo.sh test ./test/go -run '^TestStringEmptySuffixKeepsBase$'`
- `go test ./test/go`
- `./dev/docker.sh amd64 bash -lc "go test ./test/go -run '^TestStringEmptySuffixKeepsBase$' && LLGO_ROOT=\$PWD ./dev/llgo.sh test ./test/go -run '^TestStringEmptySuffixKeepsBase$'"`
- `./dev/docker.sh arm64 bash -lc "go test ./test/go -run '^TestStringEmptySuffixKeepsBase$' && LLGO_ROOT=\$PWD ./dev/llgo.sh test ./test/go -run '^TestStringEmptySuffixKeepsBase$'"`
