### PR TITLE
runtime: fix mixed unbuffered select progress

### DIFF
--- a/runtime/internal/runtime/z_chan.go
+++ b/runtime/internal/runtime/z_chan.go
@@ -31,14 +31,16 @@ const (
 )
 
 type Chan struct {
-	mutex    sync.Mutex
-	cond     sync.Cond
-	data     unsafe.Pointer
-	getp     int
-	len      int
-	cap      int
-	sops     []*selectOp
-	sends    uint16
+	mutex sync.Mutex
+	cond  sync.Cond
+	data  unsafe.Pointer
+	getp  int
+	len   int
+	cap   int
+	sops  []*selectOp
+	// sends counts goroutines blocked in unbuffered send, including select-send.
+	sends uint16
+	// selsends is the subset of sends originating from select operations.
 	selsends uint16
 	close    bool
 }
@@ -120,7 +122,7 @@ func ChanSend(p *Chan, v unsafe.Pointer, eltSize int) bool {
 			p.sends++
 			// A blocked unbuffered send must wake select-based receivers so they can
 			// retry ChanTryRecv after observing that a sender is now waiting.
-			if p.sends == 1 {
+			if p.sends == 1 || p.sends-1 == p.selsends {
 				notifyOps(p)
 			}
 			p.cond.Wait(&p.mutex)
@@ -156,7 +158,7 @@ func ChanTryRecv(p *Chan, v unsafe.Pointer, eltSize int) (recvOK bool, tryOK boo
 	return chanTryRecv(p, v, eltSize, true)
 }
 
-func chanTryRecv(p *Chan, v unsafe.Pointer, eltSize int, waitSelectSend bool) (recvOK bool, tryOK bool) {
+func chanTryRecv(p *Chan, v unsafe.Pointer, eltSize int, acceptSelectSend bool) (recvOK bool, tryOK bool) {
 	n := p.cap
 	p.mutex.Lock()
 	if n == 0 {
@@ -165,7 +167,7 @@ func chanTryRecv(p *Chan, v unsafe.Pointer, eltSize int, waitSelectSend bool) (r
 			p.mutex.Unlock()
 			return
 		}
-		if !waitSelectSend && p.sends == p.selsends {
+		if !acceptSelectSend && p.sends == p.selsends {
 			p.mutex.Unlock()
 			return
 		}
@@ -314,6 +316,7 @@ func Select(ops ...ChanOp) (isel int, recvOK bool) {
 	selOp := new(selectOp) // TODO(xsw): use c.AllocaNew[selectOp]()
 	selOp.init()
 	sendFirst := selectSendFirst(ops)
+	sendChans := selectSendChans(ops)
 	for _, op := range ops {
 		if op.C == nil {
 			continue
@@ -322,7 +325,7 @@ func Select(ops ...ChanOp) (isel int, recvOK bool) {
 	}
 	var tryOK bool
 	for {
-		if isel, recvOK, tryOK = trySelect(ops, sendFirst); tryOK {
+		if isel, recvOK, tryOK = trySelect(ops, sendFirst, sendChans); tryOK {
 			break
 		}
 		selOp.wait()
@@ -337,20 +340,24 @@ func Select(ops ...ChanOp) (isel int, recvOK bool) {
 	return
 }
 
-func trySelect(ops []ChanOp, sendFirst bool) (isel int, recvOK, tryOK bool) {
+func trySelect(ops []ChanOp, sendFirst bool, sendChans map[*Chan]bool) (isel int, recvOK, tryOK bool) {
+	// Split probing by direction. If sends are probed first, the recv phase must
+	// not accept select-only senders, because this select's own sends already
+	// failed to commit to a peer. If recvs are probed first, they may accept
+	// select-senders because our own sends have not been attempted yet.
 	if sendFirst {
-		if isel, recvOK, tryOK = trySelectDir(ops, true, false); tryOK {
+		if isel, recvOK, tryOK = trySelectDir(ops, true, false, nil); tryOK {
 			return
 		}
-		return trySelectDir(ops, false, false)
+		return trySelectDir(ops, false, false, sendChans)
 	}
-	if isel, recvOK, tryOK = trySelectDir(ops, false, true); tryOK {
+	if isel, recvOK, tryOK = trySelectDir(ops, false, true, sendChans); tryOK {
 		return
 	}
-	return trySelectDir(ops, true, true)
+	return trySelectDir(ops, true, true, nil)
 }
 
-func trySelectDir(ops []ChanOp, send bool, waitSelectSend bool) (isel int, recvOK, tryOK bool) {
+func trySelectDir(ops []ChanOp, send bool, acceptSelectSend bool, sendChans map[*Chan]bool) (isel int, recvOK, tryOK bool) {
 	for isel = range ops {
 		op := ops[isel]
 		if op.C == nil || op.Send != send {
@@ -362,24 +369,25 @@ func trySelectDir(ops []ChanOp, send bool, waitSelectSend bool) (isel int, recvO
 			}
 			continue
 		}
-		wait := waitSelectSend
-		if wait && selectHasSendOnChan(ops, op.C) {
-			wait = false
+		accept := acceptSelectSend
+		if accept && sendChans[op.C] {
+			accept = false
 		}
-		if recvOK, tryOK = chanTryRecv(op.C, op.Val, int(op.Size), wait); tryOK {
+		if recvOK, tryOK = chanTryRecv(op.C, op.Val, int(op.Size), accept); tryOK {
 			return
 		}
 	}
 	return
 }
 
-func selectHasSendOnChan(ops []ChanOp, c *Chan) bool {
+func selectSendChans(ops []ChanOp) map[*Chan]bool {
+	sendChans := make(map[*Chan]bool)
 	for _, op := range ops {
-		if op.C == c && op.Send {
-			return true
+		if op.C != nil && op.Send {
+			sendChans[op.C] = true
 		}
 	}
-	return false
+	return sendChans
 }
 
 func selectSendFirst(ops []ChanOp) bool {
@@ -405,6 +413,9 @@ func selectSendFirst(ops []ChanOp) bool {
 	if minRecv == maxUintptr {
 		return true
 	}
+	// Deterministically break mirrored select ties by channel address. Peers
+	// operating on the same channel pair with swapped directions then probe in
+	// opposite orders, allowing at least one side to make progress.
 	return minSend < minRecv
 }
 

--- a/runtime/internal/runtime/z_chan.go
+++ b/runtime/internal/runtime/z_chan.go
@@ -31,15 +31,16 @@ const (
 )
 
 type Chan struct {
-	mutex sync.Mutex
-	cond  sync.Cond
-	data  unsafe.Pointer
-	getp  int
-	len   int
-	cap   int
-	sops  []*selectOp
-	sends uint16
-	close bool
+	mutex    sync.Mutex
+	cond     sync.Cond
+	data     unsafe.Pointer
+	getp     int
+	len      int
+	cap      int
+	sops     []*selectOp
+	sends    uint16
+	selsends uint16
+	close    bool
 }
 
 func NewChan(eltSize, cap int) *Chan {
@@ -152,11 +153,19 @@ func ChanSend(p *Chan, v unsafe.Pointer, eltSize int) bool {
 }
 
 func ChanTryRecv(p *Chan, v unsafe.Pointer, eltSize int) (recvOK bool, tryOK bool) {
+	return chanTryRecv(p, v, eltSize, true)
+}
+
+func chanTryRecv(p *Chan, v unsafe.Pointer, eltSize int, waitSelectSend bool) (recvOK bool, tryOK bool) {
 	n := p.cap
 	p.mutex.Lock()
 	if n == 0 {
 		if p.sends == 0 || p.getp == chanHasRecv || p.close {
 			tryOK = p.close
+			p.mutex.Unlock()
+			return
+		}
+		if !waitSelectSend && p.sends == p.selsends {
 			p.mutex.Unlock()
 			return
 		}
@@ -304,6 +313,7 @@ func TrySelect(ops ...ChanOp) (isel int, recvOK, tryOK bool) {
 func Select(ops ...ChanOp) (isel int, recvOK bool) {
 	selOp := new(selectOp) // TODO(xsw): use c.AllocaNew[selectOp]()
 	selOp.init()
+	sendFirst := selectSendFirst(ops)
 	for _, op := range ops {
 		if op.C == nil {
 			continue
@@ -312,7 +322,7 @@ func Select(ops ...ChanOp) (isel int, recvOK bool) {
 	}
 	var tryOK bool
 	for {
-		if isel, recvOK, tryOK = TrySelect(ops...); tryOK {
+		if isel, recvOK, tryOK = trySelect(ops, sendFirst); tryOK {
 			break
 		}
 		selOp.wait()
@@ -327,6 +337,77 @@ func Select(ops ...ChanOp) (isel int, recvOK bool) {
 	return
 }
 
+func trySelect(ops []ChanOp, sendFirst bool) (isel int, recvOK, tryOK bool) {
+	if sendFirst {
+		if isel, recvOK, tryOK = trySelectDir(ops, true, false); tryOK {
+			return
+		}
+		return trySelectDir(ops, false, false)
+	}
+	if isel, recvOK, tryOK = trySelectDir(ops, false, true); tryOK {
+		return
+	}
+	return trySelectDir(ops, true, true)
+}
+
+func trySelectDir(ops []ChanOp, send bool, waitSelectSend bool) (isel int, recvOK, tryOK bool) {
+	for isel = range ops {
+		op := ops[isel]
+		if op.C == nil || op.Send != send {
+			continue
+		}
+		if op.Send {
+			if tryOK = ChanTrySend(op.C, op.Val, int(op.Size)); tryOK {
+				return
+			}
+			continue
+		}
+		wait := waitSelectSend
+		if wait && selectHasSendOnChan(ops, op.C) {
+			wait = false
+		}
+		if recvOK, tryOK = chanTryRecv(op.C, op.Val, int(op.Size), wait); tryOK {
+			return
+		}
+	}
+	return
+}
+
+func selectHasSendOnChan(ops []ChanOp, c *Chan) bool {
+	for _, op := range ops {
+		if op.C == c && op.Send {
+			return true
+		}
+	}
+	return false
+}
+
+func selectSendFirst(ops []ChanOp) bool {
+	const maxUintptr = ^uintptr(0)
+	minRecv := maxUintptr
+	minSend := maxUintptr
+	for _, op := range ops {
+		if op.C == nil {
+			continue
+		}
+		addr := uintptr(unsafe.Pointer(op.C))
+		if op.Send {
+			if addr < minSend {
+				minSend = addr
+			}
+		} else if addr < minRecv {
+			minRecv = addr
+		}
+	}
+	if minSend == maxUintptr {
+		return false
+	}
+	if minRecv == maxUintptr {
+		return true
+	}
+	return minSend < minRecv
+}
+
 func prepareSelect(c *Chan, selOp *selectOp, isSend bool) {
 	c.mutex.Lock()
 	// Unbuffered channel select support:
@@ -338,6 +419,7 @@ func prepareSelect(c *Chan, selOp *selectOp, isSend bool) {
 	// net.Pipe) to avoid deadlocks.
 	if c.cap == 0 && isSend {
 		c.sends++
+		c.selsends++
 	}
 	c.sops = append(c.sops, selOp)
 	if c.cap == 0 && isSend {
@@ -351,6 +433,7 @@ func endSelect(c *Chan, selOp *selectOp, isSend bool) {
 	c.mutex.Lock()
 	if c.cap == 0 && isSend {
 		c.sends--
+		c.selsends--
 	}
 	for i, op := range c.sops {
 		if op == selOp {

--- a/test/select_test.go
+++ b/test/select_test.go
@@ -52,3 +52,34 @@ func TestSelectRecvWakesForBlockedUnbufferedSend(t *testing.T) {
 		close(done)
 	}
 }
+
+func TestSelectMixedUnbufferedPeersMakeProgress(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		a := make(chan struct{})
+		b := make(chan struct{})
+		done := make(chan struct{}, 2)
+
+		go func() {
+			select {
+			case <-a:
+			case b <- struct{}{}:
+			}
+			done <- struct{}{}
+		}()
+		go func() {
+			select {
+			case <-b:
+			case a <- struct{}{}:
+			}
+			done <- struct{}{}
+		}()
+
+		for j := 0; j < 2; j++ {
+			select {
+			case <-done:
+			case <-time.After(200 * time.Millisecond):
+				t.Fatalf("iteration %d: mixed unbuffered select peers did not make progress", i)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

Fixes llgo runtime select progress when two goroutines use mixed unbuffered receive/send selects against each other.

```go
go func() {
    select {
    case <-a:
    case b <- struct{}{}:
    }
    done <- struct{}{}
}()
go func() {
    select {
    case <-b:
    case a <- struct{}{}:
    }
    done <- struct{}{}
}()
```

Without this change, llgo can deadlock because a select receive may wait on a select-send that only advertised possible progress but has not committed to sending yet. The runtime now tracks select-sends separately from real blocked sends, chooses a deterministic send/receive probing order, and avoids pairing a select receive with a send case from the same select.

## Tests

- `go test ./test`
- `LLGO_ROOT=$PWD ./dev/llgo.sh test ./test`
