### PR TITLE
ssa: distinguish generic local runtime types

### DIFF
--- a/cl/compile.go
+++ b/cl/compile.go
@@ -341,10 +341,14 @@ func (p *context) compileFuncDecl(pkg llssa.Package, f *ssa.Function) (llssa.Fun
 	if ftype != goFunc {
 		return nil, nil, ignoredFunc
 	}
-	oldGoFn := p.goFn
-	p.goFn = f
-	sig := p.patchType(f.Signature).(*types.Signature)
-	p.goFn = oldGoFn
+	sig := func() *types.Signature {
+		oldGoFn := p.goFn
+		p.goFn = f
+		defer func() {
+			p.goFn = oldGoFn
+		}()
+		return p.patchType(f.Signature).(*types.Signature)
+	}()
 	state := p.state
 	isInit := (f.Name() == "init" && sig.Recv() == nil)
 	if isInit && state == pkgHasPatch {
@@ -1363,6 +1367,23 @@ func (p *context) _patchType(typ types.Type) (types.Type, bool) {
 		if t, ok := p._patchType(typ.Elem()); ok {
 			return types.NewChan(typ.Dir(), t), true
 		}
+	case *types.Struct:
+		var patched bool
+		vars := make([]*types.Var, typ.NumFields())
+		tags := make([]string, typ.NumFields())
+		for i := 0; i < typ.NumFields(); i++ {
+			v := typ.Field(i)
+			if t, ok := p._patchType(v.Type()); ok {
+				vars[i] = types.NewField(v.Pos(), v.Pkg(), v.Name(), t, v.Anonymous())
+				patched = true
+			} else {
+				vars[i] = v
+			}
+			tags[i] = typ.Tag(i)
+		}
+		if patched {
+			return types.NewStruct(vars, tags), true
+		}
 	case *types.Named:
 		if t, ok := p.patchLocalGenericNamed(typ); ok {
 			return t, true
@@ -1405,13 +1426,25 @@ func (p *context) patchLocalGenericNamed(t *types.Named) (*types.Named, bool) {
 	if p.goFn == nil || len(p.goFn.TypeArgs()) == 0 || !p.isGenericLocalType(t.Obj()) {
 		return nil, false
 	}
-	obj := types.NewTypeName(token.NoPos, t.Obj().Pkg(), p.localNamedName(t, false), nil)
+	if isPatchedLocalGenericName(t.Obj().Name()) {
+		return nil, false
+	}
+	obj := types.NewTypeName(t.Obj().Pos(), t.Obj().Pkg(), p.localNamedName(t, true), nil)
 	return types.NewNamed(obj, t.Underlying(), nil), true
+}
+
+func isPatchedLocalGenericName(name string) bool {
+	// The patched name embeds type arguments in brackets. Go identifiers cannot
+	// contain '[', so this also prevents repeatedly expanding the generated name.
+	return strings.Contains(name, "[")
 }
 
 func (p *context) localNamedName(t *types.Named, suffix bool) string {
 	obj := t.Obj()
 	name := obj.Name()
+	if isPatchedLocalGenericName(name) {
+		return name
+	}
 	outer := p.localTypeOuterArgs(obj)
 	own := typeListArgs(t.TypeArgs(), p.typeArgName)
 	switch {
@@ -1431,6 +1464,8 @@ func (p *context) localNamedName(t *types.Named, suffix bool) string {
 }
 
 func (p *context) localTypeOuterArgs(obj types.Object) []string {
+	// localNamedName is also used by non-local type arguments, so keep this
+	// guard here even though patchLocalGenericNamed has already checked it.
 	if p.goFn == nil || len(p.goFn.TypeArgs()) == 0 || !p.isGenericLocalType(obj) {
 		return nil
 	}
@@ -1454,6 +1489,8 @@ func typeListArgs(list *types.TypeList, nameOf func(types.Type) string) []string
 }
 
 func (p *context) typeArgName(t types.Type) string {
+	// Keep this formatter aligned with ssa/abi.typeArgString; this variant must
+	// additionally encode local generic type names while patching frontend types.
 	switch t := t.(type) {
 	case *types.Alias:
 		return p.typeArgName(types.Unalias(t))
@@ -1462,7 +1499,7 @@ func (p *context) typeArgName(t types.Type) string {
 	case *types.Named:
 		name := p.localNamedName(t, p.isLocalType(t.Obj()))
 		if pkg := t.Obj().Pkg(); pkg != nil {
-			return pkg.Name() + "." + name
+			return pkg.Path() + "." + name
 		}
 		return name
 	case *types.Pointer:

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -26,6 +26,7 @@ import (
 	"log"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/goplus/llgo/cl/blocks"
@@ -140,6 +141,7 @@ type context struct {
 	prog        llssa.Program
 	pkg         llssa.Package
 	fn          llssa.Function
+	goFn        *ssa.Function
 	fset        *token.FileSet
 	goProg      *ssa.Program
 	goTyps      *types.Package
@@ -339,7 +341,10 @@ func (p *context) compileFuncDecl(pkg llssa.Package, f *ssa.Function) (llssa.Fun
 	if ftype != goFunc {
 		return nil, nil, ignoredFunc
 	}
+	oldGoFn := p.goFn
+	p.goFn = f
 	sig := p.patchType(f.Signature).(*types.Signature)
+	p.goFn = oldGoFn
 	state := p.state
 	isInit := (f.Name() == "init" && sig.Recv() == nil)
 	if isInit && state == pkgHasPatch {
@@ -384,10 +389,12 @@ func (p *context) compileFuncDecl(pkg llssa.Package, f *ssa.Function) (llssa.Fun
 		dbgEnabled := enableDbg && (f == nil || f.Origin() == nil)
 		dbgSymsEnabled := enableDbgSyms && (f == nil || f.Origin() == nil)
 		p.inits = append(p.inits, func() {
+			oldFn, oldGoFn := p.fn, p.goFn
 			p.fn = fn
+			p.goFn = f
 			p.state = state // restore pkgState when compiling funcBody
 			defer func() {
-				p.fn = nil
+				p.fn, p.goFn = oldFn, oldGoFn
 			}()
 			p.phis = nil
 			if dbgSymsEnabled {
@@ -861,7 +868,7 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 			max = p.compileValue(b, v.Max)
 		}
 		ret = b.Slice(x, low, high, max)
-		ret.Type = b.Prog.Type(v.Type(), llssa.InGo)
+		ret.Type = p.type_(v.Type(), llssa.InGo)
 	case *ssa.MakeInterface:
 		if refs := *v.Referrers(); len(refs) == 1 {
 			switch ref := refs[0].(type) {
@@ -1329,7 +1336,37 @@ func (p *context) _patchType(typ types.Type) (types.Type, bool) {
 		if t, ok := p._patchType(typ.Elem()); ok {
 			return types.NewPointer(t), true
 		}
+	case *types.Slice:
+		if t, ok := p._patchType(typ.Elem()); ok {
+			return types.NewSlice(t), true
+		}
+	case *types.Array:
+		if t, ok := p._patchType(typ.Elem()); ok {
+			return types.NewArray(t, typ.Len()), true
+		}
+	case *types.Map:
+		var patched bool
+		key := typ.Key()
+		elem := typ.Elem()
+		if t, ok := p._patchType(key); ok {
+			key = t
+			patched = true
+		}
+		if t, ok := p._patchType(elem); ok {
+			elem = t
+			patched = true
+		}
+		if patched {
+			return types.NewMap(key, elem), true
+		}
+	case *types.Chan:
+		if t, ok := p._patchType(typ.Elem()); ok {
+			return types.NewChan(typ.Dir(), t), true
+		}
 	case *types.Named:
+		if t, ok := p.patchLocalGenericNamed(typ); ok {
+			return t, true
+		}
 		o := typ.Obj()
 		if pkg := o.Pkg(); typepatch.IsPatched(pkg) {
 			if patch, ok := p.patches[pkg.Path()]; ok {
@@ -1362,6 +1399,212 @@ func (p *context) _patchType(typ types.Type) (types.Type, bool) {
 		}
 	}
 	return typ, false
+}
+
+func (p *context) patchLocalGenericNamed(t *types.Named) (*types.Named, bool) {
+	if p.goFn == nil || len(p.goFn.TypeArgs()) == 0 || !p.isGenericLocalType(t.Obj()) {
+		return nil, false
+	}
+	obj := types.NewTypeName(token.NoPos, t.Obj().Pkg(), p.localNamedName(t, false), nil)
+	return types.NewNamed(obj, t.Underlying(), nil), true
+}
+
+func (p *context) localNamedName(t *types.Named, suffix bool) string {
+	obj := t.Obj()
+	name := obj.Name()
+	outer := p.localTypeOuterArgs(obj)
+	own := typeListArgs(t.TypeArgs(), p.typeArgName)
+	switch {
+	case len(outer) != 0 && len(own) != 0:
+		name += "[" + strings.Join(outer, ",") + ";" + strings.Join(own, ",") + "]"
+	case len(outer) != 0:
+		name += "[" + strings.Join(outer, ",") + "]"
+	case len(own) != 0:
+		name += "[" + strings.Join(own, ",") + "]"
+	}
+	if suffix {
+		if n := p.localTypeOrdinal(obj); n != 0 {
+			name += "·" + strconv.Itoa(n)
+		}
+	}
+	return name
+}
+
+func (p *context) localTypeOuterArgs(obj types.Object) []string {
+	if p.goFn == nil || len(p.goFn.TypeArgs()) == 0 || !p.isGenericLocalType(obj) {
+		return nil
+	}
+	args := p.goFn.TypeArgs()
+	ret := make([]string, len(args))
+	for i, arg := range args {
+		ret[i] = p.typeArgName(arg)
+	}
+	return ret
+}
+
+func typeListArgs(list *types.TypeList, nameOf func(types.Type) string) []string {
+	if list == nil {
+		return nil
+	}
+	ret := make([]string, list.Len())
+	for i := 0; i < list.Len(); i++ {
+		ret[i] = nameOf(list.At(i))
+	}
+	return ret
+}
+
+func (p *context) typeArgName(t types.Type) string {
+	switch t := t.(type) {
+	case *types.Alias:
+		return p.typeArgName(types.Unalias(t))
+	case *types.Basic:
+		return t.String()
+	case *types.Named:
+		name := p.localNamedName(t, p.isLocalType(t.Obj()))
+		if pkg := t.Obj().Pkg(); pkg != nil {
+			return pkg.Name() + "." + name
+		}
+		return name
+	case *types.Pointer:
+		return "*" + p.typeArgName(t.Elem())
+	case *types.Slice:
+		return "[]" + p.typeArgName(t.Elem())
+	case *types.Array:
+		return fmt.Sprintf("[%v]%s", t.Len(), p.typeArgName(t.Elem()))
+	case *types.Map:
+		return fmt.Sprintf("map[%s]%s", p.typeArgName(t.Key()), p.typeArgName(t.Elem()))
+	case *types.Chan:
+		s := chanDirName(t.Dir())
+		elem := p.typeArgName(t.Elem())
+		if t.Dir() == types.SendRecv {
+			if ch, ok := t.Elem().(*types.Chan); ok && ch.Dir() == types.RecvOnly {
+				elem = "(" + elem + ")"
+			}
+		}
+		return fmt.Sprintf("%s %s", s, elem)
+	default:
+		return types.TypeString(t, func(pkg *types.Package) string {
+			if pkg == nil {
+				return ""
+			}
+			return pkg.Name()
+		})
+	}
+}
+
+func chanDirName(dir types.ChanDir) string {
+	switch dir {
+	case types.SendRecv:
+		return "chan"
+	case types.SendOnly:
+		return "chan<-"
+	case types.RecvOnly:
+		return "<-chan"
+	default:
+		panic("invalid channel direction")
+	}
+}
+
+func (p *context) isGenericLocalType(obj types.Object) bool {
+	if !p.isLocalType(obj) {
+		return false
+	}
+	if obj.Parent() == nil {
+		return p.inCurrentFunction(obj.Pos())
+	}
+	for scope := obj.Parent(); scope != nil; scope = scope.Parent() {
+		if pkg := obj.Pkg(); pkg != nil && scope == pkg.Scope() {
+			return false
+		}
+		if scopeHasTypeParams(scope) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *context) isLocalType(obj types.Object) bool {
+	if obj == nil || obj.Pkg() == nil {
+		return false
+	}
+	parent := obj.Parent()
+	if parent == nil {
+		return obj.Pos().IsValid()
+	}
+	return parent != obj.Pkg().Scope()
+}
+
+func scopeHasTypeParams(scope *types.Scope) bool {
+	for _, name := range scope.Names() {
+		if isTypeParamObject(scope.Lookup(name)) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *context) localTypeOrdinal(obj types.Object) int {
+	scope := obj.Parent()
+	if scope == nil || !obj.Pos().IsValid() {
+		return p.localTypeOrdinalBySyntax(obj.Pos())
+	}
+	n := 0
+	for _, name := range scope.Names() {
+		o := scope.Lookup(name)
+		if _, ok := o.(*types.TypeName); !ok || isTypeParamObject(o) {
+			continue
+		}
+		if pos := o.Pos(); pos.IsValid() && pos <= obj.Pos() {
+			n++
+		}
+	}
+	return n
+}
+
+func (p *context) inCurrentFunction(pos token.Pos) bool {
+	if !pos.IsValid() {
+		return false
+	}
+	syntax := p.currentFunctionSyntax()
+	return syntax != nil && syntax.Pos() <= pos && pos <= syntax.End()
+}
+
+func (p *context) localTypeOrdinalBySyntax(pos token.Pos) int {
+	if !p.inCurrentFunction(pos) {
+		return 0
+	}
+	n := 0
+	ast.Inspect(p.currentFunctionSyntax(), func(node ast.Node) bool {
+		spec, ok := node.(*ast.TypeSpec)
+		if !ok {
+			return true
+		}
+		if spec.Name != nil && spec.Name.Pos().IsValid() && spec.Name.Pos() <= pos {
+			n++
+		}
+		return true
+	})
+	return n
+}
+
+func (p *context) currentFunctionSyntax() ast.Node {
+	if p.goFn == nil {
+		return nil
+	}
+	fn := p.goFn
+	if origin := fn.Origin(); origin != nil {
+		fn = origin
+	}
+	return fn.Syntax()
+}
+
+func isTypeParamObject(obj types.Object) bool {
+	tn, ok := obj.(*types.TypeName)
+	if !ok {
+		return false
+	}
+	_, ok = tn.Type().(*types.TypeParam)
+	return ok
 }
 
 func instantiate(orig types.Type, t *types.Named) (typ types.Type) {

--- a/cl/funcname_nested_closure_test.go
+++ b/cl/funcname_nested_closure_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 
 	"github.com/goplus/gogen/packages"
+	"github.com/goplus/llgo/internal/typepatch"
+	"github.com/goplus/llgo/ssa/ssatest"
 	"golang.org/x/tools/go/ssa"
 	"golang.org/x/tools/go/ssa/ssautil"
 )
@@ -173,6 +175,35 @@ func use() {
 	}, nil)); ok {
 		t.Fatal("_patchType should not patch structs without local generic fields")
 	}
+	if _, ok := ctx._patchType(types.NewTuple(types.NewVar(token.NoPos, ssapkg.Pkg, "v", local))); !ok {
+		t.Fatal("_patchType should patch tuple elements")
+	}
+	if _, ok := ctx._patchType(types.NewSignatureType(nil, nil, nil,
+		types.NewTuple(types.NewParam(token.NoPos, ssapkg.Pkg, "p", local)),
+		types.NewTuple(types.NewVar(token.NoPos, ssapkg.Pkg, "r", local)),
+		false)); !ok {
+		t.Fatal("_patchType should patch signature params and results")
+	}
+	if _, ok := ctx._patchType(types.NewTuple(types.NewVar(token.NoPos, ssapkg.Pkg, "v", types.Typ[types.Int]))); ok {
+		t.Fatal("_patchType should not patch tuple without local generic elements")
+	}
+
+	oldPkg := types.NewPackage("example.com/patched", "patched")
+	oldObj := types.NewTypeName(token.NoPos, oldPkg, "N", nil)
+	oldNamed := types.NewNamed(oldObj, types.Typ[types.Int], nil)
+	oldPkg.Scope().Insert(oldObj)
+	patchPkg := types.NewPackage(oldPkg.Path(), oldPkg.Name())
+	patchObj := types.NewTypeName(token.NoPos, patchPkg, "N", nil)
+	patchNamed := types.NewNamed(patchObj, types.Typ[types.String], nil)
+	patchPkg.Scope().Insert(patchObj)
+	typepatch.Merge(patchPkg, oldPkg, nil, false)
+	patchCtx := &context{
+		prog:    ssatest.NewProgram(t, nil),
+		patches: Patches{oldPkg.Path(): {Types: patchPkg}},
+	}
+	if got, ok := patchCtx._patchType(oldNamed); !ok || !types.Identical(got, patchNamed) {
+		t.Fatalf("_patchType(patched named) = %v, %v, want patched named", got, ok)
+	}
 
 	pkglessObj := types.NewTypeName(token.NoPos, nil, "Pkgless", nil)
 	pkgless := types.NewNamed(pkglessObj, types.Typ[types.Int], nil)
@@ -184,6 +215,9 @@ func use() {
 	if got := ctx.typeArgName(alias); !strings.Contains(got, "foo.two[") {
 		t.Fatalf("typeArgName(alias) = %q, want unaliased local named type", got)
 	}
+	if got := ctx.typeArgName(types.NewPointer(local)); !strings.HasPrefix(got, "*foo.two[") {
+		t.Fatalf("typeArgName(pointer) = %q, want pointer to patched local name", got)
+	}
 	send := types.NewChan(types.SendOnly, types.Typ[types.Int])
 	recv := types.NewChan(types.RecvOnly, types.Typ[types.Int])
 	if got := ctx.typeArgName(send); !strings.Contains(got, "chan<-") {
@@ -194,6 +228,34 @@ func use() {
 	}
 	if got := ctx.typeArgName(types.NewSignatureType(nil, nil, nil, nil, nil, false)); !strings.Contains(got, "func") {
 		t.Fatalf("typeArgName(signature) = %q, want fallback TypeString", got)
+	}
+	otherPkg := types.NewPackage("example.com/bar", "bar")
+	other := types.NewNamed(types.NewTypeName(token.NoPos, otherPkg, "Other", nil), types.Typ[types.Int], nil)
+	sigWithPkg := types.NewSignatureType(nil, nil, nil,
+		types.NewTuple(types.NewParam(token.NoPos, otherPkg, "x", other)),
+		nil, false)
+	if got := ctx.typeArgName(sigWithPkg); !strings.Contains(got, "bar.Other") {
+		t.Fatalf("typeArgName(signature with package) = %q, want package-qualified param", got)
+	}
+
+	patchedObj := types.NewTypeName(token.NoPos, ssapkg.Pkg, "Already[int]", nil)
+	patched := types.NewNamed(patchedObj, types.Typ[types.Int], nil)
+	if got := ctx.localNamedName(patched, true); got != "Already[int]" {
+		t.Fatalf("localNamedName(already patched) = %q, want unchanged name", got)
+	}
+
+	topTypeParamObj := types.NewTypeName(token.NoPos, ssapkg.Pkg, "V", nil)
+	topTypeParam := types.NewTypeParam(topTypeParamObj, types.NewInterfaceType(nil, nil))
+	topBoxObj := types.NewTypeName(token.NoPos, ssapkg.Pkg, "TopBox", nil)
+	ssapkg.Pkg.Scope().Insert(topBoxObj)
+	topBox := types.NewNamed(topBoxObj, types.Typ[types.Int], nil)
+	topBox.SetTypeParams([]*types.TypeParam{topTypeParam})
+	topBoxInt, err := types.Instantiate(types.NewContext(), topBox, []types.Type{types.Typ[types.Int]}, false)
+	if err != nil {
+		t.Fatalf("Instantiate(TopBox[int]) failed: %v", err)
+	}
+	if got := ctx.localNamedName(topBoxInt.(*types.Named), false); !strings.Contains(got, "[int]") || strings.Contains(got, ";") {
+		t.Fatalf("localNamedName(top-level generic) = %q, want own args only", got)
 	}
 
 	tpObj := types.NewTypeName(token.NoPos, ssapkg.Pkg, "T", nil)
@@ -209,6 +271,70 @@ func use() {
 	}
 	if isTypeParamObject(types.NewVar(token.NoPos, ssapkg.Pkg, "v", types.Typ[types.Int])) {
 		t.Fatal("isTypeParamObject should ignore non-type names")
+	}
+
+	localScope := types.NewScope(ssapkg.Pkg.Scope(), token.NoPos, token.NoPos, "local")
+	localScope.Insert(types.NewVar(token.NoPos, ssapkg.Pkg, "v", types.Typ[types.Int]))
+	localScope.Insert(tpObj)
+	localScope.Insert(types.NewTypeName(token.Pos(10), ssapkg.Pkg, "Before", types.Typ[types.Int]))
+	manualObj := types.NewTypeName(token.Pos(20), ssapkg.Pkg, "Manual", nil)
+	localScope.Insert(manualObj)
+	localScope.Insert(types.NewTypeName(token.Pos(30), ssapkg.Pkg, "After", types.Typ[types.Int]))
+	manual := types.NewNamed(manualObj, types.Typ[types.Int], nil)
+	if got := ctx.localTypeOrdinal(manual.Obj()); got != 2 {
+		t.Fatalf("localTypeOrdinal(manual) = %d, want 2", got)
+	}
+	if !ctx.isGenericLocalType(manual.Obj()) {
+		t.Fatal("manual object in type-param scope should be generic local")
+	}
+
+	localPlainScope := types.NewScope(nil, token.NoPos, token.NoPos, "plain")
+	plainObj := types.NewTypeName(token.Pos(1), ssapkg.Pkg, "Plain", nil)
+	localPlainScope.Insert(plainObj)
+	if ctx.isGenericLocalType(plainObj) {
+		t.Fatal("local type without type-param scope should not be generic local")
+	}
+	childScope := types.NewScope(ssapkg.Pkg.Scope(), token.NoPos, token.NoPos, "child")
+	childObj := types.NewTypeName(token.Pos(2), ssapkg.Pkg, "Child", nil)
+	childScope.Insert(childObj)
+	if ctx.isGenericLocalType(childObj) {
+		t.Fatal("local type whose scope reaches package scope without type params should not be generic local")
+	}
+	if !ctx.isGenericLocalType(types.NewTypeName(fn.Syntax().Pos()+1, ssapkg.Pkg, "SyntaxLocal", nil)) {
+		t.Fatal("parentless object inside current function syntax should be generic local")
+	}
+	if ctx.inCurrentFunction(token.NoPos) {
+		t.Fatal("invalid position should not be inside current function")
+	}
+	if (&context{}).currentFunctionSyntax() != nil {
+		t.Fatal("currentFunctionSyntax without goFn should be nil")
+	}
+	if (&context{}).localTypeOrdinalBySyntax(token.Pos(1)) != 0 {
+		t.Fatal("localTypeOrdinalBySyntax without current function should be zero")
+	}
+	if !ctx.inCurrentFunction(fn.Syntax().Pos() + 1) {
+		t.Fatal("position inside current function should be detected")
+	}
+
+	typeParamObj := types.NewTypeName(token.NoPos, ssapkg.Pkg, "U", nil)
+	typeParam := types.NewTypeParam(typeParamObj, types.NewInterfaceType(nil, nil))
+	genericScope := types.NewScope(ssapkg.Pkg.Scope(), token.NoPos, token.NoPos, "generic")
+	genericScope.Insert(typeParamObj)
+	boxObj := types.NewTypeName(token.Pos(40), ssapkg.Pkg, "Box", nil)
+	genericScope.Insert(boxObj)
+	box := types.NewNamed(boxObj, types.NewStruct([]*types.Var{
+		types.NewField(token.NoPos, ssapkg.Pkg, "value", typeParam, false),
+	}, nil), nil)
+	box.SetTypeParams([]*types.TypeParam{typeParam})
+	boxInt, err := types.Instantiate(types.NewContext(), box, []types.Type{types.Typ[types.Int]}, false)
+	if err != nil {
+		t.Fatalf("Instantiate(Box[int]) failed: %v", err)
+	}
+	if got := ctx.localNamedName(boxInt.(*types.Named), false); !strings.Contains(got, ";int]") {
+		t.Fatalf("localNamedName(local generic with own args) = %q, want outer and own args", got)
+	}
+	if got := typeListArgs(boxInt.(*types.Named).TypeArgs(), ctx.typeArgName); len(got) != 1 || got[0] != "int" {
+		t.Fatalf("typeListArgs(non-nil) = %v, want [int]", got)
 	}
 
 	mustPanicContains(t, "invalid channel direction", func() {

--- a/cl/funcname_nested_closure_test.go
+++ b/cl/funcname_nested_closure_test.go
@@ -134,6 +134,88 @@ func localType[T any]() any {
 	}
 }
 
+func TestGenericLocalTypePatchHelperBranches(t *testing.T) {
+	ssapkg := buildSSAPackage(t, `package foo
+
+func outer[T any]() any {
+	type one struct{ value T }
+	type two struct{ value T }
+	_ = one{}
+	return two{}
+}
+
+func use() {
+	_ = outer[int]()
+}
+`)
+	fn, local := firstGenericLocalNamed(t, ssapkg)
+	ctx := &context{goFn: fn}
+
+	if ctx.isGenericLocalType(nil) {
+		t.Fatal("nil object should not be a generic local type")
+	}
+	topObj := types.NewTypeName(token.NoPos, ssapkg.Pkg, "Top", nil)
+	if ctx.isLocalType(topObj) {
+		t.Fatal("top-level type should not be local")
+	}
+	if ctx.localTypeOuterArgs(topObj) != nil {
+		t.Fatal("top-level type should not report outer type arguments")
+	}
+	if _, ok := (&context{}).patchLocalGenericNamed(local); ok {
+		t.Fatal("patchLocalGenericNamed should require a current generic function")
+	}
+
+	if _, ok := ctx._patchType(types.NewMap(local, types.Typ[types.Int])); !ok {
+		t.Fatal("_patchType should patch map key local type")
+	}
+	if _, ok := ctx._patchType(types.NewStruct([]*types.Var{
+		types.NewField(token.NoPos, ssapkg.Pkg, "plain", types.Typ[types.Int], false),
+	}, nil)); ok {
+		t.Fatal("_patchType should not patch structs without local generic fields")
+	}
+
+	pkglessObj := types.NewTypeName(token.NoPos, nil, "Pkgless", nil)
+	pkgless := types.NewNamed(pkglessObj, types.Typ[types.Int], nil)
+	if got := ctx.typeArgName(pkgless); !strings.Contains(got, "Pkgless") {
+		t.Fatalf("typeArgName(pkgless) = %q, want local name", got)
+	}
+	aliasObj := types.NewTypeName(token.NoPos, ssapkg.Pkg, "Alias", nil)
+	alias := types.NewAlias(aliasObj, local)
+	if got := ctx.typeArgName(alias); !strings.Contains(got, "foo.two[") {
+		t.Fatalf("typeArgName(alias) = %q, want unaliased local named type", got)
+	}
+	send := types.NewChan(types.SendOnly, types.Typ[types.Int])
+	recv := types.NewChan(types.RecvOnly, types.Typ[types.Int])
+	if got := ctx.typeArgName(send); !strings.Contains(got, "chan<-") {
+		t.Fatalf("typeArgName(send chan) = %q, want chan<-", got)
+	}
+	if got := ctx.typeArgName(types.NewChan(types.SendRecv, recv)); !strings.Contains(got, "chan (<-chan int)") {
+		t.Fatalf("typeArgName(chan recv) = %q, want parenthesized recv channel", got)
+	}
+	if got := ctx.typeArgName(types.NewSignatureType(nil, nil, nil, nil, nil, false)); !strings.Contains(got, "func") {
+		t.Fatalf("typeArgName(signature) = %q, want fallback TypeString", got)
+	}
+
+	tpObj := types.NewTypeName(token.NoPos, ssapkg.Pkg, "T", nil)
+	tparam := types.NewTypeParam(tpObj, types.NewInterfaceType(nil, nil))
+	scopeWithTypeParam := types.NewScope(ssapkg.Pkg.Scope(), token.NoPos, token.NoPos, "typed")
+	scopeWithTypeParam.Insert(types.NewTypeName(token.NoPos, ssapkg.Pkg, "N", types.Typ[types.Int]))
+	scopeWithTypeParam.Insert(types.NewTypeName(token.NoPos, ssapkg.Pkg, "T", tparam))
+	if !scopeHasTypeParams(scopeWithTypeParam) {
+		t.Fatal("scopeHasTypeParams should detect type parameters")
+	}
+	if !isTypeParamObject(tpObj) {
+		t.Fatal("isTypeParamObject should detect type parameter type names")
+	}
+	if isTypeParamObject(types.NewVar(token.NoPos, ssapkg.Pkg, "v", types.Typ[types.Int])) {
+		t.Fatal("isTypeParamObject should ignore non-type names")
+	}
+
+	mustPanicContains(t, "invalid channel direction", func() {
+		_ = chanDirName(types.ChanDir(99))
+	})
+}
+
 func firstGenericLocalNamed(t *testing.T, ssapkg *ssa.Package) (*ssa.Function, *types.Named) {
 	t.Helper()
 	for fn := range ssautil.AllFunctions(ssapkg.Prog) {

--- a/cl/funcname_nested_closure_test.go
+++ b/cl/funcname_nested_closure_test.go
@@ -74,6 +74,120 @@ func expectTwoDistinctNamesForTypes(t *testing.T, got []string, suffix string) {
 	}
 }
 
+func TestGenericLocalTypePatchHelpers(t *testing.T) {
+	ssapkg := buildSSAPackage(t, `package foo
+
+func use() {
+	_ = localType[int]()
+	_ = localType[string]()
+}
+
+func localType[T any]() any {
+	type local struct {
+		value T
+	}
+	return local{}
+}
+`)
+
+	fn, local := firstGenericLocalNamed(t, ssapkg)
+	ctx := &context{goFn: fn}
+	if !ctx.isGenericLocalType(local.Obj()) {
+		t.Fatalf("%s should be detected as a generic local type", local.Obj().Name())
+	}
+
+	patched, ok := ctx.patchLocalGenericNamed(local)
+	if !ok {
+		t.Fatalf("patchLocalGenericNamed(%v) was not patched", local)
+	}
+	name := patched.Obj().Name()
+	if !strings.Contains(name, "[") || !strings.Contains(name, "·") {
+		t.Fatalf("patched local generic name = %q, want type args and ordinal suffix", name)
+	}
+	if _, ok := ctx.patchLocalGenericNamed(patched); ok {
+		t.Fatalf("already-patched local generic name %q should not be patched again", name)
+	}
+
+	for _, typ := range []types.Type{
+		types.NewPointer(local),
+		types.NewSlice(local),
+		types.NewArray(local, 2),
+		types.NewMap(types.Typ[types.String], local),
+		types.NewChan(types.SendRecv, local),
+		types.NewStruct([]*types.Var{types.NewField(token.NoPos, ssapkg.Pkg, "field", local, false)}, []string{`json:"field"`}),
+	} {
+		if _, ok := ctx._patchType(typ); !ok {
+			t.Fatalf("_patchType(%v) did not patch nested local generic type", typ)
+		}
+	}
+
+	argName := ctx.typeArgName(types.NewMap(
+		types.NewChan(types.RecvOnly, types.Typ[types.Int]),
+		types.NewArray(types.NewSlice(local), 3),
+	))
+	if !strings.Contains(argName, "<-chan int") || !strings.Contains(argName, "[]") {
+		t.Fatalf("typeArgName did not format nested composite type: %q", argName)
+	}
+
+	if got := typeListArgs(nil, ctx.typeArgName); got != nil {
+		t.Fatalf("typeListArgs(nil) = %v, want nil", got)
+	}
+}
+
+func firstGenericLocalNamed(t *testing.T, ssapkg *ssa.Package) (*ssa.Function, *types.Named) {
+	t.Helper()
+	for fn := range ssautil.AllFunctions(ssapkg.Prog) {
+		if fn == nil || len(fn.TypeArgs()) == 0 {
+			continue
+		}
+		for _, block := range fn.Blocks {
+			for _, instr := range block.Instrs {
+				if mi, ok := instr.(*ssa.MakeInterface); ok {
+					if named := findLocalNamed(mi.X.Type(), ssapkg.Pkg); named != nil {
+						return fn, named
+					}
+				}
+				if val, ok := instr.(ssa.Value); ok {
+					if named := findLocalNamed(val.Type(), ssapkg.Pkg); named != nil {
+						return fn, named
+					}
+				}
+			}
+		}
+	}
+	t.Fatal("could not find instantiated generic local named type")
+	return nil, nil
+}
+
+func findLocalNamed(typ types.Type, pkg *types.Package) *types.Named {
+	switch t := types.Unalias(typ).(type) {
+	case *types.Named:
+		if obj := t.Obj(); obj != nil && obj.Pkg() == pkg && obj.Parent() != pkg.Scope() {
+			return t
+		}
+	case *types.Pointer:
+		return findLocalNamed(t.Elem(), pkg)
+	case *types.Slice:
+		return findLocalNamed(t.Elem(), pkg)
+	case *types.Array:
+		return findLocalNamed(t.Elem(), pkg)
+	case *types.Map:
+		if named := findLocalNamed(t.Key(), pkg); named != nil {
+			return named
+		}
+		return findLocalNamed(t.Elem(), pkg)
+	case *types.Chan:
+		return findLocalNamed(t.Elem(), pkg)
+	case *types.Struct:
+		for i := 0; i < t.NumFields(); i++ {
+			if named := findLocalNamed(t.Field(i).Type(), pkg); named != nil {
+				return named
+			}
+		}
+	}
+	return nil
+}
+
 func TestFuncName_NestedClosureInMethodIncludesRecv(t *testing.T) {
 	const src = `package foo
 

--- a/ssa/abi/abi.go
+++ b/ssa/abi/abi.go
@@ -412,8 +412,14 @@ func (b *Builder) structHash(t *types.Struct) (ret []byte, pkg string) {
 	return
 }
 
-func scopeIndex(scope, root *types.Scope, id string) string {
+func scopeIndex(scope, root *types.Scope, id string) (string, bool) {
+	if scope == nil || root == nil {
+		return "", false
+	}
 	parent := scope.Parent()
+	if parent == nil {
+		return "", false
+	}
 	n := parent.NumChildren()
 	for i := 0; i < n; i++ {
 		if parent.Child(i) == scope {
@@ -422,7 +428,7 @@ func scopeIndex(scope, root *types.Scope, id string) string {
 		}
 	}
 	if parent == root {
-		return id
+		return id, true
 	}
 	return scopeIndex(parent, root, id)
 }
@@ -433,7 +439,12 @@ func scopeIndices(obj types.Object) string {
 		return ""
 	}
 	if obj.Parent() != pkg.Scope() {
-		return scopeIndex(obj.Parent(), pkg.Scope(), "")
+		if ids, ok := scopeIndex(obj.Parent(), pkg.Scope(), ""); ok {
+			return ids
+		}
+		if pos := obj.Pos(); pos.IsValid() {
+			return ".p" + strconv.Itoa(int(pos))
+		}
 	}
 	return ""
 }

--- a/ssa/abi/abi_patch_test.go
+++ b/ssa/abi/abi_patch_test.go
@@ -105,6 +105,29 @@ func TestTypeName_DetachedLocalScopeUsesPosition(t *testing.T) {
 	}
 }
 
+func TestScopeIndexHandlesRootAndInvalidScopes(t *testing.T) {
+	pkg := types.NewPackage("example.com/p", "p")
+	root := pkg.Scope()
+	parent := types.NewScope(root, token.NoPos, token.NoPos, "parent")
+	child := types.NewScope(parent, token.NoPos, token.NoPos, "child")
+
+	if got, ok := scopeIndex(child, root, ""); !ok || got != ".0.0" {
+		t.Fatalf("scopeIndex(child, root) = %q, %v, want .0.0, true", got, ok)
+	}
+	if _, ok := scopeIndex(nil, root, ""); ok {
+		t.Fatal("scopeIndex(nil, root) succeeded")
+	}
+	if _, ok := scopeIndex(child, nil, ""); ok {
+		t.Fatal("scopeIndex(child, nil) succeeded")
+	}
+	if _, ok := scopeIndex(root, root, ""); ok {
+		t.Fatal("scopeIndex(root, root) succeeded")
+	}
+	if _, ok := scopeIndex(types.NewScope(nil, token.NoPos, token.NoPos, "detached"), root, ""); ok {
+		t.Fatal("scopeIndex(detached, root) succeeded")
+	}
+}
+
 func TestBasicName_RuneAlias(t *testing.T) {
 	if got := BasicName(types.Typ[types.Rune]); got != "_llgo_int32" {
 		t.Fatalf("BasicName(rune) = %q, want %q", got, "_llgo_int32")

--- a/ssa/abi/abi_patch_test.go
+++ b/ssa/abi/abi_patch_test.go
@@ -91,6 +91,20 @@ func TestTypeName_NamedWithoutPackage(t *testing.T) {
 	}
 }
 
+func TestTypeName_DetachedLocalScopeUsesPosition(t *testing.T) {
+	b := New(unsafe.Sizeof(uintptr(0)), types.SizesFor("gc", runtime.GOARCH))
+	pkg := types.NewPackage("example.com/p", "p")
+	local := types.NewScope(nil, token.Pos(100), token.Pos(200), "detached")
+	obj := types.NewTypeName(token.Pos(123), pkg, "Local", nil)
+	local.Insert(obj)
+	named := types.NewNamed(obj, types.Typ[types.Int], nil)
+
+	got, _ := b.TypeName(named)
+	if !strings.Contains(got, "Local.p123") {
+		t.Fatalf("TypeName = %q, want position suffix for detached local scope", got)
+	}
+}
+
 func TestBasicName_RuneAlias(t *testing.T) {
 	if got := BasicName(types.Typ[types.Rune]); got != "_llgo_int32" {
 		t.Fatalf("BasicName(rune) = %q, want %q", got, "_llgo_int32")

--- a/test/go/generic_local_types_test.go
+++ b/test/go/generic_local_types_test.go
@@ -2,6 +2,7 @@ package gotest
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -15,7 +16,19 @@ func genericLocalRuntimeType[T any]() reflect.Type {
 func TestGenericLocalRuntimeTypesIncludeOuterArgs(t *testing.T) {
 	intType := genericLocalRuntimeType[int]()
 	stringType := genericLocalRuntimeType[string]()
+	sameIntType := genericLocalRuntimeType[int]()
+	if intType != sameIntType {
+		t.Fatalf("same local generic runtime type has different identities: %v != %v", intType, sameIntType)
+	}
 	if intType == stringType {
 		t.Fatalf("local generic runtime types are identical: %v", intType)
+	}
+	intName := intType.String()
+	stringName := stringType.String()
+	if !strings.Contains(intName, "int") {
+		t.Fatalf("local generic int type name does not include type argument: %q", intName)
+	}
+	if !strings.Contains(stringName, "string") {
+		t.Fatalf("local generic string type name does not include type argument: %q", stringName)
 	}
 }

--- a/test/go/generic_local_types_test.go
+++ b/test/go/generic_local_types_test.go
@@ -1,0 +1,21 @@
+package gotest
+
+import (
+	"reflect"
+	"testing"
+)
+
+func genericLocalRuntimeType[T any]() reflect.Type {
+	type local struct {
+		value T
+	}
+	return reflect.TypeOf(local{})
+}
+
+func TestGenericLocalRuntimeTypesIncludeOuterArgs(t *testing.T) {
+	intType := genericLocalRuntimeType[int]()
+	stringType := genericLocalRuntimeType[string]()
+	if intType == stringType {
+		t.Fatalf("local generic runtime types are identical: %v", intType)
+	}
+}


### PR DESCRIPTION
## What

Fixes runtime type identity for local types declared inside generic functions.

```go
func localType[T any]() reflect.Type {
    type local struct { value T }
    return reflect.TypeOf(local{})
}

if localType[int]() == localType[string]() {
    panic("local generic runtime types collapsed")
}
```

Without this change, llgo can either crash while building runtime type names for detached local scopes or collapse local generic runtime types across different outer type arguments. The compiler now carries the current Go SSA function while patching types, encodes outer generic arguments into local named type identities, and gives detached local scopes a stable position suffix.

## Tests

- `go test ./ssa/abi -run 'TestTypeName_DetachedLocalScopeUsesPosition|TestTypeName_NamedWithoutPackage'`
- `go test ./test/go -run '^TestGenericLocalRuntimeTypesIncludeOuterArgs$'`
- `LLGO_ROOT=$PWD ./dev/llgo.sh test ./test/go -run '^TestGenericLocalRuntimeTypesIncludeOuterArgs$'`
- `go test ./cl ./ssa ./ssa/abi`
- `go test ./test/go`
- `LLGO_ROOT=$PWD ./dev/llgo.sh test ./test/go`
