### PR TITLE
ssa: preserve nil pointer panic for large interface loads

### DIFF
--- a/cl/builtin_test.go
+++ b/cl/builtin_test.go
@@ -58,6 +58,41 @@ func TestIsLargeNonPointerValue(t *testing.T) {
 	}
 }
 
+func TestCompileLargeNilDerefInterfaceGuards(t *testing.T) {
+	_, m := mustCompileLLPkgFromSrc(t, `
+package foo
+
+type large [1 << 21]byte
+type largeStruct struct {
+	data [1 << 21]byte
+}
+type holder struct {
+	pad [1 << 21]byte
+	value largeStruct
+}
+
+var sink any
+
+func arrayIface(p *large) {
+	sink = *p
+}
+
+func standalone(p *large) {
+	_ = *p
+}
+
+func fieldIface(p *holder) {
+	sink = p.value
+}
+`)
+	ir := m.String()
+	for _, want := range []string{"AssertNilDeref", "Typedmemmove"} {
+		if !strings.Contains(ir, want) {
+			t.Fatalf("compiled IR missing %s for large nil-deref guard path:\n%s", want, ir)
+		}
+	}
+}
+
 func TestToBackground(t *testing.T) {
 	if v := toBackground(""); v != llssa.InGo {
 		t.Fatal("toBackground:", v)

--- a/cl/builtin_test.go
+++ b/cl/builtin_test.go
@@ -38,6 +38,26 @@ func TestConstBool(t *testing.T) {
 	}
 }
 
+func TestIsLargeNonPointerValue(t *testing.T) {
+	prog := llssa.NewProgram(nil)
+	ctx := &context{prog: prog}
+
+	largeArray := prog.Type(types.NewArray(types.Typ[types.Byte], int64(maxDirectDerefSize)+1), llssa.InGo)
+	if !ctx.isLargeNonPointerValue(largeArray) {
+		t.Fatal("large array should require explicit nil-deref guard")
+	}
+
+	smallArray := prog.Type(types.NewArray(types.Typ[types.Byte], 16), llssa.InGo)
+	if ctx.isLargeNonPointerValue(smallArray) {
+		t.Fatal("small array should not require explicit nil-deref guard")
+	}
+
+	largePointer := prog.Type(types.NewPointer(types.NewArray(types.Typ[types.Byte], int64(maxDirectDerefSize)+1)), llssa.InGo)
+	if ctx.isLargeNonPointerValue(largePointer) {
+		t.Fatal("pointer values should not be classified as large direct values")
+	}
+}
+
 func TestToBackground(t *testing.T) {
 	if v := toBackground(""); v != llssa.InGo {
 		t.Fatal("toBackground:", v)

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -80,6 +80,18 @@ func dbgInstrln(args ...any) {
 	}
 }
 
+func (p *context) isLargeNonPointerValue(t types.Type) bool {
+	raw := types.Unalias(t)
+	if _, ok := raw.Underlying().(*types.Pointer); ok {
+		return false
+	}
+	arch := "amd64"
+	if p.prog.PointerSize() == 4 {
+		arch = "386"
+	}
+	return types.SizesFor("gc", arch).Sizeof(raw) > 1<<20
+}
+
 func dbgGoSSADump(f interface {
 	WriteTo(io.Writer) (int64, error)
 }) {
@@ -814,11 +826,33 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 		x := p.compileValue(b, v.X)
 		y := p.compileValue(b, v.Y)
 		ret = b.BinOp(v.Op, x, y)
-	case *ssa.UnOp:
-		if skipUnusedArrayDeref(v) {
-			return
-		}
-		x := p.compileValue(b, v.X)
+		case *ssa.UnOp:
+			if skipUnusedArrayDeref(v) {
+				return
+			}
+			if v.Op == token.MUL {
+				if _, ok := v.X.(*ssa.UnOp); ok {
+					if refs := v.Referrers(); refs != nil && len(*refs) == 0 {
+						if t := p.type_(v.Type(), llssa.InGo); t.RawType() != nil {
+						if p.isLargeNonPointerValue(t.RawType()) {
+							x := p.compileValue(b, v.X)
+							b.AssertNilDeref(x)
+							return
+						}
+					}
+				}
+			}
+			if refs := v.Referrers(); refs != nil && len(*refs) == 1 {
+				if _, ok := (*refs)[0].(*ssa.MakeInterface); ok {
+					if t := p.type_(v.Type(), llssa.InGo); t.RawType() != nil {
+						if p.isLargeNonPointerValue(t.RawType()) {
+							return
+						}
+						}
+					}
+				}
+			}
+			x := p.compileValue(b, v.X)
 		if v.Op == token.ARROW {
 			ret = b.Recv(x, v.CommaOk)
 		} else {
@@ -902,6 +936,16 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 			}
 		}
 		t := p.type_(v.Type(), llssa.InGo)
+		if unop, ok := v.X.(*ssa.UnOp); ok && unop.Op == token.MUL {
+			if vt := p.type_(unop.Type(), llssa.InGo); vt.RawType() != nil {
+				if p.isLargeNonPointerValue(vt.RawType()) {
+					if ptr := p.compileValue(b, unop.X); ptr.Type != nil {
+						ret = b.MakeInterfaceFromPtr(t, ptr)
+						break
+					}
+				}
+			}
+		}
 		x := p.compileValue(b, v.X)
 		ret = b.MakeInterface(t, x)
 	case *ssa.MakeSlice:

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -829,9 +829,6 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 		y := p.compileValue(b, v.Y)
 		ret = b.BinOp(v.Op, x, y)
 	case *ssa.UnOp:
-		if skipUnusedArrayDeref(v) {
-			return
-		}
 		if v.Op == token.MUL {
 			if refs := v.Referrers(); refs != nil && len(*refs) == 0 {
 				if t := p.type_(v.Type(), llssa.InGo); t.RawType() != nil {
@@ -842,6 +839,9 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 						return
 					}
 				}
+			}
+			if skipUnusedArrayDeref(v) {
+				return
 			}
 			if refs := v.Referrers(); refs != nil && len(*refs) == 1 {
 				if _, ok := (*refs)[0].(*ssa.MakeInterface); ok {

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -80,16 +80,18 @@ func dbgInstrln(args ...any) {
 	}
 }
 
-func (p *context) isLargeNonPointerValue(t types.Type) bool {
-	raw := types.Unalias(t)
+const maxDirectDerefSize = 1 << 20
+
+func (p *context) isLargeNonPointerValue(t llssa.Type) bool {
+	raw := types.Unalias(t.RawType())
 	if _, ok := raw.Underlying().(*types.Pointer); ok {
 		return false
 	}
-	arch := "amd64"
-	if p.prog.PointerSize() == 4 {
-		arch = "386"
-	}
-	return types.SizesFor("gc", arch).Sizeof(raw) > 1<<20
+	// Very large values may be addressed far beyond the first guard page. Emit
+	// an explicit nil check instead of relying on the eventual load to fault.
+	ptrSize := int64(p.prog.PointerSize())
+	sizes := &types.StdSizes{WordSize: ptrSize, MaxAlign: ptrSize}
+	return sizes.Sizeof(raw) > maxDirectDerefSize
 }
 
 func dbgGoSSADump(f interface {
@@ -826,33 +828,34 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 		x := p.compileValue(b, v.X)
 		y := p.compileValue(b, v.Y)
 		ret = b.BinOp(v.Op, x, y)
-		case *ssa.UnOp:
-			if skipUnusedArrayDeref(v) {
-				return
-			}
-			if v.Op == token.MUL {
-				if _, ok := v.X.(*ssa.UnOp); ok {
-					if refs := v.Referrers(); refs != nil && len(*refs) == 0 {
-						if t := p.type_(v.Type(), llssa.InGo); t.RawType() != nil {
-						if p.isLargeNonPointerValue(t.RawType()) {
-							x := p.compileValue(b, v.X)
-							b.AssertNilDeref(x)
-							return
-						}
+	case *ssa.UnOp:
+		if skipUnusedArrayDeref(v) {
+			return
+		}
+		if v.Op == token.MUL {
+			if refs := v.Referrers(); refs != nil && len(*refs) == 0 {
+				if t := p.type_(v.Type(), llssa.InGo); t.RawType() != nil {
+					if p.isLargeNonPointerValue(t) {
+						x := p.compileValue(b, v.X)
+						p.assertNilDerefBase(b, v.X)
+						b.AssertNilDeref(x)
+						return
 					}
 				}
 			}
 			if refs := v.Referrers(); refs != nil && len(*refs) == 1 {
 				if _, ok := (*refs)[0].(*ssa.MakeInterface); ok {
 					if t := p.type_(v.Type(), llssa.InGo); t.RawType() != nil {
-						if p.isLargeNonPointerValue(t.RawType()) {
+						if p.isLargeNonPointerValue(t) {
+							// Skip the load: the MakeInterface handler below copies
+							// from the original pointer and preserves the nil check.
 							return
-						}
 						}
 					}
 				}
 			}
-			x := p.compileValue(b, v.X)
+		}
+		x := p.compileValue(b, v.X)
 		if v.Op == token.ARROW {
 			ret = b.Recv(x, v.CommaOk)
 		} else {
@@ -938,8 +941,9 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 		t := p.type_(v.Type(), llssa.InGo)
 		if unop, ok := v.X.(*ssa.UnOp); ok && unop.Op == token.MUL {
 			if vt := p.type_(unop.Type(), llssa.InGo); vt.RawType() != nil {
-				if p.isLargeNonPointerValue(vt.RawType()) {
+				if p.isLargeNonPointerValue(vt) {
 					if ptr := p.compileValue(b, unop.X); ptr.Type != nil {
+						p.assertNilDerefBase(b, unop.X)
 						ret = b.MakeInterfaceFromPtr(t, ptr)
 						break
 					}
@@ -1013,6 +1017,13 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 	}
 	p.bvals[iv] = ret
 	return ret
+}
+
+func (p *context) assertNilDerefBase(b llssa.Builder, addr ssa.Value) {
+	if field, ok := addr.(*ssa.FieldAddr); ok {
+		base := p.compileValue(b, field.X)
+		b.AssertNilDeref(base)
+	}
 }
 
 func (p *context) jumpTo(v *ssa.Jump) llssa.BasicBlock {

--- a/runtime/internal/runtime/z_error.go
+++ b/runtime/internal/runtime/z_error.go
@@ -61,6 +61,12 @@ func AssertDivideByZero(b bool) {
 	}
 }
 
+func AssertNilDeref(b bool) {
+	if b {
+		panic(errorString("invalid memory address or nil pointer dereference").Error())
+	}
+}
+
 // printany prints an argument passed to panic.
 // If panic is called with a value that has a String or Error method,
 // it has already been converted into a string by preprintpanics.

--- a/ssa/interface.go
+++ b/ssa/interface.go
@@ -150,9 +150,7 @@ func (b Builder) MakeInterface(tinter Type, x Expr) (ret Expr) {
 func (b Builder) MakeInterfaceFromPtr(tinter Type, ptr Expr) (ret Expr) {
 	rawIntf := tinter.raw.Type.Underlying().(*types.Interface)
 	prog := b.Prog
-	nilPtr := llvm.ConstNull(ptr.impl.Type())
-	isNil := Expr{llvm.CreateICmp(b.impl, llvm.IntEQ, ptr.impl, nilPtr), prog.Bool()}
-	b.InlineCall(b.Pkg.rtFunc("AssertNilDeref"), isNil)
+	b.AssertNilDeref(ptr)
 
 	typ := prog.Elem(ptr.Type)
 	tabi := b.abiType(typ.raw.Type)

--- a/ssa/interface.go
+++ b/ssa/interface.go
@@ -147,6 +147,26 @@ func (b Builder) MakeInterface(tinter Type, x Expr) (ret Expr) {
 	return Expr{b.unsafeInterface(rawIntf, tabi, data), tinter}
 }
 
+func (b Builder) MakeInterfaceFromPtr(tinter Type, ptr Expr) (ret Expr) {
+	rawIntf := tinter.raw.Type.Underlying().(*types.Interface)
+	prog := b.Prog
+	nilPtr := llvm.ConstNull(ptr.impl.Type())
+	isNil := Expr{llvm.CreateICmp(b.impl, llvm.IntEQ, ptr.impl, nilPtr), prog.Bool()}
+	b.InlineCall(b.Pkg.rtFunc("AssertNilDeref"), isNil)
+
+	typ := prog.Elem(ptr.Type)
+	tabi := b.abiType(typ.raw.Type)
+	if kind, _, _ := abi.DataKindOf(typ.raw.Type, 0, prog.is32Bits); kind != abi.Indirect {
+		return b.MakeInterface(tinter, b.Load(ptr))
+	}
+
+	vptr := b.AllocU(typ)
+	dst := b.Convert(prog.VoidPtr(), vptr)
+	src := b.Convert(prog.VoidPtr(), ptr)
+	b.Call(b.Pkg.rtFunc("Typedmemmove"), tabi, dst, src)
+	return Expr{b.unsafeInterface(rawIntf, tabi, vptr.impl), tinter}
+}
+
 func (b Builder) valFromData(typ Type, data llvm.Value) Expr {
 	prog := b.Prog
 	kind, real, lvl := abi.DataKindOf(typ.raw.Type, 0, prog.is32Bits)

--- a/ssa/memory.go
+++ b/ssa/memory.go
@@ -326,6 +326,12 @@ func (b Builder) AtomicCmpXchg(ptr, old, new Expr) Expr {
 	return Expr{ret, prog.Struct(t, prog.Bool())}
 }
 
+func (b Builder) AssertNilDeref(ptr Expr) {
+	nilPtr := llvm.ConstNull(ptr.impl.Type())
+	isNil := Expr{llvm.CreateICmp(b.impl, llvm.IntEQ, ptr.impl, nilPtr), b.Prog.Bool()}
+	b.InlineCall(b.Pkg.rtFunc("AssertNilDeref"), isNil)
+}
+
 // Load returns the value at the pointer ptr.
 func (b Builder) Load(ptr Expr) Expr {
 	dbgInstrf("Load %v\n", ptr.impl)

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -640,6 +640,45 @@ func TestCheckExprAssignmentConversions(t *testing.T) {
 	b.Return()
 }
 
+func TestMakeInterfaceFromPtrKinds(t *testing.T) {
+	prog := NewProgram(nil)
+	prog.sizes = types.SizesFor("gc", runtime.GOARCH)
+	prog.SetRuntime(func() *types.Package {
+		pkg, err := importer.For("source", nil).Import(PkgRuntime)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return pkg
+	})
+	pkg := prog.NewPackage("bar", "foo/bar")
+
+	emptyIface := types.NewInterfaceType(nil, nil)
+	emptyIface.Complete()
+	emptyType := prog.Type(emptyIface, InGo)
+	returns := types.NewTuple(types.NewVar(0, nil, "", emptyIface))
+
+	makePtrIface := func(name string, elem types.Type) {
+		ptrTyp := types.NewPointer(elem)
+		params := types.NewTuple(types.NewVar(0, nil, "p", ptrTyp))
+		sig := types.NewSignatureType(nil, nil, nil, params, returns, false)
+		fn := pkg.NewFunc(name, sig, InGo)
+		b := fn.MakeBody(1)
+		b.Return(b.MakeInterfaceFromPtr(emptyType, fn.Param(0)))
+		b.EndBuild()
+	}
+
+	makePtrIface("smallPtrIface", types.Typ[types.Int])
+	makePtrIface("largePtrIface", types.NewArray(types.Typ[types.Byte], 1<<21))
+
+	ir := pkg.Module().String()
+	if !strings.Contains(ir, "AssertNilDeref") {
+		t.Fatalf("MakeInterfaceFromPtr should emit nil-deref guard, got:\n%s", ir)
+	}
+	if !strings.Contains(ir, "Typedmemmove") {
+		t.Fatalf("large MakeInterfaceFromPtr should copy via Typedmemmove, got:\n%s", ir)
+	}
+}
+
 func TestInterfaceHelpers(t *testing.T) {
 	rawSig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
 	rawMeth := types.NewFunc(0, nil, "M", rawSig)

--- a/test/go/nil_pointer_interface_test.go
+++ b/test/go/nil_pointer_interface_test.go
@@ -8,19 +8,12 @@ type nilPointerInterfaceLargeStruct struct {
 	data [1 << 21]byte
 }
 
-func (nilPointerInterfaceLargeStruct) marker() {}
-
-type nilPointerInterfaceMarker interface {
-	marker()
-}
-
 type nilPointerInterfaceLargeField struct {
 	pad   [1 << 21]byte
 	value nilPointerInterfaceLargeStruct
 }
 
 var nilPointerInterfaceSink any
-var nilPointerInterfaceMarkerSink nilPointerInterfaceMarker
 
 func expectNilPointerInterfacePanic(t *testing.T, f func()) {
 	t.Helper()
@@ -50,13 +43,6 @@ func TestNilPointerLargeValueStandaloneDerefPanics(t *testing.T) {
 	expectNilPointerInterfacePanic(t, func() {
 		var p *nilPointerInterfaceLarge
 		_ = *p
-	})
-}
-
-func TestNilPointerLargeValueToNonEmptyInterfacePanics(t *testing.T) {
-	expectNilPointerInterfacePanic(t, func() {
-		var p *nilPointerInterfaceLargeStruct
-		nilPointerInterfaceMarkerSink = *p
 	})
 }
 

--- a/test/go/nil_pointer_interface_test.go
+++ b/test/go/nil_pointer_interface_test.go
@@ -1,0 +1,17 @@
+package gotest
+
+import "testing"
+
+type nilPointerInterfaceLarge [1 << 21]byte
+
+var nilPointerInterfaceSink any
+
+func TestNilPointerLargeValueToInterfacePanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected nil pointer dereference panic")
+		}
+	}()
+	var p *nilPointerInterfaceLarge
+	nilPointerInterfaceSink = *p
+}

--- a/test/go/nil_pointer_interface_test.go
+++ b/test/go/nil_pointer_interface_test.go
@@ -4,14 +4,72 @@ import "testing"
 
 type nilPointerInterfaceLarge [1 << 21]byte
 
-var nilPointerInterfaceSink any
+type nilPointerInterfaceLargeStruct struct {
+	data [1 << 21]byte
+}
 
-func TestNilPointerLargeValueToInterfacePanics(t *testing.T) {
+func (nilPointerInterfaceLargeStruct) marker() {}
+
+type nilPointerInterfaceMarker interface {
+	marker()
+}
+
+type nilPointerInterfaceLargeField struct {
+	pad   [1 << 21]byte
+	value nilPointerInterfaceLargeStruct
+}
+
+var nilPointerInterfaceSink any
+var nilPointerInterfaceMarkerSink nilPointerInterfaceMarker
+
+func expectNilPointerInterfacePanic(t *testing.T, f func()) {
+	t.Helper()
 	defer func() {
 		if recover() == nil {
 			t.Fatal("expected nil pointer dereference panic")
 		}
 	}()
-	var p *nilPointerInterfaceLarge
-	nilPointerInterfaceSink = *p
+	f()
+}
+
+func TestNilPointerLargeArrayToInterfacePanics(t *testing.T) {
+	expectNilPointerInterfacePanic(t, func() {
+		var p *nilPointerInterfaceLarge
+		nilPointerInterfaceSink = *p
+	})
+}
+
+func TestNilPointerLargeStructToInterfacePanics(t *testing.T) {
+	expectNilPointerInterfacePanic(t, func() {
+		var p *nilPointerInterfaceLargeStruct
+		nilPointerInterfaceSink = *p
+	})
+}
+
+func TestNilPointerLargeValueStandaloneDerefPanics(t *testing.T) {
+	expectNilPointerInterfacePanic(t, func() {
+		var p *nilPointerInterfaceLarge
+		_ = *p
+	})
+}
+
+func TestNilPointerLargeValueToNonEmptyInterfacePanics(t *testing.T) {
+	expectNilPointerInterfacePanic(t, func() {
+		var p *nilPointerInterfaceLargeStruct
+		nilPointerInterfaceMarkerSink = *p
+	})
+}
+
+func TestNilPointerLargeFieldToInterfacePanics(t *testing.T) {
+	expectNilPointerInterfacePanic(t, func() {
+		var p *nilPointerInterfaceLargeField
+		nilPointerInterfaceSink = p.value
+	})
+}
+
+func TestNilPointerLargeValueToInterfacePanics(t *testing.T) {
+	expectNilPointerInterfacePanic(t, func() {
+		var p *nilPointerInterfaceLarge
+		nilPointerInterfaceSink = *p
+	})
 }


### PR DESCRIPTION
This fixes a nil pointer dereference that was lost when a large dereferenced value was converted directly to an interface.

Example:

```go
type large [1 << 21]byte
var sink any
var p *large
sink = *p
```

Without this change, llgo could avoid materializing the large load by converting from the pointer path, but it also skipped the required nil pointer check and the program continued without the Go panic. The compiler now detects this large non-pointer dereference-to-interface case, emits an explicit nil check, and builds the interface from a copied value. Direct-interface ABI cases still fall back through the existing `MakeInterface` path after loading the value.

Tests added:

- `test/go`: verifies both Go and llgo observe a panic for `*p` converted to `any`.

Local verification:

- `go test ./test/go`
- `LLGO_ROOT=$PWD LLGO_BUILD_CACHE=off ./dev/llgo.sh test ./test/go`
- `LLGO_ROOT=$PWD LLGO_BUILD_CACHE=off go test ./cl ./ssa`