### PR TITLE
Fix invalid LLVM IR by updating abitype and buildVal

### DIFF
--- a/cl/_testgo/cursor/out.ll
+++ b/cl/_testgo/cursor/out.ll
@@ -17,10 +17,10 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/cursor"
 %"github.com/goplus/llgo/runtime/abi.ArrayType" = type { %"github.com/goplus/llgo/runtime/abi.Type", ptr, ptr, i64 }
 %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" = type { ptr, i32 }
 %"github.com/goplus/llgo/runtime/internal/runtime.iface" = type { ptr, ptr }
+%"github.com/goplus/llgo/cl/_testgo/cursor.event" = type { %"github.com/goplus/llgo/runtime/internal/runtime.iface", i64, i32, i32 }
 %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]" = type { ptr, ptr }
 %"github.com/goplus/llgo/cl/_testgo/cursor.Inspector" = type { %"github.com/goplus/llgo/runtime/internal/runtime.Slice" }
 %"github.com/goplus/llgo/runtime/internal/runtime.eface" = type { ptr, ptr }
-%"github.com/goplus/llgo/cl/_testgo/cursor.event" = type { %"github.com/goplus/llgo/runtime/internal/runtime.iface", i64, i32, i32 }
 
 @"github.com/goplus/llgo/cl/_testgo/cursor.init$guard" = global i1 false, align 1
 @0 = private unnamed_addr constant [36 x i8] c"iterator call did not preserve panic", align 1
@@ -528,163 +528,163 @@ source_filename = "github.com/goplus/llgo/cl/_testgo/cursor"
 define { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.FindNode"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %0, %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1) {
 _llgo_0:
   %2 = alloca %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", align 8
-  call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
-  store %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %0, ptr %2, align 8
-  %3 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1, ptr %3, align 8
-  %4 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
-  %5 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 1)
+  %3 = alloca %"github.com/goplus/llgo/cl/_testgo/cursor.event", align 8
+  %4 = alloca %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", align 8
+  call void @llvm.memset(ptr %4, i8 0, i64 16, i1 false)
+  store %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %0, ptr %4, align 8
+  %5 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.iface" %1, ptr %5, align 8
+  %6 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
+  %7 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 1)
   br i1 false, label %_llgo_1, label %_llgo_2
 
 _llgo_1:                                          ; preds = %_llgo_0
-  %6 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %2, align 8
-  %7 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %3, align 8
-  %8 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
-  %9 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %8, i64 0
-  store %"github.com/goplus/llgo/runtime/internal/runtime.iface" %7, ptr %9, align 8
-  %10 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %8, 0
-  %11 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %10, i64 1, 1
-  %12 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %11, i64 1, 2
-  %13 = call %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]" @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.Preorder"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %6, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %12)
-  %14 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
-  %15 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 32)
-  %16 = getelementptr inbounds { ptr, ptr, ptr, ptr }, ptr %15, i32 0, i32 0
-  store ptr %14, ptr %16, align 8
-  %17 = getelementptr inbounds { ptr, ptr, ptr, ptr }, ptr %15, i32 0, i32 1
-  store ptr %3, ptr %17, align 8
-  %18 = getelementptr inbounds { ptr, ptr, ptr, ptr }, ptr %15, i32 0, i32 2
-  store ptr %4, ptr %18, align 8
-  %19 = getelementptr inbounds { ptr, ptr, ptr, ptr }, ptr %15, i32 0, i32 3
+  %8 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %4, align 8
+  %9 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %5, align 8
+  %10 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
+  %11 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %10, i64 0
+  store %"github.com/goplus/llgo/runtime/internal/runtime.iface" %9, ptr %11, align 8
+  %12 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %10, 0
+  %13 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %12, i64 1, 1
+  %14 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %13, i64 1, 2
+  %15 = call %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]" @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.Preorder"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %8, %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %14)
+  %16 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 8)
+  %17 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 32)
+  %18 = getelementptr inbounds { ptr, ptr, ptr, ptr }, ptr %17, i32 0, i32 0
+  store ptr %16, ptr %18, align 8
+  %19 = getelementptr inbounds { ptr, ptr, ptr, ptr }, ptr %17, i32 0, i32 1
   store ptr %5, ptr %19, align 8
-  %20 = insertvalue { ptr, ptr } { ptr @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.FindNode$1", ptr undef }, ptr %15, 1
-  %21 = extractvalue %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]" %13, 1
-  %22 = extractvalue %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]" %13, 0
-  call void %22(ptr %21, { ptr, ptr } %20)
-  %23 = load i64, ptr %14, align 4
-  %24 = icmp eq i64 %23, -1
-  br i1 %24, label %_llgo_4, label %_llgo_5
+  %20 = getelementptr inbounds { ptr, ptr, ptr, ptr }, ptr %17, i32 0, i32 2
+  store ptr %6, ptr %20, align 8
+  %21 = getelementptr inbounds { ptr, ptr, ptr, ptr }, ptr %17, i32 0, i32 3
+  store ptr %7, ptr %21, align 8
+  %22 = insertvalue { ptr, ptr } { ptr @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.FindNode$1", ptr undef }, ptr %17, 1
+  %23 = extractvalue %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]" %15, 1
+  %24 = extractvalue %"iter.Seq[github.com/goplus/llgo/cl/_testgo/cursor.Cursor]" %15, 0
+  call void %24(ptr %23, { ptr, ptr } %22)
+  %25 = load i64, ptr %16, align 4
+  %26 = icmp eq i64 %25, -1
+  br i1 %26, label %_llgo_4, label %_llgo_5
 
 _llgo_2:                                          ; preds = %_llgo_0
-  %25 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
-  %26 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %25, i64 0
-  %27 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %3, align 8
-  store %"github.com/goplus/llgo/runtime/internal/runtime.iface" %27, ptr %26, align 8
-  %28 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %25, 0
-  %29 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %28, i64 1, 1
-  %30 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %29, i64 1, 2
-  %31 = call i64 @"github.com/goplus/llgo/cl/_testgo/cursor.maskOf"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %30)
-  %32 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %2, i32 0, i32 0
-  %33 = load ptr, ptr %32, align 8
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Inspector", ptr %33, i32 0, i32 0
-  %35 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %34, align 8
-  %36 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %2, align 8
-  %37 = call { i32, i32 } @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.indices"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %36)
-  %38 = extractvalue { i32, i32 } %37, 0
-  %39 = extractvalue { i32, i32 } %37, 1
+  %27 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 16)
+  %28 = getelementptr inbounds %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %27, i64 0
+  %29 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %5, align 8
+  store %"github.com/goplus/llgo/runtime/internal/runtime.iface" %29, ptr %28, align 8
+  %30 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" undef, ptr %27, 0
+  %31 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %30, i64 1, 1
+  %32 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %31, i64 1, 2
+  %33 = call i64 @"github.com/goplus/llgo/cl/_testgo/cursor.maskOf"(%"github.com/goplus/llgo/runtime/internal/runtime.Slice" %32)
+  %34 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %4, i32 0, i32 0
+  %35 = load ptr, ptr %34, align 8
+  %36 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Inspector", ptr %35, i32 0, i32 0
+  %37 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %36, align 8
+  %38 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %4, align 8
+  %39 = call { i32, i32 } @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.indices"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %38)
+  %40 = extractvalue { i32, i32 } %39, 0
+  %41 = extractvalue { i32, i32 } %39, 1
   br label %_llgo_9
 
 _llgo_3:                                          ; preds = %_llgo_7, %_llgo_6
-  store %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" zeroinitializer, ptr %4, align 8
-  store i1 false, ptr %5, align 1
-  %40 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %4, align 8
-  %41 = load i1, ptr %5, align 1
-  %42 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } undef, %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %40, 0
-  %43 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %42, i1 %41, 1
-  ret { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %43
+  store %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" zeroinitializer, ptr %6, align 8
+  store i1 false, ptr %7, align 1
+  %42 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %6, align 8
+  %43 = load i1, ptr %7, align 1
+  %44 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } undef, %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %42, 0
+  %45 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %44, i1 %43, 1
+  ret { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %45
 
 _llgo_4:                                          ; preds = %_llgo_1
-  %44 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
-  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 36 }, ptr %44, align 8
-  %45 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %44, 1
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %45)
+  %46 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 16)
+  store %"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @0, i64 36 }, ptr %46, align 8
+  %47 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %46, 1
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.Panic"(%"github.com/goplus/llgo/runtime/internal/runtime.eface" %47)
   unreachable
 
 _llgo_5:                                          ; preds = %_llgo_1
-  %46 = icmp eq i64 %23, 0
-  br i1 %46, label %_llgo_6, label %_llgo_7
+  %48 = icmp eq i64 %25, 0
+  br i1 %48, label %_llgo_6, label %_llgo_7
 
 _llgo_6:                                          ; preds = %_llgo_5
-  store i64 -2, ptr %14, align 4
+  store i64 -2, ptr %16, align 4
   br label %_llgo_3
 
 _llgo_7:                                          ; preds = %_llgo_5
-  %47 = icmp eq i64 %23, 1
-  br i1 %47, label %_llgo_8, label %_llgo_3
+  %49 = icmp eq i64 %25, 1
+  br i1 %49, label %_llgo_8, label %_llgo_3
 
 _llgo_8:                                          ; preds = %_llgo_7
-  %48 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %4, align 8
-  %49 = load i1, ptr %5, align 1
-  %50 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } undef, %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %48, 0
-  %51 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %50, i1 %49, 1
-  ret { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %51
+  %50 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %6, align 8
+  %51 = load i1, ptr %7, align 1
+  %52 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } undef, %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %50, 0
+  %53 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %52, i1 %51, 1
+  ret { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %53
 
 _llgo_9:                                          ; preds = %_llgo_13, %_llgo_2
-  %52 = phi i32 [ %38, %_llgo_2 ], [ %75, %_llgo_13 ]
-  %53 = icmp slt i32 %52, %39
-  br i1 %53, label %_llgo_10, label %_llgo_11
+  %54 = phi i32 [ %40, %_llgo_2 ], [ %76, %_llgo_13 ]
+  %55 = icmp slt i32 %54, %41
+  br i1 %55, label %_llgo_10, label %_llgo_11
 
 _llgo_10:                                         ; preds = %_llgo_9
-  %54 = alloca %"github.com/goplus/llgo/cl/_testgo/cursor.event", align 8
-  call void @llvm.memset(ptr %54, i8 0, i64 32, i1 false)
-  %55 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %35, 0
-  %56 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %35, 1
-  %57 = sext i32 %52 to i64
-  %58 = icmp slt i64 %57, 0
-  %59 = icmp sge i64 %57, %56
-  %60 = or i1 %59, %58
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %60)
-  %61 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %55, i64 %57
-  %62 = load %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %61, align 8
-  store %"github.com/goplus/llgo/cl/_testgo/cursor.event" %62, ptr %54, align 8
-  %63 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %54, i32 0, i32 2
-  %64 = load i32, ptr %63, align 4
-  %65 = icmp sgt i32 %64, %52
-  br i1 %65, label %_llgo_12, label %_llgo_13
+  call void @llvm.memset(ptr %3, i8 0, i64 32, i1 false)
+  %56 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %37, 0
+  %57 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %37, 1
+  %58 = sext i32 %54 to i64
+  %59 = icmp slt i64 %58, 0
+  %60 = icmp sge i64 %58, %57
+  %61 = or i1 %60, %59
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %61)
+  %62 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %56, i64 %58
+  %63 = load %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %62, align 8
+  store %"github.com/goplus/llgo/cl/_testgo/cursor.event" %63, ptr %3, align 8
+  %64 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %3, i32 0, i32 2
+  %65 = load i32, ptr %64, align 4
+  %66 = icmp sgt i32 %65, %54
+  br i1 %66, label %_llgo_12, label %_llgo_13
 
 _llgo_11:                                         ; preds = %_llgo_9
-  store %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" zeroinitializer, ptr %4, align 8
-  store i1 false, ptr %5, align 1
-  %66 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %4, align 8
-  %67 = load i1, ptr %5, align 1
-  %68 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } undef, %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %66, 0
-  %69 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %68, i1 %67, 1
-  ret { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %69
+  store %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" zeroinitializer, ptr %6, align 8
+  store i1 false, ptr %7, align 1
+  %67 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %6, align 8
+  %68 = load i1, ptr %7, align 1
+  %69 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } undef, %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %67, 0
+  %70 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %69, i1 %68, 1
+  ret { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %70
 
 _llgo_12:                                         ; preds = %_llgo_10
-  %70 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %54, i32 0, i32 1
-  %71 = load i64, ptr %70, align 4
-  %72 = and i64 %71, %31
-  %73 = icmp ne i64 %72, 0
-  br i1 %73, label %_llgo_16, label %_llgo_15
+  %71 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %3, i32 0, i32 1
+  %72 = load i64, ptr %71, align 4
+  %73 = and i64 %72, %33
+  %74 = icmp ne i64 %73, 0
+  br i1 %74, label %_llgo_16, label %_llgo_15
 
 _llgo_13:                                         ; preds = %_llgo_17, %_llgo_15, %_llgo_10
-  %74 = phi i32 [ %52, %_llgo_10 ], [ %52, %_llgo_15 ], [ %87, %_llgo_17 ]
-  %75 = add i32 %74, 1
+  %75 = phi i32 [ %54, %_llgo_10 ], [ %54, %_llgo_15 ], [ %87, %_llgo_17 ]
+  %76 = add i32 %75, 1
   br label %_llgo_9
 
 _llgo_14:                                         ; preds = %_llgo_16
-  %76 = alloca %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", align 8
-  call void @llvm.memset(ptr %76, i8 0, i64 16, i1 false)
-  %77 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %76, i32 0, i32 0
-  %78 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %2, i32 0, i32 0
+  call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+  %77 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %2, i32 0, i32 0
+  %78 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %4, i32 0, i32 0
   %79 = load ptr, ptr %78, align 8
-  %80 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %76, i32 0, i32 1
+  %80 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %2, i32 0, i32 1
   store ptr %79, ptr %77, align 8
-  store i32 %52, ptr %80, align 4
-  %81 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %76, align 8
-  store %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %81, ptr %4, align 8
-  store i1 true, ptr %5, align 1
-  %82 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %4, align 8
-  %83 = load i1, ptr %5, align 1
+  store i32 %54, ptr %80, align 4
+  %81 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %2, align 8
+  store %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %81, ptr %6, align 8
+  store i1 true, ptr %7, align 1
+  %82 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %6, align 8
+  %83 = load i1, ptr %7, align 1
   %84 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } undef, %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %82, 0
   %85 = insertvalue { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %84, i1 %83, 1
   ret { %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", i1 } %85
 
 _llgo_15:                                         ; preds = %_llgo_16, %_llgo_12
-  %86 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %54, i32 0, i32 2
+  %86 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %3, i32 0, i32 2
   %87 = load i32, ptr %86, align 4
-  %88 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %35, 0
-  %89 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %35, 1
+  %88 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %37, 0
+  %89 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %37, 1
   %90 = sext i32 %87 to i64
   %91 = icmp slt i64 %90, 0
   %92 = icmp sge i64 %90, %89
@@ -693,14 +693,14 @@ _llgo_15:                                         ; preds = %_llgo_16, %_llgo_12
   %94 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %88, i64 %90
   %95 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %94, i32 0, i32 1
   %96 = load i64, ptr %95, align 4
-  %97 = and i64 %96, %31
+  %97 = and i64 %96, %33
   %98 = icmp eq i64 %97, 0
   br i1 %98, label %_llgo_17, label %_llgo_13
 
 _llgo_16:                                         ; preds = %_llgo_12
-  %99 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %54, i32 0, i32 0
+  %99 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %3, i32 0, i32 0
   %100 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %99, align 8
-  %101 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %3, align 8
+  %101 = load %"github.com/goplus/llgo/runtime/internal/runtime.iface", ptr %5, align 8
   %102 = call ptr @"github.com/goplus/llgo/runtime/internal/runtime.IfaceType"(%"github.com/goplus/llgo/runtime/internal/runtime.iface" %100)
   %103 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.iface" %100, 1
   %104 = insertvalue %"github.com/goplus/llgo/runtime/internal/runtime.eface" undef, ptr %102, 0
@@ -817,95 +817,95 @@ _llgo_0:
 
 define void @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.Preorder$1"(ptr %0, { ptr, ptr } %1) {
 _llgo_0:
-  %2 = load { ptr, ptr }, ptr %0, align 8
-  %3 = extractvalue { ptr, ptr } %2, 0
-  %4 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %3, i32 0, i32 0
-  %5 = load ptr, ptr %4, align 8
-  %6 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Inspector", ptr %5, i32 0, i32 0
-  %7 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %6, align 8
-  %8 = extractvalue { ptr, ptr } %2, 0
-  %9 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %8, align 8
-  %10 = call { i32, i32 } @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.indices"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %9)
-  %11 = extractvalue { i32, i32 } %10, 0
-  %12 = extractvalue { i32, i32 } %10, 1
+  %2 = alloca %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", align 8
+  %3 = alloca %"github.com/goplus/llgo/cl/_testgo/cursor.event", align 8
+  %4 = load { ptr, ptr }, ptr %0, align 8
+  %5 = extractvalue { ptr, ptr } %4, 0
+  %6 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %5, i32 0, i32 0
+  %7 = load ptr, ptr %6, align 8
+  %8 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Inspector", ptr %7, i32 0, i32 0
+  %9 = load %"github.com/goplus/llgo/runtime/internal/runtime.Slice", ptr %8, align 8
+  %10 = extractvalue { ptr, ptr } %4, 0
+  %11 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %10, align 8
+  %12 = call { i32, i32 } @"github.com/goplus/llgo/cl/_testgo/cursor.Cursor.indices"(%"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %11)
+  %13 = extractvalue { i32, i32 } %12, 0
+  %14 = extractvalue { i32, i32 } %12, 1
   br label %_llgo_1
 
 _llgo_1:                                          ; preds = %_llgo_5, %_llgo_8, %_llgo_0
-  %13 = phi i32 [ %11, %_llgo_0 ], [ %59, %_llgo_8 ], [ %33, %_llgo_5 ]
-  %14 = icmp slt i32 %13, %12
-  br i1 %14, label %_llgo_2, label %_llgo_3
+  %15 = phi i32 [ %13, %_llgo_0 ], [ %59, %_llgo_8 ], [ %34, %_llgo_5 ]
+  %16 = icmp slt i32 %15, %14
+  br i1 %16, label %_llgo_2, label %_llgo_3
 
 _llgo_2:                                          ; preds = %_llgo_1
-  %15 = alloca %"github.com/goplus/llgo/cl/_testgo/cursor.event", align 8
-  call void @llvm.memset(ptr %15, i8 0, i64 32, i1 false)
-  %16 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %7, 0
-  %17 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %7, 1
-  %18 = sext i32 %13 to i64
-  %19 = icmp slt i64 %18, 0
-  %20 = icmp sge i64 %18, %17
-  %21 = or i1 %20, %19
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %21)
-  %22 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %16, i64 %18
-  %23 = load %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %22, align 8
-  store %"github.com/goplus/llgo/cl/_testgo/cursor.event" %23, ptr %15, align 8
-  %24 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %15, i32 0, i32 2
-  %25 = load i32, ptr %24, align 4
-  %26 = icmp sgt i32 %25, %13
-  br i1 %26, label %_llgo_4, label %_llgo_5
+  call void @llvm.memset(ptr %3, i8 0, i64 32, i1 false)
+  %17 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %9, 0
+  %18 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %9, 1
+  %19 = sext i32 %15 to i64
+  %20 = icmp slt i64 %19, 0
+  %21 = icmp sge i64 %19, %18
+  %22 = or i1 %21, %20
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %22)
+  %23 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %17, i64 %19
+  %24 = load %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %23, align 8
+  store %"github.com/goplus/llgo/cl/_testgo/cursor.event" %24, ptr %3, align 8
+  %25 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %3, i32 0, i32 2
+  %26 = load i32, ptr %25, align 4
+  %27 = icmp sgt i32 %26, %15
+  br i1 %27, label %_llgo_4, label %_llgo_5
 
 _llgo_3:                                          ; preds = %_llgo_7, %_llgo_1
   ret void
 
 _llgo_4:                                          ; preds = %_llgo_2
-  %27 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %15, i32 0, i32 1
-  %28 = load i64, ptr %27, align 4
-  %29 = extractvalue { ptr, ptr } %2, 1
-  %30 = load i64, ptr %29, align 4
-  %31 = and i64 %28, %30
-  %32 = icmp ne i64 %31, 0
-  br i1 %32, label %_llgo_7, label %_llgo_6
+  %28 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %3, i32 0, i32 1
+  %29 = load i64, ptr %28, align 4
+  %30 = extractvalue { ptr, ptr } %4, 1
+  %31 = load i64, ptr %30, align 4
+  %32 = and i64 %29, %31
+  %33 = icmp ne i64 %32, 0
+  br i1 %33, label %_llgo_7, label %_llgo_6
 
 _llgo_5:                                          ; preds = %_llgo_6, %_llgo_2
-  %33 = add i32 %13, 1
+  %34 = add i32 %15, 1
   br label %_llgo_1
 
 _llgo_6:                                          ; preds = %_llgo_7, %_llgo_4
-  %34 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %15, i32 0, i32 2
-  %35 = load i32, ptr %34, align 4
-  %36 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %7, 0
-  %37 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %7, 1
-  %38 = sext i32 %35 to i64
-  %39 = icmp slt i64 %38, 0
-  %40 = icmp sge i64 %38, %37
-  %41 = or i1 %40, %39
-  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %41)
-  %42 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %36, i64 %38
-  %43 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %42, i32 0, i32 1
-  %44 = load i64, ptr %43, align 4
-  %45 = extractvalue { ptr, ptr } %2, 1
-  %46 = load i64, ptr %45, align 4
-  %47 = and i64 %44, %46
-  %48 = icmp eq i64 %47, 0
-  br i1 %48, label %_llgo_8, label %_llgo_5
+  %35 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %3, i32 0, i32 2
+  %36 = load i32, ptr %35, align 4
+  %37 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %9, 0
+  %38 = extractvalue %"github.com/goplus/llgo/runtime/internal/runtime.Slice" %9, 1
+  %39 = sext i32 %36 to i64
+  %40 = icmp slt i64 %39, 0
+  %41 = icmp sge i64 %39, %38
+  %42 = or i1 %41, %40
+  call void @"github.com/goplus/llgo/runtime/internal/runtime.AssertIndexRange"(i1 %42)
+  %43 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %37, i64 %39
+  %44 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.event", ptr %43, i32 0, i32 1
+  %45 = load i64, ptr %44, align 4
+  %46 = extractvalue { ptr, ptr } %4, 1
+  %47 = load i64, ptr %46, align 4
+  %48 = and i64 %45, %47
+  %49 = icmp eq i64 %48, 0
+  br i1 %49, label %_llgo_8, label %_llgo_5
 
 _llgo_7:                                          ; preds = %_llgo_4
-  %49 = alloca %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", align 8
-  call void @llvm.memset(ptr %49, i8 0, i64 16, i1 false)
-  %50 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %49, i32 0, i32 0
-  %51 = extractvalue { ptr, ptr } %2, 0
+  call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+  %50 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %2, i32 0, i32 0
+  %51 = extractvalue { ptr, ptr } %4, 0
   %52 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %51, i32 0, i32 0
   %53 = load ptr, ptr %52, align 8
-  %54 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %49, i32 0, i32 1
+  %54 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %2, i32 0, i32 1
   store ptr %53, ptr %50, align 8
-  store i32 %13, ptr %54, align 4
-  %55 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %49, align 8
+  store i32 %15, ptr %54, align 4
+  %55 = load %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor", ptr %2, align 8
   %56 = extractvalue { ptr, ptr } %1, 1
   %57 = extractvalue { ptr, ptr } %1, 0
   %58 = call i1 %57(ptr %56, %"github.com/goplus/llgo/cl/_testgo/cursor.Cursor" %55)
   br i1 %58, label %_llgo_6, label %_llgo_3
 
 _llgo_8:                                          ; preds = %_llgo_6
-  %59 = add i32 %35, 1
+  %59 = add i32 %36, 1
   br label %_llgo_1
 }
 

--- a/cl/_testrt/abinamed/in.go
+++ b/cl/_testrt/abinamed/in.go
@@ -9,170 +9,170 @@ import (
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/abinamed.main"() {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 48)
-// CHECK-NEXT:   store %"{{.*}}/cl/_testrt/abinamed.T" zeroinitializer, ptr %0, align 8
-// CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/abinamed.T", ptr undef }, ptr %0, 1
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/cl/_testrt/abinamed.toEface"(%"{{.*}}/runtime/internal/runtime.eface" %1)
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 72)
-// CHECK-NEXT:   store %"{{.*}}/runtime/abi.Type" zeroinitializer, ptr %3, align 8
-// CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/runtime/abi.Type", ptr undef }, ptr %3, 1
+// CHECK-NEXT:   %0 = alloca %"{{.*}}/runtime/abi.StructField", align 8
+// CHECK-NEXT:   %1 = alloca %"{{.*}}/runtime/abi.StructField", align 8
+// CHECK-NEXT:   %2 = alloca %"{{.*}}/runtime/abi.StructField", align 8
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 48)
+// CHECK-NEXT:   store %"{{.*}}/cl/_testrt/abinamed.T" zeroinitializer, ptr %3, align 8
+// CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/abinamed.T", ptr undef }, ptr %3, 1
 // CHECK-NEXT:   %5 = call ptr @"{{.*}}/cl/_testrt/abinamed.toEface"(%"{{.*}}/runtime/internal/runtime.eface" %4)
-// CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %2, i32 0, i32 0
-// CHECK-NEXT:   %7 = load ptr, ptr %6, align 8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %7)
+// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 72)
+// CHECK-NEXT:   store %"{{.*}}/runtime/abi.Type" zeroinitializer, ptr %6, align 8
+// CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/runtime/abi.Type", ptr undef }, ptr %6, 1
+// CHECK-NEXT:   %8 = call ptr @"{{.*}}/cl/_testrt/abinamed.toEface"(%"{{.*}}/runtime/internal/runtime.eface" %7)
+// CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %5, i32 0, i32 0
+// CHECK-NEXT:   %10 = load ptr, ptr %9, align 8
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %10)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %2, i32 0, i32 0
-// CHECK-NEXT:   %9 = load ptr, ptr %8, align 8
-// CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %9, i32 0, i32 10
-// CHECK-NEXT:   %11 = load ptr, ptr %10, align 8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %11)
+// CHECK-NEXT:   %11 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %5, i32 0, i32 0
+// CHECK-NEXT:   %12 = load ptr, ptr %11, align 8
+// CHECK-NEXT:   %13 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %12, i32 0, i32 10
+// CHECK-NEXT:   %14 = load ptr, ptr %13, align 8
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %14)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %12 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %5, i32 0, i32 0
-// CHECK-NEXT:   %13 = load ptr, ptr %12, align 8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %13)
+// CHECK-NEXT:   %15 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %8, i32 0, i32 0
+// CHECK-NEXT:   %16 = load ptr, ptr %15, align 8
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %16)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %14 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %5, i32 0, i32 0
-// CHECK-NEXT:   %15 = load ptr, ptr %14, align 8
-// CHECK-NEXT:   %16 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %15, i32 0, i32 10
-// CHECK-NEXT:   %17 = load ptr, ptr %16, align 8
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %17)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %18 = alloca %"{{.*}}/runtime/abi.StructField", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %18, i8 0, i64 56, i1 false)
-// CHECK-NEXT:   %19 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %17 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %8, i32 0, i32 0
+// CHECK-NEXT:   %18 = load ptr, ptr %17, align 8
+// CHECK-NEXT:   %19 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %18, i32 0, i32 10
 // CHECK-NEXT:   %20 = load ptr, ptr %19, align 8
-// CHECK-NEXT:   %21 = call ptr @"{{.*}}/runtime/abi.(*Type).StructType"(ptr %20)
-// CHECK-NEXT:   %22 = getelementptr inbounds %"{{.*}}/runtime/abi.StructType", ptr %21, i32 0, i32 2
-// CHECK-NEXT:   %23 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %22, align 8
-// CHECK-NEXT:   %24 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %23, 0
-// CHECK-NEXT:   %25 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %23, 1
-// CHECK-NEXT:   %26 = icmp sge i64 0, %25
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %26)
-// CHECK-NEXT:   %27 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %24, i64 0
-// CHECK-NEXT:   %28 = load %"{{.*}}/runtime/abi.StructField", ptr %27, align 8
-// CHECK-NEXT:   store %"{{.*}}/runtime/abi.StructField" %28, ptr %18, align 8
-// CHECK-NEXT:   %29 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %18, i32 0, i32 1
-// CHECK-NEXT:   %30 = load ptr, ptr %29, align 8
-// CHECK-NEXT:   %31 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %2, i32 0, i32 0
-// CHECK-NEXT:   %32 = load ptr, ptr %31, align 8
-// CHECK-NEXT:   %33 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %32, i32 0, i32 10
-// CHECK-NEXT:   %34 = load ptr, ptr %33, align 8
-// CHECK-NEXT:   %35 = icmp ne ptr %30, %34
-// CHECK-NEXT:   br i1 %35, label %_llgo_1, label %_llgo_2
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %20)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   %21 = alloca %"{{.*}}/runtime/abi.StructField", align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %21, i8 0, i64 56, i1 false)
+// CHECK-NEXT:   %22 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %5, i32 0, i32 0
+// CHECK-NEXT:   %23 = load ptr, ptr %22, align 8
+// CHECK-NEXT:   %24 = call ptr @"{{.*}}/runtime/abi.(*Type).StructType"(ptr %23)
+// CHECK-NEXT:   %25 = getelementptr inbounds %"{{.*}}/runtime/abi.StructType", ptr %24, i32 0, i32 2
+// CHECK-NEXT:   %26 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %25, align 8
+// CHECK-NEXT:   %27 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %26, 0
+// CHECK-NEXT:   %28 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %26, 1
+// CHECK-NEXT:   %29 = icmp sge i64 0, %28
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %29)
+// CHECK-NEXT:   %30 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %27, i64 0
+// CHECK-NEXT:   %31 = load %"{{.*}}/runtime/abi.StructField", ptr %30, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/abi.StructField" %31, ptr %21, align 8
+// CHECK-NEXT:   %32 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %21, i32 0, i32 1
+// CHECK-NEXT:   %33 = load ptr, ptr %32, align 8
+// CHECK-NEXT:   %34 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %5, i32 0, i32 0
+// CHECK-NEXT:   %35 = load ptr, ptr %34, align 8
+// CHECK-NEXT:   %36 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %35, i32 0, i32 10
+// CHECK-NEXT:   %37 = load ptr, ptr %36, align 8
+// CHECK-NEXT:   %38 = icmp ne ptr %33, %37
+// CHECK-NEXT:   br i1 %38, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %36 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @125, i64 13 }, ptr %36, align 8
-// CHECK-NEXT:   %37 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %36, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %37)
+// CHECK-NEXT:   %39 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @125, i64 13 }, ptr %39, align 8
+// CHECK-NEXT:   %40 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %39, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %40)
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %38 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %18, i32 0, i32 1
-// CHECK-NEXT:   %39 = load ptr, ptr %38, align 8
-// CHECK-NEXT:   %40 = call ptr @"{{.*}}/runtime/abi.(*Type).Elem"(ptr %39)
-// CHECK-NEXT:   %41 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %41 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %21, i32 0, i32 1
 // CHECK-NEXT:   %42 = load ptr, ptr %41, align 8
-// CHECK-NEXT:   %43 = icmp ne ptr %40, %42
-// CHECK-NEXT:   br i1 %43, label %_llgo_3, label %_llgo_4
+// CHECK-NEXT:   %43 = call ptr @"{{.*}}/runtime/abi.(*Type).Elem"(ptr %42)
+// CHECK-NEXT:   %44 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %5, i32 0, i32 0
+// CHECK-NEXT:   %45 = load ptr, ptr %44, align 8
+// CHECK-NEXT:   %46 = icmp ne ptr %43, %45
+// CHECK-NEXT:   br i1 %46, label %_llgo_3, label %_llgo_4
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %44 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @126, i64 18 }, ptr %44, align 8
-// CHECK-NEXT:   %45 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %44, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %45)
+// CHECK-NEXT:   %47 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @126, i64 18 }, ptr %47, align 8
+// CHECK-NEXT:   %48 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %47, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %48)
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %46 = alloca %"{{.*}}/runtime/abi.StructField", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %46, i8 0, i64 56, i1 false)
-// CHECK-NEXT:   %47 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %2, i32 0, i32 0
-// CHECK-NEXT:   %48 = load ptr, ptr %47, align 8
-// CHECK-NEXT:   %49 = call ptr @"{{.*}}/runtime/abi.(*Type).StructType"(ptr %48)
-// CHECK-NEXT:   %50 = getelementptr inbounds %"{{.*}}/runtime/abi.StructType", ptr %49, i32 0, i32 2
-// CHECK-NEXT:   %51 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %50, align 8
-// CHECK-NEXT:   %52 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %51, 0
-// CHECK-NEXT:   %53 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %51, 1
-// CHECK-NEXT:   %54 = icmp sge i64 1, %53
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %54)
-// CHECK-NEXT:   %55 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %52, i64 1
-// CHECK-NEXT:   %56 = load %"{{.*}}/runtime/abi.StructField", ptr %55, align 8
-// CHECK-NEXT:   store %"{{.*}}/runtime/abi.StructField" %56, ptr %46, align 8
-// CHECK-NEXT:   %57 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %46, i32 0, i32 1
-// CHECK-NEXT:   %58 = load ptr, ptr %57, align 8
-// CHECK-NEXT:   %59 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %5, i32 0, i32 0
+// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 56, i1 false)
+// CHECK-NEXT:   %49 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %5, i32 0, i32 0
+// CHECK-NEXT:   %50 = load ptr, ptr %49, align 8
+// CHECK-NEXT:   %51 = call ptr @"{{.*}}/runtime/abi.(*Type).StructType"(ptr %50)
+// CHECK-NEXT:   %52 = getelementptr inbounds %"{{.*}}/runtime/abi.StructType", ptr %51, i32 0, i32 2
+// CHECK-NEXT:   %53 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %52, align 8
+// CHECK-NEXT:   %54 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %53, 0
+// CHECK-NEXT:   %55 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %53, 1
+// CHECK-NEXT:   %56 = icmp sge i64 1, %55
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %56)
+// CHECK-NEXT:   %57 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %54, i64 1
+// CHECK-NEXT:   %58 = load %"{{.*}}/runtime/abi.StructField", ptr %57, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/abi.StructField" %58, ptr %2, align 8
+// CHECK-NEXT:   %59 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %2, i32 0, i32 1
 // CHECK-NEXT:   %60 = load ptr, ptr %59, align 8
-// CHECK-NEXT:   %61 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %60, i32 0, i32 10
+// CHECK-NEXT:   %61 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %8, i32 0, i32 0
 // CHECK-NEXT:   %62 = load ptr, ptr %61, align 8
-// CHECK-NEXT:   %63 = icmp ne ptr %58, %62
-// CHECK-NEXT:   br i1 %63, label %_llgo_5, label %_llgo_6
+// CHECK-NEXT:   %63 = getelementptr inbounds %"{{.*}}/runtime/abi.Type", ptr %62, i32 0, i32 10
+// CHECK-NEXT:   %64 = load ptr, ptr %63, align 8
+// CHECK-NEXT:   %65 = icmp ne ptr %60, %64
+// CHECK-NEXT:   br i1 %65, label %_llgo_5, label %_llgo_6
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_4
-// CHECK-NEXT:   %64 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @127, i64 13 }, ptr %64, align 8
-// CHECK-NEXT:   %65 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %64, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %65)
+// CHECK-NEXT:   %66 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @127, i64 13 }, ptr %66, align 8
+// CHECK-NEXT:   %67 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %66, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %67)
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_4
-// CHECK-NEXT:   %66 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %46, i32 0, i32 1
-// CHECK-NEXT:   %67 = load ptr, ptr %66, align 8
-// CHECK-NEXT:   %68 = call ptr @"{{.*}}/runtime/abi.(*Type).Elem"(ptr %67)
-// CHECK-NEXT:   %69 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %5, i32 0, i32 0
-// CHECK-NEXT:   %70 = load ptr, ptr %69, align 8
-// CHECK-NEXT:   %71 = icmp ne ptr %68, %70
-// CHECK-NEXT:   br i1 %71, label %_llgo_7, label %_llgo_8
+// CHECK-NEXT:   %68 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %2, i32 0, i32 1
+// CHECK-NEXT:   %69 = load ptr, ptr %68, align 8
+// CHECK-NEXT:   %70 = call ptr @"{{.*}}/runtime/abi.(*Type).Elem"(ptr %69)
+// CHECK-NEXT:   %71 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %8, i32 0, i32 0
+// CHECK-NEXT:   %72 = load ptr, ptr %71, align 8
+// CHECK-NEXT:   %73 = icmp ne ptr %70, %72
+// CHECK-NEXT:   br i1 %73, label %_llgo_7, label %_llgo_8
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   %72 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @128, i64 18 }, ptr %72, align 8
-// CHECK-NEXT:   %73 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %72, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %73)
+// CHECK-NEXT:   %74 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @128, i64 18 }, ptr %74, align 8
+// CHECK-NEXT:   %75 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %74, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %75)
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   %74 = alloca %"{{.*}}/runtime/abi.StructField", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %74, i8 0, i64 56, i1 false)
-// CHECK-NEXT:   %75 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %2, i32 0, i32 0
-// CHECK-NEXT:   %76 = load ptr, ptr %75, align 8
-// CHECK-NEXT:   %77 = call ptr @"{{.*}}/runtime/abi.(*Type).StructType"(ptr %76)
-// CHECK-NEXT:   %78 = getelementptr inbounds %"{{.*}}/runtime/abi.StructType", ptr %77, i32 0, i32 2
-// CHECK-NEXT:   %79 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %78, align 8
-// CHECK-NEXT:   %80 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %79, 0
-// CHECK-NEXT:   %81 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %79, 1
-// CHECK-NEXT:   %82 = icmp sge i64 2, %81
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %82)
-// CHECK-NEXT:   %83 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %80, i64 2
-// CHECK-NEXT:   %84 = load %"{{.*}}/runtime/abi.StructField", ptr %83, align 8
-// CHECK-NEXT:   store %"{{.*}}/runtime/abi.StructField" %84, ptr %74, align 8
-// CHECK-NEXT:   %85 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %74, i32 0, i32 1
-// CHECK-NEXT:   %86 = load ptr, ptr %85, align 8
-// CHECK-NEXT:   %87 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %5, i32 0, i32 0
-// CHECK-NEXT:   %88 = load ptr, ptr %87, align 8
-// CHECK-NEXT:   %89 = call ptr @"{{.*}}/runtime/abi.(*Type).StructType"(ptr %88)
-// CHECK-NEXT:   %90 = getelementptr inbounds %"{{.*}}/runtime/abi.StructType", ptr %89, i32 0, i32 2
-// CHECK-NEXT:   %91 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %90, align 8
-// CHECK-NEXT:   %92 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %91, 0
-// CHECK-NEXT:   %93 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %91, 1
-// CHECK-NEXT:   %94 = icmp sge i64 0, %93
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %94)
-// CHECK-NEXT:   %95 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %92, i64 0
-// CHECK-NEXT:   %96 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %95, i32 0, i32 1
-// CHECK-NEXT:   %97 = load ptr, ptr %96, align 8
-// CHECK-NEXT:   %98 = icmp ne ptr %86, %97
-// CHECK-NEXT:   br i1 %98, label %_llgo_9, label %_llgo_10
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 56, i1 false)
+// CHECK-NEXT:   %76 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %5, i32 0, i32 0
+// CHECK-NEXT:   %77 = load ptr, ptr %76, align 8
+// CHECK-NEXT:   %78 = call ptr @"{{.*}}/runtime/abi.(*Type).StructType"(ptr %77)
+// CHECK-NEXT:   %79 = getelementptr inbounds %"{{.*}}/runtime/abi.StructType", ptr %78, i32 0, i32 2
+// CHECK-NEXT:   %80 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %79, align 8
+// CHECK-NEXT:   %81 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %80, 0
+// CHECK-NEXT:   %82 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %80, 1
+// CHECK-NEXT:   %83 = icmp sge i64 2, %82
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %83)
+// CHECK-NEXT:   %84 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %81, i64 2
+// CHECK-NEXT:   %85 = load %"{{.*}}/runtime/abi.StructField", ptr %84, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/abi.StructField" %85, ptr %1, align 8
+// CHECK-NEXT:   %86 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %87 = load ptr, ptr %86, align 8
+// CHECK-NEXT:   %88 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %8, i32 0, i32 0
+// CHECK-NEXT:   %89 = load ptr, ptr %88, align 8
+// CHECK-NEXT:   %90 = call ptr @"{{.*}}/runtime/abi.(*Type).StructType"(ptr %89)
+// CHECK-NEXT:   %91 = getelementptr inbounds %"{{.*}}/runtime/abi.StructType", ptr %90, i32 0, i32 2
+// CHECK-NEXT:   %92 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %91, align 8
+// CHECK-NEXT:   %93 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %92, 0
+// CHECK-NEXT:   %94 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %92, 1
+// CHECK-NEXT:   %95 = icmp sge i64 0, %94
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %95)
+// CHECK-NEXT:   %96 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %93, i64 0
+// CHECK-NEXT:   %97 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %96, i32 0, i32 1
+// CHECK-NEXT:   %98 = load ptr, ptr %97, align 8
+// CHECK-NEXT:   %99 = icmp ne ptr %87, %98
+// CHECK-NEXT:   br i1 %99, label %_llgo_9, label %_llgo_10
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_9:                                          ; preds = %_llgo_8
-// CHECK-NEXT:   %99 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @129, i64 13 }, ptr %99, align 8
-// CHECK-NEXT:   %100 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %99, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %100)
+// CHECK-NEXT:   %100 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @129, i64 13 }, ptr %100, align 8
+// CHECK-NEXT:   %101 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %100, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %101)
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_10:                                         ; preds = %_llgo_8
-// CHECK-NEXT:   %101 = alloca %"{{.*}}/runtime/abi.StructField", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %101, i8 0, i64 56, i1 false)
-// CHECK-NEXT:   %102 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 56, i1 false)
+// CHECK-NEXT:   %102 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %5, i32 0, i32 0
 // CHECK-NEXT:   %103 = load ptr, ptr %102, align 8
 // CHECK-NEXT:   %104 = call ptr @"{{.*}}/runtime/abi.(*Type).StructType"(ptr %103)
 // CHECK-NEXT:   %105 = getelementptr inbounds %"{{.*}}/runtime/abi.StructType", ptr %104, i32 0, i32 2
@@ -183,11 +183,11 @@ import (
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %109)
 // CHECK-NEXT:   %110 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %107, i64 3
 // CHECK-NEXT:   %111 = load %"{{.*}}/runtime/abi.StructField", ptr %110, align 8
-// CHECK-NEXT:   store %"{{.*}}/runtime/abi.StructField" %111, ptr %101, align 8
-// CHECK-NEXT:   %112 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %101, i32 0, i32 1
+// CHECK-NEXT:   store %"{{.*}}/runtime/abi.StructField" %111, ptr %0, align 8
+// CHECK-NEXT:   %112 = getelementptr inbounds %"{{.*}}/runtime/abi.StructField", ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %113 = load ptr, ptr %112, align 8
 // CHECK-NEXT:   %114 = call ptr @"{{.*}}/runtime/abi.(*Type).Elem"(ptr %113)
-// CHECK-NEXT:   %115 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %115 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %5, i32 0, i32 0
 // CHECK-NEXT:   %116 = load ptr, ptr %115, align 8
 // CHECK-NEXT:   %117 = icmp ne ptr %114, %116
 // CHECK-NEXT:   br i1 %117, label %_llgo_11, label %_llgo_12

--- a/cl/_testrt/makemap/in.go
+++ b/cl/_testrt/makemap/in.go
@@ -231,127 +231,134 @@ type N1 [1]int
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/makemap.make2"() {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_string", i64 0)
-// CHECK-NEXT:   %1 = call i64 @"{{.*}}/runtime/internal/runtime.MapLen"(ptr %0)
-// CHECK-NEXT:   %2 = icmp eq ptr %0, null
-// CHECK-NEXT:   %3 = icmp ne ptr %0, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %0)
+// CHECK-NEXT:   %0 = alloca [1 x i64], align 8
+// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_string", i64 0)
+// CHECK-NEXT:   %2 = call i64 @"{{.*}}/runtime/internal/runtime.MapLen"(ptr %1)
+// CHECK-NEXT:   %3 = icmp eq ptr %1, null
+// CHECK-NEXT:   %4 = icmp ne ptr %1, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %1)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %1)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %2)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %2)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %3)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %4)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %4 = call i64 @"{{.*}}/runtime/internal/runtime.MapLen"(ptr null)
+// CHECK-NEXT:   %5 = call i64 @"{{.*}}/runtime/internal/runtime.MapLen"(ptr null)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr null)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %4)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %5)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 true)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 false)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_any]_llgo_int", i64 0)
-// CHECK-NEXT:   %6 = alloca [1 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %6, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %6, i64 0
-// CHECK-NEXT:   store i64 1, ptr %7, align 4
-// CHECK-NEXT:   %8 = load [1 x i64], ptr %6, align 4
-// CHECK-NEXT:   %9 = extractvalue [1 x i64] %8, 0
-// CHECK-NEXT:   %10 = inttoptr i64 %9 to ptr
-// CHECK-NEXT:   %11 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_github.com/goplus/llgo/cl/_testrt/makemap.N1", ptr undef }, ptr %10, 1
-// CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %11, ptr %12, align 8
-// CHECK-NEXT:   %13 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %5, ptr %12)
-// CHECK-NEXT:   store i64 100, ptr %13, align 4
-// CHECK-NEXT:   %14 = alloca [1 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %14, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   %15 = getelementptr inbounds i64, ptr %14, i64 0
-// CHECK-NEXT:   store i64 2, ptr %15, align 4
-// CHECK-NEXT:   %16 = load [1 x i64], ptr %14, align 4
-// CHECK-NEXT:   %17 = extractvalue [1 x i64] %16, 0
-// CHECK-NEXT:   %18 = inttoptr i64 %17 to ptr
-// CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_github.com/goplus/llgo/cl/_testrt/makemap.N1", ptr undef }, ptr %18, 1
-// CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %19, ptr %20, align 8
-// CHECK-NEXT:   %21 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %5, ptr %20)
-// CHECK-NEXT:   store i64 200, ptr %21, align 4
-// CHECK-NEXT:   %22 = alloca [1 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %22, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   %23 = getelementptr inbounds i64, ptr %22, i64 0
-// CHECK-NEXT:   store i64 3, ptr %23, align 4
-// CHECK-NEXT:   %24 = load [1 x i64], ptr %22, align 4
-// CHECK-NEXT:   %25 = extractvalue [1 x i64] %24, 0
-// CHECK-NEXT:   %26 = inttoptr i64 %25 to ptr
-// CHECK-NEXT:   %27 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_github.com/goplus/llgo/cl/_testrt/makemap.N1", ptr undef }, ptr %26, 1
-// CHECK-NEXT:   %28 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %27, ptr %28, align 8
-// CHECK-NEXT:   %29 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %5, ptr %28)
-// CHECK-NEXT:   store i64 300, ptr %29, align 4
-// CHECK-NEXT:   %30 = alloca [1 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %30, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   %31 = getelementptr inbounds i64, ptr %30, i64 0
-// CHECK-NEXT:   store i64 2, ptr %31, align 4
-// CHECK-NEXT:   %32 = load [1 x i64], ptr %30, align 4
-// CHECK-NEXT:   %33 = extractvalue [1 x i64] %32, 0
-// CHECK-NEXT:   %34 = inttoptr i64 %33 to ptr
-// CHECK-NEXT:   %35 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_github.com/goplus/llgo/cl/_testrt/makemap.N1", ptr undef }, ptr %34, 1
-// CHECK-NEXT:   %36 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %35, ptr %36, align 8
-// CHECK-NEXT:   %37 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %5, ptr %36)
-// CHECK-NEXT:   store i64 -200, ptr %37, align 4
-// CHECK-NEXT:   %38 = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @"map[_llgo_any]_llgo_int", ptr %5)
+// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_any]_llgo_int", i64 0)
+// CHECK-NEXT:   %7 = alloca [1 x i64], align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %7, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   %8 = getelementptr inbounds i64, ptr %7, i64 0
+// CHECK-NEXT:   store i64 1, ptr %8, align 4
+// CHECK-NEXT:   %9 = load [1 x i64], ptr %7, align 4
+// CHECK-NEXT:   %10 = extractvalue [1 x i64] %9, 0
+// CHECK-NEXT:   %11 = inttoptr i64 %10 to ptr
+// CHECK-NEXT:   %12 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.N1", ptr undef }, ptr %11, 1
+// CHECK-NEXT:   %13 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %12, ptr %13, align 8
+// CHECK-NEXT:   %14 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %6, ptr %13)
+// CHECK-NEXT:   store i64 100, ptr %14, align 4
+// CHECK-NEXT:   %15 = alloca [1 x i64], align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %15, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   %16 = getelementptr inbounds i64, ptr %15, i64 0
+// CHECK-NEXT:   store i64 2, ptr %16, align 4
+// CHECK-NEXT:   %17 = load [1 x i64], ptr %15, align 4
+// CHECK-NEXT:   %18 = extractvalue [1 x i64] %17, 0
+// CHECK-NEXT:   %19 = inttoptr i64 %18 to ptr
+// CHECK-NEXT:   %20 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.N1", ptr undef }, ptr %19, 1
+// CHECK-NEXT:   %21 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %20, ptr %21, align 8
+// CHECK-NEXT:   %22 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %6, ptr %21)
+// CHECK-NEXT:   store i64 200, ptr %22, align 4
+// CHECK-NEXT:   %23 = alloca [1 x i64], align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %23, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   %24 = getelementptr inbounds i64, ptr %23, i64 0
+// CHECK-NEXT:   store i64 3, ptr %24, align 4
+// CHECK-NEXT:   %25 = load [1 x i64], ptr %23, align 4
+// CHECK-NEXT:   %26 = extractvalue [1 x i64] %25, 0
+// CHECK-NEXT:   %27 = inttoptr i64 %26 to ptr
+// CHECK-NEXT:   %28 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.N1", ptr undef }, ptr %27, 1
+// CHECK-NEXT:   %29 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %28, ptr %29, align 8
+// CHECK-NEXT:   %30 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %6, ptr %29)
+// CHECK-NEXT:   store i64 300, ptr %30, align 4
+// CHECK-NEXT:   %31 = alloca [1 x i64], align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %31, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   %32 = getelementptr inbounds i64, ptr %31, i64 0
+// CHECK-NEXT:   store i64 2, ptr %32, align 4
+// CHECK-NEXT:   %33 = load [1 x i64], ptr %31, align 4
+// CHECK-NEXT:   %34 = extractvalue [1 x i64] %33, 0
+// CHECK-NEXT:   %35 = inttoptr i64 %34 to ptr
+// CHECK-NEXT:   %36 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.N1", ptr undef }, ptr %35, 1
+// CHECK-NEXT:   %37 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %36, ptr %37, align 8
+// CHECK-NEXT:   %38 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %6, ptr %37)
+// CHECK-NEXT:   store i64 -200, ptr %38, align 4
+// CHECK-NEXT:   %39 = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @"map[_llgo_any]_llgo_int", ptr %6)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_7, %_llgo_0
-// CHECK-NEXT:   %39 = call { i1, ptr, ptr } @"{{.*}}/runtime/internal/runtime.MapIterNext"(ptr %38)
-// CHECK-NEXT:   %40 = extractvalue { i1, ptr, ptr } %39, 0
-// CHECK-NEXT:   br i1 %40, label %_llgo_4, label %_llgo_5
+// CHECK-NEXT:   %40 = call { i1, ptr, ptr } @"{{.*}}/runtime/internal/runtime.MapIterNext"(ptr %39)
+// CHECK-NEXT:   %41 = extractvalue { i1, ptr, ptr } %40, 0
+// CHECK-NEXT:   br i1 %41, label %_llgo_4, label %_llgo_5
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   %41 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %51, 1
-// CHECK-NEXT:   %42 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %51, 2
-// CHECK-NEXT:   %43 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %41, 0
-// CHECK-NEXT:   %44 = icmp eq ptr %43, @"_llgo_github.com/goplus/llgo/cl/_testrt/makemap.N1"
-// CHECK-NEXT:   br i1 %44, label %_llgo_7, label %_llgo_8
+// CHECK-NEXT:   %42 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %52, 1
+// CHECK-NEXT:   %43 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %52, 2
+// CHECK-NEXT:   %44 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %42, 0
+// CHECK-NEXT:   %45 = icmp eq ptr %44, @"_llgo_{{.*}}/cl/_testrt/makemap.N1"
+// CHECK-NEXT:   br i1 %45, label %_llgo_7, label %_llgo_8
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_6
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %45 = extractvalue { i1, ptr, ptr } %39, 1
-// CHECK-NEXT:   %46 = extractvalue { i1, ptr, ptr } %39, 2
-// CHECK-NEXT:   %47 = load %"{{.*}}/runtime/internal/runtime.eface", ptr %45, align 8
-// CHECK-NEXT:   %48 = load i64, ptr %46, align 4
-// CHECK-NEXT:   %49 = insertvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } { i1 true, %"{{.*}}/runtime/internal/runtime.eface" undef, i64 undef }, %"{{.*}}/runtime/internal/runtime.eface" %47, 1
-// CHECK-NEXT:   %50 = insertvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %49, i64 %48, 2
+// CHECK-NEXT:   %46 = extractvalue { i1, ptr, ptr } %40, 1
+// CHECK-NEXT:   %47 = extractvalue { i1, ptr, ptr } %40, 2
+// CHECK-NEXT:   %48 = load %"{{.*}}/runtime/internal/runtime.eface", ptr %46, align 8
+// CHECK-NEXT:   %49 = load i64, ptr %47, align 4
+// CHECK-NEXT:   %50 = insertvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } { i1 true, %"{{.*}}/runtime/internal/runtime.eface" undef, i64 undef }, %"{{.*}}/runtime/internal/runtime.eface" %48, 1
+// CHECK-NEXT:   %51 = insertvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %50, i64 %49, 2
 // CHECK-NEXT:   br label %_llgo_6
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_1
 // CHECK-NEXT:   br label %_llgo_6
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-// CHECK-NEXT:   %51 = phi { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } [ %50, %_llgo_4 ], [ zeroinitializer, %_llgo_5 ]
-// CHECK-NEXT:   %52 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %51, 0
-// CHECK-NEXT:   br i1 %52, label %_llgo_2, label %_llgo_3
+// CHECK-NEXT:   %52 = phi { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } [ %51, %_llgo_4 ], [ zeroinitializer, %_llgo_5 ]
+// CHECK-NEXT:   %53 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %52, 0
+// CHECK-NEXT:   br i1 %53, label %_llgo_2, label %_llgo_3
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %53 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %41, 1
-// CHECK-NEXT:   %54 = ptrtoint ptr %53 to i64
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %54)
+// CHECK-NEXT:   %54 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %42, 1
+// CHECK-NEXT:   %55 = ptrtoint ptr %54 to i64
+// CHECK-NEXT:   %56 = insertvalue [1 x i64] undef, i64 %55, 0
+// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   store [1 x i64] %56, ptr %0, align 4
+// CHECK-NEXT:   %57 = getelementptr inbounds i64, ptr %0, i64 0
+// CHECK-NEXT:   %58 = load i64, ptr %57, align 4
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %58)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %42)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %43)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %55 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @32, i64 81 }, ptr %55, align 8
-// CHECK-NEXT:   %56 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %55, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %56)
+// CHECK-NEXT:   %59 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @32, i64 81 }, ptr %59, align 8
+// CHECK-NEXT:   %60 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %59, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %60)
 // CHECK-NEXT:   unreachable
 // CHECK-NEXT: }
+
 func make2() {
 	m2 := make(map[int]string)
 	println(m2, len(m2), m2 == nil, m2 != nil)
@@ -378,109 +385,109 @@ type K2 [1]*N
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/makemap.make3"() {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca [1 x %"{{.*}}/cl/_testrt/makemap.N"], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 2, i1 false)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %0, i64 0
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %1, i32 0, i32 0
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %1, i32 0, i32 1
-// CHECK-NEXT:   store i8 1, ptr %2, align 1
-// CHECK-NEXT:   store i8 2, ptr %3, align 1
-// CHECK-NEXT:   %4 = load [1 x %"{{.*}}/cl/_testrt/makemap.N"], ptr %0, align 1
-// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 2)
-// CHECK-NEXT:   store [1 x %"{{.*}}/cl/_testrt/makemap.N"] %4, ptr %5, align 1
-// CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_github.com/goplus/llgo/cl/_testrt/makemap.K", ptr undef }, ptr %5, 1
-// CHECK-NEXT:   %7 = alloca [1 x %"{{.*}}/cl/_testrt/makemap.N"], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %7, i8 0, i64 2, i1 false)
-// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %7, i64 0
-// CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %8, i32 0, i32 0
-// CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %8, i32 0, i32 1
-// CHECK-NEXT:   store i8 1, ptr %9, align 1
-// CHECK-NEXT:   store i8 2, ptr %10, align 1
-// CHECK-NEXT:   %11 = load [1 x %"{{.*}}/cl/_testrt/makemap.N"], ptr %7, align 1
-// CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 2)
-// CHECK-NEXT:   store [1 x %"{{.*}}/cl/_testrt/makemap.N"] %11, ptr %12, align 1
-// CHECK-NEXT:   %13 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_github.com/goplus/llgo/cl/_testrt/makemap.K", ptr undef }, ptr %12, 1
-// CHECK-NEXT:   %14 = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"(%"{{.*}}/runtime/internal/runtime.eface" %6, %"{{.*}}/runtime/internal/runtime.eface" %13)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %14)
+// CHECK-NEXT:   %1 = alloca [1 x %"{{.*}}/cl/_testrt/makemap.N"], align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 2, i1 false)
+// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %1, i64 0
+// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %2, i32 0, i32 1
+// CHECK-NEXT:   store i8 1, ptr %3, align 1
+// CHECK-NEXT:   store i8 2, ptr %4, align 1
+// CHECK-NEXT:   %5 = load [1 x %"{{.*}}/cl/_testrt/makemap.N"], ptr %1, align 1
+// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 2)
+// CHECK-NEXT:   store [1 x %"{{.*}}/cl/_testrt/makemap.N"] %5, ptr %6, align 1
+// CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.K", ptr undef }, ptr %6, 1
+// CHECK-NEXT:   %8 = alloca [1 x %"{{.*}}/cl/_testrt/makemap.N"], align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %8, i8 0, i64 2, i1 false)
+// CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %8, i64 0
+// CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %9, i32 0, i32 0
+// CHECK-NEXT:   %11 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %9, i32 0, i32 1
+// CHECK-NEXT:   store i8 1, ptr %10, align 1
+// CHECK-NEXT:   store i8 2, ptr %11, align 1
+// CHECK-NEXT:   %12 = load [1 x %"{{.*}}/cl/_testrt/makemap.N"], ptr %8, align 1
+// CHECK-NEXT:   %13 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 2)
+// CHECK-NEXT:   store [1 x %"{{.*}}/cl/_testrt/makemap.N"] %12, ptr %13, align 1
+// CHECK-NEXT:   %14 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.K", ptr undef }, ptr %13, 1
+// CHECK-NEXT:   %15 = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"(%"{{.*}}/runtime/internal/runtime.eface" %7, %"{{.*}}/runtime/internal/runtime.eface" %14)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %15)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %15 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_any]_llgo_int", i64 0)
-// CHECK-NEXT:   %16 = alloca [1 x %"{{.*}}/cl/_testrt/makemap.N"], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %16, i8 0, i64 2, i1 false)
-// CHECK-NEXT:   %17 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %16, i64 0
-// CHECK-NEXT:   %18 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %17, i32 0, i32 0
-// CHECK-NEXT:   %19 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %17, i32 0, i32 1
-// CHECK-NEXT:   store i8 1, ptr %18, align 1
-// CHECK-NEXT:   store i8 2, ptr %19, align 1
-// CHECK-NEXT:   %20 = load [1 x %"{{.*}}/cl/_testrt/makemap.N"], ptr %16, align 1
-// CHECK-NEXT:   %21 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 2)
-// CHECK-NEXT:   store [1 x %"{{.*}}/cl/_testrt/makemap.N"] %20, ptr %21, align 1
-// CHECK-NEXT:   %22 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_github.com/goplus/llgo/cl/_testrt/makemap.K", ptr undef }, ptr %21, 1
-// CHECK-NEXT:   %23 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %22, ptr %23, align 8
-// CHECK-NEXT:   %24 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %15, ptr %23)
-// CHECK-NEXT:   store i64 100, ptr %24, align 4
-// CHECK-NEXT:   %25 = alloca [1 x %"{{.*}}/cl/_testrt/makemap.N"], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %25, i8 0, i64 2, i1 false)
-// CHECK-NEXT:   %26 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %25, i64 0
-// CHECK-NEXT:   %27 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %26, i32 0, i32 0
-// CHECK-NEXT:   %28 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %26, i32 0, i32 1
-// CHECK-NEXT:   store i8 3, ptr %27, align 1
-// CHECK-NEXT:   store i8 4, ptr %28, align 1
-// CHECK-NEXT:   %29 = load [1 x %"{{.*}}/cl/_testrt/makemap.N"], ptr %25, align 1
-// CHECK-NEXT:   %30 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 2)
-// CHECK-NEXT:   store [1 x %"{{.*}}/cl/_testrt/makemap.N"] %29, ptr %30, align 1
-// CHECK-NEXT:   %31 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_github.com/goplus/llgo/cl/_testrt/makemap.K", ptr undef }, ptr %30, 1
-// CHECK-NEXT:   %32 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %31, ptr %32, align 8
-// CHECK-NEXT:   %33 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %15, ptr %32)
-// CHECK-NEXT:   store i64 200, ptr %33, align 4
-// CHECK-NEXT:   %34 = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @"map[_llgo_any]_llgo_int", ptr %15)
+// CHECK-NEXT:   %16 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_any]_llgo_int", i64 0)
+// CHECK-NEXT:   %17 = alloca [1 x %"{{.*}}/cl/_testrt/makemap.N"], align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %17, i8 0, i64 2, i1 false)
+// CHECK-NEXT:   %18 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %17, i64 0
+// CHECK-NEXT:   %19 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %18, i32 0, i32 0
+// CHECK-NEXT:   %20 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %18, i32 0, i32 1
+// CHECK-NEXT:   store i8 1, ptr %19, align 1
+// CHECK-NEXT:   store i8 2, ptr %20, align 1
+// CHECK-NEXT:   %21 = load [1 x %"{{.*}}/cl/_testrt/makemap.N"], ptr %17, align 1
+// CHECK-NEXT:   %22 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 2)
+// CHECK-NEXT:   store [1 x %"{{.*}}/cl/_testrt/makemap.N"] %21, ptr %22, align 1
+// CHECK-NEXT:   %23 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.K", ptr undef }, ptr %22, 1
+// CHECK-NEXT:   %24 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %23, ptr %24, align 8
+// CHECK-NEXT:   %25 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %16, ptr %24)
+// CHECK-NEXT:   store i64 100, ptr %25, align 4
+// CHECK-NEXT:   %26 = alloca [1 x %"{{.*}}/cl/_testrt/makemap.N"], align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %26, i8 0, i64 2, i1 false)
+// CHECK-NEXT:   %27 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %26, i64 0
+// CHECK-NEXT:   %28 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %27, i32 0, i32 0
+// CHECK-NEXT:   %29 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %27, i32 0, i32 1
+// CHECK-NEXT:   store i8 3, ptr %28, align 1
+// CHECK-NEXT:   store i8 4, ptr %29, align 1
+// CHECK-NEXT:   %30 = load [1 x %"{{.*}}/cl/_testrt/makemap.N"], ptr %26, align 1
+// CHECK-NEXT:   %31 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 2)
+// CHECK-NEXT:   store [1 x %"{{.*}}/cl/_testrt/makemap.N"] %30, ptr %31, align 1
+// CHECK-NEXT:   %32 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.K", ptr undef }, ptr %31, 1
+// CHECK-NEXT:   %33 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %32, ptr %33, align 8
+// CHECK-NEXT:   %34 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %16, ptr %33)
+// CHECK-NEXT:   store i64 200, ptr %34, align 4
+// CHECK-NEXT:   %35 = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @"map[_llgo_any]_llgo_int", ptr %16)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_7, %_llgo_0
-// CHECK-NEXT:   %35 = call { i1, ptr, ptr } @"{{.*}}/runtime/internal/runtime.MapIterNext"(ptr %34)
-// CHECK-NEXT:   %36 = extractvalue { i1, ptr, ptr } %35, 0
-// CHECK-NEXT:   br i1 %36, label %_llgo_4, label %_llgo_5
+// CHECK-NEXT:   %36 = call { i1, ptr, ptr } @"{{.*}}/runtime/internal/runtime.MapIterNext"(ptr %35)
+// CHECK-NEXT:   %37 = extractvalue { i1, ptr, ptr } %36, 0
+// CHECK-NEXT:   br i1 %37, label %_llgo_4, label %_llgo_5
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   %37 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %47, 1
-// CHECK-NEXT:   %38 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %47, 2
-// CHECK-NEXT:   %39 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %37, 0
-// CHECK-NEXT:   %40 = icmp eq ptr %39, @"_llgo_github.com/goplus/llgo/cl/_testrt/makemap.K"
-// CHECK-NEXT:   br i1 %40, label %_llgo_7, label %_llgo_8
+// CHECK-NEXT:   %38 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %48, 1
+// CHECK-NEXT:   %39 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %48, 2
+// CHECK-NEXT:   %40 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %38, 0
+// CHECK-NEXT:   %41 = icmp eq ptr %40, @"_llgo_{{.*}}/cl/_testrt/makemap.K"
+// CHECK-NEXT:   br i1 %41, label %_llgo_7, label %_llgo_8
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_6
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %41 = extractvalue { i1, ptr, ptr } %35, 1
-// CHECK-NEXT:   %42 = extractvalue { i1, ptr, ptr } %35, 2
-// CHECK-NEXT:   %43 = load %"{{.*}}/runtime/internal/runtime.eface", ptr %41, align 8
-// CHECK-NEXT:   %44 = load i64, ptr %42, align 4
-// CHECK-NEXT:   %45 = insertvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } { i1 true, %"{{.*}}/runtime/internal/runtime.eface" undef, i64 undef }, %"{{.*}}/runtime/internal/runtime.eface" %43, 1
-// CHECK-NEXT:   %46 = insertvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %45, i64 %44, 2
+// CHECK-NEXT:   %42 = extractvalue { i1, ptr, ptr } %36, 1
+// CHECK-NEXT:   %43 = extractvalue { i1, ptr, ptr } %36, 2
+// CHECK-NEXT:   %44 = load %"{{.*}}/runtime/internal/runtime.eface", ptr %42, align 8
+// CHECK-NEXT:   %45 = load i64, ptr %43, align 4
+// CHECK-NEXT:   %46 = insertvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } { i1 true, %"{{.*}}/runtime/internal/runtime.eface" undef, i64 undef }, %"{{.*}}/runtime/internal/runtime.eface" %44, 1
+// CHECK-NEXT:   %47 = insertvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %46, i64 %45, 2
 // CHECK-NEXT:   br label %_llgo_6
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_1
 // CHECK-NEXT:   br label %_llgo_6
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-// CHECK-NEXT:   %47 = phi { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } [ %46, %_llgo_4 ], [ zeroinitializer, %_llgo_5 ]
-// CHECK-NEXT:   %48 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %47, 0
-// CHECK-NEXT:   br i1 %48, label %_llgo_2, label %_llgo_3
+// CHECK-NEXT:   %48 = phi { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } [ %47, %_llgo_4 ], [ zeroinitializer, %_llgo_5 ]
+// CHECK-NEXT:   %49 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %48, 0
+// CHECK-NEXT:   br i1 %49, label %_llgo_2, label %_llgo_3
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %49 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %37, 1
-// CHECK-NEXT:   %50 = load [1 x %"{{.*}}/cl/_testrt/makemap.N"], ptr %49, align 1
-// CHECK-NEXT:   %51 = alloca [1 x %"{{.*}}/cl/_testrt/makemap.N"], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %51, i8 0, i64 2, i1 false)
-// CHECK-NEXT:   store [1 x %"{{.*}}/cl/_testrt/makemap.N"] %50, ptr %51, align 1
-// CHECK-NEXT:   %52 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %51, i64 0
+// CHECK-NEXT:   %50 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %38, 1
+// CHECK-NEXT:   %51 = load [1 x %"{{.*}}/cl/_testrt/makemap.N"], ptr %50, align 1
+// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 2, i1 false)
+// CHECK-NEXT:   store [1 x %"{{.*}}/cl/_testrt/makemap.N"] %51, ptr %0, align 1
+// CHECK-NEXT:   %52 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %0, i64 0
 // CHECK-NEXT:   %53 = load %"{{.*}}/cl/_testrt/makemap.N", ptr %52, align 1
 // CHECK-NEXT:   %54 = extractvalue %"{{.*}}/cl/_testrt/makemap.N" %53, 0
 // CHECK-NEXT:   %55 = sext i8 %54 to i64
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %55)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %38)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %39)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
@@ -491,6 +498,7 @@ type K2 [1]*N
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %57)
 // CHECK-NEXT:   unreachable
 // CHECK-NEXT: }
+
 func make3() {
 	var a any = K{N{1, 2}}
 	var b any = K{N{1, 2}}
@@ -507,118 +515,125 @@ func make3() {
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/makemap.make4"() {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca [1 x ptr], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   %1 = getelementptr inbounds ptr, ptr %0, i64 0
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 2)
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %2, i32 0, i32 0
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %2, i32 0, i32 1
-// CHECK-NEXT:   store i8 1, ptr %3, align 1
-// CHECK-NEXT:   store i8 2, ptr %4, align 1
-// CHECK-NEXT:   store ptr %2, ptr %1, align 8
-// CHECK-NEXT:   %5 = load [1 x ptr], ptr %0, align 8
-// CHECK-NEXT:   %6 = extractvalue [1 x ptr] %5, 0
-// CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_github.com/goplus/llgo/cl/_testrt/makemap.K2", ptr undef }, ptr %6, 1
-// CHECK-NEXT:   %8 = alloca [1 x ptr], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %8, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   %9 = getelementptr inbounds ptr, ptr %8, i64 0
-// CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 2)
-// CHECK-NEXT:   %11 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %10, i32 0, i32 0
-// CHECK-NEXT:   %12 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %10, i32 0, i32 1
-// CHECK-NEXT:   store i8 1, ptr %11, align 1
-// CHECK-NEXT:   store i8 2, ptr %12, align 1
-// CHECK-NEXT:   store ptr %10, ptr %9, align 8
-// CHECK-NEXT:   %13 = load [1 x ptr], ptr %8, align 8
-// CHECK-NEXT:   %14 = extractvalue [1 x ptr] %13, 0
-// CHECK-NEXT:   %15 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_github.com/goplus/llgo/cl/_testrt/makemap.K2", ptr undef }, ptr %14, 1
-// CHECK-NEXT:   %16 = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"(%"{{.*}}/runtime/internal/runtime.eface" %7, %"{{.*}}/runtime/internal/runtime.eface" %15)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %16)
+// CHECK-NEXT:   %1 = alloca [1 x ptr], align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   %2 = getelementptr inbounds ptr, ptr %1, i64 0
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 2)
+// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %3, i32 0, i32 0
+// CHECK-NEXT:   %5 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %3, i32 0, i32 1
+// CHECK-NEXT:   store i8 1, ptr %4, align 1
+// CHECK-NEXT:   store i8 2, ptr %5, align 1
+// CHECK-NEXT:   store ptr %3, ptr %2, align 8
+// CHECK-NEXT:   %6 = load [1 x ptr], ptr %1, align 8
+// CHECK-NEXT:   %7 = extractvalue [1 x ptr] %6, 0
+// CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.K2", ptr undef }, ptr %7, 1
+// CHECK-NEXT:   %9 = alloca [1 x ptr], align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %9, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   %10 = getelementptr inbounds ptr, ptr %9, i64 0
+// CHECK-NEXT:   %11 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 2)
+// CHECK-NEXT:   %12 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %11, i32 0, i32 0
+// CHECK-NEXT:   %13 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %11, i32 0, i32 1
+// CHECK-NEXT:   store i8 1, ptr %12, align 1
+// CHECK-NEXT:   store i8 2, ptr %13, align 1
+// CHECK-NEXT:   store ptr %11, ptr %10, align 8
+// CHECK-NEXT:   %14 = load [1 x ptr], ptr %9, align 8
+// CHECK-NEXT:   %15 = extractvalue [1 x ptr] %14, 0
+// CHECK-NEXT:   %16 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.K2", ptr undef }, ptr %15, 1
+// CHECK-NEXT:   %17 = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"(%"{{.*}}/runtime/internal/runtime.eface" %8, %"{{.*}}/runtime/internal/runtime.eface" %16)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %17)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %17 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_any]_llgo_int", i64 0)
-// CHECK-NEXT:   %18 = alloca [1 x ptr], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %18, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   %19 = getelementptr inbounds ptr, ptr %18, i64 0
-// CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 2)
-// CHECK-NEXT:   %21 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %20, i32 0, i32 0
-// CHECK-NEXT:   %22 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %20, i32 0, i32 1
-// CHECK-NEXT:   store i8 1, ptr %21, align 1
-// CHECK-NEXT:   store i8 2, ptr %22, align 1
-// CHECK-NEXT:   store ptr %20, ptr %19, align 8
-// CHECK-NEXT:   %23 = load [1 x ptr], ptr %18, align 8
-// CHECK-NEXT:   %24 = extractvalue [1 x ptr] %23, 0
-// CHECK-NEXT:   %25 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_github.com/goplus/llgo/cl/_testrt/makemap.K2", ptr undef }, ptr %24, 1
-// CHECK-NEXT:   %26 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %25, ptr %26, align 8
-// CHECK-NEXT:   %27 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %17, ptr %26)
-// CHECK-NEXT:   store i64 100, ptr %27, align 4
-// CHECK-NEXT:   %28 = alloca [1 x ptr], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %28, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   %29 = getelementptr inbounds ptr, ptr %28, i64 0
-// CHECK-NEXT:   %30 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 2)
-// CHECK-NEXT:   %31 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %30, i32 0, i32 0
-// CHECK-NEXT:   %32 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %30, i32 0, i32 1
-// CHECK-NEXT:   store i8 3, ptr %31, align 1
-// CHECK-NEXT:   store i8 4, ptr %32, align 1
-// CHECK-NEXT:   store ptr %30, ptr %29, align 8
-// CHECK-NEXT:   %33 = load [1 x ptr], ptr %28, align 8
-// CHECK-NEXT:   %34 = extractvalue [1 x ptr] %33, 0
-// CHECK-NEXT:   %35 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_github.com/goplus/llgo/cl/_testrt/makemap.K2", ptr undef }, ptr %34, 1
-// CHECK-NEXT:   %36 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %35, ptr %36, align 8
-// CHECK-NEXT:   %37 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %17, ptr %36)
-// CHECK-NEXT:   store i64 200, ptr %37, align 4
-// CHECK-NEXT:   %38 = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @"map[_llgo_any]_llgo_int", ptr %17)
+// CHECK-NEXT:   %18 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_any]_llgo_int", i64 0)
+// CHECK-NEXT:   %19 = alloca [1 x ptr], align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %19, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   %20 = getelementptr inbounds ptr, ptr %19, i64 0
+// CHECK-NEXT:   %21 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 2)
+// CHECK-NEXT:   %22 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %21, i32 0, i32 0
+// CHECK-NEXT:   %23 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %21, i32 0, i32 1
+// CHECK-NEXT:   store i8 1, ptr %22, align 1
+// CHECK-NEXT:   store i8 2, ptr %23, align 1
+// CHECK-NEXT:   store ptr %21, ptr %20, align 8
+// CHECK-NEXT:   %24 = load [1 x ptr], ptr %19, align 8
+// CHECK-NEXT:   %25 = extractvalue [1 x ptr] %24, 0
+// CHECK-NEXT:   %26 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.K2", ptr undef }, ptr %25, 1
+// CHECK-NEXT:   %27 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %26, ptr %27, align 8
+// CHECK-NEXT:   %28 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %18, ptr %27)
+// CHECK-NEXT:   store i64 100, ptr %28, align 4
+// CHECK-NEXT:   %29 = alloca [1 x ptr], align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %29, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   %30 = getelementptr inbounds ptr, ptr %29, i64 0
+// CHECK-NEXT:   %31 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 2)
+// CHECK-NEXT:   %32 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %31, i32 0, i32 0
+// CHECK-NEXT:   %33 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %31, i32 0, i32 1
+// CHECK-NEXT:   store i8 3, ptr %32, align 1
+// CHECK-NEXT:   store i8 4, ptr %33, align 1
+// CHECK-NEXT:   store ptr %31, ptr %30, align 8
+// CHECK-NEXT:   %34 = load [1 x ptr], ptr %29, align 8
+// CHECK-NEXT:   %35 = extractvalue [1 x ptr] %34, 0
+// CHECK-NEXT:   %36 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.K2", ptr undef }, ptr %35, 1
+// CHECK-NEXT:   %37 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %36, ptr %37, align 8
+// CHECK-NEXT:   %38 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %18, ptr %37)
+// CHECK-NEXT:   store i64 200, ptr %38, align 4
+// CHECK-NEXT:   %39 = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @"map[_llgo_any]_llgo_int", ptr %18)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_7, %_llgo_0
-// CHECK-NEXT:   %39 = call { i1, ptr, ptr } @"{{.*}}/runtime/internal/runtime.MapIterNext"(ptr %38)
-// CHECK-NEXT:   %40 = extractvalue { i1, ptr, ptr } %39, 0
-// CHECK-NEXT:   br i1 %40, label %_llgo_4, label %_llgo_5
+// CHECK-NEXT:   %40 = call { i1, ptr, ptr } @"{{.*}}/runtime/internal/runtime.MapIterNext"(ptr %39)
+// CHECK-NEXT:   %41 = extractvalue { i1, ptr, ptr } %40, 0
+// CHECK-NEXT:   br i1 %41, label %_llgo_4, label %_llgo_5
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   %41 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %51, 1
-// CHECK-NEXT:   %42 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %51, 2
-// CHECK-NEXT:   %43 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %41, 0
-// CHECK-NEXT:   %44 = icmp eq ptr %43, @"_llgo_github.com/goplus/llgo/cl/_testrt/makemap.K2"
-// CHECK-NEXT:   br i1 %44, label %_llgo_7, label %_llgo_8
+// CHECK-NEXT:   %42 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %52, 1
+// CHECK-NEXT:   %43 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %52, 2
+// CHECK-NEXT:   %44 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %42, 0
+// CHECK-NEXT:   %45 = icmp eq ptr %44, @"_llgo_{{.*}}/cl/_testrt/makemap.K2"
+// CHECK-NEXT:   br i1 %45, label %_llgo_7, label %_llgo_8
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_6
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %45 = extractvalue { i1, ptr, ptr } %39, 1
-// CHECK-NEXT:   %46 = extractvalue { i1, ptr, ptr } %39, 2
-// CHECK-NEXT:   %47 = load %"{{.*}}/runtime/internal/runtime.eface", ptr %45, align 8
-// CHECK-NEXT:   %48 = load i64, ptr %46, align 4
-// CHECK-NEXT:   %49 = insertvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } { i1 true, %"{{.*}}/runtime/internal/runtime.eface" undef, i64 undef }, %"{{.*}}/runtime/internal/runtime.eface" %47, 1
-// CHECK-NEXT:   %50 = insertvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %49, i64 %48, 2
+// CHECK-NEXT:   %46 = extractvalue { i1, ptr, ptr } %40, 1
+// CHECK-NEXT:   %47 = extractvalue { i1, ptr, ptr } %40, 2
+// CHECK-NEXT:   %48 = load %"{{.*}}/runtime/internal/runtime.eface", ptr %46, align 8
+// CHECK-NEXT:   %49 = load i64, ptr %47, align 4
+// CHECK-NEXT:   %50 = insertvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } { i1 true, %"{{.*}}/runtime/internal/runtime.eface" undef, i64 undef }, %"{{.*}}/runtime/internal/runtime.eface" %48, 1
+// CHECK-NEXT:   %51 = insertvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %50, i64 %49, 2
 // CHECK-NEXT:   br label %_llgo_6
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_1
 // CHECK-NEXT:   br label %_llgo_6
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_5, %_llgo_4
-// CHECK-NEXT:   %51 = phi { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } [ %50, %_llgo_4 ], [ zeroinitializer, %_llgo_5 ]
-// CHECK-NEXT:   %52 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %51, 0
-// CHECK-NEXT:   br i1 %52, label %_llgo_2, label %_llgo_3
+// CHECK-NEXT:   %52 = phi { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } [ %51, %_llgo_4 ], [ zeroinitializer, %_llgo_5 ]
+// CHECK-NEXT:   %53 = extractvalue { i1, %"{{.*}}/runtime/internal/runtime.eface", i64 } %52, 0
+// CHECK-NEXT:   br i1 %53, label %_llgo_2, label %_llgo_3
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %53 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %41, 1
-// CHECK-NEXT:   %54 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %53, i32 0, i32 0
-// CHECK-NEXT:   %55 = load i8, ptr %54, align 1
-// CHECK-NEXT:   %56 = sext i8 %55 to i64
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %56)
+// CHECK-NEXT:   %54 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %42, 1
+// CHECK-NEXT:   %55 = insertvalue [1 x ptr] undef, ptr %54, 0
+// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   store [1 x ptr] %55, ptr %0, align 8
+// CHECK-NEXT:   %56 = getelementptr inbounds ptr, ptr %0, i64 0
+// CHECK-NEXT:   %57 = load ptr, ptr %56, align 8
+// CHECK-NEXT:   %58 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %57, i32 0, i32 0
+// CHECK-NEXT:   %59 = load i8, ptr %58, align 1
+// CHECK-NEXT:   %60 = sext i8 %59 to i64
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %60)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %42)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %43)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %57 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @42, i64 81 }, ptr %57, align 8
-// CHECK-NEXT:   %58 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %57, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %58)
+// CHECK-NEXT:   %61 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @42, i64 81 }, ptr %61, align 8
+// CHECK-NEXT:   %62 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %61, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %62)
 // CHECK-NEXT:   unreachable
 // CHECK-NEXT: }
+
 func make4() {
 	var a any = K2{&N{1, 2}}
 	var b any = K2{&N{1, 2}}
@@ -686,6 +701,7 @@ func make4() {
 // CHECK-NEXT:   %21 = extractvalue { i1, ptr, i64 } %20, 0
 // CHECK-NEXT:   br i1 %21, label %_llgo_2, label %_llgo_3
 // CHECK-NEXT: }
+
 func make5() {
 	ch := make(chan int)
 	var a any = ch
@@ -706,9 +722,9 @@ type M map[int]string
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_int]_llgo_string", i64 0)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store i64 1, ptr %1, align 4
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"_llgo_github.com/goplus/llgo/cl/_testrt/makemap.M", ptr %0, ptr %1)
+// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"_llgo_{{.*}}/cl/_testrt/makemap.M", ptr %0, ptr %1)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @16, i64 5 }, ptr %2, align 8
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @"_llgo_github.com/goplus/llgo/cl/_testrt/makemap.M", ptr %0)
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @"_llgo_{{.*}}/cl/_testrt/makemap.M", ptr %0)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
@@ -745,6 +761,7 @@ type M map[int]string
 // CHECK-NEXT:   %15 = extractvalue { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } %14, 0
 // CHECK-NEXT:   br i1 %15, label %_llgo_2, label %_llgo_3
 // CHECK-NEXT: }
+
 func make6() {
 	var m M
 	m = make(map[int]string)
@@ -756,16 +773,16 @@ func make6() {
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/makemap.make7"() {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_github.com/goplus/llgo/cl/_testrt/makemap.N.7.0]_llgo_string", i64 2)
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_{{.*}}/cl/_testrt/makemap.N.7.0]_llgo_string", i64 2)
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store i64 1, ptr %1, align 4
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_github.com/goplus/llgo/cl/_testrt/makemap.N.7.0]_llgo_string", ptr %0, ptr %1)
+// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_{{.*}}/cl/_testrt/makemap.N.7.0]_llgo_string", ptr %0, ptr %1)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @16, i64 5 }, ptr %2, align 8
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store i64 2, ptr %3, align 4
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_github.com/goplus/llgo/cl/_testrt/makemap.N.7.0]_llgo_string", ptr %0, ptr %3)
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_{{.*}}/cl/_testrt/makemap.N.7.0]_llgo_string", ptr %0, ptr %3)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @17, i64 5 }, ptr %4, align 8
-// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @"map[_llgo_github.com/goplus/llgo/cl/_testrt/makemap.N.7.0]_llgo_string", ptr %0)
+// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.NewMapIter"(ptr @"map[_llgo_{{.*}}/cl/_testrt/makemap.N.7.0]_llgo_string", ptr %0)
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_2, %_llgo_0
@@ -785,7 +802,7 @@ func make6() {
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_6
 // CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
 // CHECK-NEXT:   store i64 1, ptr %10, align 4
-// CHECK-NEXT:   %11 = call ptr @"{{.*}}/runtime/internal/runtime.MapAccess1"(ptr @"map[_llgo_github.com/goplus/llgo/cl/_testrt/makemap.N.7.0]_llgo_string", ptr %0, ptr %10)
+// CHECK-NEXT:   %11 = call ptr @"{{.*}}/runtime/internal/runtime.MapAccess1"(ptr @"map[_llgo_{{.*}}/cl/_testrt/makemap.N.7.0]_llgo_string", ptr %0, ptr %10)
 // CHECK-NEXT:   %12 = load %"{{.*}}/runtime/internal/runtime.String", ptr %11, align 8
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %12)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
@@ -808,6 +825,7 @@ func make6() {
 // CHECK-NEXT:   %20 = extractvalue { i1, i64, %"{{.*}}/runtime/internal/runtime.String" } %19, 0
 // CHECK-NEXT:   br i1 %20, label %_llgo_2, label %_llgo_3
 // CHECK-NEXT: }
+
 func make7() {
 	type N int
 	m := map[N]string{

--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -553,11 +553,11 @@ func (p Package) getAbiTypesFor(name string, filter func(sym *AbiSymbol) bool) E
 	size := uint64(len(names))
 	typ := prog.Slice(prog.AbiTypePtr())
 	g := p.doNewVar(name+"$slice", prog.Pointer(typ))
-	g.impl.SetInitializer(prog.ctx.ConstStruct([]llvm.Value{
+	g.impl.SetInitializer(llvm.ConstNamedStruct(typ.ll, []llvm.Value{
 		array.impl,
 		prog.IntVal(size, prog.Int()).impl,
 		prog.IntVal(size, prog.Int()).impl,
-	}, false))
+	}))
 	g.impl.SetGlobalConstant(true)
 	return g.Expr
 }

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -774,7 +774,7 @@ func (b Builder) ChangeType(t Type, x Expr) (ret Expr) {
 		case vkClosure:
 			// TODO(xsw): change type should be a noop instruction
 			convType := func() Expr {
-				r := Expr{llvm.CreateAlloca(b.impl, t.ll), b.Prog.Pointer(t)}
+				r := Expr{b.createEntryAlloca(t.ll), b.Prog.Pointer(t)}
 				b.Store(r, x)
 				return b.Load(r)
 			}
@@ -804,7 +804,7 @@ func (b Builder) ChangeType(t Type, x Expr) (ret Expr) {
 		if x.impl.Type().String() == t.ll.String() {
 			ret.impl = x.impl
 		} else {
-			ptr := llvm.CreateAlloca(b.impl, t.ll)
+			ptr := b.createEntryAlloca(t.ll)
 			b.impl.CreateStore(x.impl, ptr)
 			ret.impl = llvm.CreateLoad(b.impl, t.ll, ptr)
 		}

--- a/ssa/interface.go
+++ b/ssa/interface.go
@@ -200,7 +200,7 @@ func (b Builder) buildVal(typ Type, val llvm.Value, lvl int) Expr {
 	case *types.Array:
 		telem := b.Prog.rawType(t.Elem())
 		elem := b.buildVal(telem, val, lvl-1)
-		return Expr{llvm.ConstArray(typ.ll, []llvm.Value{elem.impl}), typ}
+		return Expr{aggregateValue(b.impl, typ.ll, elem.impl), typ}
 	}
 	panic("todo")
 }

--- a/ssa/memory.go
+++ b/ssa/memory.go
@@ -117,7 +117,7 @@ func (b Builder) Alloc(elem Type, heap bool) (ret Expr) {
 	if heap {
 		ret = b.InlineCall(pkg.rtFunc("AllocZ"), size)
 	} else {
-		ret = Expr{llvm.CreateAlloca(b.impl, elem.ll), prog.VoidPtr()}
+		ret = Expr{b.createEntryAlloca(elem.ll), prog.VoidPtr()}
 		ret.impl = b.zeroinit(ret, size).impl
 	}
 	ret.Type = prog.Pointer(elem)
@@ -156,6 +156,18 @@ func (b Builder) AllocaT(t Type) (ret Expr) {
 	ret.impl = llvm.CreateAlloca(b.impl, t.ll)
 	ret.Type = prog.Pointer(t)
 	return
+}
+
+func (b Builder) createEntryAlloca(typ llvm.Type) llvm.Value {
+	entry := b.Func.impl.EntryBasicBlock()
+	entryB := b.Prog.ctx.NewBuilder()
+	defer entryB.Dispose()
+	if first := entry.FirstInstruction(); !first.IsNil() {
+		entryB.SetInsertPointBefore(first)
+	} else {
+		entryB.SetInsertPointAtEnd(entry)
+	}
+	return llvm.CreateAlloca(entryB, typ)
 }
 
 /* TODO(xsw):

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -601,6 +601,43 @@ func TestMakeInterfaceKinds(t *testing.T) {
 	bNE.Return(bNE.MakeInterface(nonEmptyType, prog.Val(7)))
 }
 
+func TestTypeAssertSingleElemArrayUsesInsertValue(t *testing.T) {
+	prog := NewProgram(nil)
+	prog.sizes = types.SizesFor("gc", runtime.GOARCH)
+	prog.SetRuntime(func() *types.Package {
+		pkg, err := importer.For("source", nil).Import(PkgRuntime)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return pkg
+	})
+	pkg := prog.NewPackage("bar", "foo/bar")
+
+	emptyIface := types.NewInterfaceType(nil, nil)
+	emptyIface.Complete()
+	arrayRaw := types.NewArray(types.Typ[types.Int], 1)
+	arrayType := prog.Type(arrayRaw, InGo)
+
+	params := types.NewTuple(types.NewVar(0, nil, "x", emptyIface))
+	results := types.NewTuple(
+		types.NewVar(0, nil, "", arrayRaw),
+		types.NewVar(0, nil, "", types.Typ[types.Bool]),
+	)
+	sig := types.NewSignatureType(nil, nil, nil, params, results, false)
+	fn := pkg.NewFunc("assertArray", sig, InGo)
+	b := fn.MakeBody(1)
+	ret := b.TypeAssert(fn.Param(0), arrayType, true)
+	b.Return(b.Extract(ret, 0), b.Extract(ret, 1))
+
+	ir := fn.impl.String()
+	if !strings.Contains(ir, "insertvalue [1 x i") {
+		t.Fatalf("single element array type assert should rebuild via insertvalue:\n%s", ir)
+	}
+	if strings.Contains(ir, "alloca [1 x i") {
+		t.Fatalf("single element array type assert should not rebuild via alloca:\n%s", ir)
+	}
+}
+
 func TestInterfaceHelpers(t *testing.T) {
 	rawSig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
 	rawMeth := types.NewFunc(0, nil, "M", rawSig)
@@ -707,6 +744,34 @@ func TestExprCoverageHelpers(t *testing.T) {
 	b.Return()
 }
 
+func TestLocalAllocInNonEntryBlockUsesEntryAlloca(t *testing.T) {
+	prog := NewProgram(nil)
+	pkg := prog.NewPackage("bar", "foo/bar")
+	sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+	fn := pkg.NewFunc("fn", sig, InGo)
+	b := fn.MakeBody(2)
+	next := fn.Block(1)
+	b.Jump(next)
+	b.SetBlock(next)
+	arr := prog.Type(types.NewArray(types.Typ[types.Int], 1), InGo)
+	b.Alloc(arr, false)
+	b.Return()
+
+	ir := pkg.String()
+	entry := strings.Index(ir, "_llgo_0:")
+	nextBlock := strings.Index(ir, "_llgo_1:")
+	alloca := strings.Index(ir, "alloca [1 x i64]")
+	if entry < 0 || nextBlock < 0 || alloca < 0 {
+		t.Fatalf("missing expected blocks or alloca:\n%s", ir)
+	}
+	if alloca < entry || alloca > nextBlock {
+		t.Fatalf("alloca should be in entry block:\n%s", ir)
+	}
+	if strings.Contains(ir[nextBlock:], "alloca [1 x i64]") {
+		t.Fatalf("alloca leaked into non-entry block:\n%s", ir)
+	}
+}
+
 func TestTypes(t *testing.T) {
 	ctx := llvm.NewContext()
 	llvmIntType(ctx, 4)
@@ -809,12 +874,12 @@ func TestVar(t *testing.T) {
 	pkg.NewVarEx("a", prog.Type(typ, InGo))
 	a.Init(prog.Val(100))
 	b := pkg.NewVar("b", typ, InGo)
-	b.Init(a.Expr)
+	b.Init(Expr{llvm.ConstPtrToInt(a.impl, prog.Int().ll), prog.Int()})
 	assertPkg(t, pkg, `; ModuleID = 'foo/bar'
 source_filename = "foo/bar"
 
 @a = global i64 100, align 8
-@b = global i64 @a, align 8
+@b = global i64 ptrtoint (ptr @a to i64), align 8
 `)
 }
 
@@ -974,7 +1039,8 @@ func TestFuncMultiRet(t *testing.T) {
 	a := pkg.NewVar("a", types.NewPointer(types.Typ[types.Int]), InGo)
 	fn := pkg.NewFunc("fn", sig, InGo)
 	b := fn.MakeBody(1)
-	b.Return(a.Expr, fn.Param(0))
+	aInt := Expr{llvm.ConstPtrToInt(a.impl, prog.Int().ll), prog.Int()}
+	b.Return(aInt, fn.Param(0))
 	assertPkg(t, pkg, `; ModuleID = 'foo/bar'
 source_filename = "foo/bar"
 
@@ -982,7 +1048,7 @@ source_filename = "foo/bar"
 
 define { i64, double } @fn(double %0) {
 _llgo_0:
-  %1 = insertvalue { i64, double } { ptr @a, double undef }, double %0, 1
+  %1 = insertvalue { i64, double } { i64 ptrtoint (ptr @a to i64), double undef }, double %0, 1
   ret { i64, double } %1
 }
 `)


### PR DESCRIPTION
1. use NamedStruct in abitype
2. use aggregateValue instead of ConstArray in buildVal
3. do not create alloca in non-entry block