### PR TITLE
ssa: make integer div rem lowering safe

### DIFF
--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -498,17 +498,58 @@ func (b Builder) BinOp(op token.Token, x, y Expr) Expr {
 			if llop := mathOpToLLVM[idx]; llop != 0 {
 				// Go requires integer division/modulo by zero to panic.
 				// LLVM's integer div/rem are undefined on zero divisor, so
-				// we insert an explicit runtime check here.
+				// we insert an explicit runtime check here and lower through a
+				// safe non-zero divisor so targets like x86 don't trap first.
+				var zero llvm.Value
+				var isZero llvm.Value
+				var safeY llvm.Value
 				if (op == token.QUO || op == token.REM) && (kind == vkSigned || kind == vkUnsigned) {
 					needsCheck := true
 					if rv := y.impl.IsAConstantInt(); !rv.IsNil() {
 						needsCheck = rv.ZExtValue() == 0
 					}
 					if needsCheck {
-						zero := llvm.ConstInt(y.ll, 0, false)
-						check := Expr{llvm.CreateICmp(b.impl, llvm.IntEQ, y.impl, zero), b.Prog.Bool()}
+						zero = llvm.ConstInt(y.ll, 0, false)
+						isZero = llvm.CreateICmp(b.impl, llvm.IntEQ, y.impl, zero)
+						check := Expr{isZero, b.Prog.Bool()}
 						b.InlineCall(b.Pkg.rtFunc("AssertDivideByZero"), check)
+						safeY = llvm.CreateSelect(b.impl, isZero, llvm.ConstInt(y.ll, 1, false), y.impl)
 					}
+				}
+				// On x86/x86_64, signed div/rem of minInt by -1 traps even
+				// though Go defines it to produce quotient=minInt and
+				// remainder=0. Lower through safe operands and select the
+				// Go-defined result for that overflow case.
+				needsOverflowCheck := false
+				if (op == token.QUO || op == token.REM) && kind == vkSigned {
+					needsOverflowCheck = true
+					if rv := y.impl.IsAConstantInt(); !rv.IsNil() {
+						needsOverflowCheck = rv.SExtValue() == -1
+					}
+				}
+				if needsOverflowCheck {
+					bits := b.Prog.SizeOf(x.Type) * 8
+					minInt := llvm.ConstInt(x.ll, uint64(1)<<(bits-1), false)
+					negOne := llvm.ConstAllOnes(y.ll)
+					isMinInt := llvm.CreateICmp(b.impl, llvm.IntEQ, x.impl, minInt)
+					isNegOne := llvm.CreateICmp(b.impl, llvm.IntEQ, y.impl, negOne)
+					overflow := llvm.CreateAnd(b.impl, isMinInt, isNegOne)
+
+					safeX := llvm.CreateSelect(b.impl, overflow, llvm.ConstInt(x.ll, 0, false), x.impl)
+					if safeY.IsNil() {
+						safeY = y.impl
+					}
+					safeY = llvm.CreateSelect(b.impl, overflow, llvm.ConstInt(y.ll, 1, false), safeY)
+					v := llvm.CreateBinOp(b.impl, llop, safeX, safeY)
+					if op == token.QUO {
+						v = llvm.CreateSelect(b.impl, overflow, x.impl, v)
+					} else {
+						v = llvm.CreateSelect(b.impl, overflow, llvm.ConstInt(x.ll, 0, false), v)
+					}
+					return Expr{v, x.Type}
+				}
+				if !safeY.IsNil() {
+					return Expr{llvm.CreateBinOp(b.impl, llop, x.impl, safeY), x.Type}
 				}
 				return Expr{llvm.CreateBinOp(b.impl, llop, x.impl, y.impl), x.Type}
 			}

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -500,8 +500,8 @@ func (b Builder) BinOp(op token.Token, x, y Expr) Expr {
 				// LLVM's integer div/rem are undefined on zero divisor, so
 				// we insert an explicit runtime check here and lower through a
 				// safe non-zero divisor so targets like x86 don't trap first.
-				var zero llvm.Value
-				var isZero llvm.Value
+				// safeY carries the zero-safe divisor into the signed overflow
+				// lowering below when both guards are needed.
 				var safeY llvm.Value
 				if (op == token.QUO || op == token.REM) && (kind == vkSigned || kind == vkUnsigned) {
 					needsCheck := true
@@ -509,8 +509,8 @@ func (b Builder) BinOp(op token.Token, x, y Expr) Expr {
 						needsCheck = rv.ZExtValue() == 0
 					}
 					if needsCheck {
-						zero = llvm.ConstInt(y.ll, 0, false)
-						isZero = llvm.CreateICmp(b.impl, llvm.IntEQ, y.impl, zero)
+						zero := llvm.ConstInt(y.ll, 0, false)
+						isZero := llvm.CreateICmp(b.impl, llvm.IntEQ, y.impl, zero)
 						check := Expr{isZero, b.Prog.Bool()}
 						b.InlineCall(b.Pkg.rtFunc("AssertDivideByZero"), check)
 						safeY = llvm.CreateSelect(b.impl, isZero, llvm.ConstInt(y.ll, 1, false), y.impl)
@@ -527,9 +527,19 @@ func (b Builder) BinOp(op token.Token, x, y Expr) Expr {
 						needsOverflowCheck = rv.SExtValue() == -1
 					}
 				}
+				var minIntVal uint64
 				if needsOverflowCheck {
 					bits := b.Prog.SizeOf(x.Type) * 8
-					minInt := llvm.ConstInt(x.ll, uint64(1)<<(bits-1), false)
+					if bits == 0 || bits > 64 {
+						panic("unexpected integer bit width")
+					}
+					minIntVal = uint64(1) << (bits - 1)
+					if rv := x.impl.IsAConstantInt(); !rv.IsNil() {
+						needsOverflowCheck = rv.ZExtValue() == minIntVal
+					}
+				}
+				if needsOverflowCheck {
+					minInt := llvm.ConstInt(x.ll, minIntVal, false)
 					negOne := llvm.ConstAllOnes(y.ll)
 					isMinInt := llvm.CreateICmp(b.impl, llvm.IntEQ, x.impl, minInt)
 					isNegOne := llvm.CreateICmp(b.impl, llvm.IntEQ, y.impl, negOne)

--- a/test/go/binop_test.go
+++ b/test/go/binop_test.go
@@ -692,6 +692,36 @@ func TestBinOpIntegerDivision(t *testing.T) {
 	}
 }
 
+func TestBinOpSignedMinIntDivisionOverflow(t *testing.T) {
+	minInt := -int(^uint(0)>>1) - 1
+	negOne := -1
+	if got := minInt / negOne; got != minInt {
+		t.Fatalf("minInt / -1 = %d, want %d", got, minInt)
+	}
+	if got := minInt % negOne; got != 0 {
+		t.Fatalf("minInt %% -1 = %d, want 0", got)
+	}
+
+	var minInt8 int8 = -128
+	var negOne8 int8 = -1
+	if got := minInt8 / negOne8; got != minInt8 {
+		t.Fatalf("int8 min / -1 = %d, want %d", got, minInt8)
+	}
+	if got := minInt8 % negOne8; got != 0 {
+		t.Fatalf("int8 min %% -1 = %d, want 0", got)
+	}
+}
+
+func TestBinOpIntegerDivideByZeroPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("division by zero did not panic")
+		}
+	}()
+	zero := 0
+	_ = 1 / zero
+}
+
 // TestBinOpIntegerModulo tests modulo for all integer types
 func TestBinOpIntegerModulo(t *testing.T) {
 	// Typed % Typed

--- a/test/go/binop_test.go
+++ b/test/go/binop_test.go
@@ -710,6 +710,33 @@ func TestBinOpSignedMinIntDivisionOverflow(t *testing.T) {
 	if got := minInt8 % negOne8; got != 0 {
 		t.Fatalf("int8 min %% -1 = %d, want 0", got)
 	}
+
+	var minInt16 int16 = -32768
+	var negOne16 int16 = -1
+	if got := minInt16 / negOne16; got != minInt16 {
+		t.Fatalf("int16 min / -1 = %d, want %d", got, minInt16)
+	}
+	if got := minInt16 % negOne16; got != 0 {
+		t.Fatalf("int16 min %% -1 = %d, want 0", got)
+	}
+
+	var minInt32 int32 = -2147483648
+	var negOne32 int32 = -1
+	if got := minInt32 / negOne32; got != minInt32 {
+		t.Fatalf("int32 min / -1 = %d, want %d", got, minInt32)
+	}
+	if got := minInt32 % negOne32; got != 0 {
+		t.Fatalf("int32 min %% -1 = %d, want 0", got)
+	}
+
+	var minInt64 int64 = -9223372036854775808
+	var negOne64 int64 = -1
+	if got := minInt64 / negOne64; got != minInt64 {
+		t.Fatalf("int64 min / -1 = %d, want %d", got, minInt64)
+	}
+	if got := minInt64 % negOne64; got != 0 {
+		t.Fatalf("int64 min %% -1 = %d, want 0", got)
+	}
 }
 
 func TestBinOpIntegerDivideByZeroPanics(t *testing.T) {
@@ -720,6 +747,16 @@ func TestBinOpIntegerDivideByZeroPanics(t *testing.T) {
 	}()
 	zero := 0
 	_ = 1 / zero
+}
+
+func TestBinOpIntegerRemainderByZeroPanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("remainder by zero did not panic")
+		}
+	}()
+	zero := 0
+	_ = 1 % zero
 }
 
 // TestBinOpIntegerModulo tests modulo for all integer types


### PR DESCRIPTION
This PR splits an independent non-source-patch fix from `analysis/goroot-xfail-priority`.

It fixes integer division and remainder lowering so llgo preserves Go semantics for two edge cases:

- signed `minInt / -1` must produce `minInt` instead of trapping on x86/x86_64
- signed `minInt % -1` must produce `0`
- dynamic division by zero must still trigger Go panic semantics, not LLVM integer div/rem undefined behavior first

Without this PR, GOROOT integer div/rem cases can fail or trap before the runtime divide-by-zero check gets a chance to run.

Tests added:
- `TestBinOpSignedMinIntDivisionOverflow`
- `TestBinOpIntegerDivideByZeroPanics`

Validation:
- `go test ./ssa`
- `go test ./test/go`
- `LLGO_ROOT=$PWD go run ./cmd/llgo test ./test/go -run 'TestBinOp(SignedMinIntDivisionOverflow|IntegerDivideByZeroPanics)'