### PR TITLE
ssa: keep goroutine startup data gc visible

### DIFF
--- a/cl/_testgo/goroutine/in.go
+++ b/cl/_testgo/goroutine/in.go
@@ -5,14 +5,14 @@ package main
 func main() {
 	// CHECK: call ptr @"{{.*}}AllocZ"(i64 1)
 	// CHECK: store i1 false, ptr %0, align 1
-	// CHECK: call ptr @malloc(i64 16)
+	// CHECK: call ptr @"{{.*}}AllocU"(i64 16)
 	// CHECK: call i32 @"{{.*}}CreateThread"(ptr %3, ptr null, ptr @"{{.*}}goroutine._llgo_routine$1", ptr %1)
 	done := false
 	go println("hello")
 	go func(s string) {
 		// CHECK: call ptr @"{{.*}}AllocU"(i64 8)
 		// CHECK: { ptr @"{{.*}}goroutine.main$1", ptr undef }
-		// CHECK: call ptr @malloc(i64 32)
+		// CHECK: call ptr @"{{.*}}AllocU"(i64 32)
 		// CHECK: call i32 @"{{.*}}CreateThread"(ptr %11, ptr null, ptr @"{{.*}}goroutine._llgo_routine$2", ptr %8)
 		// CHECK: call void @"{{.*}}PrintString"(%"{{.*}}String" { ptr @2, i64 1 })
 		// CHECK: ret void
@@ -38,7 +38,6 @@ func main() {
 // CHECK-NEXT:   %2 = extractvalue { %"{{.*}}String" } %1, 0
 // CHECK-NEXT:   call void @"{{.*}}PrintString"(%"{{.*}}String" %2)
 // CHECK-NEXT:   call void @"{{.*}}PrintByte"(i8 10)
-// CHECK-NEXT:   call void @free(ptr %0)
 // CHECK-NEXT:   ret ptr null
 
 // CHECK-LABEL: define ptr @"{{.*}}goroutine._llgo_routine$2"(ptr %0) {
@@ -49,5 +48,4 @@ func main() {
 // CHECK-NEXT:   %4 = extractvalue { ptr, ptr } %2, 1
 // CHECK-NEXT:   %5 = extractvalue { ptr, ptr } %2, 0
 // CHECK-NEXT:   call void %5(ptr %4, %"{{.*}}String" %3)
-// CHECK-NEXT:   call void @free(ptr %0)
 // CHECK-NEXT:   ret ptr null

--- a/cl/_testgo/selects/in.go
+++ b/cl/_testgo/selects/in.go
@@ -21,7 +21,7 @@ package main
 // CHECK-NEXT:   %10 = getelementptr inbounds { ptr, ptr, ptr }, ptr %7, i32 0, i32 2
 // CHECK-NEXT:   store ptr %4, ptr %10, align 8
 // CHECK-NEXT:   %11 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/selects.main$1", ptr undef }, ptr %7, 1
-// CHECK-NEXT:   %12 = call ptr @malloc(i64 16)
+// CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
 // CHECK-NEXT:   %13 = getelementptr inbounds { { ptr, ptr } }, ptr %12, i32 0, i32 0
 // CHECK-NEXT:   store { ptr, ptr } %11, ptr %13, align 8
 // CHECK-NEXT:   %14 = alloca i8, i64 8, align 1

--- a/ssa/goroutine.go
+++ b/ssa/goroutine.go
@@ -73,7 +73,9 @@ func (b Builder) Go(fn Expr, buildCall func(Builder, Expr, ...Expr) Expr, args .
 	}
 	t := prog.Struct(typs...)
 	voidPtr := prog.VoidPtr()
-	data := Expr{b.aggregateMalloc(t, flds...), voidPtr}
+	// Goroutine startup data may carry Go pointers, including closure ctx.
+	// Keep it in GC-managed memory so it remains visible across the thread start.
+	data := Expr{b.aggregateAllocU(t, flds...), voidPtr}
 	size := prog.SizeOf(voidPtr)
 	pthd := b.Alloca(prog.IntVal(uint64(size), prog.Uintptr()))
 	b.pthreadCreate(pthd, prog.Nil(voidPtr), pkg.routine(t, fn, buildCall, len(args)), data)
@@ -100,7 +102,6 @@ func (p Package) routine(t Type, fn Expr, buildCall func(Builder, Expr, ...Expr)
 		args[i] = b.getField(data, i+offset)
 	}
 	buildCall(b, fn, args...)
-	b.free(param)
 	b.Return(prog.Nil(prog.VoidPtr()))
 	return routine.Expr
 }

--- a/ssa/goroutine_patch_test.go
+++ b/ssa/goroutine_patch_test.go
@@ -1,23 +1,19 @@
+//go:build !llgo
+// +build !llgo
+
 package ssa_test
 
 import (
-	"go/token"
 	"go/types"
 	"strings"
 	"testing"
 
-	"github.com/goplus/gogen/packages"
 	"github.com/goplus/llgo/ssa"
+	"github.com/goplus/llgo/ssa/ssatest"
 )
 
 func TestGoClosureStartupUsesGCManagedMemory(t *testing.T) {
-	prog := ssa.NewProgram(nil)
-	prog.SetRuntime(func() *types.Package {
-		fset := token.NewFileSet()
-		imp := packages.NewImporter(fset)
-		pkg, _ := imp.Import(ssa.PkgRuntime)
-		return pkg
-	})
+	prog := ssatest.NewProgram(t, nil)
 	pkg := prog.NewPackage("bar", "foo/bar")
 
 	ctxFields := []*types.Var{
@@ -45,6 +41,8 @@ func TestGoClosureStartupUsesGCManagedMemory(t *testing.T) {
 	if strings.Contains(ir, "@free") {
 		t.Fatalf("goroutine startup data should not use free:\n%s", ir)
 	}
+	// The closure context and the goroutine startup record both must remain
+	// visible to the runtime GC until the new goroutine consumes them.
 	if got := strings.Count(ir, `"github.com/goplus/llgo/runtime/internal/runtime.AllocU"`); got < 2 {
 		t.Fatalf("expected closure ctx and goroutine startup data to use AllocU, got %d:\n%s", got, ir)
 	}

--- a/ssa/goroutine_patch_test.go
+++ b/ssa/goroutine_patch_test.go
@@ -1,0 +1,51 @@
+package ssa_test
+
+import (
+	"go/token"
+	"go/types"
+	"strings"
+	"testing"
+
+	"github.com/goplus/gogen/packages"
+	"github.com/goplus/llgo/ssa"
+)
+
+func TestGoClosureStartupUsesGCManagedMemory(t *testing.T) {
+	prog := ssa.NewProgram(nil)
+	prog.SetRuntime(func() *types.Package {
+		fset := token.NewFileSet()
+		imp := packages.NewImporter(fset)
+		pkg, _ := imp.Import(ssa.PkgRuntime)
+		return pkg
+	})
+	pkg := prog.NewPackage("bar", "foo/bar")
+
+	ctxFields := []*types.Var{
+		types.NewField(0, nil, "x", types.Typ[types.Int], false),
+	}
+	ctxStruct := types.NewStruct(ctxFields, nil)
+	ctxParam := types.NewParam(0, nil, "__llgo_ctx", types.NewPointer(ctxStruct))
+	innerSig := types.NewSignatureType(nil, nil, nil, types.NewTuple(ctxParam), nil, false)
+	inner := pkg.NewFunc("inner", innerSig, ssa.InGo)
+	ib := inner.MakeBody(1)
+	ib.Return()
+
+	outer := pkg.NewFunc("outer", ssa.NoArgsNoRet, ssa.InGo)
+	ob := outer.MakeBody(1)
+	closure := ob.MakeClosure(inner.Expr, []ssa.Expr{prog.Val(42)})
+	ob.Go(closure, func(b ssa.Builder, fn ssa.Expr, args ...ssa.Expr) ssa.Expr {
+		return b.Call(fn, args...)
+	})
+	ob.Return()
+
+	ir := pkg.String()
+	if strings.Contains(ir, "@malloc") {
+		t.Fatalf("goroutine startup data should not use malloc:\n%s", ir)
+	}
+	if strings.Contains(ir, "@free") {
+		t.Fatalf("goroutine startup data should not use free:\n%s", ir)
+	}
+	if got := strings.Count(ir, `"github.com/goplus/llgo/runtime/internal/runtime.AllocU"`); got < 2 {
+		t.Fatalf("expected closure ctx and goroutine startup data to use AllocU, got %d:\n%s", got, ir)
+	}
+}


### PR DESCRIPTION
This PR splits an independent non-source-patch fix from `analysis/goroot-xfail-priority`.

It changes goroutine startup data allocation from C `malloc/free` to llgo runtime `AllocU`. The startup data can contain Go pointers, including closure context pointers; allocating it outside GC-managed memory can hide those pointers from GC while the new thread is starting.

Without this PR, goroutines launched from closures may carry a closure context through non-GC memory, which can make the context invisible to the collector.

Tests added/updated:
- `TestGoClosureStartupUsesGCManagedMemory`
- updated key CHECK lines in `cl/_testgo/goroutine/in.go` and `cl/_testgo/selects/in.go` from `malloc/free` to `AllocU`/no-free

Validation:
- `go test ./ssa -run 'TestGoClosureStartupUsesGCManagedMemory|TestFromTestgo'`\n- `go test ./ssa`