### PR TITLE
cl,ssa: implement go:nointerface and refactor directive extraction

### DIFF
--- a/cl/import.go
+++ b/cl/import.go
@@ -84,6 +84,36 @@ func (p *pkgSymInfo) initLinknames(ctx *context) {
 	}
 }
 
+func (p *pkgSymInfo) hasNoInterfaceByPos(fset *token.FileSet, pos token.Pos) bool {
+	fp := fset.Position(pos)
+	if fp.Line <= 1 {
+		return false
+	}
+	b, ok := p.files[fp.Filename]
+	if !ok {
+		var err error
+		b, err = os.ReadFile(fp.Filename)
+		if err != nil {
+			return false
+		}
+		p.files[fp.Filename] = b
+	}
+	lines := bytes.Split(b, []byte{'\n'})
+	for i := fp.Line - 2; i >= 0 && i < len(lines); i-- {
+		line := strings.TrimSpace(string(lines[i]))
+		if line == "//go:nointerface" {
+			return true
+		}
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, "//") {
+			break
+		}
+	}
+	return false
+}
+
 // PkgKindOf returns the kind of a package.
 func PkgKindOf(pkg *types.Package) (int, string) {
 	scope := pkg.Scope()
@@ -162,6 +192,9 @@ start:
 						fn := t.Method(i)
 						fullName, inPkgName := typesFuncName(pkgPath, fn)
 						syms.addSym(fset, fn.Pos(), fullName, inPkgName, false)
+						if syms.hasNoInterfaceByPos(fset, fn.Pos()) {
+							p.prog.SetNoInterfaceMethod(fn.Pos())
+						}
 					}
 				}
 			}
@@ -179,7 +212,9 @@ func (p *context) initFiles(pkgPath string, files []*ast.File, cPkg bool) {
 		for _, decl := range file.Decls {
 			switch decl := decl.(type) {
 			case *ast.FuncDecl:
-				p.collectNoInterfaceByDoc(decl.Doc, decl.Name.Pos())
+				if decl.Recv != nil {
+					p.collectNoInterfaceByDoc(decl.Doc, decl.Name.Pos())
+				}
 				fullName, inPkgName := astFuncName(pkgPath, decl)
 				if !p.processLinknameByDoc(decl.Doc, fullName, inPkgName, false, true) && cPkg {
 					// package C (https://github.com/goplus/llgo/issues/1165)

--- a/cl/import.go
+++ b/cl/import.go
@@ -17,7 +17,6 @@
 package cl
 
 import (
-	"bytes"
 	"fmt"
 	"go/ast"
 	"go/constant"
@@ -35,54 +34,9 @@ import (
 
 // -----------------------------------------------------------------------------
 
-type symInfo struct {
-	file     string
+type importSym struct {
 	fullName string
 	isVar    bool
-}
-
-type pkgSymInfo struct {
-	files map[string][]byte  // file => content
-	syms  map[string]symInfo // name => isVar
-}
-
-func newPkgSymInfo() *pkgSymInfo {
-	return &pkgSymInfo{
-		files: make(map[string][]byte),
-		syms:  make(map[string]symInfo),
-	}
-}
-
-func (p *pkgSymInfo) addSym(fset *token.FileSet, pos token.Pos, fullName, inPkgName string, isVar bool) {
-	f := fset.File(pos)
-	if fp := f.Position(pos); fp.Line > 2 {
-		file := fp.Filename
-		if _, ok := p.files[file]; !ok {
-			b, err := os.ReadFile(file)
-			if err == nil {
-				p.files[file] = b
-			}
-		}
-		p.syms[inPkgName] = symInfo{file, fullName, isVar}
-	}
-}
-
-func (p *pkgSymInfo) initLinknames(ctx *context) {
-	sep := []byte{'\n'}
-	commentPrefix := []byte{'/', '/'}
-	for file, b := range p.files {
-		lines := bytes.Split(b, sep)
-		for _, line := range lines {
-			if bytes.HasPrefix(line, commentPrefix) {
-				ctx.initLinkname(string(line), true, func(inPkgName string, isExport bool) (fullName string, isVar, ok bool) {
-					if sym, ok := p.syms[inPkgName]; ok && file == sym.file {
-						return sym.fullName, sym.isVar, true
-					}
-					return
-				})
-			}
-		}
-	}
 }
 
 // PkgKindOf returns the kind of a package.
@@ -147,16 +101,14 @@ start:
 	i.kind = kind
 	fset := p.fset
 	names := scope.Names()
-	syms := newPkgSymInfo()
-	importFiles := make(map[string]struct{})
+	importFiles := make(map[string]map[string]importSym)
 	for _, name := range names {
 		obj := scope.Lookup(name)
 		switch obj := obj.(type) {
 		case *types.Func:
 			if pos := obj.Pos(); pos != token.NoPos {
 				fullName, inPkgName := typesFuncName(pkgPath, obj)
-				syms.addSym(fset, pos, fullName, inPkgName, false)
-				addImportFile(importFiles, fset, pos)
+				addImportSym(importFiles, fset, pos, fullName, inPkgName, false)
 			}
 		case *types.TypeName:
 			if !obj.IsAlias() {
@@ -164,30 +116,26 @@ start:
 					for i, n := 0, t.NumMethods(); i < n; i++ {
 						fn := t.Method(i)
 						fullName, inPkgName := typesFuncName(pkgPath, fn)
-						syms.addSym(fset, fn.Pos(), fullName, inPkgName, false)
-						addImportFile(importFiles, fset, fn.Pos())
+						addImportSym(importFiles, fset, fn.Pos(), fullName, inPkgName, false)
 					}
 				}
 			}
 		case *types.Var:
 			if pos := obj.Pos(); pos != token.NoPos {
-				syms.addSym(fset, pos, pkgPath+"."+name, name, true)
-				addImportFile(importFiles, fset, pos)
+				addImportSym(importFiles, fset, pos, pkgPath+"."+name, name, true)
 			}
 		}
 	}
-	syms.initLinknames(p)
-	p.collectImportedNoInterface(pkgPath, importFiles)
+	p.collectImportedDirectives(pkgPath, importFiles)
 }
 
 func (p *context) initFiles(pkgPath string, files []*ast.File, cPkg bool) {
 	for _, file := range files {
-		processASTFileNoInterface(p.prog, pkgPath, file)
 		for _, decl := range file.Decls {
 			switch decl := decl.(type) {
 			case *ast.FuncDecl:
-				fullName, inPkgName := astFuncName(pkgPath, decl)
-				if !p.processLinknameByDoc(decl.Doc, fullName, inPkgName, false, true) && cPkg {
+				fullName, inPkgName, hasLinkname := p.processFuncDirectives(pkgPath, decl, true, true)
+				if !hasLinkname && cPkg {
 					// package C (https://github.com/goplus/llgo/issues/1165)
 					if decl.Recv == nil && token.IsExported(inPkgName) {
 						exportName := strings.TrimPrefix(inPkgName, "X")
@@ -198,12 +146,7 @@ func (p *context) initFiles(pkgPath string, files []*ast.File, cPkg bool) {
 			case *ast.GenDecl:
 				switch decl.Tok {
 				case token.VAR:
-					if len(decl.Specs) == 1 {
-						if names := decl.Specs[0].(*ast.ValueSpec).Names; len(names) == 1 {
-							inPkgName := names[0].Name
-							p.processLinknameByDoc(decl.Doc, pkgPath+"."+inPkgName, inPkgName, true, true)
-						}
-					}
+					p.processVarLinkname(pkgPath, decl, true)
 				case token.CONST:
 					fallthrough
 				case token.TYPE:
@@ -224,6 +167,25 @@ func (p *context) initFiles(pkgPath string, files []*ast.File, cPkg bool) {
 	}
 }
 
+func (p *context) processFuncDirectives(pkgPath string, decl *ast.FuncDecl, allowExport, collectNoInterface bool) (fullName, inPkgName string, hasLinkname bool) {
+	fullName, inPkgName = astFuncName(pkgPath, decl)
+	if collectNoInterface && decl.Recv != nil && hasNoInterfaceDirective(decl.Doc) {
+		p.prog.SetNoInterfaceMethod(fullName)
+	}
+	hasLinkname = p.processLinknameByDoc(decl.Doc, fullName, inPkgName, false, allowExport)
+	return
+}
+
+func (p *context) processVarLinkname(pkgPath string, decl *ast.GenDecl, allowExport bool) {
+	if len(decl.Specs) != 1 {
+		return
+	}
+	if names := decl.Specs[0].(*ast.ValueSpec).Names; len(names) == 1 {
+		inPkgName := names[0].Name
+		p.processLinknameByDoc(decl.Doc, pkgPath+"."+inPkgName, inPkgName, true, allowExport)
+	}
+}
+
 // PreCollectLinknames scans syntax files before SSA compilation and populates
 // prog.Linkname for package-level //go:linkname / //llgo:link declarations.
 // It intentionally ignores //export because there is no package export context
@@ -234,53 +196,59 @@ func PreCollectLinknames(prog llssa.Program, pkgPath string, files []*ast.File) 
 		for _, decl := range file.Decls {
 			switch decl := decl.(type) {
 			case *ast.FuncDecl:
-				fullName, inPkgName := astFuncName(pkgPath, decl)
-				ctx.processLinknameByDoc(decl.Doc, fullName, inPkgName, false, false)
+				ctx.processFuncDirectives(pkgPath, decl, false, false)
 			case *ast.GenDecl:
-				if decl.Tok == token.VAR && len(decl.Specs) == 1 {
-					if names := decl.Specs[0].(*ast.ValueSpec).Names; len(names) == 1 {
-						inPkgName := names[0].Name
-						ctx.processLinknameByDoc(decl.Doc, pkgPath+"."+inPkgName, inPkgName, true, false)
-					}
+				if decl.Tok == token.VAR {
+					ctx.processVarLinkname(pkgPath, decl, false)
 				}
 			}
 		}
 	}
 }
 
-func addImportFile(files map[string]struct{}, fset *token.FileSet, pos token.Pos) {
+func addImportSym(files map[string]map[string]importSym, fset *token.FileSet, pos token.Pos, fullName, inPkgName string, isVar bool) {
 	if pos == token.NoPos {
 		return
 	}
 	if f := fset.File(pos); f != nil {
 		if file := f.Position(pos).Filename; file != "" {
-			files[file] = struct{}{}
+			syms := files[file]
+			if syms == nil {
+				syms = make(map[string]importSym)
+				files[file] = syms
+			}
+			syms[inPkgName] = importSym{fullName: fullName, isVar: isVar}
 		}
 	}
 }
 
-func (p *context) collectImportedNoInterface(pkgPath string, files map[string]struct{}) {
+func (p *context) collectImportedDirectives(pkgPath string, files map[string]map[string]importSym) {
 	fset := token.NewFileSet()
-	for file := range files {
+	for file, syms := range files {
 		parsed, err := parser.ParseFile(fset, file, nil, parser.ParseComments)
 		if err != nil {
 			continue
 		}
-		processASTFileNoInterface(p.prog, pkgPath, parsed)
+		p.collectImportedLinknames(parsed, syms)
+		for _, decl := range parsed.Decls {
+			switch decl := decl.(type) {
+			case *ast.FuncDecl:
+				p.processFuncDirectives(pkgPath, decl, false, true)
+			}
+		}
 	}
 }
 
-func processASTFileNoInterface(prog llssa.Program, pkgPath string, file *ast.File) {
-	if file == nil {
-		return
-	}
-	for _, decl := range file.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Recv == nil || !hasNoInterfaceDirective(fn.Doc) {
-			continue
+func (p *context) collectImportedLinknames(file *ast.File, syms map[string]importSym) {
+	for _, group := range file.Comments {
+		for _, comment := range group.List {
+			p.initLinkname(comment.Text, true, func(inPkgName string, isExport bool) (fullName string, isVar, ok bool) {
+				if sym, ok := syms[inPkgName]; ok {
+					return sym.fullName, sym.isVar, true
+				}
+				return
+			})
 		}
-		fullName, _ := astFuncName(pkgPath, fn)
-		prog.SetNoInterfaceMethod(fullName)
 	}
 }
 

--- a/cl/import.go
+++ b/cl/import.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/constant"
+	"go/parser"
 	"go/token"
 	"go/types"
 	"os"
@@ -82,36 +83,6 @@ func (p *pkgSymInfo) initLinknames(ctx *context) {
 			}
 		}
 	}
-}
-
-func (p *pkgSymInfo) hasNoInterfaceByPos(fset *token.FileSet, pos token.Pos) bool {
-	fp := fset.Position(pos)
-	if fp.Line <= 1 {
-		return false
-	}
-	b, ok := p.files[fp.Filename]
-	if !ok {
-		var err error
-		b, err = os.ReadFile(fp.Filename)
-		if err != nil {
-			return false
-		}
-		p.files[fp.Filename] = b
-	}
-	lines := bytes.Split(b, []byte{'\n'})
-	for i := fp.Line - 2; i >= 0 && i < len(lines); i-- {
-		line := strings.TrimSpace(string(lines[i]))
-		if line == "//go:nointerface" {
-			return true
-		}
-		if line == "" {
-			continue
-		}
-		if !strings.HasPrefix(line, "//") {
-			break
-		}
-	}
-	return false
 }
 
 // PkgKindOf returns the kind of a package.
@@ -177,6 +148,7 @@ start:
 	fset := p.fset
 	names := scope.Names()
 	syms := newPkgSymInfo()
+	importFiles := make(map[string]struct{})
 	for _, name := range names {
 		obj := scope.Lookup(name)
 		switch obj := obj.(type) {
@@ -184,6 +156,7 @@ start:
 			if pos := obj.Pos(); pos != token.NoPos {
 				fullName, inPkgName := typesFuncName(pkgPath, obj)
 				syms.addSym(fset, pos, fullName, inPkgName, false)
+				addImportFile(importFiles, fset, pos)
 			}
 		case *types.TypeName:
 			if !obj.IsAlias() {
@@ -192,29 +165,27 @@ start:
 						fn := t.Method(i)
 						fullName, inPkgName := typesFuncName(pkgPath, fn)
 						syms.addSym(fset, fn.Pos(), fullName, inPkgName, false)
-						if syms.hasNoInterfaceByPos(fset, fn.Pos()) {
-							p.prog.SetNoInterfaceMethod(fn.Pos())
-						}
+						addImportFile(importFiles, fset, fn.Pos())
 					}
 				}
 			}
 		case *types.Var:
 			if pos := obj.Pos(); pos != token.NoPos {
 				syms.addSym(fset, pos, pkgPath+"."+name, name, true)
+				addImportFile(importFiles, fset, pos)
 			}
 		}
 	}
 	syms.initLinknames(p)
+	p.collectImportedNoInterface(pkgPath, importFiles)
 }
 
 func (p *context) initFiles(pkgPath string, files []*ast.File, cPkg bool) {
 	for _, file := range files {
+		processASTFileNoInterface(p.prog, pkgPath, file)
 		for _, decl := range file.Decls {
 			switch decl := decl.(type) {
 			case *ast.FuncDecl:
-				if decl.Recv != nil {
-					p.collectNoInterfaceByDoc(decl.Doc, decl.Name.Pos())
-				}
 				fullName, inPkgName := astFuncName(pkgPath, decl)
 				if !p.processLinknameByDoc(decl.Doc, fullName, inPkgName, false, true) && cPkg {
 					// package C (https://github.com/goplus/llgo/issues/1165)
@@ -253,18 +224,6 @@ func (p *context) initFiles(pkgPath string, files []*ast.File, cPkg bool) {
 	}
 }
 
-func (p *context) collectNoInterfaceByDoc(doc *ast.CommentGroup, pos token.Pos) {
-	if doc == nil {
-		return
-	}
-	for _, comment := range doc.List {
-		if strings.TrimSpace(comment.Text) == "//go:nointerface" {
-			p.prog.SetNoInterfaceMethod(pos)
-			return
-		}
-	}
-}
-
 // PreCollectLinknames scans syntax files before SSA compilation and populates
 // prog.Linkname for package-level //go:linkname / //llgo:link declarations.
 // It intentionally ignores //export because there is no package export context
@@ -287,6 +246,54 @@ func PreCollectLinknames(prog llssa.Program, pkgPath string, files []*ast.File) 
 			}
 		}
 	}
+}
+
+func addImportFile(files map[string]struct{}, fset *token.FileSet, pos token.Pos) {
+	if pos == token.NoPos {
+		return
+	}
+	if f := fset.File(pos); f != nil {
+		if file := f.Position(pos).Filename; file != "" {
+			files[file] = struct{}{}
+		}
+	}
+}
+
+func (p *context) collectImportedNoInterface(pkgPath string, files map[string]struct{}) {
+	fset := token.NewFileSet()
+	for file := range files {
+		parsed, err := parser.ParseFile(fset, file, nil, parser.ParseComments)
+		if err != nil {
+			continue
+		}
+		processASTFileNoInterface(p.prog, pkgPath, parsed)
+	}
+}
+
+func processASTFileNoInterface(prog llssa.Program, pkgPath string, file *ast.File) {
+	if file == nil {
+		return
+	}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Recv == nil || !hasNoInterfaceDirective(fn.Doc) {
+			continue
+		}
+		fullName, _ := astFuncName(pkgPath, fn)
+		prog.SetNoInterfaceMethod(fullName)
+	}
+}
+
+func hasNoInterfaceDirective(doc *ast.CommentGroup) bool {
+	if doc == nil {
+		return false
+	}
+	for _, comment := range doc.List {
+		if strings.TrimSpace(comment.Text) == "//go:nointerface" {
+			return true
+		}
+	}
+	return false
 }
 
 // Collect skip names and skip other annotations, such as go: and llgo:

--- a/cl/import.go
+++ b/cl/import.go
@@ -179,6 +179,7 @@ func (p *context) initFiles(pkgPath string, files []*ast.File, cPkg bool) {
 		for _, decl := range file.Decls {
 			switch decl := decl.(type) {
 			case *ast.FuncDecl:
+				p.collectNoInterfaceByDoc(decl.Doc, decl.Name.Pos())
 				fullName, inPkgName := astFuncName(pkgPath, decl)
 				if !p.processLinknameByDoc(decl.Doc, fullName, inPkgName, false, true) && cPkg {
 					// package C (https://github.com/goplus/llgo/issues/1165)
@@ -213,6 +214,18 @@ func (p *context) initFiles(pkgPath string, files []*ast.File, cPkg bool) {
 					}
 				}
 			}
+		}
+	}
+}
+
+func (p *context) collectNoInterfaceByDoc(doc *ast.CommentGroup, pos token.Pos) {
+	if doc == nil {
+		return
+	}
+	for _, comment := range doc.List {
+		if strings.TrimSpace(comment.Text) == "//go:nointerface" {
+			p.prog.SetNoInterfaceMethod(pos)
+			return
 		}
 	}
 }

--- a/cl/import_coverage_test.go
+++ b/cl/import_coverage_test.go
@@ -58,53 +58,56 @@ type (
 	ParsePkgSyntax(prog, pkg, []*ast.File{file})
 }
 
-func TestPkgSymInfoAddSymAndInitLinknamesCoverage(t *testing.T) {
+func TestCollectImportedDirectivesCoverage(t *testing.T) {
 	dir := t.TempDir()
 	srcPath := filepath.Join(dir, "p.go")
-	src := "package p\n\n//go:linkname Foo c_foo\nfunc Foo()\n"
+	src := `package p
+import _ "unsafe"
+
+//go:linkname Foo c_foo
+
+func Foo()
+
+//llgo:link Bar c_bar
+const marker = 1
+
+func Bar()
+
+// llgo:link Baz c_baz
+type markerType int
+
+func Baz()
+
+type T struct{}
+
+//go:nointerface
+func (T) Bad()
+`
 	if err := os.WriteFile(srcPath, []byte(src), 0o644); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, srcPath, src, parser.ParseComments)
-	if err != nil {
-		t.Fatalf("ParseFile failed: %v", err)
-	}
-
-	var fnPos token.Pos
-	for _, decl := range file.Decls {
-		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Name.Name == "Foo" {
-			fnPos = fn.Name.Pos()
-			break
-		}
-	}
-	if fnPos == token.NoPos {
-		t.Fatalf("failed to find Foo position")
-	}
-
-	syms := newPkgSymInfo()
-	syms.addSym(fset, fnPos, "example.com/p.Foo", "Foo", false)
-
-	tf := fset.File(file.Pos())
-	syms.addSym(fset, tf.LineStart(2), "example.com/p.Skip", "Skip", false)
-	if _, ok := syms.syms["Skip"]; ok {
-		t.Fatalf("symbol with line<=2 should be skipped")
-	}
-
-	// cover os.ReadFile error branch inside addSym.
-	ff := fset.AddFile(filepath.Join(dir, "missing.go"), -1, 100)
-	ff.SetLines([]int{0, 10, 20, 30, 40, 50})
-	syms.addSym(fset, ff.LineStart(4), "example.com/p.Miss", "Miss", false)
-	if _, ok := syms.syms["Miss"]; !ok {
-		t.Fatalf("symbol should still be recorded when file read fails")
-	}
-
 	prog := llssa.NewProgram(nil)
 	ctx := &context{prog: prog}
-	syms.initLinknames(ctx)
+	ctx.collectImportedDirectives("example.com/p", map[string]map[string]importSym{
+		srcPath: {
+			"Foo": {fullName: "example.com/p.Foo"},
+			"Bar": {fullName: "example.com/p.Bar"},
+			"Baz": {fullName: "example.com/p.Baz"},
+		},
+		filepath.Join(dir, "bad.go"): nil,
+	})
 	if got, ok := prog.Linkname("example.com/p.Foo"); !ok || got != "c_foo" {
 		t.Fatalf("linkname = (%q,%v), want (%q,%v)", got, ok, "c_foo", true)
+	}
+	if got, ok := prog.Linkname("example.com/p.Bar"); !ok || got != "c_bar" {
+		t.Fatalf("llgo linkname = (%q,%v), want (%q,%v)", got, ok, "c_bar", true)
+	}
+	if got, ok := prog.Linkname("example.com/p.Baz"); !ok || got != "c_baz" {
+		t.Fatalf("spaced llgo linkname = (%q,%v), want (%q,%v)", got, ok, "c_baz", true)
+	}
+	if !prog.IsNoInterfaceMethod("example.com/p.T.Bad") {
+		t.Fatalf("Bad was not marked nointerface")
 	}
 }
 

--- a/cl/import_patch_test.go
+++ b/cl/import_patch_test.go
@@ -79,6 +79,17 @@ func TestInitFilesCollectsGoNoInterface(t *testing.T) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "p.go", `package p
 
+//llgo:skip FromImport
+import _ "unsafe"
+
+//llgo:skip FromConst
+const C = 1
+
+//go:generate ignored
+// llgo:skip FromType
+//llgo:skipall
+type U struct{}
+
 type T struct{}
 
 //go:nointerface
@@ -110,12 +121,36 @@ func Plain() {}
 	if prog.IsNoInterfaceMethod(funcNames["Plain"]) {
 		t.Fatal("Plain function was incorrectly marked nointerface")
 	}
+	for _, name := range []string{"FromImport", "FromConst", "FromType"} {
+		if _, ok := c.skips[name]; !ok {
+			t.Fatalf("%s was not collected from llgo:skip", name)
+		}
+	}
+	if !c.skipall {
+		t.Fatal("llgo:skipall was not collected from type doc")
+	}
 }
 
 func TestImportPkgCollectsGoNoInterface(t *testing.T) {
 	src := `package p
 
+import _ "unsafe"
+
 const LLGoPackage = "decl"
+
+//go:linkname Foo c_foo
+
+func Foo()
+
+//llgo:link Bar c_bar
+const marker = 1
+
+func Bar()
+
+// llgo:link Baz c_baz
+type markerType int
+
+func Baz()
 
 type T struct{}
 
@@ -146,6 +181,15 @@ func (T) Good() {}
 	prog := llssa.NewProgram(nil)
 	c := &context{prog: prog, fset: fset}
 	c.importPkg(pkg, &pkgInfo{})
+	if got, ok := prog.Linkname("example.com/p.Foo"); !ok || got != "c_foo" {
+		t.Fatalf("imported Foo linkname = (%q,%v), want (%q,%v)", got, ok, "c_foo", true)
+	}
+	if got, ok := prog.Linkname("example.com/p.Bar"); !ok || got != "c_bar" {
+		t.Fatalf("imported Bar linkname = (%q,%v), want (%q,%v)", got, ok, "c_bar", true)
+	}
+	if got, ok := prog.Linkname("example.com/p.Baz"); !ok || got != "c_baz" {
+		t.Fatalf("imported Baz linkname = (%q,%v), want (%q,%v)", got, ok, "c_baz", true)
+	}
 	badName, _ := typesFuncName(pkg.Path(), methods["Bad"])
 	goodName, _ := typesFuncName(pkg.Path(), methods["Good"])
 	if !prog.IsNoInterfaceMethod(badName) {

--- a/cl/import_patch_test.go
+++ b/cl/import_patch_test.go
@@ -72,3 +72,24 @@ func TestVarNameGoLinkRuntimeAndNonRuntime(t *testing.T) {
 		t.Fatalf("non-runtime varName = (%q,%d,%v), want (%q,%d,%v)", name, vtyp, define, "go:example.com/p.G", goVar, false)
 	}
 }
+
+func TestInitFilesCollectsGoNoInterface(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "p.go", `package p
+
+type T struct{}
+
+//go:nointerface
+func (T) Bad() {}
+`, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+	fn := file.Decls[1].(*ast.FuncDecl)
+	prog := llssa.NewProgram(nil)
+	c := &context{prog: prog, skips: make(map[string]none)}
+	c.initFiles("p", []*ast.File{file}, false)
+	if !prog.IsNoInterfaceMethod(types.NewFunc(fn.Name.Pos(), types.NewPackage("p", "p"), "Bad", nil)) {
+		t.Fatal("Bad was not marked nointerface")
+	}
+}

--- a/cl/import_patch_test.go
+++ b/cl/import_patch_test.go
@@ -8,6 +8,8 @@ import (
 	"go/parser"
 	"go/token"
 	"go/types"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/goplus/gogen/packages"
@@ -81,15 +83,73 @@ type T struct{}
 
 //go:nointerface
 func (T) Bad() {}
+func (T) Good() {}
+
+//go:nointerface
+func Plain() {}
 `, parser.ParseComments)
 	if err != nil {
 		t.Fatalf("ParseFile failed: %v", err)
 	}
-	fn := file.Decls[1].(*ast.FuncDecl)
+	funcPos := make(map[string]token.Pos)
+	for _, decl := range file.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok {
+			funcPos[fn.Name.Name] = fn.Name.Pos()
+		}
+	}
 	prog := llssa.NewProgram(nil)
 	c := &context{prog: prog, skips: make(map[string]none)}
 	c.initFiles("p", []*ast.File{file}, false)
-	if !prog.IsNoInterfaceMethod(types.NewFunc(fn.Name.Pos(), types.NewPackage("p", "p"), "Bad", nil)) {
+	pkg := types.NewPackage("p", "p")
+	if !prog.IsNoInterfaceMethod(types.NewFunc(funcPos["Bad"], pkg, "Bad", nil)) {
 		t.Fatal("Bad was not marked nointerface")
+	}
+	if prog.IsNoInterfaceMethod(types.NewFunc(funcPos["Good"], pkg, "Good", nil)) {
+		t.Fatal("Good was incorrectly marked nointerface")
+	}
+	if prog.IsNoInterfaceMethod(types.NewFunc(funcPos["Plain"], pkg, "Plain", nil)) {
+		t.Fatal("Plain function was incorrectly marked nointerface")
+	}
+}
+
+func TestImportPkgCollectsGoNoInterface(t *testing.T) {
+	src := `package p
+
+const LLGoPackage = "decl"
+
+type T struct{}
+
+//go:nointerface
+func (T) Bad() {}
+func (T) Good() {}
+`
+	srcPath := filepath.Join(t.TempDir(), "p.go")
+	if err := os.WriteFile(srcPath, []byte(src), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, srcPath, src, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("ParseFile failed: %v", err)
+	}
+	files := []*ast.File{file}
+	pkg := types.NewPackage("example.com/p", "p")
+	imp := packages.NewImporter(fset)
+	if _, _, err := ssautil.BuildPackage(&types.Config{Importer: imp}, fset, pkg, files, gossa.SanityCheckFunctions); err != nil {
+		t.Fatalf("BuildPackage failed: %v", err)
+	}
+	named := pkg.Scope().Lookup("T").Type().(*types.Named)
+	methods := make(map[string]*types.Func)
+	for i := 0; i < named.NumMethods(); i++ {
+		methods[named.Method(i).Name()] = named.Method(i)
+	}
+	prog := llssa.NewProgram(nil)
+	c := &context{prog: prog, fset: fset}
+	c.importPkg(pkg, &pkgInfo{})
+	if !prog.IsNoInterfaceMethod(methods["Bad"]) {
+		t.Fatal("imported Bad was not marked nointerface")
+	}
+	if prog.IsNoInterfaceMethod(methods["Good"]) {
+		t.Fatal("imported Good was incorrectly marked nointerface")
 	}
 }

--- a/cl/import_patch_test.go
+++ b/cl/import_patch_test.go
@@ -91,23 +91,23 @@ func Plain() {}
 	if err != nil {
 		t.Fatalf("ParseFile failed: %v", err)
 	}
-	funcPos := make(map[string]token.Pos)
+	funcNames := make(map[string]string)
 	for _, decl := range file.Decls {
 		if fn, ok := decl.(*ast.FuncDecl); ok {
-			funcPos[fn.Name.Name] = fn.Name.Pos()
+			fullName, _ := astFuncName("p", fn)
+			funcNames[fn.Name.Name] = fullName
 		}
 	}
 	prog := llssa.NewProgram(nil)
 	c := &context{prog: prog, skips: make(map[string]none)}
 	c.initFiles("p", []*ast.File{file}, false)
-	pkg := types.NewPackage("p", "p")
-	if !prog.IsNoInterfaceMethod(types.NewFunc(funcPos["Bad"], pkg, "Bad", nil)) {
+	if !prog.IsNoInterfaceMethod(funcNames["Bad"]) {
 		t.Fatal("Bad was not marked nointerface")
 	}
-	if prog.IsNoInterfaceMethod(types.NewFunc(funcPos["Good"], pkg, "Good", nil)) {
+	if prog.IsNoInterfaceMethod(funcNames["Good"]) {
 		t.Fatal("Good was incorrectly marked nointerface")
 	}
-	if prog.IsNoInterfaceMethod(types.NewFunc(funcPos["Plain"], pkg, "Plain", nil)) {
+	if prog.IsNoInterfaceMethod(funcNames["Plain"]) {
 		t.Fatal("Plain function was incorrectly marked nointerface")
 	}
 }
@@ -146,10 +146,12 @@ func (T) Good() {}
 	prog := llssa.NewProgram(nil)
 	c := &context{prog: prog, fset: fset}
 	c.importPkg(pkg, &pkgInfo{})
-	if !prog.IsNoInterfaceMethod(methods["Bad"]) {
+	badName, _ := typesFuncName(pkg.Path(), methods["Bad"])
+	goodName, _ := typesFuncName(pkg.Path(), methods["Good"])
+	if !prog.IsNoInterfaceMethod(badName) {
 		t.Fatal("imported Bad was not marked nointerface")
 	}
-	if prog.IsNoInterfaceMethod(methods["Good"]) {
+	if prog.IsNoInterfaceMethod(goodName) {
 		t.Fatal("imported Good was incorrectly marked nointerface")
 	}
 }

--- a/internal/build/source_patch_test.go
+++ b/internal/build/source_patch_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -156,6 +157,31 @@ func TestApplySourcePatchForPkg_Cases(t *testing.T) {
 	} {
 		t.Run(caseName, func(t *testing.T) {
 			runSourcePatchCase(t, caseName)
+		})
+	}
+}
+
+func TestParseSourcePatchLLGoSkipDirectives(t *testing.T) {
+	cases := []struct {
+		line        string
+		wantSkipAll bool
+		wantNames   []string
+		wantOK      bool
+	}{
+		{line: "//llgo:skipall", wantSkipAll: true, wantOK: true},
+		{line: "// llgo:skipall", wantSkipAll: true, wantOK: true},
+		{line: "//llgo:skip Drop Keep", wantNames: []string{"Drop", "Keep"}, wantOK: true},
+		{line: "// llgo:skip Drop", wantNames: []string{"Drop"}, wantOK: true},
+		{line: "//go:generate ignored"},
+		{line: "//llgo:link Name C.name"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.line, func(t *testing.T) {
+			gotSkipAll, gotNames, gotOK := parseSourcePatchDirective(tt.line)
+			if gotSkipAll != tt.wantSkipAll || gotOK != tt.wantOK || !slices.Equal(gotNames, tt.wantNames) {
+				t.Fatalf("parseSourcePatchDirective(%q) = (%v,%v,%v), want (%v,%v,%v)",
+					tt.line, gotSkipAll, gotNames, gotOK, tt.wantSkipAll, tt.wantNames, tt.wantOK)
+			}
 		})
 	}
 }

--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -458,6 +458,9 @@ func (b Builder) abiUncommonMethods(t types.Type, methods []*types.Selection) ll
 }
 
 func (p Program) abiRuntimeMethods(mset *types.MethodSet) []*types.Selection {
+	if !p.hasNoInterfaceMethods() {
+		return methodSelections(mset)
+	}
 	n := mset.Len()
 	methods := make([]*types.Selection, 0, n)
 	for i := 0; i < n; i++ {
@@ -466,6 +469,15 @@ func (p Program) abiRuntimeMethods(mset *types.MethodSet) []*types.Selection {
 			continue
 		}
 		methods = append(methods, m)
+	}
+	return methods
+}
+
+func methodSelections(mset *types.MethodSet) []*types.Selection {
+	n := mset.Len()
+	methods := make([]*types.Selection, n)
+	for i := 0; i < n; i++ {
+		methods[i] = mset.At(i)
 	}
 	return methods
 }

--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -390,16 +390,16 @@ type UncommonType struct {
 }
 */
 
-func (b Builder) abiUncommonType(t types.Type, mset *types.MethodSet) llvm.Value {
+func (b Builder) abiUncommonType(t types.Type, methods []*types.Selection) llvm.Value {
 	prog := b.Prog
 	ft := prog.rtType("uncommonType")
 	var fields []llvm.Value
 	_, pkgPath := b.abiUncommonPkg(t)
 	fields = append(fields, b.Str(pkgPath).impl)
-	mcount := mset.Len()
+	mcount := len(methods)
 	var xcount int
 	for i := 0; i < mcount; i++ {
-		if ast.IsExported(mset.At(i).Obj().Name()) {
+		if ast.IsExported(methods[i].Obj().Name()) {
 			xcount++
 		}
 	}
@@ -419,10 +419,10 @@ type Method struct {
 }
 */
 
-func (b Builder) abiUncommonMethods(t types.Type, mset *types.MethodSet) llvm.Value {
+func (b Builder) abiUncommonMethods(t types.Type, methods []*types.Selection) llvm.Value {
 	prog := b.Prog
 	ft := prog.rtType("Method")
-	n := mset.Len()
+	n := len(methods)
 	fields := make([]llvm.Value, n)
 	pkg, _ := b.abiUncommonPkg(t)
 	anonymous := pkg == nil
@@ -430,7 +430,7 @@ func (b Builder) abiUncommonMethods(t types.Type, mset *types.MethodSet) llvm.Va
 		pkg = types.NewPackage(b.Pkg.Path(), "")
 	}
 	for i := 0; i < n; i++ {
-		m := mset.At(i)
+		m := methods[i]
 		obj := m.Obj()
 		mName := obj.Name()
 		name := b.Str(mName).impl
@@ -455,6 +455,19 @@ func (b Builder) abiUncommonMethods(t types.Type, mset *types.MethodSet) llvm.Va
 		fields[i] = llvm.ConstNamedStruct(ft.ll, values)
 	}
 	return llvm.ConstArray(ft.ll, fields)
+}
+
+func (p Program) abiRuntimeMethods(mset *types.MethodSet) []*types.Selection {
+	n := mset.Len()
+	methods := make([]*types.Selection, 0, n)
+	for i := 0; i < n; i++ {
+		m := mset.At(i)
+		if fn, ok := m.Obj().(*types.Func); ok && p.IsNoInterfaceMethod(fn) {
+			continue
+		}
+		methods = append(methods, m)
+	}
+	return methods
 }
 
 // closure func type
@@ -498,6 +511,10 @@ func (b Builder) abiType(t types.Type) Expr {
 			t = prog.patchType(t)
 		}
 		mset, hasUncommon := b.abiUncommonMethodSet(t)
+		var methods []*types.Selection
+		if hasUncommon {
+			methods = prog.abiRuntimeMethods(mset)
+		}
 		rt := prog.rtNamed(prog.abi.RuntimeName(t))
 		var typ types.Type = rt
 		if hasUncommon {
@@ -506,7 +523,7 @@ func (b Builder) abiType(t types.Type) Expr {
 			fields := []*types.Var{
 				types.NewVar(token.NoPos, nil, "T", rt),
 				types.NewVar(token.NoPos, nil, "U", ut),
-				types.NewVar(token.NoPos, nil, "M", types.NewArray(mt, int64(mset.Len()))),
+				types.NewVar(token.NoPos, nil, "M", types.NewArray(mt, int64(len(methods)))),
 			}
 			typ = types.NewStruct(fields, nil)
 		}
@@ -520,8 +537,8 @@ func (b Builder) abiType(t types.Type) Expr {
 		if hasUncommon {
 			fields = []llvm.Value{
 				llvm.ConstNamedStruct(prog.Type(rt, InGo).ll, fields),
-				b.abiUncommonType(t, mset),
-				b.abiUncommonMethods(t, mset),
+				b.abiUncommonType(t, methods),
+				b.abiUncommonMethods(t, methods),
 			}
 		}
 		g.impl.SetInitializer(llvm.ConstNamedStruct(g.impl.GlobalValueType(), fields))

--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -465,8 +465,15 @@ func (p Program) abiRuntimeMethods(mset *types.MethodSet) []*types.Selection {
 	methods := make([]*types.Selection, 0, n)
 	for i := 0; i < n; i++ {
 		m := mset.At(i)
-		if fn, ok := m.Obj().(*types.Func); ok && p.IsNoInterfaceMethod(fn) {
-			continue
+		if fn, ok := m.Obj().(*types.Func); ok {
+			pkg := fn.Pkg()
+			if pkg != nil {
+				sig := fn.Type().(*types.Signature)
+				fullName := FuncName(pkg, fn.Name(), sig.Recv(), false)
+				if p.IsNoInterfaceMethod(fullName) {
+					continue
+				}
+			}
 		}
 		methods = append(methods, m)
 	}

--- a/ssa/abitype_patch_test.go
+++ b/ssa/abitype_patch_test.go
@@ -1,0 +1,25 @@
+package ssa
+
+import (
+	"go/token"
+	"go/types"
+	"testing"
+)
+
+func TestAbiRuntimeMethodsSkipsNoInterface(t *testing.T) {
+	prog := NewProgram(nil)
+	pkg := types.NewPackage("p", "p")
+	obj := types.NewTypeName(token.NoPos, pkg, "T", nil)
+	named := types.NewNamed(obj, types.NewStruct(nil, nil), nil)
+	recv := types.NewVar(token.NoPos, pkg, "", named)
+	bad := types.NewFunc(token.Pos(10), pkg, "Bad", types.NewSignature(recv, nil, nil, false))
+	good := types.NewFunc(token.Pos(20), pkg, "Good", types.NewSignature(recv, nil, nil, false))
+	named.AddMethod(bad)
+	named.AddMethod(good)
+
+	prog.SetNoInterfaceMethod(bad.Pos())
+	methods := prog.abiRuntimeMethods(types.NewMethodSet(named))
+	if len(methods) != 1 || methods[0].Obj() != good {
+		t.Fatalf("runtime methods = %v, want only Good", methods)
+	}
+}

--- a/ssa/abitype_patch_test.go
+++ b/ssa/abitype_patch_test.go
@@ -17,7 +17,8 @@ func TestAbiRuntimeMethodsSkipsNoInterface(t *testing.T) {
 	named.AddMethod(bad)
 	named.AddMethod(good)
 
-	prog.SetNoInterfaceMethod(bad.Pos())
+	badName := FuncName(pkg, bad.Name(), bad.Type().(*types.Signature).Recv(), false)
+	prog.SetNoInterfaceMethod(badName)
 	methods := prog.abiRuntimeMethods(types.NewMethodSet(named))
 	if len(methods) != 1 || methods[0].Obj() != good {
 		t.Fatalf("runtime methods = %v, want only Good", methods)

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -124,7 +124,7 @@ type aProgram struct {
 	patchType func(types.Type) types.Type
 
 	compileMethods      func(Package, types.Type)
-	noInterfaceMethods  map[token.Pos]struct{}
+	noInterfaceMethods  map[string]struct{}
 	noInterfaceMethodsM sync.RWMutex
 
 	rt    *types.Package
@@ -288,7 +288,7 @@ func NewProgram(target *Target) Program {
 		target: target, td: td, tm: tm, is32Bits: is32Bits,
 		ptrSize: td.PointerSize(), named: make(map[string]Type), fnnamed: make(map[string]int),
 		linkname: make(map[string]string), abiSymbol: make(map[string]*AbiSymbol),
-		noInterfaceMethods: make(map[token.Pos]struct{}),
+		noInterfaceMethods: make(map[string]struct{}),
 	}
 	prog.abi.Init(uintptr(prog.ptrSize), (*goProgram)(unsafe.Pointer(prog)))
 	return prog
@@ -325,22 +325,22 @@ func (p Program) SetCompileMethods(check func(Package, types.Type)) {
 	p.compileMethods = check
 }
 
-func (p Program) SetNoInterfaceMethod(pos token.Pos) {
-	if pos == token.NoPos {
+func (p Program) SetNoInterfaceMethod(name string) {
+	if name == "" {
 		return
 	}
 	p.noInterfaceMethodsM.Lock()
 	defer p.noInterfaceMethodsM.Unlock()
-	p.noInterfaceMethods[pos] = struct{}{}
+	p.noInterfaceMethods[name] = struct{}{}
 }
 
-func (p Program) IsNoInterfaceMethod(fn *types.Func) bool {
-	if fn == nil || fn.Pos() == token.NoPos {
+func (p Program) IsNoInterfaceMethod(name string) bool {
+	if name == "" {
 		return false
 	}
 	p.noInterfaceMethodsM.RLock()
 	defer p.noInterfaceMethodsM.RUnlock()
-	_, ok := p.noInterfaceMethods[fn.Pos()]
+	_, ok := p.noInterfaceMethods[name]
 	return ok
 }
 

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"runtime"
 	"strconv"
+	"sync"
 	"unsafe"
 
 	"github.com/goplus/llgo/internal/env"
@@ -122,8 +123,9 @@ type aProgram struct {
 
 	patchType func(types.Type) types.Type
 
-	compileMethods     func(Package, types.Type)
-	noInterfaceMethods map[token.Pos]struct{}
+	compileMethods      func(Package, types.Type)
+	noInterfaceMethods  map[token.Pos]struct{}
+	noInterfaceMethodsM sync.RWMutex
 
 	rt    *types.Package
 	rtget func() *types.Package
@@ -286,6 +288,7 @@ func NewProgram(target *Target) Program {
 		target: target, td: td, tm: tm, is32Bits: is32Bits,
 		ptrSize: td.PointerSize(), named: make(map[string]Type), fnnamed: make(map[string]int),
 		linkname: make(map[string]string), abiSymbol: make(map[string]*AbiSymbol),
+		noInterfaceMethods: make(map[token.Pos]struct{}),
 	}
 	prog.abi.Init(uintptr(prog.ptrSize), (*goProgram)(unsafe.Pointer(prog)))
 	return prog
@@ -326,9 +329,8 @@ func (p Program) SetNoInterfaceMethod(pos token.Pos) {
 	if pos == token.NoPos {
 		return
 	}
-	if p.noInterfaceMethods == nil {
-		p.noInterfaceMethods = make(map[token.Pos]struct{})
-	}
+	p.noInterfaceMethodsM.Lock()
+	defer p.noInterfaceMethodsM.Unlock()
 	p.noInterfaceMethods[pos] = struct{}{}
 }
 
@@ -336,8 +338,16 @@ func (p Program) IsNoInterfaceMethod(fn *types.Func) bool {
 	if fn == nil || fn.Pos() == token.NoPos {
 		return false
 	}
+	p.noInterfaceMethodsM.RLock()
+	defer p.noInterfaceMethodsM.RUnlock()
 	_, ok := p.noInterfaceMethods[fn.Pos()]
 	return ok
+}
+
+func (p Program) hasNoInterfaceMethods() bool {
+	p.noInterfaceMethodsM.RLock()
+	defer p.noInterfaceMethodsM.RUnlock()
+	return len(p.noInterfaceMethods) != 0
 }
 
 // SetRuntime sets the runtime.

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -122,7 +122,8 @@ type aProgram struct {
 
 	patchType func(types.Type) types.Type
 
-	compileMethods func(Package, types.Type)
+	compileMethods     func(Package, types.Type)
+	noInterfaceMethods map[token.Pos]struct{}
 
 	rt    *types.Package
 	rtget func() *types.Package
@@ -319,6 +320,24 @@ func (p Program) patch(typ types.Type) types.Type {
 
 func (p Program) SetCompileMethods(check func(Package, types.Type)) {
 	p.compileMethods = check
+}
+
+func (p Program) SetNoInterfaceMethod(pos token.Pos) {
+	if pos == token.NoPos {
+		return
+	}
+	if p.noInterfaceMethods == nil {
+		p.noInterfaceMethods = make(map[token.Pos]struct{})
+	}
+	p.noInterfaceMethods[pos] = struct{}{}
+}
+
+func (p Program) IsNoInterfaceMethod(fn *types.Func) bool {
+	if fn == nil || fn.Pos() == token.NoPos {
+		return false
+	}
+	_, ok := p.noInterfaceMethods[fn.Pos()]
+	return ok
 }
 
 // SetRuntime sets the runtime.

--- a/test/go/directives_test.go
+++ b/test/go/directives_test.go
@@ -1,0 +1,61 @@
+//go:build llgo
+// +build llgo
+
+package gotest
+
+import _ "unsafe"
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/goplus/lib/c"
+)
+
+//go:linkname directiveSqrt C.sqrt
+func directiveSqrt(x c.Double) c.Double
+
+//llgo:link directiveAbs C.abs
+func directiveAbs(x c.Int) c.Int { return 0 }
+
+// llgo:link directiveAbsSpaced C.abs
+func directiveAbsSpaced(x c.Int) c.Int { return 0 }
+
+type directiveNoInterface struct{}
+
+//go:nointerface
+func (directiveNoInterface) Hidden() {}
+
+func (directiveNoInterface) Visible() {}
+
+//llgo:skip directiveSkippedBad
+type directiveSkipAnchor struct{}
+
+//go:linkname directiveSkippedMissing C.llgo_missing_directive_skip
+func directiveSkippedMissing()
+
+func directiveSkippedBad() {
+	directiveSkippedMissing()
+}
+
+func TestLLGoDirectiveLinknameForms(t *testing.T) {
+	if got := float64(directiveSqrt(9)); got != 3 {
+		t.Fatalf("go:linkname sqrt = %v, want 3", got)
+	}
+	if got := int(directiveAbs(-4)); got != 4 {
+		t.Fatalf("llgo:link abs = %d, want 4", got)
+	}
+	if got := int(directiveAbsSpaced(-5)); got != 5 {
+		t.Fatalf("spaced llgo:link abs = %d, want 5", got)
+	}
+}
+
+func TestLLGoDirectiveNoInterface(t *testing.T) {
+	typ := reflect.TypeOf(directiveNoInterface{})
+	if _, ok := typ.MethodByName("Hidden"); ok {
+		t.Fatal("go:nointerface method Hidden was present in runtime method set")
+	}
+	if _, ok := typ.MethodByName("Visible"); !ok {
+		t.Fatal("ordinary method Visible was missing from runtime method set")
+	}
+}


### PR DESCRIPTION
## Summary
- implement go:nointerface metadata collection and make runtime method metadata omit marked methods
- refactor compiler directive extraction so function/variable declaration directives share AST-based helpers
- preserve imported go:linkname / llgo:link compatibility by scanning full AST comment lists and matching directive symbol names in the same file
- cover supported directive forms: go:linkname, llgo:link, spaced llgo:link, go:nointerface, llgo:skip, and llgo:skipall

## Tests
- go test ./cl -run 'Test(CollectImportedDirectivesCoverage|InitFilesCollectsGoNoInterface|ImportPkgCollectsGoNoInterface|PreCollectLinknames)$'
- go test ./internal/build -run 'Test(ParseSourcePatchLLGoSkipDirectives|ApplySourcePatchForPkg_Cases)$'
- go test ./test/go
- LLGO_BUILD_CACHE=off go run ./cmd/llgo test ./test/go -run 'TestLLGoDirective'
- go test ./cl -timeout 15m
- go test ./ssa