### PR TITLE
test: cover LLGo directive comments

### DIFF
--- a/test/go/directives_skipall_fixture_test.go
+++ b/test/go/directives_skipall_fixture_test.go
@@ -1,0 +1,38 @@
+//go:build llgo && directive_skipall_fixture
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gotest
+
+import _ "unsafe"
+
+// This file is a spelling fixture for //llgo:skipall. It is intentionally behind
+// an explicit build tag because enabling it in the normal test package skips
+// package codegen, including the package init symbol expected by the test main.
+// Manual exercise: go run ./cmd/llgo test -tags directive_skipall_fixture ./test/go.
+// The command is expected to fail during link if included in the ordinary test
+// package; source-patch skipall behavior is covered by internal/build tests.
+//
+//llgo:skipall
+type directiveSkipAllAnchor struct{}
+
+//go:linkname directiveSkipAllMissing C.llgo_missing_directive_skipall
+func directiveSkipAllMissing()
+
+func directiveSkipAllBad() {
+	directiveSkipAllMissing()
+}

--- a/test/go/directives_test.go
+++ b/test/go/directives_test.go
@@ -1,0 +1,69 @@
+//go:build llgo
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gotest
+
+import (
+	"testing"
+	_ "unsafe"
+
+	"github.com/goplus/lib/c"
+)
+
+//go:linkname directiveSqrt C.sqrt
+func directiveSqrt(x c.Double) c.Double
+
+//llgo:link directiveAbs C.abs
+func directiveAbs(x c.Int) c.Int { return 0 }
+
+// The spaced form is an LLGo extension and intentionally differs from Go's
+// compiler directive spelling.
+// llgo:link directiveAbsSpaced C.abs
+func directiveAbsSpaced(x c.Int) c.Int { return 0 }
+
+// The anchor type keeps the named //llgo:skip directive attached to a declaration
+// where LLGo collects skip comments, while the skipped symbol is named explicitly.
+//
+//llgo:skip DirectiveSkippedBad
+type directiveSkipAnchor struct{}
+
+//go:linkname directiveSkippedMissing C.llgo_missing_directive_skip
+func directiveSkippedMissing()
+
+func DirectiveSkippedBad() {
+	directiveSkippedMissing()
+}
+
+func TestLLGoDirectiveLinknameForms(t *testing.T) {
+	if got := float64(directiveSqrt(9)); got != 3 {
+		t.Fatalf("go:linkname sqrt = %v, want 3", got)
+	}
+	if got := int(directiveAbs(-4)); got != 4 {
+		t.Fatalf("llgo:link abs = %d, want 4", got)
+	}
+	if got := int(directiveAbsSpaced(-5)); got != 5 {
+		t.Fatalf("spaced llgo:link abs = %d, want 5", got)
+	}
+}
+
+func TestLLGoDirectiveSkip(t *testing.T) {
+	_ = t
+	// This is a link-time regression check. If //llgo:skip above is ignored,
+	// DirectiveSkippedBad is compiled and the package fails to link because
+	// C.llgo_missing_directive_skip does not exist.
+}


### PR DESCRIPTION
## Summary
- add LLGo runtime tests for //go:linkname, //llgo:link, // llgo:link, and //llgo:skip
- add a build-tagged test/go fixture containing //llgo:skipall so the directive spelling is covered without changing default test package codegen
- keep this PR test-only; it does not include go:nointerface support or compiler refactoring

## Tests
- go test ./test/go
- LLGO_BUILD_CACHE=off go run ./cmd/llgo test ./test/go -run 'TestLLGoDirective'

## Notes
- The //llgo:skip test is a link-time regression check: if the skipped function is compiled, it references a deliberately missing C symbol and the package fails to link.
- The //llgo:skipall fixture is behind an explicit build tag because enabling skipall in the normal test package skips package codegen, including the package init symbol expected by the generated test main.