### PR TITLE
ssa: fix zero-value map indexing

### DIFF
--- a/cl/_testlibgo/mapzero/expect.txt
+++ b/cl/_testlibgo/mapzero/expect.txt
@@ -1,0 +1,1 @@
+runtime error: index out of range

--- a/cl/_testlibgo/mapzero/in.go
+++ b/cl/_testlibgo/mapzero/in.go
@@ -10,7 +10,7 @@ func main() {
 		err := recover()
 		fmt.Println(err)
 	}()
-    // CHECK: call ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAccess1"(ptr @"map[_llgo_int]_llgo_int", ptr null, ptr {{%.*}})
+	// CHECK: call ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAccess1"(ptr @"map[_llgo_int]_llgo_int", ptr null, ptr {{%.*}})
 	m := [0]map[int]int{}[a][0]
 	print(m)
 }

--- a/cl/_testlibgo/mapzero/in.go
+++ b/cl/_testlibgo/mapzero/in.go
@@ -1,0 +1,16 @@
+// LITTEST
+package main
+
+import "fmt"
+
+var a = 0
+
+func main() {
+	defer func() {
+		err := recover()
+		fmt.Println(err)
+	}()
+	// CHECK: call ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAccess1"(ptr @"map[_llgo_int]_llgo_int", ptr null, ptr %21)
+	m := [0]map[int]int{}[a][0]
+	print(m)
+}

--- a/cl/_testlibgo/mapzero/in.go
+++ b/cl/_testlibgo/mapzero/in.go
@@ -10,7 +10,7 @@ func main() {
 		err := recover()
 		fmt.Println(err)
 	}()
-	// CHECK: call ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAccess1"(ptr @"map[_llgo_int]_llgo_int", ptr null, ptr %21)
+// CHECK: call ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAccess1"(ptr @"map[_llgo_int]_llgo_int", ptr null, ptr {{%.*}})
 	m := [0]map[int]int{}[a][0]
 	print(m)
 }

--- a/cl/_testlibgo/mapzero/in.go
+++ b/cl/_testlibgo/mapzero/in.go
@@ -10,7 +10,7 @@ func main() {
 		err := recover()
 		fmt.Println(err)
 	}()
-// CHECK: call ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAccess1"(ptr @"map[_llgo_int]_llgo_int", ptr null, ptr {{%.*}})
+    // CHECK: call ptr @"github.com/goplus/llgo/runtime/internal/runtime.MapAccess1"(ptr @"map[_llgo_int]_llgo_int", ptr null, ptr {{%.*}})
 	m := [0]map[int]int{}[a][0]
 	print(m)
 }

--- a/ssa/datastruct.go
+++ b/ssa/datastruct.go
@@ -284,9 +284,6 @@ func (b Builder) Index(x, idx Expr, takeAddr func() (addr Expr, zero bool)) Expr
 		return prog.Zero(telem)
 	}
 	if ptr.IsNil() {
-		if x.impl.IsConstant() {
-			return Expr{llvm.ConstExtractElement(x.impl, idx.impl), telem}
-		}
 		ptr = b.Alloc(x.Type, false)
 		b.impl.CreateStore(x.impl, ptr.impl)
 	}

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -163,7 +163,7 @@ func (p Program) Zero(t Type) Expr {
 		}
 		ret = p.Zero(p.rtType(name)).impl
 	case *types.Map:
-		ret = p.Zero(p.rtType("Map")).impl
+		ret = p.Zero(p.Pointer(p.rtType("Map"))).impl
 	case *types.Tuple:
 		n := u.Len()
 		flds := make([]llvm.Value, n)


### PR DESCRIPTION
## Summary
- represent zero-value maps as null `*runtime.Map` pointers in SSA zero-value lowering
- avoid constant-extracting array elements from nil-backed values so zero-value map indexing stays on the normal load path
- add `cl/_testgo/mapzero` to cover the runtime output and the FileCheck expectation
