### PR TITLE
ssa,test: lower builtin panic in defer paths

### DIFF
--- a/cl/_testlibgo/deferpanic/expect.txt
+++ b/cl/_testlibgo/deferpanic/expect.txt
@@ -1,0 +1,2 @@
+run main
+panic in defer

--- a/cl/_testlibgo/deferpanic/in.go
+++ b/cl/_testlibgo/deferpanic/in.go
@@ -1,0 +1,13 @@
+// LITTEST
+package main
+
+// CHECK: define void @"{{.*}}/deferpanic.main"(){{.*}} {
+func main() {
+	defer func() {
+		e := recover()
+		println(e.(string))
+	}()
+	// CHECK: call void @"{{.*}}/runtime/internal/runtime.Panic"
+	defer panic("panic in defer")
+	println("run main")
+}

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -1473,7 +1473,11 @@ func (b Builder) BuiltinCall(fn string, args ...Expr) (ret Expr) {
 			}
 		}
 		panic("invalid argument for unsafe.Offsetof: must be a selector expression")
+	case "panic":
+		b.Panic(args[0])
+		return
 	}
+
 	panic("todo: " + fn)
 }
 


### PR DESCRIPTION
## Summary
- lower builtin `panic` calls through `Builder.Panic` during SSA lowering
- add `cl/_testdata/deferpanic` coverage for panic raised from a deferred call
- verify the deferred `recover()` path prints the expected output

## Testing
- not run