### PR TITLE
ssa: handle union types in type conversion

### DIFF
--- a/ssa/type_cvt.go
+++ b/ssa/type_cvt.go
@@ -121,6 +121,8 @@ func (p goTypes) cvtType(typ types.Type) (raw types.Type, cvt bool) {
 		return typ.Underlying(), false
 	case *types.Alias:
 		return p.cvtType(types.Unalias(t))
+	case *types.Union:
+		return p.cvtUnion(t)
 	default:
 		panic(fmt.Sprintf("cvtType: unexpected type - %T", typ))
 	}
@@ -322,6 +324,27 @@ func (p goTypes) cvtStruct(typ *types.Struct) (raw *types.Struct, cvt bool) {
 		return types.NewStruct(flds, nil), true
 	}
 	return typ, false
+}
+
+func (p goTypes) cvtUnion(typ *types.Union) (raw *types.Union, cvt bool) {
+	if v, ok := p.typs[unsafe.Pointer(typ)]; ok {
+		raw = (*types.Union)(v)
+		cvt = typ != raw
+		return
+	}
+	defer func() {
+		p.typs[unsafe.Pointer(typ)] = unsafe.Pointer(raw)
+	}()
+	n := typ.Len()
+	terms := make([]*types.Term, n)
+	for i := 0; i < n; i++ {
+		f := typ.Term(i)
+		if t, cvt := p.cvtType(f.Type()); cvt {
+			f = types.NewTerm(f.Tilde(), t)
+		}
+		terms[i] = f
+	}
+	return types.NewUnion(terms), true
 }
 
 // -----------------------------------------------------------------------------

--- a/test/typeunion_test.go
+++ b/test/typeunion_test.go
@@ -1,0 +1,54 @@
+package test
+
+import "testing"
+
+type PublicKey any
+
+type VerificationKey interface {
+	PublicKey | []uint8
+}
+
+type VerificationKeySet struct {
+	Keys []VerificationKey
+}
+
+func checkVerificationKey(got any) int {
+	switch have := got.(type) {
+	case VerificationKeySet:
+		return len(have.Keys)
+
+	case VerificationKey:
+
+		_ = have
+		return 100
+
+	default:
+		return -1
+	}
+}
+
+func TestVerificationKeyUnionDegenerate(t *testing.T) {
+	set := VerificationKeySet{
+		Keys: []VerificationKey{
+			[]uint8{1, 2, 3},
+			123,
+			"abc",
+		},
+	}
+
+	if got := checkVerificationKey(set); got != 3 {
+		t.Fatalf("checkVerificationKey(VerificationKeySet) = %d, want 3", got)
+	}
+
+	if got := checkVerificationKey([]uint8{1, 2}); got != 100 {
+		t.Fatalf("checkVerificationKey([]uint8) = %d, want 100", got)
+	}
+
+	if got := checkVerificationKey(123); got != 100 {
+		t.Fatalf("checkVerificationKey(int) = %d, want 100", got)
+	}
+
+	if got := checkVerificationKey("hello"); got != 100 {
+		t.Fatalf("checkVerificationKey(string) = %d, want 100", got)
+	}
+}


### PR DESCRIPTION
## Summary
- teach `goTypes.cvtType` to convert `*types.Union` values recursively
- cache converted union types the same way as other composite types
- add a regression test covering a degenerate union interface used as a value type

## Testing
- `go test ./test -run TestVerificationKeyUnionDegenerate -count=1`