### PR TITLE
ci: disable automatic GOROOT workflow

### DIFF
--- a/.github/workflows/goroot.yml
+++ b/.github/workflows/goroot.yml
@@ -1,13 +1,7 @@
 name: GOROOT
 
 on:
-  push:
-    branches:
-      - "**"
-      - "!dependabot/**"
-      - "!xgopilot/**"
-  pull_request:
-    branches: ["**"]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary

Disable automatic `GOROOT` workflow runs on push and pull_request events. The workflow remains available through `workflow_dispatch` so it can still be run manually when needed.

## Rationale

The GOROOT matrix is expensive and currently consumes substantial CI capacity. This keeps normal PR CI lighter while preserving a manual path for full GOROOT validation.

## Testing

- `git diff --check`