### PR TITLE
Improve build performance with simple hot-path optimizations

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -384,7 +384,7 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	})
 	preCollectRuntimeLinknames(prog, altPkgs)
 
-	buildMode := ssaBuildMode
+	buildMode := ssaBuildMode()
 	cabiOptimize := true
 	passOpt := true
 	if IsDbgEnabled() || mode == ModeGen {
@@ -571,9 +571,17 @@ func (p Package) isNeedRuntimeOrPyInit() (needRuntime, needPyInit bool) {
 	return
 }
 
-const (
-	ssaBuildMode = ssa.SanityCheckFunctions | ssa.InstantiateGenerics
-)
+func ssaBuildMode() ssa.BuilderMode {
+	mode := ssa.InstantiateGenerics
+	if ssaSanityEnabled() {
+		mode |= ssa.SanityCheckFunctions
+	}
+	return mode
+}
+
+func ssaSanityEnabled() bool {
+	return isEnvOn(llgoSSASanity, false)
+}
 
 type context struct {
 	env            *llvm.Env
@@ -1708,9 +1716,11 @@ func fixUntypedShiftTypes(p *packages.Package) {
 }
 
 func applyPatches(ctx *context, p *packages.Package, verbose bool) {
-	// Fix untyped shift types before SSA build
+	// Fix untyped shift types before SSA sanity checking.
 	// See: https://github.com/golang/go/issues/77067
-	fixUntypedShiftTypes(p)
+	if ssaSanityEnabled() {
+		fixUntypedShiftTypes(p)
+	}
 
 	// fix instance patch
 	for id, inst := range p.TypesInfo.Instances {
@@ -1780,6 +1790,7 @@ const llgoWasiThreads = "LLGO_WASI_THREADS"
 const llgoStdioNobuf = "LLGO_STDIO_NOBUF"
 const llgoFullRpath = "LLGO_FULL_RPATH"
 const llgoBuildCache = "LLGO_BUILD_CACHE"
+const llgoSSASanity = "LLGO_SSA_SANITY"
 
 // for Plan9 asm translation debug
 const llgoPlan9ASMPkgs = "LLGO_PLAN9ASM_PKGS"

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -972,8 +972,6 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, outputPa
 	needRuntime := false
 	needPyInit := false
 	var needAbiInit int
-	methodByIndex := make(map[int]none)
-	methodByName := make(map[string]none)
 	allPkgs := []*packages.Package{pkg}
 	for _, v := range pkgs {
 		allPkgs = append(allPkgs, v.Package)
@@ -1029,12 +1027,6 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, outputPa
 		needRuntime = needRuntime || need1
 		needPyInit = needPyInit || need2
 		needAbiInit |= aPkg.LPkg.NeedAbiInit
-		for k, _ := range aPkg.LPkg.MethodByIndex {
-			methodByIndex[k] = none{}
-		}
-		for k, _ := range aPkg.LPkg.MethodByName {
-			methodByName[k] = none{}
-		}
 
 		linkArgs = append(linkArgs, aPkg.LinkArgs...)
 		if aPkg.ArchiveFile != "" {
@@ -1052,12 +1044,10 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, outputPa
 	// This is compiled directly to .o and added to linkInputs (not cached)
 	// Use a stable synthetic name to avoid confusing it with the real main package in traces/logs.
 	entryPkg := genMainModule(ctx, llssa.PkgRuntime, pkg, &genConfig{
-		rtInit:        needRuntime,
-		pyInit:        needPyInit,
-		abiInit:       needAbiInit,
-		methodByIndex: methodByIndex,
-		methodByName:  methodByName,
-		abiSymbols:    linkedModuleGlobals(linkedOrder),
+		rtInit:     needRuntime,
+		pyInit:     needPyInit,
+		abiInit:    needAbiInit,
+		abiSymbols: linkedModuleGlobals(linkedOrder),
 	})
 	entryObjFile, err := exportObject(ctx, "entry_main", entryPkg.ExportFile, entryPkg.LPkg)
 	if err != nil {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1602,6 +1602,7 @@ func buildSSAPkgs(ctx *context, initial []*packages.Package, verbose bool) ([]*a
 	prog := ctx.progSSA
 	var all []*aPackage
 	var errs []*packages.Package
+	var createdSSA bool
 	packages.Visit(initial, nil, func(p *packages.Package) {
 		if p.Types != nil && !p.IllTyped {
 			pkgPath := p.PkgPath
@@ -1610,7 +1611,10 @@ func buildSSAPkgs(ctx *context, initial []*packages.Package, verbose bool) ([]*a
 				return
 			}
 			var altPkg *packages.Cached
-			var ssaPkg = createSSAPkg(ctx, prog, p, verbose)
+			ssaPkg, created := createSSAPkg(ctx, prog, p, verbose)
+			if created {
+				createdSSA = true
+			}
 			if ctx.hasAltPkg(pkgPath) {
 				if altPkg = ctx.dedup.Check(altPkgPathPrefix + pkgPath); altPkg == nil {
 					return
@@ -1644,7 +1648,9 @@ func buildSSAPkgs(ctx *context, initial []*packages.Package, verbose bool) ([]*a
 		}
 		return nil, fmt.Errorf("cannot build SSA for packages")
 	}
-	prog.Build()
+	if createdSSA {
+		prog.Build()
+	}
 	for _, pkg := range all {
 		fixSSAOrder(pkg.SSA, pkg.Syntax)
 	}
@@ -1755,16 +1761,17 @@ func applyPatches(ctx *context, p *packages.Package, verbose bool) {
 	}
 }
 
-func createSSAPkg(ctx *context, prog *ssa.Program, p *packages.Package, verbose bool) *ssa.Package {
+func createSSAPkg(ctx *context, prog *ssa.Program, p *packages.Package, verbose bool) (*ssa.Package, bool) {
 	pkgSSA := prog.ImportedPackage(p.ID)
-	if pkgSSA == nil {
-		if debugBuild || verbose {
-			log.Println("==> BuildSSA", p.ID)
-		}
-		applyPatches(ctx, p, verbose)
-		pkgSSA = prog.CreatePackage(p.Types, p.Syntax, p.TypesInfo, true)
+	if pkgSSA != nil {
+		return pkgSSA, false
 	}
-	return pkgSSA
+	if debugBuild || verbose {
+		log.Println("==> BuildSSA", p.ID)
+	}
+	applyPatches(ctx, p, verbose)
+	pkgSSA = prog.CreatePackage(p.Types, p.Syntax, p.TypesInfo, true)
+	return pkgSSA, true
 }
 
 /*

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -972,7 +972,8 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, outputPa
 	needRuntime := false
 	needPyInit := false
 	var needAbiInit int
-	allPkgs := []*packages.Package{pkg}
+	allPkgs := make([]*packages.Package, 1, len(pkgs)+1)
+	allPkgs[0] = pkg
 	for _, v := range pkgs {
 		allPkgs = append(allPkgs, v.Package)
 	}
@@ -987,12 +988,12 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, outputPa
 	}
 	// archiveInputs contains package .a files. Object files are prepended later so
 	// archive extraction can see their undefined references in a single linker pass.
-	var archiveInputs []string
-	var linkArgs []string
+	archiveInputs := make([]string, 0, len(pkgs)+1)
+	linkArgs := make([]string, 0, len(pkgs))
 	var rtLinkInputs []string
 	var rtLinkArgs []string
-	linkedPkgs := make(map[string]bool) // Track linked packages by ID to avoid duplicates
-	var linkedOrder []Package
+	linkedPkgs := make(map[string]bool, len(pkgs)+1) // Track linked packages by ID to avoid duplicates
+	linkedOrder := make([]Package, 0, len(pkgs)+1)
 	packages.Visit(visitRoots, nil, func(p *packages.Package) {
 		// Skip if already linked this package (by ID)
 		if linkedPkgs[p.ID] {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -613,8 +613,9 @@ type context struct {
 	cacheManager *cacheManager
 	llvmVersion  string
 
-	// go list derived file lists (SFiles, etc.)
+	// Plan9 assembly file discovery caches.
 	sfilesCache map[string][]string // pkg.ID -> absolute .s/.S file paths
+	asmDirCache map[string]bool     // package directory -> whether it contains any .s/.S files
 
 	// plan9asm package policy parsed from env.
 	plan9asmOnce sync.Once

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/constant"
+	"go/parser"
 	"go/token"
 	"go/types"
 	"log"
@@ -293,6 +294,7 @@ func Do(args []string, conf *Config) ([]Package, error) {
 		Fset:       token.NewFileSet(),
 		Tests:      conf.Mode == ModeTest,
 		Env:        append(slices.Clone(os.Environ()), "GOOS="+conf.Goos, "GOARCH="+conf.Goarch),
+		ParseFile:  parseBuildFile,
 	}
 	if conf.Mode == ModeTest {
 		cfg.Mode |= packages.NeedForTest
@@ -677,6 +679,10 @@ func normalizeToArchive(ctx *context, aPkg *aPackage, verbose bool) error {
 	aPkg.ObjFiles = nil
 	aPkg.ArchiveFile = archivePath
 	return nil
+}
+
+func parseBuildFile(fset *token.FileSet, filename string, src []byte) (*ast.File, error) {
+	return parser.ParseFile(fset, filename, src, parser.AllErrors|parser.ParseComments|parser.SkipObjectResolution)
 }
 
 func buildAllPkgs(ctx *context, pkgs []*aPackage, verbose bool) ([]*aPackage, error) {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1644,6 +1644,10 @@ func buildSSAPkgs(ctx *context, initial []*packages.Package, verbose bool) ([]*a
 		}
 		return nil, fmt.Errorf("cannot build SSA for packages")
 	}
+	prog.Build()
+	for _, pkg := range all {
+		fixSSAOrder(pkg.SSA, pkg.Syntax)
+	}
 	return all, nil
 }
 
@@ -1759,9 +1763,6 @@ func createSSAPkg(ctx *context, prog *ssa.Program, p *packages.Package, verbose 
 		}
 		applyPatches(ctx, p, verbose)
 		pkgSSA = prog.CreatePackage(p.Types, p.Syntax, p.TypesInfo, true)
-		pkgSSA.Build() // TODO(xsw): build concurrently
-		// Apply local SSA fixups once when package SSA is first built.
-		fixSSAOrder(pkgSSA, p.Syntax)
 	}
 	return pkgSSA
 }

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -203,6 +203,26 @@ func envGOPATH() (string, error) {
 	return filepath.Join(home, "go"), nil
 }
 
+func prependEnvPath(dir string) {
+	if dir == "" {
+		return
+	}
+	sep := string(os.PathListSeparator)
+	pathEnv := os.Getenv("PATH")
+	parts := filepath.SplitList(pathEnv)
+	if len(parts) > 0 && parts[0] == dir {
+		return
+	}
+	out := make([]string, 0, len(parts)+1)
+	out = append(out, dir)
+	for _, part := range parts {
+		if part != "" && part != dir {
+			out = append(out, part)
+		}
+	}
+	os.Setenv("PATH", strings.Join(out, sep))
+}
+
 // -----------------------------------------------------------------------------
 
 const (
@@ -382,7 +402,7 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	altSSAPkgs(progSSA, patches, altPkgs[1:], conf, verbose)
 
 	env := llvm.New("")
-	os.Setenv("PATH", env.BinDir()+":"+os.Getenv("PATH")) // TODO(xsw): check windows
+	prependEnvPath(env.BinDir())
 
 	output := conf.OutFile != ""
 	ctx := &context{env: env, conf: cfg, progSSA: progSSA, prog: prog, dedup: dedup,

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -32,6 +32,26 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+func TestPrependEnvPath(t *testing.T) {
+	sep := string(os.PathListSeparator)
+	t.Setenv("PATH", strings.Join([]string{"/usr/bin", "/opt/llvm/bin", "/bin", "/opt/llvm/bin"}, sep))
+	prependEnvPath("/opt/llvm/bin")
+	want := strings.Join([]string{"/opt/llvm/bin", "/usr/bin", "/bin"}, sep)
+	if got := os.Getenv("PATH"); got != want {
+		t.Fatalf("PATH = %q, want %q", got, want)
+	}
+
+	prependEnvPath("/opt/llvm/bin")
+	if got := os.Getenv("PATH"); got != want {
+		t.Fatalf("second prepend changed PATH to %q, want %q", got, want)
+	}
+
+	prependEnvPath("")
+	if got := os.Getenv("PATH"); got != want {
+		t.Fatalf("empty prepend changed PATH to %q, want %q", got, want)
+	}
+}
+
 func TestNeedsLinuxNoPIE(t *testing.T) {
 	ctx := &context{buildConf: &Config{Goos: "linux"}}
 	if !needsLinuxNoPIE(ctx, nil) {

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/goplus/llgo/internal/mockable"
 	"github.com/goplus/llgo/internal/packages"
 	llssa "github.com/goplus/llgo/ssa"
+	gossa "golang.org/x/tools/go/ssa"
 )
 
 func TestMain(m *testing.M) {
@@ -49,6 +50,27 @@ func TestPrependEnvPath(t *testing.T) {
 	prependEnvPath("")
 	if got := os.Getenv("PATH"); got != want {
 		t.Fatalf("empty prepend changed PATH to %q, want %q", got, want)
+	}
+}
+
+func TestSSABuildModeSanityOptIn(t *testing.T) {
+	t.Setenv(llgoSSASanity, "")
+	if ssaSanityEnabled() {
+		t.Fatal("SSA sanity should default to disabled")
+	}
+	if got := ssaBuildMode(); got&gossa.SanityCheckFunctions != 0 {
+		t.Fatalf("default SSA build mode enables sanity checks: %v", got)
+	}
+	if got := ssaBuildMode(); got&gossa.InstantiateGenerics == 0 {
+		t.Fatalf("default SSA build mode does not instantiate generics: %v", got)
+	}
+
+	t.Setenv(llgoSSASanity, "1")
+	if !ssaSanityEnabled() {
+		t.Fatal("SSA sanity should be enabled by LLGO_SSA_SANITY=1")
+	}
+	if got := ssaBuildMode(); got&gossa.SanityCheckFunctions == 0 {
+		t.Fatalf("opt-in SSA build mode does not enable sanity checks: %v", got)
 	}
 }
 

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -33,6 +33,26 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+func TestParseBuildFileSkipsObjectResolutionAndKeepsComments(t *testing.T) {
+	src := []byte("package p\n//go:linkname f C.f\nfunc f() {}\n")
+	file, err := parseBuildFile(token.NewFileSet(), "p.go", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if file.Scope != nil {
+		t.Fatalf("file.Scope = %v, want nil with parser.SkipObjectResolution", file.Scope)
+	}
+	if len(file.Comments) == 0 {
+		t.Fatal("parseBuildFile should preserve comments for LLGo directives")
+	}
+	ast.Inspect(file, func(n ast.Node) bool {
+		if ident, ok := n.(*ast.Ident); ok && ident.Obj != nil {
+			t.Fatalf("identifier %q has parser object %v, want nil", ident.Name, ident.Obj)
+		}
+		return true
+	})
+}
+
 func TestPrependEnvPath(t *testing.T) {
 	sep := string(os.PathListSeparator)
 	t.Setenv("PATH", strings.Join([]string{"/usr/bin", "/opt/llvm/bin", "/bin", "/opt/llvm/bin"}, sep))

--- a/internal/build/collect.go
+++ b/internal/build/collect.go
@@ -88,6 +88,7 @@ func (c *context) collectEnvInputs(m *manifestBuilder) {
 		llgoWasiThreads,
 		llgoStdioNobuf,
 		llgoFullRpath,
+		llgoSSASanity,
 	}
 	for _, envVar := range envVars {
 		if v := os.Getenv(envVar); v != "" {

--- a/internal/build/main_module.go
+++ b/internal/build/main_module.go
@@ -37,12 +37,10 @@ import (
 )
 
 type genConfig struct {
-	rtInit        bool
-	pyInit        bool
-	abiInit       int
-	methodByIndex map[int]none
-	methodByName  map[string]none
-	abiSymbols    map[string]none
+	rtInit     bool
+	pyInit     bool
+	abiInit    int
+	abiSymbols map[string]none
 }
 
 // genMainModule generates the main entry module for an llgo program.

--- a/internal/build/plan9asm.go
+++ b/internal/build/plan9asm.go
@@ -412,6 +412,20 @@ func pkgSFiles(ctx *context, pkg *packages.Package) ([]string, error) {
 		return v, nil
 	}
 
+	// internal/chacha8rand has highly optimized arch asm on amd64/arm64.
+	// Until full vector lowering lands, force the generic stub entry, which
+	// tail-jumps to block_generic and preserves package behavior. Do this before
+	// trusting OtherFiles because go/packages may expose the selected optimized
+	// assembly there on some platforms.
+	if pkg.PkgPath == "internal/chacha8rand" {
+		stub := filepath.Join(pkg.Dir, "chacha8_stub.s")
+		if _, err := os.Stat(stub); err == nil {
+			paths := []string{stub}
+			ctx.sfilesCache[pkg.ID] = paths
+			return paths, nil
+		}
+	}
+
 	var metadataSFiles []string
 	for _, file := range pkg.OtherFiles {
 		if strings.HasSuffix(file, ".s") || strings.HasSuffix(file, ".S") {
@@ -438,18 +452,6 @@ func pkgSFiles(ctx *context, pkg *packages.Package) ([]string, error) {
 	bp, err := buildCtx.ImportDir(pkg.Dir, 0)
 	if err != nil {
 		return nil, fmt.Errorf("inspect asm files for %s: %w", pkg.PkgPath, err)
-	}
-
-	// internal/chacha8rand has highly optimized arch asm on amd64/arm64.
-	// Until full vector lowering lands, force the generic stub entry, which
-	// tail-jumps to block_generic and preserves package behavior.
-	if pkg.PkgPath == "internal/chacha8rand" && bp.Dir != "" {
-		stub := filepath.Join(bp.Dir, "chacha8_stub.s")
-		if _, err := os.Stat(stub); err == nil {
-			paths := []string{stub}
-			ctx.sfilesCache[pkg.ID] = paths
-			return paths, nil
-		}
 	}
 
 	paths := make([]string, 0, len(bp.SFiles))

--- a/internal/build/plan9asm.go
+++ b/internal/build/plan9asm.go
@@ -2,10 +2,9 @@ package build
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
+	"go/build"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -17,12 +16,9 @@ import (
 	gllvm "github.com/xgo-dev/llvm"
 )
 
-// compilePkgSFiles translates Go/Plan9 assembly files selected by `go list -json`
-// for this package/target into LLVM IR, compiles them to .o, and returns the
-// object files for linking.
-//
-// NOTE: golang.org/x/tools/go/packages.Package does not expose SFiles, so we
-// query `go list -json` here to get the exact filtered set for GOOS/GOARCH.
+// compilePkgSFiles translates Go/Plan9 assembly files selected for this
+// package/target into LLVM IR, compiles them to .o, and returns the object files
+// for linking.
 func compilePkgSFiles(ctx *context, aPkg *aPackage, pkg *packages.Package, verbose bool) ([]string, error) {
 	sfiles, err := pkgSFiles(ctx, pkg)
 	if err != nil {
@@ -366,6 +362,39 @@ func plan9asmEnabledByDefault(conf *Config, pkgPath string) bool {
 	return !llruntime.HasAltPkg(pkgPath) || llruntime.HasAdditiveAltPkg(pkgPath)
 }
 
+func (c *context) dirHasAsmFile(dir string) bool {
+	if c == nil {
+		return dirHasAsmFile(dir)
+	}
+	if c.asmDirCache == nil {
+		c.asmDirCache = make(map[string]bool)
+	}
+	if has, ok := c.asmDirCache[dir]; ok {
+		return has
+	}
+	has := dirHasAsmFile(dir)
+	c.asmDirCache[dir] = has
+	return has
+}
+
+func dirHasAsmFile(dir string) bool {
+	f, err := os.Open(dir)
+	if err != nil {
+		return true
+	}
+	defer f.Close()
+	names, err := f.Readdirnames(-1)
+	if err != nil {
+		return true
+	}
+	for _, name := range names {
+		if strings.HasSuffix(name, ".s") || strings.HasSuffix(name, ".S") {
+			return true
+		}
+	}
+	return false
+}
+
 func pkgSFiles(ctx *context, pkg *packages.Package) ([]string, error) {
 	if pkg == nil || pkg.PkgPath == "" {
 		return nil, nil
@@ -376,15 +405,6 @@ func pkgSFiles(ctx *context, pkg *packages.Package) ([]string, error) {
 	if pkg.Dir == "" {
 		return nil, nil
 	}
-	// Fast path: if directory has no .s/.S at all, skip `go list`.
-	if pkg.Dir != "" {
-		if ss, _ := filepath.Glob(filepath.Join(pkg.Dir, "*.s")); len(ss) == 0 {
-			if ss, _ := filepath.Glob(filepath.Join(pkg.Dir, "*.S")); len(ss) == 0 {
-				return nil, nil
-			}
-		}
-	}
-
 	if ctx.sfilesCache == nil {
 		ctx.sfilesCache = make(map[string][]string)
 	}
@@ -392,40 +412,39 @@ func pkgSFiles(ctx *context, pkg *packages.Package) ([]string, error) {
 		return v, nil
 	}
 
-	args := []string{"list", "-json"}
-	if ctx.conf != nil && len(ctx.conf.BuildFlags) > 0 {
-		args = append(args, ctx.conf.BuildFlags...)
-	}
-	args = append(args, pkg.PkgPath)
-
-	cmd := exec.Command("go", args...)
-	cmd.Dir = pkg.Dir
-	cmd.Env = append(os.Environ(),
-		"GOOS="+ctx.buildConf.Goos,
-		"GOARCH="+ctx.buildConf.Goarch,
-	)
-	out, err := cmd.Output()
-	if err != nil {
-		var errBuf bytes.Buffer
-		if ee, ok := err.(*exec.ExitError); ok && len(ee.Stderr) > 0 {
-			errBuf.Write(ee.Stderr)
+	var metadataSFiles []string
+	for _, file := range pkg.OtherFiles {
+		if strings.HasSuffix(file, ".s") || strings.HasSuffix(file, ".S") {
+			metadataSFiles = append(metadataSFiles, file)
 		}
-		return nil, fmt.Errorf("go list -json %s failed: %w\n%s", pkg.PkgPath, err, strings.TrimSpace(errBuf.String()))
+	}
+	if len(metadataSFiles) > 0 {
+		ctx.sfilesCache[pkg.ID] = metadataSFiles
+		return metadataSFiles, nil
 	}
 
-	var lp struct {
-		Dir    string   `json:"Dir"`
-		SFiles []string `json:"SFiles"`
+	// Fast path: if directory has no .s/.S at all, skip source selection.
+	if !ctx.dirHasAsmFile(pkg.Dir) {
+		ctx.sfilesCache[pkg.ID] = nil
+		return nil, nil
 	}
-	if err := json.Unmarshal(out, &lp); err != nil {
-		return nil, fmt.Errorf("go list -json %s: parse: %w", pkg.PkgPath, err)
+
+	buildCtx := build.Default
+	buildCtx.GOOS = ctx.buildConf.Goos
+	buildCtx.GOARCH = ctx.buildConf.Goarch
+	if ctx.conf != nil {
+		buildCtx.BuildTags = parseSourcePatchBuildTags(ctx.conf.BuildFlags)
+	}
+	bp, err := buildCtx.ImportDir(pkg.Dir, 0)
+	if err != nil {
+		return nil, fmt.Errorf("inspect asm files for %s: %w", pkg.PkgPath, err)
 	}
 
 	// internal/chacha8rand has highly optimized arch asm on amd64/arm64.
 	// Until full vector lowering lands, force the generic stub entry, which
 	// tail-jumps to block_generic and preserves package behavior.
-	if pkg.PkgPath == "internal/chacha8rand" && lp.Dir != "" {
-		stub := filepath.Join(lp.Dir, "chacha8_stub.s")
+	if pkg.PkgPath == "internal/chacha8rand" && bp.Dir != "" {
+		stub := filepath.Join(bp.Dir, "chacha8_stub.s")
 		if _, err := os.Stat(stub); err == nil {
 			paths := []string{stub}
 			ctx.sfilesCache[pkg.ID] = paths
@@ -433,12 +452,12 @@ func pkgSFiles(ctx *context, pkg *packages.Package) ([]string, error) {
 		}
 	}
 
-	paths := make([]string, 0, len(lp.SFiles))
-	for _, f := range lp.SFiles {
-		if lp.Dir == "" {
+	paths := make([]string, 0, len(bp.SFiles))
+	for _, f := range bp.SFiles {
+		if bp.Dir == "" {
 			continue
 		}
-		paths = append(paths, filepath.Join(lp.Dir, f))
+		paths = append(paths, filepath.Join(bp.Dir, f))
 	}
 	ctx.sfilesCache[pkg.ID] = paths
 	return paths, nil

--- a/internal/build/plan9asm_altpkg_test.go
+++ b/internal/build/plan9asm_altpkg_test.go
@@ -4,10 +4,116 @@
 package build
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/goplus/llgo/internal/cabi"
+	"github.com/goplus/llgo/internal/packages"
 )
+
+func TestDirHasAsmFile(t *testing.T) {
+	dir := t.TempDir()
+	if dirHasAsmFile(dir) {
+		t.Fatal("empty directory should not have asm files")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "note.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if dirHasAsmFile(dir) {
+		t.Fatal("directory with no .s/.S files should not have asm files")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "lower.s"), []byte("TEXT ·x(SB),$0-0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !dirHasAsmFile(dir) {
+		t.Fatal("directory with .s file should have asm files")
+	}
+
+	upperDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(upperDir, "upper.S"), []byte("TEXT ·x(SB),$0-0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !dirHasAsmFile(upperDir) {
+		t.Fatal("directory with .S file should have asm files")
+	}
+	if !dirHasAsmFile(filepath.Join(t.TempDir(), "missing")) {
+		t.Fatal("unreadable/missing directory should fall back to source selection")
+	}
+}
+
+func TestPkgSFilesUsesOtherFiles(t *testing.T) {
+	dir := t.TempDir()
+	pkg := &packages.Package{
+		ID:         "example.com/otherfiles",
+		PkgPath:    "example.com/otherfiles",
+		Dir:        dir,
+		OtherFiles: []string{filepath.Join(dir, "selected.s"), filepath.Join(dir, "note.txt")},
+	}
+	ctx := &context{conf: &packages.Config{}, buildConf: &Config{Goos: "linux", Goarch: "amd64"}}
+	files, err := pkgSFiles(ctx, pkg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(dir, "selected.s")
+	if len(files) != 1 || files[0] != want {
+		t.Fatalf("pkgSFiles returned %v, want [%s]", files, want)
+	}
+	if got := ctx.sfilesCache[pkg.ID]; len(got) != 1 || got[0] != want {
+		t.Fatalf("sfiles cache = %v, want [%s]", got, want)
+	}
+}
+
+func TestPkgSFilesUsesBuildContextSelection(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package p\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "selected_amd64.s"), []byte("TEXT ·selected(SB),$0-0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "skipped_arm64.s"), []byte("TEXT ·skipped(SB),$0-0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ctx := &context{conf: &packages.Config{}, buildConf: &Config{Goos: "linux", Goarch: "amd64"}}
+	pkg := &packages.Package{ID: "example.com/asmselect", PkgPath: "example.com/asmselect", Dir: dir}
+	files, err := pkgSFiles(ctx, pkg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(dir, "selected_amd64.s")
+	if len(files) != 1 || files[0] != want {
+		t.Fatalf("pkgSFiles returned %v, want [%s]", files, want)
+	}
+	if has, ok := ctx.asmDirCache[dir]; !ok || !has {
+		t.Fatalf("asm dir cache[%s] = %v, %v; want true", dir, has, ok)
+	}
+}
+
+func TestPkgSFilesCachesNoAsmResult(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ctx := &context{conf: &packages.Config{}, buildConf: &Config{Goos: "linux", Goarch: "amd64"}}
+	pkg := &packages.Package{ID: "example.com/noasm", PkgPath: "example.com/noasm", Dir: dir}
+	files, err := pkgSFiles(ctx, pkg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("pkgSFiles returned %v, want no files", files)
+	}
+	if ctx.sfilesCache == nil {
+		t.Fatal("sfiles cache was not initialized")
+	}
+	if _, ok := ctx.sfilesCache[pkg.ID]; !ok {
+		t.Fatal("no-asm result was not cached")
+	}
+	if has, ok := ctx.asmDirCache[dir]; !ok || has {
+		t.Fatalf("asm dir cache[%s] = %v, %v; want false", dir, has, ok)
+	}
+}
 
 func TestHasAltPkgForTarget_AllowsAdditivePatchWithPlan9Asm(t *testing.T) {
 	conf := &Config{Goarch: "arm64", AbiMode: cabi.ModeAllFunc}

--- a/internal/build/plan9asm_altpkg_test.go
+++ b/internal/build/plan9asm_altpkg_test.go
@@ -64,6 +64,29 @@ func TestPkgSFilesUsesOtherFiles(t *testing.T) {
 	}
 }
 
+func TestPkgSFilesChacha8UsesStubBeforeOtherFiles(t *testing.T) {
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "chacha8_stub.s")
+	if err := os.WriteFile(stub, []byte("TEXT ·stub(SB),$0-0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	optimized := filepath.Join(dir, "chacha8_amd64.s")
+	pkg := &packages.Package{
+		ID:         "internal/chacha8rand",
+		PkgPath:    "internal/chacha8rand",
+		Dir:        dir,
+		OtherFiles: []string{optimized},
+	}
+	ctx := &context{conf: &packages.Config{}, buildConf: &Config{Goos: "linux", Goarch: "amd64"}}
+	files, err := pkgSFiles(ctx, pkg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 || files[0] != stub {
+		t.Fatalf("pkgSFiles returned %v, want stub %s", files, stub)
+	}
+}
+
 func TestPkgSFilesUsesBuildContextSelection(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package p\n"), 0o644); err != nil {

--- a/internal/build/ssa_order_fix.go
+++ b/internal/build/ssa_order_fix.go
@@ -48,7 +48,6 @@ func fixSSAOrder(pkg *ssa.Package, files []*ast.File) {
 		case *ssa.Type:
 			if tn, ok := m.Object().(*types.TypeName); ok {
 				fixSSAOrderMethods(pkg, tn.Type(), visitFn)
-				fixSSAOrderMethods(pkg, types.NewPointer(tn.Type()), visitFn)
 			}
 		}
 	}
@@ -58,9 +57,12 @@ func fixSSAOrderMethods(pkg *ssa.Package, typ types.Type, visitFn func(*ssa.Func
 	if pkg == nil || pkg.Prog == nil || typ == nil {
 		return
 	}
-	mset := pkg.Prog.MethodSets.MethodSet(typ)
-	for i, n := 0, mset.Len(); i < n; i++ {
-		if fn := pkg.Prog.MethodValue(mset.At(i)); fn != nil {
+	named, ok := typ.(*types.Named)
+	if !ok {
+		return
+	}
+	for i, n := 0, named.NumMethods(); i < n; i++ {
+		if fn := pkg.Prog.FuncValue(named.Method(i)); fn != nil {
 			visitFn(fn)
 		}
 	}

--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/goplus/llgo/internal/crosscompile/compile"
 	"github.com/goplus/llgo/internal/env"
@@ -96,14 +97,35 @@ func getCanonicalArchName(triple string) string {
 	return arch
 }
 
-// getMacOSSysroot returns the macOS SDK path using xcrun
+var (
+	macOSSysrootMu     sync.Mutex
+	macOSSysrootCached string
+	macOSSysrootLookup = func() (string, error) {
+		cmd := exec.Command("xcrun", "--sdk", "macosx", "--show-sdk-path")
+		output, err := cmd.Output()
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(string(output)), nil
+	}
+)
+
+// getMacOSSysroot returns the macOS SDK path using xcrun.
 func getMacOSSysroot() (string, error) {
-	cmd := exec.Command("xcrun", "--sdk", "macosx", "--show-sdk-path")
-	output, err := cmd.Output()
+	macOSSysrootMu.Lock()
+	defer macOSSysrootMu.Unlock()
+	if macOSSysrootCached != "" {
+		return macOSSysrootCached, nil
+	}
+
+	sysroot, err := macOSSysrootLookup()
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(string(output)), nil
+	if sysroot != "" {
+		macOSSysrootCached = sysroot
+	}
+	return sysroot, nil
 }
 
 // getESPClangRoot returns the ESP Clang root directory, checking LLGoROOT first,

--- a/internal/crosscompile/crosscompile_test.go
+++ b/internal/crosscompile/crosscompile_test.go
@@ -4,6 +4,7 @@
 package crosscompile
 
 import (
+	"errors"
 	"os"
 	"runtime"
 	"slices"
@@ -18,6 +19,69 @@ const (
 	includePrefix     = "-I"
 	libPrefix         = "-L"
 )
+
+func resetMacOSSysrootForTest(t *testing.T) {
+	t.Helper()
+	macOSSysrootMu.Lock()
+	oldCached := macOSSysrootCached
+	oldLookup := macOSSysrootLookup
+	macOSSysrootCached = ""
+	macOSSysrootMu.Unlock()
+	t.Cleanup(func() {
+		macOSSysrootMu.Lock()
+		macOSSysrootCached = oldCached
+		macOSSysrootLookup = oldLookup
+		macOSSysrootMu.Unlock()
+	})
+}
+
+func TestGetMacOSSysrootCachesSuccess(t *testing.T) {
+	resetMacOSSysrootForTest(t)
+	calls := 0
+	macOSSysrootLookup = func() (string, error) {
+		calls++
+		return "/test/sdk", nil
+	}
+	first, err := getMacOSSysroot()
+	if err != nil {
+		t.Fatalf("first getMacOSSysroot: %v", err)
+	}
+	second, err := getMacOSSysroot()
+	if err != nil {
+		t.Fatalf("second getMacOSSysroot: %v", err)
+	}
+	if first != "/test/sdk" || second != "/test/sdk" {
+		t.Fatalf("sysroots = %q, %q; want cached /test/sdk", first, second)
+	}
+	if calls != 1 {
+		t.Fatalf("lookup calls = %d, want 1", calls)
+	}
+}
+
+func TestGetMacOSSysrootDoesNotCacheErrors(t *testing.T) {
+	resetMacOSSysrootForTest(t)
+	calls := 0
+	macOSSysrootLookup = func() (string, error) {
+		calls++
+		if calls == 1 {
+			return "", errors.New("temporary xcrun failure")
+		}
+		return "/test/sdk", nil
+	}
+	if _, err := getMacOSSysroot(); err == nil {
+		t.Fatal("first getMacOSSysroot succeeded, want error")
+	}
+	got, err := getMacOSSysroot()
+	if err != nil {
+		t.Fatalf("second getMacOSSysroot: %v", err)
+	}
+	if got != "/test/sdk" {
+		t.Fatalf("sysroot = %q, want /test/sdk", got)
+	}
+	if calls != 2 {
+		t.Fatalf("lookup calls = %d, want retry after error", calls)
+	}
+}
 
 func TestUseCrossCompileSDK(t *testing.T) {
 	// Skip long-running tests unless explicitly enabled

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 )
 
 const (
@@ -45,9 +46,16 @@ func GOROOTAndGOVERSIONWithEnv(env []string) (goroot, goversion string, err erro
 	return vals[0], vals[1], nil
 }
 
+var goEnvCache sync.Map
+
 func GoEnvWithEnv(env []string, vars ...string) ([]string, error) {
 	if len(vars) == 0 {
 		return nil, fmt.Errorf("go env requires at least one variable")
+	}
+	cacheKey := goEnvCacheKey(env, vars)
+	if cached, ok := goEnvCache.Load(cacheKey); ok {
+		vals := cached.([]string)
+		return append([]string(nil), vals...), nil
 	}
 	args := append([]string{"env"}, vars...)
 	cmd := exec.Command("go", args...)
@@ -69,7 +77,27 @@ func GoEnvWithEnv(env []string, vars ...string) ([]string, error) {
 	for i := range got {
 		got[i] = strings.TrimSpace(got[i])
 	}
+	goEnvCache.Store(cacheKey, append([]string(nil), got...))
 	return got, nil
+}
+
+func goEnvCacheKey(env []string, vars []string) string {
+	var b strings.Builder
+	b.WriteString(os.Getenv("PATH"))
+	b.WriteByte('\x00')
+	for _, v := range vars {
+		b.WriteString(v)
+		b.WriteByte('\x00')
+	}
+	b.WriteByte('\x00')
+	if len(env) == 0 {
+		env = os.Environ()
+	}
+	for _, entry := range env {
+		b.WriteString(entry)
+		b.WriteByte('\x00')
+	}
+	return b.String()
 }
 
 func LLGoCacheDir() string {

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -46,7 +46,10 @@ func GOROOTAndGOVERSIONWithEnv(env []string) (goroot, goversion string, err erro
 	return vals[0], vals[1], nil
 }
 
-var goEnvCache sync.Map
+var (
+	goEnvCache     sync.Map
+	llgoRootWarned sync.Map
+)
 
 func GoEnvWithEnv(env []string, vars ...string) ([]string, error) {
 	if len(vars) == 0 {
@@ -149,7 +152,9 @@ func LLGoROOT() string {
 			return ""
 		}
 		if root, ok := isLLGoRoot(root); ok {
-			fmt.Fprintln(os.Stderr, "WARNING: Using LLGO root for devel: "+root)
+			if _, loaded := llgoRootWarned.LoadOrStore(root, true); !loaded {
+				fmt.Fprintln(os.Stderr, "WARNING: Using LLGO root for devel: "+root)
+			}
 			return root
 		}
 	}

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -95,6 +95,37 @@ func TestGOROOTAndGOVERSIONWithEnv(t *testing.T) {
 	})
 }
 
+func TestGoEnvWithEnvCachesSuccessfulResults(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake go shell script is Unix-only")
+	}
+	dir := t.TempDir()
+	countFile := filepath.Join(dir, "count")
+	goPath := filepath.Join(dir, "go")
+	script := "#!/bin/sh\ncount=0\nif [ -f " + countFile + " ]; then count=$(cat " + countFile + "); fi\ncount=$((count + 1))\necho $count > " + countFile + "\necho /tmp/fake-goroot\necho go1.99.0\n"
+	if err := os.WriteFile(goPath, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	for i := 0; i < 2; i++ {
+		got, err := GoEnvWithEnv(nil, "GOROOT", "GOVERSION")
+		if err != nil {
+			t.Fatalf("GoEnvWithEnv call %d: %v", i, err)
+		}
+		if strings.Join(got, ",") != "/tmp/fake-goroot,go1.99.0" {
+			t.Fatalf("GoEnvWithEnv call %d = %v", i, got)
+		}
+	}
+	count, err := os.ReadFile(countFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(count)) != "1" {
+		t.Fatalf("fake go invoked %s times, want 1", strings.TrimSpace(string(count)))
+	}
+}
+
 func TestGoEnvWithEnvErrors(t *testing.T) {
 	t.Run("without variables", func(t *testing.T) {
 		if got, err := GoEnvWithEnv(nil); err == nil || got != nil {

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -4,12 +4,48 @@
 package env
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 )
+
+func TestLLGoROOTWarnsOnceForDevelRoot(t *testing.T) {
+	origLLGoRoot := os.Getenv("LLGO_ROOT")
+	os.Setenv("LLGO_ROOT", "")
+	t.Cleanup(func() { os.Setenv("LLGO_ROOT", origLLGoRoot) })
+
+	oldWarned := llgoRootWarned
+	llgoRootWarned = sync.Map{}
+	t.Cleanup(func() { llgoRootWarned = oldWarned })
+
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	root1 := LLGoROOT()
+	root2 := LLGoROOT()
+	w.Close()
+	os.Stderr = oldStderr
+	defer r.Close()
+
+	if root1 == "" || root2 == "" {
+		t.Skip("LLGoROOT did not resolve a development root")
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "WARNING: Using LLGO root for devel: " + root1
+	if got := strings.Count(string(out), want); got != 1 {
+		t.Fatalf("devel root warning count = %d, output %q", got, out)
+	}
+}
 
 func TestGOROOT(t *testing.T) {
 	// Test with GOROOT environment variable set

--- a/internal/goembed/goembed.go
+++ b/internal/goembed/goembed.go
@@ -27,7 +27,7 @@ type VarData struct {
 type VarMap map[string]VarData
 
 func LoadDirectives(fset *token.FileSet, files []*ast.File) (VarMap, error) {
-	if len(files) == 0 {
+	if len(files) == 0 || !hasEmbedDirective(files) {
 		return nil, nil
 	}
 	byVar := make(VarMap)
@@ -87,6 +87,25 @@ func LoadDirectives(fset *token.FileSet, files []*ast.File) (VarMap, error) {
 		}
 	}
 	return byVar, nil
+}
+
+func hasEmbedDirective(files []*ast.File) bool {
+	for _, file := range files {
+		if file == nil {
+			continue
+		}
+		for _, group := range file.Comments {
+			if group == nil {
+				continue
+			}
+			for _, comment := range group.List {
+				if comment != nil && strings.Contains(comment.Text, "go:embed") {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func FileImportsEmbed(file *ast.File) bool {

--- a/internal/packages/load.go
+++ b/internal/packages/load.go
@@ -359,12 +359,13 @@ func loadPackageEx(dedup Deduper, ld *loader, lpkg *loaderPackage) {
 		smallCap = 4
 	}
 	lpkg.TypesInfo = &types.Info{
-		Types:      make(map[ast.Expr]types.TypeAndValue, typeInfoCap),
-		Defs:       make(map[*ast.Ident]types.Object, identCap),
-		Uses:       make(map[*ast.Ident]types.Object, identCap),
-		Implicits:  make(map[ast.Node]types.Object, smallCap),
-		Instances:  make(map[*ast.Ident]types.Instance, smallCap),
-		Scopes:     make(map[ast.Node]*types.Scope, smallCap),
+		Types:     make(map[ast.Expr]types.TypeAndValue, typeInfoCap),
+		Defs:      make(map[*ast.Ident]types.Object, identCap),
+		Uses:      make(map[*ast.Ident]types.Object, identCap),
+		Implicits: make(map[ast.Node]types.Object, smallCap),
+		Instances: make(map[*ast.Ident]types.Instance, smallCap),
+		// Scopes are not consumed by LLGo or x/tools/go/ssa during compilation.
+		// Leaving it nil avoids recording every lexical scope during type checking.
 		Selections: make(map[*ast.SelectorExpr]*types.Selection, smallCap),
 	}
 	lpkg.TypesSizes = ld.sizes

--- a/internal/packages/load.go
+++ b/internal/packages/load.go
@@ -468,19 +468,29 @@ func loadPackageEx(dedup Deduper, ld *loader, lpkg *loaderPackage) {
 	lpkg.IllTyped = illTyped
 }
 
+const packageLoadParallelFanout = 4
+
 func loadRecursiveEx(dedup Deduper, ld *loader, lpkg *loaderPackage) {
 	lpkg.loadOnce.Do(func() {
-		// Load the direct dependencies, in parallel.
-		var wg sync.WaitGroup
-		for _, ipkg := range lpkg.Imports {
-			imp := ld.pkgs[ipkg.ID]
-			wg.Add(1)
-			go func(imp *loaderPackage) {
-				loadRecursiveEx(dedup, ld, imp)
-				wg.Done()
-			}(imp)
+		// Most packages have a narrow import fanout; loading those branches
+		// sequentially avoids a large number of short-lived goroutines while
+		// still using parallelism for wider parts of the graph.
+		if len(lpkg.Imports) <= packageLoadParallelFanout {
+			for _, ipkg := range lpkg.Imports {
+				loadRecursiveEx(dedup, ld, ld.pkgs[ipkg.ID])
+			}
+		} else {
+			var wg sync.WaitGroup
+			for _, ipkg := range lpkg.Imports {
+				imp := ld.pkgs[ipkg.ID]
+				wg.Add(1)
+				go func(imp *loaderPackage) {
+					loadRecursiveEx(dedup, ld, imp)
+					wg.Done()
+				}(imp)
+			}
+			wg.Wait()
 		}
-		wg.Wait()
 		loadPackageEx(dedup, ld, lpkg)
 	})
 }
@@ -621,15 +631,19 @@ func refineEx(dedup Deduper, ld *loader, response *packages.DriverResponse) ([]*
 	// Load type data and syntax if needed, starting at
 	// the initial packages (roots of the import DAG).
 	if ld.Mode&NeedTypes != 0 || ld.Mode&NeedSyntax != 0 {
-		var wg sync.WaitGroup
-		for _, lpkg := range initial {
-			wg.Add(1)
-			go func(lpkg *loaderPackage) {
-				loadRecursiveEx(dedup, ld, lpkg)
-				wg.Done()
-			}(lpkg)
+		if len(initial) == 1 {
+			loadRecursiveEx(dedup, ld, initial[0])
+		} else {
+			var wg sync.WaitGroup
+			for _, lpkg := range initial {
+				wg.Add(1)
+				go func(lpkg *loaderPackage) {
+					loadRecursiveEx(dedup, ld, lpkg)
+					wg.Done()
+				}(lpkg)
+			}
+			wg.Wait()
 		}
-		wg.Wait()
 	}
 
 	// If the context is done, return its error and

--- a/internal/packages/load.go
+++ b/internal/packages/load.go
@@ -346,14 +346,26 @@ func loadPackageEx(dedup Deduper, ld *loader, lpkg *loaderPackage) {
 		return
 	}
 
+	typeInfoCap := len(lpkg.Syntax) * 1024
+	if typeInfoCap < 16 {
+		typeInfoCap = 16
+	}
+	identCap := typeInfoCap / 2
+	if identCap < 16 {
+		identCap = 16
+	}
+	smallCap := len(lpkg.Syntax) * 8
+	if smallCap < 4 {
+		smallCap = 4
+	}
 	lpkg.TypesInfo = &types.Info{
-		Types:      make(map[ast.Expr]types.TypeAndValue),
-		Defs:       make(map[*ast.Ident]types.Object),
-		Uses:       make(map[*ast.Ident]types.Object),
-		Implicits:  make(map[ast.Node]types.Object),
-		Instances:  make(map[*ast.Ident]types.Instance),
-		Scopes:     make(map[ast.Node]*types.Scope),
-		Selections: make(map[*ast.SelectorExpr]*types.Selection),
+		Types:      make(map[ast.Expr]types.TypeAndValue, typeInfoCap),
+		Defs:       make(map[*ast.Ident]types.Object, identCap),
+		Uses:       make(map[*ast.Ident]types.Object, identCap),
+		Implicits:  make(map[ast.Node]types.Object, smallCap),
+		Instances:  make(map[*ast.Ident]types.Instance, smallCap),
+		Scopes:     make(map[ast.Node]*types.Scope, smallCap),
+		Selections: make(map[*ast.SelectorExpr]*types.Selection, smallCap),
 	}
 	lpkg.TypesSizes = ld.sizes
 

--- a/internal/packages/load.go
+++ b/internal/packages/load.go
@@ -67,6 +67,24 @@ const (
 	DebugPackagesLoad = false
 )
 
+var runtimeGoMinor = parseRuntimeGoMinor(runtime.Version())
+
+func parseRuntimeGoMinor(version string) int {
+	const prefix = "go1."
+	if !strings.HasPrefix(version, prefix) {
+		return 0
+	}
+	minor := 0
+	for i := len(prefix); i < len(version); i++ {
+		c := version[i]
+		if c < '0' || c > '9' {
+			break
+		}
+		minor = minor*10 + int(c-'0')
+	}
+	return minor
+}
+
 // A Config specifies details about how packages should be loaded.
 // The zero value is a valid configuration.
 // Calls to Load do not modify this struct.
@@ -303,8 +321,7 @@ func loadPackageEx(dedup Deduper, ld *loader, lpkg *loaderPackage) {
 	// - golang.org/issue/55883 (go/packages confusing error)
 	//
 	// Should we assert a hard minimum of (currently) go1.16 here?
-	var runtimeVersion int
-	if _, err := fmt.Sscanf(runtime.Version(), "go1.%d", &runtimeVersion); err == nil && runtimeVersion < lpkg.goVersion {
+	if runtimeVersion := runtimeGoMinor; runtimeVersion != 0 && runtimeVersion < lpkg.goVersion {
 		defer func() {
 			if len(lpkg.Errors) > 0 {
 				appendError(packages.Error{

--- a/internal/packages/load_test.go
+++ b/internal/packages/load_test.go
@@ -1,0 +1,22 @@
+package packages
+
+import "testing"
+
+func TestParseRuntimeGoMinor(t *testing.T) {
+	tests := []struct {
+		version string
+		want    int
+	}{
+		{"go1.21.13", 21},
+		{"go1.26.0", 26},
+		{"go1.26rc1", 26},
+		{"devel go1.27", 0},
+		{"go2.0", 0},
+		{"", 0},
+	}
+	for _, tt := range tests {
+		if got := parseRuntimeGoMinor(tt.version); got != tt.want {
+			t.Fatalf("parseRuntimeGoMinor(%q) = %d, want %d", tt.version, got, tt.want)
+		}
+	}
+}

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -1180,11 +1180,7 @@ func (b Builder) checkReflect(fn Expr, args []Expr) {
 		pkg.NeedAbiInit |= ReflectStructOf
 	case "reflect.Value.Method":
 		if len(args) == 2 {
-			if v, ok := extractConstInt(args[1].impl); ok {
-				if pkg.MethodByIndex == nil {
-					pkg.MethodByIndex = make(map[int]none)
-				}
-				pkg.MethodByIndex[v] = none{}
+			if _, ok := extractConstInt(args[1].impl); ok {
 				pkg.NeedAbiInit |= ReflectMethodByIndex
 				return
 			}
@@ -1192,11 +1188,7 @@ func (b Builder) checkReflect(fn Expr, args []Expr) {
 		}
 	case "reflect.Value.MethodByName":
 		if len(args) == 2 {
-			if v, ok := extractConstString(args[1].impl); ok {
-				if pkg.MethodByName == nil {
-					pkg.MethodByName = make(map[string]none)
-				}
-				pkg.MethodByName[v] = none{}
+			if _, ok := extractConstString(args[1].impl); ok {
 				pkg.NeedAbiInit |= ReflectMethodByName
 				return
 			}

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -740,18 +740,14 @@ type aPackage struct {
 
 	iRoutine int
 
-	NeedRuntime   bool
-	NeedPyInit    bool
-	NeedAbiInit   int // bitmask of Reflect* flags indicating which reflect type-construction operations are used
-	MethodByIndex map[int]none
-	MethodByName  map[string]none
+	NeedRuntime bool
+	NeedPyInit  bool
+	NeedAbiInit int // bitmask of Reflect* flags indicating which reflect type-construction operations are used
 
 	export         map[string]string   // pkgPath.nameInPkg => exportname
 	preserveSyms   map[string]struct{} // set of exported symbol names
 	llvmUsedValues []llvm.Value
 }
-
-type none struct{}
 
 type Package = *aPackage
 

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"runtime"
 	"strconv"
+	"sync"
 	"unsafe"
 
 	"github.com/goplus/llgo/internal/env"
@@ -87,8 +88,19 @@ const (
 	InitAll    = InitAllTargets | InitAllAsmParsers | InitAllAsmPrinters | InitAllTargetInfos | InitAllTargetMCs
 )
 
+var (
+	initializeMu    sync.Mutex
+	initializedLLVM InitFlags
+)
+
 // Initialize initializes the LLVM library.
 func Initialize(flags InitFlags) {
+	initializeMu.Lock()
+	defer initializeMu.Unlock()
+	flags &^= initializedLLVM
+	if flags == 0 {
+		return
+	}
 	if flags&InitAllTargetInfos != 0 {
 		llvm.InitializeAllTargetInfos()
 	}
@@ -110,6 +122,7 @@ func Initialize(flags InitFlags) {
 	if flags&InitNativeAsmPrinter != 0 {
 		llvm.InitializeNativeAsmPrinter()
 	}
+	initializedLLVM |= flags
 }
 
 // -----------------------------------------------------------------------------

--- a/ssa/type_cvt.go
+++ b/ssa/type_cvt.go
@@ -234,51 +234,87 @@ func (p goTypes) cvtFunc(sig *types.Signature, recv *types.Var) (raw *types.Sign
 
 func (p goTypes) cvtTuple(t *types.Tuple) (*types.Tuple, bool) {
 	n := t.Len()
-	vars := make([]*types.Var, n)
-	needcvt := false
+	var vars []*types.Var
 	for i := 0; i < n; i++ {
 		v := t.At(i)
-		if t, cvt := p.cvtType(v.Type()); cvt {
-			v = types.NewParam(v.Pos(), v.Pkg(), v.Name(), t)
-			needcvt = true
+		if raw, cvt := p.cvtType(v.Type()); cvt {
+			if vars == nil {
+				vars = make([]*types.Var, n)
+				for j := 0; j < i; j++ {
+					vars[j] = t.At(j)
+				}
+			}
+			v = types.NewParam(v.Pos(), v.Pkg(), v.Name(), raw)
 		}
-		vars[i] = v
+		if vars != nil {
+			vars[i] = v
+		}
 	}
-	if needcvt {
+	if vars != nil {
 		return types.NewTuple(vars...), true
 	}
 	return t, false
 }
 
-func (p goTypes) cvtExplicitMethods(typ *types.Interface) ([]*types.Func, bool) {
+func explicitMethods(typ *types.Interface) []*types.Func {
 	n := typ.NumExplicitMethods()
 	methods := make([]*types.Func, n)
-	needcvt := false
+	for i := 0; i < n; i++ {
+		methods[i] = typ.ExplicitMethod(i)
+	}
+	return methods
+}
+
+func embeddedTypes(typ *types.Interface) []types.Type {
+	n := typ.NumEmbeddeds()
+	embeddeds := make([]types.Type, n)
+	for i := 0; i < n; i++ {
+		embeddeds[i] = typ.EmbeddedType(i)
+	}
+	return embeddeds
+}
+
+func (p goTypes) cvtExplicitMethods(typ *types.Interface) ([]*types.Func, bool) {
+	n := typ.NumExplicitMethods()
+	var methods []*types.Func
 	for i := 0; i < n; i++ {
 		m := typ.ExplicitMethod(i)
 		sig := m.Type().(*types.Signature)
 		if raw := p.cvtFunc(sig, nil); sig != raw {
+			if methods == nil {
+				methods = make([]*types.Func, n)
+				for j := 0; j < i; j++ {
+					methods[j] = typ.ExplicitMethod(j)
+				}
+			}
 			m = types.NewFunc(m.Pos(), m.Pkg(), m.Name(), raw)
-			needcvt = true
 		}
-		methods[i] = m
+		if methods != nil {
+			methods[i] = m
+		}
 	}
-	return methods, needcvt
+	return methods, methods != nil
 }
 
 func (p goTypes) cvtEmbeddedTypes(typ *types.Interface) ([]types.Type, bool) {
 	n := typ.NumEmbeddeds()
-	embeddeds := make([]types.Type, n)
-	needcvt := false
+	var embeddeds []types.Type
 	for i := 0; i < n; i++ {
 		t := typ.EmbeddedType(i)
 		if raw, cvt := p.cvtType(t); cvt {
+			if embeddeds == nil {
+				embeddeds = make([]types.Type, n)
+				for j := 0; j < i; j++ {
+					embeddeds[j] = typ.EmbeddedType(j)
+				}
+			}
 			t = raw
-			needcvt = true
 		}
-		embeddeds[i] = t
+		if embeddeds != nil {
+			embeddeds[i] = t
+		}
 	}
-	return embeddeds, needcvt
+	return embeddeds, embeddeds != nil
 }
 
 func (p goTypes) cvtInterface(typ *types.Interface) (raw *types.Interface, cvt bool) {
@@ -293,6 +329,12 @@ func (p goTypes) cvtInterface(typ *types.Interface) (raw *types.Interface, cvt b
 	methods, cvt1 := p.cvtExplicitMethods(typ)
 	embeddeds, cvt2 := p.cvtEmbeddedTypes(typ)
 	if cvt1 || cvt2 {
+		if !cvt1 {
+			methods = explicitMethods(typ)
+		}
+		if !cvt2 {
+			embeddeds = embeddedTypes(typ)
+		}
 		return types.NewInterfaceType(methods, embeddeds), true
 	}
 	return typ, false
@@ -308,17 +350,23 @@ func (p goTypes) cvtStruct(typ *types.Struct) (raw *types.Struct, cvt bool) {
 		p.typs[unsafe.Pointer(typ)] = unsafe.Pointer(raw)
 	}()
 	n := typ.NumFields()
-	flds := make([]*types.Var, n)
-	needcvt := false
+	var flds []*types.Var
 	for i := 0; i < n; i++ {
 		f := typ.Field(i)
-		if t, cvt := p.cvtType(f.Type()); cvt {
-			f = types.NewField(f.Pos(), f.Pkg(), f.Name(), t, f.Anonymous())
-			needcvt = true
+		if raw, cvt := p.cvtType(f.Type()); cvt {
+			if flds == nil {
+				flds = make([]*types.Var, n)
+				for j := 0; j < i; j++ {
+					flds[j] = typ.Field(j)
+				}
+			}
+			f = types.NewField(f.Pos(), f.Pkg(), f.Name(), raw, f.Anonymous())
 		}
-		flds[i] = f
+		if flds != nil {
+			flds[i] = f
+		}
 	}
-	if needcvt {
+	if flds != nil {
 		return types.NewStruct(flds, nil), true
 	}
 	return typ, false

--- a/xtool/env/llvm/llvm.go
+++ b/xtool/env/llvm/llvm.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/goplus/llgo/internal/env"
 	"github.com/goplus/llgo/xtool/clang"
@@ -69,17 +70,29 @@ type Env struct {
 	binDir string
 }
 
+var bindirCache sync.Map
+
 // New creates a new [Env] instance.
 func New(llvmConfigBin string) *Env {
+	cacheKey := llvmConfigBin
 	if llvmConfigBin == "" {
 		llvmConfigBin = defaultLLVMConfigBin()
+		cacheKey = "default\x00" + os.Getenv("LLVM_CONFIG") + "\x00" + os.Getenv("PATH") + "\x00" + llvmConfigBin
+	}
+	if cached, ok := bindirCache.Load(cacheKey); ok {
+		return &Env{binDir: cached.(string)}
 	}
 
 	// Note that an empty binDir is acceptable. In this case, LLVM
 	// executables are assumed to be in PATH.
-	binDir, _ := exec.Command(llvmConfigBin, "--bindir").Output()
+	binDir, err := exec.Command(llvmConfigBin, "--bindir").Output()
+	trimmed := strings.TrimSpace(string(binDir))
+	if err == nil {
+		actual, _ := bindirCache.LoadOrStore(cacheKey, trimmed)
+		trimmed = actual.(string)
+	}
 
-	e := &Env{binDir: strings.TrimSpace(string(binDir))}
+	e := &Env{binDir: trimmed}
 	return e
 }
 

--- a/xtool/env/llvm/llvm_test.go
+++ b/xtool/env/llvm/llvm_test.go
@@ -1,0 +1,58 @@
+package llvm
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestNewCachesSuccessfulBindir(t *testing.T) {
+	if os.PathSeparator != '/' {
+		t.Skip("fake llvm-config shell script is Unix-only")
+	}
+	bindirCache = sync.Map{}
+	dir := t.TempDir()
+	countFile := filepath.Join(dir, "count")
+	config := filepath.Join(dir, "llvm-config")
+	script := "#!/bin/sh\ncount=0\nif [ -f " + countFile + " ]; then count=$(cat " + countFile + "); fi\ncount=$((count + 1))\necho $count > " + countFile + "\necho /tmp/llvm-bin\n"
+	if err := os.WriteFile(config, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := New(config).BinDir(); got != "/tmp/llvm-bin" {
+		t.Fatalf("first BinDir = %q", got)
+	}
+	if got := New(config).BinDir(); got != "/tmp/llvm-bin" {
+		t.Fatalf("second BinDir = %q", got)
+	}
+	count, err := os.ReadFile(countFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(count)) != "1" {
+		t.Fatalf("llvm-config invoked %s times, want 1", strings.TrimSpace(string(count)))
+	}
+}
+
+func TestNewDoesNotCacheBindirFailures(t *testing.T) {
+	if os.PathSeparator != '/' {
+		t.Skip("fake llvm-config shell script is Unix-only")
+	}
+	bindirCache = sync.Map{}
+	dir := t.TempDir()
+	countFile := filepath.Join(dir, "count")
+	config := filepath.Join(dir, "llvm-config")
+	script := "#!/bin/sh\ncount=0\nif [ -f " + countFile + " ]; then count=$(cat " + countFile + "); fi\ncount=$((count + 1))\necho $count > " + countFile + "\nif [ $count -eq 1 ]; then exit 2; fi\necho /tmp/llvm-bin\n"
+	if err := os.WriteFile(config, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := New(config).BinDir(); got != "" {
+		t.Fatalf("failed BinDir = %q, want empty", got)
+	}
+	if got := New(config).BinDir(); got != "/tmp/llvm-bin" {
+		t.Fatalf("retry BinDir = %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

This extracts the lower-risk, source-only build performance changes from the larger build-perf branch.

Included changes focus on simple hot-path reductions:

- cache repeated tool/sysroot/LLVM setup work
- make SSA sanity checking opt-in for normal builds
- reduce package load/type-check allocations
- skip parser object resolution for build loads
- avoid unused type scopes
- use upstream parallel `go/ssa.Program.Build`
- skip redundant SSA program builds
- avoid MethodSet construction in SSA order fixup
- reduce embed/type-conversion allocations
- avoid external `go list -json` for Plan9 asm discovery while preserving `internal/chacha8rand` stub behavior
- remove unused reflect/method metadata maps
- pre-size predictable `linkMainPkg` scratch containers
- cache parsed runtime Go minor version

Intentionally excluded from this PR:

- async LLVM/object emission changes
- stdin-based IR compilation
- build-cache publication/archive scheduling changes
- manifest writer/format optimizations
- CI workflow fan-out/sharding changes

The branch does not modify cache archive/manifest generation or cache publication ordering. The only cache-related behavior kept is adding `LLGO_SSA_SANITY` to build env inputs when sanity checking is explicitly enabled, so cached artifacts distinguish sanity mode from normal builds.

## Local timing

Representative paired local runs on darwin/arm64, Go 1.24.11:

### `go test ./internal/build -run '^TestExtest$' -count=3`

- main: `35.621s` reported, `36.82s` wall
- this PR: `32.356s` / `32.359s` reported, `32.88s` / `32.91s` wall

Approx wall improvement: ~10.6%.

### `go test ./internal/build -count=1`

- main: `48.644s` reported, `49.17s` wall
- this PR: `43.259s` / `44.594s` reported, `43.78s` / `45.19s` wall

Approx wall improvement: ~8-11%.

## Validation

- `go test ./internal/packages ./internal/build ./internal/crosscompile ./internal/env ./internal/goembed ./ssa ./xtool/env/llvm -count=1`
- `go test ./internal/build -run '^TestExtest$' -count=3`
- `go test ./test/std/math/rand/v2 ./test/std/reflect -count=1`
- `go test ./internal/build -run '^TestPkgSFilesChacha8UsesStubBeforeOtherFiles$|^TestParallelObjectEmit|MainModule|Abi|Reflect' -count=1`
- `go build -a -tags=dev -o /tmp/llgo-build-perf-simple ./cmd/llgo`
