### PR TITLE
feat(metadata): add PackageMeta Builder for summary extraction during compilation

### DIFF
--- a/chore/gentests/gentests.go
+++ b/chore/gentests/gentests.go
@@ -40,6 +40,7 @@ func main() {
 	llgenDir(dir + "/cl/_testdata")
 
 	genExpects(dir)
+	genMetaDir(dir + "/cl/_testmeta")
 }
 
 func llgenDir(dir string) {
@@ -97,6 +98,35 @@ func runExpectDir(root, relDir string) {
 			continue
 		}
 		check(os.WriteFile(expectFile, output, 0644))
+	}
+}
+
+func genMetaDir(dir string) {
+	fis, err := os.ReadDir(dir)
+	check(err)
+	for _, fi := range fis {
+		name := fi.Name()
+		if !fi.IsDir() || strings.HasPrefix(name, "_") {
+			continue
+		}
+		testDir := filepath.Join(dir, name)
+		expectFile := filepath.Join(testDir, "meta-expect.txt")
+		expect, err := os.ReadFile(expectFile)
+		if err != nil && !os.IsNotExist(err) {
+			fmt.Fprintln(os.Stderr, "error reading", expectFile, ":", err)
+			continue
+		}
+		fmt.Fprintln(os.Stderr, "meta", testDir)
+		meta, err := cltest.CaptureMeta(testDir)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "error:", testDir, err)
+			if len(expect) == 0 {
+				continue
+			}
+			check(os.WriteFile(expectFile, []byte{';'}, 0644))
+			continue
+		}
+		check(os.WriteFile(expectFile, []byte(meta), 0644))
 	}
 }
 

--- a/cl/_testmeta/iface/in.go
+++ b/cl/_testmeta/iface/in.go
@@ -1,0 +1,22 @@
+package main
+
+type Stringer interface {
+	String() string
+}
+
+type MyType struct {
+	x int
+}
+
+func (m MyType) String() string {
+	return "hello"
+}
+
+func useIface(s Stringer) {
+	s.String()
+}
+
+func main() {
+	var s Stringer = MyType{x: 42}
+	useIface(s)
+}

--- a/cl/_testmeta/iface/meta-expect.txt
+++ b/cl/_testmeta/iface/meta-expect.txt
@@ -1,0 +1,34 @@
+[TypeChildren]
+*_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to:
+    _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to
+*_llgo_github.com/goplus/llgo/cl/_testmeta/iface.MyType:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/iface.MyType
+*_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U:
+    _llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U
+*_llgo_int:
+    _llgo_int
+*_llgo_string:
+    _llgo_string
+_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to:
+    _llgo_string
+_llgo_github.com/goplus/llgo/cl/_testmeta/iface.MyType:
+    _llgo_int
+
+[InterfaceInfo]
+_llgo_github.com/goplus/llgo/cl/_testmeta/iface.Stringer:
+    String _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to
+
+[UseIface]
+github.com/goplus/llgo/cl/_testmeta/iface.main:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/iface.MyType
+
+[UseIfaceMethod]
+github.com/goplus/llgo/cl/_testmeta/iface.useIface:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/iface.Stringer String _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to
+
+[MethodInfo]
+*_llgo_github.com/goplus/llgo/cl/_testmeta/iface.MyType:
+    String _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to github.com/goplus/llgo/cl/_testmeta/iface.(*MyType).String github.com/goplus/llgo/cl/_testmeta/iface.(*MyType).String
+_llgo_github.com/goplus/llgo/cl/_testmeta/iface.MyType:
+    String _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to github.com/goplus/llgo/cl/_testmeta/iface.(*MyType).String github.com/goplus/llgo/cl/_testmeta/iface.MyType.String
+

--- a/cl/_testmeta/methods/in.go
+++ b/cl/_testmeta/methods/in.go
@@ -1,0 +1,21 @@
+package main
+
+type MyType struct {
+	x int
+}
+
+func (m MyType) ExportedMethod() string {
+	return ""
+}
+
+func (m MyType) unexportedMethod() int {
+	return 0
+}
+
+func main() {
+	m := MyType{42}
+	_ = m.ExportedMethod()
+	_ = m.unexportedMethod()
+	var i interface{} = m
+	_ = i
+}

--- a/cl/_testmeta/methods/meta-expect.txt
+++ b/cl/_testmeta/methods/meta-expect.txt
@@ -1,0 +1,30 @@
+[TypeChildren]
+*_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA:
+    _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
+*_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to:
+    _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to
+*_llgo_github.com/goplus/llgo/cl/_testmeta/methods.MyType:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/methods.MyType
+*_llgo_int:
+    _llgo_int
+*_llgo_string:
+    _llgo_string
+_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA:
+    _llgo_int
+_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to:
+    _llgo_string
+_llgo_github.com/goplus/llgo/cl/_testmeta/methods.MyType:
+    _llgo_int
+
+[UseIface]
+github.com/goplus/llgo/cl/_testmeta/methods.main:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/methods.MyType
+
+[MethodInfo]
+*_llgo_github.com/goplus/llgo/cl/_testmeta/methods.MyType:
+    ExportedMethod _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to github.com/goplus/llgo/cl/_testmeta/methods.(*MyType).ExportedMethod github.com/goplus/llgo/cl/_testmeta/methods.(*MyType).ExportedMethod
+    github.com/goplus/llgo/cl/_testmeta/methods.unexportedMethod _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA github.com/goplus/llgo/cl/_testmeta/methods.(*MyType).unexportedMethod github.com/goplus/llgo/cl/_testmeta/methods.(*MyType).unexportedMethod
+_llgo_github.com/goplus/llgo/cl/_testmeta/methods.MyType:
+    ExportedMethod _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to github.com/goplus/llgo/cl/_testmeta/methods.(*MyType).ExportedMethod github.com/goplus/llgo/cl/_testmeta/methods.MyType.ExportedMethod
+    github.com/goplus/llgo/cl/_testmeta/methods.unexportedMethod _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA github.com/goplus/llgo/cl/_testmeta/methods.(*MyType).unexportedMethod github.com/goplus/llgo/cl/_testmeta/methods.MyType.unexportedMethod
+

--- a/cl/_testmeta/nested/in.go
+++ b/cl/_testmeta/nested/in.go
@@ -1,0 +1,21 @@
+package main
+
+type Inner struct {
+	s string
+}
+
+type Outer struct {
+	inner Inner
+	x     int
+}
+
+func (o Outer) Method() string {
+	return o.inner.s
+}
+
+func main() {
+	o := Outer{Inner{"hello"}, 42}
+	_ = o.Method()
+	var i interface{} = o
+	_ = i
+}

--- a/cl/_testmeta/nested/meta-expect.txt
+++ b/cl/_testmeta/nested/meta-expect.txt
@@ -1,0 +1,29 @@
+[TypeChildren]
+*_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to:
+    _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to
+*_llgo_github.com/goplus/llgo/cl/_testmeta/nested.Inner:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/nested.Inner
+*_llgo_github.com/goplus/llgo/cl/_testmeta/nested.Outer:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/nested.Outer
+*_llgo_int:
+    _llgo_int
+*_llgo_string:
+    _llgo_string
+_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to:
+    _llgo_string
+_llgo_github.com/goplus/llgo/cl/_testmeta/nested.Inner:
+    _llgo_string
+_llgo_github.com/goplus/llgo/cl/_testmeta/nested.Outer:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/nested.Inner
+    _llgo_int
+
+[UseIface]
+github.com/goplus/llgo/cl/_testmeta/nested.main:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/nested.Outer
+
+[MethodInfo]
+*_llgo_github.com/goplus/llgo/cl/_testmeta/nested.Outer:
+    Method _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to github.com/goplus/llgo/cl/_testmeta/nested.(*Outer).Method github.com/goplus/llgo/cl/_testmeta/nested.(*Outer).Method
+_llgo_github.com/goplus/llgo/cl/_testmeta/nested.Outer:
+    Method _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to github.com/goplus/llgo/cl/_testmeta/nested.(*Outer).Method github.com/goplus/llgo/cl/_testmeta/nested.Outer.Method
+

--- a/cl/cltest/meta.go
+++ b/cl/cltest/meta.go
@@ -1,0 +1,118 @@
+package cltest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/goplus/llgo/internal/build"
+	"github.com/goplus/llgo/internal/metadata"
+	"github.com/qiniu/x/test"
+)
+
+// TestMetaFromDir runs metadata golden-file tests for all subdirectories
+// under relDir. Each subdirectory should contain in.go and meta-expect.txt.
+func TestMetaFromDir(t *testing.T, relDir string) {
+	rootDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("Getwd failed:", err)
+	}
+	dir := filepath.Join(rootDir, relDir)
+	fis, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal("ReadDir failed:", err)
+	}
+	for _, fi := range fis {
+		name := fi.Name()
+		if !fi.IsDir() || strings.HasPrefix(name, "_") {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			testMetaDir(t, filepath.Join(dir, name))
+		})
+	}
+}
+
+func testMetaDir(t *testing.T, dir string) {
+	t.Helper()
+
+	var pm *metadata.PackageMeta
+	conf := build.NewDefaultConf(build.ModeRun)
+	conf.ModuleHook = func(pkg build.Package) {
+		lpkg := pkg.LPkg
+		if lpkg == nil {
+			return
+		}
+		// Only capture metadata for the package whose source files
+		// are in the test directory.
+		if slices.ContainsFunc(pkg.Package.GoFiles, func(file string) bool {
+			return filepath.Dir(file) == dir
+		}) {
+			pm = lpkg.Meta()
+		}
+	}
+
+	_, err := runWithConf(".", dir, conf)
+	if err != nil {
+		t.Fatalf("build failed: %v", err)
+	}
+
+	if pm == nil {
+		t.Fatal("no PackageMeta captured for test package")
+	}
+
+	got := metadata.MetaString(pm)
+	expectFile := filepath.Join(dir, "meta-expect.txt")
+	expect, err := os.ReadFile(expectFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if err := os.WriteFile(expectFile, []byte(got), 0644); err != nil {
+				t.Fatalf("WriteFile %s failed: %v", expectFile, err)
+			}
+			t.Logf("wrote initial golden file: %s", expectFile)
+			return
+		}
+		t.Fatalf("ReadFile %s failed: %v", expectFile, err)
+	}
+
+	expected := string(expect)
+	if got != expected {
+		newFile := filepath.Join(dir, "meta-expect.txt.new")
+		_ = os.WriteFile(newFile, []byte(got), 0644)
+		fmt.Printf("Meta diff:\ngot:\n%s\nvs expected:\n%s\n", got, expected)
+		_ = test.Diff(t, filepath.Join(dir, "meta-expect.txt"), []byte(got), expect)
+		t.Fatal("unexpected metadata output")
+	}
+}
+
+// CaptureMeta compiles the Go package at pkgDir and returns the formatted
+// PackageMeta string. It is used by gentests to regenerate golden files.
+func CaptureMeta(pkgDir string) (string, error) {
+	var pm *metadata.PackageMeta
+	conf := build.NewDefaultConf(build.ModeRun)
+	conf.ModuleHook = func(pkg build.Package) {
+		lpkg := pkg.LPkg
+		if lpkg == nil {
+			return
+		}
+		if slices.ContainsFunc(pkg.Package.GoFiles, func(file string) bool {
+			return filepath.Dir(file) == pkgDir
+		}) {
+			pm = lpkg.Meta()
+		}
+	}
+
+	_, err := runWithConf(".", pkgDir, conf)
+	if err != nil {
+		return "", fmt.Errorf("build failed: %w", err)
+	}
+
+	if pm == nil {
+		return "", fmt.Errorf("no PackageMeta captured for package at %s", pkgDir)
+	}
+
+	return metadata.MetaString(pm), nil
+}

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/goplus/llgo/cl/blocks"
 	"github.com/goplus/llgo/internal/goembed"
+	"github.com/goplus/llgo/internal/metadata"
 	"github.com/goplus/llgo/internal/typepatch"
 	"golang.org/x/tools/go/ssa"
 
@@ -1432,6 +1433,7 @@ func newPackageEx(prog llssa.Program, patches Patches, rewrites map[string]strin
 		prog.SetRuntime(pkgTypes)
 	}
 	ret = prog.NewPackage(pkgName, pkgPath)
+	ret.SetMetaBuilder(metadata.NewBuilder())
 	if enableDbg {
 		ret.InitDebug(pkgName, pkgPath, pkgProg.Fset)
 	}
@@ -1493,6 +1495,7 @@ func newPackageEx(prog llssa.Program, patches Patches, rewrites map[string]strin
 		ctx.initAfter = nil
 		fn()
 	}
+	ret.BuildMeta()
 	ret.MaterializePreserveSyms()
 	externs = ctx.cgoSymbols
 	return

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -311,6 +311,10 @@ func TestCgofullGeneratesC2func(t *testing.T) {
 	}
 }
 
+func TestMeta(t *testing.T) {
+	cltest.TestMetaFromDir(t, "./_testmeta")
+}
+
 func TestGoPkgMath(t *testing.T) {
 	conf := build.NewDefaultConf(build.ModeInstall)
 	_, err := build.Do([]string{"math"}, conf)

--- a/internal/metadata/builder.go
+++ b/internal/metadata/builder.go
@@ -1,0 +1,79 @@
+package metadata
+
+// Builder accumulates per-package metadata facts and produces a PackageMeta.
+// It is created by the build layer and passed into cl/ssa for filling.
+type Builder struct {
+	pm      *PackageMeta
+	strToID map[string]Symbol
+}
+
+// NewBuilder creates a Builder ready to accept facts.
+func NewBuilder() *Builder {
+	return &Builder{
+		pm:      NewPackageMeta(nil),
+		strToID: make(map[string]Symbol),
+	}
+}
+
+// String registers a string and returns its Symbol ID.
+// Repeated calls with the same string return the same ID.
+func (b *Builder) String(s string) Symbol {
+	if id, ok := b.strToID[s]; ok {
+		return id
+	}
+	id := Symbol(len(b.strToID))
+	b.strToID[s] = id
+	return id
+}
+
+// AddEdge records an ordinary edge src → dst.
+func (b *Builder) AddEdge(src, dst Symbol) {
+	b.pm.OrdinaryEdges[src] = append(b.pm.OrdinaryEdges[src], dst)
+}
+
+// AddTypeChild records that parent type references child type.
+func (b *Builder) AddTypeChild(parent, child Symbol) {
+	b.pm.TypeChildren[parent] = append(b.pm.TypeChildren[parent], child)
+}
+
+// AddIfaceEntry records the method set for an interface type.
+func (b *Builder) AddIfaceEntry(iface Symbol, methods []MethodSig) {
+	b.pm.InterfaceInfo[iface] = append(b.pm.InterfaceInfo[iface], methods...)
+}
+
+// AddUseIface records types that enter the interface domain when owner is reachable.
+func (b *Builder) AddUseIface(owner Symbol, types []Symbol) {
+	b.pm.UseIface[owner] = append(b.pm.UseIface[owner], types...)
+}
+
+// AddUseIfaceMethod records interface method demands when owner is reachable.
+func (b *Builder) AddUseIfaceMethod(owner Symbol, demands []IfaceMethodDemand) {
+	b.pm.UseIfaceMethod[owner] = append(b.pm.UseIfaceMethod[owner], demands...)
+}
+
+// AddMethodInfo records the method table slots for a concrete type.
+func (b *Builder) AddMethodInfo(typeID Symbol, slots []MethodSlot) {
+	b.pm.MethodInfo[typeID] = append(b.pm.MethodInfo[typeID], slots...)
+}
+
+// AddUseNamedMethod records method names demanded via MethodByName when owner is reachable.
+func (b *Builder) AddUseNamedMethod(owner Symbol, names []Symbol) {
+	b.pm.UseNamedMethod[owner] = append(b.pm.UseNamedMethod[owner], names...)
+}
+
+// AddReflectMethod records that owner forces conservative reflection handling.
+func (b *Builder) AddReflectMethod(owner Symbol) {
+	b.pm.ReflectMethod[owner] = struct{}{}
+}
+
+// Build finalizes the builder and returns an immutable PackageMeta.
+// The Builder must not be used after Build is called.
+func (b *Builder) Build() *PackageMeta {
+	// Build string table from strToID (sorted by Symbol ID)
+	table := make([]string, len(b.strToID))
+	for s, id := range b.strToID {
+		table[id] = s
+	}
+	b.pm.stringTable = table
+	return b.pm
+}

--- a/internal/metadata/decode.go
+++ b/internal/metadata/decode.go
@@ -1,0 +1,340 @@
+package metadata
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+// ReadMeta deserializes a PackageMeta from the LLPS v1 binary format.
+func ReadMeta(r io.Reader) (*PackageMeta, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("read meta: %w", err)
+	}
+	return decodeMeta(data)
+}
+
+func decodeMeta(data []byte) (*PackageMeta, error) {
+	pos := 0
+
+	// header
+	if len(data) < 4+1 {
+		return nil, fmt.Errorf("data too short for header")
+	}
+	magic := string(data[pos : pos+4])
+	pos += 4
+	if magic != magicV1 {
+		return nil, fmt.Errorf("bad magic: %q", magic)
+	}
+
+	version, n := binary.Uvarint(data[pos:])
+	if n <= 0 {
+		return nil, fmt.Errorf("decode version: bad uvarint")
+	}
+	pos += n
+	if version != version1 {
+		return nil, fmt.Errorf("unsupported version: %d", version)
+	}
+
+	// stringTable
+	count, n := binary.Uvarint(data[pos:])
+	if n <= 0 {
+		return nil, fmt.Errorf("decode stringTable count")
+	}
+	pos += n
+
+	stringTable := make([]string, count)
+	for i := range stringTable {
+		slen, n := binary.Uvarint(data[pos:])
+		if n <= 0 {
+			return nil, fmt.Errorf("decode string %d len", i)
+		}
+		pos += n
+		if pos+int(slen) > len(data) {
+			return nil, fmt.Errorf("string %d out of range", i)
+		}
+		stringTable[i] = string(data[pos : pos+int(slen)])
+		pos += int(slen)
+	}
+
+	meta := NewPackageMeta(stringTable)
+
+	// OrdinaryEdges
+	if err := decodeOrdinaryEdges(data, &pos, meta.OrdinaryEdges); err != nil {
+		return nil, fmt.Errorf("ordinaryEdges: %w", err)
+	}
+
+	// TypeChildren
+	if err := decodeTypeChildren(data, &pos, meta.TypeChildren); err != nil {
+		return nil, fmt.Errorf("typeChildren: %w", err)
+	}
+
+	// InterfaceInfo
+	if err := decodeInterfaceInfo(data, &pos, meta.InterfaceInfo); err != nil {
+		return nil, fmt.Errorf("interfaceInfo: %w", err)
+	}
+
+	// UseIface
+	if err := decodeUseIface(data, &pos, meta.UseIface); err != nil {
+		return nil, fmt.Errorf("useIface: %w", err)
+	}
+
+	// UseIfaceMethod
+	if err := decodeUseIfaceMethod(data, &pos, meta.UseIfaceMethod); err != nil {
+		return nil, fmt.Errorf("useIfaceMethod: %w", err)
+	}
+
+	// MethodInfo
+	if err := decodeMethodInfo(data, &pos, meta.MethodInfo); err != nil {
+		return nil, fmt.Errorf("methodInfo: %w", err)
+	}
+
+	// UseNamedMethod
+	if err := decodeUseNamedMethod(data, &pos, meta.UseNamedMethod); err != nil {
+		return nil, fmt.Errorf("useNamedMethod: %w", err)
+	}
+
+	// ReflectMethod
+	if err := decodeReflectMethod(data, &pos, meta.ReflectMethod); err != nil {
+		return nil, fmt.Errorf("reflectMethod: %w", err)
+	}
+
+	return meta, nil
+}
+
+func readUvarint(data []byte, pos *int) (uint64, error) {
+	v, n := binary.Uvarint(data[*pos:])
+	if n <= 0 {
+		return 0, fmt.Errorf("bad uvarint at pos %d", *pos)
+	}
+	*pos += n
+	return v, nil
+}
+
+func decodeOrdinaryEdges(data []byte, pos *int, m map[Symbol][]Symbol) error {
+	count, err := readUvarint(data, pos)
+	if err != nil {
+		return err
+	}
+	for range count {
+		src, err := readUvarint(data, pos)
+		if err != nil {
+			return err
+		}
+		ndst, err := readUvarint(data, pos)
+		if err != nil {
+			return err
+		}
+		dsts := make([]Symbol, ndst)
+		for j := range dsts {
+			v, err := readUvarint(data, pos)
+			if err != nil {
+				return err
+			}
+			dsts[j] = Symbol(v)
+		}
+		m[Symbol(src)] = dsts
+	}
+	return nil
+}
+
+func decodeTypeChildren(data []byte, pos *int, m map[Symbol][]Symbol) error {
+	count, err := readUvarint(data, pos)
+	if err != nil {
+		return err
+	}
+	for range count {
+		parent, err := readUvarint(data, pos)
+		if err != nil {
+			return err
+		}
+		nchild, err := readUvarint(data, pos)
+		if err != nil {
+			return err
+		}
+		children := make([]Symbol, nchild)
+		for j := range children {
+			v, err := readUvarint(data, pos)
+			if err != nil {
+				return err
+			}
+			children[j] = Symbol(v)
+		}
+		m[Symbol(parent)] = children
+	}
+	return nil
+}
+
+func decodeInterfaceInfo(data []byte, pos *int, m map[Symbol][]MethodSig) error {
+	count, err := readUvarint(data, pos)
+	if err != nil {
+		return err
+	}
+	for range count {
+		iface, err := readUvarint(data, pos)
+		if err != nil {
+			return err
+		}
+		nm, err := readUvarint(data, pos)
+		if err != nil {
+			return err
+		}
+		methods := make([]MethodSig, nm)
+		for j := range methods {
+			methods[j], err = readMethodSig(data, pos)
+			if err != nil {
+				return err
+			}
+		}
+		m[Symbol(iface)] = methods
+	}
+	return nil
+}
+
+func readMethodSig(data []byte, pos *int) (MethodSig, error) {
+	name, err := readUvarint(data, pos)
+	if err != nil {
+		return MethodSig{}, err
+	}
+	mtype, err := readUvarint(data, pos)
+	if err != nil {
+		return MethodSig{}, err
+	}
+	return MethodSig{Name: Symbol(name), MType: Symbol(mtype)}, nil
+}
+
+func decodeUseIface(data []byte, pos *int, m map[Symbol][]Symbol) error {
+	count, err := readUvarint(data, pos)
+	if err != nil {
+		return err
+	}
+	for range count {
+		owner, err := readUvarint(data, pos)
+		if err != nil {
+			return err
+		}
+		ntypes, err := readUvarint(data, pos)
+		if err != nil {
+			return err
+		}
+		types := make([]Symbol, ntypes)
+		for j := range types {
+			v, err := readUvarint(data, pos)
+			if err != nil {
+				return err
+			}
+			types[j] = Symbol(v)
+		}
+		m[Symbol(owner)] = types
+	}
+	return nil
+}
+
+func decodeUseIfaceMethod(data []byte, pos *int, m map[Symbol][]IfaceMethodDemand) error {
+	count, err := readUvarint(data, pos)
+	if err != nil {
+		return err
+	}
+	for range count {
+		owner, err := readUvarint(data, pos)
+		if err != nil {
+			return err
+		}
+		nd, err := readUvarint(data, pos)
+		if err != nil {
+			return err
+		}
+		demands := make([]IfaceMethodDemand, nd)
+		for j := range demands {
+			target, err := readUvarint(data, pos)
+			if err != nil {
+				return err
+			}
+			sig, err := readMethodSig(data, pos)
+			if err != nil {
+				return err
+			}
+			demands[j] = IfaceMethodDemand{Target: Symbol(target), Sig: sig}
+		}
+		m[Symbol(owner)] = demands
+	}
+	return nil
+}
+
+func decodeMethodInfo(data []byte, pos *int, m map[Symbol][]MethodSlot) error {
+	count, err := readUvarint(data, pos)
+	if err != nil {
+		return err
+	}
+	for range count {
+		typ, err := readUvarint(data, pos)
+		if err != nil {
+			return err
+		}
+		nslots, err := readUvarint(data, pos)
+		if err != nil {
+			return err
+		}
+		slots := make([]MethodSlot, nslots)
+		for j := range slots {
+			sig, err := readMethodSig(data, pos)
+			if err != nil {
+				return err
+			}
+			ifn, err := readUvarint(data, pos)
+			if err != nil {
+				return err
+			}
+			tfn, err := readUvarint(data, pos)
+			if err != nil {
+				return err
+			}
+			slots[j] = MethodSlot{Sig: sig, IFn: Symbol(ifn), TFn: Symbol(tfn)}
+		}
+		m[Symbol(typ)] = slots
+	}
+	return nil
+}
+
+func decodeUseNamedMethod(data []byte, pos *int, m map[Symbol][]Symbol) error {
+	count, err := readUvarint(data, pos)
+	if err != nil {
+		return err
+	}
+	for range count {
+		owner, err := readUvarint(data, pos)
+		if err != nil {
+			return err
+		}
+		nnames, err := readUvarint(data, pos)
+		if err != nil {
+			return err
+		}
+		names := make([]Symbol, nnames)
+		for j := range names {
+			v, err := readUvarint(data, pos)
+			if err != nil {
+				return err
+			}
+			names[j] = Symbol(v)
+		}
+		m[Symbol(owner)] = names
+	}
+	return nil
+}
+
+func decodeReflectMethod(data []byte, pos *int, m map[Symbol]struct{}) error {
+	count, err := readUvarint(data, pos)
+	if err != nil {
+		return err
+	}
+	for range count {
+		owner, err := readUvarint(data, pos)
+		if err != nil {
+			return err
+		}
+		m[Symbol(owner)] = struct{}{}
+	}
+	return nil
+}

--- a/internal/metadata/encode.go
+++ b/internal/metadata/encode.go
@@ -1,0 +1,146 @@
+package metadata
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+const (
+	magicV1  = "LLPS"
+	version1 = 1
+)
+
+// WriteMeta serializes PackageMeta to the LLPS v1 binary format.
+func (pm *PackageMeta) WriteMeta(w io.Writer) error {
+	buf := make([]byte, 0, 4096)
+
+	// header: magic + version
+	buf = append(buf, magicV1...)
+	buf = binary.AppendUvarint(buf, version1)
+
+	// stringTable
+	buf = binary.AppendUvarint(buf, uint64(len(pm.stringTable)))
+	for _, s := range pm.stringTable {
+		buf = binary.AppendUvarint(buf, uint64(len(s)))
+		buf = append(buf, s...)
+	}
+
+	// OrdinaryEdges
+	writeOrdinaryEdges(&buf, pm.OrdinaryEdges)
+
+	// TypeChildren
+	writeTypeChildren(&buf, pm.TypeChildren)
+
+	// InterfaceInfo
+	writeInterfaceInfo(&buf, pm.InterfaceInfo)
+
+	// UseIface
+	writeUseIface(&buf, pm.UseIface)
+
+	// UseIfaceMethod
+	writeUseIfaceMethod(&buf, pm.UseIfaceMethod)
+
+	// MethodInfo
+	writeMethodInfo(&buf, pm.MethodInfo)
+
+	// UseNamedMethod
+	writeUseNamedMethod(&buf, pm.UseNamedMethod)
+
+	// ReflectMethod
+	writeReflectMethod(&buf, pm.ReflectMethod)
+
+	_, err := w.Write(buf)
+	return err
+}
+
+func writeOrdinaryEdges(buf *[]byte, m map[Symbol][]Symbol) {
+	*buf = binary.AppendUvarint(*buf, uint64(len(m)))
+	for src, dsts := range m {
+		*buf = binary.AppendUvarint(*buf, uint64(src))
+		*buf = binary.AppendUvarint(*buf, uint64(len(dsts)))
+		for _, dst := range dsts {
+			*buf = binary.AppendUvarint(*buf, uint64(dst))
+		}
+	}
+}
+
+func writeTypeChildren(buf *[]byte, m map[Symbol][]Symbol) {
+	*buf = binary.AppendUvarint(*buf, uint64(len(m)))
+	for parent, children := range m {
+		*buf = binary.AppendUvarint(*buf, uint64(parent))
+		*buf = binary.AppendUvarint(*buf, uint64(len(children)))
+		for _, child := range children {
+			*buf = binary.AppendUvarint(*buf, uint64(child))
+		}
+	}
+}
+
+func writeInterfaceInfo(buf *[]byte, m map[Symbol][]MethodSig) {
+	*buf = binary.AppendUvarint(*buf, uint64(len(m)))
+	for iface, methods := range m {
+		*buf = binary.AppendUvarint(*buf, uint64(iface))
+		*buf = binary.AppendUvarint(*buf, uint64(len(methods)))
+		for _, ms := range methods {
+			writeMethodSig(buf, ms)
+		}
+	}
+}
+
+func writeMethodSig(buf *[]byte, ms MethodSig) {
+	*buf = binary.AppendUvarint(*buf, uint64(ms.Name))
+	*buf = binary.AppendUvarint(*buf, uint64(ms.MType))
+}
+
+func writeUseIface(buf *[]byte, m map[Symbol][]Symbol) {
+	*buf = binary.AppendUvarint(*buf, uint64(len(m)))
+	for owner, types := range m {
+		*buf = binary.AppendUvarint(*buf, uint64(owner))
+		*buf = binary.AppendUvarint(*buf, uint64(len(types)))
+		for _, t := range types {
+			*buf = binary.AppendUvarint(*buf, uint64(t))
+		}
+	}
+}
+
+func writeUseIfaceMethod(buf *[]byte, m map[Symbol][]IfaceMethodDemand) {
+	*buf = binary.AppendUvarint(*buf, uint64(len(m)))
+	for owner, demands := range m {
+		*buf = binary.AppendUvarint(*buf, uint64(owner))
+		*buf = binary.AppendUvarint(*buf, uint64(len(demands)))
+		for _, d := range demands {
+			*buf = binary.AppendUvarint(*buf, uint64(d.Target))
+			writeMethodSig(buf, d.Sig)
+		}
+	}
+}
+
+func writeMethodInfo(buf *[]byte, m map[Symbol][]MethodSlot) {
+	*buf = binary.AppendUvarint(*buf, uint64(len(m)))
+	for typ, slots := range m {
+		*buf = binary.AppendUvarint(*buf, uint64(typ))
+		*buf = binary.AppendUvarint(*buf, uint64(len(slots)))
+		for _, slot := range slots {
+			writeMethodSig(buf, slot.Sig)
+			*buf = binary.AppendUvarint(*buf, uint64(slot.IFn))
+			*buf = binary.AppendUvarint(*buf, uint64(slot.TFn))
+		}
+	}
+}
+
+func writeUseNamedMethod(buf *[]byte, m map[Symbol][]Symbol) {
+	*buf = binary.AppendUvarint(*buf, uint64(len(m)))
+	for owner, names := range m {
+		*buf = binary.AppendUvarint(*buf, uint64(owner))
+		*buf = binary.AppendUvarint(*buf, uint64(len(names)))
+		for _, name := range names {
+			*buf = binary.AppendUvarint(*buf, uint64(name))
+		}
+	}
+}
+
+func writeReflectMethod(buf *[]byte, m map[Symbol]struct{}) {
+	*buf = binary.AppendUvarint(*buf, uint64(len(m)))
+	for owner := range m {
+		*buf = binary.AppendUvarint(*buf, uint64(owner))
+	}
+}

--- a/internal/metadata/format.go
+++ b/internal/metadata/format.go
@@ -1,0 +1,140 @@
+package metadata
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// FormatMeta writes a human-readable text representation of pm to w.
+// The output is intended for golden-file comparison in tests.
+func FormatMeta(w io.Writer, pm *PackageMeta) {
+	if pm == nil {
+		return
+	}
+	table := pm.stringTable
+	str := func(s Symbol) string {
+		if int(s) < len(table) {
+			return table[s]
+		}
+		return fmt.Sprintf("?%d", s)
+	}
+
+	sortSymbolKeys := func(m map[Symbol][]Symbol) []Symbol {
+		keys := make([]Symbol, 0, len(m))
+		for k := range m {
+			keys = append(keys, k)
+		}
+		sort.Slice(keys, func(i, j int) bool { return str(keys[i]) < str(keys[j]) })
+		return keys
+	}
+
+	// TypeChildren
+	if len(pm.TypeChildren) > 0 {
+		fmt.Fprintln(w, "[TypeChildren]")
+		for _, k := range sortSymbolKeys(pm.TypeChildren) {
+			fmt.Fprintf(w, "%s:\n", str(k))
+			for _, v := range pm.TypeChildren[k] {
+				fmt.Fprintf(w, "    %s\n", str(v))
+			}
+		}
+		fmt.Fprintln(w)
+	}
+
+	// InterfaceInfo
+	if len(pm.InterfaceInfo) > 0 {
+		fmt.Fprintln(w, "[InterfaceInfo]")
+		ifaceKeys := make([]Symbol, 0, len(pm.InterfaceInfo))
+		for k := range pm.InterfaceInfo {
+			ifaceKeys = append(ifaceKeys, k)
+		}
+		sort.Slice(ifaceKeys, func(i, j int) bool { return str(ifaceKeys[i]) < str(ifaceKeys[j]) })
+		for _, k := range ifaceKeys {
+			fmt.Fprintf(w, "%s:\n", str(k))
+			for _, v := range pm.InterfaceInfo[k] {
+				fmt.Fprintf(w, "    %s %s\n", str(v.Name), str(v.MType))
+			}
+		}
+		fmt.Fprintln(w)
+	}
+
+	// UseIface
+	if len(pm.UseIface) > 0 {
+		fmt.Fprintln(w, "[UseIface]")
+		for _, k := range sortSymbolKeys(pm.UseIface) {
+			fmt.Fprintf(w, "%s:\n", str(k))
+			for _, v := range pm.UseIface[k] {
+				fmt.Fprintf(w, "    %s\n", str(v))
+			}
+		}
+		fmt.Fprintln(w)
+	}
+
+	// UseIfaceMethod
+	if len(pm.UseIfaceMethod) > 0 {
+		fmt.Fprintln(w, "[UseIfaceMethod]")
+		ownerKeys := make([]Symbol, 0, len(pm.UseIfaceMethod))
+		for k := range pm.UseIfaceMethod {
+			ownerKeys = append(ownerKeys, k)
+		}
+		sort.Slice(ownerKeys, func(i, j int) bool { return str(ownerKeys[i]) < str(ownerKeys[j]) })
+		for _, k := range ownerKeys {
+			fmt.Fprintf(w, "%s:\n", str(k))
+			for _, v := range pm.UseIfaceMethod[k] {
+				fmt.Fprintf(w, "    %s %s %s\n", str(v.Target), str(v.Sig.Name), str(v.Sig.MType))
+			}
+		}
+		fmt.Fprintln(w)
+	}
+
+	// MethodInfo
+	if len(pm.MethodInfo) > 0 {
+		fmt.Fprintln(w, "[MethodInfo]")
+		typeKeys := make([]Symbol, 0, len(pm.MethodInfo))
+		for k := range pm.MethodInfo {
+			typeKeys = append(typeKeys, k)
+		}
+		sort.Slice(typeKeys, func(i, j int) bool { return str(typeKeys[i]) < str(typeKeys[j]) })
+		for _, k := range typeKeys {
+			fmt.Fprintf(w, "%s:\n", str(k))
+			for _, v := range pm.MethodInfo[k] {
+				fmt.Fprintf(w, "    %s %s %s %s\n", str(v.Sig.Name), str(v.Sig.MType), str(v.IFn), str(v.TFn))
+			}
+		}
+		fmt.Fprintln(w)
+	}
+
+	// UseNamedMethod
+	if len(pm.UseNamedMethod) > 0 {
+		fmt.Fprintln(w, "[UseNamedMethod]")
+		for _, k := range sortSymbolKeys(pm.UseNamedMethod) {
+			fmt.Fprintf(w, "%s:\n", str(k))
+			for _, v := range pm.UseNamedMethod[k] {
+				fmt.Fprintf(w, "    %s\n", str(v))
+			}
+		}
+		fmt.Fprintln(w)
+	}
+
+	// ReflectMethod
+	if len(pm.ReflectMethod) > 0 {
+		fmt.Fprintln(w, "[ReflectMethod]")
+		keys := make([]Symbol, 0, len(pm.ReflectMethod))
+		for k := range pm.ReflectMethod {
+			keys = append(keys, k)
+		}
+		sort.Slice(keys, func(i, j int) bool { return str(keys[i]) < str(keys[j]) })
+		for _, k := range keys {
+			fmt.Fprintln(w, str(k))
+		}
+		fmt.Fprintln(w)
+	}
+}
+
+// MetaString returns a formatted string representation of pm.
+func MetaString(pm *PackageMeta) string {
+	var sb strings.Builder
+	FormatMeta(&sb, pm)
+	return sb.String()
+}

--- a/internal/metadata/meta.go
+++ b/internal/metadata/meta.go
@@ -1,0 +1,60 @@
+// Package metadata defines the package summary data model and its LLPS binary
+// serialization format for whole-program method reachability analysis.
+package metadata
+
+// Symbol is an integer ID referencing a string in the unified string table.
+type Symbol = int
+
+// MethodSig describes a method signature: name + function type symbol.
+type MethodSig struct {
+	Name  Symbol // method name string table ID
+	MType Symbol // method type symbol string table ID
+}
+
+// MethodSlot describes one slot in a concrete type's method table.
+// Slots are stored in order matching Go runtime abi.Method table.
+type MethodSlot struct {
+	Sig MethodSig
+	IFn Symbol // interface method entry symbol
+	TFn Symbol // concrete type method symbol
+}
+
+// IfaceMethodDemand records an interface method call: (interface, method sig).
+type IfaceMethodDemand struct {
+	Target Symbol // target interface symbol
+	Sig    MethodSig
+}
+
+// PackageMeta holds all per-package analysis facts for whole-program method
+// reachability analysis. All strings are stored once in stringTable and
+// referenced by integer Symbol IDs throughout the other fields.
+type PackageMeta struct {
+	stringTable []string
+
+	OrdinaryEdges  map[Symbol][]Symbol          // top-level symbol -> direct references
+	TypeChildren   map[Symbol][]Symbol          // parent type -> child types
+	InterfaceInfo  map[Symbol][]MethodSig       // interface type -> method signatures
+	UseIface       map[Symbol][]Symbol          // function -> types converted to interface
+	UseIfaceMethod map[Symbol][]IfaceMethodDemand // function -> interface method calls
+	MethodInfo     map[Symbol][]MethodSlot      // concrete type -> method slots
+	UseNamedMethod map[Symbol][]Symbol          // function -> method names from MethodByName
+	ReflectMethod  map[Symbol]struct{}          // functions with conservative reflection
+}
+
+// StringTable returns the string table (read-only).
+func (pm *PackageMeta) StringTable() []string { return pm.stringTable }
+
+// NewPackageMeta creates an empty PackageMeta with initialized maps.
+func NewPackageMeta(stringTable []string) *PackageMeta {
+	return &PackageMeta{
+		stringTable:    stringTable,
+		OrdinaryEdges:  make(map[Symbol][]Symbol),
+		TypeChildren:   make(map[Symbol][]Symbol),
+		InterfaceInfo:  make(map[Symbol][]MethodSig),
+		UseIface:       make(map[Symbol][]Symbol),
+		UseIfaceMethod: make(map[Symbol][]IfaceMethodDemand),
+		MethodInfo:     make(map[Symbol][]MethodSlot),
+		UseNamedMethod: make(map[Symbol][]Symbol),
+		ReflectMethod:  make(map[Symbol]struct{}),
+	}
+}

--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -24,6 +24,7 @@ import (
 	"go/types"
 	"sort"
 
+	"github.com/goplus/llgo/internal/metadata"
 	"github.com/goplus/llgo/ssa/abi"
 	"github.com/xgo-dev/llvm"
 )
@@ -429,13 +430,17 @@ func (b Builder) abiUncommonMethods(t types.Type, mset *types.MethodSet) llvm.Va
 	if anonymous {
 		pkg = types.NewPackage(b.Pkg.Path(), "")
 	}
+	typeName, _ := prog.abi.TypeName(t)
+	mb := b.Pkg.MetaBuilder()
+	var slots []metadata.MethodSlot
 	for i := 0; i < n; i++ {
 		m := mset.At(i)
 		obj := m.Obj()
 		mName := obj.Name()
+		fullName := mthName(obj)
 		name := b.Str(mName).impl
 		if !token.IsExported(mName) {
-			name = b.Str(abi.FullName(obj.Pkg(), mName)).impl
+			name = b.Str(fullName).impl
 		}
 		mSig := m.Type().(*types.Signature)
 		var tfn, ifn llvm.Value
@@ -453,8 +458,91 @@ func (b Builder) abiUncommonMethods(t types.Type, mset *types.MethodSet) llvm.Va
 		values = append(values, ifn)
 		values = append(values, tfn)
 		fields[i] = llvm.ConstNamedStruct(ft.ll, values)
+		if mb != nil {
+			mtypName, _ := prog.abi.TypeName(ftyp)
+			slots = append(slots, metadata.MethodSlot{
+				Sig: metadata.MethodSig{
+					Name:  mb.String(fullName),
+					MType: mb.String(mtypName),
+				},
+				IFn: mb.String(ifn.Name()),
+				TFn: mb.String(tfn.Name()),
+			})
+		}
+	}
+	if mb != nil && len(slots) > 0 {
+		mb.AddMethodInfo(mb.String(typeName), slots)
 	}
 	return llvm.ConstArray(ft.ll, fields)
+}
+
+// mthName returns the semantic method name used in ABI metadata.
+// Exported methods keep their declared identifier; unexported methods
+// are qualified with their package path.
+func mthName(obj types.Object) string {
+	rawName := obj.Name()
+	if token.IsExported(rawName) {
+		return rawName
+	}
+	return abi.FullName(obj.Pkg(), rawName)
+}
+
+// collectTypeChildren records parent → child ABI type symbol relationships
+// for whole-program TypeChildren analysis.
+func (b Builder) collectTypeChildren(t types.Type, parentName string) {
+	mb := b.Pkg.MetaBuilder()
+	if mb == nil {
+		return
+	}
+	prog := b.Prog
+	parent := mb.String(parentName)
+
+	switch ut := types.Unalias(t).(type) {
+	case *types.Named:
+		b.collectTypeChildren(ut.Underlying(), parentName)
+	case *types.Pointer:
+		if childName, ok := prog.abi.TypeName(ut.Elem()); ok && childName != "" {
+			mb.AddTypeChild(parent, mb.String(childName))
+		}
+	case *types.Struct:
+		for i := 0; i < ut.NumFields(); i++ {
+			if childName, ok := prog.abi.TypeName(ut.Field(i).Type()); ok && childName != "" {
+				mb.AddTypeChild(parent, mb.String(childName))
+			}
+		}
+	case *types.Array:
+		if childName, ok := prog.abi.TypeName(ut.Elem()); ok && childName != "" {
+			mb.AddTypeChild(parent, mb.String(childName))
+		}
+	case *types.Slice:
+		if childName, ok := prog.abi.TypeName(ut.Elem()); ok && childName != "" {
+			mb.AddTypeChild(parent, mb.String(childName))
+		}
+	case *types.Chan:
+		if childName, ok := prog.abi.TypeName(ut.Elem()); ok && childName != "" {
+			mb.AddTypeChild(parent, mb.String(childName))
+		}
+	case *types.Map:
+		if childName, ok := prog.abi.TypeName(ut.Key()); ok && childName != "" {
+			mb.AddTypeChild(parent, mb.String(childName))
+		}
+		if childName, ok := prog.abi.TypeName(ut.Elem()); ok && childName != "" {
+			mb.AddTypeChild(parent, mb.String(childName))
+		}
+	case *types.Signature:
+		params := ut.Params()
+		results := ut.Results()
+		for i := 0; i < params.Len(); i++ {
+			if childName, ok := prog.abi.TypeName(params.At(i).Type()); ok && childName != "" {
+				mb.AddTypeChild(parent, mb.String(childName))
+			}
+		}
+		for i := 0; i < results.Len(); i++ {
+			if childName, ok := prog.abi.TypeName(results.At(i).Type()); ok && childName != "" {
+				mb.AddTypeChild(parent, mb.String(childName))
+			}
+		}
+	}
 }
 
 // closure func type
@@ -528,6 +616,7 @@ func (b Builder) abiType(t types.Type) Expr {
 		g.impl.SetGlobalConstant(true)
 		g.impl.SetLinkage(llvm.WeakODRLinkage)
 		prog.abiSymbol[name] = &AbiSymbol{Name: name, PkgPath: pkg.Path(), Raw: t, Typ: g.Type, MSet: mset}
+		b.collectTypeChildren(t, name)
 	}
 	return Expr{llvm.ConstGEP(g.impl.GlobalValueType(), g.impl, []llvm.Value{
 		llvm.ConstInt(prog.Int32().ll, 0, false),

--- a/ssa/interface.go
+++ b/ssa/interface.go
@@ -20,6 +20,7 @@ import (
 	"go/token"
 	"go/types"
 
+	"github.com/goplus/llgo/internal/metadata"
 	"github.com/goplus/llgo/ssa/abi"
 	"github.com/xgo-dev/llvm"
 )
@@ -48,6 +49,50 @@ func (b Builder) unsafeInterface(rawIntf *types.Interface, t Expr, data llvm.Val
 	tintf := b.abiType(rawIntf)
 	itab := b.newItab(tintf, t)
 	return b.unsafeIface(itab.impl, data)
+}
+
+// emitIfaceMethodUse records an interface method call for metadata.
+func (b Builder) emitIfaceMethodUse(ownerName, intfTypeName string, method *types.Func) {
+	mb := b.Pkg.MetaBuilder()
+	if mb == nil {
+		return
+	}
+	prog := b.Prog
+	mtypName, _ := prog.abi.TypeName(funcType(prog, method.Type()))
+	mb.AddUseIfaceMethod(mb.String(ownerName), []metadata.IfaceMethodDemand{{
+		Target: mb.String(intfTypeName),
+		Sig: metadata.MethodSig{
+			Name:  mb.String(mthName(method)),
+			MType: mb.String(mtypName),
+		},
+	}})
+}
+
+// emitInterfaceInfo records the complete method set of an interface.
+func (b Builder) emitInterfaceInfo(intfTypeName string, rawIntf *types.Interface) {
+	mb := b.Pkg.MetaBuilder()
+	if mb == nil {
+		return
+	}
+	prog := b.Prog
+	n := rawIntf.NumMethods()
+	methods := make([]metadata.MethodSig, 0, n)
+	for i := 0; i < n; i++ {
+		im := rawIntf.Method(i)
+		imtypName, _ := prog.abi.TypeName(funcType(prog, im.Type()))
+		methods = append(methods, metadata.MethodSig{
+			Name:  mb.String(mthName(im)),
+			MType: mb.String(imtypName),
+		})
+	}
+	mb.AddIfaceEntry(mb.String(intfTypeName), methods)
+}
+
+// emitUseIface records that a concrete type enters the interface domain.
+func (b Builder) emitUseIface(ownerName, typeName string) {
+	if mb := b.Pkg.MetaBuilder(); mb != nil {
+		mb.AddUseIface(mb.String(ownerName), []metadata.Symbol{mb.String(typeName)})
+	}
 }
 
 func iMethodOf(rawIntf *types.Interface, name string) int {
@@ -80,6 +125,10 @@ func (b Builder) Imethod(intf Expr, method *types.Func) Expr {
 	}
 	tclosure := prog.Type(sig, InGo)
 	i := iMethodOf(rawIntf, method.Name())
+	ownerName := b.Func.impl.Name()
+	intfTypeName, _ := prog.abi.TypeName(intf.raw.Type)
+	b.emitIfaceMethodUse(ownerName, intfTypeName, method)
+	b.emitInterfaceInfo(intfTypeName, rawIntf)
 	data := b.InlineCall(b.Pkg.rtFunc("IfacePtrData"), intf)
 	impl := intf.impl
 	itab := Expr{b.faceItab(impl), prog.VoidPtrPtr()}
@@ -115,6 +164,11 @@ func (b Builder) MakeInterface(tinter Type, x Expr) (ret Expr) {
 	prog := b.Prog
 	typ := x.Type
 	tabi := b.abiType(typ.raw.Type)
+	if _, ok := typ.raw.Type.Underlying().(*types.Interface); !ok {
+		ownerName := b.Func.impl.Name()
+		typeName, _ := prog.abi.TypeName(typ.raw.Type)
+		b.emitUseIface(ownerName, typeName)
+	}
 	if !directIfaceType(typ.raw.Type) {
 		vptr := b.AllocU(typ)
 		b.Store(vptr, x)

--- a/ssa/metadata.go
+++ b/ssa/metadata.go
@@ -1,0 +1,19 @@
+package ssa
+
+import "github.com/goplus/llgo/internal/metadata"
+
+// EmitUseNamedMethod records a MethodByName-like exact method-name demand for
+// later whole-program deadcode analysis.
+func (p Package) EmitUseNamedMethod(owner, name string) {
+	if mb := p.MetaBuilder(); mb != nil {
+		mb.AddUseNamedMethod(mb.String(owner), []metadata.Symbol{mb.String(name)})
+	}
+}
+
+// EmitReflectMethod records a conservative reflection marker for later
+// whole-program deadcode analysis.
+func (p Package) EmitReflectMethod(owner string) {
+	if mb := p.MetaBuilder(); mb != nil {
+		mb.AddReflectMethod(mb.String(owner))
+	}
+}

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -26,6 +26,7 @@ import (
 	"unsafe"
 
 	"github.com/goplus/llgo/internal/env"
+	"github.com/goplus/llgo/internal/metadata"
 	"github.com/goplus/llgo/ssa/abi"
 	"github.com/xgo-dev/llvm"
 	"golang.org/x/tools/go/types/typeutil"
@@ -736,11 +737,31 @@ type aPackage struct {
 	export         map[string]string   // pkgPath.nameInPkg => exportname
 	preserveSyms   map[string]struct{} // set of exported symbol names
 	llvmUsedValues []llvm.Value
+
+	metaBuilder *metadata.Builder
+	pkgMeta     *metadata.PackageMeta
 }
 
 type none struct{}
 
 type Package = *aPackage
+
+// SetMetaBuilder sets the metadata builder for this package.
+func (p Package) SetMetaBuilder(b *metadata.Builder) { p.metaBuilder = b }
+
+// MetaBuilder returns the package's metadata builder, or nil.
+func (p Package) MetaBuilder() *metadata.Builder { return p.metaBuilder }
+
+// BuildMeta finalizes the metadata builder and stores the PackageMeta.
+func (p Package) BuildMeta() {
+	if p.metaBuilder != nil {
+		p.pkgMeta = p.metaBuilder.Build()
+		p.metaBuilder = nil
+	}
+}
+
+// Meta returns the finalized PackageMeta, or nil.
+func (p Package) Meta() *metadata.PackageMeta { return p.pkgMeta }
 
 func (p Package) Module() llvm.Module {
 	return p.mod


### PR DESCRIPTION
## Summary

First PR for [Whole-Program Method Reachability Analysis and Package Summary Cache (#1853)](https://github.com/xgo-dev/llgo/issues/1853). Implements **Package Summary extraction** — collecting metadata facts during compilation and storing them in `PackageMeta`.

## What's Included

### Core Infrastructure
- **`internal/metadata/`** — V1 binary format (LLPS, `encode.go`/`decode.go`/`meta.go` from #1853 bench work), `Builder` (`builder.go`), and human-readable formatter (`format.go`)

### SSA-Layer Metadata Collection
- **`ssa/abitype.go`** — `collectTypeChildren()` for parent→child ABI type relationships; `mthName()` for method name normalization; `MethodInfo` collection in `abiUncommonMethods()`
- **`ssa/interface.go`** — Interface metadata: `emitIfaceMethodUse`, `emitInterfaceInfo`, `emitUseIface` during `Imethod`/`MakeInterface`
- **`ssa/metadata.go`** — Bridge functions `EmitUseNamedMethod`/`EmitReflectMethod` for future cl-layer use
- **`ssa/package.go`** — `SetMetaBuilder`/`MetaBuilder`/`BuildMeta`/`Meta` accessors

### CL-Layer Wiring
- **`cl/compile.go`** — Creates Builder, calls `BuildMeta()` after deferred init functions
- **`internal/build/build.go`** — `ModuleHook` callback field on Config

### Testing
- **`cl/_testmeta/`** — 3 golden-file test cases (iface, methods, nested)
- **`cl/cltest/meta.go`** — `TestMetaFromDir` helper + `CaptureMeta` for regeneration
- **`cl/compile_test.go`** — `TestMeta` entry point
- **`chore/gentests/gentests.go`** — `genMetaDir` for golden file regeneration

## What's Excluded (Separate PRs)
- **OrdinaryEdges** — top-level symbol reachability
- **Recursive TypeChildren** — full dependency chain
- **cl/instr.go** reflection interception
- **Cache serialization/deserialization** and reuse

## Test Plan
- [x] `LLGO_ROOT=. go test ./cl/ -run TestMeta -v` — all 3 cases PASS
- [x] `go build ./...` compiles cleanly
- [x] Golden files use `[SectionName]\nkey:\n    value` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)