### PR TITLE
metadata: add in-memory package summary extraction

### DIFF
--- a/chore/gentests/gentests.go
+++ b/chore/gentests/gentests.go
@@ -38,6 +38,7 @@ func main() {
 	llgenDir(dir + "/cl/_testgo")
 	llgenDir(dir + "/cl/_testpy")
 	llgenDir(dir + "/cl/_testdata")
+	genMetaDir(dir + "/cl/_testmeta")
 
 	genExpects(dir)
 }
@@ -70,6 +71,34 @@ func genExpects(root string) {
 	runExpectDir(root, "cl/_testgo")
 	runExpectDir(root, "cl/_testpy")
 	runExpectDir(root, "cl/_testdata")
+}
+
+func genMetaDir(dir string) {
+	fis, err := os.ReadDir(dir)
+	check(err)
+	for _, fi := range fis {
+		name := fi.Name()
+		if !fi.IsDir() || strings.HasPrefix(name, "_") {
+			continue
+		}
+		testDir := filepath.Join(dir, name)
+		if _, err := os.Stat(filepath.Join(testDir, "in.go")); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			check(err)
+		}
+		relPath, err := filepath.Rel(filepath.Dir(filepath.Dir(dir)), testDir)
+		check(err)
+		relPath = filepath.ToSlash(relPath)
+		fmt.Fprintln(os.Stderr, "meta", relPath)
+		meta, err := cltest.CaptureMeta("./"+relPath, testDir)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "error:", relPath, err)
+			continue
+		}
+		check(os.WriteFile(filepath.Join(testDir, "meta-expect.txt"), []byte(meta), 0644))
+	}
 }
 
 func runExpectDir(root, relDir string) {

--- a/cl/_testmeta/ifaceuse_basic/in.go
+++ b/cl/_testmeta/ifaceuse_basic/in.go
@@ -1,0 +1,11 @@
+package main
+
+type T struct{}
+
+func sink(v any) {
+	_ = v
+}
+
+func main() {
+	sink(T{})
+}

--- a/cl/_testmeta/ifaceuse_basic/meta-expect.txt
+++ b/cl/_testmeta/ifaceuse_basic/meta-expect.txt
@@ -1,0 +1,26 @@
+[TypeChildren]
+*_llgo_github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.T:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.T
+
+[OrdinaryEdges]
+*_llgo_github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.T:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.T
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0:
+    github.com/goplus/llgo/runtime/internal/runtime.memequal0
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr:
+    github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+_llgo_github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.T:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0
+    *_llgo_github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.T
+github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.init:
+    github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.init$guard
+github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.main:
+    github.com/goplus/llgo/runtime/internal/runtime.AllocU
+    _llgo_github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.T
+    github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.sink
+
+[UseIface]
+github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.main:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/ifaceuse_basic.T
+

--- a/cl/_testmeta/interface_anyonmous/in.go
+++ b/cl/_testmeta/interface_anyonmous/in.go
@@ -1,0 +1,18 @@
+package main
+
+type T struct{}
+
+func (T) M() {}
+func (T) N() {}
+
+func use(v interface {
+	M()
+	N()
+}) {
+	v.M()
+	v.N()
+}
+
+func main() {
+	use(T{})
+}

--- a/cl/_testmeta/interface_anyonmous/meta-expect.txt
+++ b/cl/_testmeta/interface_anyonmous/meta-expect.txt
@@ -1,0 +1,74 @@
+[TypeChildren]
+*_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
+    _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+*_llgo_github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T
+*_llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo:
+    _llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo
+_llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo:
+    _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+
+[InterfaceInfo]
+_llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo:
+    M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+    N _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+
+[OrdinaryEdges]
+*_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+*_llgo_github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T
+*_llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal:
+    github.com/goplus/llgo/runtime/internal/runtime.interequal
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0:
+    github.com/goplus/llgo/runtime/internal/runtime.memequal0
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr:
+    github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
+    *_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+_llgo_github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0
+    *_llgo_github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T
+_llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal
+    *_llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo
+    _llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo$imethods
+_llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo$imethods:
+    _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.(*T).M:
+    github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T.M
+github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.(*T).N:
+    github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T.N
+github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.init:
+    github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.init$guard
+github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.main:
+    github.com/goplus/llgo/runtime/internal/runtime.AllocU
+    _llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo
+    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T
+    github.com/goplus/llgo/runtime/internal/runtime.NewItab
+    github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.use
+github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.use:
+    github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData
+
+[UseIface]
+github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.main:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T
+
+[UseIfaceMethod]
+github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.use:
+    _llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+    _llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo N _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+
+[MethodInfo]
+*_llgo_github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T:
+    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.(*T).M github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.(*T).M
+    1 N _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.(*T).N github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.(*T).N
+_llgo_github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T:
+    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.(*T).M github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T.M
+    1 N _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.(*T).N github.com/goplus/llgo/cl/_testmeta/interface_anyonmous.T.N
+

--- a/cl/_testmeta/interface_named/in.go
+++ b/cl/_testmeta/interface_named/in.go
@@ -1,0 +1,17 @@
+package main
+
+type I interface {
+	M()
+}
+
+type T struct{}
+
+func (T) M() {}
+
+func use(v I) {
+	v.M()
+}
+
+func main() {
+	use(T{})
+}

--- a/cl/_testmeta/interface_named/meta-expect.txt
+++ b/cl/_testmeta/interface_named/meta-expect.txt
@@ -1,0 +1,68 @@
+[TypeChildren]
+*_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
+    _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+*_llgo_github.com/goplus/llgo/cl/_testmeta/interface_named.T:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_named.T
+*_llgo_iface$anEWstLioBmxcO9rxTXClbAzDIEQLw2tApwq0mcSt88:
+    _llgo_iface$anEWstLioBmxcO9rxTXClbAzDIEQLw2tApwq0mcSt88
+_llgo_iface$anEWstLioBmxcO9rxTXClbAzDIEQLw2tApwq0mcSt88:
+    _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+
+[InterfaceInfo]
+_llgo_github.com/goplus/llgo/cl/_testmeta/interface_named.I:
+    M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+
+[OrdinaryEdges]
+*_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+*_llgo_github.com/goplus/llgo/cl/_testmeta/interface_named.T:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_named.T
+*_llgo_iface$anEWstLioBmxcO9rxTXClbAzDIEQLw2tApwq0mcSt88:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_iface$anEWstLioBmxcO9rxTXClbAzDIEQLw2tApwq0mcSt88
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal:
+    github.com/goplus/llgo/runtime/internal/runtime.interequal
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0:
+    github.com/goplus/llgo/runtime/internal/runtime.memequal0
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr:
+    github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
+    *_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+_llgo_github.com/goplus/llgo/cl/_testmeta/interface_named.T:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0
+    *_llgo_github.com/goplus/llgo/cl/_testmeta/interface_named.T
+_llgo_iface$anEWstLioBmxcO9rxTXClbAzDIEQLw2tApwq0mcSt88:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal
+    *_llgo_iface$anEWstLioBmxcO9rxTXClbAzDIEQLw2tApwq0mcSt88
+    _llgo_iface$anEWstLioBmxcO9rxTXClbAzDIEQLw2tApwq0mcSt88$imethods
+_llgo_iface$anEWstLioBmxcO9rxTXClbAzDIEQLw2tApwq0mcSt88$imethods:
+    _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+github.com/goplus/llgo/cl/_testmeta/interface_named.(*T).M:
+    github.com/goplus/llgo/cl/_testmeta/interface_named.T.M
+github.com/goplus/llgo/cl/_testmeta/interface_named.init:
+    github.com/goplus/llgo/cl/_testmeta/interface_named.init$guard
+github.com/goplus/llgo/cl/_testmeta/interface_named.main:
+    github.com/goplus/llgo/runtime/internal/runtime.AllocU
+    _llgo_iface$anEWstLioBmxcO9rxTXClbAzDIEQLw2tApwq0mcSt88
+    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_named.T
+    github.com/goplus/llgo/runtime/internal/runtime.NewItab
+    github.com/goplus/llgo/cl/_testmeta/interface_named.use
+github.com/goplus/llgo/cl/_testmeta/interface_named.use:
+    github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData
+
+[UseIface]
+github.com/goplus/llgo/cl/_testmeta/interface_named.main:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_named.T
+
+[UseIfaceMethod]
+github.com/goplus/llgo/cl/_testmeta/interface_named.use:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_named.I M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+
+[MethodInfo]
+*_llgo_github.com/goplus/llgo/cl/_testmeta/interface_named.T:
+    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/interface_named.(*T).M github.com/goplus/llgo/cl/_testmeta/interface_named.(*T).M
+_llgo_github.com/goplus/llgo/cl/_testmeta/interface_named.T:
+    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/interface_named.(*T).M github.com/goplus/llgo/cl/_testmeta/interface_named.T.M
+

--- a/cl/_testmeta/interface_unexported/in.go
+++ b/cl/_testmeta/interface_unexported/in.go
@@ -1,0 +1,17 @@
+package main
+
+type I interface {
+	m()
+}
+
+type T struct{}
+
+func (T) m() {}
+
+func use(v I) {
+	v.m()
+}
+
+func main() {
+	use(T{})
+}

--- a/cl/_testmeta/interface_unexported/meta-expect.txt
+++ b/cl/_testmeta/interface_unexported/meta-expect.txt
@@ -1,0 +1,68 @@
+[TypeChildren]
+*_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
+    _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+*_llgo_github.com/goplus/llgo/cl/_testmeta/interface_unexported.T:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_unexported.T
+*github.com/goplus/llgo/cl/_testmeta/interface_unexported.iface$SE5y-KS93u1u9p1qAf9LRB1hncS44rJIq27_JZbIQVo:
+    github.com/goplus/llgo/cl/_testmeta/interface_unexported.iface$SE5y-KS93u1u9p1qAf9LRB1hncS44rJIq27_JZbIQVo
+github.com/goplus/llgo/cl/_testmeta/interface_unexported.iface$SE5y-KS93u1u9p1qAf9LRB1hncS44rJIq27_JZbIQVo:
+    _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+
+[InterfaceInfo]
+_llgo_github.com/goplus/llgo/cl/_testmeta/interface_unexported.I:
+    github.com/goplus/llgo/cl/_testmeta/interface_unexported.m _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+
+[OrdinaryEdges]
+*_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+*_llgo_github.com/goplus/llgo/cl/_testmeta/interface_unexported.T:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_unexported.T
+*github.com/goplus/llgo/cl/_testmeta/interface_unexported.iface$SE5y-KS93u1u9p1qAf9LRB1hncS44rJIq27_JZbIQVo:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    github.com/goplus/llgo/cl/_testmeta/interface_unexported.iface$SE5y-KS93u1u9p1qAf9LRB1hncS44rJIq27_JZbIQVo
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal:
+    github.com/goplus/llgo/runtime/internal/runtime.interequal
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0:
+    github.com/goplus/llgo/runtime/internal/runtime.memequal0
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr:
+    github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
+    *_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+_llgo_github.com/goplus/llgo/cl/_testmeta/interface_unexported.T:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0
+    *_llgo_github.com/goplus/llgo/cl/_testmeta/interface_unexported.T
+github.com/goplus/llgo/cl/_testmeta/interface_unexported.(*T).m:
+    github.com/goplus/llgo/cl/_testmeta/interface_unexported.T.m
+github.com/goplus/llgo/cl/_testmeta/interface_unexported.iface$SE5y-KS93u1u9p1qAf9LRB1hncS44rJIq27_JZbIQVo:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal
+    *github.com/goplus/llgo/cl/_testmeta/interface_unexported.iface$SE5y-KS93u1u9p1qAf9LRB1hncS44rJIq27_JZbIQVo
+    github.com/goplus/llgo/cl/_testmeta/interface_unexported.iface$SE5y-KS93u1u9p1qAf9LRB1hncS44rJIq27_JZbIQVo$imethods
+github.com/goplus/llgo/cl/_testmeta/interface_unexported.iface$SE5y-KS93u1u9p1qAf9LRB1hncS44rJIq27_JZbIQVo$imethods:
+    _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+github.com/goplus/llgo/cl/_testmeta/interface_unexported.init:
+    github.com/goplus/llgo/cl/_testmeta/interface_unexported.init$guard
+github.com/goplus/llgo/cl/_testmeta/interface_unexported.main:
+    github.com/goplus/llgo/runtime/internal/runtime.AllocU
+    github.com/goplus/llgo/cl/_testmeta/interface_unexported.iface$SE5y-KS93u1u9p1qAf9LRB1hncS44rJIq27_JZbIQVo
+    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_unexported.T
+    github.com/goplus/llgo/runtime/internal/runtime.NewItab
+    github.com/goplus/llgo/cl/_testmeta/interface_unexported.use
+github.com/goplus/llgo/cl/_testmeta/interface_unexported.use:
+    github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData
+
+[UseIface]
+github.com/goplus/llgo/cl/_testmeta/interface_unexported.main:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_unexported.T
+
+[UseIfaceMethod]
+github.com/goplus/llgo/cl/_testmeta/interface_unexported.use:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_unexported.I github.com/goplus/llgo/cl/_testmeta/interface_unexported.m _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+
+[MethodInfo]
+*_llgo_github.com/goplus/llgo/cl/_testmeta/interface_unexported.T:
+    0 github.com/goplus/llgo/cl/_testmeta/interface_unexported.m _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/interface_unexported.(*T).m github.com/goplus/llgo/cl/_testmeta/interface_unexported.(*T).m
+_llgo_github.com/goplus/llgo/cl/_testmeta/interface_unexported.T:
+    0 github.com/goplus/llgo/cl/_testmeta/interface_unexported.m _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/interface_unexported.(*T).m github.com/goplus/llgo/cl/_testmeta/interface_unexported.T.m
+

--- a/cl/_testmeta/methodinfo_imported/in.go
+++ b/cl/_testmeta/methodinfo_imported/in.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"bytes"
+	"io"
+)
+
+func main() {
+	var r io.Reader = bytes.NewBuffer(nil)
+	_, _ = r.Read(nil)
+}

--- a/cl/_testmeta/methodinfo_imported/meta-expect.txt
+++ b/cl/_testmeta/methodinfo_imported/meta-expect.txt
@@ -1,0 +1,499 @@
+[TypeChildren]
+*[]_llgo_uint8:
+    []_llgo_uint8
+*_llgo_bool:
+    _llgo_bool
+*_llgo_bytes.Buffer:
+    _llgo_bytes.Buffer
+*_llgo_bytes.readOp:
+    _llgo_bytes.readOp
+*_llgo_error:
+    _llgo_error
+*_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
+    _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+*_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w:
+    _llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w
+*_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA:
+    _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
+*_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk:
+    _llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk
+*_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o:
+    _llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o
+*_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA:
+    _llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA
+*_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk:
+    _llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk
+*_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY:
+    _llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY
+*_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0:
+    _llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0
+*_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY:
+    _llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY
+*_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU:
+    _llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU
+*_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ:
+    _llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ
+*_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y:
+    _llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y
+*_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M:
+    _llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M
+*_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw:
+    _llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw
+*_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8:
+    _llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8
+*_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw:
+    _llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw
+*_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M:
+    _llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M
+*_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg:
+    _llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg
+*_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to:
+    _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to
+*_llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw:
+    _llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw
+*_llgo_int:
+    _llgo_int
+*_llgo_int32:
+    _llgo_int32
+*_llgo_int64:
+    _llgo_int64
+*_llgo_io.Reader:
+    _llgo_io.Reader
+*_llgo_io.Writer:
+    _llgo_io.Writer
+*_llgo_string:
+    _llgo_string
+*_llgo_uint8:
+    _llgo_uint8
+[]_llgo_uint8:
+    _llgo_uint8
+_llgo_bytes.Buffer:
+    []_llgo_uint8
+    _llgo_int
+    _llgo_bytes.readOp
+_llgo_error:
+    _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to
+_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w:
+    _llgo_error
+_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA:
+    _llgo_int
+_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk:
+    []_llgo_uint8
+    _llgo_int
+    _llgo_error
+_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o:
+    _llgo_uint8
+    _llgo_string
+    _llgo_error
+_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA:
+    _llgo_int
+_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk:
+    _llgo_bool
+_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY:
+    []_llgo_uint8
+_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0:
+    _llgo_uint8
+    []_llgo_uint8
+    _llgo_error
+_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY:
+    _llgo_int
+    []_llgo_uint8
+_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU:
+    _llgo_int
+_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ:
+    _llgo_uint8
+    _llgo_error
+_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y:
+    _llgo_int32
+    _llgo_int
+    _llgo_error
+_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M:
+    _llgo_int
+    _llgo_bool
+_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw:
+    _llgo_string
+    _llgo_int
+    _llgo_error
+_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8:
+    _llgo_io.Reader
+    _llgo_int64
+    _llgo_error
+_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw:
+    _llgo_int32
+    _llgo_int
+    _llgo_error
+_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M:
+    _llgo_io.Writer
+    _llgo_int64
+    _llgo_error
+_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg:
+    _llgo_uint8
+    _llgo_error
+_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to:
+    _llgo_string
+_llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw:
+    _llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk
+_llgo_io.Reader:
+    _llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk
+_llgo_io.Writer:
+    _llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk
+
+[InterfaceInfo]
+_llgo_io.Reader:
+    Read _llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk
+
+[OrdinaryEdges]
+*[]_llgo_uint8:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    []_llgo_uint8
+*_llgo_bool:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_bool
+*_llgo_bytes.Buffer:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_bytes.Buffer
+*_llgo_bytes.readOp:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_bytes.readOp
+*_llgo_error:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_error
+*_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+*_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w
+*_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
+*_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk
+*_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o
+*_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA
+*_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk
+*_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY
+*_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0
+*_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY
+*_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU
+*_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ
+*_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y
+*_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M
+*_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw
+*_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8
+*_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw
+*_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M
+*_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg
+*_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to
+*_llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw
+*_llgo_int:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_int
+*_llgo_int32:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_int32
+*_llgo_int64:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_int64
+*_llgo_io.Reader:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_io.Reader
+*_llgo_io.Writer:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_io.Writer
+*_llgo_string:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_string
+*_llgo_uint8:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_uint8
+[]_llgo_uint8:
+    *[]_llgo_uint8
+    _llgo_uint8
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal:
+    github.com/goplus/llgo/runtime/internal/runtime.interequal
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal32:
+    github.com/goplus/llgo/runtime/internal/runtime.memequal32
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64:
+    github.com/goplus/llgo/runtime/internal/runtime.memequal64
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8:
+    github.com/goplus/llgo/runtime/internal/runtime.memequal8
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr:
+    github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal:
+    github.com/goplus/llgo/runtime/internal/runtime.strequal
+_llgo_bool:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8
+    *_llgo_bool
+_llgo_bytes.Buffer:
+    *_llgo_bytes.Buffer
+    bytes.struct$8M6lRFZ7Fk2XCr2laNI9Y7uQtk2A8VDBrezMuq2Fkuo$fields
+_llgo_bytes.readOp:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8
+    *_llgo_bytes.readOp
+_llgo_error:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal
+    *_llgo_error
+    _llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU$imethods
+_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
+    *_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w:
+    *_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w
+    _llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w$out
+_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w$out:
+    _llgo_error
+_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA:
+    *_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
+    _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA$out
+_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA$out:
+    _llgo_int
+_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk:
+    *_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk
+    _llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk$in
+    _llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk$out
+_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk$in:
+    []_llgo_uint8
+_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk$out:
+    _llgo_int
+    _llgo_error
+_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o:
+    *_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o
+    _llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o$in
+    _llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o$out
+_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o$in:
+    _llgo_uint8
+_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o$out:
+    _llgo_string
+    _llgo_error
+_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA:
+    *_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA
+    _llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA$in
+_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA$in:
+    _llgo_int
+_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk:
+    *_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk
+    _llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk$out
+_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk$out:
+    _llgo_bool
+_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY:
+    *_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY
+    _llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY$out
+_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY$out:
+    []_llgo_uint8
+_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0:
+    *_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0
+    _llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0$in
+    _llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0$out
+_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0$in:
+    _llgo_uint8
+_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0$out:
+    []_llgo_uint8
+    _llgo_error
+_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY:
+    *_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY
+    _llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY$in
+    _llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY$out
+_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY$in:
+    _llgo_int
+_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY$out:
+    []_llgo_uint8
+_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU:
+    *_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU
+    _llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU$in
+    _llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU$out
+_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU$in:
+    _llgo_int
+_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU$out:
+    _llgo_int
+_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ:
+    *_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ
+    _llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ$out
+_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ$out:
+    _llgo_uint8
+    _llgo_error
+_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y:
+    *_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y
+    _llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y$out
+_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y$out:
+    _llgo_int32
+    _llgo_int
+    _llgo_error
+_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M:
+    *_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M
+    _llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M$in
+    _llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M$out
+_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M$in:
+    _llgo_int
+_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M$out:
+    _llgo_int
+    _llgo_bool
+_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw:
+    *_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw
+    _llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw$in
+    _llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw$out
+_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw$in:
+    _llgo_string
+_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw$out:
+    _llgo_int
+    _llgo_error
+_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8:
+    *_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8
+    _llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8$in
+    _llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8$out
+_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8$in:
+    _llgo_io.Reader
+_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8$out:
+    _llgo_int64
+    _llgo_error
+_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw:
+    *_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw
+    _llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw$in
+    _llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw$out
+_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw$in:
+    _llgo_int32
+_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw$out:
+    _llgo_int
+    _llgo_error
+_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M:
+    *_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M
+    _llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M$in
+    _llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M$out
+_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M$in:
+    _llgo_io.Writer
+_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M$out:
+    _llgo_int64
+    _llgo_error
+_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg:
+    *_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg
+    _llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg$in
+    _llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg$out
+_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg$in:
+    _llgo_uint8
+_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg$out:
+    _llgo_error
+_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to:
+    *_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to
+    _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to$out
+_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to$out:
+    _llgo_string
+_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU$imethods:
+    _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to
+_llgo_iface$kr1iSWwMezh0B9LdQN0MhEZUNZvBlHPhlst95jAyxE0$imethods:
+    _llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk
+_llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal
+    *_llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw
+    _llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw$imethods
+_llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw$imethods:
+    _llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk
+_llgo_int:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64
+    *_llgo_int
+_llgo_int32:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal32
+    *_llgo_int32
+_llgo_int64:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64
+    *_llgo_int64
+_llgo_io.Reader:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal
+    *_llgo_io.Reader
+    _llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw$imethods
+_llgo_io.Writer:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal
+    *_llgo_io.Writer
+    _llgo_iface$kr1iSWwMezh0B9LdQN0MhEZUNZvBlHPhlst95jAyxE0$imethods
+_llgo_string:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal
+    *_llgo_string
+_llgo_uint8:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal8
+    *_llgo_uint8
+bytes.struct$8M6lRFZ7Fk2XCr2laNI9Y7uQtk2A8VDBrezMuq2Fkuo$fields:
+    []_llgo_uint8
+    _llgo_int
+    _llgo_bytes.readOp
+github.com/goplus/llgo/cl/_testmeta/methodinfo_imported.init:
+    github.com/goplus/llgo/cl/_testmeta/methodinfo_imported.init$guard
+    bytes.init
+    io.init
+github.com/goplus/llgo/cl/_testmeta/methodinfo_imported.main:
+    bytes.NewBuffer
+    _llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw
+    *_llgo_bytes.Buffer
+    github.com/goplus/llgo/runtime/internal/runtime.NewItab
+    github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData
+
+[UseIface]
+github.com/goplus/llgo/cl/_testmeta/methodinfo_imported.main:
+    *_llgo_bytes.Buffer
+
+[UseIfaceMethod]
+github.com/goplus/llgo/cl/_testmeta/methodinfo_imported.main:
+    _llgo_io.Reader Read _llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk
+
+[MethodInfo]
+*_llgo_bytes.Buffer:
+    0 Available _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA bytes.(*Buffer).Available bytes.(*Buffer).Available
+    1 AvailableBuffer _llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY bytes.(*Buffer).AvailableBuffer bytes.(*Buffer).AvailableBuffer
+    2 Bytes _llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY bytes.(*Buffer).Bytes bytes.(*Buffer).Bytes
+    3 Cap _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA bytes.(*Buffer).Cap bytes.(*Buffer).Cap
+    4 Grow _llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA bytes.(*Buffer).Grow bytes.(*Buffer).Grow
+    5 Len _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA bytes.(*Buffer).Len bytes.(*Buffer).Len
+    6 Next _llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY bytes.(*Buffer).Next bytes.(*Buffer).Next
+    7 Read _llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk bytes.(*Buffer).Read bytes.(*Buffer).Read
+    8 ReadByte _llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ bytes.(*Buffer).ReadByte bytes.(*Buffer).ReadByte
+    9 ReadBytes _llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0 bytes.(*Buffer).ReadBytes bytes.(*Buffer).ReadBytes
+    10 ReadFrom _llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8 bytes.(*Buffer).ReadFrom bytes.(*Buffer).ReadFrom
+    11 ReadRune _llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y bytes.(*Buffer).ReadRune bytes.(*Buffer).ReadRune
+    12 ReadString _llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o bytes.(*Buffer).ReadString bytes.(*Buffer).ReadString
+    13 Reset _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac bytes.(*Buffer).Reset bytes.(*Buffer).Reset
+    14 String _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to bytes.(*Buffer).String bytes.(*Buffer).String
+    15 Truncate _llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA bytes.(*Buffer).Truncate bytes.(*Buffer).Truncate
+    16 UnreadByte _llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w bytes.(*Buffer).UnreadByte bytes.(*Buffer).UnreadByte
+    17 UnreadRune _llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w bytes.(*Buffer).UnreadRune bytes.(*Buffer).UnreadRune
+    18 Write _llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk bytes.(*Buffer).Write bytes.(*Buffer).Write
+    19 WriteByte _llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg bytes.(*Buffer).WriteByte bytes.(*Buffer).WriteByte
+    20 WriteRune _llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw bytes.(*Buffer).WriteRune bytes.(*Buffer).WriteRune
+    21 WriteString _llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw bytes.(*Buffer).WriteString bytes.(*Buffer).WriteString
+    22 WriteTo _llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M bytes.(*Buffer).WriteTo bytes.(*Buffer).WriteTo
+    23 bytes.empty _llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk bytes.(*Buffer).empty bytes.(*Buffer).empty
+    24 bytes.grow _llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU bytes.(*Buffer).grow bytes.(*Buffer).grow
+    25 bytes.readSlice _llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0 bytes.(*Buffer).readSlice bytes.(*Buffer).readSlice
+    26 bytes.tryGrowByReslice _llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M bytes.(*Buffer).tryGrowByReslice bytes.(*Buffer).tryGrowByReslice
+

--- a/cl/_testmeta/reflect_dynamic/in.go
+++ b/cl/_testmeta/reflect_dynamic/in.go
@@ -1,0 +1,15 @@
+package main
+
+import "reflect"
+
+type T struct{}
+
+func (T) M() {}
+
+func use(name string) {
+	_ = reflect.ValueOf(T{}).MethodByName(name)
+}
+
+func main() {
+	use("M")
+}

--- a/cl/_testmeta/reflect_dynamic/meta-expect.txt
+++ b/cl/_testmeta/reflect_dynamic/meta-expect.txt
@@ -1,0 +1,48 @@
+[TypeChildren]
+*_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
+    _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+*_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T
+
+[OrdinaryEdges]
+*_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+*_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0:
+    github.com/goplus/llgo/runtime/internal/runtime.memequal0
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr:
+    github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
+    *_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0
+    *_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T
+github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.(*T).M:
+    github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T.M
+github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.init:
+    github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.init$guard
+    reflect.init
+github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.main:
+    github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.use
+github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.use:
+    github.com/goplus/llgo/runtime/internal/runtime.AllocU
+    _llgo_github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T
+    reflect.ValueOf
+    reflect.Value.MethodByName
+
+[UseIface]
+github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.use:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T
+
+[MethodInfo]
+*_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T:
+    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.(*T).M github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.(*T).M
+_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T:
+    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.(*T).M github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.T.M
+
+[ReflectMethod]
+github.com/goplus/llgo/cl/_testmeta/reflect_dynamic.use
+

--- a/cl/_testmeta/reflect_method_index/in.go
+++ b/cl/_testmeta/reflect_method_index/in.go
@@ -1,0 +1,20 @@
+package main
+
+import "reflect"
+
+type T struct{}
+
+func (T) M() {}
+
+func useValue() {
+	_ = reflect.ValueOf(T{}).Method(0)
+}
+
+func useType() {
+	_ = reflect.TypeOf(T{}).Method(0)
+}
+
+func main() {
+	useValue()
+	useType()
+}

--- a/cl/_testmeta/reflect_method_index/meta-expect.txt
+++ b/cl/_testmeta/reflect_method_index/meta-expect.txt
@@ -1,0 +1,101 @@
+[TypeChildren]
+*_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
+    _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+*_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_method_index.T:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/reflect_method_index.T
+
+[InterfaceInfo]
+_llgo_reflect.Type:
+    Align _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
+    AssignableTo _llgo_func$Kxk9fspGkjXcoNWf2ucHG1vOQ5VHxVtYionfm-DnvWE
+    Bits _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
+    CanSeq _llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk
+    CanSeq2 _llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk
+    ChanDir _llgo_func$JO3khPIbANSMBmoN6P7ybYAeUBd3Gv6toVUqNeE7qbE
+    Comparable _llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk
+    ConvertibleTo _llgo_func$Kxk9fspGkjXcoNWf2ucHG1vOQ5VHxVtYionfm-DnvWE
+    Elem _llgo_func$b6KOG2Oj7wt8ogb9H8QPbhEfXhxMMjdxRZgPLK_UOwI
+    Field _llgo_func$Q3NYrysaKgu1MtMuLQwb-k5QcKGHihnt-tV_NlNJQFA
+    FieldAlign _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
+    FieldByIndex _llgo_func$LPPtiM49dEPl48CC3WRhXm3YPnfUJEZE_k8Tx3rMuSk
+    FieldByName _llgo_func$dEvABJ5r0MMUlf4smWpIDG5dO8AuGklGdNJ1xneL3UM
+    FieldByNameFunc _llgo_func$xySrXVFC_2LK2oP71R2UryKi6UmdEJUo9k6aQuz4TvI
+    Implements _llgo_func$Kxk9fspGkjXcoNWf2ucHG1vOQ5VHxVtYionfm-DnvWE
+    In _llgo_func$dPYu3A0LoGTV2Hd8PW4KPw2ITiUSo9q-4Bg9ZrPITnY
+    IsVariadic _llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk
+    Key _llgo_func$b6KOG2Oj7wt8ogb9H8QPbhEfXhxMMjdxRZgPLK_UOwI
+    Kind _llgo_func$w8Mj2LK8G5p7MIiGWR6MYjyXy3L8SVVzYlT1bb6KNXk
+    Len _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
+    Method _llgo_func$FmJJGomlX5kINJGxQdQDCAkD89ySoMslAYFrziWInVc
+    MethodByName _llgo_func$aM2cVUtLQbPq1YHtnabQiM7XJ5Cg5RyV6BIDWrqey7E
+    Name _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to
+    NumField _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
+    NumIn _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
+    NumMethod _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
+    NumOut _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
+    Out _llgo_func$dPYu3A0LoGTV2Hd8PW4KPw2ITiUSo9q-4Bg9ZrPITnY
+    OverflowComplex _llgo_func$cGkbH-2LQOLoq64Rqj3WeO56U8al7FfVkf5K1FFbPpE
+    OverflowFloat _llgo_func$uk7PgUVap9GZdvS8R_mZCDbAbqnAbcNryqybtDogUNI
+    OverflowInt _llgo_func$odFOIClZoEVGbTP_BEfZxVM5ex3r8Fj1afUEeP_awp8
+    OverflowUint _llgo_func$7I97sofX8UqJA96mVIy89KPUfSM_efkrR-mJQ9qaHfk
+    PkgPath _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to
+    Size _llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s
+    String _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to
+    reflect.common _llgo_func$w6XuV-1SmW103DbauPseXBpW50HpxXAEsUsGFibl0Uw
+    reflect.uncommon _llgo_func$iG49bujiXjI2lVflYdE0hPXlCAABL-XKRANSNJEKOio
+
+[OrdinaryEdges]
+*_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+*_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_method_index.T:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_github.com/goplus/llgo/cl/_testmeta/reflect_method_index.T
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0:
+    github.com/goplus/llgo/runtime/internal/runtime.memequal0
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr:
+    github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
+    *_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_method_index.T:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0
+    *_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_method_index.T
+github.com/goplus/llgo/cl/_testmeta/reflect_method_index.(*T).M:
+    github.com/goplus/llgo/cl/_testmeta/reflect_method_index.T.M
+github.com/goplus/llgo/cl/_testmeta/reflect_method_index.init:
+    github.com/goplus/llgo/cl/_testmeta/reflect_method_index.init$guard
+    reflect.init
+github.com/goplus/llgo/cl/_testmeta/reflect_method_index.main:
+    github.com/goplus/llgo/cl/_testmeta/reflect_method_index.useValue
+    github.com/goplus/llgo/cl/_testmeta/reflect_method_index.useType
+github.com/goplus/llgo/cl/_testmeta/reflect_method_index.useType:
+    github.com/goplus/llgo/runtime/internal/runtime.AllocU
+    _llgo_github.com/goplus/llgo/cl/_testmeta/reflect_method_index.T
+    reflect.TypeOf
+    github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData
+github.com/goplus/llgo/cl/_testmeta/reflect_method_index.useValue:
+    github.com/goplus/llgo/runtime/internal/runtime.AllocU
+    _llgo_github.com/goplus/llgo/cl/_testmeta/reflect_method_index.T
+    reflect.ValueOf
+    reflect.Value.Method
+
+[UseIface]
+github.com/goplus/llgo/cl/_testmeta/reflect_method_index.useType:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/reflect_method_index.T
+github.com/goplus/llgo/cl/_testmeta/reflect_method_index.useValue:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/reflect_method_index.T
+
+[UseIfaceMethod]
+github.com/goplus/llgo/cl/_testmeta/reflect_method_index.useType:
+    _llgo_reflect.Type Method _llgo_func$FmJJGomlX5kINJGxQdQDCAkD89ySoMslAYFrziWInVc
+
+[MethodInfo]
+*_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_method_index.T:
+    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/reflect_method_index.(*T).M github.com/goplus/llgo/cl/_testmeta/reflect_method_index.(*T).M
+_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_method_index.T:
+    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/reflect_method_index.(*T).M github.com/goplus/llgo/cl/_testmeta/reflect_method_index.T.M
+
+[ReflectMethod]
+github.com/goplus/llgo/cl/_testmeta/reflect_method_index.useType
+github.com/goplus/llgo/cl/_testmeta/reflect_method_index.useValue
+

--- a/cl/_testmeta/reflect_named/in.go
+++ b/cl/_testmeta/reflect_named/in.go
@@ -1,0 +1,13 @@
+package main
+
+import "reflect"
+
+type T struct{}
+
+func (T) M() {}
+func (T) m() {}
+
+func main() {
+	_, _ = reflect.TypeOf(T{}).MethodByName("M")
+	_, _ = reflect.TypeOf(T{}).MethodByName("m")
+}

--- a/cl/_testmeta/reflect_named/meta-expect.txt
+++ b/cl/_testmeta/reflect_named/meta-expect.txt
@@ -1,0 +1,96 @@
+[TypeChildren]
+*_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
+    _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+*_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_named.T:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/reflect_named.T
+
+[InterfaceInfo]
+_llgo_reflect.Type:
+    Align _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
+    AssignableTo _llgo_func$Kxk9fspGkjXcoNWf2ucHG1vOQ5VHxVtYionfm-DnvWE
+    Bits _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
+    CanSeq _llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk
+    CanSeq2 _llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk
+    ChanDir _llgo_func$JO3khPIbANSMBmoN6P7ybYAeUBd3Gv6toVUqNeE7qbE
+    Comparable _llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk
+    ConvertibleTo _llgo_func$Kxk9fspGkjXcoNWf2ucHG1vOQ5VHxVtYionfm-DnvWE
+    Elem _llgo_func$b6KOG2Oj7wt8ogb9H8QPbhEfXhxMMjdxRZgPLK_UOwI
+    Field _llgo_func$Q3NYrysaKgu1MtMuLQwb-k5QcKGHihnt-tV_NlNJQFA
+    FieldAlign _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
+    FieldByIndex _llgo_func$LPPtiM49dEPl48CC3WRhXm3YPnfUJEZE_k8Tx3rMuSk
+    FieldByName _llgo_func$dEvABJ5r0MMUlf4smWpIDG5dO8AuGklGdNJ1xneL3UM
+    FieldByNameFunc _llgo_func$xySrXVFC_2LK2oP71R2UryKi6UmdEJUo9k6aQuz4TvI
+    Implements _llgo_func$Kxk9fspGkjXcoNWf2ucHG1vOQ5VHxVtYionfm-DnvWE
+    In _llgo_func$dPYu3A0LoGTV2Hd8PW4KPw2ITiUSo9q-4Bg9ZrPITnY
+    IsVariadic _llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk
+    Key _llgo_func$b6KOG2Oj7wt8ogb9H8QPbhEfXhxMMjdxRZgPLK_UOwI
+    Kind _llgo_func$w8Mj2LK8G5p7MIiGWR6MYjyXy3L8SVVzYlT1bb6KNXk
+    Len _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
+    Method _llgo_func$FmJJGomlX5kINJGxQdQDCAkD89ySoMslAYFrziWInVc
+    MethodByName _llgo_func$aM2cVUtLQbPq1YHtnabQiM7XJ5Cg5RyV6BIDWrqey7E
+    Name _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to
+    NumField _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
+    NumIn _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
+    NumMethod _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
+    NumOut _llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA
+    Out _llgo_func$dPYu3A0LoGTV2Hd8PW4KPw2ITiUSo9q-4Bg9ZrPITnY
+    OverflowComplex _llgo_func$cGkbH-2LQOLoq64Rqj3WeO56U8al7FfVkf5K1FFbPpE
+    OverflowFloat _llgo_func$uk7PgUVap9GZdvS8R_mZCDbAbqnAbcNryqybtDogUNI
+    OverflowInt _llgo_func$odFOIClZoEVGbTP_BEfZxVM5ex3r8Fj1afUEeP_awp8
+    OverflowUint _llgo_func$7I97sofX8UqJA96mVIy89KPUfSM_efkrR-mJQ9qaHfk
+    PkgPath _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to
+    Size _llgo_func$1kITCsyu7hFLMxHLR7kDlvu4SOra_HtrtdFUQH9P13s
+    String _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to
+    reflect.common _llgo_func$w6XuV-1SmW103DbauPseXBpW50HpxXAEsUsGFibl0Uw
+    reflect.uncommon _llgo_func$iG49bujiXjI2lVflYdE0hPXlCAABL-XKRANSNJEKOio
+
+[OrdinaryEdges]
+*_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+*_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_named.T:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_github.com/goplus/llgo/cl/_testmeta/reflect_named.T
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0:
+    github.com/goplus/llgo/runtime/internal/runtime.memequal0
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr:
+    github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac:
+    *_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_named.T:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal0
+    *_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_named.T
+github.com/goplus/llgo/cl/_testmeta/reflect_named.(*T).M:
+    github.com/goplus/llgo/cl/_testmeta/reflect_named.T.M
+github.com/goplus/llgo/cl/_testmeta/reflect_named.(*T).m:
+    github.com/goplus/llgo/cl/_testmeta/reflect_named.T.m
+github.com/goplus/llgo/cl/_testmeta/reflect_named.init:
+    github.com/goplus/llgo/cl/_testmeta/reflect_named.init$guard
+    reflect.init
+github.com/goplus/llgo/cl/_testmeta/reflect_named.main:
+    github.com/goplus/llgo/runtime/internal/runtime.AllocU
+    _llgo_github.com/goplus/llgo/cl/_testmeta/reflect_named.T
+    reflect.TypeOf
+    github.com/goplus/llgo/runtime/internal/runtime.IfacePtrData
+
+[UseIface]
+github.com/goplus/llgo/cl/_testmeta/reflect_named.main:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/reflect_named.T
+
+[UseIfaceMethod]
+github.com/goplus/llgo/cl/_testmeta/reflect_named.main:
+    _llgo_reflect.Type MethodByName _llgo_func$aM2cVUtLQbPq1YHtnabQiM7XJ5Cg5RyV6BIDWrqey7E
+
+[MethodInfo]
+*_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_named.T:
+    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/reflect_named.(*T).M github.com/goplus/llgo/cl/_testmeta/reflect_named.(*T).M
+    1 github.com/goplus/llgo/cl/_testmeta/reflect_named.m _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/reflect_named.(*T).m github.com/goplus/llgo/cl/_testmeta/reflect_named.(*T).m
+_llgo_github.com/goplus/llgo/cl/_testmeta/reflect_named.T:
+    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/reflect_named.(*T).M github.com/goplus/llgo/cl/_testmeta/reflect_named.T.M
+    1 github.com/goplus/llgo/cl/_testmeta/reflect_named.m _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/reflect_named.(*T).m github.com/goplus/llgo/cl/_testmeta/reflect_named.T.m
+
+[UseNamedMethod]
+github.com/goplus/llgo/cl/_testmeta/reflect_named.main:
+    M
+    m
+

--- a/cl/_testmeta/typechildren_basic/in.go
+++ b/cl/_testmeta/typechildren_basic/in.go
@@ -1,0 +1,16 @@
+package main
+
+type Inner struct {
+	S string
+}
+
+type Outer struct {
+	I Inner
+	N int
+}
+
+func use(any) {}
+
+func main() {
+	use(Outer{})
+}

--- a/cl/_testmeta/typechildren_basic/meta-expect.txt
+++ b/cl/_testmeta/typechildren_basic/meta-expect.txt
@@ -1,0 +1,64 @@
+[TypeChildren]
+*_llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Inner:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Inner
+*_llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Outer:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Outer
+*_llgo_int:
+    _llgo_int
+*_llgo_string:
+    _llgo_string
+_llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Inner:
+    _llgo_string
+_llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Outer:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Inner
+    _llgo_int
+
+[OrdinaryEdges]
+*_llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Inner:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Inner
+*_llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Outer:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Outer
+*_llgo_int:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_int
+*_llgo_string:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+    _llgo_string
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64:
+    github.com/goplus/llgo/runtime/internal/runtime.memequal64
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequalptr:
+    github.com/goplus/llgo/runtime/internal/runtime.memequalptr
+__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal:
+    github.com/goplus/llgo/runtime/internal/runtime.strequal
+_llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Inner:
+    github.com/goplus/llgo/runtime/internal/runtime.structequal
+    *_llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Inner
+    _llgo_struct$MTAKiWNMPODH0G9-y5PI3BUGLd6hRciSbX1QTpCDOZg$fields
+_llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Outer:
+    github.com/goplus/llgo/runtime/internal/runtime.structequal
+    *_llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Outer
+    _llgo_struct$VaHvQdd7oPMFznC6BSA9M_OXdmuO77w_Ys1GnWZpjRM$fields
+_llgo_int:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.memequal64
+    *_llgo_int
+_llgo_string:
+    __llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.strequal
+    *_llgo_string
+_llgo_struct$MTAKiWNMPODH0G9-y5PI3BUGLd6hRciSbX1QTpCDOZg$fields:
+    _llgo_string
+_llgo_struct$VaHvQdd7oPMFznC6BSA9M_OXdmuO77w_Ys1GnWZpjRM$fields:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Inner
+    _llgo_int
+github.com/goplus/llgo/cl/_testmeta/typechildren_basic.init:
+    github.com/goplus/llgo/cl/_testmeta/typechildren_basic.init$guard
+github.com/goplus/llgo/cl/_testmeta/typechildren_basic.main:
+    github.com/goplus/llgo/runtime/internal/runtime.AllocU
+    _llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Outer
+    github.com/goplus/llgo/cl/_testmeta/typechildren_basic.use
+
+[UseIface]
+github.com/goplus/llgo/cl/_testmeta/typechildren_basic.main:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/typechildren_basic.Outer
+

--- a/cl/cltest/cltest.go
+++ b/cl/cltest/cltest.go
@@ -358,7 +358,9 @@ func withModuleCapture(conf *build.Config, pkgDir string) (*build.Config, *strin
 			return filepath.Dir(file) == pkgDir
 		}) {
 			module = pkg.LPkg.String()
-			meta = metadata.MetaString(pkg.Meta)
+			if pkg.Meta != nil {
+				meta = metadata.MetaString(pkg.Meta)
+			}
 		}
 	}
 	return &localConf, &module, &meta

--- a/cl/cltest/cltest.go
+++ b/cl/cltest/cltest.go
@@ -39,6 +39,7 @@ import (
 	"github.com/goplus/llgo/internal/build"
 	"github.com/goplus/llgo/internal/littest"
 	"github.com/goplus/llgo/internal/llgen"
+	"github.com/goplus/llgo/internal/metadata"
 	"github.com/goplus/llgo/internal/mockable"
 	"github.com/goplus/llgo/ssa/ssatest"
 	"github.com/qiniu/x/test"
@@ -66,6 +67,7 @@ type runOptions struct {
 	filter      func(string) string
 	checkIR     bool
 	checkOutput bool
+	checkMeta   bool
 }
 
 // RunOption customizes directory-based test behavior.
@@ -96,6 +98,13 @@ func WithOutputCheck(enabled bool) RunOption {
 func WithIRCheck(enabled bool) RunOption {
 	return func(opts *runOptions) {
 		opts.checkIR = enabled
+	}
+}
+
+// WithMetaCheck enables or disables package metadata golden checks.
+func WithMetaCheck(enabled bool) RunOption {
+	return func(opts *runOptions) {
+		opts.checkMeta = enabled
 	}
 }
 
@@ -243,12 +252,22 @@ func testRunAndTestFrom(t *testing.T, pkgDir, relPkg, sel string, opts runOption
 		if opts.checkIR {
 			testFrom(t, pkgDir, sel)
 		}
+		if opts.checkMeta {
+			conf, _, capturedMeta := withModuleCapture(opts.conf, pkgDir)
+			output, err := runWithConf(relPkg, pkgDir, conf)
+			if err != nil {
+				t.Logf("raw output:\n%s", string(output))
+				t.Fatalf("run failed: %v\noutput: %s", err, string(output))
+			}
+			assertExpectedMeta(t, pkgDir, relPkg, capturedMeta)
+		}
 		return
 	}
 
 	var irSpec littest.Spec
 	conf := opts.conf
 	var capturedIR *string
+	var capturedMeta *string
 	var checkIR bool
 	if opts.checkIR {
 		irSpec, checkIR, err = readIRSpec(pkgDir)
@@ -256,8 +275,11 @@ func testRunAndTestFrom(t *testing.T, pkgDir, relPkg, sel string, opts runOption
 			t.Fatal("LoadSpec failed:", err)
 		}
 		if checkIR {
-			conf, capturedIR = withModuleCapture(opts.conf, pkgDir)
+			conf, capturedIR, capturedMeta = withModuleCapture(opts.conf, pkgDir)
 		}
+	}
+	if opts.checkMeta && capturedMeta == nil {
+		conf, capturedIR, capturedMeta = withModuleCapture(conf, pkgDir)
 	}
 
 	output, err := runWithConf(relPkg, pkgDir, conf)
@@ -267,6 +289,9 @@ func testRunAndTestFrom(t *testing.T, pkgDir, relPkg, sel string, opts runOption
 	}
 
 	assertExpectedOutput(t, pkgDir, expectedOutput, output, opts)
+	if opts.checkMeta {
+		assertExpectedMeta(t, pkgDir, relPkg, capturedMeta)
+	}
 	if !checkIR {
 		return
 	}
@@ -279,9 +304,36 @@ func testRunAndTestFrom(t *testing.T, pkgDir, relPkg, sel string, opts runOption
 	}
 }
 
+func assertExpectedMeta(t *testing.T, pkgDir, relPkg string, capturedMeta *string) {
+	t.Helper()
+	expectedMeta, hasMeta, err := readGolden(filepath.Join(pkgDir, "meta-expect.txt"))
+	if err != nil {
+		t.Fatal("ReadFile failed:", err)
+	}
+	if !hasMeta {
+		t.Fatal("missing meta-expect.txt")
+	}
+	if capturedMeta == nil {
+		t.Fatalf("metadata snapshot missing for %s", relPkg)
+	}
+	if test.Diff(t, filepath.Join(pkgDir, "meta-expect.txt.new"), []byte(*capturedMeta), expectedMeta) {
+		t.Fatal("metadata: unexpected result")
+	}
+}
+
 func RunAndCapture(relPkg, pkgDir string) ([]byte, error) {
 	conf := build.NewDefaultConf(build.ModeRun)
 	return RunAndCaptureWithConf(relPkg, pkgDir, conf)
+}
+
+// CaptureMeta builds relPkg and returns the package metadata captured for pkgDir.
+func CaptureMeta(relPkg, pkgDir string) (string, error) {
+	conf, _, capturedMeta := withModuleCapture(build.NewDefaultConf(build.ModeRun), pkgDir)
+	output, err := runWithConf(relPkg, pkgDir, conf)
+	if err != nil {
+		return "", fmt.Errorf("%w\noutput: %s", err, string(output))
+	}
+	return *capturedMeta, nil
 }
 
 // RunAndCaptureWithConf runs llgo with a custom build config and captures output.
@@ -289,12 +341,14 @@ func RunAndCaptureWithConf(relPkg, pkgDir string, conf *build.Config) ([]byte, e
 	return runWithConf(relPkg, pkgDir, conf)
 }
 
-func withModuleCapture(conf *build.Config, pkgDir string) (*build.Config, *string) {
+func withModuleCapture(conf *build.Config, pkgDir string) (*build.Config, *string, *string) {
 	if conf == nil {
 		conf = build.NewDefaultConf(build.ModeRun)
 	}
 	localConf := *conf
+	localConf.CaptureMeta = true
 	var module string
+	var meta string
 	prevHook := localConf.ModuleHook
 	localConf.ModuleHook = func(pkg build.Package) {
 		if prevHook != nil {
@@ -304,9 +358,10 @@ func withModuleCapture(conf *build.Config, pkgDir string) (*build.Config, *strin
 			return filepath.Dir(file) == pkgDir
 		}) {
 			module = pkg.LPkg.String()
+			meta = metadata.MetaString(pkg.Meta)
 		}
 	}
-	return &localConf, &module
+	return &localConf, &module, &meta
 }
 
 func runWithConf(relPkg, pkgDir string, conf *build.Config) ([]byte, error) {

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/goplus/llgo/cl/blocks"
 	"github.com/goplus/llgo/internal/goembed"
+	"github.com/goplus/llgo/internal/metadata"
 	"github.com/goplus/llgo/internal/typepatch"
 	"golang.org/x/tools/go/ssa"
 
@@ -1407,17 +1408,17 @@ func NewPackage(prog llssa.Program, pkg *ssa.Package, files []*ast.File) (ret ll
 // The rewrites map uses short variable names (without package qualifier) and
 // only affects string-typed globals defined in the current package.
 func NewPackageEx(prog llssa.Program, patches Patches, rewrites map[string]string, pkg *ssa.Package, files []*ast.File) (ret llssa.Package, externs []string, err error) {
-	return newPackageEx(prog, patches, rewrites, pkg, files, nil)
+	return newPackageEx(prog, patches, rewrites, pkg, files, nil, nil)
 }
 
 // NewPackageExWithEmbed compiles a package using pre-loaded go:embed metadata.
 //
 // This avoids re-scanning directives when the caller already loaded them.
-func NewPackageExWithEmbed(prog llssa.Program, patches Patches, rewrites map[string]string, pkg *ssa.Package, files []*ast.File, embedMap goembed.VarMap) (ret llssa.Package, externs []string, err error) {
-	return newPackageEx(prog, patches, rewrites, pkg, files, &embedMap)
+func NewPackageExWithEmbed(prog llssa.Program, patches Patches, rewrites map[string]string, pkg *ssa.Package, files []*ast.File, embedMap goembed.VarMap, metaBuilder *metadata.Builder) (ret llssa.Package, externs []string, err error) {
+	return newPackageEx(prog, patches, rewrites, pkg, files, &embedMap, metaBuilder)
 }
 
-func newPackageEx(prog llssa.Program, patches Patches, rewrites map[string]string, pkg *ssa.Package, files []*ast.File, embedMap *goembed.VarMap) (ret llssa.Package, externs []string, err error) {
+func newPackageEx(prog llssa.Program, patches Patches, rewrites map[string]string, pkg *ssa.Package, files []*ast.File, embedMap *goembed.VarMap, metaBuilder *metadata.Builder) (ret llssa.Package, externs []string, err error) {
 	pkgProg := pkg.Prog
 	pkgTypes := pkg.Pkg
 	oldTypes := pkgTypes
@@ -1432,6 +1433,7 @@ func newPackageEx(prog llssa.Program, patches Patches, rewrites map[string]strin
 		prog.SetRuntime(pkgTypes)
 	}
 	ret = prog.NewPackage(pkgName, pkgPath)
+	ret.MetaBuilder = metaBuilder
 	if enableDbg {
 		ret.InitDebug(pkgName, pkgPath, pkgProg.Fset)
 	}

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -173,6 +173,14 @@ func TestRunAndTestFromTestgo(t *testing.T) {
 	cltest.RunAndTestFromDir(t, "", "./_testgo", nil)
 }
 
+func TestRunAndTestFromTestmeta(t *testing.T) {
+	cltest.RunAndTestFromDir(t, "", "./_testmeta", nil,
+		cltest.WithOutputCheck(false),
+		cltest.WithIRCheck(false),
+		cltest.WithMetaCheck(true),
+	)
+}
+
 func TestFilterEmulatorOutput(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cl/embed_with_map_compile_test.go
+++ b/cl/embed_with_map_compile_test.go
@@ -57,7 +57,7 @@ var files embed.FS
 
 	prog := ssatest.NewProgramEx(t, nil, imp)
 	prog.TypeSizes(types.SizesFor("gc", runtime.GOARCH))
-	ret, _, err := cl.NewPackageExWithEmbed(prog, nil, nil, fooPkg, files, embedMap)
+	ret, _, err := cl.NewPackageExWithEmbed(prog, nil, nil, fooPkg, files, embedMap, nil)
 	if err != nil {
 		t.Fatalf("NewPackageExWithEmbed failed: %v", err)
 	}

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/goplus/llgo/internal/metadata"
 	"golang.org/x/tools/go/ssa"
 
 	llssa "github.com/goplus/llgo/ssa"
@@ -51,6 +52,65 @@ func constBool(v ssa.Value) (ret bool, ok bool) {
 		}
 	}
 	return
+}
+
+func isNamedType(t types.Type, pkgPath, name string) bool {
+	named, ok := types.Unalias(t).(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj != nil && obj.Name() == name && obj.Pkg() != nil && obj.Pkg().Path() == pkgPath
+}
+
+func staticCallMethod(call *ssa.CallCommon) (recv types.Type, method string, ok bool) {
+	fn := call.StaticCallee()
+	if fn == nil || fn.Signature == nil || fn.Signature.Recv() == nil {
+		return nil, "", false
+	}
+	return fn.Signature.Recv().Type(), fn.Name(), true
+}
+
+func reflectMethodNameArg(call *ssa.CallCommon) (nameArg ssa.Value, ok bool) {
+	if method := call.Method; method != nil {
+		if !isNamedType(call.Value.Type(), "reflect", "Type") {
+			return nil, false
+		}
+		if method.Name() != "MethodByName" {
+			return nil, method.Name() == "Method"
+		}
+		return call.Args[0], true
+	}
+
+	recv, methodName, ok := staticCallMethod(call)
+	if !ok || !isNamedType(recv, "reflect", "Value") {
+		return nil, false
+	}
+	if methodName != "MethodByName" {
+		return nil, methodName == "Method"
+	}
+	return call.Args[len(call.Args)-1], true
+}
+
+func (p *context) markReflectMethodCall(call *ssa.CallCommon) {
+	if p.fn == nil || p.pkg.MetaBuilder == nil {
+		return
+	}
+	nameArg, ok := reflectMethodNameArg(call)
+	if !ok {
+		return
+	}
+	mb := p.pkg.MetaBuilder
+	owner := mb.Symbol(p.fn.Name())
+	if nameArg == nil {
+		mb.AddReflectMethod(owner)
+		return
+	}
+	if name, ok := constStr(nameArg); ok {
+		mb.AddUseNamedMethod(owner, []metadata.Name{mb.Name(name)})
+		return
+	}
+	mb.AddReflectMethod(owner)
 }
 
 // func pystr(string) *py.Object
@@ -839,6 +899,7 @@ func (p *context) emitDo(b llssa.Builder, act llssa.DoAction, ds *explicitDeferS
 }
 
 func (p *context) callEx(b llssa.Builder, act llssa.DoAction, call *ssa.CallCommon, ds *explicitDeferStack) (ret llssa.Expr) {
+	p.markReflectMethodCall(call)
 	cv := call.Value
 	if mthd := call.Method; mthd != nil {
 		o := p.compileValue(b, cv)

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -46,6 +46,7 @@ import (
 	"github.com/goplus/llgo/internal/flash"
 	"github.com/goplus/llgo/internal/goembed"
 	"github.com/goplus/llgo/internal/header"
+	"github.com/goplus/llgo/internal/metadata"
 	"github.com/goplus/llgo/internal/mockable"
 	"github.com/goplus/llgo/internal/monitor"
 	"github.com/goplus/llgo/internal/optlevel"
@@ -158,6 +159,7 @@ type Config struct {
 	// packages in the current build.
 	GlobalRewrites map[string]Rewrites
 	ModuleHook     ModuleHook
+	CaptureMeta    bool // collect in-memory package metadata for tests/debugging
 }
 
 type Rewrites map[string]string
@@ -1267,10 +1269,18 @@ func buildPkg(ctx *context, aPkg *aPackage, verbose bool) error {
 		return fmt.Errorf("load go:embed directives for %s failed: %w", pkgPath, err)
 	}
 
-	ret, externs, err := cl.NewPackageExWithEmbed(ctx.prog, ctx.patches, aPkg.rewriteVars, aPkg.SSA, syntax, embedMap)
+	var metaBuilder *metadata.Builder
+	if ctx.buildConf.CaptureMeta && !aPkg.CacheHit {
+		metaBuilder = metadata.NewBuilder()
+	}
+	ret, externs, err := cl.NewPackageExWithEmbed(ctx.prog, ctx.patches, aPkg.rewriteVars, aPkg.SSA, syntax, embedMap, metaBuilder)
 	check(err)
 
 	aPkg.LPkg = ret
+	if metaBuilder != nil {
+		extractOrdinaryEdges(metaBuilder, ret.Module())
+		aPkg.Meta = metaBuilder.Build()
+	}
 	if hook := ctx.buildConf.ModuleHook; hook != nil {
 		hook(aPkg)
 	}
@@ -1554,6 +1564,7 @@ type aPackage struct {
 	LinkArgs    []string
 	ObjFiles    []string // object files: .o or .ll (output of compiler, input to archiver)
 	ArchiveFile string   // archive file: .a (output of archiver, used for linking)
+	Meta        *metadata.PackageMeta
 	rewriteVars map[string]string
 
 	// Cache related fields

--- a/internal/build/metadata_edges.go
+++ b/internal/build/metadata_edges.go
@@ -1,0 +1,133 @@
+package build
+
+import (
+	"strings"
+
+	"github.com/goplus/llgo/internal/metadata"
+	"github.com/xgo-dev/llvm"
+)
+
+func extractOrdinaryEdges(builder *metadata.Builder, mod llvm.Module) {
+	if builder == nil {
+		return
+	}
+	for fn := mod.FirstFunction(); !fn.IsNil(); fn = llvm.NextFunction(fn) {
+		src := fn.Name()
+		if src == "" || fn.IsDeclaration() {
+			continue
+		}
+		collector := ordinaryEdgeCollector{builder: builder, src: src}
+		for bb := fn.FirstBasicBlock(); !bb.IsNil(); bb = llvm.NextBasicBlock(bb) {
+			for instr := bb.FirstInstruction(); !instr.IsNil(); instr = llvm.NextInstruction(instr) {
+				collector.scanOperands(instr)
+			}
+		}
+	}
+	for global := mod.FirstGlobal(); !global.IsNil(); global = llvm.NextGlobal(global) {
+		src := global.Name()
+		if src == "" {
+			continue
+		}
+		init := global.Initializer()
+		if init.IsNil() {
+			continue
+		}
+		collector := ordinaryEdgeCollector{builder: builder, src: src}
+		collector.scanGlobalInitializer(init)
+	}
+}
+
+type ordinaryEdgeCollector struct {
+	builder *metadata.Builder
+	src     string
+	seen    map[llvm.Value]struct{}
+}
+
+func (c *ordinaryEdgeCollector) scanGlobalInitializer(v llvm.Value) {
+	if isUncommonTypeInitializer(v) {
+		for i, n := 0, v.OperandsCount(); i < n; i++ {
+			if i == 2 {
+				continue
+			}
+			c.scan(v.Operand(i))
+		}
+		return
+	}
+	c.scan(v)
+}
+
+func (c *ordinaryEdgeCollector) scanOperands(v llvm.Value) {
+	for i, n := 0, v.OperandsCount(); i < n; i++ {
+		c.scan(v.Operand(i))
+	}
+}
+
+func (c *ordinaryEdgeCollector) scan(v llvm.Value) {
+	if v.IsNil() {
+		return
+	}
+	if isMethodTable(v) {
+		return
+	}
+	if name := namedModuleSymbol(v); name != "" {
+		c.add(name)
+		return
+	}
+	if v.IsAConstant().IsNil() {
+		return
+	}
+	if c.seen == nil {
+		c.seen = make(map[llvm.Value]struct{})
+	}
+	if _, ok := c.seen[v]; ok {
+		return
+	}
+	c.seen[v] = struct{}{}
+	for i, n := 0, v.OperandsCount(); i < n; i++ {
+		c.scan(v.Operand(i))
+	}
+}
+
+func (c *ordinaryEdgeCollector) add(dst string) {
+	if dst == "" || dst == c.src {
+		return
+	}
+	c.builder.AddEdge(c.builder.Symbol(c.src), c.builder.Symbol(dst))
+}
+
+func namedModuleSymbol(v llvm.Value) string {
+	if !v.IsAFunction().IsNil() || !v.IsAGlobalVariable().IsNil() {
+		return v.Name()
+	}
+	return ""
+}
+
+func isUncommonTypeInitializer(v llvm.Value) bool {
+	if v.IsAConstantStruct().IsNil() || v.OperandsCount() != 3 {
+		return false
+	}
+	return isMethodTable(v.Operand(2))
+}
+
+func isMethodTable(v llvm.Value) bool {
+	if v.IsNil() || v.IsAConstantArray().IsNil() || v.OperandsCount() == 0 {
+		return false
+	}
+	methodTy := v.Type().ElementType()
+	if methodTy.TypeKind() != llvm.StructTypeKind {
+		return false
+	}
+	if strings.HasSuffix(methodTy.StructName(), ".Method") {
+		return true
+	}
+	for i, n := 0, v.OperandsCount(); i < n; i++ {
+		method := v.Operand(i)
+		if method.IsAConstantStruct().IsNil() || method.OperandsCount() != 4 {
+			return false
+		}
+		if namedModuleSymbol(method.Operand(2)) == "" || namedModuleSymbol(method.Operand(3)) == "" {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/build/metadata_edges_test.go
+++ b/internal/build/metadata_edges_test.go
@@ -1,0 +1,106 @@
+package build
+
+import (
+	"testing"
+
+	"github.com/goplus/llgo/internal/metadata"
+	"github.com/xgo-dev/llvm"
+)
+
+func TestExtractOrdinaryEdgesFromFunctionAndGlobal(t *testing.T) {
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	mod := ctx.NewModule("ordinary")
+	defer mod.Dispose()
+
+	voidTy := ctx.VoidType()
+	fnTy := llvm.FunctionType(voidTy, nil, false)
+	mainFn := llvm.AddFunction(mod, "pkg.main", fnTy)
+	helperFn := llvm.AddFunction(mod, "pkg.helper", fnTy)
+
+	b := ctx.NewBuilder()
+	defer b.Dispose()
+	entry := ctx.AddBasicBlock(mainFn, "entry")
+	b.SetInsertPointAtEnd(entry)
+	b.CreateCall(fnTy, helperFn, nil, "")
+	b.CreateRetVoid()
+
+	global := llvm.AddGlobal(mod, llvm.PointerType(fnTy, 0), "pkg.global")
+	global.SetInitializer(helperFn)
+
+	mb := metadata.NewBuilder()
+	extractOrdinaryEdges(mb, mod)
+	pm := mb.Build()
+
+	mainSym := mb.Symbol("pkg.main")
+	helperSym := mb.Symbol("pkg.helper")
+	globalSym := mb.Symbol("pkg.global")
+
+	if !hasOrdinaryEdge(pm, mainSym, helperSym) {
+		t.Fatalf("missing ordinary edge pkg.main -> pkg.helper")
+	}
+	if !hasOrdinaryEdge(pm, globalSym, helperSym) {
+		t.Fatalf("missing ordinary edge pkg.global -> pkg.helper")
+	}
+}
+
+func TestExtractOrdinaryEdgesSkipsUncommonMethodTable(t *testing.T) {
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	mod := ctx.NewModule("ordinary")
+	defer mod.Dispose()
+
+	voidTy := ctx.VoidType()
+	fnTy := llvm.FunctionType(voidTy, nil, false)
+	ifn := llvm.AddFunction(mod, "pkg.(*T).M", fnTy)
+	tfn := llvm.AddFunction(mod, "pkg.T.M", fnTy)
+
+	i8ptrTy := llvm.PointerType(ctx.Int8Type(), 0)
+	methodTy := ctx.StructCreateNamed("runtime/internal/runtime.Method")
+	methodTy.StructSetBody([]llvm.Type{i8ptrTy, i8ptrTy, llvm.PointerType(fnTy, 0), llvm.PointerType(fnTy, 0)}, false)
+	methods := llvm.ConstArray(methodTy, []llvm.Value{
+		llvm.ConstNamedStruct(methodTy, []llvm.Value{
+			llvm.ConstNull(i8ptrTy),
+			llvm.ConstNull(i8ptrTy),
+			ifn,
+			tfn,
+		}),
+	})
+
+	typeTy := ctx.StructCreateNamed("pkg.T.type")
+	typeTy.StructSetBody([]llvm.Type{i8ptrTy, i8ptrTy, methods.Type()}, false)
+	typeDesc := llvm.AddGlobal(mod, typeTy, "_llgo_pkg.T")
+	typeDesc.SetInitializer(llvm.ConstNamedStruct(typeTy, []llvm.Value{
+		llvm.ConstNull(i8ptrTy),
+		llvm.ConstNull(i8ptrTy),
+		methods,
+	}))
+
+	mb := metadata.NewBuilder()
+	extractOrdinaryEdges(mb, mod)
+	pm := mb.Build()
+
+	typeSym := mb.Symbol("_llgo_pkg.T")
+	if hasOrdinaryEdge(pm, typeSym, mb.Symbol("pkg.(*T).M")) {
+		t.Fatalf("method table IFn was recorded as an ordinary edge")
+	}
+	if hasOrdinaryEdge(pm, typeSym, mb.Symbol("pkg.T.M")) {
+		t.Fatalf("method table TFn was recorded as an ordinary edge")
+	}
+}
+
+func hasOrdinaryEdge(pm *metadata.PackageMeta, src, dst metadata.Symbol) bool {
+	found := false
+	pm.ForEachOrdinaryEdge(func(edgeSrc metadata.Symbol, dsts []metadata.Symbol) {
+		if edgeSrc != src {
+			return
+		}
+		for _, edgeDst := range dsts {
+			if edgeDst == dst {
+				found = true
+				return
+			}
+		}
+	})
+	return found
+}

--- a/internal/metadata/builder.go
+++ b/internal/metadata/builder.go
@@ -1,0 +1,135 @@
+package metadata
+
+// Builder accumulates per-package metadata facts and builds a PackageMeta.
+type Builder struct {
+	pm      *PackageMeta
+	strToID map[string]uint32
+}
+
+// NewBuilder creates an empty metadata builder.
+func NewBuilder() *Builder {
+	return &Builder{
+		pm:      NewPackageMeta(nil),
+		strToID: make(map[string]uint32),
+	}
+}
+
+// Symbol registers a module-level named symbol.
+func (b *Builder) Symbol(s string) Symbol {
+	return Symbol(b.intern(s))
+}
+
+// Name registers a plain semantic name.
+func (b *Builder) Name(s string) Name {
+	return Name(b.intern(s))
+}
+
+func (b *Builder) intern(s string) uint32 {
+	if id, ok := b.strToID[s]; ok {
+		return id
+	}
+	id := uint32(len(b.strToID))
+	b.strToID[s] = id
+	return id
+}
+
+// AddEdge records an ordinary reachability edge src -> dst.
+func (b *Builder) AddEdge(src, dst Symbol) {
+	addUniqueSymbol(&b.pm.ordinaryEdges, src, dst)
+}
+
+// AddTypeChild records that parent type references child type.
+func (b *Builder) AddTypeChild(parent, child Symbol) {
+	addUniqueSymbol(&b.pm.typeChildren, parent, child)
+}
+
+// AddIfaceEntry records the method set of an interface type.
+func (b *Builder) AddIfaceEntry(iface Symbol, methods []MethodSig) {
+	for _, method := range methods {
+		addUniqueMethodSig(&b.pm.interfaceInfo, iface, method)
+	}
+}
+
+// AddUseIface records types converted to interface when owner is reachable.
+func (b *Builder) AddUseIface(owner Symbol, types []Symbol) {
+	for _, typ := range types {
+		addUniqueSymbol(&b.pm.useIface, owner, typ)
+	}
+}
+
+// AddUseIfaceMethod records interface method calls when owner is reachable.
+func (b *Builder) AddUseIfaceMethod(owner Symbol, demands []IfaceMethodDemand) {
+	for _, demand := range demands {
+		addUniqueIfaceMethodDemand(&b.pm.useIfaceMethod, owner, demand)
+	}
+}
+
+// AddMethodInfo records concrete type method table slots.
+func (b *Builder) AddMethodInfo(typeID Symbol, slots []MethodSlot) {
+	if len(slots) == 0 {
+		return
+	}
+	b.pm.methodInfo[typeID] = append(b.pm.methodInfo[typeID], slots...)
+}
+
+// AddUseNamedMethod records constant MethodByName method names.
+func (b *Builder) AddUseNamedMethod(owner Symbol, names []Name) {
+	for _, name := range names {
+		addUniqueName(&b.pm.useNamedMethod, owner, name)
+	}
+}
+
+// AddReflectMethod records that owner triggers conservative reflection handling.
+func (b *Builder) AddReflectMethod(owner Symbol) {
+	b.pm.reflectMethod[owner] = struct{}{}
+}
+
+// Build finalizes the builder and returns the package metadata.
+func (b *Builder) Build() *PackageMeta {
+	table := make([]string, len(b.strToID))
+	for s, id := range b.strToID {
+		table[id] = s
+	}
+	b.pm.stringTable = table
+	return b.pm
+}
+
+func addUniqueSymbol(m *map[Symbol][]Symbol, key, value Symbol) {
+	values := (*m)[key]
+	for _, existing := range values {
+		if existing == value {
+			return
+		}
+	}
+	(*m)[key] = append(values, value)
+}
+
+func addUniqueName(m *map[Symbol][]Name, key Symbol, value Name) {
+	values := (*m)[key]
+	for _, existing := range values {
+		if existing == value {
+			return
+		}
+	}
+	(*m)[key] = append(values, value)
+}
+
+func addUniqueMethodSig(m *map[Symbol][]MethodSig, key Symbol, value MethodSig) {
+	values := (*m)[key]
+	for _, existing := range values {
+		if existing == value {
+			return
+		}
+	}
+	(*m)[key] = append(values, value)
+}
+
+func addUniqueIfaceMethodDemand(m *map[Symbol][]IfaceMethodDemand, key Symbol, value IfaceMethodDemand) {
+	values := (*m)[key]
+	for _, existing := range values {
+		if existing == value {
+			return
+		}
+	}
+	(*m)[key] = append(values, value)
+}

--- a/internal/metadata/builder.go
+++ b/internal/metadata/builder.go
@@ -2,15 +2,27 @@ package metadata
 
 // Builder accumulates per-package metadata facts and builds a PackageMeta.
 type Builder struct {
-	pm      *PackageMeta
-	strToID map[string]uint32
+	pm                 *PackageMeta
+	strToID            map[string]uint32
+	seenEdge           map[[2]Symbol]struct{}
+	seenTypeChild      map[[2]Symbol]struct{}
+	seenInterfaceInfo  map[interfaceInfoKey]struct{}
+	seenUseIface       map[[2]Symbol]struct{}
+	seenUseIfaceMethod map[useIfaceMethodKey]struct{}
+	seenUseNamedMethod map[useNamedMethodKey]struct{}
 }
 
 // NewBuilder creates an empty metadata builder.
 func NewBuilder() *Builder {
 	return &Builder{
-		pm:      NewPackageMeta(nil),
-		strToID: make(map[string]uint32),
+		pm:                 NewPackageMeta(nil),
+		strToID:            make(map[string]uint32),
+		seenEdge:           make(map[[2]Symbol]struct{}),
+		seenTypeChild:      make(map[[2]Symbol]struct{}),
+		seenInterfaceInfo:  make(map[interfaceInfoKey]struct{}),
+		seenUseIface:       make(map[[2]Symbol]struct{}),
+		seenUseIfaceMethod: make(map[useIfaceMethodKey]struct{}),
+		seenUseNamedMethod: make(map[useNamedMethodKey]struct{}),
 	}
 }
 
@@ -35,32 +47,57 @@ func (b *Builder) intern(s string) uint32 {
 
 // AddEdge records an ordinary reachability edge src -> dst.
 func (b *Builder) AddEdge(src, dst Symbol) {
-	addUniqueSymbol(&b.pm.ordinaryEdges, src, dst)
+	key := [2]Symbol{src, dst}
+	if _, ok := b.seenEdge[key]; ok {
+		return
+	}
+	b.seenEdge[key] = struct{}{}
+	b.pm.ordinaryEdges[src] = append(b.pm.ordinaryEdges[src], dst)
 }
 
 // AddTypeChild records that parent type references child type.
 func (b *Builder) AddTypeChild(parent, child Symbol) {
-	addUniqueSymbol(&b.pm.typeChildren, parent, child)
+	key := [2]Symbol{parent, child}
+	if _, ok := b.seenTypeChild[key]; ok {
+		return
+	}
+	b.seenTypeChild[key] = struct{}{}
+	b.pm.typeChildren[parent] = append(b.pm.typeChildren[parent], child)
 }
 
 // AddIfaceEntry records the method set of an interface type.
 func (b *Builder) AddIfaceEntry(iface Symbol, methods []MethodSig) {
 	for _, method := range methods {
-		addUniqueMethodSig(&b.pm.interfaceInfo, iface, method)
+		key := interfaceInfoKey{Iface: iface, Sig: method}
+		if _, ok := b.seenInterfaceInfo[key]; ok {
+			continue
+		}
+		b.seenInterfaceInfo[key] = struct{}{}
+		b.pm.interfaceInfo[iface] = append(b.pm.interfaceInfo[iface], method)
 	}
 }
 
 // AddUseIface records types converted to interface when owner is reachable.
 func (b *Builder) AddUseIface(owner Symbol, types []Symbol) {
 	for _, typ := range types {
-		addUniqueSymbol(&b.pm.useIface, owner, typ)
+		key := [2]Symbol{owner, typ}
+		if _, ok := b.seenUseIface[key]; ok {
+			continue
+		}
+		b.seenUseIface[key] = struct{}{}
+		b.pm.useIface[owner] = append(b.pm.useIface[owner], typ)
 	}
 }
 
 // AddUseIfaceMethod records interface method calls when owner is reachable.
 func (b *Builder) AddUseIfaceMethod(owner Symbol, demands []IfaceMethodDemand) {
 	for _, demand := range demands {
-		addUniqueIfaceMethodDemand(&b.pm.useIfaceMethod, owner, demand)
+		key := useIfaceMethodKey{Owner: owner, Demand: demand}
+		if _, ok := b.seenUseIfaceMethod[key]; ok {
+			continue
+		}
+		b.seenUseIfaceMethod[key] = struct{}{}
+		b.pm.useIfaceMethod[owner] = append(b.pm.useIfaceMethod[owner], demand)
 	}
 }
 
@@ -75,7 +112,12 @@ func (b *Builder) AddMethodInfo(typeID Symbol, slots []MethodSlot) {
 // AddUseNamedMethod records constant MethodByName method names.
 func (b *Builder) AddUseNamedMethod(owner Symbol, names []Name) {
 	for _, name := range names {
-		addUniqueName(&b.pm.useNamedMethod, owner, name)
+		key := useNamedMethodKey{Owner: owner, Name: name}
+		if _, ok := b.seenUseNamedMethod[key]; ok {
+			continue
+		}
+		b.seenUseNamedMethod[key] = struct{}{}
+		b.pm.useNamedMethod[owner] = append(b.pm.useNamedMethod[owner], name)
 	}
 }
 
@@ -94,42 +136,17 @@ func (b *Builder) Build() *PackageMeta {
 	return b.pm
 }
 
-func addUniqueSymbol(m *map[Symbol][]Symbol, key, value Symbol) {
-	values := (*m)[key]
-	for _, existing := range values {
-		if existing == value {
-			return
-		}
-	}
-	(*m)[key] = append(values, value)
+type interfaceInfoKey struct {
+	Iface Symbol
+	Sig   MethodSig
 }
 
-func addUniqueName(m *map[Symbol][]Name, key Symbol, value Name) {
-	values := (*m)[key]
-	for _, existing := range values {
-		if existing == value {
-			return
-		}
-	}
-	(*m)[key] = append(values, value)
+type useIfaceMethodKey struct {
+	Owner  Symbol
+	Demand IfaceMethodDemand
 }
 
-func addUniqueMethodSig(m *map[Symbol][]MethodSig, key Symbol, value MethodSig) {
-	values := (*m)[key]
-	for _, existing := range values {
-		if existing == value {
-			return
-		}
-	}
-	(*m)[key] = append(values, value)
-}
-
-func addUniqueIfaceMethodDemand(m *map[Symbol][]IfaceMethodDemand, key Symbol, value IfaceMethodDemand) {
-	values := (*m)[key]
-	for _, existing := range values {
-		if existing == value {
-			return
-		}
-	}
-	(*m)[key] = append(values, value)
+type useNamedMethodKey struct {
+	Owner Symbol
+	Name  Name
 }

--- a/internal/metadata/format.go
+++ b/internal/metadata/format.go
@@ -1,0 +1,141 @@
+package metadata
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+// FormatMeta writes a stable human-readable representation for tests.
+func FormatMeta(w io.Writer, pm *PackageMeta) {
+	if pm == nil {
+		return
+	}
+
+	sym := func(s Symbol) string {
+		if int(s) < len(pm.stringTable) {
+			return pm.stringTable[s]
+		}
+		return fmt.Sprintf("?%d", s)
+	}
+	name := func(n Name) string {
+		if int(n) < len(pm.stringTable) {
+			return pm.stringTable[n]
+		}
+		return fmt.Sprintf("?%d", n)
+	}
+	keys := func(m map[Symbol][]Symbol) []Symbol { return sortedFormatKeys(m, sym) }
+
+	if len(pm.typeChildren) > 0 {
+		fmt.Fprintln(w, "[TypeChildren]")
+		for _, key := range keys(pm.typeChildren) {
+			fmt.Fprintf(w, "%s:\n", sym(key))
+			for _, child := range pm.typeChildren[key] {
+				fmt.Fprintf(w, "    %s\n", sym(child))
+			}
+		}
+		fmt.Fprintln(w)
+	}
+
+	if len(pm.interfaceInfo) > 0 {
+		fmt.Fprintln(w, "[InterfaceInfo]")
+		for _, iface := range sortedFormatKeys(pm.interfaceInfo, sym) {
+			fmt.Fprintf(w, "%s:\n", sym(iface))
+			for _, method := range pm.interfaceInfo[iface] {
+				fmt.Fprintf(w, "    %s %s\n", name(method.Name), sym(method.MType))
+			}
+		}
+		fmt.Fprintln(w)
+	}
+
+	if len(pm.ordinaryEdges) > 0 {
+		fmt.Fprintln(w, "[OrdinaryEdges]")
+		for _, key := range keys(pm.ordinaryEdges) {
+			fmt.Fprintf(w, "%s:\n", sym(key))
+			for _, dst := range pm.ordinaryEdges[key] {
+				fmt.Fprintf(w, "    %s\n", sym(dst))
+			}
+		}
+		fmt.Fprintln(w)
+	}
+
+	if len(pm.useIface) > 0 {
+		fmt.Fprintln(w, "[UseIface]")
+		for _, key := range keys(pm.useIface) {
+			fmt.Fprintf(w, "%s:\n", sym(key))
+			for _, typ := range pm.useIface[key] {
+				fmt.Fprintf(w, "    %s\n", sym(typ))
+			}
+		}
+		fmt.Fprintln(w)
+	}
+
+	if len(pm.useIfaceMethod) > 0 {
+		fmt.Fprintln(w, "[UseIfaceMethod]")
+		for _, owner := range sortedFormatKeys(pm.useIfaceMethod, sym) {
+			fmt.Fprintf(w, "%s:\n", sym(owner))
+			for _, demand := range pm.useIfaceMethod[owner] {
+				fmt.Fprintf(w, "    %s %s %s\n", sym(demand.Target), name(demand.Sig.Name), sym(demand.Sig.MType))
+			}
+		}
+		fmt.Fprintln(w)
+	}
+
+	if len(pm.methodInfo) > 0 {
+		fmt.Fprintln(w, "[MethodInfo]")
+		for _, typ := range sortedFormatKeys(pm.methodInfo, sym) {
+			fmt.Fprintf(w, "%s:\n", sym(typ))
+			for i, slot := range pm.methodInfo[typ] {
+				fmt.Fprintf(w, "    %d %s %s %s %s\n", i, name(slot.Sig.Name), sym(slot.Sig.MType), sym(slot.IFn), sym(slot.TFn))
+			}
+		}
+		fmt.Fprintln(w)
+	}
+
+	if len(pm.useNamedMethod) > 0 {
+		fmt.Fprintln(w, "[UseNamedMethod]")
+		for _, owner := range sortedFormatKeys(pm.useNamedMethod, sym) {
+			fmt.Fprintf(w, "%s:\n", sym(owner))
+			for _, methodName := range pm.useNamedMethod[owner] {
+				fmt.Fprintf(w, "    %s\n", name(methodName))
+			}
+		}
+		fmt.Fprintln(w)
+	}
+
+	if len(pm.reflectMethod) > 0 {
+		owners := sortedFormatSetKeys(pm.reflectMethod, sym)
+
+		fmt.Fprintln(w, "[ReflectMethod]")
+		for _, owner := range owners {
+			fmt.Fprintln(w, sym(owner))
+		}
+		fmt.Fprintln(w)
+	}
+}
+
+// MetaString returns the formatted metadata string.
+func MetaString(pm *PackageMeta) string {
+	var sb strings.Builder
+	FormatMeta(&sb, pm)
+	return sb.String()
+}
+
+func sortedFormatKeys[V any](m map[Symbol]V, name func(Symbol) string) []Symbol {
+	keys := make([]Symbol, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool { return name(keys[i]) < name(keys[j]) })
+	return keys
+}
+
+func sortedFormatSetKeys(m map[Symbol]struct{}, name func(Symbol) string) []Symbol {
+	keys := make([]Symbol, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool { return name(keys[i]) < name(keys[j]) })
+	return keys
+}

--- a/internal/metadata/format.go
+++ b/internal/metadata/format.go
@@ -9,10 +9,6 @@ import (
 
 // FormatMeta writes a stable human-readable representation for tests.
 func FormatMeta(w io.Writer, pm *PackageMeta) {
-	if pm == nil {
-		return
-	}
-
 	sym := func(s Symbol) string {
 		if int(s) < len(pm.stringTable) {
 			return pm.stringTable[s]

--- a/internal/metadata/global_summary.go
+++ b/internal/metadata/global_summary.go
@@ -125,37 +125,37 @@ func (g *GlobalSummary) ConcreteTypes() []Symbol {
 
 // OrdinaryEdges returns direct ordinary references from sym.
 func (g *GlobalSummary) OrdinaryEdges(sym Symbol) []Symbol {
-	return cloneSymbols(g.ordinaryEdges[sym])
+	return g.ordinaryEdges[sym]
 }
 
 // TypeChildren returns child type symbols for typ.
 func (g *GlobalSummary) TypeChildren(typ Symbol) []Symbol {
-	return cloneSymbols(g.typeChildren[typ])
+	return g.typeChildren[typ]
 }
 
 // InterfaceMethods returns the method set for iface.
 func (g *GlobalSummary) InterfaceMethods(iface Symbol) []MethodSig {
-	return cloneMethodSigs(g.interfaceInfo[iface])
+	return g.interfaceInfo[iface]
 }
 
 // UseIface returns concrete types that enter interface semantics from fn.
 func (g *GlobalSummary) UseIface(fn Symbol) []Symbol {
-	return cloneSymbols(g.useIface[fn])
+	return g.useIface[fn]
 }
 
 // UseIfaceMethod returns interface method demands emitted by fn.
 func (g *GlobalSummary) UseIfaceMethod(fn Symbol) []IfaceMethodDemand {
-	return cloneIfaceMethodDemands(g.useIfaceMethod[fn])
+	return g.useIfaceMethod[fn]
 }
 
 // MethodSlots returns ABI method slots for typ.
 func (g *GlobalSummary) MethodSlots(typ Symbol) []MethodSlot {
-	return cloneMethodSlots(g.methodInfo[typ])
+	return g.methodInfo[typ]
 }
 
 // UseNamedMethod returns constant MethodByName names emitted by fn.
 func (g *GlobalSummary) UseNamedMethod(fn Symbol) []Name {
-	return cloneNames(g.useNamedMethod[fn])
+	return g.useNamedMethod[fn]
 }
 
 // HasReflectMethod reports whether fn triggers conservative reflection handling.
@@ -230,7 +230,7 @@ func (b *globalSummaryBuilder) addMethodSlots(typ Symbol, slots []MethodSlot) er
 		}
 		return fmt.Errorf("conflicting MethodInfo for %s", b.summary.SymbolName(typ))
 	}
-	b.summary.methodInfo[typ] = cloneMethodSlots(slots)
+	b.summary.methodInfo[typ] = slots
 	return nil
 }
 

--- a/internal/metadata/global_summary.go
+++ b/internal/metadata/global_summary.go
@@ -1,0 +1,317 @@
+package metadata
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+)
+
+// GlobalSummary is a whole-program metadata view in one global Symbol/Name space.
+type GlobalSummary struct {
+	stringTable []string
+
+	symbolByText map[string]Symbol
+	nameByText   map[string]Name
+
+	ordinaryEdges  map[Symbol][]Symbol
+	typeChildren   map[Symbol][]Symbol
+	interfaceInfo  map[Symbol][]MethodSig
+	useIface       map[Symbol][]Symbol
+	useIfaceMethod map[Symbol][]IfaceMethodDemand
+	methodInfo     map[Symbol][]MethodSlot
+	useNamedMethod map[Symbol][]Name
+	reflectMethod  map[Symbol]struct{}
+}
+
+// NewGlobalSummary merges package-local metadata into a whole-program view.
+func NewGlobalSummary(pkgs []*PackageMeta) (*GlobalSummary, error) {
+	b := newGlobalSummaryBuilder()
+	for _, pm := range pkgs {
+		if pm == nil {
+			continue
+		}
+		r := newPackageRemapper(pm, b)
+
+		pm.ForEachOrdinaryEdge(func(src Symbol, dsts []Symbol) {
+			gsrc := r.symbol(src)
+			for _, dst := range dsts {
+				addUniqueSymbol(&b.summary.ordinaryEdges, gsrc, r.symbol(dst))
+			}
+		})
+		pm.ForEachTypeChild(func(parent Symbol, children []Symbol) {
+			gparent := r.symbol(parent)
+			for _, child := range children {
+				addUniqueSymbol(&b.summary.typeChildren, gparent, r.symbol(child))
+			}
+		})
+		pm.ForEachInterface(func(iface Symbol, methods []MethodSig) {
+			giface := r.symbol(iface)
+			for _, method := range methods {
+				addUniqueMethodSig(&b.summary.interfaceInfo, giface, r.methodSig(method))
+			}
+		})
+		pm.ForEachUseIface(func(owner Symbol, types []Symbol) {
+			gowner := r.symbol(owner)
+			for _, typ := range types {
+				addUniqueSymbol(&b.summary.useIface, gowner, r.symbol(typ))
+			}
+		})
+		pm.ForEachUseIfaceMethod(func(owner Symbol, demands []IfaceMethodDemand) {
+			gowner := r.symbol(owner)
+			for _, demand := range demands {
+				addUniqueIfaceMethodDemand(&b.summary.useIfaceMethod, gowner, IfaceMethodDemand{
+					Target: r.symbol(demand.Target),
+					Sig:    r.methodSig(demand.Sig),
+				})
+			}
+		})
+		var methodErr error
+		pm.ForEachMethodInfo(func(typ Symbol, slots []MethodSlot) {
+			if methodErr != nil {
+				return
+			}
+			gtyp := r.symbol(typ)
+			gslots := make([]MethodSlot, 0, len(slots))
+			for _, slot := range slots {
+				gslots = append(gslots, MethodSlot{
+					Sig: r.methodSig(slot.Sig),
+					IFn: r.symbol(slot.IFn),
+					TFn: r.symbol(slot.TFn),
+				})
+			}
+			methodErr = b.addMethodSlots(gtyp, gslots)
+		})
+		if methodErr != nil {
+			return nil, methodErr
+		}
+		pm.ForEachUseNamedMethod(func(owner Symbol, names []Name) {
+			gowner := r.symbol(owner)
+			for _, name := range names {
+				addUniqueName(&b.summary.useNamedMethod, gowner, r.name(name))
+			}
+		})
+		pm.ForEachReflectMethod(func(owner Symbol) {
+			b.summary.reflectMethod[r.symbol(owner)] = struct{}{}
+		})
+	}
+	return b.build(), nil
+}
+
+// LookupSymbol returns a global Symbol for a module-level symbol name.
+func (g *GlobalSummary) LookupSymbol(name string) (Symbol, bool) {
+	if g == nil {
+		return 0, false
+	}
+	sym, ok := g.symbolByText[name]
+	return sym, ok
+}
+
+// SymbolName returns the text referenced by a global Symbol.
+func (g *GlobalSummary) SymbolName(sym Symbol) string {
+	if g == nil || int(sym) >= len(g.stringTable) {
+		return ""
+	}
+	return g.stringTable[sym]
+}
+
+// Name returns the text referenced by a global Name.
+func (g *GlobalSummary) Name(ref Name) string {
+	if g == nil || int(ref) >= len(g.stringTable) {
+		return ""
+	}
+	return g.stringTable[ref]
+}
+
+// Interfaces returns all interface type symbols known to the summary.
+func (g *GlobalSummary) Interfaces() []Symbol {
+	if g == nil {
+		return nil
+	}
+	return sortedGlobalKeys(g.interfaceInfo, g.SymbolName)
+}
+
+// ConcreteTypes returns all concrete type symbols with method slots.
+func (g *GlobalSummary) ConcreteTypes() []Symbol {
+	if g == nil {
+		return nil
+	}
+	return sortedGlobalKeys(g.methodInfo, g.SymbolName)
+}
+
+// OrdinaryEdges returns direct ordinary references from sym.
+func (g *GlobalSummary) OrdinaryEdges(sym Symbol) []Symbol {
+	if g == nil {
+		return nil
+	}
+	return cloneSymbols(g.ordinaryEdges[sym])
+}
+
+// TypeChildren returns child type symbols for typ.
+func (g *GlobalSummary) TypeChildren(typ Symbol) []Symbol {
+	if g == nil {
+		return nil
+	}
+	return cloneSymbols(g.typeChildren[typ])
+}
+
+// InterfaceMethods returns the method set for iface.
+func (g *GlobalSummary) InterfaceMethods(iface Symbol) []MethodSig {
+	if g == nil {
+		return nil
+	}
+	return cloneMethodSigs(g.interfaceInfo[iface])
+}
+
+// UseIface returns concrete types that enter interface semantics from fn.
+func (g *GlobalSummary) UseIface(fn Symbol) []Symbol {
+	if g == nil {
+		return nil
+	}
+	return cloneSymbols(g.useIface[fn])
+}
+
+// UseIfaceMethod returns interface method demands emitted by fn.
+func (g *GlobalSummary) UseIfaceMethod(fn Symbol) []IfaceMethodDemand {
+	if g == nil {
+		return nil
+	}
+	return cloneIfaceMethodDemands(g.useIfaceMethod[fn])
+}
+
+// MethodSlots returns ABI method slots for typ.
+func (g *GlobalSummary) MethodSlots(typ Symbol) []MethodSlot {
+	if g == nil {
+		return nil
+	}
+	return cloneMethodSlots(g.methodInfo[typ])
+}
+
+// UseNamedMethod returns constant MethodByName names emitted by fn.
+func (g *GlobalSummary) UseNamedMethod(fn Symbol) []Name {
+	if g == nil {
+		return nil
+	}
+	return cloneNames(g.useNamedMethod[fn])
+}
+
+// HasReflectMethod reports whether fn triggers conservative reflection handling.
+func (g *GlobalSummary) HasReflectMethod(fn Symbol) bool {
+	if g == nil {
+		return false
+	}
+	_, ok := g.reflectMethod[fn]
+	return ok
+}
+
+type globalSummaryBuilder struct {
+	summary  *GlobalSummary
+	idByText map[string]uint32
+}
+
+func newGlobalSummaryBuilder() *globalSummaryBuilder {
+	return &globalSummaryBuilder{
+		summary: &GlobalSummary{
+			symbolByText:   make(map[string]Symbol),
+			nameByText:     make(map[string]Name),
+			ordinaryEdges:  make(map[Symbol][]Symbol),
+			typeChildren:   make(map[Symbol][]Symbol),
+			interfaceInfo:  make(map[Symbol][]MethodSig),
+			useIface:       make(map[Symbol][]Symbol),
+			useIfaceMethod: make(map[Symbol][]IfaceMethodDemand),
+			methodInfo:     make(map[Symbol][]MethodSlot),
+			useNamedMethod: make(map[Symbol][]Name),
+			reflectMethod:  make(map[Symbol]struct{}),
+		},
+		idByText: make(map[string]uint32),
+	}
+}
+
+func (b *globalSummaryBuilder) internSymbol(text string) Symbol {
+	id := b.internText(text)
+	sym := Symbol(id)
+	b.summary.symbolByText[text] = sym
+	return sym
+}
+
+func (b *globalSummaryBuilder) internName(text string) Name {
+	id := b.internText(text)
+	name := Name(id)
+	b.summary.nameByText[text] = name
+	return name
+}
+
+func (b *globalSummaryBuilder) internText(text string) uint32 {
+	if id, ok := b.idByText[text]; ok {
+		return id
+	}
+	id := uint32(len(b.summary.stringTable))
+	b.idByText[text] = id
+	b.summary.stringTable = append(b.summary.stringTable, text)
+	return id
+}
+
+func (b *globalSummaryBuilder) addMethodSlots(typ Symbol, slots []MethodSlot) error {
+	if existing, ok := b.summary.methodInfo[typ]; ok {
+		if reflect.DeepEqual(existing, slots) {
+			return nil
+		}
+		return fmt.Errorf("conflicting MethodInfo for %s", b.summary.SymbolName(typ))
+	}
+	b.summary.methodInfo[typ] = cloneMethodSlots(slots)
+	return nil
+}
+
+func (b *globalSummaryBuilder) build() *GlobalSummary {
+	return b.summary
+}
+
+type packageRemapper struct {
+	pm *PackageMeta
+	b  *globalSummaryBuilder
+
+	symbols map[Symbol]Symbol
+	names   map[Name]Name
+}
+
+func newPackageRemapper(pm *PackageMeta, b *globalSummaryBuilder) *packageRemapper {
+	return &packageRemapper{
+		pm:      pm,
+		b:       b,
+		symbols: make(map[Symbol]Symbol),
+		names:   make(map[Name]Name),
+	}
+}
+
+func (r *packageRemapper) symbol(local Symbol) Symbol {
+	if global, ok := r.symbols[local]; ok {
+		return global
+	}
+	global := r.b.internSymbol(r.pm.SymbolName(local))
+	r.symbols[local] = global
+	return global
+}
+
+func (r *packageRemapper) name(local Name) Name {
+	if global, ok := r.names[local]; ok {
+		return global
+	}
+	global := r.b.internName(r.pm.Name(local))
+	r.names[local] = global
+	return global
+}
+
+func (r *packageRemapper) methodSig(local MethodSig) MethodSig {
+	return MethodSig{
+		Name:  r.name(local.Name),
+		MType: r.symbol(local.MType),
+	}
+}
+
+func sortedGlobalKeys[V any](m map[Symbol]V, name func(Symbol) string) []Symbol {
+	keys := make([]Symbol, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool { return name(keys[i]) < name(keys[j]) })
+	return keys
+}

--- a/internal/metadata/global_summary.go
+++ b/internal/metadata/global_summary.go
@@ -27,39 +27,36 @@ type GlobalSummary struct {
 func NewGlobalSummary(pkgs []*PackageMeta) (*GlobalSummary, error) {
 	b := newGlobalSummaryBuilder()
 	for _, pm := range pkgs {
-		if pm == nil {
-			continue
-		}
 		r := newPackageRemapper(pm, b)
 
 		pm.ForEachOrdinaryEdge(func(src Symbol, dsts []Symbol) {
 			gsrc := r.symbol(src)
 			for _, dst := range dsts {
-				addUniqueSymbol(&b.summary.ordinaryEdges, gsrc, r.symbol(dst))
+				b.addEdge(gsrc, r.symbol(dst))
 			}
 		})
 		pm.ForEachTypeChild(func(parent Symbol, children []Symbol) {
 			gparent := r.symbol(parent)
 			for _, child := range children {
-				addUniqueSymbol(&b.summary.typeChildren, gparent, r.symbol(child))
+				b.addTypeChild(gparent, r.symbol(child))
 			}
 		})
 		pm.ForEachInterface(func(iface Symbol, methods []MethodSig) {
 			giface := r.symbol(iface)
 			for _, method := range methods {
-				addUniqueMethodSig(&b.summary.interfaceInfo, giface, r.methodSig(method))
+				b.addInterfaceMethod(giface, r.methodSig(method))
 			}
 		})
 		pm.ForEachUseIface(func(owner Symbol, types []Symbol) {
 			gowner := r.symbol(owner)
 			for _, typ := range types {
-				addUniqueSymbol(&b.summary.useIface, gowner, r.symbol(typ))
+				b.addUseIface(gowner, r.symbol(typ))
 			}
 		})
 		pm.ForEachUseIfaceMethod(func(owner Symbol, demands []IfaceMethodDemand) {
 			gowner := r.symbol(owner)
 			for _, demand := range demands {
-				addUniqueIfaceMethodDemand(&b.summary.useIfaceMethod, gowner, IfaceMethodDemand{
+				b.addUseIfaceMethod(gowner, IfaceMethodDemand{
 					Target: r.symbol(demand.Target),
 					Sig:    r.methodSig(demand.Sig),
 				})
@@ -67,9 +64,6 @@ func NewGlobalSummary(pkgs []*PackageMeta) (*GlobalSummary, error) {
 		})
 		var methodErr error
 		pm.ForEachMethodInfo(func(typ Symbol, slots []MethodSlot) {
-			if methodErr != nil {
-				return
-			}
 			gtyp := r.symbol(typ)
 			gslots := make([]MethodSlot, 0, len(slots))
 			for _, slot := range slots {
@@ -87,7 +81,7 @@ func NewGlobalSummary(pkgs []*PackageMeta) (*GlobalSummary, error) {
 		pm.ForEachUseNamedMethod(func(owner Symbol, names []Name) {
 			gowner := r.symbol(owner)
 			for _, name := range names {
-				addUniqueName(&b.summary.useNamedMethod, gowner, r.name(name))
+				b.addUseNamedMethod(gowner, r.name(name))
 			}
 		})
 		pm.ForEachReflectMethod(func(owner Symbol) {
@@ -99,16 +93,13 @@ func NewGlobalSummary(pkgs []*PackageMeta) (*GlobalSummary, error) {
 
 // LookupSymbol returns a global Symbol for a module-level symbol name.
 func (g *GlobalSummary) LookupSymbol(name string) (Symbol, bool) {
-	if g == nil {
-		return 0, false
-	}
 	sym, ok := g.symbolByText[name]
 	return sym, ok
 }
 
 // SymbolName returns the text referenced by a global Symbol.
 func (g *GlobalSummary) SymbolName(sym Symbol) string {
-	if g == nil || int(sym) >= len(g.stringTable) {
+	if int(sym) >= len(g.stringTable) {
 		return ""
 	}
 	return g.stringTable[sym]
@@ -116,7 +107,7 @@ func (g *GlobalSummary) SymbolName(sym Symbol) string {
 
 // Name returns the text referenced by a global Name.
 func (g *GlobalSummary) Name(ref Name) string {
-	if g == nil || int(ref) >= len(g.stringTable) {
+	if int(ref) >= len(g.stringTable) {
 		return ""
 	}
 	return g.stringTable[ref]
@@ -124,88 +115,64 @@ func (g *GlobalSummary) Name(ref Name) string {
 
 // Interfaces returns all interface type symbols known to the summary.
 func (g *GlobalSummary) Interfaces() []Symbol {
-	if g == nil {
-		return nil
-	}
 	return sortedGlobalKeys(g.interfaceInfo, g.SymbolName)
 }
 
 // ConcreteTypes returns all concrete type symbols with method slots.
 func (g *GlobalSummary) ConcreteTypes() []Symbol {
-	if g == nil {
-		return nil
-	}
 	return sortedGlobalKeys(g.methodInfo, g.SymbolName)
 }
 
 // OrdinaryEdges returns direct ordinary references from sym.
 func (g *GlobalSummary) OrdinaryEdges(sym Symbol) []Symbol {
-	if g == nil {
-		return nil
-	}
 	return cloneSymbols(g.ordinaryEdges[sym])
 }
 
 // TypeChildren returns child type symbols for typ.
 func (g *GlobalSummary) TypeChildren(typ Symbol) []Symbol {
-	if g == nil {
-		return nil
-	}
 	return cloneSymbols(g.typeChildren[typ])
 }
 
 // InterfaceMethods returns the method set for iface.
 func (g *GlobalSummary) InterfaceMethods(iface Symbol) []MethodSig {
-	if g == nil {
-		return nil
-	}
 	return cloneMethodSigs(g.interfaceInfo[iface])
 }
 
 // UseIface returns concrete types that enter interface semantics from fn.
 func (g *GlobalSummary) UseIface(fn Symbol) []Symbol {
-	if g == nil {
-		return nil
-	}
 	return cloneSymbols(g.useIface[fn])
 }
 
 // UseIfaceMethod returns interface method demands emitted by fn.
 func (g *GlobalSummary) UseIfaceMethod(fn Symbol) []IfaceMethodDemand {
-	if g == nil {
-		return nil
-	}
 	return cloneIfaceMethodDemands(g.useIfaceMethod[fn])
 }
 
 // MethodSlots returns ABI method slots for typ.
 func (g *GlobalSummary) MethodSlots(typ Symbol) []MethodSlot {
-	if g == nil {
-		return nil
-	}
 	return cloneMethodSlots(g.methodInfo[typ])
 }
 
 // UseNamedMethod returns constant MethodByName names emitted by fn.
 func (g *GlobalSummary) UseNamedMethod(fn Symbol) []Name {
-	if g == nil {
-		return nil
-	}
 	return cloneNames(g.useNamedMethod[fn])
 }
 
 // HasReflectMethod reports whether fn triggers conservative reflection handling.
 func (g *GlobalSummary) HasReflectMethod(fn Symbol) bool {
-	if g == nil {
-		return false
-	}
 	_, ok := g.reflectMethod[fn]
 	return ok
 }
 
 type globalSummaryBuilder struct {
-	summary  *GlobalSummary
-	idByText map[string]uint32
+	summary            *GlobalSummary
+	idByText           map[string]uint32
+	seenEdge           map[[2]Symbol]struct{}
+	seenTypeChild      map[[2]Symbol]struct{}
+	seenInterfaceInfo  map[interfaceInfoKey]struct{}
+	seenUseIface       map[[2]Symbol]struct{}
+	seenUseIfaceMethod map[useIfaceMethodKey]struct{}
+	seenUseNamedMethod map[useNamedMethodKey]struct{}
 }
 
 func newGlobalSummaryBuilder() *globalSummaryBuilder {
@@ -222,7 +189,13 @@ func newGlobalSummaryBuilder() *globalSummaryBuilder {
 			useNamedMethod: make(map[Symbol][]Name),
 			reflectMethod:  make(map[Symbol]struct{}),
 		},
-		idByText: make(map[string]uint32),
+		idByText:           make(map[string]uint32),
+		seenEdge:           make(map[[2]Symbol]struct{}),
+		seenTypeChild:      make(map[[2]Symbol]struct{}),
+		seenInterfaceInfo:  make(map[interfaceInfoKey]struct{}),
+		seenUseIface:       make(map[[2]Symbol]struct{}),
+		seenUseIfaceMethod: make(map[useIfaceMethodKey]struct{}),
+		seenUseNamedMethod: make(map[useNamedMethodKey]struct{}),
 	}
 }
 
@@ -259,6 +232,60 @@ func (b *globalSummaryBuilder) addMethodSlots(typ Symbol, slots []MethodSlot) er
 	}
 	b.summary.methodInfo[typ] = cloneMethodSlots(slots)
 	return nil
+}
+
+func (b *globalSummaryBuilder) addEdge(src, dst Symbol) {
+	key := [2]Symbol{src, dst}
+	if _, ok := b.seenEdge[key]; ok {
+		return
+	}
+	b.seenEdge[key] = struct{}{}
+	b.summary.ordinaryEdges[src] = append(b.summary.ordinaryEdges[src], dst)
+}
+
+func (b *globalSummaryBuilder) addTypeChild(parent, child Symbol) {
+	key := [2]Symbol{parent, child}
+	if _, ok := b.seenTypeChild[key]; ok {
+		return
+	}
+	b.seenTypeChild[key] = struct{}{}
+	b.summary.typeChildren[parent] = append(b.summary.typeChildren[parent], child)
+}
+
+func (b *globalSummaryBuilder) addInterfaceMethod(iface Symbol, method MethodSig) {
+	key := interfaceInfoKey{Iface: iface, Sig: method}
+	if _, ok := b.seenInterfaceInfo[key]; ok {
+		return
+	}
+	b.seenInterfaceInfo[key] = struct{}{}
+	b.summary.interfaceInfo[iface] = append(b.summary.interfaceInfo[iface], method)
+}
+
+func (b *globalSummaryBuilder) addUseIface(owner, typ Symbol) {
+	key := [2]Symbol{owner, typ}
+	if _, ok := b.seenUseIface[key]; ok {
+		return
+	}
+	b.seenUseIface[key] = struct{}{}
+	b.summary.useIface[owner] = append(b.summary.useIface[owner], typ)
+}
+
+func (b *globalSummaryBuilder) addUseIfaceMethod(owner Symbol, demand IfaceMethodDemand) {
+	key := useIfaceMethodKey{Owner: owner, Demand: demand}
+	if _, ok := b.seenUseIfaceMethod[key]; ok {
+		return
+	}
+	b.seenUseIfaceMethod[key] = struct{}{}
+	b.summary.useIfaceMethod[owner] = append(b.summary.useIfaceMethod[owner], demand)
+}
+
+func (b *globalSummaryBuilder) addUseNamedMethod(owner Symbol, name Name) {
+	key := useNamedMethodKey{Owner: owner, Name: name}
+	if _, ok := b.seenUseNamedMethod[key]; ok {
+		return
+	}
+	b.seenUseNamedMethod[key] = struct{}{}
+	b.summary.useNamedMethod[owner] = append(b.summary.useNamedMethod[owner], name)
 }
 
 func (b *globalSummaryBuilder) build() *GlobalSummary {

--- a/internal/metadata/global_summary_test.go
+++ b/internal/metadata/global_summary_test.go
@@ -1,0 +1,158 @@
+package metadata
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGlobalSummaryMergesLocalIDsByText(t *testing.T) {
+	pkgA, refsA := buildGlobalSummaryPkgA()
+	pkgB, refsB := buildGlobalSummaryPkgB()
+
+	if refsA.intType == refsB.intType {
+		t.Fatal("test setup should use different local Symbol IDs for _llgo_int")
+	}
+
+	summary, err := NewGlobalSummary([]*PackageMeta{pkgA, pkgB})
+	if err != nil {
+		t.Fatalf("NewGlobalSummary: %v", err)
+	}
+
+	intSymA, ok := summary.LookupSymbol("_llgo_int")
+	if !ok {
+		t.Fatal("LookupSymbol(_llgo_int) failed")
+	}
+	if got := summary.SymbolName(intSymA); got != "_llgo_int" {
+		t.Fatalf("SymbolName(_llgo_int) = %q", got)
+	}
+
+	funcType, ok := summary.LookupSymbol("_llgo_func$X")
+	if !ok {
+		t.Fatal("LookupSymbol(_llgo_func$X) failed")
+	}
+	mainA := mustLookupSymbol(t, summary, "pkg/a.main")
+	useA := mustLookupSymbol(t, summary, "pkg/a.use")
+	typeB := mustLookupSymbol(t, summary, "_llgo_pkg/b.T")
+	ifaceB := mustLookupSymbol(t, summary, "_llgo_iface$B")
+	ifnB := mustLookupSymbol(t, summary, "pkg/b.(*T).M")
+	tfnB := mustLookupSymbol(t, summary, "pkg/b.T.M")
+
+	if got := summary.OrdinaryEdges(mainA); !reflect.DeepEqual(got, []Symbol{useA}) {
+		t.Fatalf("OrdinaryEdges(pkg/a.main) = %#v, want %#v", got, []Symbol{useA})
+	}
+	if got := summary.TypeChildren(typeB); !reflect.DeepEqual(got, []Symbol{intSymA}) {
+		t.Fatalf("TypeChildren(_llgo_pkg/b.T) = %#v, want %#v", got, []Symbol{intSymA})
+	}
+	if got := summary.UseIface(mainA); !reflect.DeepEqual(got, []Symbol{typeB}) {
+		t.Fatalf("UseIface(pkg/a.main) = %#v, want %#v", got, []Symbol{typeB})
+	}
+
+	methodName := summary.UseNamedMethod(useA)
+	if len(methodName) != 1 || summary.Name(methodName[0]) != "M" {
+		t.Fatalf("UseNamedMethod(pkg/a.use) = %#v, want name M", methodName)
+	}
+	if _, ok := summary.LookupSymbol("M"); ok {
+		t.Fatal("LookupSymbol found method name that only appeared as Name")
+	}
+
+	wantSig := MethodSig{Name: methodName[0], MType: funcType}
+	if got := summary.InterfaceMethods(ifaceB); !reflect.DeepEqual(got, []MethodSig{wantSig}) {
+		t.Fatalf("InterfaceMethods(_llgo_iface$B) = %#v, want %#v", got, []MethodSig{wantSig})
+	}
+	if got := summary.UseIfaceMethod(useA); !reflect.DeepEqual(got, []IfaceMethodDemand{{Target: ifaceB, Sig: wantSig}}) {
+		t.Fatalf("UseIfaceMethod(pkg/a.use) = %#v", got)
+	}
+	if got := summary.MethodSlots(typeB); !reflect.DeepEqual(got, []MethodSlot{{Sig: wantSig, IFn: ifnB, TFn: tfnB}}) {
+		t.Fatalf("MethodSlots(_llgo_pkg/b.T) = %#v", got)
+	}
+	if !summary.HasReflectMethod(useA) {
+		t.Fatal("HasReflectMethod(pkg/a.use) = false, want true")
+	}
+
+	if got := summary.Interfaces(); !reflect.DeepEqual(got, []Symbol{ifaceB}) {
+		t.Fatalf("Interfaces() = %#v, want %#v", got, []Symbol{ifaceB})
+	}
+	if got := summary.ConcreteTypes(); !reflect.DeepEqual(got, []Symbol{typeB}) {
+		t.Fatalf("ConcreteTypes() = %#v, want %#v", got, []Symbol{typeB})
+	}
+}
+
+func TestGlobalSummaryRejectsConflictingMethodSlots(t *testing.T) {
+	pkgA, _ := buildGlobalSummaryPkgB()
+
+	// Rebuild pkgB with the same type and slot signature but a different TFn.
+	b := NewBuilder()
+	typ := b.Symbol("_llgo_pkg/b.T")
+	methodName := b.Name("M")
+	funcType := b.Symbol("_llgo_func$X")
+	ifn := b.Symbol("pkg/b.(*T).M")
+	tfn := b.Symbol("pkg/b.T.M.conflict")
+	b.AddMethodInfo(typ, []MethodSlot{{
+		Sig: MethodSig{Name: methodName, MType: funcType},
+		IFn: ifn,
+		TFn: tfn,
+	}})
+	pkgB := b.Build()
+
+	if _, err := NewGlobalSummary([]*PackageMeta{pkgA, pkgB}); err == nil {
+		t.Fatal("NewGlobalSummary accepted conflicting MethodInfo for the same type")
+	}
+}
+
+type globalSummaryRefs struct {
+	intType Symbol
+}
+
+func buildGlobalSummaryPkgA() (*PackageMeta, globalSummaryRefs) {
+	b := NewBuilder()
+	main := b.Symbol("pkg/a.main")
+	use := b.Symbol("pkg/a.use")
+	methodName := b.Name("M")
+	typ := b.Symbol("_llgo_pkg/b.T")
+	iface := b.Symbol("_llgo_iface$B")
+	funcType := b.Symbol("_llgo_func$X")
+	intType := b.Symbol("_llgo_int")
+
+	b.AddEdge(main, use)
+	b.AddUseIface(main, []Symbol{typ})
+	b.AddUseIfaceMethod(use, []IfaceMethodDemand{{
+		Target: iface,
+		Sig:    MethodSig{Name: methodName, MType: funcType},
+	}})
+	b.AddUseNamedMethod(use, []Name{methodName})
+	b.AddReflectMethod(use)
+
+	return b.Build(), globalSummaryRefs{intType: intType}
+}
+
+func buildGlobalSummaryPkgB() (*PackageMeta, globalSummaryRefs) {
+	b := NewBuilder()
+	other := b.Symbol("pkg/b.other")
+	intType := b.Symbol("_llgo_int")
+	typ := b.Symbol("_llgo_pkg/b.T")
+	methodName := b.Name("M")
+	funcType := b.Symbol("_llgo_func$X")
+	iface := b.Symbol("_llgo_iface$B")
+	ifn := b.Symbol("pkg/b.(*T).M")
+	tfn := b.Symbol("pkg/b.T.M")
+
+	b.AddEdge(other, intType)
+	b.AddTypeChild(typ, intType)
+	b.AddIfaceEntry(iface, []MethodSig{{Name: methodName, MType: funcType}})
+	b.AddMethodInfo(typ, []MethodSlot{{
+		Sig: MethodSig{Name: methodName, MType: funcType},
+		IFn: ifn,
+		TFn: tfn,
+	}})
+
+	return b.Build(), globalSummaryRefs{intType: intType}
+}
+
+func mustLookupSymbol(t *testing.T, summary *GlobalSummary, name string) Symbol {
+	t.Helper()
+	sym, ok := summary.LookupSymbol(name)
+	if !ok {
+		t.Fatalf("LookupSymbol(%q) failed", name)
+	}
+	return sym
+}

--- a/internal/metadata/global_summary_test.go
+++ b/internal/metadata/global_summary_test.go
@@ -77,6 +77,63 @@ func TestGlobalSummaryMergesLocalIDsByText(t *testing.T) {
 	}
 }
 
+func TestGlobalSummaryNameLookupsReturnEmptyStringForOutOfRangeIDs(t *testing.T) {
+	summary, err := NewGlobalSummary([]*PackageMeta{buildGlobalDuplicateFactsPackage()})
+	if err != nil {
+		t.Fatalf("NewGlobalSummary: %v", err)
+	}
+
+	if got := summary.SymbolName(Symbol(len(summary.stringTable))); got != "" {
+		t.Fatalf("SymbolName(out-of-range) = %q, want empty string", got)
+	}
+	if got := summary.Name(Name(len(summary.stringTable))); got != "" {
+		t.Fatalf("Name(out-of-range) = %q, want empty string", got)
+	}
+}
+
+func TestGlobalSummaryDeduplicatesMergedFacts(t *testing.T) {
+	pkgA := buildGlobalDuplicateFactsPackage()
+	pkgB := buildGlobalDuplicateFactsPackage()
+
+	summary, err := NewGlobalSummary([]*PackageMeta{pkgA, pkgB})
+	if err != nil {
+		t.Fatalf("NewGlobalSummary: %v", err)
+	}
+
+	main := mustLookupSymbol(t, summary, "pkg.main")
+	use := mustLookupSymbol(t, summary, "pkg.use")
+	typ := mustLookupSymbol(t, summary, "_llgo_pkg.T")
+	iface := mustLookupSymbol(t, summary, "_llgo_iface$I")
+	funcType := mustLookupSymbol(t, summary, "_llgo_func$M")
+	ifn := mustLookupSymbol(t, summary, "pkg.(*T).M")
+	tfn := mustLookupSymbol(t, summary, "pkg.T.M")
+	methodNames := summary.UseNamedMethod(use)
+	if len(methodNames) != 1 {
+		t.Fatalf("UseNamedMethod len = %d (%#v), want 1", len(methodNames), methodNames)
+	}
+	wantSig := MethodSig{Name: methodNames[0], MType: funcType}
+
+	if got := summary.OrdinaryEdges(main); !reflect.DeepEqual(got, []Symbol{use}) {
+		t.Fatalf("OrdinaryEdges(pkg.main) = %#v, want %#v", got, []Symbol{use})
+	}
+	if got := summary.TypeChildren(typ); !reflect.DeepEqual(got, []Symbol{funcType}) {
+		t.Fatalf("TypeChildren(_llgo_pkg.T) = %#v, want %#v", got, []Symbol{funcType})
+	}
+	if got := summary.InterfaceMethods(iface); !reflect.DeepEqual(got, []MethodSig{wantSig}) {
+		t.Fatalf("InterfaceMethods(_llgo_iface$I) = %#v, want %#v", got, []MethodSig{wantSig})
+	}
+	if got := summary.UseIface(main); !reflect.DeepEqual(got, []Symbol{typ}) {
+		t.Fatalf("UseIface(pkg.main) = %#v, want %#v", got, []Symbol{typ})
+	}
+	wantDemand := IfaceMethodDemand{Target: iface, Sig: wantSig}
+	if got := summary.UseIfaceMethod(use); !reflect.DeepEqual(got, []IfaceMethodDemand{wantDemand}) {
+		t.Fatalf("UseIfaceMethod(pkg.use) = %#v, want %#v", got, []IfaceMethodDemand{wantDemand})
+	}
+	if got := summary.MethodSlots(typ); !reflect.DeepEqual(got, []MethodSlot{{Sig: wantSig, IFn: ifn, TFn: tfn}}) {
+		t.Fatalf("MethodSlots(_llgo_pkg.T) = %#v", got)
+	}
+}
+
 func TestGlobalSummaryRejectsConflictingMethodSlots(t *testing.T) {
 	pkgA, _ := buildGlobalSummaryPkgB()
 
@@ -97,6 +154,28 @@ func TestGlobalSummaryRejectsConflictingMethodSlots(t *testing.T) {
 	if _, err := NewGlobalSummary([]*PackageMeta{pkgA, pkgB}); err == nil {
 		t.Fatal("NewGlobalSummary accepted conflicting MethodInfo for the same type")
 	}
+}
+
+func buildGlobalDuplicateFactsPackage() *PackageMeta {
+	b := NewBuilder()
+	main := b.Symbol("pkg.main")
+	use := b.Symbol("pkg.use")
+	typ := b.Symbol("_llgo_pkg.T")
+	iface := b.Symbol("_llgo_iface$I")
+	methodName := b.Name("M")
+	funcType := b.Symbol("_llgo_func$M")
+	ifn := b.Symbol("pkg.(*T).M")
+	tfn := b.Symbol("pkg.T.M")
+	sig := MethodSig{Name: methodName, MType: funcType}
+
+	b.AddEdge(main, use)
+	b.AddTypeChild(typ, funcType)
+	b.AddIfaceEntry(iface, []MethodSig{sig})
+	b.AddUseIface(main, []Symbol{typ})
+	b.AddUseIfaceMethod(use, []IfaceMethodDemand{{Target: iface, Sig: sig}})
+	b.AddUseNamedMethod(use, []Name{methodName})
+	b.AddMethodInfo(typ, []MethodSlot{{Sig: sig, IFn: ifn, TFn: tfn}})
+	return b.Build()
 }
 
 type globalSummaryRefs struct {

--- a/internal/metadata/meta.go
+++ b/internal/metadata/meta.go
@@ -56,17 +56,9 @@ func NewPackageMeta(stringTable []string) *PackageMeta {
 	}
 }
 
-// StringTable returns a copy of the package-local string table.
-func (pm *PackageMeta) StringTable() []string {
-	if pm == nil {
-		return nil
-	}
-	return append([]string(nil), pm.stringTable...)
-}
-
 // SymbolName returns the string referenced by a Symbol.
 func (pm *PackageMeta) SymbolName(sym Symbol) string {
-	if pm == nil || int(sym) >= len(pm.stringTable) {
+	if int(sym) >= len(pm.stringTable) {
 		return ""
 	}
 	return pm.stringTable[sym]
@@ -74,7 +66,7 @@ func (pm *PackageMeta) SymbolName(sym Symbol) string {
 
 // Name returns the string referenced by a Name.
 func (pm *PackageMeta) Name(ref Name) string {
-	if pm == nil || int(ref) >= len(pm.stringTable) {
+	if int(ref) >= len(pm.stringTable) {
 		return ""
 	}
 	return pm.stringTable[ref]
@@ -82,100 +74,56 @@ func (pm *PackageMeta) Name(ref Name) string {
 
 // ForEachOrdinaryEdge visits each ordinary reachability edge group.
 func (pm *PackageMeta) ForEachOrdinaryEdge(fn func(src Symbol, dsts []Symbol)) {
-	if pm == nil {
-		return
-	}
 	for src, dsts := range pm.ordinaryEdges {
-		fn(src, cloneSymbols(dsts))
+		fn(src, dsts)
 	}
 }
 
 // ForEachTypeChild visits each type-child edge group.
 func (pm *PackageMeta) ForEachTypeChild(fn func(parent Symbol, children []Symbol)) {
-	if pm == nil {
-		return
-	}
 	for parent, children := range pm.typeChildren {
-		fn(parent, cloneSymbols(children))
+		fn(parent, children)
 	}
 }
 
 // ForEachInterface visits each interface method set.
 func (pm *PackageMeta) ForEachInterface(fn func(iface Symbol, methods []MethodSig)) {
-	if pm == nil {
-		return
-	}
 	for iface, methods := range pm.interfaceInfo {
-		fn(iface, cloneMethodSigs(methods))
+		fn(iface, methods)
 	}
 }
 
 // ForEachUseIface visits each function's concrete types used as interfaces.
 func (pm *PackageMeta) ForEachUseIface(fn func(owner Symbol, types []Symbol)) {
-	if pm == nil {
-		return
-	}
 	for owner, types := range pm.useIface {
-		fn(owner, cloneSymbols(types))
+		fn(owner, types)
 	}
 }
 
 // ForEachUseIfaceMethod visits each function's interface method demands.
 func (pm *PackageMeta) ForEachUseIfaceMethod(fn func(owner Symbol, demands []IfaceMethodDemand)) {
-	if pm == nil {
-		return
-	}
 	for owner, demands := range pm.useIfaceMethod {
-		fn(owner, cloneIfaceMethodDemands(demands))
+		fn(owner, demands)
 	}
 }
 
 // ForEachMethodInfo visits each concrete type's method slots.
 func (pm *PackageMeta) ForEachMethodInfo(fn func(typ Symbol, slots []MethodSlot)) {
-	if pm == nil {
-		return
-	}
 	for typ, slots := range pm.methodInfo {
-		fn(typ, cloneMethodSlots(slots))
+		fn(typ, slots)
 	}
 }
 
 // ForEachUseNamedMethod visits each function's constant MethodByName names.
 func (pm *PackageMeta) ForEachUseNamedMethod(fn func(owner Symbol, names []Name)) {
-	if pm == nil {
-		return
-	}
 	for owner, names := range pm.useNamedMethod {
-		fn(owner, cloneNames(names))
+		fn(owner, names)
 	}
 }
 
 // ForEachReflectMethod visits each function that needs conservative reflection handling.
 func (pm *PackageMeta) ForEachReflectMethod(fn func(owner Symbol)) {
-	if pm == nil {
-		return
-	}
 	for owner := range pm.reflectMethod {
 		fn(owner)
 	}
-}
-
-func cloneSymbols(in []Symbol) []Symbol {
-	return append([]Symbol(nil), in...)
-}
-
-func cloneNames(in []Name) []Name {
-	return append([]Name(nil), in...)
-}
-
-func cloneMethodSigs(in []MethodSig) []MethodSig {
-	return append([]MethodSig(nil), in...)
-}
-
-func cloneIfaceMethodDemands(in []IfaceMethodDemand) []IfaceMethodDemand {
-	return append([]IfaceMethodDemand(nil), in...)
-}
-
-func cloneMethodSlots(in []MethodSlot) []MethodSlot {
-	return append([]MethodSlot(nil), in...)
 }

--- a/internal/metadata/meta.go
+++ b/internal/metadata/meta.go
@@ -1,0 +1,181 @@
+// Package metadata defines package summary facts and their LLPS binary format.
+package metadata
+
+// Symbol is a module-level named entity participating in reachability.
+type Symbol uint32
+
+// Name is a plain name reference used for semantic matching.
+type Name uint32
+
+// MethodSig describes a method by short name and function type symbol.
+type MethodSig struct {
+	Name  Name
+	MType Symbol
+}
+
+// MethodSlot describes one entry in a concrete type's ABI method table.
+type MethodSlot struct {
+	Sig MethodSig
+	IFn Symbol
+	TFn Symbol
+}
+
+// IfaceMethodDemand records one reachable interface method call.
+type IfaceMethodDemand struct {
+	Target Symbol
+	Sig    MethodSig
+}
+
+// PackageMeta holds all single-package facts needed by whole-program analysis.
+type PackageMeta struct {
+	stringTable []string
+
+	ordinaryEdges  map[Symbol][]Symbol
+	typeChildren   map[Symbol][]Symbol
+	interfaceInfo  map[Symbol][]MethodSig
+	useIface       map[Symbol][]Symbol
+	useIfaceMethod map[Symbol][]IfaceMethodDemand
+	methodInfo     map[Symbol][]MethodSlot
+	useNamedMethod map[Symbol][]Name
+	reflectMethod  map[Symbol]struct{}
+}
+
+// NewPackageMeta creates an empty PackageMeta with initialized maps.
+func NewPackageMeta(stringTable []string) *PackageMeta {
+	table := append([]string(nil), stringTable...)
+	return &PackageMeta{
+		stringTable:    table,
+		ordinaryEdges:  make(map[Symbol][]Symbol),
+		typeChildren:   make(map[Symbol][]Symbol),
+		interfaceInfo:  make(map[Symbol][]MethodSig),
+		useIface:       make(map[Symbol][]Symbol),
+		useIfaceMethod: make(map[Symbol][]IfaceMethodDemand),
+		methodInfo:     make(map[Symbol][]MethodSlot),
+		useNamedMethod: make(map[Symbol][]Name),
+		reflectMethod:  make(map[Symbol]struct{}),
+	}
+}
+
+// StringTable returns a copy of the package-local string table.
+func (pm *PackageMeta) StringTable() []string {
+	if pm == nil {
+		return nil
+	}
+	return append([]string(nil), pm.stringTable...)
+}
+
+// SymbolName returns the string referenced by a Symbol.
+func (pm *PackageMeta) SymbolName(sym Symbol) string {
+	if pm == nil || int(sym) >= len(pm.stringTable) {
+		return ""
+	}
+	return pm.stringTable[sym]
+}
+
+// Name returns the string referenced by a Name.
+func (pm *PackageMeta) Name(ref Name) string {
+	if pm == nil || int(ref) >= len(pm.stringTable) {
+		return ""
+	}
+	return pm.stringTable[ref]
+}
+
+// ForEachOrdinaryEdge visits each ordinary reachability edge group.
+func (pm *PackageMeta) ForEachOrdinaryEdge(fn func(src Symbol, dsts []Symbol)) {
+	if pm == nil {
+		return
+	}
+	for src, dsts := range pm.ordinaryEdges {
+		fn(src, cloneSymbols(dsts))
+	}
+}
+
+// ForEachTypeChild visits each type-child edge group.
+func (pm *PackageMeta) ForEachTypeChild(fn func(parent Symbol, children []Symbol)) {
+	if pm == nil {
+		return
+	}
+	for parent, children := range pm.typeChildren {
+		fn(parent, cloneSymbols(children))
+	}
+}
+
+// ForEachInterface visits each interface method set.
+func (pm *PackageMeta) ForEachInterface(fn func(iface Symbol, methods []MethodSig)) {
+	if pm == nil {
+		return
+	}
+	for iface, methods := range pm.interfaceInfo {
+		fn(iface, cloneMethodSigs(methods))
+	}
+}
+
+// ForEachUseIface visits each function's concrete types used as interfaces.
+func (pm *PackageMeta) ForEachUseIface(fn func(owner Symbol, types []Symbol)) {
+	if pm == nil {
+		return
+	}
+	for owner, types := range pm.useIface {
+		fn(owner, cloneSymbols(types))
+	}
+}
+
+// ForEachUseIfaceMethod visits each function's interface method demands.
+func (pm *PackageMeta) ForEachUseIfaceMethod(fn func(owner Symbol, demands []IfaceMethodDemand)) {
+	if pm == nil {
+		return
+	}
+	for owner, demands := range pm.useIfaceMethod {
+		fn(owner, cloneIfaceMethodDemands(demands))
+	}
+}
+
+// ForEachMethodInfo visits each concrete type's method slots.
+func (pm *PackageMeta) ForEachMethodInfo(fn func(typ Symbol, slots []MethodSlot)) {
+	if pm == nil {
+		return
+	}
+	for typ, slots := range pm.methodInfo {
+		fn(typ, cloneMethodSlots(slots))
+	}
+}
+
+// ForEachUseNamedMethod visits each function's constant MethodByName names.
+func (pm *PackageMeta) ForEachUseNamedMethod(fn func(owner Symbol, names []Name)) {
+	if pm == nil {
+		return
+	}
+	for owner, names := range pm.useNamedMethod {
+		fn(owner, cloneNames(names))
+	}
+}
+
+// ForEachReflectMethod visits each function that needs conservative reflection handling.
+func (pm *PackageMeta) ForEachReflectMethod(fn func(owner Symbol)) {
+	if pm == nil {
+		return
+	}
+	for owner := range pm.reflectMethod {
+		fn(owner)
+	}
+}
+
+func cloneSymbols(in []Symbol) []Symbol {
+	return append([]Symbol(nil), in...)
+}
+
+func cloneNames(in []Name) []Name {
+	return append([]Name(nil), in...)
+}
+
+func cloneMethodSigs(in []MethodSig) []MethodSig {
+	return append([]MethodSig(nil), in...)
+}
+
+func cloneIfaceMethodDemands(in []IfaceMethodDemand) []IfaceMethodDemand {
+	return append([]IfaceMethodDemand(nil), in...)
+}
+
+func cloneMethodSlots(in []MethodSlot) []MethodSlot {
+	return append([]MethodSlot(nil), in...)
+}

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -41,6 +41,17 @@ func TestBuilderSeparatesSymbolAndNameReferences(t *testing.T) {
 	}
 }
 
+func TestPackageMetaNameLookupsReturnEmptyStringForOutOfRangeIDs(t *testing.T) {
+	pm := NewPackageMeta([]string{"main"})
+
+	if got := pm.SymbolName(Symbol(1)); got != "" {
+		t.Fatalf("SymbolName(out-of-range) = %q, want empty string", got)
+	}
+	if got := pm.Name(Name(1)); got != "" {
+		t.Fatalf("Name(out-of-range) = %q, want empty string", got)
+	}
+}
+
 func TestBuilderDeduplicatesFacts(t *testing.T) {
 	b := NewBuilder()
 	main := b.Symbol("main")
@@ -168,6 +179,26 @@ github.com/goplus/llgo/cl/_testmeta/interface_anonymous.use:
 
 [ReflectMethod]
 github.com/goplus/llgo/cl/_testmeta/interface_anonymous.use
+
+`
+	if got != want {
+		t.Fatalf("MetaString mismatch\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestFormatMetaPrintsUnknownSymbolAndNameReferences(t *testing.T) {
+	pm := NewPackageMeta([]string{"owner"})
+	pm.useIface[Symbol(0)] = []Symbol{Symbol(2)}
+	pm.useNamedMethod[Symbol(0)] = []Name{Name(3)}
+
+	got := MetaString(pm)
+	want := `[UseIface]
+owner:
+    ?2
+
+[UseNamedMethod]
+owner:
+    ?3
 
 `
 	if got != want {

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -1,0 +1,172 @@
+package metadata
+
+import "testing"
+
+func TestBuilderSeparatesSymbolAndNameReferences(t *testing.T) {
+	b := NewBuilder()
+
+	mainSym := b.Symbol("main")
+	mainName := b.Name("main")
+	readName := b.Name("Read")
+	fnType := b.Symbol("_llgo_func$A1")
+	typ := b.Symbol("*reader")
+	ifn := b.Symbol("(*reader).Read$iface")
+	tfn := b.Symbol("(*reader).Read")
+
+	if uint32(mainSym) != uint32(mainName) {
+		t.Fatalf("shared string table should allow equal backing IDs for equal text: Symbol=%d Name=%d", mainSym, mainName)
+	}
+
+	b.AddEdge(mainSym, tfn)
+	b.AddUseNamedMethod(mainSym, []Name{mainName, readName})
+	b.AddMethodInfo(typ, []MethodSlot{{
+		Sig: MethodSig{Name: readName, MType: fnType},
+		IFn: ifn,
+		TFn: tfn,
+	}})
+
+	pm := b.Build()
+	if got := pm.SymbolName(mainSym); got != "main" {
+		t.Fatalf("SymbolName(main) = %q, want main", got)
+	}
+	if got := pm.Name(mainName); got != "main" {
+		t.Fatalf("Name(main) = %q, want main", got)
+	}
+	slots := collectMethodSlots(pm, typ)
+	if got := pm.Name(slots[0].Sig.Name); got != "Read" {
+		t.Fatalf("method name = %q, want Read", got)
+	}
+	if got := pm.SymbolName(slots[0].Sig.MType); got != "_llgo_func$A1" {
+		t.Fatalf("method type = %q, want _llgo_func$A1", got)
+	}
+}
+
+func TestFormatMetaStableOutput(t *testing.T) {
+	got := MetaString(buildFullTestMeta())
+	want := `[TypeChildren]
+*_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to:
+    _llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to
+*_llgo_github.com/goplus/llgo/cl/_testmeta/nested.Inner:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/nested.Inner
+*_llgo_github.com/goplus/llgo/cl/_testmeta/nested.Outer:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/nested.Outer
+*_llgo_int:
+    _llgo_int
+*_llgo_string:
+    _llgo_string
+_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to:
+    _llgo_string
+_llgo_github.com/goplus/llgo/cl/_testmeta/nested.Inner:
+    _llgo_string
+_llgo_github.com/goplus/llgo/cl/_testmeta/nested.Outer:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/nested.Inner
+    _llgo_int
+
+[InterfaceInfo]
+_llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo:
+    M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+    N _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+
+[OrdinaryEdges]
+github.com/goplus/llgo/cl/_testmeta/interface_anonymous.main:
+    github.com/goplus/llgo/cl/_testmeta/interface_anonymous.use
+
+[UseIface]
+github.com/goplus/llgo/cl/_testmeta/interface_anonymous.main:
+    _llgo_github.com/goplus/llgo/cl/_testmeta/interface_anonymous.T
+
+[UseIfaceMethod]
+github.com/goplus/llgo/cl/_testmeta/interface_anonymous.use:
+    _llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+    _llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo N _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac
+
+[MethodInfo]
+*_llgo_github.com/goplus/llgo/cl/_testmeta/interface_anonymous.T:
+    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/interface_anonymous.(*T).M github.com/goplus/llgo/cl/_testmeta/interface_anonymous.(*T).M
+    1 N _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/interface_anonymous.(*T).N github.com/goplus/llgo/cl/_testmeta/interface_anonymous.(*T).N
+_llgo_github.com/goplus/llgo/cl/_testmeta/interface_anonymous.T:
+    0 M _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/interface_anonymous.(*T).M github.com/goplus/llgo/cl/_testmeta/interface_anonymous.T.M
+    1 N _llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac github.com/goplus/llgo/cl/_testmeta/interface_anonymous.(*T).N github.com/goplus/llgo/cl/_testmeta/interface_anonymous.T.N
+
+[UseNamedMethod]
+github.com/goplus/llgo/cl/_testmeta/interface_anonymous.use:
+    M
+
+[ReflectMethod]
+github.com/goplus/llgo/cl/_testmeta/interface_anonymous.use
+
+`
+	if got != want {
+		t.Fatalf("MetaString mismatch\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func buildFullTestMeta() *PackageMeta {
+	b := NewBuilder()
+
+	nestedFuncPtr := b.Symbol("*_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to")
+	nestedFunc := b.Symbol("_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to")
+	nestedInnerPtr := b.Symbol("*_llgo_github.com/goplus/llgo/cl/_testmeta/nested.Inner")
+	nestedInner := b.Symbol("_llgo_github.com/goplus/llgo/cl/_testmeta/nested.Inner")
+	nestedOuterPtr := b.Symbol("*_llgo_github.com/goplus/llgo/cl/_testmeta/nested.Outer")
+	nestedOuter := b.Symbol("_llgo_github.com/goplus/llgo/cl/_testmeta/nested.Outer")
+	intPtr := b.Symbol("*_llgo_int")
+	intType := b.Symbol("_llgo_int")
+	stringPtr := b.Symbol("*_llgo_string")
+	stringType := b.Symbol("_llgo_string")
+
+	b.AddTypeChild(nestedFuncPtr, nestedFunc)
+	b.AddTypeChild(nestedInnerPtr, nestedInner)
+	b.AddTypeChild(nestedOuterPtr, nestedOuter)
+	b.AddTypeChild(intPtr, intType)
+	b.AddTypeChild(stringPtr, stringType)
+	b.AddTypeChild(nestedFunc, stringType)
+	b.AddTypeChild(nestedInner, stringType)
+	b.AddTypeChild(nestedOuter, nestedInner)
+	b.AddTypeChild(nestedOuter, intType)
+
+	main := b.Symbol("github.com/goplus/llgo/cl/_testmeta/interface_anonymous.main")
+	use := b.Symbol("github.com/goplus/llgo/cl/_testmeta/interface_anonymous.use")
+	iface := b.Symbol("_llgo_iface$f14WsslTA1u5wwC83jLU0HU2u2mmAWxBVE38vPBbRAo")
+	typ := b.Symbol("_llgo_github.com/goplus/llgo/cl/_testmeta/interface_anonymous.T")
+	ptrTyp := b.Symbol("*_llgo_github.com/goplus/llgo/cl/_testmeta/interface_anonymous.T")
+	methodType := b.Symbol("_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac")
+	mName := b.Name("M")
+	nName := b.Name("N")
+	mSig := MethodSig{Name: mName, MType: methodType}
+	nSig := MethodSig{Name: nName, MType: methodType}
+	ptrM := b.Symbol("github.com/goplus/llgo/cl/_testmeta/interface_anonymous.(*T).M")
+	ptrN := b.Symbol("github.com/goplus/llgo/cl/_testmeta/interface_anonymous.(*T).N")
+	valM := b.Symbol("github.com/goplus/llgo/cl/_testmeta/interface_anonymous.T.M")
+	valN := b.Symbol("github.com/goplus/llgo/cl/_testmeta/interface_anonymous.T.N")
+
+	b.AddEdge(main, use)
+	b.AddIfaceEntry(iface, []MethodSig{mSig, nSig})
+	b.AddUseIface(main, []Symbol{typ})
+	b.AddUseIfaceMethod(use, []IfaceMethodDemand{
+		{Target: iface, Sig: mSig},
+		{Target: iface, Sig: nSig},
+	})
+	b.AddMethodInfo(ptrTyp, []MethodSlot{
+		{Sig: mSig, IFn: ptrM, TFn: ptrM},
+		{Sig: nSig, IFn: ptrN, TFn: ptrN},
+	})
+	b.AddMethodInfo(typ, []MethodSlot{
+		{Sig: mSig, IFn: ptrM, TFn: valM},
+		{Sig: nSig, IFn: ptrN, TFn: valN},
+	})
+	b.AddUseNamedMethod(use, []Name{mName})
+	b.AddReflectMethod(use)
+
+	return b.Build()
+}
+
+func collectMethodSlots(pm *PackageMeta, want Symbol) []MethodSlot {
+	var got []MethodSlot
+	pm.ForEachMethodInfo(func(typ Symbol, slots []MethodSlot) {
+		if typ == want {
+			got = append(got, slots...)
+		}
+	})
+	return got
+}

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -41,6 +41,80 @@ func TestBuilderSeparatesSymbolAndNameReferences(t *testing.T) {
 	}
 }
 
+func TestBuilderDeduplicatesFacts(t *testing.T) {
+	b := NewBuilder()
+	main := b.Symbol("main")
+	use := b.Symbol("use")
+	typ := b.Symbol("_llgo_T")
+	iface := b.Symbol("_llgo_I")
+	name := b.Name("M")
+	mtype := b.Symbol("_llgo_func")
+	sig := MethodSig{Name: name, MType: mtype}
+	demand := IfaceMethodDemand{Target: iface, Sig: sig}
+
+	for range 2 {
+		b.AddEdge(main, use)
+		b.AddTypeChild(typ, mtype)
+		b.AddIfaceEntry(iface, []MethodSig{sig})
+		b.AddUseIface(main, []Symbol{typ})
+		b.AddUseIfaceMethod(use, []IfaceMethodDemand{demand})
+		b.AddUseNamedMethod(use, []Name{name})
+	}
+
+	pm := b.Build()
+	assertSymbolGroup(t, "OrdinaryEdges", pm, pm.ForEachOrdinaryEdge, main, []Symbol{use})
+	assertSymbolGroup(t, "TypeChildren", pm, pm.ForEachTypeChild, typ, []Symbol{mtype})
+	assertSymbolGroup(t, "UseIface", pm, pm.ForEachUseIface, main, []Symbol{typ})
+
+	var ifaceMethods []MethodSig
+	pm.ForEachInterface(func(gotIface Symbol, methods []MethodSig) {
+		if gotIface == iface {
+			ifaceMethods = append(ifaceMethods, methods...)
+		}
+	})
+	if len(ifaceMethods) != 1 || ifaceMethods[0] != sig {
+		t.Fatalf("InterfaceInfo = %#v, want %#v", ifaceMethods, []MethodSig{sig})
+	}
+
+	var demands []IfaceMethodDemand
+	pm.ForEachUseIfaceMethod(func(owner Symbol, got []IfaceMethodDemand) {
+		if owner == use {
+			demands = append(demands, got...)
+		}
+	})
+	if len(demands) != 1 || demands[0] != demand {
+		t.Fatalf("UseIfaceMethod = %#v, want %#v", demands, []IfaceMethodDemand{demand})
+	}
+
+	var names []Name
+	pm.ForEachUseNamedMethod(func(owner Symbol, got []Name) {
+		if owner == use {
+			names = append(names, got...)
+		}
+	})
+	if len(names) != 1 || names[0] != name {
+		t.Fatalf("UseNamedMethod = %#v, want %#v", names, []Name{name})
+	}
+}
+
+func TestBuilderSkipsEmptyMethodInfo(t *testing.T) {
+	b := NewBuilder()
+	typ := b.Symbol("_llgo_T")
+
+	b.AddMethodInfo(typ, nil)
+
+	pm := b.Build()
+	var got []MethodSlot
+	pm.ForEachMethodInfo(func(candidate Symbol, slots []MethodSlot) {
+		if candidate == typ {
+			got = append(got, slots...)
+		}
+	})
+	if len(got) != 0 {
+		t.Fatalf("MethodInfo for empty slots = %#v, want none", got)
+	}
+}
+
 func TestFormatMetaStableOutput(t *testing.T) {
 	got := MetaString(buildFullTestMeta())
 	want := `[TypeChildren]
@@ -98,6 +172,25 @@ github.com/goplus/llgo/cl/_testmeta/interface_anonymous.use
 `
 	if got != want {
 		t.Fatalf("MetaString mismatch\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func assertSymbolGroup(t *testing.T, group string, pm *PackageMeta, visit func(func(Symbol, []Symbol)), key Symbol, want []Symbol) {
+	t.Helper()
+
+	var got []Symbol
+	visit(func(candidate Symbol, values []Symbol) {
+		if candidate == key {
+			got = append(got, values...)
+		}
+	})
+	if len(got) != len(want) {
+		t.Fatalf("%s len = %d (%#v), want %d (%#v)", group, len(got), got, len(want), want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("%s = %#v, want %#v", group, got, want)
+		}
 	}
 }
 

--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -26,8 +26,6 @@ import (
 
 	"github.com/goplus/llgo/ssa/abi"
 	"github.com/xgo-dev/llvm"
-
-	"github.com/goplus/llgo/internal/metadata"
 )
 
 // -----------------------------------------------------------------------------
@@ -345,71 +343,6 @@ func (b Builder) abiExtendedFields(t types.Type, name string) (fields []llvm.Val
 	return
 }
 
-func (b Builder) recordTypeChildren(parentName string, t types.Type) {
-	mb := b.Pkg.MetaBuilder
-	if mb == nil {
-		return
-	}
-	parent := mb.Symbol(parentName)
-	for _, child := range b.directTypeChildren(t) {
-		childName, _ := b.Prog.abi.TypeName(child)
-		mb.AddTypeChild(parent, mb.Symbol(childName))
-	}
-}
-
-func (b Builder) directTypeChildren(t types.Type) []types.Type {
-	switch t := types.Unalias(t).(type) {
-	case *types.Basic:
-		return nil
-	case *types.Pointer:
-		return []types.Type{abi.PublicType(t.Elem())}
-	case *types.Chan:
-		return []types.Type{abi.PublicType(t.Elem())}
-	case *types.Slice:
-		return []types.Type{abi.PublicType(t.Elem())}
-	case *types.Array:
-		elem := abi.PublicType(t.Elem())
-		return []types.Type{elem, types.NewSlice(elem)}
-	case *types.Map:
-		return []types.Type{
-			abi.PublicType(t.Key()),
-			abi.PublicType(t.Elem()),
-			// Map type descriptors reference their runtime bucket type too.
-			b.Prog.abi.MapBucket(t),
-		}
-	case *types.Signature:
-		var children []types.Type
-		children = appendTupleTypeChildren(children, t.Params())
-		children = appendTupleTypeChildren(children, t.Results())
-		return children
-	case *types.Struct:
-		children := make([]types.Type, 0, t.NumFields())
-		for i := 0; i < t.NumFields(); i++ {
-			children = append(children, abi.PublicType(t.Field(i).Type()))
-		}
-		return children
-	case *types.Interface:
-		children := make([]types.Type, 0, t.NumMethods())
-		for i := 0; i < t.NumMethods(); i++ {
-			children = append(children, funcType(b.Prog, t.Method(i).Type()))
-		}
-		return children
-	case *types.Named:
-		return b.directTypeChildren(t.Underlying())
-	}
-	return nil
-}
-
-func appendTupleTypeChildren(children []types.Type, tuple *types.Tuple) []types.Type {
-	if tuple == nil {
-		return children
-	}
-	for i := 0; i < tuple.Len(); i++ {
-		children = append(children, abi.PublicType(tuple.At(i).Type()))
-	}
-	return children
-}
-
 func (b Builder) abiUncommonPkg(t types.Type) (*types.Package, string) {
 retry:
 	switch typ := types.Unalias(t).(type) {
@@ -491,11 +424,7 @@ func (b Builder) abiUncommonMethods(t types.Type, mset *types.MethodSet) llvm.Va
 	ft := prog.rtType("Method")
 	n := mset.Len()
 	fields := make([]llvm.Value, n)
-	var slots []metadata.MethodSlot
-	typeName, _ := prog.abi.TypeName(t)
-	if b.Pkg.MetaBuilder != nil {
-		slots = make([]metadata.MethodSlot, 0, n)
-	}
+	methodInfo := b.newMethodInfoRecorder(t, n)
 	pkg, _ := b.abiUncommonPkg(t)
 	anonymous := pkg == nil
 	if anonymous {
@@ -526,21 +455,9 @@ func (b Builder) abiUncommonMethods(t types.Type, mset *types.MethodSet) llvm.Va
 		values = append(values, ifn)
 		values = append(values, tfn)
 		fields[i] = llvm.ConstNamedStruct(ft.ll, values)
-		if mb := b.Pkg.MetaBuilder; mb != nil {
-			mtypeName, _ := prog.abi.TypeName(ftyp)
-			slots = append(slots, metadata.MethodSlot{
-				Sig: metadata.MethodSig{
-					Name:  mb.Name(fullName),
-					MType: mb.Symbol(mtypeName),
-				},
-				IFn: mb.Symbol(ifn.Name()),
-				TFn: mb.Symbol(tfn.Name()),
-			})
-		}
+		methodInfo.add(obj, ftyp, ifn, tfn)
 	}
-	if mb := b.Pkg.MetaBuilder; mb != nil {
-		mb.AddMethodInfo(mb.Symbol(typeName), slots)
-	}
+	methodInfo.finish()
 	return llvm.ConstArray(ft.ll, fields)
 }
 
@@ -548,14 +465,6 @@ func (b Builder) abiUncommonMethods(t types.Type, mset *types.MethodSet) llvm.Va
 func funcType(prog Program, typ types.Type) types.Type {
 	ftyp := prog.Type(typ, InGo)
 	return ftyp.raw.Type.(*types.Struct).Field(0).Type()
-}
-
-func mthName(method *types.Func) string {
-	name := method.Name()
-	if token.IsExported(name) {
-		return name
-	}
-	return abi.FullName(method.Pkg(), name)
 }
 
 func (b Builder) abiMethodFunc(anonymous bool, mPkg *types.Package, mName string, mSig *types.Signature) (tfn llvm.Value) {

--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/goplus/llgo/ssa/abi"
 	"github.com/xgo-dev/llvm"
+
+	"github.com/goplus/llgo/internal/metadata"
 )
 
 // -----------------------------------------------------------------------------
@@ -343,6 +345,71 @@ func (b Builder) abiExtendedFields(t types.Type, name string) (fields []llvm.Val
 	return
 }
 
+func (b Builder) recordTypeChildren(parentName string, t types.Type) {
+	mb := b.Pkg.MetaBuilder
+	if mb == nil {
+		return
+	}
+	parent := mb.Symbol(parentName)
+	for _, child := range b.directTypeChildren(t) {
+		childName, _ := b.Prog.abi.TypeName(child)
+		mb.AddTypeChild(parent, mb.Symbol(childName))
+	}
+}
+
+func (b Builder) directTypeChildren(t types.Type) []types.Type {
+	switch t := types.Unalias(t).(type) {
+	case *types.Basic:
+		return nil
+	case *types.Pointer:
+		return []types.Type{abi.PublicType(t.Elem())}
+	case *types.Chan:
+		return []types.Type{abi.PublicType(t.Elem())}
+	case *types.Slice:
+		return []types.Type{abi.PublicType(t.Elem())}
+	case *types.Array:
+		elem := abi.PublicType(t.Elem())
+		return []types.Type{elem, types.NewSlice(elem)}
+	case *types.Map:
+		return []types.Type{
+			abi.PublicType(t.Key()),
+			abi.PublicType(t.Elem()),
+			// Map type descriptors reference their runtime bucket type too.
+			b.Prog.abi.MapBucket(t),
+		}
+	case *types.Signature:
+		var children []types.Type
+		children = appendTupleTypeChildren(children, t.Params())
+		children = appendTupleTypeChildren(children, t.Results())
+		return children
+	case *types.Struct:
+		children := make([]types.Type, 0, t.NumFields())
+		for i := 0; i < t.NumFields(); i++ {
+			children = append(children, abi.PublicType(t.Field(i).Type()))
+		}
+		return children
+	case *types.Interface:
+		children := make([]types.Type, 0, t.NumMethods())
+		for i := 0; i < t.NumMethods(); i++ {
+			children = append(children, funcType(b.Prog, t.Method(i).Type()))
+		}
+		return children
+	case *types.Named:
+		return b.directTypeChildren(t.Underlying())
+	}
+	return nil
+}
+
+func appendTupleTypeChildren(children []types.Type, tuple *types.Tuple) []types.Type {
+	if tuple == nil {
+		return children
+	}
+	for i := 0; i < tuple.Len(); i++ {
+		children = append(children, abi.PublicType(tuple.At(i).Type()))
+	}
+	return children
+}
+
 func (b Builder) abiUncommonPkg(t types.Type) (*types.Package, string) {
 retry:
 	switch typ := types.Unalias(t).(type) {
@@ -424,6 +491,11 @@ func (b Builder) abiUncommonMethods(t types.Type, mset *types.MethodSet) llvm.Va
 	ft := prog.rtType("Method")
 	n := mset.Len()
 	fields := make([]llvm.Value, n)
+	var slots []metadata.MethodSlot
+	typeName, _ := prog.abi.TypeName(t)
+	if b.Pkg.MetaBuilder != nil {
+		slots = make([]metadata.MethodSlot, 0, n)
+	}
 	pkg, _ := b.abiUncommonPkg(t)
 	anonymous := pkg == nil
 	if anonymous {
@@ -431,11 +503,12 @@ func (b Builder) abiUncommonMethods(t types.Type, mset *types.MethodSet) llvm.Va
 	}
 	for i := 0; i < n; i++ {
 		m := mset.At(i)
-		obj := m.Obj()
+		obj := m.Obj().(*types.Func)
 		mName := obj.Name()
+		fullName := mthName(obj)
 		name := b.Str(mName).impl
 		if !token.IsExported(mName) {
-			name = b.Str(abi.FullName(obj.Pkg(), mName)).impl
+			name = b.Str(fullName).impl
 		}
 		mSig := m.Type().(*types.Signature)
 		var tfn, ifn llvm.Value
@@ -453,6 +526,20 @@ func (b Builder) abiUncommonMethods(t types.Type, mset *types.MethodSet) llvm.Va
 		values = append(values, ifn)
 		values = append(values, tfn)
 		fields[i] = llvm.ConstNamedStruct(ft.ll, values)
+		if mb := b.Pkg.MetaBuilder; mb != nil {
+			mtypeName, _ := prog.abi.TypeName(ftyp)
+			slots = append(slots, metadata.MethodSlot{
+				Sig: metadata.MethodSig{
+					Name:  mb.Name(fullName),
+					MType: mb.Symbol(mtypeName),
+				},
+				IFn: mb.Symbol(ifn.Name()),
+				TFn: mb.Symbol(tfn.Name()),
+			})
+		}
+	}
+	if mb := b.Pkg.MetaBuilder; mb != nil {
+		mb.AddMethodInfo(mb.Symbol(typeName), slots)
 	}
 	return llvm.ConstArray(ft.ll, fields)
 }
@@ -461,6 +548,14 @@ func (b Builder) abiUncommonMethods(t types.Type, mset *types.MethodSet) llvm.Va
 func funcType(prog Program, typ types.Type) types.Type {
 	ftyp := prog.Type(typ, InGo)
 	return ftyp.raw.Type.(*types.Struct).Field(0).Type()
+}
+
+func mthName(method *types.Func) string {
+	name := method.Name()
+	if token.IsExported(name) {
+		return name
+	}
+	return abi.FullName(method.Pkg(), name)
 }
 
 func (b Builder) abiMethodFunc(anonymous bool, mPkg *types.Package, mName string, mSig *types.Signature) (tfn llvm.Value) {
@@ -497,6 +592,7 @@ func (b Builder) abiType(t types.Type) Expr {
 		if prog.patchType != nil {
 			t = prog.patchType(t)
 		}
+		b.recordTypeChildren(name, t)
 		mset, hasUncommon := b.abiUncommonMethodSet(t)
 		rt := prog.rtNamed(prog.abi.RuntimeName(t))
 		var typ types.Type = rt

--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -455,9 +455,13 @@ func (b Builder) abiUncommonMethods(t types.Type, mset *types.MethodSet) llvm.Va
 		values = append(values, ifn)
 		values = append(values, tfn)
 		fields[i] = llvm.ConstNamedStruct(ft.ll, values)
-		methodInfo.add(obj, ftyp, ifn, tfn)
+		if methodInfo != nil {
+			methodInfo.add(obj, ftyp, ifn, tfn)
+		}
 	}
-	methodInfo.finish()
+	if methodInfo != nil {
+		methodInfo.finish()
+	}
 	return llvm.ConstArray(ft.ll, fields)
 }
 

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -24,6 +24,7 @@ import (
 	"go/types"
 	"log"
 
+	"github.com/goplus/llgo/internal/metadata"
 	"github.com/xgo-dev/llvm"
 )
 
@@ -1186,9 +1187,15 @@ func (b Builder) checkReflect(fn Expr, args []Expr) {
 				}
 				pkg.MethodByIndex[v] = none{}
 				pkg.NeedAbiInit |= ReflectMethodByIndex
+				if mb := pkg.MetaBuilder; mb != nil {
+					mb.AddReflectMethod(mb.Symbol(b.Func.Name()))
+				}
 				return
 			}
 			pkg.NeedAbiInit |= ReflectMethodDynamic
+			if mb := pkg.MetaBuilder; mb != nil {
+				mb.AddReflectMethod(mb.Symbol(b.Func.Name()))
+			}
 		}
 	case "reflect.Value.MethodByName":
 		if len(args) == 2 {
@@ -1198,9 +1205,15 @@ func (b Builder) checkReflect(fn Expr, args []Expr) {
 				}
 				pkg.MethodByName[v] = none{}
 				pkg.NeedAbiInit |= ReflectMethodByName
+				if mb := pkg.MetaBuilder; mb != nil {
+					mb.AddUseNamedMethod(mb.Symbol(b.Func.Name()), []metadata.Name{mb.Name(v)})
+				}
 				return
 			}
 			pkg.NeedAbiInit |= ReflectMethodDynamic
+			if mb := pkg.MetaBuilder; mb != nil {
+				mb.AddReflectMethod(mb.Symbol(b.Func.Name()))
+			}
 		}
 	}
 }

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -24,7 +24,6 @@ import (
 	"go/types"
 	"log"
 
-	"github.com/goplus/llgo/internal/metadata"
 	"github.com/xgo-dev/llvm"
 )
 
@@ -1187,15 +1186,9 @@ func (b Builder) checkReflect(fn Expr, args []Expr) {
 				}
 				pkg.MethodByIndex[v] = none{}
 				pkg.NeedAbiInit |= ReflectMethodByIndex
-				if mb := pkg.MetaBuilder; mb != nil {
-					mb.AddReflectMethod(mb.Symbol(b.Func.Name()))
-				}
 				return
 			}
 			pkg.NeedAbiInit |= ReflectMethodDynamic
-			if mb := pkg.MetaBuilder; mb != nil {
-				mb.AddReflectMethod(mb.Symbol(b.Func.Name()))
-			}
 		}
 	case "reflect.Value.MethodByName":
 		if len(args) == 2 {
@@ -1205,15 +1198,9 @@ func (b Builder) checkReflect(fn Expr, args []Expr) {
 				}
 				pkg.MethodByName[v] = none{}
 				pkg.NeedAbiInit |= ReflectMethodByName
-				if mb := pkg.MetaBuilder; mb != nil {
-					mb.AddUseNamedMethod(mb.Symbol(b.Func.Name()), []metadata.Name{mb.Name(v)})
-				}
 				return
 			}
 			pkg.NeedAbiInit |= ReflectMethodDynamic
-			if mb := pkg.MetaBuilder; mb != nil {
-				mb.AddReflectMethod(mb.Symbol(b.Func.Name()))
-			}
 		}
 	}
 }

--- a/ssa/interface.go
+++ b/ssa/interface.go
@@ -20,7 +20,6 @@ import (
 	"go/token"
 	"go/types"
 
-	"github.com/goplus/llgo/internal/metadata"
 	"github.com/goplus/llgo/ssa/abi"
 	"github.com/xgo-dev/llvm"
 )
@@ -81,28 +80,7 @@ func (b Builder) Imethod(intf Expr, method *types.Func) Expr {
 	}
 	tclosure := prog.Type(sig, InGo)
 	i := iMethodOf(rawIntf, method.Name())
-	if mb := b.Pkg.MetaBuilder; mb != nil {
-		intfTypeName, _ := prog.abi.TypeName(intf.raw.Type)
-		mtypeName, _ := prog.abi.TypeName(funcType(prog, method.Type()))
-		mb.AddUseIfaceMethod(mb.Symbol(b.Func.Name()), []metadata.IfaceMethodDemand{{
-			Target: mb.Symbol(intfTypeName),
-			Sig: metadata.MethodSig{
-				Name:  mb.Name(mthName(method)),
-				MType: mb.Symbol(mtypeName),
-			},
-		}})
-
-		methods := make([]metadata.MethodSig, 0, rawIntf.NumMethods())
-		for i := 0; i < rawIntf.NumMethods(); i++ {
-			im := rawIntf.Method(i)
-			imtypeName, _ := prog.abi.TypeName(funcType(prog, im.Type()))
-			methods = append(methods, metadata.MethodSig{
-				Name:  mb.Name(mthName(im)),
-				MType: mb.Symbol(imtypeName),
-			})
-		}
-		mb.AddIfaceEntry(mb.Symbol(intfTypeName), methods)
-	}
+	b.recordInterfaceMethodCall(intf, rawIntf, method)
 	data := b.InlineCall(b.Pkg.rtFunc("IfacePtrData"), intf)
 	impl := intf.impl
 	itab := Expr{b.faceItab(impl), prog.VoidPtrPtr()}
@@ -137,12 +115,7 @@ func (b Builder) MakeInterface(tinter Type, x Expr) (ret Expr) {
 	}
 	prog := b.Prog
 	typ := x.Type
-	if mb := b.Pkg.MetaBuilder; mb != nil {
-		if _, ok := types.Unalias(typ.raw.Type).Underlying().(*types.Interface); !ok {
-			typeName, _ := prog.abi.TypeName(typ.raw.Type)
-			mb.AddUseIface(mb.Symbol(b.Func.Name()), []metadata.Symbol{mb.Symbol(typeName)})
-		}
-	}
+	b.recordInterfaceUse(typ.raw.Type)
 	tabi := b.abiType(typ.raw.Type)
 	if !directIfaceType(typ.raw.Type) {
 		vptr := b.AllocU(typ)

--- a/ssa/interface.go
+++ b/ssa/interface.go
@@ -20,6 +20,7 @@ import (
 	"go/token"
 	"go/types"
 
+	"github.com/goplus/llgo/internal/metadata"
 	"github.com/goplus/llgo/ssa/abi"
 	"github.com/xgo-dev/llvm"
 )
@@ -80,6 +81,28 @@ func (b Builder) Imethod(intf Expr, method *types.Func) Expr {
 	}
 	tclosure := prog.Type(sig, InGo)
 	i := iMethodOf(rawIntf, method.Name())
+	if mb := b.Pkg.MetaBuilder; mb != nil {
+		intfTypeName, _ := prog.abi.TypeName(intf.raw.Type)
+		mtypeName, _ := prog.abi.TypeName(funcType(prog, method.Type()))
+		mb.AddUseIfaceMethod(mb.Symbol(b.Func.Name()), []metadata.IfaceMethodDemand{{
+			Target: mb.Symbol(intfTypeName),
+			Sig: metadata.MethodSig{
+				Name:  mb.Name(mthName(method)),
+				MType: mb.Symbol(mtypeName),
+			},
+		}})
+
+		methods := make([]metadata.MethodSig, 0, rawIntf.NumMethods())
+		for i := 0; i < rawIntf.NumMethods(); i++ {
+			im := rawIntf.Method(i)
+			imtypeName, _ := prog.abi.TypeName(funcType(prog, im.Type()))
+			methods = append(methods, metadata.MethodSig{
+				Name:  mb.Name(mthName(im)),
+				MType: mb.Symbol(imtypeName),
+			})
+		}
+		mb.AddIfaceEntry(mb.Symbol(intfTypeName), methods)
+	}
 	data := b.InlineCall(b.Pkg.rtFunc("IfacePtrData"), intf)
 	impl := intf.impl
 	itab := Expr{b.faceItab(impl), prog.VoidPtrPtr()}
@@ -114,6 +137,12 @@ func (b Builder) MakeInterface(tinter Type, x Expr) (ret Expr) {
 	}
 	prog := b.Prog
 	typ := x.Type
+	if mb := b.Pkg.MetaBuilder; mb != nil {
+		if _, ok := types.Unalias(typ.raw.Type).Underlying().(*types.Interface); !ok {
+			typeName, _ := prog.abi.TypeName(typ.raw.Type)
+			mb.AddUseIface(mb.Symbol(b.Func.Name()), []metadata.Symbol{mb.Symbol(typeName)})
+		}
+	}
 	tabi := b.abiType(typ.raw.Type)
 	if !directIfaceType(typ.raw.Type) {
 		vptr := b.AllocU(typ)

--- a/ssa/metadata.go
+++ b/ssa/metadata.go
@@ -25,12 +25,8 @@ import (
 	"github.com/xgo-dev/llvm"
 )
 
-func (b Builder) meta() *metadata.Builder {
-	return b.Pkg.MetaBuilder
-}
-
 func (b Builder) recordTypeChildren(parentName string, t types.Type) {
-	mb := b.meta()
+	mb := b.Pkg.MetaBuilder
 	if mb == nil {
 		return
 	}
@@ -95,7 +91,7 @@ func appendTupleTypeChildren(children []types.Type, tuple *types.Tuple) []types.
 }
 
 func (b Builder) recordInterfaceMethodCall(intf Expr, rawIntf *types.Interface, method *types.Func) {
-	mb := b.meta()
+	mb := b.Pkg.MetaBuilder
 	if mb == nil {
 		return
 	}
@@ -122,7 +118,7 @@ func (b Builder) recordInterfaceMethodCall(intf Expr, rawIntf *types.Interface, 
 }
 
 func (b Builder) recordInterfaceUse(t types.Type) {
-	mb := b.meta()
+	mb := b.Pkg.MetaBuilder
 	if mb == nil {
 		return
 	}
@@ -141,7 +137,7 @@ type methodInfoRecorder struct {
 }
 
 func (b Builder) newMethodInfoRecorder(t types.Type, n int) methodInfoRecorder {
-	mb := b.meta()
+	mb := b.Pkg.MetaBuilder
 	if mb == nil {
 		return methodInfoRecorder{}
 	}

--- a/ssa/metadata.go
+++ b/ssa/metadata.go
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ssa
+
+import (
+	"go/token"
+	"go/types"
+
+	"github.com/goplus/llgo/internal/metadata"
+	"github.com/goplus/llgo/ssa/abi"
+	"github.com/xgo-dev/llvm"
+)
+
+func (b Builder) meta() *metadata.Builder {
+	return b.Pkg.MetaBuilder
+}
+
+func (b Builder) recordTypeChildren(parentName string, t types.Type) {
+	mb := b.meta()
+	if mb == nil {
+		return
+	}
+	parent := mb.Symbol(parentName)
+	for _, child := range b.directTypeChildren(t) {
+		childName, _ := b.Prog.abi.TypeName(child)
+		mb.AddTypeChild(parent, mb.Symbol(childName))
+	}
+}
+
+func (b Builder) directTypeChildren(t types.Type) []types.Type {
+	switch t := types.Unalias(t).(type) {
+	case *types.Basic:
+		return nil
+	case *types.Pointer:
+		return []types.Type{abi.PublicType(t.Elem())}
+	case *types.Chan:
+		return []types.Type{abi.PublicType(t.Elem())}
+	case *types.Slice:
+		return []types.Type{abi.PublicType(t.Elem())}
+	case *types.Array:
+		elem := abi.PublicType(t.Elem())
+		return []types.Type{elem, types.NewSlice(elem)}
+	case *types.Map:
+		return []types.Type{
+			abi.PublicType(t.Key()),
+			abi.PublicType(t.Elem()),
+			// Map type descriptors reference their runtime bucket type too.
+			b.Prog.abi.MapBucket(t),
+		}
+	case *types.Signature:
+		var children []types.Type
+		children = appendTupleTypeChildren(children, t.Params())
+		children = appendTupleTypeChildren(children, t.Results())
+		return children
+	case *types.Struct:
+		children := make([]types.Type, 0, t.NumFields())
+		for i := 0; i < t.NumFields(); i++ {
+			children = append(children, abi.PublicType(t.Field(i).Type()))
+		}
+		return children
+	case *types.Interface:
+		children := make([]types.Type, 0, t.NumMethods())
+		for i := 0; i < t.NumMethods(); i++ {
+			children = append(children, funcType(b.Prog, t.Method(i).Type()))
+		}
+		return children
+	case *types.Named:
+		return b.directTypeChildren(t.Underlying())
+	}
+	return nil
+}
+
+func appendTupleTypeChildren(children []types.Type, tuple *types.Tuple) []types.Type {
+	if tuple == nil {
+		return children
+	}
+	for i := 0; i < tuple.Len(); i++ {
+		children = append(children, abi.PublicType(tuple.At(i).Type()))
+	}
+	return children
+}
+
+func (b Builder) recordInterfaceMethodCall(intf Expr, rawIntf *types.Interface, method *types.Func) {
+	mb := b.meta()
+	if mb == nil {
+		return
+	}
+	intfTypeName, _ := b.Prog.abi.TypeName(intf.raw.Type)
+	mtypeName, _ := b.Prog.abi.TypeName(funcType(b.Prog, method.Type()))
+	mb.AddUseIfaceMethod(mb.Symbol(b.Func.Name()), []metadata.IfaceMethodDemand{{
+		Target: mb.Symbol(intfTypeName),
+		Sig: metadata.MethodSig{
+			Name:  mb.Name(mthName(method)),
+			MType: mb.Symbol(mtypeName),
+		},
+	}})
+
+	methods := make([]metadata.MethodSig, 0, rawIntf.NumMethods())
+	for i := 0; i < rawIntf.NumMethods(); i++ {
+		im := rawIntf.Method(i)
+		imtypeName, _ := b.Prog.abi.TypeName(funcType(b.Prog, im.Type()))
+		methods = append(methods, metadata.MethodSig{
+			Name:  mb.Name(mthName(im)),
+			MType: mb.Symbol(imtypeName),
+		})
+	}
+	mb.AddIfaceEntry(mb.Symbol(intfTypeName), methods)
+}
+
+func (b Builder) recordInterfaceUse(t types.Type) {
+	mb := b.meta()
+	if mb == nil {
+		return
+	}
+	if _, ok := types.Unalias(t).Underlying().(*types.Interface); ok {
+		return
+	}
+	typeName, _ := b.Prog.abi.TypeName(t)
+	mb.AddUseIface(mb.Symbol(b.Func.Name()), []metadata.Symbol{mb.Symbol(typeName)})
+}
+
+type methodInfoRecorder struct {
+	b       Builder
+	mb      *metadata.Builder
+	typeSym metadata.Symbol
+	slots   []metadata.MethodSlot
+}
+
+func (b Builder) newMethodInfoRecorder(t types.Type, n int) methodInfoRecorder {
+	mb := b.meta()
+	if mb == nil {
+		return methodInfoRecorder{}
+	}
+	typeName, _ := b.Prog.abi.TypeName(t)
+	return methodInfoRecorder{
+		b:       b,
+		mb:      mb,
+		typeSym: mb.Symbol(typeName),
+		slots:   make([]metadata.MethodSlot, 0, n),
+	}
+}
+
+func (r *methodInfoRecorder) add(method *types.Func, ftyp types.Type, ifn, tfn llvm.Value) {
+	if r.mb == nil {
+		return
+	}
+	mtypeName, _ := r.b.Prog.abi.TypeName(ftyp)
+	r.slots = append(r.slots, metadata.MethodSlot{
+		Sig: metadata.MethodSig{
+			Name:  r.mb.Name(mthName(method)),
+			MType: r.mb.Symbol(mtypeName),
+		},
+		IFn: r.mb.Symbol(ifn.Name()),
+		TFn: r.mb.Symbol(tfn.Name()),
+	})
+}
+
+func (r *methodInfoRecorder) finish() {
+	if r.mb == nil {
+		return
+	}
+	r.mb.AddMethodInfo(r.typeSym, r.slots)
+}
+
+func mthName(method *types.Func) string {
+	name := method.Name()
+	if token.IsExported(name) {
+		return name
+	}
+	return abi.FullName(method.Pkg(), name)
+}

--- a/ssa/metadata.go
+++ b/ssa/metadata.go
@@ -54,8 +54,6 @@ func (b Builder) directTypeChildren(t types.Type) []types.Type {
 		return []types.Type{
 			abi.PublicType(t.Key()),
 			abi.PublicType(t.Elem()),
-			// Map type descriptors reference their runtime bucket type too.
-			b.Prog.abi.MapBucket(t),
 		}
 	case *types.Signature:
 		var children []types.Type
@@ -122,6 +120,9 @@ func (b Builder) recordInterfaceUse(t types.Type) {
 	if mb == nil {
 		return
 	}
+	// UseIface tracks concrete types that may provide interface method
+	// implementations; interface-to-interface conversions do not contribute
+	// concrete method slots.
 	if _, ok := types.Unalias(t).Underlying().(*types.Interface); ok {
 		return
 	}
@@ -136,13 +137,13 @@ type methodInfoRecorder struct {
 	slots   []metadata.MethodSlot
 }
 
-func (b Builder) newMethodInfoRecorder(t types.Type, n int) methodInfoRecorder {
+func (b Builder) newMethodInfoRecorder(t types.Type, n int) *methodInfoRecorder {
 	mb := b.Pkg.MetaBuilder
 	if mb == nil {
-		return methodInfoRecorder{}
+		return nil
 	}
 	typeName, _ := b.Prog.abi.TypeName(t)
-	return methodInfoRecorder{
+	return &methodInfoRecorder{
 		b:       b,
 		mb:      mb,
 		typeSym: mb.Symbol(typeName),
@@ -151,9 +152,6 @@ func (b Builder) newMethodInfoRecorder(t types.Type, n int) methodInfoRecorder {
 }
 
 func (r *methodInfoRecorder) add(method *types.Func, ftyp types.Type, ifn, tfn llvm.Value) {
-	if r.mb == nil {
-		return
-	}
 	mtypeName, _ := r.b.Prog.abi.TypeName(ftyp)
 	r.slots = append(r.slots, metadata.MethodSlot{
 		Sig: metadata.MethodSig{
@@ -166,9 +164,6 @@ func (r *methodInfoRecorder) add(method *types.Func, ftyp types.Type, ifn, tfn l
 }
 
 func (r *methodInfoRecorder) finish() {
-	if r.mb == nil {
-		return
-	}
 	r.mb.AddMethodInfo(r.typeSym, r.slots)
 }
 

--- a/ssa/metadata_test.go
+++ b/ssa/metadata_test.go
@@ -1,0 +1,354 @@
+//go:build !llgo
+// +build !llgo
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ssa
+
+import (
+	"go/importer"
+	"go/token"
+	"go/types"
+	"reflect"
+	"testing"
+
+	"github.com/goplus/llgo/internal/metadata"
+)
+
+func newMetadataTestBuilder(t *testing.T) (Builder, *metadata.Builder) {
+	t.Helper()
+
+	prog := NewProgram(nil)
+	prog.SetRuntime(func() *types.Package {
+		pkg, err := importer.For("source", nil).Import(PkgRuntime)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return pkg
+	})
+	pkg := prog.NewPackage("foo", "foo")
+	mb := metadata.NewBuilder()
+	pkg.MetaBuilder = mb
+	fn := pkg.NewFunc("foo.main", NoArgsNoRet, InGo)
+	return fn.MakeBody(1), mb
+}
+
+func TestRecordInterfaceUseSkipsInterfaceTypes(t *testing.T) {
+	b, mb := newMetadataTestBuilder(t)
+
+	typePkg := types.NewPackage("foo", "foo")
+	concrete := types.NewNamed(types.NewTypeName(token.NoPos, typePkg, "T", nil), types.NewStruct(nil, nil), nil)
+	iface := types.NewNamed(types.NewTypeName(token.NoPos, typePkg, "I", nil), types.NewInterfaceType(nil, nil).Complete(), nil)
+
+	b.recordInterfaceUse(concrete)
+	b.recordInterfaceUse(iface)
+
+	meta := mb.Build()
+	got := make(map[string][]string)
+	meta.ForEachUseIface(func(owner metadata.Symbol, typs []metadata.Symbol) {
+		for _, typ := range typs {
+			got[meta.SymbolName(owner)] = append(got[meta.SymbolName(owner)], meta.SymbolName(typ))
+		}
+	})
+
+	want := map[string][]string{
+		"foo.main": {"_llgo_foo.T"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("UseIface = %#v, want %#v", got, want)
+	}
+}
+
+func TestRecordInterfaceUseSkipsWhenMetaBuilderDisabled(t *testing.T) {
+	prog := NewProgram(nil)
+	pkg := prog.NewPackage("foo", "foo")
+	fn := pkg.NewFunc("foo.main", NoArgsNoRet, InGo)
+	b := fn.MakeBody(1)
+
+	b.recordInterfaceUse(types.Typ[types.Int])
+}
+
+func TestDirectTypeChildrenRecordsSemanticTypeEdges(t *testing.T) {
+	b, _ := newMetadataTestBuilder(t)
+	typePkg := types.NewPackage("foo", "foo")
+	namedElem := types.NewNamed(types.NewTypeName(token.NoPos, typePkg, "Elem", nil), types.NewStruct(nil, nil), nil)
+	methodSig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+	methodTypeName, _ := b.Prog.abi.TypeName(funcType(b.Prog, methodSig))
+
+	cases := []struct {
+		name string
+		typ  types.Type
+		want []string
+	}{
+		{
+			name: "pointer",
+			typ:  types.NewPointer(namedElem),
+			want: []string{"_llgo_foo.Elem"},
+		},
+		{
+			name: "chan",
+			typ:  types.NewChan(types.SendRecv, types.Typ[types.Int]),
+			want: []string{"_llgo_int"},
+		},
+		{
+			name: "slice",
+			typ:  types.NewSlice(types.Typ[types.String]),
+			want: []string{"_llgo_string"},
+		},
+		{
+			name: "array",
+			typ:  types.NewArray(types.Typ[types.Int], 3),
+			want: []string{"_llgo_int", "[]_llgo_int"},
+		},
+		{
+			name: "map",
+			typ:  types.NewMap(types.Typ[types.String], types.Typ[types.Int]),
+			want: []string{"_llgo_string", "_llgo_int"},
+		},
+		{
+			name: "signature",
+			typ: types.NewSignatureType(nil, nil, nil,
+				types.NewTuple(types.NewVar(token.NoPos, nil, "x", types.Typ[types.String])),
+				types.NewTuple(types.NewVar(token.NoPos, nil, "ok", types.Typ[types.Bool])),
+				false),
+			want: []string{"_llgo_string", "_llgo_bool"},
+		},
+		{
+			name: "struct",
+			typ: types.NewStruct([]*types.Var{
+				types.NewVar(token.NoPos, nil, "S", types.Typ[types.String]),
+				types.NewVar(token.NoPos, nil, "E", namedElem),
+			}, nil),
+			want: []string{"_llgo_string", "_llgo_foo.Elem"},
+		},
+		{
+			name: "interface",
+			typ: types.NewInterfaceType([]*types.Func{
+				types.NewFunc(token.NoPos, typePkg, "M", methodSig),
+			}, nil).Complete(),
+			want: []string{methodTypeName},
+		},
+		{
+			name: "basic",
+			typ:  types.Typ[types.Bool],
+			want: []string{},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			gotTypes := b.directTypeChildren(tt.typ)
+			got := typeNames(t, b, gotTypes)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("directTypeChildren(%s) = %#v, want %#v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRecordTypeChildrenStoresChildSymbols(t *testing.T) {
+	b, mb := newMetadataTestBuilder(t)
+
+	b.recordTypeChildren("_llgo_foo.S", types.NewStruct([]*types.Var{
+		types.NewVar(token.NoPos, nil, "N", types.Typ[types.Int]),
+		types.NewVar(token.NoPos, nil, "S", types.Typ[types.String]),
+	}, nil))
+
+	meta := mb.Build()
+	got := make(map[string][]string)
+	meta.ForEachTypeChild(func(parent metadata.Symbol, children []metadata.Symbol) {
+		for _, child := range children {
+			got[meta.SymbolName(parent)] = append(got[meta.SymbolName(parent)], meta.SymbolName(child))
+		}
+	})
+
+	want := map[string][]string{
+		"_llgo_foo.S": {"_llgo_int", "_llgo_string"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("TypeChildren = %#v, want %#v", got, want)
+	}
+}
+
+func TestRecordTypeChildrenSkipsWhenMetaBuilderDisabled(t *testing.T) {
+	prog := NewProgram(nil)
+	pkg := prog.NewPackage("foo", "foo")
+	fn := pkg.NewFunc("foo.main", NoArgsNoRet, InGo)
+	b := fn.MakeBody(1)
+
+	b.recordTypeChildren("_llgo_foo.S", types.Typ[types.Int])
+}
+
+func TestDirectTypeChildrenDoesNotRecordMapBucket(t *testing.T) {
+	b, _ := newMetadataTestBuilder(t)
+	mapTyp := types.NewMap(types.Typ[types.String], types.Typ[types.Int])
+
+	got := typeNames(t, b, b.directTypeChildren(mapTyp))
+	want := []string{"_llgo_string", "_llgo_int"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("directTypeChildren(map) = %#v, want only semantic key/elem edges %#v", got, want)
+	}
+}
+
+func TestDirectTypeChildrenFallsBackForUnknownType(t *testing.T) {
+	b, _ := newMetadataTestBuilder(t)
+
+	if got := b.directTypeChildren(fakeType{}); got != nil {
+		t.Fatalf("directTypeChildren(fakeType) = %#v, want nil", got)
+	}
+}
+
+func TestAppendTupleTypeChildrenAllowsNilTuple(t *testing.T) {
+	existing := []types.Type{types.Typ[types.Int]}
+
+	got := appendTupleTypeChildren(existing, nil)
+	if !reflect.DeepEqual(got, existing) {
+		t.Fatalf("appendTupleTypeChildren(existing, nil) = %#v, want %#v", got, existing)
+	}
+}
+
+func TestDirectTypeChildrenExpandsNamedUnderlyingType(t *testing.T) {
+	b, _ := newMetadataTestBuilder(t)
+	typePkg := types.NewPackage("foo", "foo")
+	named := types.NewNamed(
+		types.NewTypeName(token.NoPos, typePkg, "S", nil),
+		types.NewStruct([]*types.Var{
+			types.NewVar(token.NoPos, nil, "N", types.Typ[types.Int]),
+		}, nil),
+		nil,
+	)
+
+	got := typeNames(t, b, b.directTypeChildren(named))
+	want := []string{"_llgo_int"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("directTypeChildren(named) = %#v, want %#v", got, want)
+	}
+}
+
+type fakeType struct{}
+
+func (fakeType) Underlying() types.Type { return fakeType{} }
+func (fakeType) String() string         { return "fake" }
+
+func TestRecordInterfaceMethodCallRecordsDemandAndInterfaceInfo(t *testing.T) {
+	b, mb := newMetadataTestBuilder(t)
+	typePkg := types.NewPackage("foo", "foo")
+	sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+	method := types.NewFunc(token.NoPos, typePkg, "M", sig)
+	rawIntf := types.NewInterfaceType([]*types.Func{method}, nil).Complete()
+	intfExpr := Expr{Type: b.Prog.Type(rawIntf, InGo)}
+
+	b.recordInterfaceMethodCall(intfExpr, rawIntf, method)
+
+	meta := mb.Build()
+	gotDemands := make(map[string][]string)
+	meta.ForEachUseIfaceMethod(func(owner metadata.Symbol, demands []metadata.IfaceMethodDemand) {
+		for _, demand := range demands {
+			gotDemands[meta.SymbolName(owner)] = append(gotDemands[meta.SymbolName(owner)],
+				meta.SymbolName(demand.Target)+"."+meta.Name(demand.Sig.Name)+":"+meta.SymbolName(demand.Sig.MType))
+		}
+	})
+	gotIfaceInfo := make(map[string][]string)
+	meta.ForEachInterface(func(iface metadata.Symbol, methods []metadata.MethodSig) {
+		for _, method := range methods {
+			gotIfaceInfo[meta.SymbolName(iface)] = append(gotIfaceInfo[meta.SymbolName(iface)],
+				meta.Name(method.Name)+":"+meta.SymbolName(method.MType))
+		}
+	})
+
+	wantIface, _ := b.Prog.abi.TypeName(rawIntf)
+	wantMType, _ := b.Prog.abi.TypeName(funcType(b.Prog, sig))
+	wantDemands := map[string][]string{
+		"foo.main": {wantIface + ".M:" + wantMType},
+	}
+	wantIfaceInfo := map[string][]string{
+		wantIface: {"M:" + wantMType},
+	}
+	if !reflect.DeepEqual(gotDemands, wantDemands) {
+		t.Fatalf("UseIfaceMethod = %#v, want %#v", gotDemands, wantDemands)
+	}
+	if !reflect.DeepEqual(gotIfaceInfo, wantIfaceInfo) {
+		t.Fatalf("InterfaceInfo = %#v, want %#v", gotIfaceInfo, wantIfaceInfo)
+	}
+}
+
+func TestRecordInterfaceMethodCallSkipsWhenMetaBuilderDisabled(t *testing.T) {
+	prog := NewProgram(nil)
+	pkg := prog.NewPackage("foo", "foo")
+	fn := pkg.NewFunc("foo.main", NoArgsNoRet, InGo)
+	b := fn.MakeBody(1)
+	method := types.NewFunc(token.NoPos, nil, "M", types.NewSignatureType(nil, nil, nil, nil, nil, false))
+	rawIntf := types.NewInterfaceType([]*types.Func{method}, nil).Complete()
+
+	b.recordInterfaceMethodCall(Expr{}, rawIntf, method)
+}
+
+func TestMethodInfoRecorderRecordsMethodSlots(t *testing.T) {
+	b, mb := newMetadataTestBuilder(t)
+	typePkg := types.NewPackage("foo", "foo")
+	recvType := types.NewNamed(types.NewTypeName(token.NoPos, typePkg, "T", nil), types.NewStruct(nil, nil), nil)
+	recv := types.NewVar(token.NoPos, typePkg, "", recvType)
+	sig := types.NewSignatureType(recv, nil, nil, nil, nil, false)
+	method := types.NewFunc(token.NoPos, typePkg, "m", sig)
+	ftyp := funcType(b.Prog, sig)
+	ifn := b.Pkg.NewFunc("foo.(*T).M", sig, InGo).impl
+	tfn := b.Pkg.NewFunc("foo.T.M", sig, InGo).impl
+
+	recorder := b.newMethodInfoRecorder(recvType, 1)
+	recorder.add(method, ftyp, ifn, tfn)
+	recorder.finish()
+
+	meta := mb.Build()
+	got := make(map[string][]string)
+	meta.ForEachMethodInfo(func(typ metadata.Symbol, slots []metadata.MethodSlot) {
+		for _, slot := range slots {
+			got[meta.SymbolName(typ)] = append(got[meta.SymbolName(typ)],
+				meta.Name(slot.Sig.Name)+":"+meta.SymbolName(slot.Sig.MType)+":"+meta.SymbolName(slot.IFn)+":"+meta.SymbolName(slot.TFn))
+		}
+	})
+
+	wantMType, _ := b.Prog.abi.TypeName(ftyp)
+	want := map[string][]string{
+		"_llgo_foo.T": {"foo.m:" + wantMType + ":foo.(*T).M:foo.T.M"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("MethodInfo = %#v, want %#v", got, want)
+	}
+}
+
+func TestMethodInfoRecorderSkipsWhenMetaBuilderDisabled(t *testing.T) {
+	prog := NewProgram(nil)
+	pkg := prog.NewPackage("foo", "foo")
+	fn := pkg.NewFunc("foo.main", NoArgsNoRet, InGo)
+	b := fn.MakeBody(1)
+	recorder := b.newMethodInfoRecorder(types.Typ[types.Int], 1)
+
+	if recorder != nil {
+		t.Fatalf("newMethodInfoRecorder without MetaBuilder = %#v, want nil", recorder)
+	}
+}
+
+func typeNames(t *testing.T, b Builder, typs []types.Type) []string {
+	t.Helper()
+
+	names := make([]string, 0, len(typs))
+	for _, typ := range typs {
+		name, _ := b.Prog.abi.TypeName(typ)
+		names = append(names, name)
+	}
+	return names
+}

--- a/ssa/metadata_test.go
+++ b/ssa/metadata_test.go
@@ -342,6 +342,40 @@ func TestMethodInfoRecorderSkipsWhenMetaBuilderDisabled(t *testing.T) {
 	}
 }
 
+func TestAbiUncommonMethodsRecordsMethodInfoWhenMetaBuilderEnabled(t *testing.T) {
+	b, mb := newMetadataTestBuilder(t)
+	recvType, sig := newMetadataMethodType()
+	mset := types.NewMethodSet(recvType)
+	if mset.Len() == 0 {
+		t.Fatal("test setup: method set should not be empty")
+	}
+
+	if got := b.abiUncommonMethods(recvType, mset); got.IsNil() {
+		t.Fatal("abiUncommonMethods returned nil")
+	}
+
+	meta := mb.Build()
+	var got []metadata.MethodSlot
+	meta.ForEachMethodInfo(func(typ metadata.Symbol, slots []metadata.MethodSlot) {
+		if meta.SymbolName(typ) == "_llgo_foo.T" {
+			got = append(got, slots...)
+		}
+	})
+	if len(got) != 1 {
+		t.Fatalf("MethodInfo slot count = %d (%#v), want 1", len(got), got)
+	}
+	wantMType, _ := b.Prog.abi.TypeName(funcType(b.Prog, sig))
+	if meta.Name(got[0].Sig.Name) != "M" {
+		t.Fatalf("MethodInfo name = %q, want M", meta.Name(got[0].Sig.Name))
+	}
+	if meta.SymbolName(got[0].Sig.MType) != wantMType {
+		t.Fatalf("MethodInfo mtype = %q, want %q", meta.SymbolName(got[0].Sig.MType), wantMType)
+	}
+	if meta.SymbolName(got[0].IFn) == "" || meta.SymbolName(got[0].TFn) == "" {
+		t.Fatalf("MethodInfo function symbols should be recorded: %#v", got[0])
+	}
+}
+
 func typeNames(t *testing.T, b Builder, typs []types.Type) []string {
 	t.Helper()
 
@@ -351,4 +385,29 @@ func typeNames(t *testing.T, b Builder, typs []types.Type) []string {
 		names = append(names, name)
 	}
 	return names
+}
+
+func newMetadataDisabledTestBuilder(t *testing.T) Builder {
+	t.Helper()
+
+	prog := NewProgram(nil)
+	prog.SetRuntime(func() *types.Package {
+		pkg, err := importer.For("source", nil).Import(PkgRuntime)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return pkg
+	})
+	pkg := prog.NewPackage("foo", "foo")
+	fn := pkg.NewFunc("foo.main", NoArgsNoRet, InGo)
+	return fn.MakeBody(1)
+}
+
+func newMetadataMethodType() (*types.Named, *types.Signature) {
+	typePkg := types.NewPackage("foo", "foo")
+	recvType := types.NewNamed(types.NewTypeName(token.NoPos, typePkg, "T", nil), types.NewStruct(nil, nil), nil)
+	recv := types.NewVar(token.NoPos, typePkg, "", recvType)
+	sig := types.NewSignatureType(recv, nil, nil, nil, nil, false)
+	recvType.AddMethod(types.NewFunc(token.NoPos, typePkg, "M", sig))
+	return recvType, sig
 }

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -26,6 +26,7 @@ import (
 	"unsafe"
 
 	"github.com/goplus/llgo/internal/env"
+	"github.com/goplus/llgo/internal/metadata"
 	"github.com/goplus/llgo/ssa/abi"
 	"github.com/xgo-dev/llvm"
 	"golang.org/x/tools/go/types/typeutil"
@@ -732,6 +733,7 @@ type aPackage struct {
 	NeedAbiInit   int // bitmask of Reflect* flags indicating which reflect type-construction operations are used
 	MethodByIndex map[int]none
 	MethodByName  map[string]none
+	MetaBuilder   *metadata.Builder
 
 	export         map[string]string   // pkgPath.nameInPkg => exportname
 	preserveSyms   map[string]struct{} // set of exported symbol names


### PR DESCRIPTION
## Summary
- add in-memory package metadata summary types, builder, global merge view, and stable text formatting
- collect metadata facts for interfaces, interface uses/calls, method tables, reflection method access, type children, and ordinary symbol edges
- add _testmeta golden coverage and gentests support for regenerating metadata expectations

## Proposal
Part of #1853.

## Scope
- no .meta binary serialization format
- no build cache read/write changes
- no deadcode/DCE analyzer or linker override changes
- normal builds do not collect metadata unless the explicit test/debug capture path enables it

## Tests
- go test ./internal/metadata ./internal/build ./chore/gentests -count=1
- go test ./cl -run TestRunAndTestFromTestmeta -count=1

Note: full ./cl was not used as the PR gate because this local checkout currently hits unrelated environment/test issues, including missing cl/_testgo/reflectmethod/out.ll and temporary-directory no-space-left-on-device errors.