### PR TITLE
ssa: preserve struct tags during type conversion

### DIFF
--- a/ssa/abi/abi.go
+++ b/ssa/abi/abi.go
@@ -407,6 +407,9 @@ func (b *Builder) structHash(t *types.Struct) (ret []byte, pkg string) {
 		}
 		ft, _ := b.TypeName(f.Type())
 		fmt.Fprintln(h, name, ft)
+		if tag := t.Tag(i); tag != "" {
+			fmt.Fprintln(h, "tag", tag)
+		}
 	}
 	ret = h.Sum(b.buf[:0])
 	return

--- a/ssa/abi/abi_coverage_test.go
+++ b/ssa/abi/abi_coverage_test.go
@@ -245,6 +245,14 @@ func TestStructInterfaceClosureAndPathCoverage(t *testing.T) {
 	if got, pub := b.StructName(pubStruct); !strings.HasPrefix(got, "_llgo_struct$") || pub {
 		t.Fatalf("StructName(public struct)=(%q,%v), want _llgo_struct$*,false", got, pub)
 	}
+	taggedStruct := types.NewStruct([]*types.Var{
+		types.NewField(token.NoPos, pkg, "X", types.Typ[types.Int], false),
+	}, []string{`json:"x"`})
+	plainName, _ := b.StructName(pubStruct)
+	taggedName, _ := b.StructName(taggedStruct)
+	if plainName == taggedName {
+		t.Fatalf("StructName should distinguish struct tags")
+	}
 
 	privStruct := types.NewStruct([]*types.Var{
 		types.NewField(token.NoPos, pkg, "x", types.Typ[types.Int], false),

--- a/ssa/type_cvt.go
+++ b/ssa/type_cvt.go
@@ -311,6 +311,7 @@ func (p goTypes) cvtStruct(typ *types.Struct) (raw *types.Struct, cvt bool) {
 	}()
 	n := typ.NumFields()
 	flds := make([]*types.Var, n)
+	tags := make([]string, n)
 	needcvt := false
 	for i := 0; i < n; i++ {
 		f := typ.Field(i)
@@ -319,9 +320,10 @@ func (p goTypes) cvtStruct(typ *types.Struct) (raw *types.Struct, cvt bool) {
 			needcvt = true
 		}
 		flds[i] = f
+		tags[i] = typ.Tag(i)
 	}
 	if needcvt {
-		return types.NewStruct(flds, nil), true
+		return types.NewStruct(flds, tags), true
 	}
 	return typ, false
 }

--- a/ssa/type_patch_test.go
+++ b/ssa/type_patch_test.go
@@ -232,3 +232,20 @@ func f() {
 		t.Fatalf("toType(opaque elem) raw = %v, want unsafe.Pointer", got)
 	}
 }
+
+func TestCvtStructPreservesTags(t *testing.T) {
+	sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+	st := types.NewStruct([]*types.Var{
+		types.NewField(token.NoPos, nil, "Fn", sig, false),
+	}, []string{`protobuf:"bytes,1,opt,name=fn" json:"fn,omitempty"`})
+
+	raw, cvt := newGoTypes().cvtType(st)
+	if !cvt {
+		t.Fatalf("cvtType did not convert function field")
+	}
+	got := raw.(*types.Struct).Tag(0)
+	want := `protobuf:"bytes,1,opt,name=fn" json:"fn,omitempty"`
+	if got != want {
+		t.Fatalf("converted struct tag = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- preserve struct tags when rebuilding converted struct types
- include non-empty struct tags in the ABI struct hash
- add focused coverage for tag preservation and ABI shape distinction
- Update for https://github.com/xgo-dev/llgo/issues/1867

## Testing
- PATH=/opt/tools/go1.26.2.linux-amd64/go/bin:$PATH GOROOT=/opt/tools/go1.26.2.linux-amd64/go/ go test ./ssa -run TestCvtStructPreservesTags -count=1
- PATH=/opt/tools/go1.26.2.linux-amd64/go/bin:$PATH GOROOT=/opt/tools/go1.26.2.linux-amd64/go/ go test ./ssa/abi -run TestStructInterfaceClosureAndPathCoverage -count=1
- rebuilt etcdctl with LLGO_DEBUG_SYMBOLS=1 and verified `etcdctl version` no longer panics