### PR TITLE
ssa: use Go type identity for named closure changetype

### DIFF
--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -824,7 +824,7 @@ func (b Builder) ChangeType(t Type, x Expr) (ret Expr) {
 				case *types.Struct:
 					return convType()
 				case *types.Named:
-					if x.impl.Type().String() != t.ll.String() {
+					if !types.Identical(x.RawType(), t.RawType()) {
 						return convNamedType()
 					}
 				}

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -348,6 +348,58 @@ attributes #0 = { null_pointer_is_valid }
 	assertPkg(t, pkg, expected)
 }
 
+func TestChangeTypeNamedClosureUsesGoTypeIdentity(t *testing.T) {
+	prog := NewProgram(nil)
+	pkg := prog.NewPackage("bar", "foo/bar")
+	tpkg := types.NewPackage("foo/bar", "bar")
+
+	params := types.NewTuple(types.NewVar(0, tpkg, "x", types.Typ[types.Int]))
+	rets := types.NewTuple(types.NewVar(0, tpkg, "", types.Typ[types.Int]))
+	baseSig := types.NewSignatureType(nil, nil, nil, params, rets, false)
+	srcNamed := types.NewNamed(types.NewTypeName(0, tpkg, "SrcFn", nil), baseSig, nil)
+	dstNamed := types.NewNamed(types.NewTypeName(0, tpkg, "DstFn", nil), baseSig, nil)
+
+	convertSig := types.NewSignatureType(
+		nil,
+		nil,
+		nil,
+		types.NewTuple(types.NewParam(0, tpkg, "v", srcNamed)),
+		types.NewTuple(types.NewParam(0, tpkg, "", dstNamed)),
+		false,
+	)
+	convertFn := pkg.NewFunc("convertNamedClosure", convertSig, InGo)
+	b := convertFn.MakeBody(1)
+	b.Return(b.ChangeType(prog.Type(dstNamed, InGo), convertFn.Param(0)))
+
+	ir := convertFn.impl.String()
+	if !strings.Contains(ir, `insertvalue %"foo/bar.DstFn"`) {
+		t.Fatalf("named closure conversion did not rebuild destination type:\n%s", ir)
+	}
+	if strings.Contains(ir, `ret %"foo/bar.SrcFn"`) {
+		t.Fatalf("named closure conversion returned source type:\n%s", ir)
+	}
+	if !strings.Contains(ir, `ret %"foo/bar.DstFn"`) {
+		t.Fatalf("named closure conversion did not return destination type:\n%s", ir)
+	}
+
+	sameSig := types.NewSignatureType(
+		nil,
+		nil,
+		nil,
+		types.NewTuple(types.NewParam(0, tpkg, "v", srcNamed)),
+		types.NewTuple(types.NewParam(0, tpkg, "", srcNamed)),
+		false,
+	)
+	sameFn := pkg.NewFunc("sameNamedClosure", sameSig, InGo)
+	sb := sameFn.MakeBody(1)
+	sb.Return(sb.ChangeType(prog.Type(srcNamed, InGo), sameFn.Param(0)))
+
+	sameIR := sameFn.impl.String()
+	if strings.Contains(sameIR, "insertvalue") {
+		t.Fatalf("identical named closure type should not be rebuilt:\n%s", sameIR)
+	}
+}
+
 func TestConvertNamedStructValue(t *testing.T) {
 	prog := NewProgram(nil)
 	pkg := prog.NewPackage("bar", "foo/bar")


### PR DESCRIPTION
## Summary
- replace LLVM type string comparison in named closure changetype with `types.Identical` on Go raw types
- add regression coverage for named closure conversion between distinct and identical Go named types

## Tests
- `go test ./ssa -run 'TestClosureFuncPtrValue|TestChangeTypeNamedClosureUsesGoTypeIdentity|TestConvertNamedStructValue|TestClosureNoCtxValue'`\n\nNote: `go test ./ssa` is currently blocked in this workspace by `TestFromTestlibgo/atomic` failing with a Go overlay error for files beneath `GOMODCACHE`; this is unrelated to this change.