### PR TITLE
runtime: grow zero-sized append slices

### DIFF
--- a/runtime/internal/runtime/z_slice.go
+++ b/runtime/internal/runtime/z_slice.go
@@ -68,9 +68,16 @@ func SliceAppend(src Slice, data unsafe.Pointer, num, etSize int) Slice {
 func GrowSlice(src Slice, num, etSize int) Slice {
 	oldLen := src.len
 	newLen := oldLen + num
+	if newLen < 0 {
+		panicgrowslicelen()
+	}
 	if newLen > src.cap {
 		newCap := nextslicecap(newLen, src.cap)
-		p := AllocZ(uintptr(newCap * etSize))
+		mem, overflow := math.MulUintptr(uintptr(etSize), uintptr(newCap))
+		if overflow || mem > maxAlloc {
+			panicgrowslicelen()
+		}
+		p := AllocZ(mem)
 		if oldLen != 0 {
 			c.Memcpy(p, src.data, uintptr(oldLen*etSize))
 		}
@@ -146,6 +153,10 @@ func panicmakeslicelen() {
 
 func panicmakeslicecap() {
 	panic(errorString("makeslice: cap out of range"))
+}
+
+func panicgrowslicelen() {
+	panic(errorString("growslice: len out of range"))
 }
 
 func SliceClear(t *abi.SliceType, s Slice) {

--- a/runtime/internal/runtime/z_slice.go
+++ b/runtime/internal/runtime/z_slice.go
@@ -55,11 +55,11 @@ func NewSlice3(base unsafe.Pointer, eltSize, cap, i, j, k int) (s Slice) {
 
 // SliceAppend append elem data and returns a slice.
 func SliceAppend(src Slice, data unsafe.Pointer, num, etSize int) Slice {
+	oldLen := src.len
+	src = GrowSlice(src, num, etSize)
 	if etSize == 0 {
 		return src
 	}
-	oldLen := src.len
-	src = GrowSlice(src, num, etSize)
 	c.Memcpy(c.Advance(src.data, oldLen*etSize), data, uintptr(num*etSize))
 	return src
 }

--- a/test/go/append_zero_size_test.go
+++ b/test/go/append_zero_size_test.go
@@ -1,0 +1,34 @@
+package gotest
+
+import "testing"
+
+type appendZeroSize struct{}
+
+func TestAppendZeroSizedElementsUpdatesSliceHeader(t *testing.T) {
+	got := append([]appendZeroSize{}, make([]appendZeroSize, 2)...)
+	if len(got) != 2 {
+		t.Fatalf("len(append(empty, make(2)...)) = %d, want 2", len(got))
+	}
+	if cap(got) < len(got) {
+		t.Fatalf("cap after zero-sized append = %d, want at least len %d", cap(got), len(got))
+	}
+
+	got = append(got, appendZeroSize{})
+	if len(got) != 3 {
+		t.Fatalf("len after single zero-sized append = %d, want 3", len(got))
+	}
+	if cap(got) < len(got) {
+		t.Fatalf("cap after single zero-sized append = %d, want at least len %d", cap(got), len(got))
+	}
+}
+
+func TestAppendZeroSizedElementsWithinCapacity(t *testing.T) {
+	base := make([]appendZeroSize, 1, 4)
+	got := append(base, make([]appendZeroSize, 2)...)
+	if len(got) != 3 {
+		t.Fatalf("len(append(len=1 cap=4, make(2)...)) = %d, want 3", len(got))
+	}
+	if cap(got) != 4 {
+		t.Fatalf("cap after append within capacity = %d, want 4", cap(got))
+	}
+}

--- a/test/go/append_zero_size_test.go
+++ b/test/go/append_zero_size_test.go
@@ -49,6 +49,12 @@ func TestAppendZeroSizedElementsLengthOverflow(t *testing.T) {
 	expectAppendPanicContaining(t, "len out of range", func() {
 		s = append(s, oneElem...)
 	})
+
+	a := make([]appendZeroSize, maxInt)
+	b := make([]appendZeroSize, maxInt)
+	expectAppendPanicContaining(t, "len out of range", func() {
+		_ = append(a, b...)
+	})
 }
 
 func expectAppendPanicContaining(t *testing.T, want string, f func()) {

--- a/test/go/append_zero_size_test.go
+++ b/test/go/append_zero_size_test.go
@@ -1,6 +1,10 @@
 package gotest
 
-import "testing"
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
 
 type appendZeroSize struct{}
 
@@ -31,4 +35,39 @@ func TestAppendZeroSizedElementsWithinCapacity(t *testing.T) {
 	if cap(got) != 4 {
 		t.Fatalf("cap after append within capacity = %d, want 4", cap(got))
 	}
+}
+
+func TestAppendZeroSizedElementsLengthOverflow(t *testing.T) {
+	const maxInt = int(^uint(0) >> 1)
+
+	s := make([]appendZeroSize, maxInt)
+	expectAppendPanicContaining(t, "len out of range", func() {
+		s = append(s, appendZeroSize{})
+	})
+
+	oneElem := make([]appendZeroSize, 1)
+	expectAppendPanicContaining(t, "len out of range", func() {
+		s = append(s, oneElem...)
+	})
+}
+
+func expectAppendPanicContaining(t *testing.T, want string, f func()) {
+	t.Helper()
+	defer func() {
+		err := recover()
+		if err == nil {
+			t.Fatalf("expected panic containing %q", want)
+		}
+		if got := appendPanicString(err); !strings.Contains(got, want) {
+			t.Fatalf("panic = %q, want contains %q", got, want)
+		}
+	}()
+	f()
+}
+
+func appendPanicString(v any) string {
+	if err, ok := v.(interface{ Error() string }); ok {
+		return err.Error()
+	}
+	return fmt.Sprint(v)
 }

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -3682,10 +3682,6 @@ xfails:
     reason: go1.26 goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
-    case: fixedbugs/issue7550.go
-    reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
     case: fixedbugs/issue8048.go
     reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64
@@ -3874,10 +3870,6 @@ xfails:
     directive: run
     case: fixedbugs/issue73920.go
     reason: go1.26 goroot run failure on linux/amd64
-  - platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue7550.go
-    reason: current main goroot run failure on linux/amd64
   - platform: linux/amd64
     directive: run
     case: fixedbugs/issue8048.go

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1772,10 +1772,6 @@ flakes:
 xfails:
   - platform: darwin/arm64
     directive: run
-    case: append.go
-    reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
     case: chancap.go
     reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -3624,10 +3624,6 @@ xfails:
     reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
-    case: fixedbugs/issue29190.go
-    reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
     case: fixedbugs/issue32187.go
     reason: current main goroot run failure on darwin/arm64
   - version: go1.24
@@ -3819,10 +3815,6 @@ xfails:
   - platform: linux/amd64
     directive: run
     case: fixedbugs/issue26094.go
-    reason: current main goroot run failure on linux/amd64
-  - platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue29190.go
     reason: current main goroot run failure on linux/amd64
   - platform: linux/amd64
     directive: run


### PR DESCRIPTION
Summary
- Grow zero-sized append slices before skipping byte copies so len/cap update.
- Panic from `GrowSlice` when append length overflows, and guard growslice allocation-size multiplication.
- Add `test/go` coverage for zero-size append length overflow matching `fixedbugs/issue29190.go` and `fixedbugs/issue7550.go`, including `maxInt+1` and `maxInt+maxInt` append forms.
- Remove the covered `fixedbugs/issue29190.go` and `fixedbugs/issue7550.go` xfails for darwin/arm64 and linux/amd64.

Scope / notes
- This PR remains limited to append/growslice/zero-size length overflow behavior.
- It does not touch GC, liveness, finalizer, goroutine, nil, chan, print, recover, or unrelated runtime behavior.
- `fixedbugs/issue7550.go` is in scope because it creates two zero-sized slices of length `maxInt` and must panic during `append(a, b...)` when `oldLen+num` overflows.
- Non-zero-sized `maxInt` slice append is not added as a local fixture because constructing the source slice would require an impossible allocation; the runtime path now checks both signed length overflow and allocation-size overflow.
- GOROOT CI is workflow_dispatch-only and too slow for regular PR gating. The regression is covered in `test/go` and verified with the focused external GOROOT case.

Tests
- `go test ./test/go -run TestAppendZeroSizedElementsLengthOverflow -count=1 -v` PASS
- `go test ./test/goroot -run TestGoRootRunCases -count=1 -v -args -goroot /Users/lijie/sdk/go1.26.0 -dirs fixedbugs -case '^fixedbugs/issue7550\\.go$'` PASS
- `go test ./test/go -count=1` PASS
- `(cd runtime && go test ./internal/runtime -count=1)` PASS (no test files)
- `go test ./ssa -count=1` PASS
- `go test ./cl -count=1` PASS (433.704s)
