### PR TITLE
fix channel capacity and close handoff semantics

### DIFF
--- a/runtime/internal/runtime/z_chan.go
+++ b/runtime/internal/runtime/z_chan.go
@@ -21,6 +21,7 @@ import (
 
 	c "github.com/goplus/llgo/runtime/internal/clite"
 	"github.com/goplus/llgo/runtime/internal/clite/pthread/sync"
+	"github.com/goplus/llgo/runtime/internal/runtime/math"
 )
 
 // -----------------------------------------------------------------------------
@@ -47,14 +48,25 @@ type Chan struct {
 }
 
 func NewChan(eltSize, cap int) *Chan {
+	if cap < 0 {
+		panicMakeChanSize()
+	}
+	mem, overflow := math.MulUintptr(uintptr(eltSize), uintptr(cap))
+	if overflow || mem > maxAlloc {
+		panicMakeChanSize()
+	}
 	ret := new(Chan)
 	if cap > 0 {
-		ret.data = AllocU(uintptr(cap * eltSize))
+		ret.data = AllocU(mem)
 		ret.cap = cap
 	}
 	ret.mutex.Init(nil)
 	ret.cond.Init(nil)
 	return ret
+}
+
+func panicMakeChanSize() {
+	panic(errorString("makechan: size out of range"))
 }
 
 func ChanLen(p *Chan) (n int) {
@@ -235,7 +247,10 @@ func chanTryRecv(p *Chan, v unsafe.Pointer, eltSize int, acceptSelectSend bool) 
 			p.cond.Wait(&p.mutex)
 		}
 		recvOK = p.getp != chanHasRecv
-		tryOK = recvOK || p.close
+		if !recvOK {
+			zeroChanRecv(v, eltSize)
+		}
+		tryOK = true
 		p.mutex.Unlock()
 	} else {
 		recvOK, tryOK = true, true
@@ -285,6 +300,9 @@ func ChanRecv(p *Chan, v unsafe.Pointer, eltSize int) (recvOK bool) {
 			p.cond.Wait(&p.mutex)
 		}
 		recvOK = p.getp != chanHasRecv
+		if !recvOK {
+			zeroChanRecv(v, eltSize)
+		}
 		p.mutex.Unlock()
 	} else {
 		recvOK = true

--- a/runtime/internal/runtime/z_chan.go
+++ b/runtime/internal/runtime/z_chan.go
@@ -88,10 +88,24 @@ func ChanClose(p *Chan) {
 		panic("close of nil channel")
 	}
 	p.mutex.Lock()
+	if p.close {
+		p.mutex.Unlock()
+		panic("close of closed channel")
+	}
 	p.close = true
 	notifyOps(p)
 	p.mutex.Unlock()
 	p.cond.Broadcast()
+}
+
+func panicSendOnClosedChan() {
+	panic("send on closed channel")
+}
+
+func zeroChanRecv(v unsafe.Pointer, eltSize int) {
+	if v != nil && eltSize > 0 {
+		c.Memset(v, 0, uintptr(eltSize))
+	}
 }
 
 func ChanTrySend(p *Chan, v unsafe.Pointer, eltSize int) bool {
@@ -102,7 +116,7 @@ func ChanTrySend(p *Chan, v unsafe.Pointer, eltSize int) bool {
 	p.mutex.Lock()
 	if p.close {
 		p.mutex.Unlock()
-		panic("send on closed channel")
+		panicSendOnClosedChan()
 	}
 	if n == 0 {
 		if p.getp != chanHasRecv {
@@ -148,7 +162,7 @@ func ChanSend(p *Chan, v unsafe.Pointer, eltSize int) bool {
 		}
 		if p.close {
 			p.mutex.Unlock()
-			panic("send on closed channel")
+			panicSendOnClosedChan()
 		}
 		if p.data != nil {
 			c.Memcpy(p.data, v, uintptr(eltSize))
@@ -160,7 +174,7 @@ func ChanSend(p *Chan, v unsafe.Pointer, eltSize int) bool {
 		}
 		if p.close {
 			p.mutex.Unlock()
-			panic("send on closed channel")
+			panicSendOnClosedChan()
 		}
 		off := (p.getp + p.len) % n
 		c.Memcpy(c.Advance(p.data, off*eltSize), v, uintptr(eltSize))
@@ -185,6 +199,9 @@ func chanTryRecv(p *Chan, v unsafe.Pointer, eltSize int, acceptSelectSend bool) 
 	if n == 0 {
 		if p.sends == 0 || p.getp == chanHasRecv || p.close {
 			tryOK = p.close
+			if p.close {
+				zeroChanRecv(v, eltSize)
+			}
 			p.mutex.Unlock()
 			return
 		}
@@ -197,6 +214,9 @@ func chanTryRecv(p *Chan, v unsafe.Pointer, eltSize int, acceptSelectSend bool) 
 	} else {
 		if p.len == 0 {
 			tryOK = p.close
+			if p.close {
+				zeroChanRecv(v, eltSize)
+			}
 			p.mutex.Unlock()
 			return
 		}
@@ -235,6 +255,7 @@ func ChanRecv(p *Chan, v unsafe.Pointer, eltSize int) (recvOK bool) {
 			p.cond.Wait(&p.mutex)
 		}
 		if p.close {
+			zeroChanRecv(v, eltSize)
 			p.mutex.Unlock()
 			return false
 		}
@@ -243,6 +264,7 @@ func ChanRecv(p *Chan, v unsafe.Pointer, eltSize int) (recvOK bool) {
 	} else {
 		for p.len == 0 {
 			if p.close {
+				zeroChanRecv(v, eltSize)
 				p.mutex.Unlock()
 				return false
 			}

--- a/test/go/closed_channel_test.go
+++ b/test/go/closed_channel_test.go
@@ -1,8 +1,7 @@
 package gotest
 
 import (
-	"fmt"
-	"strings"
+	"strconv"
 	"testing"
 )
 
@@ -75,16 +74,51 @@ func TestCloseClosedChannelPanics(t *testing.T) {
 	})
 }
 
-func expectChannelPanicContaining(t *testing.T, want string, f func()) {
-	t.Helper()
-	defer func() {
-		err := recover()
-		if err == nil {
-			t.Fatalf("expected panic containing %q", want)
+func TestMakeChannelCapacityOutOfRangePanics(t *testing.T) {
+	type intChan chan int
+
+	n := -1
+	expectChannelPanicContaining(t, "makechan: size out of range", func() {
+		_ = make(intChan, n)
+	})
+	expectChannelPanicContaining(t, "makechan: size out of range", func() {
+		_ = make(intChan, int64(n))
+	})
+
+	if strconv.IntSize == 64 {
+		var n2 int64 = 1 << 59
+		expectChannelPanicContaining(t, "makechan: size out of range", func() {
+			_ = make(intChan, int(n2))
+		})
+		n2 = 1<<63 - 1
+		expectChannelPanicContaining(t, "makechan: size out of range", func() {
+			_ = make(intChan, int(n2))
+		})
+	} else {
+		n = 1<<31 - 1
+		expectChannelPanicContaining(t, "makechan: size out of range", func() {
+			_ = make(intChan, n)
+		})
+		expectChannelPanicContaining(t, "makechan: size out of range", func() {
+			_ = make(intChan, int64(n))
+		})
+	}
+}
+
+func TestUnbufferedRangeReceivesLastValueBeforeClose(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		ch := make(chan int)
+		go func(v int) {
+			ch <- v
+			close(ch)
+		}(i)
+
+		var got []int
+		for v := range ch {
+			got = append(got, v)
 		}
-		if got := fmt.Sprint(err); !strings.Contains(got, want) {
-			t.Fatalf("panic = %q, want contains %q", got, want)
+		if len(got) != 1 || got[0] != i {
+			t.Fatalf("iteration %d: range over send-then-close channel = %v, want [%d]", i, got, i)
 		}
-	}()
-	f()
+	}
 }

--- a/test/go/closed_channel_test.go
+++ b/test/go/closed_channel_test.go
@@ -1,0 +1,90 @@
+package gotest
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestClosedChannelReceiveYieldsZeroAndOKFalse(t *testing.T) {
+	ch := make(chan int, 1)
+	ch <- 7
+	close(ch)
+
+	if got, ok := <-ch; got != 7 || !ok {
+		t.Fatalf("buffered receive from closed channel = %d, %v, want 7, true", got, ok)
+	}
+	if got, ok := <-ch; got != 0 || ok {
+		t.Fatalf("empty receive from closed channel = %d, %v, want 0, false", got, ok)
+	}
+
+	got := 99
+	select {
+	case got = <-ch:
+	default:
+		t.Fatal("receive from closed channel did not select")
+	}
+	if got != 0 {
+		t.Fatalf("select receive from closed channel stored %d, want 0", got)
+	}
+}
+
+func TestSendOnClosedChannelPanics(t *testing.T) {
+	ch := make(chan int)
+	close(ch)
+
+	expectChannelPanicContaining(t, "send on closed channel", func() {
+		ch <- 1
+	})
+}
+
+func TestSelectSendOnClosedChannelPanics(t *testing.T) {
+	ch := make(chan int)
+	close(ch)
+
+	expectChannelPanicContaining(t, "send on closed channel", func() {
+		select {
+		case ch <- 1:
+			t.Fatal("send on closed channel selected without panic")
+		default:
+			t.Fatal("default selected for send on closed channel")
+		}
+	})
+
+	expectChannelPanicContaining(t, "send on closed channel", func() {
+		var never chan int
+		select {
+		case ch <- 1:
+			t.Fatal("send on closed channel selected without panic")
+		case <-never:
+			t.Fatal("nil channel receive selected")
+		}
+	})
+}
+
+func TestCloseClosedChannelPanics(t *testing.T) {
+	expectChannelPanicContaining(t, "close of nil channel", func() {
+		var ch chan int
+		close(ch)
+	})
+
+	ch := make(chan int)
+	close(ch)
+	expectChannelPanicContaining(t, "close of closed channel", func() {
+		close(ch)
+	})
+}
+
+func expectChannelPanicContaining(t *testing.T, want string, f func()) {
+	t.Helper()
+	defer func() {
+		err := recover()
+		if err == nil {
+			t.Fatalf("expected panic containing %q", want)
+		}
+		if got := fmt.Sprint(err); !strings.Contains(got, want) {
+			t.Fatalf("panic = %q, want contains %q", got, want)
+		}
+	}()
+	f()
+}

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1746,7 +1746,7 @@ xfails:
     reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
-    case: closedchan.go
+    case: init1.go
     reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
@@ -1851,11 +1851,6 @@ xfails:
   - version: go1.24
     platform: linux/amd64
     directive: run
-    case: closedchan.go
-    reason: go1.24 goroot run failure on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
     case: init1.go
     reason: go1.24 goroot run failure on linux/amd64
   - version: go1.24
@@ -1937,11 +1932,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: chancap.go
-    reason: go1.25 goroot run failure on linux/amd64
-  - version: go1.25
-    platform: linux/amd64
-    directive: run
-    case: closedchan.go
     reason: go1.25 goroot run failure on linux/amd64
   - version: go1.25
     platform: linux/amd64
@@ -2032,11 +2022,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: chancap.go
-    reason: go1.26 goroot run failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: closedchan.go
     reason: go1.26 goroot run failure on linux/amd64
   - version: go1.26
     platform: linux/amd64

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1722,11 +1722,6 @@ flakes:
     directive: run
     case: goprint.go
     reason: go1.26.0 goroot run can either pass or mismatch stderr on linux/amd64
-  - version: go1.26.0
-    platform: linux/amd64
-    directive: run
-    case: typeparam/orderedmap.go
-    reason: go1.26.0 goroot run can either pass or miss final unbuffered select receive on linux/amd64
   - platform: darwin/arm64
     directive: run
     case: fixedbugs/issue48898.go
@@ -1740,10 +1735,6 @@ flakes:
     case: goprint.go
     reason: darwin/arm64 goroot run can either pass or fail
 xfails:
-  - platform: darwin/arm64
-    directive: run
-    case: chancap.go
-    reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
     case: init1.go
@@ -1846,11 +1837,6 @@ xfails:
   - version: go1.24
     platform: linux/amd64
     directive: run
-    case: chancap.go
-    reason: go1.24 goroot run failure on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
     case: init1.go
     reason: go1.24 goroot run failure on linux/amd64
   - version: go1.24
@@ -1927,11 +1913,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: append.go
-    reason: go1.25 goroot run failure on linux/amd64
-  - version: go1.25
-    platform: linux/amd64
-    directive: run
-    case: chancap.go
     reason: go1.25 goroot run failure on linux/amd64
   - version: go1.25
     platform: linux/amd64
@@ -2017,11 +1998,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: append.go
-    reason: go1.26 goroot run failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: chancap.go
     reason: go1.26 goroot run failure on linux/amd64
   - version: go1.26
     platform: linux/amd64
@@ -3197,10 +3173,6 @@ xfails:
     case: typeparam/mdempsky/15.go
     reason: go:nointerface methods still satisfy interfaces on darwin/arm64
   - platform: darwin/arm64
-    directive: run
-    case: typeparam/orderedmap.go
-    reason: select over unbuffered channel misses final iteration value on darwin/arm64
-  - platform: darwin/arm64
     directive: runoutput
     case: index0.go
     reason: current main goroot runoutput failure on darwin/arm64
@@ -3309,16 +3281,6 @@ xfails:
     directive: run
     case: typeparam/mdempsky/15.go
     reason: go:nointerface methods still satisfy interfaces on linux/amd64
-  - version: go1.24.11
-    platform: linux/amd64
-    directive: run
-    case: typeparam/orderedmap.go
-    reason: go1.24.11 select over unbuffered channel misses final iteration value on linux/amd64
-  - version: go1.25.0
-    platform: linux/amd64
-    directive: run
-    case: typeparam/orderedmap.go
-    reason: go1.25.0 select over unbuffered channel misses final iteration value on linux/amd64
   - platform: linux/amd64
     directive: runoutput
     case: index0.go


### PR DESCRIPTION
## Summary
- Reject negative, overflowing, and over-max `make(chan, n)` capacities with the Go-compatible `makechan: size out of range` runtime error.
- Preserve completed unbuffered receive handoffs when `close` races after the sender copied the value, fixing range-over-channel dropping the final value.
- Add focused `test/go` coverage for channel capacity panics and send-then-close range behavior.
- Remove fixed goroot xfail/flaky entries for `chancap.go`, `range.go`, and `typeparam/orderedmap.go`; keep `typeparam/chans.go` xfailed because its remaining failure is `TestRanger` finalizer/goroutine behavior, outside this PR scope.

## Coverage
- Covered: `closedchan.go` from the earlier commit on this branch; `chancap.go`; `range.go`; `typeparam/orderedmap.go` after confirming the root cause is channel handoff/close, not generic type handling.
- Not covered: `typeparam/chans.go` still fails in `TestRanger` after `runtime.GC()` waits for a finalizer-driven close; this is intentionally left for the paused finalizer/goroutine area.
- Not touched: select-only stack/handshake cases and `chan/goroutines.go`.

## Tests
- `go test ./test/go -count=1`
- `(cd runtime && go test ./... -count=1)`
- `go test ./ssa -count=1`
- `go test ./cl -count=1`
- `go test ./test/goroot -run TestGoRootRunCases -count=1 -args -goroot $(go env GOROOT) -dirs .,typeparam -case "^(chancap|closedchan|range)\\.go$|^typeparam/orderedmap\\.go$" -directive-mode runlike -run-timeout 30s -xfail /tmp/llgo-empty-xfail.yaml`
- `go test ./test/goroot -run TestGoRootRunCases -count=1 -args -goroot /opt/homebrew/Cellar/go@1.25/1.25.7_1/libexec -dirs .,typeparam -case "^(chancap|closedchan|range)\\.go$|^typeparam/orderedmap\\.go$" -directive-mode runlike -run-timeout 30s -xfail /tmp/llgo-empty-xfail.yaml`
- `go test ./test/goroot -run TestGoRootRunCases -count=1 -args -goroot $(go env GOROOT) -dirs .,typeparam -case "^(chancap|closedchan|range)\\.go$|^typeparam/(chans|orderedmap)\\.go$" -directive-mode runlike -run-timeout 75s`

Classification check:
- `go test ./test/goroot -run TestGoRootRunCases -count=1 -args -goroot $(go env GOROOT) -dirs typeparam -case "^typeparam/chans\\.go$" -directive-mode runlike -run-timeout 75s -xfail /tmp/llgo-empty-xfail.yaml` fails at `_Ranger Send should have failed, but timed out`, confirming the remaining `typeparam/chans.go` issue is finalizer/goroutine sensitive.