### PR TITLE
fix generic local runtime type names

### DIFF
--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1646,7 +1646,7 @@ func (p *context) patchLocalGenericNamed(t *types.Named) (*types.Named, bool) {
 	if isPatchedLocalGenericName(t.Obj().Name()) {
 		return nil, false
 	}
-	obj := types.NewTypeName(t.Obj().Pos(), t.Obj().Pkg(), p.localNamedName(t, true), nil)
+	obj := types.NewTypeName(t.Obj().Pos(), t.Obj().Pkg(), p.localNamedName(t, false), nil)
 	return types.NewNamed(obj, t.Underlying(), nil), true
 }
 
@@ -1716,7 +1716,7 @@ func (p *context) typeArgName(t types.Type) string {
 	case *types.Named:
 		name := p.localNamedName(t, p.isLocalType(t.Obj()))
 		if pkg := t.Obj().Pkg(); pkg != nil {
-			return pkg.Path() + "." + name
+			return reflectTypeArgPkgPath(pkg) + "." + name
 		}
 		return name
 	case *types.Pointer:
@@ -1737,12 +1737,7 @@ func (p *context) typeArgName(t types.Type) string {
 		}
 		return fmt.Sprintf("%s %s", s, elem)
 	default:
-		return types.TypeString(t, func(pkg *types.Package) string {
-			if pkg == nil {
-				return ""
-			}
-			return pkg.Name()
-		})
+		return types.TypeString(t, reflectTypeArgPkgPath)
 	}
 }
 
@@ -1757,6 +1752,16 @@ func chanDirName(dir types.ChanDir) string {
 	default:
 		panic("invalid channel direction")
 	}
+}
+
+func reflectTypeArgPkgPath(pkg *types.Package) string {
+	if pkg == nil {
+		return ""
+	}
+	if pkg.Path() == "command-line-arguments" && pkg.Name() != "" {
+		return pkg.Name()
+	}
+	return llssa.PathOf(pkg)
 }
 
 func (p *context) isGenericLocalType(obj types.Object) bool {

--- a/cl/funcname_nested_closure_test.go
+++ b/cl/funcname_nested_closure_test.go
@@ -103,8 +103,8 @@ func localType[T any]() any {
 		t.Fatalf("patchLocalGenericNamed(%v) was not patched", local)
 	}
 	name := patched.Obj().Name()
-	if !strings.Contains(name, "[") || !strings.Contains(name, "·") {
-		t.Fatalf("patched local generic name = %q, want type args and ordinal suffix", name)
+	if !strings.Contains(name, "[") || strings.Contains(name, "·") {
+		t.Fatalf("patched local generic name = %q, want type args without ordinal suffix", name)
 	}
 	if _, ok := ctx.patchLocalGenericNamed(patched); ok {
 		t.Fatalf("already-patched local generic name %q should not be patched again", name)
@@ -234,7 +234,7 @@ func use() {
 	sigWithPkg := types.NewSignatureType(nil, nil, nil,
 		types.NewTuple(types.NewParam(token.NoPos, otherPkg, "x", other)),
 		nil, false)
-	if got := ctx.typeArgName(sigWithPkg); !strings.Contains(got, "bar.Other") {
+	if got := ctx.typeArgName(sigWithPkg); !strings.Contains(got, "example.com/bar.Other") {
 		t.Fatalf("typeArgName(signature with package) = %q, want package-qualified param", got)
 	}
 

--- a/test/go/generic_local_types_test.go
+++ b/test/go/generic_local_types_test.go
@@ -1,6 +1,10 @@
 package gotest
 
 import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -30,5 +34,113 @@ func TestGenericLocalRuntimeTypesIncludeOuterArgs(t *testing.T) {
 	}
 	if !strings.Contains(stringName, "string") {
 		t.Fatalf("local generic string type name does not include type argument: %q", stringName)
+	}
+}
+
+type genericLocalIntish interface{ ~int }
+
+func genericNestedLocalRuntimeTypes[A genericLocalIntish]() (reflect.Type, reflect.Type) {
+	type Int int
+	type T[B genericLocalIntish] struct{}
+	type U[_ any] int
+	return reflect.TypeOf(T[int]{}), reflect.TypeOf(T[U[int]]{})
+}
+
+func TestGenericNestedLocalRuntimeTypeNames(t *testing.T) {
+	direct, nested := genericNestedLocalRuntimeTypes[int]()
+	if got, want := direct.String(), "gotest.T[int;int]"; got != want {
+		t.Fatalf("direct local generic type name = %q, want %q", got, want)
+	}
+	nestedName := nested.String()
+	const nestedPrefix = "gotest.T[int;github.com/goplus/llgo/test/go.U[int;int]·"
+	if !strings.HasPrefix(nestedName, nestedPrefix) || !strings.HasSuffix(nestedName, "]") {
+		t.Fatalf("nested local generic type name = %q, want %q plus numeric suffix", nestedName, nestedPrefix)
+	}
+	ordinal := strings.TrimSuffix(strings.TrimPrefix(nestedName, nestedPrefix), "]")
+	if ordinal == "" {
+		t.Fatalf("nested local generic type name = %q, want numeric local type suffix", nestedName)
+	}
+	for _, r := range ordinal {
+		if r < '0' || r > '9' {
+			t.Fatalf("nested local generic type name = %q, want numeric local type suffix", nestedName)
+		}
+	}
+}
+
+const genericNestedLocalCommandLineProbe = `package main
+
+import (
+	"fmt"
+	"reflect"
+)
+
+type intish interface{ ~int }
+
+func nested[A intish]() (reflect.Type, reflect.Type) {
+	type Int int
+	type T[B intish] struct{}
+	type U[_ any] int
+	return reflect.TypeOf(T[int]{}), reflect.TypeOf(T[U[int]]{})
+}
+
+func main() {
+	direct, nested := nested[int]()
+	fmt.Println(direct)
+	fmt.Println(nested)
+}
+`
+
+func TestGenericNestedLocalRuntimeTypeNamesForCommandLineMain(t *testing.T) {
+	dir, err := os.MkdirTemp("", "llgo-generic-local-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+	file := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(file, []byte(genericNestedLocalCommandLineProbe), 0644); err != nil {
+		t.Fatal(err)
+	}
+	repoRoot := genericLocalRepoRoot(t)
+	goOut := runGenericLocalProbe(t, repoRoot, "go", "run", file)
+	const want = "main.T[int;int]\nmain.T[int;main.U[int;int]·3]\n"
+	if goOut != want {
+		t.Fatalf("go probe output = %q, want %q", goOut, want)
+	}
+	t.Setenv("LLGO_ROOT", repoRoot)
+	llgoOut := runGenericLocalProbe(t, repoRoot, "go", "run", "./cmd/llgo", "run", file)
+	if llgoOut != goOut {
+		t.Fatalf("llgo probe output = %q, want go output %q", llgoOut, goOut)
+	}
+}
+
+func runGenericLocalProbe(t *testing.T, dir, name string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = os.Environ()
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("%s %v failed: %v\n%s", name, args, err, stderr.String())
+	}
+	return string(out)
+}
+
+func genericLocalRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("repo root not found")
+		}
+		dir = parent
 	}
 }

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1756,7 +1756,7 @@ flakes:
     platform: linux/amd64
     directive: run
     case: typeparam/orderedmap.go
-    reason: go1.26.0 goroot run can either pass or fail on linux/amd64
+    reason: go1.26.0 goroot run can either pass or miss final unbuffered select receive on linux/amd64
   - platform: darwin/arm64
     directive: run
     case: fixedbugs/issue48898.go
@@ -1882,12 +1882,12 @@ xfails:
   - platform: darwin/arm64
     directive: run
     case: typeparam/mdempsky/16.go
-    reason: current main goroot run failure on darwin/arm64
+    reason: nil-deref panic value does not implement runtime.Error on darwin/arm64
   - version: go1.26
     platform: darwin/arm64
     directive: run
     case: typeparam/mdempsky/15.go
-    reason: go1.26 goroot run failure on darwin/arm64
+    reason: go1.26 go:nointerface methods still satisfy interfaces on darwin/arm64
   - version: go1.24
     platform: linux/amd64
     directive: run
@@ -1992,7 +1992,7 @@ xfails:
     platform: linux/amd64
     directive: run
     case: typeparam/mdempsky/16.go
-    reason: go1.24 goroot run failure on linux/amd64
+    reason: go1.24 nil-deref panic value does not implement runtime.Error on linux/amd64
   - version: go1.25
     platform: linux/amd64
     directive: run
@@ -2102,7 +2102,7 @@ xfails:
     platform: linux/amd64
     directive: run
     case: typeparam/mdempsky/16.go
-    reason: go1.25 goroot run failure on linux/amd64
+    reason: go1.25 nil-deref panic value does not implement runtime.Error on linux/amd64
   - version: go1.26
     platform: linux/amd64
     directive: run
@@ -2227,12 +2227,12 @@ xfails:
     platform: linux/amd64
     directive: run
     case: typeparam/mdempsky/16.go
-    reason: go1.26 goroot run failure on linux/amd64
+    reason: go1.26 nil-deref panic value does not implement runtime.Error on linux/amd64
   - version: go1.26
     platform: linux/amd64
     directive: run
     case: typeparam/mdempsky/15.go
-    reason: go1.26 goroot run failure on linux/amd64
+    reason: go1.26 go:nointerface methods still satisfy interfaces on linux/amd64
   - version: go1.24
     platform: linux/amd64
     directive: run
@@ -3717,29 +3717,29 @@ xfails:
   - platform: darwin/arm64
     directive: run
     case: typeparam/chans.go
-    reason: current main goroot run failure on darwin/arm64
+    reason: select over unbuffered channel misses final receive on darwin/arm64
   - platform: darwin/arm64
     directive: run
     case: typeparam/issue51521.go
-    reason: current main goroot run failure on darwin/arm64
+    reason: nil-deref panic value does not implement error on darwin/arm64
   - platform: darwin/arm64
     directive: run
     case: typeparam/mdempsky/15.go
-    reason: current main goroot run failure on darwin/arm64
+    reason: go:nointerface methods still satisfy interfaces on darwin/arm64
   - platform: darwin/arm64
     directive: run
     case: typeparam/orderedmap.go
-    reason: current main goroot run failure on darwin/arm64
+    reason: select over unbuffered channel misses final iteration value on darwin/arm64
   - version: go1.24
     platform: darwin/arm64
     directive: run
     case: typeparam/typeswitch5.go
-    reason: go1.24 goroot run failure on darwin/arm64
+    reason: go1.24 println float exponent formatting differs on darwin/arm64
   - version: go1.25
     platform: darwin/arm64
     directive: run
     case: typeparam/typeswitch5.go
-    reason: go1.25 goroot run failure on darwin/arm64
+    reason: go1.25 println float exponent formatting differs on darwin/arm64
   - platform: darwin/arm64
     directive: runoutput
     case: index0.go
@@ -3933,35 +3933,35 @@ xfails:
   - platform: linux/amd64
     directive: run
     case: typeparam/chans.go
-    reason: current main goroot run failure on linux/amd64
+    reason: select over unbuffered channel misses final receive on linux/amd64
   - platform: linux/amd64
     directive: run
     case: typeparam/issue51521.go
-    reason: current main goroot run failure on linux/amd64
+    reason: nil-deref panic value does not implement error on linux/amd64
   - platform: linux/amd64
     directive: run
     case: typeparam/mdempsky/15.go
-    reason: current main goroot run failure on linux/amd64
+    reason: go:nointerface methods still satisfy interfaces on linux/amd64
   - version: go1.24.11
     platform: linux/amd64
     directive: run
     case: typeparam/orderedmap.go
-    reason: go1.24.11 goroot run failure on linux/amd64
+    reason: go1.24.11 select over unbuffered channel misses final iteration value on linux/amd64
   - version: go1.25.0
     platform: linux/amd64
     directive: run
     case: typeparam/orderedmap.go
-    reason: go1.25.0 goroot run failure on linux/amd64
+    reason: go1.25.0 select over unbuffered channel misses final iteration value on linux/amd64
   - version: go1.24
     platform: linux/amd64
     directive: run
     case: typeparam/typeswitch5.go
-    reason: go1.24 goroot run failure on linux/amd64
+    reason: go1.24 println float exponent formatting differs on linux/amd64
   - version: go1.25
     platform: linux/amd64
     directive: run
     case: typeparam/typeswitch5.go
-    reason: go1.25 goroot run failure on linux/amd64
+    reason: go1.25 println float exponent formatting differs on linux/amd64
   - platform: linux/amd64
     directive: runoutput
     case: index0.go

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1888,10 +1888,6 @@ xfails:
     directive: run
     case: typeparam/mdempsky/15.go
     reason: go1.26 goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
-    case: typeparam/nested.go
-    reason: current main goroot run failure on darwin/arm64
   - version: go1.24
     platform: linux/amd64
     directive: run
@@ -1996,11 +1992,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: typeparam/mdempsky/16.go
-    reason: go1.24 goroot run failure on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
-    case: typeparam/nested.go
     reason: go1.24 goroot run failure on linux/amd64
   - version: go1.25
     platform: linux/amd64
@@ -2111,11 +2102,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: typeparam/mdempsky/16.go
-    reason: go1.25 goroot run failure on linux/amd64
-  - version: go1.25
-    platform: linux/amd64
-    directive: run
-    case: typeparam/nested.go
     reason: go1.25 goroot run failure on linux/amd64
   - version: go1.26
     platform: linux/amd64
@@ -2246,11 +2232,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: typeparam/mdempsky/15.go
-    reason: go1.26 goroot run failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: typeparam/nested.go
     reason: go1.26 goroot run failure on linux/amd64
   - version: go1.24
     platform: linux/amd64


### PR DESCRIPTION
## Summary

- Fix reflected runtime names for nested generic local types by formatting type arguments with reflect-style package paths (`command-line-arguments` becomes `main`).
- Stop adding the local ordinal suffix to the primary instantiated local generic type name while preserving suffixes for local types used as type arguments.
- Add stable `test/go` coverage for package and command-line `main` cases, and remove the now-fixed `typeparam/nested.go` GOROOT xfails.

## GOROOT CI

Full GOROOT CI is disabled for normal PRs (`workflow_dispatch` only) and is too slow for routine validation. This PR adds `test/go` coverage so the regression remains covered when GOROOT CI is not running.

A manual GOROOT workflow was dispatched on an upstream branch with the same head SHA because GitHub rejected dispatching `refs/pull/1879/head` directly: https://github.com/xgo-dev/llgo/actions/runs/26263992315

Targeted GOROOT commands run locally with `$(go env GOROOT)` = `/opt/homebrew/Cellar/go@1.24/1.24.11/libexec`:

```bash
go test ./test/goroot -run TestGoRoot -count=1 -timeout=10m -args -goroot "$(go env GOROOT)" -dirs typeparam -case '^typeparam/nested\.go$' -xfail /tmp/llgo-no-xfail.yaml -directive-mode legacy
```

```bash
go test ./test/goroot -run TestGoRoot -count=1 -timeout=10m -args -goroot "$(go env GOROOT)" -dirs typeparam -case '^typeparam/nested\.go$' -directive-mode legacy
```

## Tests

```bash
go test ./test/go -run 'TestGeneric(LocalRuntimeTypesIncludeOuterArgs|NestedLocalRuntimeTypeNames)' -count=1
go run ./cmd/llgo test -run 'TestGeneric(LocalRuntimeTypesIncludeOuterArgs|NestedLocalRuntimeTypeNames)' ./test/go
go test ./cl -run 'TestGenericLocalTypePatch|TestGenericLocalTypePatchHelperBranches' -count=1
go test ./ssa/abi -count=1
go test ./test/goroot -run TestGoRoot -count=1 -timeout=10m -args -goroot "$(go env GOROOT)" -dirs typeparam -case '^typeparam/nested\.go$' -xfail /tmp/llgo-no-xfail.yaml -directive-mode legacy
go test ./test/goroot -run TestGoRoot -count=1 -timeout=10m -args -goroot "$(go env GOROOT)" -dirs typeparam -case '^typeparam/nested\.go$' -directive-mode legacy
go test ./cl -count=1
```
