### PR TITLE
fix nil receiver method dispatch checks

### DIFF
--- a/cl/_testgo/abimethod/in.go
+++ b/cl/_testgo/abimethod/in.go
@@ -849,9 +849,14 @@ type I2 interface {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
-// CHECK-NEXT:   %3 = load %"{{.*}}/cl/_testgo/abimethod.T", ptr %2, align 8
-// CHECK-NEXT:   %4 = call i64 @"{{.*}}/cl/_testgo/abimethod.T.Demo1"(%"{{.*}}/cl/_testgo/abimethod.T" %3)
-// CHECK-NEXT:   ret i64 %4
+// CHECK-NEXT:   %3 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %3)
+// CHECK-NEXT:   %4 = icmp eq ptr %1, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %4)
+// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %2)
+// CHECK-NEXT:   %6 = load %"{{.*}}/cl/_testgo/abimethod.T", ptr %5, align 8
+// CHECK-NEXT:   %7 = call i64 @"{{.*}}/cl/_testgo/abimethod.T.Demo1"(%"{{.*}}/cl/_testgo/abimethod.T" %6)
+// CHECK-NEXT:   ret i64 %7
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.Demo2"(ptr %0){{.*}} {
@@ -877,9 +882,10 @@ type I2 interface {
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
-// CHECK-NEXT:   %4 = load %"{{.*}}/cl/_testgo/abimethod.T", ptr %3, align 8
-// CHECK-NEXT:   %5 = call i64 @"{{.*}}/cl/_testgo/abimethod.T.Demo1"(%"{{.*}}/cl/_testgo/abimethod.T" %4)
-// CHECK-NEXT:   ret i64 %5
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %3)
+// CHECK-NEXT:   %5 = load %"{{.*}}/cl/_testgo/abimethod.T", ptr %4, align 8
+// CHECK-NEXT:   %6 = call i64 @"{{.*}}/cl/_testgo/abimethod.T.Demo1"(%"{{.*}}/cl/_testgo/abimethod.T" %5)
+// CHECK-NEXT:   ret i64 %6
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.Demo2"({ i64, ptr } %0){{.*}} {
@@ -990,9 +996,12 @@ type I2 interface {
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; {{.*}}/cl/_testgo/abimethod.T}.Demo1"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/abimethod.T", ptr %1, align 8
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/abimethod.T.Demo1"(%"{{.*}}/cl/_testgo/abimethod.T" %2)
-// CHECK-NEXT:   ret i64 %3
+// CHECK-NEXT:   %2 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %2)
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %1)
+// CHECK-NEXT:   %4 = load %"{{.*}}/cl/_testgo/abimethod.T", ptr %3, align 8
+// CHECK-NEXT:   %5 = call i64 @"{{.*}}/cl/_testgo/abimethod.T.Demo1"(%"{{.*}}/cl/_testgo/abimethod.T" %4)
+// CHECK-NEXT:   ret i64 %5
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; {{.*}}/cl/_testgo/abimethod.T}.Demo2"(ptr %0){{.*}} {

--- a/cl/_testgo/cursor/in.go
+++ b/cl/_testgo/cursor/in.go
@@ -139,7 +139,7 @@ func (c Cursor) Node() ast.Node {
 // CHECK-NEXT:   %58 = icmp slt i64 %57, 0
 // CHECK-NEXT:   %59 = icmp uge i64 %57, %56
 // CHECK-NEXT:   %60 = or i1 %59, %58
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %60, {{.*}})
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %60, i64 %57, i1 true, i64 %56)
 // CHECK-NEXT:   %61 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %55, i64 %57
 // CHECK-NEXT:   %62 = load %"{{.*}}/cl/_testgo/cursor.event", ptr %61, align 8
 // CHECK-NEXT:   store %"{{.*}}/cl/_testgo/cursor.event" %62, ptr %54, align 8
@@ -196,7 +196,7 @@ func (c Cursor) Node() ast.Node {
 // CHECK-NEXT:   %91 = icmp slt i64 %90, 0
 // CHECK-NEXT:   %92 = icmp uge i64 %90, %89
 // CHECK-NEXT:   %93 = or i1 %92, %91
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %93, {{.*}})
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %93, i64 %90, i1 true, i64 %89)
 // CHECK-NEXT:   %94 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %88, i64 %90
 // CHECK-NEXT:   %95 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %94, i32 0, i32 1
 // CHECK-NEXT:   %96 = load i64, ptr %95, align 8
@@ -570,7 +570,7 @@ const (
 // CHECK-NEXT:   %14 = icmp slt i64 %13, 0
 // CHECK-NEXT:   %15 = icmp uge i64 %13, %12
 // CHECK-NEXT:   %16 = or i1 %15, %14
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %16, {{.*}})
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %16, i64 %13, i1 true, i64 %12)
 // CHECK-NEXT:   %17 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %11, i64 %13
 // CHECK-NEXT:   %18 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %17, i32 0, i32 0
 // CHECK-NEXT:   %19 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %18, align 8
@@ -626,7 +626,7 @@ const (
 // CHECK-NEXT:   %20 = icmp slt i64 %19, 0
 // CHECK-NEXT:   %21 = icmp uge i64 %19, %18
 // CHECK-NEXT:   %22 = or i1 %21, %20
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %22, {{.*}})
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %22, i64 %19, i1 true, i64 %18)
 // CHECK-NEXT:   %23 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %17, i64 %19
 // CHECK-NEXT:   %24 = load %"{{.*}}/cl/_testgo/cursor.event", ptr %23, align 8
 // CHECK-NEXT:   store %"{{.*}}/cl/_testgo/cursor.event" %24, ptr %16, align 8
@@ -660,7 +660,7 @@ const (
 // CHECK-NEXT:   %40 = icmp slt i64 %39, 0
 // CHECK-NEXT:   %41 = icmp uge i64 %39, %38
 // CHECK-NEXT:   %42 = or i1 %41, %40
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %42, {{.*}})
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %42, i64 %39, i1 true, i64 %38)
 // CHECK-NEXT:   %43 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %37, i64 %39
 // CHECK-NEXT:   %44 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %43, i32 0, i32 1
 // CHECK-NEXT:   %45 = load i64, ptr %44, align 8
@@ -726,7 +726,7 @@ const (
 // CHECK-NEXT:   %23 = icmp slt i64 %22, 0
 // CHECK-NEXT:   %24 = icmp uge i64 %22, %21
 // CHECK-NEXT:   %25 = or i1 %24, %23
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %25, {{.*}})
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %25, i64 %22, i1 true, i64 %21)
 // CHECK-NEXT:   %26 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %20, i64 %22
 // CHECK-NEXT:   %27 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %26, i32 0, i32 2
 // CHECK-NEXT:   %28 = load i32, ptr %27, align 4
@@ -831,7 +831,7 @@ const (
 // CHECK-NEXT:   %10 = icmp slt i64 %6, 0
 // CHECK-NEXT:   %11 = icmp uge i64 %6, %9
 // CHECK-NEXT:   %12 = or i1 %11, %10
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %12, {{.*}})
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %12, i64 %6, i1 true, i64 %9)
 // CHECK-NEXT:   %13 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.iface", ptr %8, i64 %6
 // CHECK-NEXT:   %14 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %13, align 8
 // CHECK-NEXT:   %15 = call i64 @"{{.*}}/cl/_testgo/cursor.typeOf"(%"{{.*}}/runtime/internal/runtime.iface" %14)

--- a/cl/_testgo/cursor/in.go
+++ b/cl/_testgo/cursor/in.go
@@ -605,88 +605,89 @@ const (
 // CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Inspector", ptr %5, i32 0, i32 0
 // CHECK-NEXT:   %7 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %6, align 8
 // CHECK-NEXT:   %8 = extractvalue { ptr, ptr } %2, 0
-// CHECK-NEXT:   %9 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %8, align 8
-// CHECK-NEXT:   %10 = call { i32, i32 } @"{{.*}}/cl/_testgo/cursor.Cursor.indices"(%"{{.*}}/cl/_testgo/cursor.Cursor" %9)
-// CHECK-NEXT:   %11 = extractvalue { i32, i32 } %10, 0
-// CHECK-NEXT:   %12 = extractvalue { i32, i32 } %10, 1
+// CHECK-NEXT:   %9 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %8)
+// CHECK-NEXT:   %10 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %9, align 8
+// CHECK-NEXT:   %11 = call { i32, i32 } @"{{.*}}/cl/_testgo/cursor.Cursor.indices"(%"{{.*}}/cl/_testgo/cursor.Cursor" %10)
+// CHECK-NEXT:   %12 = extractvalue { i32, i32 } %11, 0
+// CHECK-NEXT:   %13 = extractvalue { i32, i32 } %11, 1
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_5, %_llgo_8, %_llgo_0
-// CHECK-NEXT:   %13 = phi i32 [ %11, %_llgo_0 ], [ %59, %_llgo_8 ], [ %33, %_llgo_5 ]
-// CHECK-NEXT:   %14 = icmp slt i32 %13, %12
-// CHECK-NEXT:   br i1 %14, label %_llgo_2, label %_llgo_3
+// CHECK-NEXT:   %14 = phi i32 [ %12, %_llgo_0 ], [ %60, %_llgo_8 ], [ %34, %_llgo_5 ]
+// CHECK-NEXT:   %15 = icmp slt i32 %14, %13
+// CHECK-NEXT:   br i1 %15, label %_llgo_2, label %_llgo_3
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %15 = alloca %"{{.*}}/cl/_testgo/cursor.event", align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %15, i8 0, i64 32, i1 false)
-// CHECK-NEXT:   %16 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 0
-// CHECK-NEXT:   %17 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 1
-// CHECK-NEXT:   %18 = sext i32 %13 to i64
-// CHECK-NEXT:   %19 = icmp slt i64 %18, 0
-// CHECK-NEXT:   %20 = icmp uge i64 %18, %17
-// CHECK-NEXT:   %21 = or i1 %20, %19
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %21, {{.*}})
-// CHECK-NEXT:   %22 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %16, i64 %18
-// CHECK-NEXT:   %23 = load %"{{.*}}/cl/_testgo/cursor.event", ptr %22, align 8
-// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/cursor.event" %23, ptr %15, align 8
-// CHECK-NEXT:   %24 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %15, i32 0, i32 2
-// CHECK-NEXT:   %25 = load i32, ptr %24, align 4
-// CHECK-NEXT:   %26 = icmp sgt i32 %25, %13
-// CHECK-NEXT:   br i1 %26, label %_llgo_4, label %_llgo_5
+// CHECK-NEXT:   %16 = alloca %"{{.*}}/cl/_testgo/cursor.event", align 8
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %16, i8 0, i64 32, i1 false)
+// CHECK-NEXT:   %17 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 0
+// CHECK-NEXT:   %18 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 1
+// CHECK-NEXT:   %19 = sext i32 %14 to i64
+// CHECK-NEXT:   %20 = icmp slt i64 %19, 0
+// CHECK-NEXT:   %21 = icmp uge i64 %19, %18
+// CHECK-NEXT:   %22 = or i1 %21, %20
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %22, {{.*}})
+// CHECK-NEXT:   %23 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %17, i64 %19
+// CHECK-NEXT:   %24 = load %"{{.*}}/cl/_testgo/cursor.event", ptr %23, align 8
+// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/cursor.event" %24, ptr %16, align 8
+// CHECK-NEXT:   %25 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %16, i32 0, i32 2
+// CHECK-NEXT:   %26 = load i32, ptr %25, align 4
+// CHECK-NEXT:   %27 = icmp sgt i32 %26, %14
+// CHECK-NEXT:   br i1 %27, label %_llgo_4, label %_llgo_5
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_7, %_llgo_1
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %27 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %15, i32 0, i32 1
-// CHECK-NEXT:   %28 = load i64, ptr %27, align 8
-// CHECK-NEXT:   %29 = extractvalue { ptr, ptr } %2, 1
-// CHECK-NEXT:   %30 = load i64, ptr %29, align 8
-// CHECK-NEXT:   %31 = and i64 %28, %30
-// CHECK-NEXT:   %32 = icmp ne i64 %31, 0
-// CHECK-NEXT:   br i1 %32, label %_llgo_7, label %_llgo_6
+// CHECK-NEXT:   %28 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %16, i32 0, i32 1
+// CHECK-NEXT:   %29 = load i64, ptr %28, align 8
+// CHECK-NEXT:   %30 = extractvalue { ptr, ptr } %2, 1
+// CHECK-NEXT:   %31 = load i64, ptr %30, align 8
+// CHECK-NEXT:   %32 = and i64 %29, %31
+// CHECK-NEXT:   %33 = icmp ne i64 %32, 0
+// CHECK-NEXT:   br i1 %33, label %_llgo_7, label %_llgo_6
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_6, %_llgo_2
-// CHECK-NEXT:   %33 = add i32 %13, 1
+// CHECK-NEXT:   %34 = add i32 %14, 1
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_7, %_llgo_4
-// CHECK-NEXT:   %34 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %15, i32 0, i32 2
-// CHECK-NEXT:   %35 = load i32, ptr %34, align 4
-// CHECK-NEXT:   %36 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 0
-// CHECK-NEXT:   %37 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 1
-// CHECK-NEXT:   %38 = sext i32 %35 to i64
-// CHECK-NEXT:   %39 = icmp slt i64 %38, 0
-// CHECK-NEXT:   %40 = icmp uge i64 %38, %37
-// CHECK-NEXT:   %41 = or i1 %40, %39
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %41, {{.*}})
-// CHECK-NEXT:   %42 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %36, i64 %38
-// CHECK-NEXT:   %43 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %42, i32 0, i32 1
-// CHECK-NEXT:   %44 = load i64, ptr %43, align 8
-// CHECK-NEXT:   %45 = extractvalue { ptr, ptr } %2, 1
-// CHECK-NEXT:   %46 = load i64, ptr %45, align 8
-// CHECK-NEXT:   %47 = and i64 %44, %46
-// CHECK-NEXT:   %48 = icmp eq i64 %47, 0
-// CHECK-NEXT:   br i1 %48, label %_llgo_8, label %_llgo_5
+// CHECK-NEXT:   %35 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %16, i32 0, i32 2
+// CHECK-NEXT:   %36 = load i32, ptr %35, align 4
+// CHECK-NEXT:   %37 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 0
+// CHECK-NEXT:   %38 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 1
+// CHECK-NEXT:   %39 = sext i32 %36 to i64
+// CHECK-NEXT:   %40 = icmp slt i64 %39, 0
+// CHECK-NEXT:   %41 = icmp uge i64 %39, %38
+// CHECK-NEXT:   %42 = or i1 %41, %40
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %42, {{.*}})
+// CHECK-NEXT:   %43 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %37, i64 %39
+// CHECK-NEXT:   %44 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.event", ptr %43, i32 0, i32 1
+// CHECK-NEXT:   %45 = load i64, ptr %44, align 8
+// CHECK-NEXT:   %46 = extractvalue { ptr, ptr } %2, 1
+// CHECK-NEXT:   %47 = load i64, ptr %46, align 8
+// CHECK-NEXT:   %48 = and i64 %45, %47
+// CHECK-NEXT:   %49 = icmp eq i64 %48, 0
+// CHECK-NEXT:   br i1 %49, label %_llgo_8, label %_llgo_5
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_4
-// CHECK-NEXT:   %49 = alloca %"{{.*}}/cl/_testgo/cursor.Cursor", align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %49, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   %50 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %49, i32 0, i32 0
-// CHECK-NEXT:   %51 = extractvalue { ptr, ptr } %2, 0
-// CHECK-NEXT:   %52 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %51, i32 0, i32 0
-// CHECK-NEXT:   %53 = load ptr, ptr %52, align 8
-// CHECK-NEXT:   %54 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %49, i32 0, i32 1
-// CHECK-NEXT:   store ptr %53, ptr %50, align 8
-// CHECK-NEXT:   store i32 %13, ptr %54, align 4
-// CHECK-NEXT:   %55 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %49, align 8
-// CHECK-NEXT:   %56 = extractvalue { ptr, ptr } %1, 1
-// CHECK-NEXT:   %57 = extractvalue { ptr, ptr } %1, 0
-// CHECK-NEXT:   %58 = call i1 %57(ptr %56, %"{{.*}}/cl/_testgo/cursor.Cursor" %55)
-// CHECK-NEXT:   br i1 %58, label %_llgo_6, label %_llgo_3
+// CHECK-NEXT:   %50 = alloca %"{{.*}}/cl/_testgo/cursor.Cursor", align 8
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %50, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   %51 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %50, i32 0, i32 0
+// CHECK-NEXT:   %52 = extractvalue { ptr, ptr } %2, 0
+// CHECK-NEXT:   %53 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %52, i32 0, i32 0
+// CHECK-NEXT:   %54 = load ptr, ptr %53, align 8
+// CHECK-NEXT:   %55 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %50, i32 0, i32 1
+// CHECK-NEXT:   store ptr %54, ptr %51, align 8
+// CHECK-NEXT:   store i32 %14, ptr %55, align 4
+// CHECK-NEXT:   %56 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %50, align 8
+// CHECK-NEXT:   %57 = extractvalue { ptr, ptr } %1, 1
+// CHECK-NEXT:   %58 = extractvalue { ptr, ptr } %1, 0
+// CHECK-NEXT:   %59 = call i1 %58(ptr %57, %"{{.*}}/cl/_testgo/cursor.Cursor" %56)
+// CHECK-NEXT:   br i1 %59, label %_llgo_6, label %_llgo_3
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   %59 = add i32 %35, 1
+// CHECK-NEXT:   %60 = add i32 %36, 1
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-NEXT: }
 

--- a/cl/_testgo/reflect/in.go
+++ b/cl/_testgo/reflect/in.go
@@ -149,42 +149,44 @@ type T struct {
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %29, i64 0, i1 true, i64 %28)
 // CHECK-NEXT:   %30 = getelementptr inbounds %reflect.Value, ptr %27, i64 0
 // CHECK-NEXT:   %31 = load %reflect.Value, ptr %30, align 8
-// CHECK-NEXT:   %32 = call i64 @reflect.Value.Int(%reflect.Value %31)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %32)
+// CHECK-NEXT:   %32 = icmp eq ptr %30, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %32)
+// CHECK-NEXT:   %33 = call i64 @reflect.Value.Int(%reflect.Value %31)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %33)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %33 = call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %6)
-// CHECK-NEXT:   %34 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %33, 0
-// CHECK-NEXT:   %35 = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", ptr %34)
-// CHECK-NEXT:   br i1 %35, label %_llgo_3, label %_llgo_4
+// CHECK-NEXT:   %34 = call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %6)
+// CHECK-NEXT:   %35 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %34, 0
+// CHECK-NEXT:   %36 = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", ptr %35)
+// CHECK-NEXT:   br i1 %36, label %_llgo_3, label %_llgo_4
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_5
-// CHECK-NEXT:   %36 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr %36, align 8
-// CHECK-NEXT:   %37 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %36, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %37)
+// CHECK-NEXT:   %37 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr %37, align 8
+// CHECK-NEXT:   %38 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %37, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %38)
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_5
-// CHECK-NEXT:   %38 = extractvalue { ptr, ptr } %46, 1
-// CHECK-NEXT:   %39 = extractvalue { ptr, ptr } %46, 0
-// CHECK-NEXT:   %40 = call i64 %39(ptr %38, i64 100)
+// CHECK-NEXT:   %39 = extractvalue { ptr, ptr } %47, 1
+// CHECK-NEXT:   %40 = extractvalue { ptr, ptr } %47, 0
+// CHECK-NEXT:   %41 = call i64 %40(ptr %39, i64 100)
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %41 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %33, 1
-// CHECK-NEXT:   %42 = load { ptr, ptr }, ptr %41, align 8
-// CHECK-NEXT:   %43 = insertvalue { { ptr, ptr }, i1 } undef, { ptr, ptr } %42, 0
-// CHECK-NEXT:   %44 = insertvalue { { ptr, ptr }, i1 } %43, i1 true, 1
+// CHECK-NEXT:   %42 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %34, 1
+// CHECK-NEXT:   %43 = load { ptr, ptr }, ptr %42, align 8
+// CHECK-NEXT:   %44 = insertvalue { { ptr, ptr }, i1 } undef, { ptr, ptr } %43, 0
+// CHECK-NEXT:   %45 = insertvalue { { ptr, ptr }, i1 } %44, i1 true, 1
 // CHECK-NEXT:   br label %_llgo_5
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   br label %_llgo_5
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
-// CHECK-NEXT:   %45 = phi { { ptr, ptr }, i1 } [ %44, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
-// CHECK-NEXT:   %46 = extractvalue { { ptr, ptr }, i1 } %45, 0
-// CHECK-NEXT:   %47 = extractvalue { { ptr, ptr }, i1 } %45, 1
-// CHECK-NEXT:   br i1 %47, label %_llgo_2, label %_llgo_1
+// CHECK-NEXT:   %46 = phi { { ptr, ptr }, i1 } [ %45, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
+// CHECK-NEXT:   %47 = extractvalue { { ptr, ptr }, i1 } %46, 0
+// CHECK-NEXT:   %48 = extractvalue { { ptr, ptr }, i1 } %46, 1
+// CHECK-NEXT:   br i1 %48, label %_llgo_2, label %_llgo_1
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/reflect.callClosure$1"(ptr %0, i64 %1){{.*}} {
@@ -239,42 +241,44 @@ type T struct {
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %25, i64 0, i1 true, i64 %24)
 // CHECK-NEXT:   %26 = getelementptr inbounds %reflect.Value, ptr %23, i64 0
 // CHECK-NEXT:   %27 = load %reflect.Value, ptr %26, align 8
-// CHECK-NEXT:   %28 = call i64 @reflect.Value.Int(%reflect.Value %27)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %28)
+// CHECK-NEXT:   %28 = icmp eq ptr %26, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %28)
+// CHECK-NEXT:   %29 = call i64 @reflect.Value.Int(%reflect.Value %27)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %29)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %29 = call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %2)
-// CHECK-NEXT:   %30 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %29, 0
-// CHECK-NEXT:   %31 = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", ptr %30)
-// CHECK-NEXT:   br i1 %31, label %_llgo_3, label %_llgo_4
+// CHECK-NEXT:   %30 = call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %2)
+// CHECK-NEXT:   %31 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %30, 0
+// CHECK-NEXT:   %32 = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", ptr %31)
+// CHECK-NEXT:   br i1 %32, label %_llgo_3, label %_llgo_4
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_5
-// CHECK-NEXT:   %32 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr %32, align 8
-// CHECK-NEXT:   %33 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %32, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %33)
+// CHECK-NEXT:   %33 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr %33, align 8
+// CHECK-NEXT:   %34 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %33, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %34)
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_5
-// CHECK-NEXT:   %34 = extractvalue { ptr, ptr } %42, 1
-// CHECK-NEXT:   %35 = extractvalue { ptr, ptr } %42, 0
-// CHECK-NEXT:   %36 = call i64 %35(ptr %34, i64 100)
+// CHECK-NEXT:   %35 = extractvalue { ptr, ptr } %43, 1
+// CHECK-NEXT:   %36 = extractvalue { ptr, ptr } %43, 0
+// CHECK-NEXT:   %37 = call i64 %36(ptr %35, i64 100)
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %37 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %29, 1
-// CHECK-NEXT:   %38 = load { ptr, ptr }, ptr %37, align 8
-// CHECK-NEXT:   %39 = insertvalue { { ptr, ptr }, i1 } undef, { ptr, ptr } %38, 0
-// CHECK-NEXT:   %40 = insertvalue { { ptr, ptr }, i1 } %39, i1 true, 1
+// CHECK-NEXT:   %38 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %30, 1
+// CHECK-NEXT:   %39 = load { ptr, ptr }, ptr %38, align 8
+// CHECK-NEXT:   %40 = insertvalue { { ptr, ptr }, i1 } undef, { ptr, ptr } %39, 0
+// CHECK-NEXT:   %41 = insertvalue { { ptr, ptr }, i1 } %40, i1 true, 1
 // CHECK-NEXT:   br label %_llgo_5
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   br label %_llgo_5
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
-// CHECK-NEXT:   %41 = phi { { ptr, ptr }, i1 } [ %40, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
-// CHECK-NEXT:   %42 = extractvalue { { ptr, ptr }, i1 } %41, 0
-// CHECK-NEXT:   %43 = extractvalue { { ptr, ptr }, i1 } %41, 1
-// CHECK-NEXT:   br i1 %43, label %_llgo_2, label %_llgo_1
+// CHECK-NEXT:   %42 = phi { { ptr, ptr }, i1 } [ %41, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
+// CHECK-NEXT:   %43 = extractvalue { { ptr, ptr }, i1 } %42, 0
+// CHECK-NEXT:   %44 = extractvalue { { ptr, ptr }, i1 } %42, 1
+// CHECK-NEXT:   br i1 %44, label %_llgo_2, label %_llgo_1
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/reflect.callFunc$1"(i64 %0){{.*}} {
@@ -365,64 +369,68 @@ func callMethod() {
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %33, i64 0, i1 true, i64 %32)
 // CHECK-NEXT:   %34 = getelementptr inbounds %reflect.Value, ptr %31, i64 0
 // CHECK-NEXT:   %35 = load %reflect.Value, ptr %34, align 8
-// CHECK-NEXT:   %36 = call i64 @reflect.Value.Int(%reflect.Value %35)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %36)
+// CHECK-NEXT:   %36 = icmp eq ptr %34, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %36)
+// CHECK-NEXT:   %37 = call i64 @reflect.Value.Int(%reflect.Value %35)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %37)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %37 = call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %10)
-// CHECK-NEXT:   %38 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %37, 0
-// CHECK-NEXT:   %39 = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", ptr %38)
-// CHECK-NEXT:   br i1 %39, label %_llgo_3, label %_llgo_4
+// CHECK-NEXT:   %38 = call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %10)
+// CHECK-NEXT:   %39 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %38, 0
+// CHECK-NEXT:   %40 = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", ptr %39)
+// CHECK-NEXT:   br i1 %40, label %_llgo_3, label %_llgo_4
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_5
-// CHECK-NEXT:   %40 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr %40, align 8
-// CHECK-NEXT:   %41 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %40, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %41)
+// CHECK-NEXT:   %41 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr %41, align 8
+// CHECK-NEXT:   %42 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %41, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %42)
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_5
-// CHECK-NEXT:   %42 = extractvalue { ptr, ptr } %67, 1
-// CHECK-NEXT:   %43 = extractvalue { ptr, ptr } %67, 0
-// CHECK-NEXT:   %44 = call i64 %43(ptr %42, i64 1)
-// CHECK-NEXT:   %45 = call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %10)
-// CHECK-NEXT:   %46 = call %reflect.Value @reflect.ValueOf(%"{{.*}}/runtime/internal/runtime.eface" %45)
-// CHECK-NEXT:   %47 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
-// CHECK-NEXT:   %48 = getelementptr inbounds %reflect.Value, ptr %47, i64 0
-// CHECK-NEXT:   %49 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 100, ptr %49, align 8
-// CHECK-NEXT:   %50 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %49, 1
-// CHECK-NEXT:   %51 = call %reflect.Value @reflect.ValueOf(%"{{.*}}/runtime/internal/runtime.eface" %50)
-// CHECK-NEXT:   store %reflect.Value %51, ptr %48, align 8
-// CHECK-NEXT:   %52 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %47, 0
-// CHECK-NEXT:   %53 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %52, i64 1, 1
-// CHECK-NEXT:   %54 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %53, i64 1, 2
-// CHECK-NEXT:   %55 = call %"{{.*}}/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %46, %"{{.*}}/runtime/internal/runtime.Slice" %54)
-// CHECK-NEXT:   %56 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %55, 0
-// CHECK-NEXT:   %57 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %55, 1
-// CHECK-NEXT:   %58 = icmp uge i64 0, %57
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %58, i64 0, i1 true, i64 %57)
-// CHECK-NEXT:   %59 = getelementptr inbounds %reflect.Value, ptr %56, i64 0
-// CHECK-NEXT:   %60 = load %reflect.Value, ptr %59, align 8
-// CHECK-NEXT:   %61 = call i64 @reflect.Value.Int(%reflect.Value %60)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %61)
+// CHECK-NEXT:   %43 = extractvalue { ptr, ptr } %69, 1
+// CHECK-NEXT:   %44 = extractvalue { ptr, ptr } %69, 0
+// CHECK-NEXT:   %45 = call i64 %44(ptr %43, i64 1)
+// CHECK-NEXT:   %46 = call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %10)
+// CHECK-NEXT:   %47 = call %reflect.Value @reflect.ValueOf(%"{{.*}}/runtime/internal/runtime.eface" %46)
+// CHECK-NEXT:   %48 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
+// CHECK-NEXT:   %49 = getelementptr inbounds %reflect.Value, ptr %48, i64 0
+// CHECK-NEXT:   %50 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT:   store i64 100, ptr %50, align 8
+// CHECK-NEXT:   %51 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %50, 1
+// CHECK-NEXT:   %52 = call %reflect.Value @reflect.ValueOf(%"{{.*}}/runtime/internal/runtime.eface" %51)
+// CHECK-NEXT:   store %reflect.Value %52, ptr %49, align 8
+// CHECK-NEXT:   %53 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %48, 0
+// CHECK-NEXT:   %54 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %53, i64 1, 1
+// CHECK-NEXT:   %55 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %54, i64 1, 2
+// CHECK-NEXT:   %56 = call %"{{.*}}/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %47, %"{{.*}}/runtime/internal/runtime.Slice" %55)
+// CHECK-NEXT:   %57 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %56, 0
+// CHECK-NEXT:   %58 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %56, 1
+// CHECK-NEXT:   %59 = icmp uge i64 0, %58
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %59, i64 0, i1 true, i64 %58)
+// CHECK-NEXT:   %60 = getelementptr inbounds %reflect.Value, ptr %57, i64 0
+// CHECK-NEXT:   %61 = load %reflect.Value, ptr %60, align 8
+// CHECK-NEXT:   %62 = icmp eq ptr %60, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %62)
+// CHECK-NEXT:   %63 = call i64 @reflect.Value.Int(%reflect.Value %61)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %63)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %62 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %37, 1
-// CHECK-NEXT:   %63 = load { ptr, ptr }, ptr %62, align 8
-// CHECK-NEXT:   %64 = insertvalue { { ptr, ptr }, i1 } undef, { ptr, ptr } %63, 0
-// CHECK-NEXT:   %65 = insertvalue { { ptr, ptr }, i1 } %64, i1 true, 1
+// CHECK-NEXT:   %64 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %38, 1
+// CHECK-NEXT:   %65 = load { ptr, ptr }, ptr %64, align 8
+// CHECK-NEXT:   %66 = insertvalue { { ptr, ptr }, i1 } undef, { ptr, ptr } %65, 0
+// CHECK-NEXT:   %67 = insertvalue { { ptr, ptr }, i1 } %66, i1 true, 1
 // CHECK-NEXT:   br label %_llgo_5
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   br label %_llgo_5
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
-// CHECK-NEXT:   %66 = phi { { ptr, ptr }, i1 } [ %65, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
-// CHECK-NEXT:   %67 = extractvalue { { ptr, ptr }, i1 } %66, 0
-// CHECK-NEXT:   %68 = extractvalue { { ptr, ptr }, i1 } %66, 1
-// CHECK-NEXT:   br i1 %68, label %_llgo_2, label %_llgo_1
+// CHECK-NEXT:   %68 = phi { { ptr, ptr }, i1 } [ %67, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
+// CHECK-NEXT:   %69 = extractvalue { { ptr, ptr }, i1 } %68, 0
+// CHECK-NEXT:   %70 = extractvalue { { ptr, ptr }, i1 } %68, 1
+// CHECK-NEXT:   br i1 %70, label %_llgo_2, label %_llgo_1
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/reflect.callMethod"(){{.*}} {
@@ -467,64 +475,68 @@ func callMethod() {
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %27, i64 0, i1 true, i64 %26)
 // CHECK-NEXT:   %28 = getelementptr inbounds %reflect.Value, ptr %25, i64 0
 // CHECK-NEXT:   %29 = load %reflect.Value, ptr %28, align 8
-// CHECK-NEXT:   %30 = call i64 @reflect.Value.Int(%reflect.Value %29)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %30)
+// CHECK-NEXT:   %30 = icmp eq ptr %28, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %30)
+// CHECK-NEXT:   %31 = call i64 @reflect.Value.Int(%reflect.Value %29)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %31)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %31 = call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %4)
-// CHECK-NEXT:   %32 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %31, 0
-// CHECK-NEXT:   %33 = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", ptr %32)
-// CHECK-NEXT:   br i1 %33, label %_llgo_3, label %_llgo_4
+// CHECK-NEXT:   %32 = call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %4)
+// CHECK-NEXT:   %33 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %32, 0
+// CHECK-NEXT:   %34 = call i1 @"{{.*}}/runtime/internal/runtime.MatchesClosure"(ptr @"_llgo_closure$QIHBTaw1IFobr8yvWpq-2AJFm3xBNhdW_aNBicqUBGk", ptr %33)
+// CHECK-NEXT:   br i1 %34, label %_llgo_3, label %_llgo_4
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_5
-// CHECK-NEXT:   %34 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr %34, align 8
-// CHECK-NEXT:   %35 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %34, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %35)
+// CHECK-NEXT:   %35 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr %35, align 8
+// CHECK-NEXT:   %36 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %35, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %36)
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_5
-// CHECK-NEXT:   %36 = extractvalue { ptr, ptr } %61, 1
-// CHECK-NEXT:   %37 = extractvalue { ptr, ptr } %61, 0
-// CHECK-NEXT:   %38 = call i64 %37(ptr %36, i64 1)
-// CHECK-NEXT:   %39 = call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %4)
-// CHECK-NEXT:   %40 = call %reflect.Value @reflect.ValueOf(%"{{.*}}/runtime/internal/runtime.eface" %39)
-// CHECK-NEXT:   %41 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
-// CHECK-NEXT:   %42 = getelementptr inbounds %reflect.Value, ptr %41, i64 0
-// CHECK-NEXT:   %43 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 100, ptr %43, align 8
-// CHECK-NEXT:   %44 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %43, 1
-// CHECK-NEXT:   %45 = call %reflect.Value @reflect.ValueOf(%"{{.*}}/runtime/internal/runtime.eface" %44)
-// CHECK-NEXT:   store %reflect.Value %45, ptr %42, align 8
-// CHECK-NEXT:   %46 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %41, 0
-// CHECK-NEXT:   %47 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %46, i64 1, 1
-// CHECK-NEXT:   %48 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %47, i64 1, 2
-// CHECK-NEXT:   %49 = call %"{{.*}}/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %40, %"{{.*}}/runtime/internal/runtime.Slice" %48)
-// CHECK-NEXT:   %50 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %49, 0
-// CHECK-NEXT:   %51 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %49, 1
-// CHECK-NEXT:   %52 = icmp uge i64 0, %51
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %52, i64 0, i1 true, i64 %51)
-// CHECK-NEXT:   %53 = getelementptr inbounds %reflect.Value, ptr %50, i64 0
-// CHECK-NEXT:   %54 = load %reflect.Value, ptr %53, align 8
-// CHECK-NEXT:   %55 = call i64 @reflect.Value.Int(%reflect.Value %54)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %55)
+// CHECK-NEXT:   %37 = extractvalue { ptr, ptr } %63, 1
+// CHECK-NEXT:   %38 = extractvalue { ptr, ptr } %63, 0
+// CHECK-NEXT:   %39 = call i64 %38(ptr %37, i64 1)
+// CHECK-NEXT:   %40 = call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %4)
+// CHECK-NEXT:   %41 = call %reflect.Value @reflect.ValueOf(%"{{.*}}/runtime/internal/runtime.eface" %40)
+// CHECK-NEXT:   %42 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
+// CHECK-NEXT:   %43 = getelementptr inbounds %reflect.Value, ptr %42, i64 0
+// CHECK-NEXT:   %44 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT:   store i64 100, ptr %44, align 8
+// CHECK-NEXT:   %45 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %44, 1
+// CHECK-NEXT:   %46 = call %reflect.Value @reflect.ValueOf(%"{{.*}}/runtime/internal/runtime.eface" %45)
+// CHECK-NEXT:   store %reflect.Value %46, ptr %43, align 8
+// CHECK-NEXT:   %47 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %42, 0
+// CHECK-NEXT:   %48 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %47, i64 1, 1
+// CHECK-NEXT:   %49 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %48, i64 1, 2
+// CHECK-NEXT:   %50 = call %"{{.*}}/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %41, %"{{.*}}/runtime/internal/runtime.Slice" %49)
+// CHECK-NEXT:   %51 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %50, 0
+// CHECK-NEXT:   %52 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %50, 1
+// CHECK-NEXT:   %53 = icmp uge i64 0, %52
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %53, i64 0, i1 true, i64 %52)
+// CHECK-NEXT:   %54 = getelementptr inbounds %reflect.Value, ptr %51, i64 0
+// CHECK-NEXT:   %55 = load %reflect.Value, ptr %54, align 8
+// CHECK-NEXT:   %56 = icmp eq ptr %54, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %56)
+// CHECK-NEXT:   %57 = call i64 @reflect.Value.Int(%reflect.Value %55)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %57)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %56 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %31, 1
-// CHECK-NEXT:   %57 = load { ptr, ptr }, ptr %56, align 8
-// CHECK-NEXT:   %58 = insertvalue { { ptr, ptr }, i1 } undef, { ptr, ptr } %57, 0
-// CHECK-NEXT:   %59 = insertvalue { { ptr, ptr }, i1 } %58, i1 true, 1
+// CHECK-NEXT:   %58 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %32, 1
+// CHECK-NEXT:   %59 = load { ptr, ptr }, ptr %58, align 8
+// CHECK-NEXT:   %60 = insertvalue { { ptr, ptr }, i1 } undef, { ptr, ptr } %59, 0
+// CHECK-NEXT:   %61 = insertvalue { { ptr, ptr }, i1 } %60, i1 true, 1
 // CHECK-NEXT:   br label %_llgo_5
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   br label %_llgo_5
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_4, %_llgo_3
-// CHECK-NEXT:   %60 = phi { { ptr, ptr }, i1 } [ %59, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
-// CHECK-NEXT:   %61 = extractvalue { { ptr, ptr }, i1 } %60, 0
-// CHECK-NEXT:   %62 = extractvalue { { ptr, ptr }, i1 } %60, 1
-// CHECK-NEXT:   br i1 %62, label %_llgo_2, label %_llgo_1
+// CHECK-NEXT:   %62 = phi { { ptr, ptr }, i1 } [ %61, %_llgo_3 ], [ zeroinitializer, %_llgo_4 ]
+// CHECK-NEXT:   %63 = extractvalue { { ptr, ptr }, i1 } %62, 0
+// CHECK-NEXT:   %64 = extractvalue { { ptr, ptr }, i1 } %62, 1
+// CHECK-NEXT:   br i1 %64, label %_llgo_2, label %_llgo_1
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/reflect.callSlice"(){{.*}} {
@@ -584,87 +596,95 @@ func callMethod() {
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %34, i64 0, i1 true, i64 %33)
 // CHECK-NEXT:   %35 = getelementptr inbounds %reflect.Value, ptr %32, i64 0
 // CHECK-NEXT:   %36 = load %reflect.Value, ptr %35, align 8
-// CHECK-NEXT:   %37 = call i64 @reflect.Value.Int(%reflect.Value %36)
-// CHECK-NEXT:   %38 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %31, 0
-// CHECK-NEXT:   %39 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %31, 1
-// CHECK-NEXT:   %40 = icmp uge i64 1, %39
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %40, i64 1, i1 true, i64 %39)
-// CHECK-NEXT:   %41 = getelementptr inbounds %reflect.Value, ptr %38, i64 1
-// CHECK-NEXT:   %42 = load %reflect.Value, ptr %41, align 8
-// CHECK-NEXT:   %43 = call i64 @reflect.Value.Int(%reflect.Value %42)
+// CHECK-NEXT:   %37 = icmp eq ptr %35, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %37)
+// CHECK-NEXT:   %38 = call i64 @reflect.Value.Int(%reflect.Value %36)
+// CHECK-NEXT:   %39 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %31, 0
+// CHECK-NEXT:   %40 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %31, 1
+// CHECK-NEXT:   %41 = icmp uge i64 1, %40
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %41, i64 1, i1 true, i64 %40)
+// CHECK-NEXT:   %42 = getelementptr inbounds %reflect.Value, ptr %39, i64 1
+// CHECK-NEXT:   %43 = load %reflect.Value, ptr %42, align 8
+// CHECK-NEXT:   %44 = icmp eq ptr %42, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %44)
+// CHECK-NEXT:   %45 = call i64 @reflect.Value.Int(%reflect.Value %43)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 10 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %37)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %38)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %43)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %45)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %44 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 240)
-// CHECK-NEXT:   %45 = getelementptr inbounds %reflect.Value, ptr %44, i64 0
-// CHECK-NEXT:   store %reflect.Value %5, ptr %45, align 8
-// CHECK-NEXT:   %46 = getelementptr inbounds %reflect.Value, ptr %44, i64 1
-// CHECK-NEXT:   store %reflect.Value %5, ptr %46, align 8
-// CHECK-NEXT:   %47 = getelementptr inbounds %reflect.Value, ptr %44, i64 2
+// CHECK-NEXT:   %46 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 240)
+// CHECK-NEXT:   %47 = getelementptr inbounds %reflect.Value, ptr %46, i64 0
 // CHECK-NEXT:   store %reflect.Value %5, ptr %47, align 8
-// CHECK-NEXT:   %48 = getelementptr inbounds %reflect.Value, ptr %44, i64 3
+// CHECK-NEXT:   %48 = getelementptr inbounds %reflect.Value, ptr %46, i64 1
 // CHECK-NEXT:   store %reflect.Value %5, ptr %48, align 8
-// CHECK-NEXT:   %49 = getelementptr inbounds %reflect.Value, ptr %44, i64 4
+// CHECK-NEXT:   %49 = getelementptr inbounds %reflect.Value, ptr %46, i64 2
 // CHECK-NEXT:   store %reflect.Value %5, ptr %49, align 8
-// CHECK-NEXT:   %50 = getelementptr inbounds %reflect.Value, ptr %44, i64 5
+// CHECK-NEXT:   %50 = getelementptr inbounds %reflect.Value, ptr %46, i64 3
 // CHECK-NEXT:   store %reflect.Value %5, ptr %50, align 8
-// CHECK-NEXT:   %51 = getelementptr inbounds %reflect.Value, ptr %44, i64 6
+// CHECK-NEXT:   %51 = getelementptr inbounds %reflect.Value, ptr %46, i64 4
 // CHECK-NEXT:   store %reflect.Value %5, ptr %51, align 8
-// CHECK-NEXT:   %52 = getelementptr inbounds %reflect.Value, ptr %44, i64 7
+// CHECK-NEXT:   %52 = getelementptr inbounds %reflect.Value, ptr %46, i64 5
 // CHECK-NEXT:   store %reflect.Value %5, ptr %52, align 8
-// CHECK-NEXT:   %53 = getelementptr inbounds %reflect.Value, ptr %44, i64 8
+// CHECK-NEXT:   %53 = getelementptr inbounds %reflect.Value, ptr %46, i64 6
 // CHECK-NEXT:   store %reflect.Value %5, ptr %53, align 8
-// CHECK-NEXT:   %54 = getelementptr inbounds %reflect.Value, ptr %44, i64 9
-// CHECK-NEXT:   %55 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 48)
-// CHECK-NEXT:   %56 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.eface", ptr %55, i64 0
-// CHECK-NEXT:   %57 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 1, ptr %57, align 8
-// CHECK-NEXT:   %58 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %57, 1
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %58, ptr %56, align 8
-// CHECK-NEXT:   %59 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.eface", ptr %55, i64 1
-// CHECK-NEXT:   %60 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 2, ptr %60, align 8
-// CHECK-NEXT:   %61 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %60, 1
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %61, ptr %59, align 8
-// CHECK-NEXT:   %62 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.eface", ptr %55, i64 2
-// CHECK-NEXT:   %63 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 3, ptr %63, align 8
-// CHECK-NEXT:   %64 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %63, 1
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %64, ptr %62, align 8
-// CHECK-NEXT:   %65 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %55, 0
-// CHECK-NEXT:   %66 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %65, i64 3, 1
-// CHECK-NEXT:   %67 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %66, i64 3, 2
-// CHECK-NEXT:   %68 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 24)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.Slice" %67, ptr %68, align 8
-// CHECK-NEXT:   %69 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"[]_llgo_any", ptr undef }, ptr %68, 1
-// CHECK-NEXT:   %70 = call %reflect.Value @reflect.ValueOf(%"{{.*}}/runtime/internal/runtime.eface" %69)
-// CHECK-NEXT:   store %reflect.Value %70, ptr %54, align 8
-// CHECK-NEXT:   %71 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %44, 0
-// CHECK-NEXT:   %72 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %71, i64 10, 1
-// CHECK-NEXT:   %73 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %72, i64 10, 2
-// CHECK-NEXT:   %74 = call %"{{.*}}/runtime/internal/runtime.Slice" @reflect.Value.CallSlice(%reflect.Value %2, %"{{.*}}/runtime/internal/runtime.Slice" %73)
-// CHECK-NEXT:   %75 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %74, 0
-// CHECK-NEXT:   %76 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %74, 1
-// CHECK-NEXT:   %77 = icmp uge i64 0, %76
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %77, i64 0, i1 true, i64 %76)
-// CHECK-NEXT:   %78 = getelementptr inbounds %reflect.Value, ptr %75, i64 0
-// CHECK-NEXT:   %79 = load %reflect.Value, ptr %78, align 8
-// CHECK-NEXT:   %80 = call i64 @reflect.Value.Int(%reflect.Value %79)
-// CHECK-NEXT:   %81 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %74, 0
-// CHECK-NEXT:   %82 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %74, 1
-// CHECK-NEXT:   %83 = icmp uge i64 1, %82
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %83, i64 1, i1 true, i64 %82)
-// CHECK-NEXT:   %84 = getelementptr inbounds %reflect.Value, ptr %81, i64 1
-// CHECK-NEXT:   %85 = load %reflect.Value, ptr %84, align 8
-// CHECK-NEXT:   %86 = call i64 @reflect.Value.Int(%reflect.Value %85)
+// CHECK-NEXT:   %54 = getelementptr inbounds %reflect.Value, ptr %46, i64 7
+// CHECK-NEXT:   store %reflect.Value %5, ptr %54, align 8
+// CHECK-NEXT:   %55 = getelementptr inbounds %reflect.Value, ptr %46, i64 8
+// CHECK-NEXT:   store %reflect.Value %5, ptr %55, align 8
+// CHECK-NEXT:   %56 = getelementptr inbounds %reflect.Value, ptr %46, i64 9
+// CHECK-NEXT:   %57 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 48)
+// CHECK-NEXT:   %58 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.eface", ptr %57, i64 0
+// CHECK-NEXT:   %59 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT:   store i64 1, ptr %59, align 8
+// CHECK-NEXT:   %60 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %59, 1
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %60, ptr %58, align 8
+// CHECK-NEXT:   %61 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.eface", ptr %57, i64 1
+// CHECK-NEXT:   %62 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT:   store i64 2, ptr %62, align 8
+// CHECK-NEXT:   %63 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %62, 1
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %63, ptr %61, align 8
+// CHECK-NEXT:   %64 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.eface", ptr %57, i64 2
+// CHECK-NEXT:   %65 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT:   store i64 3, ptr %65, align 8
+// CHECK-NEXT:   %66 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %65, 1
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %66, ptr %64, align 8
+// CHECK-NEXT:   %67 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %57, 0
+// CHECK-NEXT:   %68 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %67, i64 3, 1
+// CHECK-NEXT:   %69 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %68, i64 3, 2
+// CHECK-NEXT:   %70 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 24)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.Slice" %69, ptr %70, align 8
+// CHECK-NEXT:   %71 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"[]_llgo_any", ptr undef }, ptr %70, 1
+// CHECK-NEXT:   %72 = call %reflect.Value @reflect.ValueOf(%"{{.*}}/runtime/internal/runtime.eface" %71)
+// CHECK-NEXT:   store %reflect.Value %72, ptr %56, align 8
+// CHECK-NEXT:   %73 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %46, 0
+// CHECK-NEXT:   %74 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %73, i64 10, 1
+// CHECK-NEXT:   %75 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %74, i64 10, 2
+// CHECK-NEXT:   %76 = call %"{{.*}}/runtime/internal/runtime.Slice" @reflect.Value.CallSlice(%reflect.Value %2, %"{{.*}}/runtime/internal/runtime.Slice" %75)
+// CHECK-NEXT:   %77 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %76, 0
+// CHECK-NEXT:   %78 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %76, 1
+// CHECK-NEXT:   %79 = icmp uge i64 0, %78
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %79, i64 0, i1 true, i64 %78)
+// CHECK-NEXT:   %80 = getelementptr inbounds %reflect.Value, ptr %77, i64 0
+// CHECK-NEXT:   %81 = load %reflect.Value, ptr %80, align 8
+// CHECK-NEXT:   %82 = icmp eq ptr %80, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %82)
+// CHECK-NEXT:   %83 = call i64 @reflect.Value.Int(%reflect.Value %81)
+// CHECK-NEXT:   %84 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %76, 0
+// CHECK-NEXT:   %85 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %76, 1
+// CHECK-NEXT:   %86 = icmp uge i64 1, %85
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %86, i64 1, i1 true, i64 %85)
+// CHECK-NEXT:   %87 = getelementptr inbounds %reflect.Value, ptr %84, i64 1
+// CHECK-NEXT:   %88 = load %reflect.Value, ptr %87, align 8
+// CHECK-NEXT:   %89 = icmp eq ptr %87, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %89)
+// CHECK-NEXT:   %90 = call i64 @reflect.Value.Int(%reflect.Value %88)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 10 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %80)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %83)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %86)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %90)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }

--- a/cl/_testgo/reflect/in.go
+++ b/cl/_testgo/reflect/in.go
@@ -148,10 +148,9 @@ type T struct {
 // CHECK-NEXT:   %29 = icmp uge i64 0, %28
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %29, i64 0, i1 true, i64 %28)
 // CHECK-NEXT:   %30 = getelementptr inbounds %reflect.Value, ptr %27, i64 0
-// CHECK-NEXT:   %31 = load %reflect.Value, ptr %30, align 8
-// CHECK-NEXT:   %32 = icmp eq ptr %30, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %32)
-// CHECK-NEXT:   %33 = call i64 @reflect.Value.Int(%reflect.Value %31)
+// CHECK-NEXT:   %31 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %30)
+// CHECK-NEXT:   %32 = load %reflect.Value, ptr %31, align 8
+// CHECK-NEXT:   %33 = call i64 @reflect.Value.Int(%reflect.Value %32)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %33)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %34 = call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %6)
@@ -240,10 +239,9 @@ type T struct {
 // CHECK-NEXT:   %25 = icmp uge i64 0, %24
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %25, i64 0, i1 true, i64 %24)
 // CHECK-NEXT:   %26 = getelementptr inbounds %reflect.Value, ptr %23, i64 0
-// CHECK-NEXT:   %27 = load %reflect.Value, ptr %26, align 8
-// CHECK-NEXT:   %28 = icmp eq ptr %26, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %28)
-// CHECK-NEXT:   %29 = call i64 @reflect.Value.Int(%reflect.Value %27)
+// CHECK-NEXT:   %27 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %26)
+// CHECK-NEXT:   %28 = load %reflect.Value, ptr %27, align 8
+// CHECK-NEXT:   %29 = call i64 @reflect.Value.Int(%reflect.Value %28)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %29)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %30 = call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %2)
@@ -368,10 +366,9 @@ func callMethod() {
 // CHECK-NEXT:   %33 = icmp uge i64 0, %32
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %33, i64 0, i1 true, i64 %32)
 // CHECK-NEXT:   %34 = getelementptr inbounds %reflect.Value, ptr %31, i64 0
-// CHECK-NEXT:   %35 = load %reflect.Value, ptr %34, align 8
-// CHECK-NEXT:   %36 = icmp eq ptr %34, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %36)
-// CHECK-NEXT:   %37 = call i64 @reflect.Value.Int(%reflect.Value %35)
+// CHECK-NEXT:   %35 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %34)
+// CHECK-NEXT:   %36 = load %reflect.Value, ptr %35, align 8
+// CHECK-NEXT:   %37 = call i64 @reflect.Value.Int(%reflect.Value %36)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %37)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %38 = call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %10)
@@ -408,10 +405,9 @@ func callMethod() {
 // CHECK-NEXT:   %59 = icmp uge i64 0, %58
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %59, i64 0, i1 true, i64 %58)
 // CHECK-NEXT:   %60 = getelementptr inbounds %reflect.Value, ptr %57, i64 0
-// CHECK-NEXT:   %61 = load %reflect.Value, ptr %60, align 8
-// CHECK-NEXT:   %62 = icmp eq ptr %60, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %62)
-// CHECK-NEXT:   %63 = call i64 @reflect.Value.Int(%reflect.Value %61)
+// CHECK-NEXT:   %61 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %60)
+// CHECK-NEXT:   %62 = load %reflect.Value, ptr %61, align 8
+// CHECK-NEXT:   %63 = call i64 @reflect.Value.Int(%reflect.Value %62)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %63)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   ret void
@@ -474,10 +470,9 @@ func callMethod() {
 // CHECK-NEXT:   %27 = icmp uge i64 0, %26
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %27, i64 0, i1 true, i64 %26)
 // CHECK-NEXT:   %28 = getelementptr inbounds %reflect.Value, ptr %25, i64 0
-// CHECK-NEXT:   %29 = load %reflect.Value, ptr %28, align 8
-// CHECK-NEXT:   %30 = icmp eq ptr %28, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %30)
-// CHECK-NEXT:   %31 = call i64 @reflect.Value.Int(%reflect.Value %29)
+// CHECK-NEXT:   %29 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %28)
+// CHECK-NEXT:   %30 = load %reflect.Value, ptr %29, align 8
+// CHECK-NEXT:   %31 = call i64 @reflect.Value.Int(%reflect.Value %30)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %31)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %32 = call %"{{.*}}/runtime/internal/runtime.eface" @reflect.Value.Interface(%reflect.Value %4)
@@ -514,10 +509,9 @@ func callMethod() {
 // CHECK-NEXT:   %53 = icmp uge i64 0, %52
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %53, i64 0, i1 true, i64 %52)
 // CHECK-NEXT:   %54 = getelementptr inbounds %reflect.Value, ptr %51, i64 0
-// CHECK-NEXT:   %55 = load %reflect.Value, ptr %54, align 8
-// CHECK-NEXT:   %56 = icmp eq ptr %54, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %56)
-// CHECK-NEXT:   %57 = call i64 @reflect.Value.Int(%reflect.Value %55)
+// CHECK-NEXT:   %55 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %54)
+// CHECK-NEXT:   %56 = load %reflect.Value, ptr %55, align 8
+// CHECK-NEXT:   %57 = call i64 @reflect.Value.Int(%reflect.Value %56)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %57)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   ret void
@@ -595,19 +589,17 @@ func callMethod() {
 // CHECK-NEXT:   %34 = icmp uge i64 0, %33
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %34, i64 0, i1 true, i64 %33)
 // CHECK-NEXT:   %35 = getelementptr inbounds %reflect.Value, ptr %32, i64 0
-// CHECK-NEXT:   %36 = load %reflect.Value, ptr %35, align 8
-// CHECK-NEXT:   %37 = icmp eq ptr %35, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %37)
-// CHECK-NEXT:   %38 = call i64 @reflect.Value.Int(%reflect.Value %36)
+// CHECK-NEXT:   %36 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %35)
+// CHECK-NEXT:   %37 = load %reflect.Value, ptr %36, align 8
+// CHECK-NEXT:   %38 = call i64 @reflect.Value.Int(%reflect.Value %37)
 // CHECK-NEXT:   %39 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %31, 0
 // CHECK-NEXT:   %40 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %31, 1
 // CHECK-NEXT:   %41 = icmp uge i64 1, %40
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %41, i64 1, i1 true, i64 %40)
 // CHECK-NEXT:   %42 = getelementptr inbounds %reflect.Value, ptr %39, i64 1
-// CHECK-NEXT:   %43 = load %reflect.Value, ptr %42, align 8
-// CHECK-NEXT:   %44 = icmp eq ptr %42, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %44)
-// CHECK-NEXT:   %45 = call i64 @reflect.Value.Int(%reflect.Value %43)
+// CHECK-NEXT:   %43 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %42)
+// CHECK-NEXT:   %44 = load %reflect.Value, ptr %43, align 8
+// CHECK-NEXT:   %45 = call i64 @reflect.Value.Int(%reflect.Value %44)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 10 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %38)
@@ -667,19 +659,17 @@ func callMethod() {
 // CHECK-NEXT:   %79 = icmp uge i64 0, %78
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %79, i64 0, i1 true, i64 %78)
 // CHECK-NEXT:   %80 = getelementptr inbounds %reflect.Value, ptr %77, i64 0
-// CHECK-NEXT:   %81 = load %reflect.Value, ptr %80, align 8
-// CHECK-NEXT:   %82 = icmp eq ptr %80, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %82)
-// CHECK-NEXT:   %83 = call i64 @reflect.Value.Int(%reflect.Value %81)
+// CHECK-NEXT:   %81 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %80)
+// CHECK-NEXT:   %82 = load %reflect.Value, ptr %81, align 8
+// CHECK-NEXT:   %83 = call i64 @reflect.Value.Int(%reflect.Value %82)
 // CHECK-NEXT:   %84 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %76, 0
 // CHECK-NEXT:   %85 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %76, 1
 // CHECK-NEXT:   %86 = icmp uge i64 1, %85
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %86, i64 1, i1 true, i64 %85)
 // CHECK-NEXT:   %87 = getelementptr inbounds %reflect.Value, ptr %84, i64 1
-// CHECK-NEXT:   %88 = load %reflect.Value, ptr %87, align 8
-// CHECK-NEXT:   %89 = icmp eq ptr %87, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %89)
-// CHECK-NEXT:   %90 = call i64 @reflect.Value.Int(%reflect.Value %88)
+// CHECK-NEXT:   %88 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %87)
+// CHECK-NEXT:   %89 = load %reflect.Value, ptr %88, align 8
+// CHECK-NEXT:   %90 = call i64 @reflect.Value.Int(%reflect.Value %89)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 10 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %83)

--- a/cl/_testgo/reflectmk/in.go
+++ b/cl/_testgo/reflectmk/in.go
@@ -503,7 +503,7 @@ func methodByName(name string) {
 // CHECK-NEXT:   %257 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %256, 0
 // CHECK-NEXT:   %258 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %256, 1
 // CHECK-NEXT:   %259 = icmp uge i64 0, %258
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %259, {{.*}})
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %259, i64 0, i1 true, i64 %258)
 // CHECK-NEXT:   %260 = getelementptr inbounds %reflect.Value, ptr %257, i64 0
 // CHECK-NEXT:   %261 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %260)
 // CHECK-NEXT:   %262 = load %reflect.Value, ptr %261, align 8
@@ -532,7 +532,7 @@ func methodByName(name string) {
 // CHECK-NEXT:   %274 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %273, 0
 // CHECK-NEXT:   %275 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %273, 1
 // CHECK-NEXT:   %276 = icmp uge i64 0, %275
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %276, {{.*}})
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %276, i64 0, i1 true, i64 %275)
 // CHECK-NEXT:   %277 = getelementptr inbounds %reflect.Value, ptr %274, i64 0
 // CHECK-NEXT:   %278 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %277)
 // CHECK-NEXT:   %279 = load %reflect.Value, ptr %278, align 8
@@ -568,7 +568,7 @@ func methodByName(name string) {
 // CHECK-NEXT:   %8 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 0
 // CHECK-NEXT:   %9 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 1
 // CHECK-NEXT:   %10 = icmp uge i64 0, %9
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %10, {{.*}})
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %10, i64 0, i1 true, i64 %9)
 // CHECK-NEXT:   %11 = getelementptr inbounds %reflect.Value, ptr %8, i64 0
 // CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %11)
 // CHECK-NEXT:   %13 = load %reflect.Value, ptr %12, align 8
@@ -602,7 +602,7 @@ func methodByName(name string) {
 // CHECK-NEXT:   %8 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 0
 // CHECK-NEXT:   %9 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 1
 // CHECK-NEXT:   %10 = icmp uge i64 0, %9
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %10, {{.*}})
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %10, i64 0, i1 true, i64 %9)
 // CHECK-NEXT:   %11 = getelementptr inbounds %reflect.Value, ptr %8, i64 0
 // CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %11)
 // CHECK-NEXT:   %13 = load %reflect.Value, ptr %12, align 8

--- a/cl/_testgo/reflectmk/in.go
+++ b/cl/_testgo/reflectmk/in.go
@@ -505,45 +505,47 @@ func methodByName(name string) {
 // CHECK-NEXT:   %259 = icmp uge i64 0, %258
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %259, {{.*}})
 // CHECK-NEXT:   %260 = getelementptr inbounds %reflect.Value, ptr %257, i64 0
-// CHECK-NEXT:   %261 = load %reflect.Value, ptr %260, align 8
-// CHECK-NEXT:   %262 = call %"{{.*}}/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %261)
-// CHECK-NEXT:   %263 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %262, %"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 5 })
-// CHECK-NEXT:   %264 = xor i1 %263, true
-// CHECK-NEXT:   br i1 %264, label %_llgo_22, label %_llgo_23
+// CHECK-NEXT:   %261 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %260)
+// CHECK-NEXT:   %262 = load %reflect.Value, ptr %261, align 8
+// CHECK-NEXT:   %263 = call %"{{.*}}/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %262)
+// CHECK-NEXT:   %264 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %263, %"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 5 })
+// CHECK-NEXT:   %265 = xor i1 %264, true
+// CHECK-NEXT:   br i1 %265, label %_llgo_22, label %_llgo_23
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_21:                                         ; preds = %_llgo_18
-// CHECK-NEXT:   %265 = getelementptr inbounds %reflect.Method, ptr %236, i32 0, i32 0
-// CHECK-NEXT:   %266 = load %"{{.*}}/runtime/internal/runtime.String", ptr %265, align 8
-// CHECK-NEXT:   %267 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %266, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 6 })
-// CHECK-NEXT:   %268 = xor i1 %267, true
-// CHECK-NEXT:   br i1 %268, label %_llgo_19, label %_llgo_20
+// CHECK-NEXT:   %266 = getelementptr inbounds %reflect.Method, ptr %236, i32 0, i32 0
+// CHECK-NEXT:   %267 = load %"{{.*}}/runtime/internal/runtime.String", ptr %266, align 8
+// CHECK-NEXT:   %268 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %267, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 6 })
+// CHECK-NEXT:   %269 = xor i1 %268, true
+// CHECK-NEXT:   br i1 %269, label %_llgo_19, label %_llgo_20
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_22:                                         ; preds = %_llgo_20
-// CHECK-NEXT:   %269 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @23, i64 18 }, ptr %269, align 8
-// CHECK-NEXT:   %270 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %269, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %270)
+// CHECK-NEXT:   %270 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @23, i64 18 }, ptr %270, align 8
+// CHECK-NEXT:   %271 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %270, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %271)
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_23:                                         ; preds = %_llgo_20
-// CHECK-NEXT:   %271 = call %reflect.Value @reflect.Value.MethodByName(%reflect.Value %254, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 6 })
-// CHECK-NEXT:   %272 = call %"{{.*}}/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %271, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer)
-// CHECK-NEXT:   %273 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %272, 0
-// CHECK-NEXT:   %274 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %272, 1
-// CHECK-NEXT:   %275 = icmp uge i64 0, %274
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %275, {{.*}})
-// CHECK-NEXT:   %276 = getelementptr inbounds %reflect.Value, ptr %273, i64 0
-// CHECK-NEXT:   %277 = load %reflect.Value, ptr %276, align 8
-// CHECK-NEXT:   %278 = call %"{{.*}}/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %277)
-// CHECK-NEXT:   %279 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %278, %"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 5 })
-// CHECK-NEXT:   %280 = xor i1 %279, true
-// CHECK-NEXT:   br i1 %280, label %_llgo_24, label %_llgo_25
+// CHECK-NEXT:   %272 = call %reflect.Value @reflect.Value.MethodByName(%reflect.Value %254, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 6 })
+// CHECK-NEXT:   %273 = call %"{{.*}}/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %272, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer)
+// CHECK-NEXT:   %274 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %273, 0
+// CHECK-NEXT:   %275 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %273, 1
+// CHECK-NEXT:   %276 = icmp uge i64 0, %275
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %276, {{.*}})
+// CHECK-NEXT:   %277 = getelementptr inbounds %reflect.Value, ptr %274, i64 0
+// CHECK-NEXT:   %278 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %277)
+// CHECK-NEXT:   %279 = load %reflect.Value, ptr %278, align 8
+// CHECK-NEXT:   %280 = call %"{{.*}}/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %279)
+// CHECK-NEXT:   %281 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %280, %"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 5 })
+// CHECK-NEXT:   %282 = xor i1 %281, true
+// CHECK-NEXT:   br i1 %282, label %_llgo_24, label %_llgo_25
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_24:                                         ; preds = %_llgo_23
-// CHECK-NEXT:   %281 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @24, i64 24 }, ptr %281, align 8
-// CHECK-NEXT:   %282 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %281, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %282)
+// CHECK-NEXT:   %283 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @24, i64 24 }, ptr %283, align 8
+// CHECK-NEXT:   %284 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %283, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %284)
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_25:                                         ; preds = %_llgo_23
@@ -568,17 +570,18 @@ func methodByName(name string) {
 // CHECK-NEXT:   %10 = icmp uge i64 0, %9
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %10, {{.*}})
 // CHECK-NEXT:   %11 = getelementptr inbounds %reflect.Value, ptr %8, i64 0
-// CHECK-NEXT:   %12 = load %reflect.Value, ptr %11, align 8
-// CHECK-NEXT:   %13 = call %"{{.*}}/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %12)
-// CHECK-NEXT:   %14 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %13, %"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 5 })
-// CHECK-NEXT:   %15 = xor i1 %14, true
-// CHECK-NEXT:   br i1 %15, label %_llgo_1, label %_llgo_2
+// CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %11)
+// CHECK-NEXT:   %13 = load %reflect.Value, ptr %12, align 8
+// CHECK-NEXT:   %14 = call %"{{.*}}/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %13)
+// CHECK-NEXT:   %15 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %14, %"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 5 })
+// CHECK-NEXT:   %16 = xor i1 %15, true
+// CHECK-NEXT:   br i1 %16, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %16 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @23, i64 18 }, ptr %16, align 8
-// CHECK-NEXT:   %17 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %16, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %17)
+// CHECK-NEXT:   %17 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @23, i64 18 }, ptr %17, align 8
+// CHECK-NEXT:   %18 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %17, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %18)
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
@@ -601,17 +604,18 @@ func methodByName(name string) {
 // CHECK-NEXT:   %10 = icmp uge i64 0, %9
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.CheckIndexRange"(i1 %10, {{.*}})
 // CHECK-NEXT:   %11 = getelementptr inbounds %reflect.Value, ptr %8, i64 0
-// CHECK-NEXT:   %12 = load %reflect.Value, ptr %11, align 8
-// CHECK-NEXT:   %13 = call %"{{.*}}/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %12)
-// CHECK-NEXT:   %14 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %13, %"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 5 })
-// CHECK-NEXT:   %15 = xor i1 %14, true
-// CHECK-NEXT:   br i1 %15, label %_llgo_1, label %_llgo_2
+// CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.AssertNilDerefPtr"(ptr %11)
+// CHECK-NEXT:   %13 = load %reflect.Value, ptr %12, align 8
+// CHECK-NEXT:   %14 = call %"{{.*}}/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %13)
+// CHECK-NEXT:   %15 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %14, %"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 5 })
+// CHECK-NEXT:   %16 = xor i1 %15, true
+// CHECK-NEXT:   br i1 %16, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %16 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @24, i64 24 }, ptr %16, align 8
-// CHECK-NEXT:   %17 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %16, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %17)
+// CHECK-NEXT:   %17 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @24, i64 24 }, ptr %17, align 8
+// CHECK-NEXT:   %18 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %17, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %18)
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0

--- a/cl/builtin_test.go
+++ b/cl/builtin_test.go
@@ -106,6 +106,39 @@ func compareInterfacePtr(p *interface{}, q interface{}) bool {
 	}
 }
 
+func TestCompileSmallNilDerefGuards(t *testing.T) {
+	_, m := mustCompileLLPkgFromSrc(t, `
+package foo
+
+type value struct {
+	n int
+}
+
+func (v value) method() int {
+	return v.n
+}
+
+func deref(p *int) int {
+	return *p
+}
+
+func unused(p *int) {
+	_ = *p
+}
+
+func field(p *value) int {
+	return p.n
+}
+
+func methodExpr(p *value) int {
+	return (*value).method(p)
+}
+`)
+	if got := strings.Count(m.String(), "AssertNilDeref"); got < 4 {
+		t.Fatalf("compiled IR has %d AssertNilDeref calls, want at least 4:\n%s", got, m.String())
+	}
+}
+
 func TestToBackground(t *testing.T) {
 	if v := toBackground(""); v != llssa.InGo {
 		t.Fatal("toBackground:", v)

--- a/cl/builtin_test.go
+++ b/cl/builtin_test.go
@@ -29,6 +29,7 @@ import (
 	"unsafe"
 
 	llssa "github.com/goplus/llgo/ssa"
+	"github.com/xgo-dev/llvm"
 	"golang.org/x/tools/go/ssa"
 )
 
@@ -106,6 +107,25 @@ func compareInterfacePtr(p *interface{}, q interface{}) bool {
 	}
 }
 
+func TestCompileNestedLargeNilDerefBaseGuard(t *testing.T) {
+	_, m := mustCompileLLPkgFromSrc(t, `
+package foo
+
+type large [1 << 21]byte
+
+func nested(pp **large) {
+	_ = **pp
+}
+`)
+	ir := m.String()
+	if strings.Count(ir, "AssertNilDerefPtr") == 0 {
+		t.Fatalf("compiled IR missing nested AssertNilDerefPtr guard:\n%s", ir)
+	}
+	if !strings.Contains(ir, "AssertNilDeref") {
+		t.Fatalf("compiled IR missing outer AssertNilDeref guard:\n%s", ir)
+	}
+}
+
 func TestCompileWrapNilCheckGuard(t *testing.T) {
 	_, m := mustCompileLLPkgFromSrc(t, `
 	package foo
@@ -153,6 +173,139 @@ func TestCompilePromotedValueMethodNilDerefGuard(t *testing.T) {
 	`)
 	if !strings.Contains(m.String(), "AssertNilDeref") {
 		t.Fatalf("compiled IR missing AssertNilDeref for promoted value method receiver:\n%s", m.String())
+	}
+}
+
+func TestCompileValueReceiverNilDerefKeepsDominance(t *testing.T) {
+	_, m := mustCompileLLPkgFromSrc(t, `
+	package foo
+
+	type stamp struct {
+		n int
+	}
+
+	func (s stamp) value() int {
+		return 1
+	}
+
+	type conn struct {
+		idle stamp
+	}
+
+	func pick(conns []*conn, cond bool) int {
+		if len(conns) == 0 {
+			return 0
+		}
+		pc := conns[0]
+		if cond {
+			_ = pc.idle.value()
+		}
+		return pc.idle.n
+	}
+	`)
+	if err := llvm.VerifyModule(m, llvm.ReturnStatusAction); err != nil {
+		t.Fatalf("compiled IR failed verifier: %v\n%s", err, m.String())
+	}
+}
+
+func TestMethodNilDerefHelperBranches(t *testing.T) {
+	ctx := &context{}
+	alloc := &ssa.Alloc{}
+	field := &ssa.FieldAddr{X: alloc}
+
+	ctx.emitNilDerefBaseCheck(nil, field)
+	ctx.assertNilDerefBase(nil, field)
+	ctx.assertNilDerefBase(nil, &ssa.UnOp{Op: token.ADD})
+
+	if arg, ok := valueReceiverNilDerefArg(nil, nil); ok || arg != nil {
+		t.Fatal("nil function should not request value receiver nil check")
+	}
+
+	recv := types.NewVar(token.NoPos, nil, "recv", types.Typ[types.Int])
+	valueMethod := &ssa.Function{
+		Signature: types.NewSignatureType(recv, nil, nil, nil, nil, false),
+	}
+	unop := &ssa.UnOp{Op: token.MUL, X: alloc}
+	if arg, ok := valueReceiverNilDerefArg(valueMethod, []ssa.Value{unop}); ok || arg != nil {
+		t.Fatal("known non-nil receiver address should not request nil check")
+	}
+
+	bound := &ssa.Function{
+		Synthetic: "bound method wrapper for value",
+		FreeVars:  []*ssa.FreeVar{nil},
+	}
+	if arg, ok := boundValueReceiverNilDerefArg(bound, nil); ok || arg != nil {
+		t.Fatal("missing bound method binding should not request nil check")
+	}
+
+	if arg, ok := boundValueReceiverNilDerefArg(
+		&ssa.Function{Synthetic: "plain closure", FreeVars: []*ssa.FreeVar{nil}},
+		[]ssa.Value{unop},
+	); ok || arg != nil {
+		t.Fatal("non-bound wrapper should not request nil check")
+	}
+
+	ssapkg := buildSSAPackage(t, `
+package foo
+
+type pointer struct{}
+
+func (*pointer) pointerMethod() int { return 1 }
+
+type value struct{}
+
+func (value) valueMethod() int { return 2 }
+
+func bindPointer(p *pointer) func() int {
+	return p.pointerMethod
+}
+
+func bindLocalValue() func() int {
+	var v value
+	return v.valueMethod
+}
+`)
+	if arg, ok := boundValueReceiverNilDerefArgFromFunc(t, ssapkg.Func("bindPointer")); ok || arg != nil {
+		t.Fatal("pointer receiver bound method should not request nil check")
+	}
+	if arg, ok := boundValueReceiverNilDerefArgFromFunc(t, ssapkg.Func("bindLocalValue")); ok || arg != nil {
+		t.Fatal("known non-nil local value binding should not request nil check")
+	}
+}
+
+func boundValueReceiverNilDerefArgFromFunc(t *testing.T, fn *ssa.Function) (*ssa.UnOp, bool) {
+	t.Helper()
+	if fn == nil {
+		t.Fatal("missing function")
+	}
+	for _, block := range fn.Blocks {
+		for _, instr := range block.Instrs {
+			closure, ok := instr.(*ssa.MakeClosure)
+			if !ok {
+				continue
+			}
+			bound, ok := closure.Fn.(*ssa.Function)
+			if !ok {
+				t.Fatalf("closure function has type %T, want *ssa.Function", closure.Fn)
+			}
+			return boundValueReceiverNilDerefArg(bound, closure.Bindings)
+		}
+	}
+	t.Fatalf("bound method closure not found in %s", fn.Name())
+	return nil, false
+}
+
+func TestCollectMethodNilDerefChecksSkipsDynamicDeferGo(t *testing.T) {
+	fn := &ssa.Function{
+		Blocks: []*ssa.BasicBlock{{
+			Instrs: []ssa.Instruction{
+				&ssa.Defer{},
+				&ssa.Go{},
+			},
+		}},
+	}
+	if got := collectMethodNilDerefChecks(fn); len(got) != 0 {
+		t.Fatalf("collectMethodNilDerefChecks() = %v, want no static checks", got)
 	}
 }
 

--- a/cl/builtin_test.go
+++ b/cl/builtin_test.go
@@ -106,9 +106,9 @@ func compareInterfacePtr(p *interface{}, q interface{}) bool {
 	}
 }
 
-func TestCompileSmallNilDerefGuards(t *testing.T) {
+func TestCompileWrapNilCheckGuard(t *testing.T) {
 	_, m := mustCompileLLPkgFromSrc(t, `
-package foo
+	package foo
 
 type value struct {
 	n int
@@ -118,24 +118,41 @@ func (v value) method() int {
 	return v.n
 }
 
-func deref(p *int) int {
-	return *p
-}
-
-func unused(p *int) {
-	_ = *p
-}
-
-func field(p *value) int {
-	return p.n
-}
-
 func methodExpr(p *value) int {
 	return (*value).method(p)
 }
+
+func methodValue(p *value) func() int {
+	return p.method
+}
 `)
-	if got := strings.Count(m.String(), "AssertNilDeref"); got < 4 {
-		t.Fatalf("compiled IR has %d AssertNilDeref calls, want at least 4:\n%s", got, m.String())
+	if !strings.Contains(m.String(), "AssertNilDeref") {
+		t.Fatalf("compiled IR missing AssertNilDeref for ssa:wrapnilchk:\n%s", m.String())
+	}
+}
+
+func TestCompilePromotedValueMethodNilDerefGuard(t *testing.T) {
+	_, m := mustCompileLLPkgFromSrc(t, `
+	package foo
+
+	type embedded struct {
+		n int
+	}
+
+	func (v embedded) value() int {
+		return v.n
+	}
+
+	type outer struct {
+		*embedded
+	}
+
+	func call(o outer) int {
+		return o.value()
+	}
+	`)
+	if !strings.Contains(m.String(), "AssertNilDeref") {
+		t.Fatalf("compiled IR missing AssertNilDeref for promoted value method receiver:\n%s", m.String())
 	}
 }
 

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -157,24 +157,25 @@ type pkgInfo struct {
 type none = struct{}
 
 type context struct {
-	prog        llssa.Program
-	pkg         llssa.Package
-	fn          llssa.Function
-	goFn        *ssa.Function
-	fset        *token.FileSet
-	goProg      *ssa.Program
-	goTyps      *types.Package
-	goPkg       *ssa.Package
-	pyMod       string
-	skips       map[string]none
-	loaded      map[*types.Package]*pkgInfo // loaded packages
-	bvals       map[ssa.Value]llssa.Expr    // block values
-	vargs       map[*ssa.Alloc][]llssa.Expr // varargs
-	funcs       map[*ssa.Function]llssa.Function
-	linkOnceFns map[*ssa.Function]none
-	stackDefers map[*ssa.Function]bool
-	anonDefers  map[*ssa.Function]bool
-	paramDIVars map[*types.Var]llssa.DIVar
+	prog                 llssa.Program
+	pkg                  llssa.Package
+	fn                   llssa.Function
+	goFn                 *ssa.Function
+	fset                 *token.FileSet
+	goProg               *ssa.Program
+	goTyps               *types.Package
+	goPkg                *ssa.Package
+	pyMod                string
+	skips                map[string]none
+	loaded               map[*types.Package]*pkgInfo // loaded packages
+	bvals                map[ssa.Value]llssa.Expr    // block values
+	methodNilDerefChecks map[*ssa.UnOp]none
+	vargs                map[*ssa.Alloc][]llssa.Expr // varargs
+	funcs                map[*ssa.Function]llssa.Function
+	linkOnceFns          map[*ssa.Function]none
+	stackDefers          map[*ssa.Function]bool
+	anonDefers           map[*ssa.Function]bool
+	paramDIVars          map[*types.Var]llssa.DIVar
 
 	patches          Patches
 	blkInfos         []blocks.Info
@@ -499,12 +500,12 @@ func (p *context) compileFuncDecl(pkg llssa.Package, f *ssa.Function) (llssa.Fun
 		dbgEnabled := enableDbg && (f == nil || f.Origin() == nil)
 		dbgSymsEnabled := enableDbgSyms && (f == nil || f.Origin() == nil)
 		p.inits = append(p.inits, func() {
-			oldFn, oldGoFn := p.fn, p.goFn
+			oldFn, oldGoFn, oldMethodNilDerefChecks := p.fn, p.goFn, p.methodNilDerefChecks
 			p.fn = fn
 			p.goFn = f
 			p.state = state // restore pkgState when compiling funcBody
 			defer func() {
-				p.fn, p.goFn = oldFn, oldGoFn
+				p.fn, p.goFn, p.methodNilDerefChecks = oldFn, oldGoFn, oldMethodNilDerefChecks
 			}()
 			p.phis = nil
 			if dbgSymsEnabled {
@@ -521,6 +522,7 @@ func (p *context) compileFuncDecl(pkg llssa.Package, f *ssa.Function) (llssa.Fun
 				b.DebugFunction(fn, pos, bodyPos)
 			}
 			p.bvals = make(map[ssa.Value]llssa.Expr)
+			p.methodNilDerefChecks = collectMethodNilDerefChecks(f)
 			off := make([]int, len(f.Blocks))
 			if isCgo {
 				p.cgoArgs = make([]llssa.Expr, len(f.Params))
@@ -1006,6 +1008,9 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 		ret = b.BinOp(v.Op, x, y)
 	case *ssa.UnOp:
 		if v.Op == token.MUL {
+			if _, ok := p.methodNilDerefChecks[v]; ok {
+				return p.compileCheckedDeref(b, v)
+			}
 			if refs := v.Referrers(); refs != nil && len(*refs) == 0 {
 				if t := p.type_(v.Type(), llssa.InGo); t.RawType() != nil {
 					if p.isLargeNonPointerValue(t) {
@@ -1270,10 +1275,22 @@ func (p *context) compileValueAs(b llssa.Builder, v ssa.Value, typ types.Type) l
 }
 
 func (p *context) assertNilDerefBase(b llssa.Builder, addr ssa.Value) {
-	if field, ok := addr.(*ssa.FieldAddr); ok {
-		p.assertNilDerefBase(b, field.X)
-		base := p.compileValue(b, field.X)
-		b.AssertNilDeref(base)
+	switch addr := addr.(type) {
+	case *ssa.UnOp:
+		if addr.Op != token.MUL || isKnownNonNilAddr(addr.X) || isWrapNilCheckCall(addr.X) {
+			return
+		}
+		p.compileCheckedDeref(b, addr)
+	case *ssa.FieldAddr:
+		if isKnownNonNilAddr(addr.X) || isWrapNilCheckCall(addr.X) {
+			return
+		}
+		p.assertNilDerefBase(b, addr.X)
+		base := p.compileValue(b, addr.X)
+		if isPointerGoType(addr.X.Type()) {
+			base = b.NilDerefCheck(base)
+		}
+		p.bvals[addr] = b.FieldAddr(base, addr.Field)
 	}
 }
 

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1068,6 +1068,10 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 				if t := p.type_(v.Type(), llssa.InGo); t.RawType() != nil && p.prog.SizeOf(t) == 0 {
 					p.assertNilDerefBase(b, v.X)
 				}
+				if isInterfaceCompareDeref(v) {
+					p.assertNilDerefBase(b, v.X)
+					b.AssertNilDeref(x)
+				}
 			}
 			ret = b.UnOp(v.Op, x)
 		}

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1020,10 +1020,18 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 						return
 					}
 				}
-			}
-			if skipUnusedArrayDeref(v) {
-				p.compileValue(b, v.X)
-				return
+				if skipUnusedArrayDeref(v) {
+					p.compileValue(b, v.X)
+					return
+				}
+				if _, ok := types.Unalias(v.Type()).Underlying().(*types.Slice); ok {
+					// Zero-length slice-to-array conversions can leave only
+					// an unused slice deref; preserve its required nil check.
+					x := p.compileValue(b, v.X)
+					p.assertNilDerefBase(b, v.X)
+					b.AssertNilDeref(x)
+					return
+				}
 			}
 			if refs := v.Referrers(); refs != nil && len(*refs) == 1 {
 				if _, ok := (*refs)[0].(*ssa.MakeInterface); ok {
@@ -1056,6 +1064,11 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 		if v.Op == token.ARROW {
 			ret = b.Recv(x, v.CommaOk)
 		} else {
+			if v.Op == token.MUL {
+				if t := p.type_(v.Type(), llssa.InGo); t.RawType() != nil && p.prog.SizeOf(t) == 0 {
+					p.assertNilDerefBase(b, v.X)
+				}
+			}
 			ret = b.UnOp(v.Op, x)
 		}
 	case *ssa.ChangeType:

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1012,16 +1012,6 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 			}
 			if refs := v.Referrers(); refs != nil && len(*refs) == 0 {
 				if t := p.type_(v.Type(), llssa.InGo); t.RawType() != nil {
-					if p.isLargeNonPointerValue(t) {
-						x := p.compileValue(b, v.X)
-						p.assertNilDerefBase(b, v.X)
-						b.AssertNilDeref(x)
-						return
-					}
-				}
-				if _, ok := types.Unalias(v.Type()).Underlying().(*types.Slice); ok {
-					// Zero-length slice-to-array conversions can leave only
-					// an unused slice deref; preserve its required nil check.
 					x := p.compileValue(b, v.X)
 					p.assertNilDerefBase(b, v.X)
 					b.AssertNilDeref(x)
@@ -1060,13 +1050,8 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 			ret = b.Recv(x, v.CommaOk)
 		} else {
 			if v.Op == token.MUL {
-				if t := p.type_(v.Type(), llssa.InGo); t.RawType() != nil && p.prog.SizeOf(t) == 0 {
-					p.assertNilDerefBase(b, v.X)
-				}
-				if isInterfaceCompareDeref(v) {
-					p.assertNilDerefBase(b, v.X)
-					b.AssertNilDeref(x)
-				}
+				p.assertNilDerefBase(b, v.X)
+				b.AssertNilDeref(x)
 			}
 			ret = b.UnOp(v.Op, x)
 		}
@@ -1288,6 +1273,7 @@ func (p *context) compileValueAs(b llssa.Builder, v ssa.Value, typ types.Type) l
 
 func (p *context) assertNilDerefBase(b llssa.Builder, addr ssa.Value) {
 	if field, ok := addr.(*ssa.FieldAddr); ok {
+		p.assertNilDerefBase(b, field.X)
 		base := p.compileValue(b, field.X)
 		b.AssertNilDeref(base)
 	}

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1006,17 +1006,19 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 		ret = b.BinOp(v.Op, x, y)
 	case *ssa.UnOp:
 		if v.Op == token.MUL {
+			if refs := v.Referrers(); refs != nil && len(*refs) == 0 {
+				if t := p.type_(v.Type(), llssa.InGo); t.RawType() != nil {
+					if p.isLargeNonPointerValue(t) {
+						x := p.compileValue(b, v.X)
+						p.assertNilDerefBase(b, v.X)
+						b.AssertNilDeref(x)
+						return
+					}
+				}
+			}
 			if skipUnusedArrayDeref(v) {
 				p.compileValue(b, v.X)
 				return
-			}
-			if refs := v.Referrers(); refs != nil && len(*refs) == 0 {
-				if t := p.type_(v.Type(), llssa.InGo); t.RawType() != nil {
-					x := p.compileValue(b, v.X)
-					p.assertNilDerefBase(b, v.X)
-					b.AssertNilDeref(x)
-					return
-				}
 			}
 			if refs := v.Referrers(); refs != nil && len(*refs) == 1 {
 				if _, ok := (*refs)[0].(*ssa.MakeInterface); ok {
@@ -1049,10 +1051,6 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 		if v.Op == token.ARROW {
 			ret = b.Recv(x, v.CommaOk)
 		} else {
-			if v.Op == token.MUL {
-				p.assertNilDerefBase(b, v.X)
-				b.AssertNilDeref(x)
-			}
 			ret = b.UnOp(v.Op, x)
 		}
 	case *ssa.ChangeType:

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -947,21 +947,105 @@ func isWrapNilCheckCall(v ssa.Value) bool {
 	return ok && builtin.Name() == "ssa:wrapnilchk"
 }
 
-func (p *context) assertValueReceiverNilDeref(b llssa.Builder, fn *ssa.Function, args []ssa.Value) {
+func (p *context) emitNilDerefBaseCheck(b llssa.Builder, addr ssa.Value) {
+	switch addr := addr.(type) {
+	case *ssa.UnOp:
+		if addr.Op != token.MUL || isKnownNonNilAddr(addr.X) || isWrapNilCheckCall(addr.X) {
+			return
+		}
+		p.emitCheckedDerefCheck(b, addr)
+	case *ssa.FieldAddr:
+		if isKnownNonNilAddr(addr.X) || isWrapNilCheckCall(addr.X) {
+			return
+		}
+		p.emitNilDerefBaseCheck(b, addr.X)
+		if isPointerGoType(addr.X.Type()) {
+			base := p.compileValue(b, addr.X)
+			b.AssertNilDeref(base)
+		}
+	}
+}
+
+func (p *context) emitCheckedDerefCheck(b llssa.Builder, arg *ssa.UnOp) {
+	p.emitNilDerefBaseCheck(b, arg.X)
+	ptr := p.compileValue(b, arg.X)
+	b.AssertNilDeref(ptr)
+}
+
+func (p *context) compileCheckedDeref(b llssa.Builder, arg *ssa.UnOp) llssa.Expr {
+	p.emitNilDerefBaseCheck(b, arg.X)
+	ptr := p.compileValue(b, arg.X)
+	checked := b.NilDerefCheck(ptr)
+	ret := b.UnOp(token.MUL, checked)
+	p.bvals[arg] = ret
+	return ret
+}
+
+func valueReceiverNilDerefArg(fn *ssa.Function, args []ssa.Value) (*ssa.UnOp, bool) {
 	if fn == nil || len(args) == 0 {
-		return
+		return nil, false
 	}
 	recv := fn.Signature.Recv()
 	if recv == nil || isPointerGoType(recv.Type()) {
-		return
+		return nil, false
 	}
 	arg, ok := args[0].(*ssa.UnOp)
 	if !ok || arg.Op != token.MUL || isKnownNonNilAddr(arg.X) || isWrapNilCheckCall(arg.X) {
-		return
+		return nil, false
 	}
-	ptr := p.compileValue(b, arg.X)
-	p.assertNilDerefBase(b, arg.X)
-	b.AssertNilDeref(ptr)
+	return arg, true
+}
+
+func boundValueReceiverNilDerefArg(fn *ssa.Function, bindings []ssa.Value) (*ssa.UnOp, bool) {
+	if fn == nil || len(fn.FreeVars) == 0 || len(bindings) == 0 {
+		return nil, false
+	}
+	if !strings.HasPrefix(fn.Synthetic, "bound method wrapper for ") {
+		return nil, false
+	}
+	if isPointerGoType(fn.FreeVars[0].Type()) {
+		return nil, false
+	}
+	arg, ok := bindings[0].(*ssa.UnOp)
+	if !ok || arg.Op != token.MUL || isKnownNonNilAddr(arg.X) || isWrapNilCheckCall(arg.X) {
+		return nil, false
+	}
+	return arg, true
+}
+
+func collectMethodNilDerefChecks(fn *ssa.Function) map[*ssa.UnOp]none {
+	var checks map[*ssa.UnOp]none
+	mark := func(arg *ssa.UnOp, ok bool) {
+		if !ok {
+			return
+		}
+		if checks == nil {
+			checks = make(map[*ssa.UnOp]none)
+		}
+		checks[arg] = none{}
+	}
+	markCall := func(call *ssa.CallCommon) {
+		if fn, ok := call.Value.(*ssa.Function); ok {
+			mark(valueReceiverNilDerefArg(fn, call.Args))
+		}
+	}
+	for _, block := range fn.Blocks {
+		for _, instr := range block.Instrs {
+			switch instr := instr.(type) {
+			case *ssa.Call:
+				markCall(&instr.Call)
+			case *ssa.Defer:
+				markCall(&instr.Call)
+			case *ssa.Go:
+				markCall(&instr.Call)
+			case *ssa.MakeClosure:
+				if bound, ok := instr.Fn.(*ssa.Function); ok {
+					mark(boundValueReceiverNilDerefArg(bound, instr.Bindings))
+				}
+			}
+		}
+	}
+	return checks
 }
 
 func (p *context) callEx(b llssa.Builder, act llssa.DoAction, call *ssa.CallCommon, ds *explicitDeferStack) (ret llssa.Expr) {
@@ -1009,7 +1093,6 @@ func (p *context) callEx(b llssa.Builder, act llssa.DoAction, call *ssa.CallComm
 		ret = p.emitDo(b, act, ds, llssa.Builtin(fn), llssa.Builder.Call, args...)
 	case *ssa.Function:
 		aFn, pyFn, ftype := p.compileFunction(cv)
-		p.assertValueReceiverNilDeref(b, cv, args)
 		// TODO(xsw): check ca != llssa.Call
 		switch ftype {
 		case cFunc:

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -921,6 +921,49 @@ func (p *context) staticArrayLenBuiltinArg(b llssa.Builder, arg ssa.Value) (llss
 	return b.Const(constant.MakeInt64(arr.Len()), p.type_(types.Typ[types.Int], llssa.InGo)), true
 }
 
+func isPointerGoType(t types.Type) bool {
+	_, ok := types.Unalias(t).Underlying().(*types.Pointer)
+	return ok
+}
+
+func isKnownNonNilAddr(v ssa.Value) bool {
+	switch v := v.(type) {
+	case *ssa.Alloc, *ssa.Global:
+		return true
+	case *ssa.FieldAddr:
+		return isKnownNonNilAddr(v.X)
+	case *ssa.IndexAddr:
+		return isKnownNonNilAddr(v.X)
+	}
+	return false
+}
+
+func isWrapNilCheckCall(v ssa.Value) bool {
+	call, ok := v.(*ssa.Call)
+	if !ok {
+		return false
+	}
+	builtin, ok := call.Call.Value.(*ssa.Builtin)
+	return ok && builtin.Name() == "ssa:wrapnilchk"
+}
+
+func (p *context) assertValueReceiverNilDeref(b llssa.Builder, fn *ssa.Function, args []ssa.Value) {
+	if fn == nil || len(args) == 0 {
+		return
+	}
+	recv := fn.Signature.Recv()
+	if recv == nil || isPointerGoType(recv.Type()) {
+		return
+	}
+	arg, ok := args[0].(*ssa.UnOp)
+	if !ok || arg.Op != token.MUL || isKnownNonNilAddr(arg.X) || isWrapNilCheckCall(arg.X) {
+		return
+	}
+	ptr := p.compileValue(b, arg.X)
+	p.assertNilDerefBase(b, arg.X)
+	b.AssertNilDeref(ptr)
+}
+
 func (p *context) callEx(b llssa.Builder, act llssa.DoAction, call *ssa.CallCommon, ds *explicitDeferStack) (ret llssa.Expr) {
 	cv := call.Value
 	if mthd := call.Method; mthd != nil {
@@ -966,6 +1009,7 @@ func (p *context) callEx(b llssa.Builder, act llssa.DoAction, call *ssa.CallComm
 		ret = p.emitDo(b, act, ds, llssa.Builtin(fn), llssa.Builder.Call, args...)
 	case *ssa.Function:
 		aFn, pyFn, ftype := p.compileFunction(cv)
+		p.assertValueReceiverNilDeref(b, cv, args)
 		// TODO(xsw): check ca != llssa.Call
 		switch ftype {
 		case cFunc:

--- a/runtime/internal/runtime/z_error.go
+++ b/runtime/internal/runtime/z_error.go
@@ -83,6 +83,11 @@ func AssertNilDeref(b bool) {
 	}
 }
 
+func AssertNilDerefPtr(ptr unsafe.Pointer) unsafe.Pointer {
+	AssertNilDeref(ptr == nil)
+	return ptr
+}
+
 func PanicWrapNilPointer(b bool, recvType, methodName string) {
 	if b {
 		recvType = panicWrapRecvType(recvType)

--- a/ssa/memory.go
+++ b/ssa/memory.go
@@ -344,6 +344,11 @@ func (b Builder) AssertNilDeref(ptr Expr) {
 	b.InlineCall(b.Pkg.rtFunc("AssertNilDeref"), isNil)
 }
 
+func (b Builder) NilDerefCheck(ptr Expr) Expr {
+	checked := b.Call(b.Pkg.rtFunc("AssertNilDerefPtr"), b.Convert(b.Prog.VoidPtr(), ptr))
+	return b.Convert(ptr.Type, checked)
+}
+
 func (b Builder) assertStaticNilDeref(ptr Expr) {
 	if ptr.impl.IsNull() {
 		b.AssertNilDeref(ptr)

--- a/test/go/method_dispatch_test.go
+++ b/test/go/method_dispatch_test.go
@@ -1,0 +1,84 @@
+package gotest
+
+import "testing"
+
+type methodDispatchEmbedded int
+
+func (methodDispatchEmbedded) value() int { return 11 }
+
+func (*methodDispatchEmbedded) pointer() int { return 12 }
+
+type methodDispatchOuter struct {
+	*methodDispatchEmbedded
+}
+
+type methodDispatchNumber int
+
+func (n methodDispatchNumber) twice() int { return int(n) * 2 }
+
+type methodDispatchPointer struct{}
+
+func (*methodDispatchPointer) marker() int { return 31 }
+
+type methodDispatchValuer interface {
+	twice() int
+}
+
+type methodDispatchPointerIface interface {
+	marker() int
+}
+
+func expectMethodDispatchPanic(t *testing.T, f func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected nil pointer dereference panic")
+		}
+	}()
+	f()
+}
+
+func TestPromotedValueMethodNilEmbeddedPointerPanics(t *testing.T) {
+	var outer methodDispatchOuter
+
+	expectMethodDispatchPanic(t, func() { _ = outer.value() })
+	expectMethodDispatchPanic(t, func() { _ = methodDispatchOuter(outer).value() })
+	expectMethodDispatchPanic(t, func() { _ = (&outer).value() })
+}
+
+func TestPromotedPointerMethodKeepsNilReceiver(t *testing.T) {
+	var outer methodDispatchOuter
+
+	if got := outer.pointer(); got != 12 {
+		t.Fatalf("outer.pointer() = %d, want 12", got)
+	}
+	if got := methodDispatchOuter(outer).pointer(); got != 12 {
+		t.Fatalf("methodDispatchOuter(outer).pointer() = %d, want 12", got)
+	}
+	if got := (&outer).pointer(); got != 12 {
+		t.Fatalf("(&outer).pointer() = %d, want 12", got)
+	}
+}
+
+func TestValueReceiverMethodExpressionAndValueNilPointerPanics(t *testing.T) {
+	var n *methodDispatchNumber
+
+	expectMethodDispatchPanic(t, func() { _ = (*methodDispatchNumber).twice(n) })
+	expectMethodDispatchPanic(t, func() { _ = n.twice })
+}
+
+func TestInterfaceCallValueReceiverOnNilPointerPanics(t *testing.T) {
+	var n *methodDispatchNumber
+	var v methodDispatchValuer = n
+
+	expectMethodDispatchPanic(t, func() { _ = v.twice() })
+}
+
+func TestInterfaceCallPointerReceiverKeepsNilReceiver(t *testing.T) {
+	var p *methodDispatchPointer
+	var v methodDispatchPointerIface = p
+
+	if got := v.marker(); got != 31 {
+		t.Fatalf("v.marker() = %d, want 31", got)
+	}
+}

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1741,14 +1741,6 @@ xfails:
     reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
-    case: method.go
-    reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
-    case: method5.go
-    reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
     case: noinit.go
     reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64
@@ -1803,16 +1795,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: init1.go
-    reason: go1.24 goroot run failure on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
-    case: method.go
-    reason: go1.24 goroot run failure on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
-    case: method5.go
     reason: go1.24 goroot run failure on linux/amd64
   - version: go1.24
     platform: linux/amd64
@@ -1878,16 +1860,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: init1.go
-    reason: go1.25 goroot run failure on linux/amd64
-  - version: go1.25
-    platform: linux/amd64
-    directive: run
-    case: method.go
-    reason: go1.25 goroot run failure on linux/amd64
-  - version: go1.25
-    platform: linux/amd64
-    directive: run
-    case: method5.go
     reason: go1.25 goroot run failure on linux/amd64
   - version: go1.25
     platform: linux/amd64
@@ -1958,16 +1930,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: init1.go
-    reason: go1.26 goroot run failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: method.go
-    reason: go1.26 goroot run failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: method5.go
     reason: go1.26 goroot run failure on linux/amd64
   - version: go1.26
     platform: linux/amd64


### PR DESCRIPTION
## Summary
- Emit explicit nil-deref guards for Go pointer indirections, while preserving the array-pointer range skip.
- Implement `ssa:wrapnilchk` so value-receiver method wrappers panic on nil pointer receivers.
- Add focused `test/go` coverage for promoted methods, method expressions/values, and interface calls on nil receivers.
- Remove the fixed `method.go` and `method5.go` GOROOT xfails.

## Testing
- `go test ./cl -run 'TestCompileSmallNilDerefGuards|TestCompileLargeNilDerefInterfaceGuards|TestIsLargeNonPointerValue' -count=1`
- `go test ./test/go -run 'Test(Promoted|ValueReceiver|InterfaceCall)' -count=1`
- `./dev/llgo.sh test -run 'Test(Promoted|ValueReceiver|InterfaceCall)' ./test/go`
- `go test ./test/goroot -count=1 -timeout 20m -run TestGoRoot -args -goroot "$(go env GOROOT)" -dirs . -case '^method\.go$' -xfail /tmp/llgo-no-xfail.yaml`
- `go test ./test/goroot -count=1 -timeout 20m -run TestGoRoot -args -goroot "$(go env GOROOT)" -dirs . -case '^method5\.go$' -xfail /tmp/llgo-no-xfail.yaml`
- `go test ./test/goroot -count=1 -timeout 20m -run TestGoRoot -args -goroot "$(go env GOROOT)" -dirs . -case '^method(5)?\.go$'`

GOROOT CI is slow/disabled, so this PR keeps stable coverage in `test/go` and lists the exact targeted GOROOT commands above. I did not push any branch to `xgo-dev/llgo`; normal PR CI should run from the fork branch.