### PR TITLE
fix unbuffered channel range close race

### DIFF
--- a/runtime/internal/runtime/z_chan.go
+++ b/runtime/internal/runtime/z_chan.go
@@ -193,8 +193,8 @@ func chanTryRecv(p *Chan, v unsafe.Pointer, eltSize int, acceptSelectSend bool) 
 		for p.getp == chanHasRecv && !p.close {
 			p.cond.Wait(&p.mutex)
 		}
-		recvOK = !p.close
-		tryOK = recvOK
+		recvOK = p.getp != chanHasRecv
+		tryOK = recvOK || p.close
 		p.mutex.Unlock()
 	} else {
 		recvOK, tryOK = true, true
@@ -237,7 +237,7 @@ func ChanRecv(p *Chan, v unsafe.Pointer, eltSize int) (recvOK bool) {
 		for p.getp == chanHasRecv && !p.close {
 			p.cond.Wait(&p.mutex)
 		}
-		recvOK = !p.close
+		recvOK = p.getp != chanHasRecv
 		p.mutex.Unlock()
 	} else {
 		recvOK = true

--- a/test/go/range_channel_close_test.go
+++ b/test/go/range_channel_close_test.go
@@ -1,0 +1,46 @@
+package gotest
+
+import "testing"
+
+func TestRangeUnbufferedChanReceivesFinalValueBeforeClose(t *testing.T) {
+	const n = 16
+	for round := 0; round < 20; round++ {
+		c := make(chan int)
+		go func() {
+			for i := 0; i < n; i++ {
+				c <- i
+			}
+			close(c)
+		}()
+
+		want := 0
+		for got := range c {
+			if got != want {
+				t.Fatalf("round %d: range value %d = %d, want %d", round, want, got, want)
+			}
+			want++
+		}
+		if want != n {
+			t.Fatalf("round %d: range received %d values, want %d", round, want, n)
+		}
+	}
+}
+
+func TestUnbufferedChanReceiveOKAfterSenderCloses(t *testing.T) {
+	for round := 0; round < 20; round++ {
+		c := make(chan int)
+		go func() {
+			c <- 99
+			close(c)
+		}()
+
+		got, ok := <-c
+		if !ok || got != 99 {
+			t.Fatalf("round %d: receive = %d, %v; want 99, true", round, got, ok)
+		}
+		got, ok = <-c
+		if ok || got != 0 {
+			t.Fatalf("round %d: closed receive = %d, %v; want 0, false", round, got, ok)
+		}
+	}
+}

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -3731,10 +3731,6 @@ xfails:
     reason: go1.25 goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
-    case: range.go
-    reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
     case: typeparam/chans.go
     reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64
@@ -3945,10 +3941,6 @@ xfails:
     directive: run
     case: print.go
     reason: go1.25 goroot run failure on linux/amd64
-  - platform: linux/amd64
-    directive: run
-    case: range.go
-    reason: current main goroot run failure on linux/amd64
   - platform: linux/amd64
     directive: run
     case: typeparam/chans.go


### PR DESCRIPTION
Summary
- Fix unbuffered channel receive comma-ok results when a sender closes immediately after completing the rendezvous.
- Add focused test/go coverage for unbuffered channel range and direct comma-ok receive.
- Remove the now-passing range.go GOROOT xfail entries.

Testing
- go test ./test/go -run 'Test(RangeUnbufferedChanReceivesFinalValueBeforeClose|UnbufferedChanReceiveOKAfterSenderCloses)$' -count=1
- go run ./cmd/llgo test -run 'Test(RangeUnbufferedChanReceivesFinalValueBeforeClose|UnbufferedChanReceiveOKAfterSenderCloses)$' -count=1 ./test/go/range_channel_close_test.go
- go test ./test/go -run 'TestRangeAssignmentConversions$' -count=1
- go run ./cmd/llgo test -run 'TestRangeAssignmentConversions$' -count=1 ./test/go/range_assignment_conversion_test.go
- go test ./cl -run 'TestSkipUnusedArrayDeref|TestRangeFuncDeferAnalysisHelpers|TestCompileRangeFuncDeferModule|TestRangeFuncDeferHelperNilAndCachePaths|TestNestedRangeFuncDeferAnalysisCombinations' -count=1
- (cd runtime && go test ./internal/runtime -count=1)
- go test ./test/goroot -count=1 -args -goroot /opt/homebrew/Cellar/go@1.24/1.24.11/libexec -dirs . -case '^range\.go$' -xfail /tmp/llgo-no-xfail.yaml
- go test ./test/goroot -count=1 -args -goroot /opt/homebrew/Cellar/go@1.24/1.24.11/libexec -dirs . -case '^range\.go$'

Notes
- GOROOT CI is slow/disabled for broad runs; this PR adds stable test/go coverage for the fixed behavior.
- Normal PR CI should run from the cpunion fork branch; no branch was pushed to xgo-dev/llgo.
- Nearby typeparam/chans.go still times out with xfail disabled on this machine, so that xfail remains unchanged.
