### PR TITLE
fix unsafe builtin bounds checks

### DIFF
--- a/cl/_testrt/slicelen/in.go
+++ b/cl/_testrt/slicelen/in.go
@@ -5,20 +5,10 @@ import (
 	"unsafe"
 )
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/slicelen.main"(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 0)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   br i1 false, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 7 })
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   br label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
+// CHECK-LINE: @0 = private unnamed_addr constant [30 x i8] c"unsafe.Slice: len out of range", align 1
+// CHECK-LINE: @1 = private unnamed_addr constant [46 x i8] c"unsafe.Slice: nil pointer with non-zero length", align 1
+// CHECK-LINE: @2 = private unnamed_addr constant [7 x i8] c"len > 0", align 1
+
 func main() {
 	var s *int
 	var lens uint32
@@ -29,3 +19,35 @@ func main() {
 		println("len > 0")
 	}
 }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/slicelen.init"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testrt/slicelen.init$guard", align 1
+// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/slicelen.init$guard", align 1
+// CHECK-NEXT:   br label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/slicelen.main"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 false, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 30 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 false, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 46 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 false, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 30 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 false, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 30 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 0)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   br i1 false, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 7 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   br label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }

--- a/cl/_testrt/unsafe/in.go
+++ b/cl/_testrt/unsafe/in.go
@@ -7,6 +7,27 @@ import (
 	"github.com/goplus/lib/c"
 )
 
+// CHECK-LINE: @0 = private unnamed_addr constant [5 x i8] c"error", align 1
+// CHECK-LINE: @2 = private unnamed_addr constant [4 x i8] c"abc\00", align 1
+// CHECK-LINE: @3 = private unnamed_addr constant [31 x i8] c"unsafe.String: len out of range", align 1
+// CHECK-LINE: @4 = private unnamed_addr constant [47 x i8] c"unsafe.String: nil pointer with non-zero length", align 1
+// CHECK-LINE: @5 = private unnamed_addr constant [3 x i8] c"abc", align 1
+// CHECK-LINE: @6 = private unnamed_addr constant [30 x i8] c"unsafe.Slice: len out of range", align 1
+// CHECK-LINE: @7 = private unnamed_addr constant [46 x i8] c"unsafe.Slice: nil pointer with non-zero length", align 1
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/unsafe.init"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testrt/unsafe.init$guard", align 1
+// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/unsafe.init$guard", align 1
+// CHECK-NEXT:   br label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
 //llgo:type C
 type T func()
 
@@ -122,102 +143,119 @@ type N struct {
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_20:                                         ; preds = %_llgo_18
-// CHECK-NEXT:   %20 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 3 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 3 })
-// CHECK-NEXT:   %21 = xor i1 %20, true
-// CHECK-NEXT:   br i1 %21, label %_llgo_21, label %_llgo_22
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 false, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 31 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 false, %"{{.*}}/runtime/internal/runtime.String" { ptr @4, i64 47 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 false, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 31 })
+// CHECK-NEXT:   %20 = icmp ult i64 add (i64 ptrtoint (ptr @2 to i64), i64 2), ptrtoint (ptr @2 to i64)
+// CHECK-NEXT:   %21 = and i1 true, %20
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 %21, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 31 })
+// CHECK-NEXT:   %22 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 3 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 3 })
+// CHECK-NEXT:   %23 = xor i1 %22, true
+// CHECK-NEXT:   br i1 %23, label %_llgo_21, label %_llgo_22
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_21:                                         ; preds = %_llgo_20
-// CHECK-NEXT:   %22 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %22, align 8
-// CHECK-NEXT:   %23 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %22, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %23)
+// CHECK-NEXT:   %24 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %24, align 8
+// CHECK-NEXT:   %25 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %24, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %25)
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_22:                                         ; preds = %_llgo_20
-// CHECK-NEXT:   %24 = load i8, ptr @2, align 1
-// CHECK-NEXT:   %25 = icmp ne i8 %24, 97
-// CHECK-NEXT:   br i1 %25, label %_llgo_23, label %_llgo_26
+// CHECK-NEXT:   %26 = load i8, ptr @2, align 1
+// CHECK-NEXT:   %27 = icmp ne i8 %26, 97
+// CHECK-NEXT:   br i1 %27, label %_llgo_23, label %_llgo_26
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_23:                                         ; preds = %_llgo_25, %_llgo_26, %_llgo_22
-// CHECK-NEXT:   %26 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %26, align 8
-// CHECK-NEXT:   %27 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %26, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %27)
+// CHECK-NEXT:   %28 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %28, align 8
+// CHECK-NEXT:   %29 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %28, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %29)
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_24:                                         ; preds = %_llgo_25
-// CHECK-NEXT:   %28 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %29 = getelementptr inbounds i64, ptr %28, i64 0
-// CHECK-NEXT:   %30 = getelementptr inbounds i64, ptr %28, i64 1
-// CHECK-NEXT:   store i64 1, ptr %29, align 8
-// CHECK-NEXT:   store i64 2, ptr %30, align 8
-// CHECK-NEXT:   %31 = getelementptr inbounds i64, ptr %28, i64 0
-// CHECK-NEXT:   %32 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %31, 0
-// CHECK-NEXT:   %33 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %32, i64 2, 1
-// CHECK-NEXT:   %34 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %33, i64 2, 2
-// CHECK-NEXT:   %35 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %34, 0
-// CHECK-NEXT:   %36 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %34, 1
-// CHECK-NEXT:   %37 = icmp uge i64 0, %36
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %37)
-// CHECK-NEXT:   %38 = getelementptr inbounds i64, ptr %35, i64 0
-// CHECK-NEXT:   %39 = load i64, ptr %38, align 8
-// CHECK-NEXT:   %40 = icmp ne i64 %39, 1
-// CHECK-NEXT:   br i1 %40, label %_llgo_27, label %_llgo_29
+// CHECK-NEXT:   %30 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT:   %31 = getelementptr inbounds i64, ptr %30, i64 0
+// CHECK-NEXT:   %32 = getelementptr inbounds i64, ptr %30, i64 1
+// CHECK-NEXT:   store i64 1, ptr %31, align 8
+// CHECK-NEXT:   store i64 2, ptr %32, align 8
+// CHECK-NEXT:   %33 = getelementptr inbounds i64, ptr %30, i64 0
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 false, %"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 30 })
+// CHECK-NEXT:   %34 = icmp eq ptr %33, null
+// CHECK-NEXT:   %35 = and i1 %34, true
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 %35, %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 46 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 false, %"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 30 })
+// CHECK-NEXT:   %36 = ptrtoint ptr %33 to i64
+// CHECK-NEXT:   %37 = add i64 %36, 15
+// CHECK-NEXT:   %38 = icmp ult i64 %37, %36
+// CHECK-NEXT:   %39 = and i1 true, %38
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertRuntimeError"(i1 %39, %"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 30 })
+// CHECK-NEXT:   %40 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %33, 0
+// CHECK-NEXT:   %41 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %40, i64 2, 1
+// CHECK-NEXT:   %42 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %41, i64 2, 2
+// CHECK-NEXT:   %43 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %42, 0
+// CHECK-NEXT:   %44 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %42, 1
+// CHECK-NEXT:   %45 = icmp uge i64 0, %44
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %45)
+// CHECK-NEXT:   %46 = getelementptr inbounds i64, ptr %43, i64 0
+// CHECK-NEXT:   %47 = load i64, ptr %46, align 8
+// CHECK-NEXT:   %48 = icmp ne i64 %47, 1
+// CHECK-NEXT:   br i1 %48, label %_llgo_27, label %_llgo_29
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_25:                                         ; preds = %_llgo_26
-// CHECK-NEXT:   %41 = load i8, ptr getelementptr inbounds (i8, ptr @2, i64 2), align 1
-// CHECK-NEXT:   %42 = icmp ne i8 %41, 99
-// CHECK-NEXT:   br i1 %42, label %_llgo_23, label %_llgo_24
+// CHECK-NEXT:   %49 = load i8, ptr getelementptr inbounds (i8, ptr @2, i64 2), align 1
+// CHECK-NEXT:   %50 = icmp ne i8 %49, 99
+// CHECK-NEXT:   br i1 %50, label %_llgo_23, label %_llgo_24
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_26:                                         ; preds = %_llgo_22
-// CHECK-NEXT:   %43 = load i8, ptr getelementptr inbounds (i8, ptr @2, i64 1), align 1
-// CHECK-NEXT:   %44 = icmp ne i8 %43, 98
-// CHECK-NEXT:   br i1 %44, label %_llgo_23, label %_llgo_25
+// CHECK-NEXT:   %51 = load i8, ptr getelementptr inbounds (i8, ptr @2, i64 1), align 1
+// CHECK-NEXT:   %52 = icmp ne i8 %51, 98
+// CHECK-NEXT:   br i1 %52, label %_llgo_23, label %_llgo_25
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_27:                                         ; preds = %_llgo_29, %_llgo_24
-// CHECK-NEXT:   %45 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %45, align 8
-// CHECK-NEXT:   %46 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %45, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %46)
+// CHECK-NEXT:   %53 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %53, align 8
+// CHECK-NEXT:   %54 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %53, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %54)
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_28:                                         ; preds = %_llgo_29
-// CHECK-NEXT:   %47 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %34, 0
-// CHECK-NEXT:   %48 = load i64, ptr %47, align 8
-// CHECK-NEXT:   %49 = icmp ne i64 %48, 1
-// CHECK-NEXT:   br i1 %49, label %_llgo_30, label %_llgo_31
+// CHECK-NEXT:   %55 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %42, 0
+// CHECK-NEXT:   %56 = load i64, ptr %55, align 8
+// CHECK-NEXT:   %57 = icmp ne i64 %56, 1
+// CHECK-NEXT:   br i1 %57, label %_llgo_30, label %_llgo_31
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_29:                                         ; preds = %_llgo_24
-// CHECK-NEXT:   %50 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %34, 0
-// CHECK-NEXT:   %51 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %34, 1
-// CHECK-NEXT:   %52 = icmp uge i64 1, %51
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %52)
-// CHECK-NEXT:   %53 = getelementptr inbounds i64, ptr %50, i64 1
-// CHECK-NEXT:   %54 = load i64, ptr %53, align 8
-// CHECK-NEXT:   %55 = icmp ne i64 %54, 2
-// CHECK-NEXT:   br i1 %55, label %_llgo_27, label %_llgo_28
+// CHECK-NEXT:   %58 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %42, 0
+// CHECK-NEXT:   %59 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %42, 1
+// CHECK-NEXT:   %60 = icmp uge i64 1, %59
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertIndexRange"(i1 %60)
+// CHECK-NEXT:   %61 = getelementptr inbounds i64, ptr %58, i64 1
+// CHECK-NEXT:   %62 = load i64, ptr %61, align 8
+// CHECK-NEXT:   %63 = icmp ne i64 %62, 2
+// CHECK-NEXT:   br i1 %63, label %_llgo_27, label %_llgo_28
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_30:                                         ; preds = %_llgo_28
-// CHECK-NEXT:   %56 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %56, align 8
-// CHECK-NEXT:   %57 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %56, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %57)
+// CHECK-NEXT:   %64 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %64, align 8
+// CHECK-NEXT:   %65 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %64, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %65)
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_31:                                         ; preds = %_llgo_28
-// CHECK-NEXT:   %58 = icmp ne i64 ptrtoint (ptr getelementptr (i8, ptr null, i64 1) to i64), 1
-// CHECK-NEXT:   br i1 %58, label %_llgo_32, label %_llgo_33
+// CHECK-NEXT:   %66 = icmp ne i64 ptrtoint (ptr getelementptr (i8, ptr null, i64 1) to i64), 1
+// CHECK-NEXT:   br i1 %66, label %_llgo_32, label %_llgo_33
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_32:                                         ; preds = %_llgo_31
-// CHECK-NEXT:   %59 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %59, align 8
-// CHECK-NEXT:   %60 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %59, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %60)
+// CHECK-NEXT:   %67 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %67, align 8
+// CHECK-NEXT:   %68 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %67, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %68)
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_33:                                         ; preds = %_llgo_31
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
+
 func main() {
 	if unsafe.Sizeof(*(*T)(nil)) != unsafe.Sizeof(0) {
 		panic("error")

--- a/ssa/datastruct.go
+++ b/ssa/datastruct.go
@@ -93,7 +93,7 @@ func (b Builder) MakeString(cstr Expr, n ...Expr) (ret Expr) {
 func (b Builder) StringData(x Expr) Expr {
 	dbgInstrf("StringData %v\n", x.impl)
 	ptr := llvm.CreateExtractValue(b.impl, x.impl, 0)
-	return Expr{ptr, b.Prog.CStr()}
+	return Expr{ptr, b.Prog.Pointer(b.Prog.Byte())}
 }
 
 // StringLen returns the length of a string.
@@ -354,7 +354,7 @@ func (b Builder) Slice(x, low, high, max Expr) (ret Expr) {
 			nCap = prog.IntVal(uint64(te.Len()), prog.Int())
 			if high.IsNil() {
 				if lowIsNil && max.IsNil() {
-					ret.impl = b.unsafeSlice(x, nCap.impl, nCap.impl).impl
+					ret.impl = b.unsafeSliceHeader(x, nCap.impl, nCap.impl).impl
 					return
 				}
 				high = nCap
@@ -378,7 +378,7 @@ func (b Builder) SliceLit(t Type, elts ...Expr) Expr {
 		b.Store(b.Advance(ptr, prog.Val(i)), elt)
 	}
 	size := llvm.ConstInt(prog.tyInt(), uint64(len(elts)), false)
-	return b.unsafeSlice(ptr, size, size)
+	return b.unsafeSliceHeader(ptr, size, size)
 }
 
 // The MakeSlice instruction yields a slice of length Len backed by a
@@ -412,9 +412,9 @@ func (b Builder) FitIntSize(n Expr) Expr {
 	typ := prog.Int()
 	if prog.SizeOf(n.Type) != prog.SizeOf(typ) {
 		srcType := n.Type
-		n.Type = typ
 		n.impl = castInt(b, n.impl, srcType, typ)
 	}
+	n.Type = typ
 	return n
 }
 

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -339,17 +339,70 @@ func (b Builder) Str(v string) Expr {
 	return Expr{aggregateValue(b.impl, prog.rtString(), data, size), prog.String()}
 }
 
-// unsafeString(data *byte, size int) string
-func (b Builder) unsafeString(data, size llvm.Value) Expr {
+// unsafeStringHeader constructs a string header from data and size.
+func (b Builder) unsafeStringHeader(data, size llvm.Value) Expr {
 	prog := b.Prog
 	return Expr{aggregateValue(b.impl, prog.rtString(), data, size), prog.String()}
 }
 
-// unsafeSlice(data *T, size, cap int) []T
-func (b Builder) unsafeSlice(data Expr, size, cap llvm.Value) Expr {
+// unsafeSliceHeader constructs a slice header from data, size, and cap.
+func (b Builder) unsafeSliceHeader(data Expr, size, cap llvm.Value) Expr {
 	prog := b.Prog
 	tslice := prog.Slice(prog.Elem(data.Type))
 	return Expr{aggregateValue(b.impl, prog.rtSlice(), data.impl, size, cap), tslice}
+}
+
+func (b Builder) checkedUnsafeString(data, size Expr) Expr {
+	size = b.FitIntSize(size)
+	b.checkUnsafeBuiltinBounds("unsafe.String", data, size, 1)
+	return b.unsafeStringHeader(data.impl, size.impl)
+}
+
+func (b Builder) checkedUnsafeSlice(data, size Expr) Expr {
+	prog := b.Prog
+	size = b.FitIntSize(size)
+	elemSize := prog.SizeOf(prog.Elem(data.Type))
+	b.checkUnsafeBuiltinBounds("unsafe.Slice", data, size, elemSize)
+	return b.unsafeSliceHeader(data, size.impl, size.impl)
+}
+
+func (b Builder) checkUnsafeBuiltinBounds(name string, data, size Expr, elemSize uint64) {
+	prog := b.Prog
+	zero := llvm.ConstInt(size.ll, 0, false)
+	isNegative := llvm.CreateICmp(b.impl, llvm.IntSLT, size.impl, zero)
+	b.assertRuntimeError(isNegative, name+": len out of range")
+
+	isNonZero := llvm.CreateICmp(b.impl, llvm.IntNE, size.impl, zero)
+	isNil := llvm.CreateICmp(b.impl, llvm.IntEQ, data.impl, llvm.ConstPointerNull(data.impl.Type()))
+	b.assertRuntimeError(llvm.CreateAnd(b.impl, isNil, isNonZero), name+": nil pointer with non-zero length")
+
+	if elemSize == 0 {
+		return
+	}
+
+	uptr := prog.Uintptr()
+	length := castUintptr(b, size.impl, size.Type, uptr)
+	maxAddr := ^uint64(0)
+	if bits := uint(prog.PointerSize() * 8); bits < 64 {
+		maxAddr = (uint64(1) << bits) - 1
+	}
+	maxLen := llvm.ConstInt(uptr.ll, maxAddr/elemSize, false)
+	lenTooLarge := llvm.CreateICmp(b.impl, llvm.IntUGT, length, maxLen)
+	b.assertRuntimeError(lenTooLarge, name+": len out of range")
+
+	byteSize := length
+	if elemSize != 1 {
+		byteSize = b.impl.CreateMul(length, llvm.ConstInt(uptr.ll, elemSize, false), "")
+	}
+	lastOffset := b.impl.CreateSub(byteSize, llvm.ConstInt(uptr.ll, 1, false), "")
+	addr := llvm.CreatePtrToInt(b.impl, data.impl, uptr.ll)
+	end := b.impl.CreateAdd(addr, lastOffset, "")
+	wrapped := llvm.CreateICmp(b.impl, llvm.IntULT, end, addr)
+	b.assertRuntimeError(llvm.CreateAnd(b.impl, isNonZero, wrapped), name+": len out of range")
+}
+
+func (b Builder) assertRuntimeError(check llvm.Value, msg string) {
+	b.InlineCall(b.Pkg.rtFunc("AssertRuntimeError"), Expr{check, b.Prog.Bool()}, b.Str(msg))
 }
 
 // -----------------------------------------------------------------------------
@@ -1413,10 +1466,9 @@ func (b Builder) BuiltinCall(fn string, args ...Expr) (ret Expr) {
 	case "imag":
 		return b.getField(args[0], 1)
 	case "String": // unsafe.String
-		return b.unsafeString(args[0].impl, args[1].impl)
+		return b.checkedUnsafeString(args[0], args[1])
 	case "Slice": // unsafe.Slice
-		size := b.FitIntSize(args[1])
-		return b.unsafeSlice(args[0], size.impl, size.impl)
+		return b.checkedUnsafeSlice(args[0], args[1])
 	case "StringData":
 		return b.StringData(args[0]) // TODO(xsw): check return type
 	case "SliceData":

--- a/test/go/unsafe_builtins_test.go
+++ b/test/go/unsafe_builtins_test.go
@@ -1,0 +1,145 @@
+package gotest
+
+import (
+	"math"
+	"testing"
+	"unsafe"
+)
+
+var (
+	unsafeBuiltinByteSink   []byte
+	unsafeBuiltinUint64Sink []uint64
+	unsafeBuiltinStringSink string
+)
+
+func TestUnsafeBuiltins(t *testing.T) {
+	var buf [16]byte
+	for i := range buf {
+		buf[i] = byte('a' + i)
+	}
+
+	p := unsafe.Pointer(&buf[1])
+	if got, want := unsafe.Add(p, 1), unsafe.Pointer(&buf[2]); got != want {
+		t.Fatalf("unsafe.Add(+1) = %p, want %p", got, want)
+	}
+	if got, want := unsafe.Add(p, -1), unsafe.Pointer(&buf[0]); got != want {
+		t.Fatalf("unsafe.Add(-1) = %p, want %p", got, want)
+	}
+
+	s := unsafe.Slice(&buf[0], len(buf))
+	if len(s) != len(buf) || cap(s) != len(buf) || &s[0] != &buf[0] {
+		t.Fatalf("unsafe.Slice header = len %d cap %d data %p, want len %d cap %d data %p",
+			len(s), cap(s), unsafe.SliceData(s), len(buf), len(buf), &buf[0])
+	}
+	if unsafe.Slice((*int)(nil), 0) != nil {
+		t.Fatal("unsafe.Slice(nil, 0) is not nil")
+	}
+
+	str := unsafe.String(&buf[0], len(buf))
+	if got, want := len(str), len(buf); got != want {
+		t.Fatalf("unsafe.String len = %d, want %d", got, want)
+	}
+	if unsafe.String(nil, 0) != "" {
+		t.Fatal("unsafe.String(nil, 0) is not empty")
+	}
+
+	text := "unsafe string data"
+	if got := string(unsafe.Slice(unsafe.StringData(text), len(text))); got != text {
+		t.Fatalf("string(unsafe.Slice(unsafe.StringData(text), len(text))) = %q, want %q", got, text)
+	}
+	if got := unsafe.String(unsafe.SliceData(s), len(s)); got != string(s) {
+		t.Fatalf("unsafe.String(unsafe.SliceData(s), len(s)) = %q, want %q", got, string(s))
+	}
+}
+
+func TestUnsafeBuiltinPanics(t *testing.T) {
+	negative := -1
+	tooBig := uint64(math.MaxUint64)
+	maxUintptr := ^uintptr(0)
+	last := (*byte)(unsafe.Pointer(maxUintptr))
+
+	tests := []struct {
+		name string
+		f    func()
+	}{
+		{
+			name: "slice nil non-zero length",
+			f: func() {
+				unsafeBuiltinByteSink = unsafe.Slice((*byte)(nil), 1)
+			},
+		},
+		{
+			name: "slice negative length",
+			f: func() {
+				unsafeBuiltinByteSink = unsafe.Slice(new(byte), negative)
+			},
+		},
+		{
+			name: "slice oversized length",
+			f: func() {
+				unsafeBuiltinByteSink = unsafe.Slice(new(byte), tooBig)
+			},
+		},
+		{
+			name: "slice element size overflow at max length",
+			f: func() {
+				unsafeBuiltinUint64Sink = unsafe.Slice(new(uint64), maxUintptr/8)
+			},
+		},
+		{
+			name: "slice element size overflow above max length",
+			f: func() {
+				unsafeBuiltinUint64Sink = unsafe.Slice(new(uint64), maxUintptr/8+1)
+			},
+		},
+		{
+			name: "slice memory end overflow",
+			f: func() {
+				unsafeBuiltinByteSink = unsafe.Slice(last, 2)
+			},
+		},
+		{
+			name: "string nil non-zero length",
+			f: func() {
+				unsafeBuiltinStringSink = unsafe.String(nil, 1)
+			},
+		},
+		{
+			name: "string negative length",
+			f: func() {
+				unsafeBuiltinStringSink = unsafe.String(new(byte), negative)
+			},
+		},
+		{
+			name: "string oversized length",
+			f: func() {
+				unsafeBuiltinStringSink = unsafe.String(new(byte), tooBig)
+			},
+		},
+		{
+			name: "string memory end overflow",
+			f: func() {
+				unsafeBuiltinStringSink = unsafe.String(last, 2)
+			},
+		},
+	}
+
+	_ = unsafe.Slice(last, 1)
+	_ = unsafe.String(last, 1)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expectUnsafeBuiltinPanic(t, tt.f)
+		})
+	}
+}
+
+func expectUnsafeBuiltinPanic(t *testing.T, f func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic")
+		}
+	}()
+	f()
+}

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1816,10 +1816,6 @@ xfails:
     reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
-    case: unsafebuiltins.go
-    reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
     case: switch.go
     reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64
@@ -1945,11 +1941,6 @@ xfails:
   - version: go1.24
     platform: linux/amd64
     directive: run
-    case: unsafebuiltins.go
-    reason: go1.24 goroot run failure on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
     case: switch.go
     reason: go1.24 goroot run failure on linux/amd64
   - version: go1.24
@@ -2051,11 +2042,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: recover3.go
-    reason: go1.25 goroot run failure on linux/amd64
-  - version: go1.25
-    platform: linux/amd64
-    directive: run
-    case: unsafebuiltins.go
     reason: go1.25 goroot run failure on linux/amd64
   - version: go1.25
     platform: linux/amd64
@@ -2166,11 +2152,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: recover3.go
-    reason: go1.26 goroot run failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: unsafebuiltins.go
     reason: go1.26 goroot run failure on linux/amd64
   - version: go1.26
     platform: linux/amd64


### PR DESCRIPTION
Summary
- Add runtime bounds checks for unsafe.Slice and unsafe.String nil, negative length, oversized length, and address-overflow cases.
- Return *byte from unsafe.StringData so unsafe.Slice(unsafe.StringData(s), len(s)) produces []byte.
- Add focused test/go coverage for unsafe.Add/Slice/String and remove the now-fixed unsafebuiltins.go xfails.

Validation
- go test ./test/go -count=1
- go test ./test/go -run 'TestUnsafeBuiltin' -count=1\n- LLGO_ROOT=/Users/lijie/source/goplus/llgo-wt-goroot-unsafe /tmp/llgo-unsafe-debug test ./test/go/unsafe_builtins_test.go\n- go test ./ssa -run 'Test.*Unsafe|Test.*Slice|Test.*String' -count=1\n- go test ./test/std/unsafe -count=1\n- go test ./test/goroot -count=1 -timeout 20m -args -goroot /opt/homebrew/Cellar/go@1.24/1.24.11/libexec -dirs . -case '^unsafebuiltins\\.go$' -xfail /tmp/llgo-no-xfail.yaml\n- go test ./test/goroot -count=1 -timeout 20m -args -goroot /opt/homebrew/Cellar/go@1.24/1.24.11/libexec -dirs . -case '^unsafebuiltins\\.go$'\n\nNotes\n- GOROOT CI is slow/disabled, so this PR adds stable test/go coverage for the fixed unsafe builtin behavior.\n- The targeted GOROOT command above used the current machine GOROOT: /opt/homebrew/Cellar/go@1.24/1.24.11/libexec.\n- Normal PR CI should run from the fork branch.