### PR TITLE
runtime: report BDWGC cycles in MemStats

### DIFF
--- a/runtime/internal/clite/bdwgc/bdwgc.go
+++ b/runtime/internal/clite/bdwgc/bdwgc.go
@@ -97,6 +97,12 @@ func IsDisabled() c.Int
 //go:linkname Gcollect C.GC_gcollect
 func Gcollect()
 
+//go:linkname GetGCNo C.GC_get_gc_no
+func GetGCNo() uintptr
+
+//go:linkname GetHeapUsageSafe C.GC_get_heap_usage_safe
+func GetHeapUsageSafe(heapSize, freeBytes, unmappedBytes, bytesSinceGC, totalBytes *uintptr)
+
 //go:linkname GetMemoryUse C.GC_get_memory_use
 func GetMemoryUse() uintptr
 

--- a/runtime/internal/lib/runtime/runtime_gc.go
+++ b/runtime/internal/lib/runtime/runtime_gc.go
@@ -8,13 +8,31 @@ import (
 	"github.com/goplus/llgo/runtime/internal/clite/bdwgc"
 )
 
+func init() {
+	bdwgc.Init()
+}
+
 func ReadMemStats(m *runtime.MemStats) {
 	if m == nil {
 		return
 	}
-	// LLGo currently doesn't provide accurate allocation statistics when using BDWGC.
-	// Populate a zeroed snapshot so stdlib callers like testing.AllocsPerRun can run.
-	*m = runtime.MemStats{}
+	var heapSize, freeBytes, unmappedBytes, bytesSinceGC, totalBytes uintptr
+	bdwgc.GetHeapUsageSafe(&heapSize, &freeBytes, &unmappedBytes, &bytesSinceGC, &totalBytes)
+
+	heapSys := heapSize + unmappedBytes
+	heapIdle := freeBytes + unmappedBytes
+	heapInuse := saturatingSub(heapSys, heapIdle)
+	heapAlloc := heapInuse
+	*m = runtime.MemStats{
+		Alloc:      uint64(heapAlloc),
+		TotalAlloc: uint64(totalBytes),
+		Sys:        uint64(heapSys),
+		HeapAlloc:  uint64(heapAlloc),
+		HeapSys:    uint64(heapSys),
+		HeapIdle:   uint64(heapIdle),
+		HeapInuse:  uint64(heapInuse),
+		NumGC:      uint32(bdwgc.GetGCNo()),
+	}
 }
 
 func GC() {
@@ -27,4 +45,11 @@ func GC() {
 	if poolCleanup != nil {
 		poolCleanup()
 	}
+}
+
+func saturatingSub(x, y uintptr) uintptr {
+	if x < y {
+		return 0
+	}
+	return x - y
 }

--- a/test/go/runtime_init_gc_test.go
+++ b/test/go/runtime_init_gc_test.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gotest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRuntimeGCStatsDuringInit(t *testing.T) {
+	dir := t.TempDir()
+	src := `package main
+
+import "runtime"
+
+var initialized bool
+
+func init() {
+	c := make(chan struct{})
+	go func() {
+		c <- struct{}{}
+	}()
+	<-c
+
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	runtime.GC()
+	runtime.ReadMemStats(&after)
+	if after.NumGC <= before.NumGC {
+		panic("NumGC did not advance during init")
+	}
+	initialized = true
+}
+
+func main() {
+	if !initialized {
+		panic("init did not run")
+	}
+}
+`
+	mainFile := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(mainFile, []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	runGoCmd(t, dir, "run", mainFile)
+
+	root := findLLGoRoot(t)
+	runGoCmd(t, root, "run", "./cmd/llgo", "run", mainFile)
+}

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1784,10 +1784,6 @@ xfails:
     reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
-    case: init1.go
-    reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
     case: method.go
     reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64


### PR DESCRIPTION
## Summary
- Initialize BDWGC for the runtime package and populate runtime.MemStats from BDWGC heap/cycle counters.
- Add test/go coverage for a goroutine plus runtime.GC during init.
- Remove only the locally verified darwin/arm64 xfail for GOROOT/test/init1.go.

## Tests
- go test ./test/go -count=1 -run TestRuntimeGCStatsDuringInit
- go test ./test/goroot -count=1 -run TestGoRoot -args -goroot "/opt/homebrew/Cellar/go@1.24/1.24.11/libexec" -dirs . -case '^init1\.go$' -xfail /tmp/llgo-empty-xfail.yaml
- (cd runtime && go test ./internal/clite/bdwgc -count=1)
- (cd runtime && go test ./internal/lib/runtime -count=1)
- go test ./test/go -count=1
- go test ./test/goroot -count=1 -run TestGoRoot -args -goroot "/opt/homebrew/Cellar/go@1.24/1.24.11/libexec" -dirs . -case '^init1\.go$'

Local GOROOT: /opt/homebrew/Cellar/go@1.24/1.24.11/libexec, go1.24.11 darwin/arm64.

## CI note
GOROOT CI is slow/disabled, so this PR relies on normal PR CI from the cpunion fork branch. I did not push to xgo-dev/llgo. If manual GOROOT workflow_dispatch cannot resolve fork refs, that remains a workflow blocker to document rather than a reason to push directly to xgo-dev.