### PR TITLE
runtime: fix nil and closed channel select semantics

### DIFF
--- a/cl/_testgo/selects/in.go
+++ b/cl/_testgo/selects/in.go
@@ -1,98 +1,14 @@
 // LITTEST
 package main
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/selects.main"(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.NewChan"(i64 0, i64 1)
-// CHECK-NEXT:   store ptr %1, ptr %0, align 8
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.NewChan"(i64 0, i64 1)
-// CHECK-NEXT:   store ptr %3, ptr %2, align 8
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.NewChan"(i64 0, i64 1)
-// CHECK-NEXT:   store ptr %5, ptr %4, align 8
-// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.NewChan"(i64 0, i64 1)
-// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 24)
-// CHECK-NEXT:   %8 = getelementptr inbounds { ptr, ptr, ptr }, ptr %7, i32 0, i32 0
-// CHECK-NEXT:   store ptr %0, ptr %8, align 8
-// CHECK-NEXT:   %9 = getelementptr inbounds { ptr, ptr, ptr }, ptr %7, i32 0, i32 1
-// CHECK-NEXT:   store ptr %2, ptr %9, align 8
-// CHECK-NEXT:   %10 = getelementptr inbounds { ptr, ptr, ptr }, ptr %7, i32 0, i32 2
-// CHECK-NEXT:   store ptr %4, ptr %10, align 8
-// CHECK-NEXT:   %11 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/selects.main$1", ptr undef }, ptr %7, 1
-// CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   %13 = getelementptr inbounds { { ptr, ptr } }, ptr %12, i32 0, i32 0
-// CHECK-NEXT:   store { ptr, ptr } %11, ptr %13, align 8
-// CHECK-NEXT:   %14 = alloca i8, i64 8, align 1
-// CHECK-NEXT:   %15 = call i32 @"{{.*}}/runtime/internal/runtime.CreateThread"(ptr %14, ptr null, ptr @"{{.*}}/cl/_testgo/selects._llgo_routine$1", ptr %12)
-// CHECK-NEXT:   %16 = load ptr, ptr %0, align 8
-// CHECK-NEXT:   %17 = alloca {}, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %17, i8 0, i64 0, i1 false)
-// CHECK-NEXT:   store {} zeroinitializer, ptr %17, align 1
-// CHECK-NEXT:   %18 = call i1 @"{{.*}}/runtime/internal/runtime.ChanSend"(ptr %16, ptr %17, i64 0)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 4 })
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %19 = load ptr, ptr %2, align 8
-// CHECK-NEXT:   %20 = alloca {}, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %20, i8 0, i64 0, i1 false)
-// CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" undef, ptr %19, 0
-// CHECK-NEXT:   %22 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %21, ptr %20, 1
-// CHECK-NEXT:   %23 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %22, i32 0, 2
-// CHECK-NEXT:   %24 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %23, i1 false, 3
-// CHECK-NEXT:   %25 = alloca {}, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %25, i8 0, i64 0, i1 false)
-// CHECK-NEXT:   %26 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" undef, ptr %6, 0
-// CHECK-NEXT:   %27 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %26, ptr %25, 1
-// CHECK-NEXT:   %28 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %27, i32 0, 2
-// CHECK-NEXT:   %29 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %28, i1 false, 3
-// CHECK-NEXT:   %30 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 48)
-// CHECK-NEXT:   %31 = getelementptr %"{{.*}}/runtime/internal/runtime.ChanOp", ptr %30, i64 0
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.ChanOp" %24, ptr %31, align 8
-// CHECK-NEXT:   %32 = getelementptr %"{{.*}}/runtime/internal/runtime.ChanOp", ptr %30, i64 1
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.ChanOp" %29, ptr %32, align 8
-// CHECK-NEXT:   %33 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %30, 0
-// CHECK-NEXT:   %34 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %33, i64 2, 1
-// CHECK-NEXT:   %35 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %34, i64 2, 2
-// CHECK-NEXT:   %36 = call { i64, i1 } @"{{.*}}/runtime/internal/runtime.Select"(%"{{.*}}/runtime/internal/runtime.Slice" %35)
-// CHECK-NEXT:   %37 = extractvalue { i64, i1 } %36, 0
-// CHECK-NEXT:   %38 = extractvalue { i64, i1 } %36, 1
-// CHECK-NEXT:   %39 = extractvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %24, 1
-// CHECK-NEXT:   %40 = load {}, ptr %39, align 1
-// CHECK-NEXT:   %41 = extractvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %29, 1
-// CHECK-NEXT:   %42 = load {}, ptr %41, align 1
-// CHECK-NEXT:   %43 = insertvalue { i64, i1, {}, {} } undef, i64 %37, 0
-// CHECK-NEXT:   %44 = insertvalue { i64, i1, {}, {} } %43, i1 %38, 1
-// CHECK-NEXT:   %45 = insertvalue { i64, i1, {}, {} } %44, {} %40, 2
-// CHECK-NEXT:   %46 = insertvalue { i64, i1, {}, {} } %45, {} %42, 3
-// CHECK-NEXT:   %47 = extractvalue { i64, i1, {}, {} } %46, 0
-// CHECK-NEXT:   %48 = icmp eq i64 %47, 0
-// CHECK-NEXT:   br i1 %48, label %_llgo_2, label %_llgo_3
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_4, %_llgo_2
-// CHECK-NEXT:   ret void
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 4 })
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %49 = icmp eq i64 %47, 1
-// CHECK-NEXT:   br i1 %49, label %_llgo_4, label %_llgo_5
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_3
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 4 })
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   br label %_llgo_1
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_3
-// CHECK-NEXT:   %50 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 31 }, ptr %50, align 8
-// CHECK-NEXT:   %51 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %50, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %51)
-// CHECK-NEXT:   unreachable
-// CHECK-NEXT: }
+// CHECK-LINE: @0 = private unnamed_addr constant [4 x i8] c"c1<-", align 1
+// CHECK-LINE: @1 = private unnamed_addr constant [4 x i8] c"<-c2", align 1
+// CHECK-LINE: @2 = private unnamed_addr constant [4 x i8] c"<-c4", align 1
+// CHECK-LINE: @3 = private unnamed_addr constant [31 x i8] c"blocking select matched no case", align 1
+// CHECK-LINE: @5 = private unnamed_addr constant [4 x i8] c"<-c1", align 1
+// CHECK-LINE: @6 = private unnamed_addr constant [4 x i8] c"c2<-", align 1
+// CHECK-LINE: @7 = private unnamed_addr constant [4 x i8] c"<-c3", align 1
+
 func main() {
 	c1 := make(chan struct{}, 1)
 	c2 := make(chan struct{}, 1)
@@ -122,53 +38,167 @@ func main() {
 	}
 }
 
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/selects.init"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/selects.init$guard", align 1
+// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/selects.init$guard", align 1
+// CHECK-NEXT:   br label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/selects.main"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.NewChan"(i64 0, i64 1)
+// CHECK-NEXT:   store ptr %1, ptr %0, align 8
+// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.NewChan"(i64 0, i64 1)
+// CHECK-NEXT:   store ptr %3, ptr %2, align 8
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.NewChan"(i64 0, i64 1)
+// CHECK-NEXT:   store ptr %5, ptr %4, align 8
+// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.NewChan"(i64 0, i64 1)
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 24)
+// CHECK-NEXT:   %8 = getelementptr inbounds { ptr, ptr, ptr }, ptr %7, i32 0, i32 0
+// CHECK-NEXT:   store ptr %0, ptr %8, align 8
+// CHECK-NEXT:   %9 = getelementptr inbounds { ptr, ptr, ptr }, ptr %7, i32 0, i32 1
+// CHECK-NEXT:   store ptr %2, ptr %9, align 8
+// CHECK-NEXT:   %10 = getelementptr inbounds { ptr, ptr, ptr }, ptr %7, i32 0, i32 2
+// CHECK-NEXT:   store ptr %4, ptr %10, align 8
+// CHECK-NEXT:   %11 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testgo/selects.main$1", ptr undef }, ptr %7, 1
+// CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   %13 = getelementptr inbounds { { ptr, ptr } }, ptr %12, i32 0, i32 0
+// CHECK-NEXT:   store { ptr, ptr } %11, ptr %13, align 8
+// CHECK-NEXT:   %14 = alloca i8, i64 8, align 1
+// CHECK-NEXT:   %15 = call i32 @"{{.*}}/runtime/internal/runtime.CreateThread"(ptr %14, ptr null, ptr @"{{.*}}/cl/_testgo/selects._llgo_routine$1", ptr %12)
+// CHECK-NEXT:   %16 = load ptr, ptr %0, align 8
+// CHECK-NEXT:   %17 = call ptr @llvm.stacksave()
+// CHECK-NEXT:   %18 = alloca {}, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %18, i8 0, i64 0, i1 false)
+// CHECK-NEXT:   store {} zeroinitializer, ptr %18, align 1
+// CHECK-NEXT:   %19 = call i1 @"{{.*}}/runtime/internal/runtime.ChanSend"(ptr %16, ptr %18, i64 0)
+// CHECK-NEXT:   call void @llvm.stackrestore(ptr %17)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 4 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   %20 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %21 = call ptr @llvm.stacksave()
+// CHECK-NEXT:   %22 = alloca {}, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %22, i8 0, i64 0, i1 false)
+// CHECK-NEXT:   %23 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" undef, ptr %20, 0
+// CHECK-NEXT:   %24 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %23, ptr %22, 1
+// CHECK-NEXT:   %25 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %24, i32 0, 2
+// CHECK-NEXT:   %26 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %25, i1 false, 3
+// CHECK-NEXT:   %27 = alloca {}, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %27, i8 0, i64 0, i1 false)
+// CHECK-NEXT:   %28 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" undef, ptr %6, 0
+// CHECK-NEXT:   %29 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %28, ptr %27, 1
+// CHECK-NEXT:   %30 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %29, i32 0, 2
+// CHECK-NEXT:   %31 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %30, i1 false, 3
+// CHECK-NEXT:   %32 = alloca i8, i64 48, align 1
+// CHECK-NEXT:   %33 = getelementptr %"{{.*}}/runtime/internal/runtime.ChanOp", ptr %32, i64 0
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.ChanOp" %26, ptr %33, align 8
+// CHECK-NEXT:   %34 = getelementptr %"{{.*}}/runtime/internal/runtime.ChanOp", ptr %32, i64 1
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.ChanOp" %31, ptr %34, align 8
+// CHECK-NEXT:   %35 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %32, 0
+// CHECK-NEXT:   %36 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %35, i64 2, 1
+// CHECK-NEXT:   %37 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %36, i64 2, 2
+// CHECK-NEXT:   %38 = call { i64, i1 } @"{{.*}}/runtime/internal/runtime.Select"(%"{{.*}}/runtime/internal/runtime.Slice" %37)
+// CHECK-NEXT:   %39 = extractvalue { i64, i1 } %38, 0
+// CHECK-NEXT:   %40 = extractvalue { i64, i1 } %38, 1
+// CHECK-NEXT:   %41 = extractvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %26, 1
+// CHECK-NEXT:   %42 = load {}, ptr %41, align 1
+// CHECK-NEXT:   %43 = extractvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %31, 1
+// CHECK-NEXT:   %44 = load {}, ptr %43, align 1
+// CHECK-NEXT:   call void @llvm.stackrestore(ptr %21)
+// CHECK-NEXT:   %45 = insertvalue { i64, i1, {}, {} } undef, i64 %39, 0
+// CHECK-NEXT:   %46 = insertvalue { i64, i1, {}, {} } %45, i1 %40, 1
+// CHECK-NEXT:   %47 = insertvalue { i64, i1, {}, {} } %46, {} %42, 2
+// CHECK-NEXT:   %48 = insertvalue { i64, i1, {}, {} } %47, {} %44, 3
+// CHECK-NEXT:   %49 = extractvalue { i64, i1, {}, {} } %48, 0
+// CHECK-NEXT:   %50 = icmp eq i64 %49, 0
+// CHECK-NEXT:   br i1 %50, label %_llgo_2, label %_llgo_3
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_4, %_llgo_2
+// CHECK-NEXT:   ret void
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 4 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   br label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %51 = icmp eq i64 %49, 1
+// CHECK-NEXT:   br i1 %51, label %_llgo_4, label %_llgo_5
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_3
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 4 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   br label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_3
+// CHECK-NEXT:   %52 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 31 }, ptr %52, align 8
+// CHECK-NEXT:   %53 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %52, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %53)
+// CHECK-NEXT:   unreachable
+// CHECK-NEXT: }
+
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/selects.main$1"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = load { ptr, ptr, ptr }, ptr %0, align 8
 // CHECK-NEXT:   %2 = extractvalue { ptr, ptr, ptr } %1, 0
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
-// CHECK-NEXT:   %4 = alloca {}, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %4, i8 0, i64 0, i1 false)
-// CHECK-NEXT:   %5 = call i1 @"{{.*}}/runtime/internal/runtime.ChanRecv"(ptr %3, ptr %4, i64 0)
-// CHECK-NEXT:   %6 = load {}, ptr %4, align 1
+// CHECK-NEXT:   %4 = call ptr @llvm.stacksave()
+// CHECK-NEXT:   %5 = alloca {}, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %5, i8 0, i64 0, i1 false)
+// CHECK-NEXT:   %6 = call i1 @"{{.*}}/runtime/internal/runtime.ChanRecv"(ptr %3, ptr %5, i64 0)
+// CHECK-NEXT:   %7 = load {}, ptr %5, align 1
+// CHECK-NEXT:   call void @llvm.stackrestore(ptr %4)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 4 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %7 = extractvalue { ptr, ptr, ptr } %1, 1
-// CHECK-NEXT:   %8 = load ptr, ptr %7, align 8
-// CHECK-NEXT:   %9 = extractvalue { ptr, ptr, ptr } %1, 2
-// CHECK-NEXT:   %10 = load ptr, ptr %9, align 8
-// CHECK-NEXT:   %11 = alloca {}, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %11, i8 0, i64 0, i1 false)
-// CHECK-NEXT:   store {} zeroinitializer, ptr %11, align 1
-// CHECK-NEXT:   %12 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" undef, ptr %8, 0
-// CHECK-NEXT:   %13 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %12, ptr %11, 1
-// CHECK-NEXT:   %14 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %13, i32 0, 2
-// CHECK-NEXT:   %15 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %14, i1 true, 3
-// CHECK-NEXT:   %16 = alloca {}, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %16, i8 0, i64 0, i1 false)
-// CHECK-NEXT:   %17 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" undef, ptr %10, 0
-// CHECK-NEXT:   %18 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %17, ptr %16, 1
-// CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %18, i32 0, 2
-// CHECK-NEXT:   %20 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %19, i1 false, 3
-// CHECK-NEXT:   %21 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 48)
-// CHECK-NEXT:   %22 = getelementptr %"{{.*}}/runtime/internal/runtime.ChanOp", ptr %21, i64 0
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.ChanOp" %15, ptr %22, align 8
-// CHECK-NEXT:   %23 = getelementptr %"{{.*}}/runtime/internal/runtime.ChanOp", ptr %21, i64 1
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.ChanOp" %20, ptr %23, align 8
-// CHECK-NEXT:   %24 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %21, 0
-// CHECK-NEXT:   %25 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %24, i64 2, 1
-// CHECK-NEXT:   %26 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %25, i64 2, 2
-// CHECK-NEXT:   %27 = call { i64, i1 } @"{{.*}}/runtime/internal/runtime.Select"(%"{{.*}}/runtime/internal/runtime.Slice" %26)
-// CHECK-NEXT:   %28 = extractvalue { i64, i1 } %27, 0
-// CHECK-NEXT:   %29 = extractvalue { i64, i1 } %27, 1
-// CHECK-NEXT:   %30 = extractvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %20, 1
-// CHECK-NEXT:   %31 = load {}, ptr %30, align 1
-// CHECK-NEXT:   %32 = insertvalue { i64, i1, {} } undef, i64 %28, 0
-// CHECK-NEXT:   %33 = insertvalue { i64, i1, {} } %32, i1 %29, 1
-// CHECK-NEXT:   %34 = insertvalue { i64, i1, {} } %33, {} %31, 2
-// CHECK-NEXT:   %35 = extractvalue { i64, i1, {} } %34, 0
-// CHECK-NEXT:   %36 = icmp eq i64 %35, 0
-// CHECK-NEXT:   br i1 %36, label %_llgo_2, label %_llgo_3
+// CHECK-NEXT:   %8 = extractvalue { ptr, ptr, ptr } %1, 1
+// CHECK-NEXT:   %9 = load ptr, ptr %8, align 8
+// CHECK-NEXT:   %10 = extractvalue { ptr, ptr, ptr } %1, 2
+// CHECK-NEXT:   %11 = load ptr, ptr %10, align 8
+// CHECK-NEXT:   %12 = call ptr @llvm.stacksave()
+// CHECK-NEXT:   %13 = alloca {}, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %13, i8 0, i64 0, i1 false)
+// CHECK-NEXT:   store {} zeroinitializer, ptr %13, align 1
+// CHECK-NEXT:   %14 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" undef, ptr %9, 0
+// CHECK-NEXT:   %15 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %14, ptr %13, 1
+// CHECK-NEXT:   %16 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %15, i32 0, 2
+// CHECK-NEXT:   %17 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %16, i1 true, 3
+// CHECK-NEXT:   %18 = alloca {}, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %18, i8 0, i64 0, i1 false)
+// CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" undef, ptr %11, 0
+// CHECK-NEXT:   %20 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %19, ptr %18, 1
+// CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %20, i32 0, 2
+// CHECK-NEXT:   %22 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %21, i1 false, 3
+// CHECK-NEXT:   %23 = alloca i8, i64 48, align 1
+// CHECK-NEXT:   %24 = getelementptr %"{{.*}}/runtime/internal/runtime.ChanOp", ptr %23, i64 0
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.ChanOp" %17, ptr %24, align 8
+// CHECK-NEXT:   %25 = getelementptr %"{{.*}}/runtime/internal/runtime.ChanOp", ptr %23, i64 1
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.ChanOp" %22, ptr %25, align 8
+// CHECK-NEXT:   %26 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %23, 0
+// CHECK-NEXT:   %27 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %26, i64 2, 1
+// CHECK-NEXT:   %28 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %27, i64 2, 2
+// CHECK-NEXT:   %29 = call { i64, i1 } @"{{.*}}/runtime/internal/runtime.Select"(%"{{.*}}/runtime/internal/runtime.Slice" %28)
+// CHECK-NEXT:   %30 = extractvalue { i64, i1 } %29, 0
+// CHECK-NEXT:   %31 = extractvalue { i64, i1 } %29, 1
+// CHECK-NEXT:   %32 = extractvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %22, 1
+// CHECK-NEXT:   %33 = load {}, ptr %32, align 1
+// CHECK-NEXT:   call void @llvm.stackrestore(ptr %12)
+// CHECK-NEXT:   %34 = insertvalue { i64, i1, {} } undef, i64 %30, 0
+// CHECK-NEXT:   %35 = insertvalue { i64, i1, {} } %34, i1 %31, 1
+// CHECK-NEXT:   %36 = insertvalue { i64, i1, {} } %35, {} %33, 2
+// CHECK-NEXT:   %37 = extractvalue { i64, i1, {} } %36, 0
+// CHECK-NEXT:   %38 = icmp eq i64 %37, 0
+// CHECK-NEXT:   br i1 %38, label %_llgo_2, label %_llgo_3
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_4, %_llgo_2
 // CHECK-NEXT:   ret void
@@ -179,8 +209,8 @@ func main() {
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %37 = icmp eq i64 %35, 1
-// CHECK-NEXT:   br i1 %37, label %_llgo_4, label %_llgo_5
+// CHECK-NEXT:   %39 = icmp eq i64 %37, 1
+// CHECK-NEXT:   br i1 %39, label %_llgo_4, label %_llgo_5
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_3
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 4 })
@@ -188,9 +218,19 @@ func main() {
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_3
-// CHECK-NEXT:   %38 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 31 }, ptr %38, align 8
-// CHECK-NEXT:   %39 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %38, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %39)
+// CHECK-NEXT:   %40 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 31 }, ptr %40, align 8
+// CHECK-NEXT:   %41 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %40, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %41)
 // CHECK-NEXT:   unreachable
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define ptr @"{{.*}}/cl/_testgo/selects._llgo_routine$1"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = load { { ptr, ptr } }, ptr %0, align 8
+// CHECK-NEXT:   %2 = extractvalue { { ptr, ptr } } %1, 0
+// CHECK-NEXT:   %3 = extractvalue { ptr, ptr } %2, 1
+// CHECK-NEXT:   %4 = extractvalue { ptr, ptr } %2, 0
+// CHECK-NEXT:   call void %4(ptr %3)
+// CHECK-NEXT:   ret ptr null
 // CHECK-NEXT: }

--- a/runtime/internal/runtime/z_chan.go
+++ b/runtime/internal/runtime/z_chan.go
@@ -80,6 +80,9 @@ func notifyOps(p *Chan) {
 }
 
 func ChanClose(p *Chan) {
+	if p == nil {
+		panic("close of nil channel")
+	}
 	p.mutex.Lock()
 	p.close = true
 	notifyOps(p)
@@ -88,10 +91,17 @@ func ChanClose(p *Chan) {
 }
 
 func ChanTrySend(p *Chan, v unsafe.Pointer, eltSize int) bool {
+	if p == nil {
+		return false
+	}
 	n := p.cap
 	p.mutex.Lock()
+	if p.close {
+		p.mutex.Unlock()
+		panic("send on closed channel")
+	}
 	if n == 0 {
-		if p.getp != chanHasRecv || p.close {
+		if p.getp != chanHasRecv {
 			p.mutex.Unlock()
 			return false
 		}
@@ -100,7 +110,7 @@ func ChanTrySend(p *Chan, v unsafe.Pointer, eltSize int) bool {
 		}
 		p.getp = chanNoSendRecv
 	} else {
-		if p.len == n || p.close {
+		if p.len == n {
 			p.mutex.Unlock()
 			return false
 		}
@@ -115,6 +125,10 @@ func ChanTrySend(p *Chan, v unsafe.Pointer, eltSize int) bool {
 }
 
 func ChanSend(p *Chan, v unsafe.Pointer, eltSize int) bool {
+	if p == nil {
+		blockForever()
+		return false
+	}
 	n := p.cap
 	p.mutex.Lock()
 	if n == 0 {
@@ -130,19 +144,19 @@ func ChanSend(p *Chan, v unsafe.Pointer, eltSize int) bool {
 		}
 		if p.close {
 			p.mutex.Unlock()
-			return false
+			panic("send on closed channel")
 		}
 		if p.data != nil {
 			c.Memcpy(p.data, v, uintptr(eltSize))
 		}
 		p.getp = chanNoSendRecv
 	} else {
-		for p.len == n {
+		for p.len == n && !p.close {
 			p.cond.Wait(&p.mutex)
 		}
 		if p.close {
 			p.mutex.Unlock()
-			return false
+			panic("send on closed channel")
 		}
 		off := (p.getp + p.len) % n
 		c.Memcpy(c.Advance(p.data, off*eltSize), v, uintptr(eltSize))
@@ -155,6 +169,9 @@ func ChanSend(p *Chan, v unsafe.Pointer, eltSize int) bool {
 }
 
 func ChanTryRecv(p *Chan, v unsafe.Pointer, eltSize int) (recvOK bool, tryOK bool) {
+	if p == nil {
+		return false, false
+	}
 	return chanTryRecv(p, v, eltSize, true)
 }
 
@@ -203,6 +220,10 @@ func chanTryRecv(p *Chan, v unsafe.Pointer, eltSize int, acceptSelectSend bool) 
 }
 
 func ChanRecv(p *Chan, v unsafe.Pointer, eltSize int) (recvOK bool) {
+	if p == nil {
+		blockForever()
+		return false
+	}
 	n := p.cap
 	p.mutex.Lock()
 	if n == 0 {
@@ -243,6 +264,17 @@ func ChanRecv(p *Chan, v unsafe.Pointer, eltSize int) (recvOK bool) {
 		recvOK = true
 	}
 	return
+}
+
+func blockForever() {
+	var mutex sync.Mutex
+	var cond sync.Cond
+	mutex.Init(nil)
+	cond.Init(nil)
+	mutex.Lock()
+	for {
+		cond.Wait(&mutex)
+	}
 }
 
 // -----------------------------------------------------------------------------

--- a/runtime/internal/runtime/z_chan.go
+++ b/runtime/internal/runtime/z_chan.go
@@ -37,6 +37,7 @@ type Chan struct {
 	getp  int
 	len   int
 	cap   int
+	sop   *selectOp
 	sops  []*selectOp
 	// sends counts goroutines blocked in unbuffered send, including select-send.
 	sends uint16
@@ -74,6 +75,9 @@ func ChanCap(p *Chan) int {
 }
 
 func notifyOps(p *Chan) {
+	if p.sop != nil {
+		p.sop.notify()
+	}
 	for _, sop := range p.sops {
 		sop.notify()
 	}
@@ -345,10 +349,9 @@ func TrySelect(ops ...ChanOp) (isel int, recvOK, tryOK bool) {
 
 // Select executes a blocking select operation.
 func Select(ops ...ChanOp) (isel int, recvOK bool) {
-	selOp := new(selectOp) // TODO(xsw): use c.AllocaNew[selectOp]()
+	selOp := (*selectOp)(c.Alloca(unsafe.Sizeof(selectOp{})))
 	selOp.init()
 	sendFirst := selectSendFirst(ops)
-	sendChans := selectSendChans(ops)
 	for _, op := range ops {
 		if op.C == nil {
 			continue
@@ -357,7 +360,7 @@ func Select(ops ...ChanOp) (isel int, recvOK bool) {
 	}
 	var tryOK bool
 	for {
-		if isel, recvOK, tryOK = trySelect(ops, sendFirst, sendChans); tryOK {
+		if isel, recvOK, tryOK = trySelect(ops, sendFirst); tryOK {
 			break
 		}
 		selOp.wait()
@@ -372,7 +375,7 @@ func Select(ops ...ChanOp) (isel int, recvOK bool) {
 	return
 }
 
-func trySelect(ops []ChanOp, sendFirst bool, sendChans map[*Chan]bool) (isel int, recvOK, tryOK bool) {
+func trySelect(ops []ChanOp, sendFirst bool) (isel int, recvOK, tryOK bool) {
 	// Split probing by direction. If sends are probed first, the recv phase must
 	// not accept select-only senders, because this select's own sends already
 	// failed to commit to a peer. If recvs are probed first, they may accept
@@ -381,15 +384,15 @@ func trySelect(ops []ChanOp, sendFirst bool, sendChans map[*Chan]bool) (isel int
 		if isel, recvOK, tryOK = trySelectDir(ops, true, false, nil); tryOK {
 			return
 		}
-		return trySelectDir(ops, false, false, sendChans)
+		return trySelectDir(ops, false, false, ops)
 	}
-	if isel, recvOK, tryOK = trySelectDir(ops, false, true, sendChans); tryOK {
+	if isel, recvOK, tryOK = trySelectDir(ops, false, true, ops); tryOK {
 		return
 	}
 	return trySelectDir(ops, true, true, nil)
 }
 
-func trySelectDir(ops []ChanOp, send bool, acceptSelectSend bool, sendChans map[*Chan]bool) (isel int, recvOK, tryOK bool) {
+func trySelectDir(ops []ChanOp, send bool, acceptSelectSend bool, allOps []ChanOp) (isel int, recvOK, tryOK bool) {
 	for isel = range ops {
 		op := ops[isel]
 		if op.C == nil || op.Send != send {
@@ -402,7 +405,7 @@ func trySelectDir(ops []ChanOp, send bool, acceptSelectSend bool, sendChans map[
 			continue
 		}
 		accept := acceptSelectSend
-		if accept && sendChans[op.C] {
+		if accept && selectHasSend(allOps, op.C) {
 			accept = false
 		}
 		if recvOK, tryOK = chanTryRecv(op.C, op.Val, int(op.Size), accept); tryOK {
@@ -412,14 +415,13 @@ func trySelectDir(ops []ChanOp, send bool, acceptSelectSend bool, sendChans map[
 	return
 }
 
-func selectSendChans(ops []ChanOp) map[*Chan]bool {
-	sendChans := make(map[*Chan]bool)
+func selectHasSend(ops []ChanOp, ch *Chan) bool {
 	for _, op := range ops {
-		if op.C != nil && op.Send {
-			sendChans[op.C] = true
+		if op.C == ch && op.Send {
+			return true
 		}
 	}
-	return sendChans
+	return false
 }
 
 func selectSendFirst(ops []ChanOp) bool {
@@ -464,7 +466,11 @@ func prepareSelect(c *Chan, selOp *selectOp, isSend bool) {
 		c.sends++
 		c.selsends++
 	}
-	c.sops = append(c.sops, selOp)
+	if c.sop == nil {
+		c.sop = selOp
+	} else {
+		c.sops = append(c.sops, selOp)
+	}
 	if c.cap == 0 && isSend {
 		// A newly-registered select-send can make a select-recv runnable.
 		notifyOps(c)
@@ -478,9 +484,16 @@ func endSelect(c *Chan, selOp *selectOp, isSend bool) {
 		c.sends--
 		c.selsends--
 	}
+	if c.sop == selOp {
+		c.sop = nil
+		c.mutex.Unlock()
+		return
+	}
 	for i, op := range c.sops {
 		if op == selOp {
-			c.sops = append(c.sops[:i], c.sops[i+1:]...)
+			copy(c.sops[i:], c.sops[i+1:])
+			c.sops[len(c.sops)-1] = nil
+			c.sops = c.sops[:len(c.sops)-1]
 			break
 		}
 	}

--- a/ssa/datastruct.go
+++ b/ssa/datastruct.go
@@ -621,7 +621,9 @@ func (b Builder) Send(ch Expr, x Expr) (ret Expr) {
 	dbgInstrf("Send %v, %v\n", ch.impl, x.impl)
 	prog := b.Prog
 	eltSize := prog.IntVal(prog.SizeOf(prog.Elem(ch.Type)), prog.Int())
+	sp := b.StackSave()
 	ret = b.InlineCall(b.Pkg.rtFunc("ChanSend"), ch, b.toPtr(x), eltSize)
+	b.StackRestore(sp)
 	return
 }
 
@@ -638,14 +640,16 @@ func (b Builder) Recv(ch Expr, commaOk bool) (ret Expr) {
 	prog := b.Prog
 	eltSize := prog.IntVal(prog.SizeOf(prog.Elem(ch.Type)), prog.Int())
 	etyp := prog.Elem(ch.Type)
+	sp := b.StackSave()
 	ptr := b.Alloc(etyp, false)
 	ok := b.InlineCall(b.Pkg.rtFunc("ChanRecv"), ch, ptr, eltSize)
+	val := b.Load(ptr)
+	b.StackRestore(sp)
 	if commaOk {
-		val := b.Load(ptr)
 		t := prog.Struct(etyp, prog.Bool())
 		return b.aggregateValue(t, val.impl, ok.impl)
 	} else {
-		return b.Load(ptr)
+		return val
 	}
 }
 
@@ -693,6 +697,7 @@ type SelectState struct {
 //	t3 = select nonblocking [<-t0, t1<-t2]
 //	t4 = select blocking []
 func (b Builder) Select(states []*SelectState, blocking bool) (ret Expr) {
+	sp := b.StackSave()
 	ops := make([]Expr, len(states))
 	for i, s := range states {
 		ops[i] = b.chanOp(s)
@@ -705,7 +710,7 @@ func (b Builder) Select(states []*SelectState, blocking bool) (ret Expr) {
 	}
 	prog := b.Prog
 	tSlice := lastParamType(prog, fn)
-	slice := b.SliceLit(tSlice, ops...)
+	slice := b.selectOpsSlice(tSlice, ops)
 	ret = b.Call(fn, slice)
 	chosen := b.impl.CreateExtractValue(ret.impl, 0, "")
 	recvOK := b.impl.CreateExtractValue(ret.impl, 1, "")
@@ -725,7 +730,20 @@ func (b Builder) Select(states []*SelectState, blocking bool) (ret Expr) {
 			results = append(results, r.impl)
 		}
 	}
+	b.StackRestore(sp)
 	return b.aggregateValue(b.Prog.Struct(typs...), results...)
+}
+
+func (b Builder) selectOpsSlice(t Type, ops []Expr) Expr {
+	prog := b.Prog
+	telem := prog.Index(t)
+	size := SizeOf(prog, telem, int64(len(ops)))
+	opPtr := Expr{b.Alloca(size).impl, prog.Pointer(telem)}
+	for i, op := range ops {
+		b.Store(b.Advance(opPtr, prog.Val(i)), op)
+	}
+	n := llvm.ConstInt(prog.tyInt(), uint64(len(ops)), false)
+	return b.unsafeSlice(opPtr, n, n)
 }
 
 func lastParamType(prog Program, fn Expr) Type {

--- a/ssa/eh.go
+++ b/ssa/eh.go
@@ -59,6 +59,16 @@ func (p Program) tyStacksave() *types.Signature {
 	return p.stackSaveTy
 }
 
+// func(unsafe.Pointer)
+func (p Program) tyStackrestore() *types.Signature {
+	if p.stackRestoreTy == nil {
+		paramPtr := types.NewParam(token.NoPos, nil, "", p.VoidPtr().raw.Type)
+		params := types.NewTuple(paramPtr)
+		p.stackRestoreTy = types.NewSignatureType(nil, nil, nil, params, nil, false)
+	}
+	return p.stackRestoreTy
+}
+
 func (b Builder) AllocaSigjmpBuf() Expr {
 	prog := b.Prog
 	sigjmpBufTy := prog.rtType("SigjmpBuf") // Get type from runtime (target architecture)
@@ -71,6 +81,12 @@ func (b Builder) AllocaSigjmpBuf() Expr {
 func (b Builder) StackSave() Expr {
 	fn := b.Pkg.cFunc("llvm.stacksave", b.Prog.tyStacksave())
 	return b.InlineCall(fn)
+}
+
+// declare void @llvm.stackrestore.p0(ptr)
+func (b Builder) StackRestore(sp Expr) {
+	fn := b.Pkg.cFunc("llvm.stackrestore", b.Prog.tyStackrestore())
+	b.InlineCall(fn, sp)
 }
 
 // addReturnsTwiceAttr adds the returns_twice attribute to a function.

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -210,6 +210,7 @@ type aProgram struct {
 	freeTy         *types.Signature
 	memsetInlineTy *types.Signature
 	stackSaveTy    *types.Signature
+	stackRestoreTy *types.Signature
 
 	createKeyTy *types.Signature
 	getSpecTy   *types.Signature

--- a/test/go/channel_select_semantics_test.go
+++ b/test/go/channel_select_semantics_test.go
@@ -1,0 +1,91 @@
+package gotest
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNilChannelSendRecvBlock(t *testing.T) {
+	done := make(chan string, 2)
+	var ch chan int
+
+	go func() {
+		ch <- 1
+		done <- "send"
+	}()
+	go func() {
+		<-ch
+		done <- "recv"
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	select {
+	case op := <-done:
+		t.Fatalf("nil channel %s completed, want block", op)
+	default:
+	}
+}
+
+func TestNilChannelSelectCasesUseDefault(t *testing.T) {
+	var ch chan int
+
+	select {
+	case ch <- 1:
+		t.Fatal("nil channel send case selected")
+	case <-ch:
+		t.Fatal("nil channel receive case selected")
+	default:
+	}
+}
+
+func TestClosedChannelSendPanics(t *testing.T) {
+	ch := make(chan int)
+	close(ch)
+
+	expectChannelPanicContaining(t, "send on closed channel", func() {
+		ch <- 1
+	})
+}
+
+func TestClosedChannelSelectSendPanics(t *testing.T) {
+	ch := make(chan int)
+	close(ch)
+
+	expectChannelPanicContaining(t, "send on closed channel", func() {
+		select {
+		case ch <- 1:
+		default:
+			t.Fatal("closed channel send selected default")
+		}
+	})
+}
+
+func TestClosedChannelSelectRecvReturnsZero(t *testing.T) {
+	ch := make(chan int)
+	close(ch)
+
+	select {
+	case v, ok := <-ch:
+		if v != 0 || ok {
+			t.Fatalf("closed channel receive = %d, %v; want 0, false", v, ok)
+		}
+	default:
+		t.Fatal("closed channel receive did not select")
+	}
+}
+
+func expectChannelPanicContaining(t *testing.T, want string, f func()) {
+	t.Helper()
+	defer func() {
+		err := recover()
+		if err == nil {
+			t.Fatalf("expected panic containing %q", want)
+		}
+		if got := fmt.Sprint(err); !strings.Contains(got, want) {
+			t.Fatalf("panic = %q, want contains %q", got, want)
+		}
+	}()
+	f()
+}

--- a/test/go/channel_select_semantics_test.go
+++ b/test/go/channel_select_semantics_test.go
@@ -76,6 +76,37 @@ func TestClosedChannelSelectRecvReturnsZero(t *testing.T) {
 	}
 }
 
+func TestHighFrequencySelectRecvHandshake(t *testing.T) {
+	const n = 100000
+	ch := make(chan int)
+	dummy := make(chan int)
+	done := make(chan struct{})
+
+	go func() {
+		for i := 0; i < n; i++ {
+			ch <- i
+		}
+		close(done)
+	}()
+
+	for i := 0; i < n; i++ {
+		select {
+		case v := <-ch:
+			if v != i {
+				t.Fatalf("receive %d = %d", i, v)
+			}
+		case <-dummy:
+			t.Fatal("dummy channel selected")
+		}
+	}
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("sender did not finish")
+	}
+}
+
 func expectChannelPanicContaining(t *testing.T, want string, f func()) {
 	t.Helper()
 	defer func() {

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -3567,10 +3567,6 @@ xfails:
     reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
-    case: chan/select3.go
-    reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
     case: convert4.go
     reason: current main goroot run failure on darwin/arm64
   - version: go1.26
@@ -3763,10 +3759,6 @@ xfails:
     directive: runoutput
     case: index0.go
     reason: current main goroot runoutput failure on darwin/arm64
-  - platform: linux/amd64
-    directive: run
-    case: chan/select3.go
-    reason: current main goroot run failure on linux/amd64
   - platform: linux/amd64
     directive: run
     case: convert4.go

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -3559,14 +3559,6 @@ xfails:
     reason: go1.26 goroot run failure on linux/amd64
   - platform: darwin/arm64
     directive: run
-    case: chan/doubleselect.go
-    reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
-    case: chan/select2.go
-    reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
     case: convert4.go
     reason: current main goroot run failure on darwin/arm64
   - version: go1.26


### PR DESCRIPTION
## Summary
- Make nil channel send/recv park instead of nil-dereferencing in the channel runtime.
- Make direct/select sends to closed channels panic from the shared send paths.
- Add focused `test/go` channel/select coverage and remove only the now-fixed `chan/select3.go` GOROOT xfails.

## Tests
- Reproduced before fix: `go test ./test/goroot -run TestGoRootRunCases/chan/select3.go -count=1 -args -goroot "$(go env GOROOT)" -dirs chan -case '^chan/select3\.go$' -xfail /tmp/llgo-no-xfail.yaml -run-timeout 20s -build-timeout 3m` failed with llgo nil pointer panic in `main$1`.
- `go test ./test/go -run 'Test(NilChannel|ClosedChannel)' -count=1`
- `go test ./test/go -count=1`
- `go run ./cmd/llgo test -count=1 ./test/go/channel_select_semantics_test.go`
- `go test ./cl -run TestRunFromTestgoSelectAllowsKnownInterleavings -count=1`
- `go test ./test/goroot -run TestGoRootRunCases/chan/select3.go -count=1 -args -goroot "$(go env GOROOT)" -dirs chan -case '^chan/select3\.go$' -xfail /tmp/llgo-no-xfail.yaml -run-timeout 20s -build-timeout 3m`
- `go test ./test/goroot -run TestGoRootRunCases/chan/select3.go -count=1 -args -goroot "$(go env GOROOT)" -dirs chan -case '^chan/select3\.go$' -run-timeout 20s -build-timeout 3m`
- Confirmed `chan/select2.go` still fails with xfail disabled, so its xfail remains.

## CI
- Full GOROOT CI is slow/disabled; this PR relies on normal PR CI from the fork branch plus the targeted GOROOT command above.
- I did not push to `xgo-dev/llgo`. If manual GOROOT `workflow_dispatch` cannot resolve fork refs, that remains a workflow blocker rather than a reason to push to upstream.
