### PR TITLE
runtime: short-circuit struct equality before string bodies

### DIFF
--- a/runtime/internal/runtime/alg.go
+++ b/runtime/internal/runtime/alg.go
@@ -266,9 +266,93 @@ func ifaceeq(tab *itab, x, y unsafe.Pointer) bool {
 	return eq(x, y)
 }
 
+func structFieldsHaveCheapMismatch(fields []structfield, p, q unsafe.Pointer) bool {
+	for _, ft := range fields {
+		if ft.Name_ == "_" {
+			continue
+		}
+		pi := add(p, ft.Offset)
+		qi := add(q, ft.Offset)
+		if typeHasCheapMismatch(ft.Typ, pi, qi) {
+			return true
+		}
+	}
+	return false
+}
+
+func typeHasCheapMismatch(t *_type, p, q unsafe.Pointer) bool {
+	switch t.Kind() {
+	case abi.Bool,
+		abi.Int, abi.Int8, abi.Int16, abi.Int32, abi.Int64,
+		abi.Uint, abi.Uint8, abi.Uint16, abi.Uint32, abi.Uint64, abi.Uintptr,
+		abi.Float32, abi.Float64, abi.Complex64, abi.Complex128,
+		abi.Pointer, abi.Chan, abi.UnsafePointer:
+		return !t.Equal(p, q)
+	case abi.String:
+		return len(*(*string)(p)) != len(*(*string)(q))
+	case abi.Struct:
+		return structFieldsHaveCheapMismatch((*structtype)(unsafe.Pointer(t)).Fields, p, q)
+	case abi.Array:
+		x := (*arraytype)(unsafe.Pointer(t))
+		elem := x.Elem
+		for i := uintptr(0); i < x.Len; i++ {
+			pi := add(p, i*elem.Size_)
+			qi := add(q, i*elem.Size_)
+			if typeHasCheapMismatch(elem, pi, qi) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func typeEqualMayPanic(t *_type) bool {
+	switch t.Kind() {
+	case abi.Interface:
+		return true
+	case abi.Struct:
+		x := (*structtype)(unsafe.Pointer(t))
+		for _, ft := range x.Fields {
+			if ft.Name_ != "_" && typeEqualMayPanic(ft.Typ) {
+				return true
+			}
+		}
+	case abi.Array:
+		return typeEqualMayPanic((*arraytype)(unsafe.Pointer(t)).Elem)
+	}
+	return false
+}
+
 func structequal(t, p, q unsafe.Pointer) bool {
 	x := (*structtype)(t)
-	for _, ft := range x.Fields {
+	fields := x.Fields
+	segmentStart := 0
+	for i, ft := range fields {
+		if ft.Name_ == "_" {
+			continue
+		}
+		if !typeEqualMayPanic(ft.Typ) {
+			continue
+		}
+		if structFieldsHaveCheapMismatch(fields[segmentStart:i], p, q) {
+			return false
+		}
+		for _, ft := range fields[segmentStart : i+1] {
+			if ft.Name_ == "_" {
+				continue
+			}
+			pi := add(p, ft.Offset)
+			qi := add(q, ft.Offset)
+			if !ft.Typ.Equal(pi, qi) {
+				return false
+			}
+		}
+		segmentStart = i + 1
+	}
+	if structFieldsHaveCheapMismatch(fields[segmentStart:], p, q) {
+		return false
+	}
+	for _, ft := range fields[segmentStart:] {
 		if ft.Name_ == "_" {
 			continue
 		}

--- a/test/go/interface_string_compare_test.go
+++ b/test/go/interface_string_compare_test.go
@@ -1,0 +1,86 @@
+//go:build linux || darwin
+
+package gotest
+
+import (
+	"reflect"
+	"syscall"
+	"testing"
+	"unsafe"
+)
+
+type compareStringInt struct {
+	S string
+	I int
+}
+
+type compareStringString struct {
+	S string
+	T string
+}
+
+type compareInterfaceThenScalar struct {
+	V any
+	N int
+}
+
+func TestInterfaceStructStringCompareShortCircuits(t *testing.T) {
+	bad1, bad2, cleanup := protectedStrings(t)
+	defer cleanup()
+
+	cases := []struct {
+		name string
+		a    any
+		b    any
+	}{
+		{
+			name: "scalar field differs after string",
+			a:    compareStringInt{S: bad1, I: 1},
+			b:    compareStringInt{S: bad2, I: 2},
+		},
+		{
+			name: "later string length differs",
+			a:    compareStringString{S: bad1, T: "a"},
+			b:    compareStringString{S: bad2, T: "aa"},
+		},
+		{
+			name: "earlier safe string differs",
+			a:    compareStringString{S: "a", T: bad1},
+			b:    compareStringString{S: "b", T: bad2},
+		},
+	}
+	for _, tc := range cases {
+		if tc.a == tc.b {
+			t.Fatalf("%s: interface struct comparison returned true", tc.name)
+		}
+	}
+}
+
+func TestInterfaceStructComparePreservesInterfacePanicOrder(t *testing.T) {
+	expectPanicContaining(t, "comparing uncomparable type []int", func() {
+		_ = compareInterfaceThenScalar{V: []int{}, N: 1} == compareInterfaceThenScalar{V: []int{}, N: 2}
+	})
+}
+
+func protectedStrings(t *testing.T) (string, string, func()) {
+	t.Helper()
+
+	pageSize := syscall.Getpagesize()
+	page, err := syscall.Mmap(-1, 0, pageSize, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_ANON|syscall.MAP_PRIVATE)
+	if err != nil {
+		t.Skipf("mmap unavailable: %v", err)
+	}
+	if err := syscall.Mprotect(page, syscall.PROT_NONE); err != nil {
+		_ = syscall.Munmap(page)
+		t.Skipf("mprotect unavailable: %v", err)
+	}
+
+	bad1 := "foo"
+	bad2 := "foo"
+	(*reflect.StringHeader)(unsafe.Pointer(&bad1)).Data = uintptr(unsafe.Pointer(&page[0]))
+	(*reflect.StringHeader)(unsafe.Pointer(&bad2)).Data = uintptr(unsafe.Pointer(&page[1]))
+
+	return bad1, bad2, func() {
+		_ = syscall.Munmap(page)
+	}
+}

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -2547,10 +2547,6 @@ xfails:
     directive: run
     case: fixedbugs/issue7690.go
     reason: latest main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
-    case: fixedbugs/issue8606b.go
-    reason: latest main goroot run failure on darwin/arm64
   - version: go1.25
     platform: linux/amd64
     directive: run
@@ -2785,11 +2781,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: fixedbugs/issue7690.go
-    reason: go1.25 goroot run failure on linux/amd64
-  - version: go1.25
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue8606b.go
     reason: go1.25 goroot run failure on linux/amd64
   - version: go1.25
     platform: linux/amd64
@@ -3168,11 +3159,6 @@ xfails:
     case: fixedbugs/issue7690.go
     reason: go1.24 goroot run failure on linux/amd64
   - version: go1.24
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue8606b.go
-    reason: go1.24 goroot run failure on linux/amd64
-  - version: go1.24
     platform: darwin/arm64
     directive: run
     case: inline_caller.go
@@ -3421,11 +3407,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: fixedbugs/issue7690.go
-    reason: go1.26 goroot run failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue8606b.go
     reason: go1.26 goroot run failure on linux/amd64
   - version: go1.26
     platform: linux/amd64


### PR DESCRIPTION
## Summary
- Add a cheap, panic-order-preserving mismatch pass for runtime struct equality so scalar fields and string lengths can reject unequal values before string body comparison.
- Add `test/go` coverage for protected-string interface struct comparisons and interface panic ordering.
- Remove fixed `fixedbugs/issue8606b.go` GOROOT xfail entries.

## GOROOT CI note
Full GOROOT runs are slow/disabled for this slice. This PR uses targeted `test/goroot` runs with the current machine GOROOT (`go env GOROOT` = `/opt/homebrew/Cellar/go@1.24/1.24.11/libexec`) and relies on normal PR CI from the fork branch. No branch was pushed to `xgo-dev/llgo`; if manual GOROOT `workflow_dispatch` cannot resolve fork refs, that should be documented rather than pushing to `xgo-dev`.

## Test coverage
New stable coverage is in `test/go/interface_string_compare_test.go` for the fixed string/interface comparison behavior.

## Targeted commands
- Reproduced before fix: `go test ./test/goroot -run TestGoRootRunCases -count=1 -timeout 10m -args -goroot $(go env GOROOT) -dirs fixedbugs -case "^fixedbugs/issue8606b\.go$" -xfail /tmp/llgo-empty-xfail.yaml -run-timeout 30s` (failed: llgo signal exit, go exit 0)
- `go test ./test/go -run "TestInterfaceStruct(StringCompareShortCircuits|ComparePreservesInterfacePanicOrder)" -count=1`
- `go run ./cmd/llgo test -run "TestInterfaceStruct(StringCompareShortCircuits|ComparePreservesInterfacePanicOrder)" -count=1 ./test/go`
- `go test ./ssa -run TestBinOp -count=1`
- `go test ./cl -run TestDoesNotExist -count=1`
- `(cd runtime && go test ./internal/runtime -run TestDoesNotExist -count=1)`
- `go test ./test/goroot -run TestGoRootRunCases -count=1 -timeout 10m -args -goroot $(go env GOROOT) -dirs fixedbugs -case "^fixedbugs/issue8606b\.go$" -xfail /tmp/llgo-empty-xfail.yaml -run-timeout 30s`
- `go test ./test/goroot -run TestGoRootRunCases -count=1 -timeout 10m -args -goroot $(go env GOROOT) -dirs fixedbugs -case "^fixedbugs/issue8606b\.go$" -run-timeout 30s`

## Residual risk
Linux GOROOT entries were removed because they are the same runtime equality root cause, but Linux GOROOT was not run locally on this darwin/arm64 host.