### PR TITLE
reflect: handle empty fields in FFI struct calls

### DIFF
--- a/runtime/internal/lib/reflect/value.go
+++ b/runtime/internal/lib/reflect/value.go
@@ -2336,16 +2336,54 @@ func toFFIType(typ *abi.Type) *ffi.Type {
 	case abi.String:
 		return ffi.TypeString
 	case abi.Struct:
-		st := typ.StructType()
-		fields := make([]*ffi.Type, len(st.Fields))
-		for i, fs := range st.Fields {
-			fields[i] = toFFIType(fs.Typ)
-		}
-		return ffi.StructOf(fields...)
+		return toFFIStructType(typ)
 	case abi.UnsafePointer:
 		return ffi.TypePointer
 	}
 	panic("reflect.toFFIType unsupport type " + typ.String())
+}
+
+func toFFIStructType(typ *abi.Type) *ffi.Type {
+	st := typ.StructType()
+	fields := make([]*ffi.Type, 0, len(st.Fields))
+	var off uintptr
+	for _, fs := range st.Fields {
+		if fs.Offset > off {
+			fields, off = appendFFIPadding(fields, off, fs.Offset-off)
+		}
+		if fs.Typ.Size_ == 0 {
+			continue
+		}
+		fields = append(fields, toFFIType(fs.Typ))
+		off = fs.Offset + fs.Typ.Size_
+	}
+	// Do not pad to typ.Size_: trailing zero-sized fields can enlarge the
+	// Go-visible size without consuming registers in llgo's callable ABI.
+	return ffi.StructOf(fields...)
+}
+
+func appendFFIPadding(fields []*ffi.Type, off, size uintptr) ([]*ffi.Type, uintptr) {
+	for size > 0 {
+		switch {
+		case off%8 == 0 && size >= 8:
+			fields = append(fields, ffi.TypeUint64)
+			off += 8
+			size -= 8
+		case off%4 == 0 && size >= 4:
+			fields = append(fields, ffi.TypeUint32)
+			off += 4
+			size -= 4
+		case off%2 == 0 && size >= 2:
+			fields = append(fields, ffi.TypeUint16)
+			off += 2
+			size -= 2
+		default:
+			fields = append(fields, ffi.TypeUint8)
+			off++
+			size--
+		}
+	}
+	return fields, off
 }
 
 func toFFISig(tin, tout []*abi.Type) (*ffi.Signature, error) {

--- a/test/go/reflect_call_empty_field_test.go
+++ b/test/go/reflect_call_empty_field_test.go
@@ -1,0 +1,24 @@
+package gotest
+
+import (
+	"reflect"
+	"testing"
+)
+
+type reflectCallEmptyField struct {
+	f1, f2 *byte
+	empty  struct{}
+}
+
+func reflectCallEmptyFieldFunc(e reflectCallEmptyField, s []string) {
+	if len(s) != 1 || s[0] != "hi" {
+		panic("bad slice")
+	}
+}
+
+func TestReflectCallStructWithEmptyField(t *testing.T) {
+	reflect.ValueOf(reflectCallEmptyFieldFunc).Call([]reflect.Value{
+		reflect.ValueOf(reflectCallEmptyField{}),
+		reflect.ValueOf([]string{"hi"}),
+	})
+}

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -2445,10 +2445,6 @@ xfails:
     reason: latest main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
-    case: fixedbugs/issue26335.go
-    reason: latest main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
     case: fixedbugs/issue27201.go
     reason: latest main goroot run failure on darwin/arm64
   - platform: darwin/arm64


### PR DESCRIPTION
## Summary
- Skip zero-sized struct fields when building reflect libffi struct argument types, while preserving explicit gaps before later non-zero fields.
- Add test/go coverage for reflect.Value.Call with a struct containing an empty trailing field followed by a slice argument.
- Remove the darwin/arm64 GOROOT xfail for fixedbugs/issue26335.go after targeted local pass.

## Focused tests
- `go test ./test/goroot -run TestGoRootRunCases -count=1 -args -goroot "$(go env GOROOT)" -llgo /tmp/llgo-reflectcall -dirs fixedbugs -case "^fixedbugs/issue26335\.go$" -xfail /tmp/llgo-empty-xfail.yaml -run-timeout 30s -build-timeout 2m`
- `go test ./test/goroot -run TestGoRootRunCases -count=1 -args -goroot "$(go env GOROOT)" -llgo /tmp/llgo-reflectcall -dirs fixedbugs -case "^fixedbugs/issue26335\.go$" -run-timeout 30s -build-timeout 2m`
- `/tmp/llgo-reflectcall test -run TestReflectCallStructWithEmptyField ./test/go`
- `go test ./test/go -run TestReflectCallStructWithEmptyField -count=1`
- `(cd runtime && go test ./internal/lib/reflect ./internal/ffi -count=1)`

## GOROOT CI
The full GOROOT workflow is workflow_dispatch-only and slow/disabled for normal PR CI. I kept the run targeted locally with the current machine GOROOT (`go env GOROOT` = `/opt/homebrew/Cellar/go@1.24/1.24.11/libexec`). If manual GOROOT dispatch cannot resolve fork refs, this PR should rely on normal PR CI from the `cpunion/llgo` fork branch and keep that blocker documented here rather than pushing any branch to `xgo-dev/llgo`.

## Notes
I only removed the darwin/arm64 xfail entry verified locally. Linux version-specific xfails for the same upstream case remain until they can be executed on Linux.