### PR TITLE
runtime: add minimal MemProfile allocation records

### DIFF
--- a/runtime/internal/lib/runtime/pprof_linkname_llgo.go
+++ b/runtime/internal/lib/runtime/pprof_linkname_llgo.go
@@ -73,11 +73,6 @@ func pprof_goroutineLeakProfileWithLabels(p []StackRecord, labels []unsafe.Point
 	return 0, true
 }
 
-//go:linkname pprof_memProfileInternal runtime.pprof_memProfileInternal
-func pprof_memProfileInternal(p []MemProfileRecord, inuseZero bool) (n int, ok bool) {
-	return 0, true
-}
-
 //go:linkname pprof_blockProfileInternal runtime.pprof_blockProfileInternal
 func pprof_blockProfileInternal(p []BlockProfileRecord) (n int, ok bool) {
 	return 0, true

--- a/runtime/internal/lib/runtime/pprof_memprofile_go123_llgo.go
+++ b/runtime/internal/lib/runtime/pprof_memprofile_go123_llgo.go
@@ -1,0 +1,50 @@
+//go:build (darwin || linux) && go1.23
+
+package runtime
+
+import _ "unsafe"
+
+type pprofMemProfileRecord struct {
+	AllocBytes, FreeBytes     int64
+	AllocObjects, FreeObjects int64
+	Stack                     []uintptr
+}
+
+//go:linkname pprof_memProfileInternal runtime.pprof_memProfileInternal
+func pprof_memProfileInternal(p []pprofMemProfileRecord, inuseZero bool) (n int, ok bool) {
+	n, _ = MemProfile(nil, inuseZero)
+	if len(p) < n {
+		return n, false
+	}
+	if n == 0 {
+		return 0, true
+	}
+	var records [64]MemProfileRecord
+	if n > len(records) {
+		return n, false
+	}
+	n, ok = MemProfile(records[:n], inuseZero)
+	if !ok {
+		return n, false
+	}
+	for i := 0; i < n; i++ {
+		p[i] = pprofMemProfileRecord{
+			AllocBytes:   records[i].AllocBytes,
+			FreeBytes:    records[i].FreeBytes,
+			AllocObjects: records[i].AllocObjects,
+			FreeObjects:  records[i].FreeObjects,
+			Stack:        pprofMemProfileStack(&records[i]),
+		}
+	}
+	return n, true
+}
+
+func pprofMemProfileStack(r *MemProfileRecord) []uintptr {
+	stack := r.Stack()
+	if len(stack) == 0 {
+		return nil
+	}
+	out := make([]uintptr, len(stack))
+	copy(out, stack)
+	return out
+}

--- a/runtime/internal/lib/runtime/pprof_memprofile_pre_go123_llgo.go
+++ b/runtime/internal/lib/runtime/pprof_memprofile_pre_go123_llgo.go
@@ -1,0 +1,10 @@
+//go:build (darwin || linux) && !go1.23
+
+package runtime
+
+import _ "unsafe"
+
+//go:linkname pprof_memProfileInternal runtime.pprof_memProfileInternal
+func pprof_memProfileInternal(p []MemProfileRecord, inuseZero bool) (n int, ok bool) {
+	return MemProfile(p, inuseZero)
+}

--- a/runtime/internal/lib/runtime/pprof_runtime_stub_llgo.go
+++ b/runtime/internal/lib/runtime/pprof_runtime_stub_llgo.go
@@ -2,18 +2,16 @@
 
 package runtime
 
-// StackRecord is a minimal placeholder for runtime/pprof.
+import llrt "github.com/goplus/llgo/runtime/internal/runtime"
+
 type StackRecord struct {
 	Stack []uintptr
 }
 
-// MemProfileRecord is a minimal placeholder for runtime/pprof.
 type MemProfileRecord struct {
-	AllocBytes   int64
-	FreeBytes    int64
-	AllocObjects int64
-	FreeObjects  int64
-	Stack        []uintptr
+	AllocBytes, FreeBytes     int64
+	AllocObjects, FreeObjects int64
+	Stack0                    [32]uintptr
 }
 
 func (r *MemProfileRecord) InUseBytes() int64 {
@@ -24,6 +22,15 @@ func (r *MemProfileRecord) InUseObjects() int64 {
 	return r.AllocObjects - r.FreeObjects
 }
 
+func (r *MemProfileRecord) Stack() []uintptr {
+	for i, pc := range r.Stack0 {
+		if pc == 0 {
+			return r.Stack0[:i]
+		}
+	}
+	return r.Stack0[:]
+}
+
 // BlockProfileRecord is a minimal placeholder for runtime/pprof.
 type BlockProfileRecord struct {
 	Count  int64
@@ -32,7 +39,31 @@ type BlockProfileRecord struct {
 }
 
 func MemProfile(p []MemProfileRecord, inuseZero bool) (n int, ok bool) {
-	return 0, false
+	n, _ = llrt.MemProfile(nil, inuseZero)
+	if len(p) < n {
+		return n, false
+	}
+	if n == 0 {
+		return 0, true
+	}
+	var records [64]llrt.MemProfileRecord
+	if n > len(records) {
+		return n, false
+	}
+	n, ok = llrt.MemProfile(records[:n], inuseZero)
+	if !ok {
+		return n, false
+	}
+	for i := 0; i < n; i++ {
+		p[i] = MemProfileRecord{
+			AllocBytes:   records[i].AllocBytes,
+			FreeBytes:    records[i].FreeBytes,
+			AllocObjects: records[i].AllocObjects,
+			FreeObjects:  records[i].FreeObjects,
+			Stack0:       records[i].Stack0,
+		}
+	}
+	return n, true
 }
 
 func BlockProfile(p []BlockProfileRecord) (n int, ok bool) {

--- a/runtime/internal/runtime/memprofile.go
+++ b/runtime/internal/runtime/memprofile.go
@@ -1,7 +1,5 @@
 package runtime
 
-import "github.com/goplus/llgo/runtime/internal/clite/sync/atomic"
-
 // MemProfileRecord describes allocations aggregated by size class.
 type MemProfileRecord struct {
 	AllocBytes, FreeBytes     int64
@@ -29,7 +27,7 @@ func (r *MemProfileRecord) Stack() []uintptr {
 type memProfileBucket struct {
 	size uintptr
 
-	objects uint64
+	objects memProfileCounter
 }
 
 var memProfileBuckets = [...]memProfileBucket{
@@ -70,7 +68,7 @@ func recordMemProfileAlloc(size uintptr) {
 	for i := range memProfileBuckets {
 		b := &memProfileBuckets[i]
 		if b.size == size {
-			atomic.Add(&b.objects, uint64(1))
+			memProfileAddObject(&b.objects)
 			return
 		}
 	}
@@ -90,7 +88,7 @@ func memProfileSizeClass(size uintptr) uintptr {
 
 func MemProfile(p []MemProfileRecord, inuseZero bool) (n int, ok bool) {
 	for i := range memProfileBuckets {
-		if atomic.Load(&memProfileBuckets[i].objects) != 0 {
+		if memProfileLoadObjects(&memProfileBuckets[i].objects) != 0 {
 			n++
 		}
 	}
@@ -100,12 +98,12 @@ func MemProfile(p []MemProfileRecord, inuseZero bool) (n int, ok bool) {
 	j := 0
 	for i := range memProfileBuckets {
 		b := &memProfileBuckets[i]
-		objects := atomic.Load(&b.objects)
+		objects := memProfileLoadObjects(&b.objects)
 		if objects == 0 {
 			continue
 		}
 		p[j] = MemProfileRecord{
-			AllocBytes:   int64(uint64(b.size) * objects),
+			AllocBytes:   int64(uint64(b.size) * uint64(objects)),
 			AllocObjects: int64(objects),
 		}
 		j++

--- a/runtime/internal/runtime/memprofile.go
+++ b/runtime/internal/runtime/memprofile.go
@@ -1,0 +1,114 @@
+package runtime
+
+import "github.com/goplus/llgo/runtime/internal/clite/sync/atomic"
+
+// MemProfileRecord describes allocations aggregated by size class.
+type MemProfileRecord struct {
+	AllocBytes, FreeBytes     int64
+	AllocObjects, FreeObjects int64
+	Stack0                    [32]uintptr
+}
+
+func (r *MemProfileRecord) InUseBytes() int64 {
+	return r.AllocBytes - r.FreeBytes
+}
+
+func (r *MemProfileRecord) InUseObjects() int64 {
+	return r.AllocObjects - r.FreeObjects
+}
+
+func (r *MemProfileRecord) Stack() []uintptr {
+	for i, pc := range r.Stack0 {
+		if pc == 0 {
+			return r.Stack0[:i]
+		}
+	}
+	return r.Stack0[:]
+}
+
+type memProfileBucket struct {
+	size uintptr
+
+	objects uint64
+}
+
+var memProfileBuckets = [...]memProfileBucket{
+	{size: 16},
+	{size: 32},
+	{size: 64},
+	{size: 128},
+	{size: 256},
+	{size: 512},
+	{size: 1024},
+	{size: 2048},
+	{size: 4096},
+	{size: 8192},
+	{size: 16384},
+	{size: 32768},
+	{size: 65536},
+	{size: 131072},
+	{size: 262144},
+	{size: 524288},
+	{size: 1048576},
+	{size: 2097152},
+	{size: 4194304},
+	{size: 8388608},
+	{size: 16777216},
+	{size: 33554432},
+	{size: 67108864},
+	{size: 134217728},
+	{size: 268435456},
+	{size: 536870912},
+	{size: 1073741824},
+}
+
+func recordMemProfileAlloc(size uintptr) {
+	if size == 0 {
+		return
+	}
+	size = memProfileSizeClass(size)
+	for i := range memProfileBuckets {
+		b := &memProfileBuckets[i]
+		if b.size == size {
+			atomic.Add(&b.objects, uint64(1))
+			return
+		}
+	}
+}
+
+func memProfileSizeClass(size uintptr) uintptr {
+	if size <= 16 {
+		return 16
+	}
+	for _, b := range memProfileBuckets {
+		if size <= b.size {
+			return b.size
+		}
+	}
+	return memProfileBuckets[len(memProfileBuckets)-1].size
+}
+
+func MemProfile(p []MemProfileRecord, inuseZero bool) (n int, ok bool) {
+	for i := range memProfileBuckets {
+		if atomic.Load(&memProfileBuckets[i].objects) != 0 {
+			n++
+		}
+	}
+	if len(p) < n {
+		return n, false
+	}
+	j := 0
+	for i := range memProfileBuckets {
+		b := &memProfileBuckets[i]
+		objects := atomic.Load(&b.objects)
+		if objects == 0 {
+			continue
+		}
+		p[j] = MemProfileRecord{
+			AllocBytes:   int64(uint64(b.size) * objects),
+			AllocObjects: int64(objects),
+		}
+		j++
+	}
+	return n, true
+}

--- a/runtime/internal/runtime/memprofile_atomic.go
+++ b/runtime/internal/runtime/memprofile_atomic.go
@@ -1,0 +1,15 @@
+//go:build !baremetal
+
+package runtime
+
+import "github.com/goplus/llgo/runtime/internal/clite/sync/atomic"
+
+type memProfileCounter = uint64
+
+func memProfileAddObject(p *memProfileCounter) {
+	atomic.Add(p, memProfileCounter(1))
+}
+
+func memProfileLoadObjects(p *memProfileCounter) memProfileCounter {
+	return atomic.Load(p)
+}

--- a/runtime/internal/runtime/memprofile_baremetal.go
+++ b/runtime/internal/runtime/memprofile_baremetal.go
@@ -1,0 +1,13 @@
+//go:build baremetal
+
+package runtime
+
+type memProfileCounter = uintptr
+
+func memProfileAddObject(p *memProfileCounter) {
+	*p = *p + 1
+}
+
+func memProfileLoadObjects(p *memProfileCounter) memProfileCounter {
+	return *p
+}

--- a/runtime/internal/runtime/z_gc.go
+++ b/runtime/internal/runtime/z_gc.go
@@ -28,12 +28,15 @@ import (
 
 // AllocU allocates uninitialized memory.
 func AllocU(size uintptr) unsafe.Pointer {
-	return bdwgc.Malloc(size)
+	ret := bdwgc.Malloc(size)
+	recordMemProfileAlloc(size)
+	return ret
 }
 
 // AllocZ allocates zero-initialized memory.
 func AllocZ(size uintptr) unsafe.Pointer {
 	ret := bdwgc.Malloc(size)
+	recordMemProfileAlloc(size)
 	return c.Memset(ret, 0, size)
 }
 

--- a/runtime/internal/runtime/z_gc_baremetal.go
+++ b/runtime/internal/runtime/z_gc_baremetal.go
@@ -26,12 +26,16 @@ import (
 
 // AllocU allocates uninitialized memory.
 func AllocU(size uintptr) unsafe.Pointer {
-	return tinygogc.Alloc(size)
+	ret := tinygogc.Alloc(size)
+	recordMemProfileAlloc(size)
+	return ret
 }
 
 // AllocZ allocates zero-initialized memory.
 func AllocZ(size uintptr) unsafe.Pointer {
-	return tinygogc.Alloc(size)
+	ret := tinygogc.Alloc(size)
+	recordMemProfileAlloc(size)
+	return ret
 }
 
 // AddCleanupPtr is not implemented in baremetal builds because tinygogc

--- a/runtime/internal/runtime/z_nogc.go
+++ b/runtime/internal/runtime/z_nogc.go
@@ -27,12 +27,15 @@ import (
 
 // AllocU allocates uninitialized memory.
 func AllocU(size uintptr) unsafe.Pointer {
-	return c.Malloc(size)
+	ret := c.Malloc(size)
+	recordMemProfileAlloc(size)
+	return ret
 }
 
 // AllocZ allocates zero-initialized memory.
 func AllocZ(size uintptr) unsafe.Pointer {
 	ret := c.Malloc(size)
+	recordMemProfileAlloc(size)
 	return c.Memset(ret, 0, size)
 }
 

--- a/test/go/memprofile/memprofile_test.go
+++ b/test/go/memprofile/memprofile_test.go
@@ -1,0 +1,55 @@
+package memprofile
+
+import (
+	"runtime"
+	"testing"
+)
+
+var tinySink []*int32
+
+func TestRuntimeMemProfileReportsTinyAllocations(t *testing.T) {
+	oldRate := runtime.MemProfileRate
+	runtime.MemProfileRate = 1
+	defer func() {
+		runtime.MemProfileRate = oldRate
+	}()
+
+	const n = 4096
+	tinySink = make([]*int32, 0, n)
+	for i := 0; i < n; i++ {
+		p := new(int32)
+		*p = int32(i)
+		tinySink = append(tinySink, p)
+	}
+	runtime.GC()
+	runtime.GC()
+
+	records := readMemProfile(t)
+	wantBytes := int64(n * 4)
+	for _, r := range records {
+		inUseObjects := r.InUseObjects()
+		inUseBytes := r.InUseBytes()
+		if inUseObjects <= 0 || inUseBytes <= 0 {
+			continue
+		}
+		if got := len(r.Stack()); got > len(r.Stack0) {
+			t.Fatalf("MemProfileRecord.Stack length = %d, want <= %d", got, len(r.Stack0))
+		}
+		if inUseBytes/inUseObjects == 16 && inUseBytes >= wantBytes {
+			return
+		}
+	}
+	t.Fatalf("MemProfile did not report tiny allocations totaling at least %d bytes: %#v", wantBytes, records)
+}
+
+func readMemProfile(t *testing.T) []runtime.MemProfileRecord {
+	t.Helper()
+	var records []runtime.MemProfileRecord
+	for {
+		n, ok := runtime.MemProfile(records, false)
+		if ok {
+			return records[:n]
+		}
+		records = make([]runtime.MemProfileRecord, n+10)
+	}
+}

--- a/test/go/memprofile/memprofile_test.go
+++ b/test/go/memprofile/memprofile_test.go
@@ -1,7 +1,10 @@
 package memprofile
 
 import (
+	"bytes"
+	"fmt"
 	"runtime"
+	"runtime/pprof"
 	"testing"
 )
 
@@ -42,6 +45,35 @@ func TestRuntimeMemProfileReportsTinyAllocations(t *testing.T) {
 	t.Fatalf("MemProfile did not report tiny allocations totaling at least %d bytes: %#v", wantBytes, records)
 }
 
+func TestRuntimePprofHeapProfileReportsTinyAllocations(t *testing.T) {
+	oldRate := runtime.MemProfileRate
+	runtime.MemProfileRate = 1
+	defer func() {
+		runtime.MemProfileRate = oldRate
+	}()
+
+	const n = 4096
+	allocateTinyObjects(n)
+	runtime.GC()
+	runtime.GC()
+
+	var buf bytes.Buffer
+	if err := pprof.Lookup("heap").WriteTo(&buf, 1); err != nil {
+		t.Fatalf("heap profile WriteTo failed: %v", err)
+	}
+
+	var inUseObjects, inUseBytes, allocObjects, allocBytes, rate int64
+	if _, err := fmt.Fscanf(bytes.NewReader(buf.Bytes()), "heap profile: %d: %d [%d: %d] @ heap/%d",
+		&inUseObjects, &inUseBytes, &allocObjects, &allocBytes, &rate); err != nil {
+		t.Fatalf("failed to parse heap profile header: %v\n%s", err, buf.String())
+	}
+	wantBytes := int64(n * 4)
+	if inUseObjects <= 0 || allocObjects <= 0 || inUseBytes < wantBytes || allocBytes < wantBytes {
+		t.Fatalf("heap profile totals = %d: %d [%d: %d], want live allocation bytes >= %d\n%s",
+			inUseObjects, inUseBytes, allocObjects, allocBytes, wantBytes, buf.String())
+	}
+}
+
 func readMemProfile(t *testing.T) []runtime.MemProfileRecord {
 	t.Helper()
 	var records []runtime.MemProfileRecord
@@ -51,5 +83,14 @@ func readMemProfile(t *testing.T) []runtime.MemProfileRecord {
 			return records[:n]
 		}
 		records = make([]runtime.MemProfileRecord, n+10)
+	}
+}
+
+func allocateTinyObjects(n int) {
+	tinySink = make([]*int32, 0, n)
+	for i := 0; i < n; i++ {
+		p := new(int32)
+		*p = int32(i)
+		tinySink = append(tinySink, p)
 	}
 }

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -2333,10 +2333,6 @@ xfails:
     reason: latest main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
-    case: finprofiled.go
-    reason: latest main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
     case: heapsampling.go
     reason: latest main goroot run failure on darwin/arm64
   - platform: darwin/arm64
@@ -2555,11 +2551,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: deferfin.go
-    reason: go1.25 goroot run failure on linux/amd64
-  - version: go1.25
-    platform: linux/amd64
-    directive: run
-    case: finprofiled.go
     reason: go1.25 goroot run failure on linux/amd64
   - version: go1.25
     platform: linux/amd64
@@ -2871,11 +2862,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: deferfin.go
-    reason: go1.24 goroot run failure on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
-    case: finprofiled.go
     reason: go1.24 goroot run failure on linux/amd64
   - version: go1.24
     platform: linux/amd64
@@ -3431,11 +3417,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: devirtualization_nil_panics.go
-    reason: go1.26 goroot run failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: finprofiled.go
     reason: go1.26 goroot run failure on linux/amd64
   - version: go1.26
     platform: linux/amd64


### PR DESCRIPTION
## Summary
- Track LLGO runtime allocations in fixed MemProfile size-class buckets and expose `runtime.MemProfile` with the Go public `MemProfileRecord`/`Stack0` shape.
- Add stable `test/go/memprofile` coverage for the MemProfile sizing loop and tiny allocation bucket.
- Remove the now-fixed `finprofiled.go` GOROOT xfails only; `heapsampling.go` remains xfailed because stack-attributed heap sampling is still missing.

## Relationship to #1905
- This PR is the minimal MemProfile foundation and should merge before #1905.
- #1905 builds on this work to add stack attribution / heap sampling support and is expected to rebase after this PR lands.
- Keeping the PRs separate keeps this ready-to-merge foundation smaller; combining them would make review and conflict resolution larger than necessary.

## Tests
- `go test ./test/go/memprofile -run TestRuntimeMemProfileReportsTinyAllocations -count=1`
- `(cd runtime && go test ./internal/runtime ./internal/lib/runtime -count=1)`
- `go build -tags=dev -o /tmp/llgo-profile ./cmd/llgo`
- `/tmp/llgo-profile test -run TestRuntimeMemProfileReportsTinyAllocations -count=1 ./test/go/memprofile`
- `go test ./test/goroot -run TestGoRootRunCases -count=1 -timeout=10m -args -goroot "$(go env GOROOT)" -dirs . -case '^finprofiled\\.go$' -xfail test/goroot/no-xfail.yaml -run-timeout=3m -build-timeout=5m`
- `go test ./test/goroot -run TestGoRootRunCases -count=1 -timeout=10m -args -goroot "$(go env GOROOT)" -dirs . -case '^finprofiled\\.go$' -run-timeout=3m -build-timeout=5m`

## Notes
- Full GOROOT CI is slow/disabled, so this PR uses targeted local GOROOT runs plus normal PR CI from the fork branch.
- Manual GOROOT workflow_dispatch was not run. If it cannot resolve fork refs, keep relying on normal PR CI rather than pushing a branch to `xgo-dev/llgo`.
- Bounded `heapsampling.go` check with xfail disabled still fails: `panic: main.allocInterleaved1:0 want objects in [45000: 55000], got [0 0 0]`, which is the remaining stack-attributed heap sampling gap.
