### PR TITLE
runtime: preserve line directive caller filenames

### DIFF
--- a/cl/caller_frame_internal_test.go
+++ b/cl/caller_frame_internal_test.go
@@ -1,0 +1,305 @@
+//go:build !llgo
+// +build !llgo
+
+package cl
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gpackages "github.com/goplus/gogen/packages"
+	llssa "github.com/goplus/llgo/ssa"
+	gossa "golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/ssa/ssautil"
+)
+
+func parseRuntimeCallerAST(t *testing.T, name, src string) *ast.File {
+	t.Helper()
+	file, err := parser.ParseFile(token.NewFileSet(), name, src, parser.ParseComments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return file
+}
+
+func compileLLPkgFromSrcPathIR(t *testing.T, pkgPath, src string) string {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "foo.go", src, parser.ParseComments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := []*ast.File{file}
+	imp := gpackages.NewImporter(fset)
+	mode := gossa.SanityCheckFunctions | gossa.InstantiateGenerics
+	ssaPkg, _, err := ssautil.BuildPackage(&types.Config{Importer: imp}, fset,
+		types.NewPackage(pkgPath, file.Name.Name), files, mode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prog := newLLSSAProg(t)
+	pkg, err := NewPackage(prog, ssaPkg, files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pkg.Module().String()
+}
+
+func TestFilesUseRuntimeCallerImportForms(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{
+			name: "no runtime import",
+			src:  `package foo; func f() {}`,
+		},
+		{
+			name: "default import",
+			src: `package foo
+import "runtime"
+func f() { _, _, _, _ = runtime.Caller(0) }
+`,
+			want: true,
+		},
+		{
+			name: "alias import",
+			src: `package foo
+import rt "runtime"
+func f() { _ = rt.FuncForPC(0) }
+`,
+			want: true,
+		},
+		{
+			name: "dot import",
+			src: `package foo
+import . "runtime"
+func f() { _ = Callers(0, nil) }
+`,
+			want: true,
+		},
+		{
+			name: "blank import",
+			src: `package foo
+import _ "runtime"
+func f() {}
+`,
+		},
+		{
+			name: "non caller selector",
+			src: `package foo
+import "runtime"
+func f() { runtime.GC() }
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file := parseRuntimeCallerAST(t, "runtime_caller.go", tt.src)
+			if got := filesUseRuntimeCaller([]*ast.File{file}); got != tt.want {
+				t.Fatalf("filesUseRuntimeCaller() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	badImport := &ast.File{Imports: []*ast.ImportSpec{{
+		Path: &ast.BasicLit{Kind: token.STRING, Value: "runtime"},
+	}}}
+	if filesUseRuntimeCaller([]*ast.File{badImport}) {
+		t.Fatal("malformed import literal should not enable runtime caller tracking")
+	}
+}
+
+func TestRuntimeCallerSSADetection(t *testing.T) {
+	if packageUsesRuntimeCaller(nil) {
+		t.Fatal("nil package should not use runtime caller")
+	}
+	if fnUsesRuntimeCaller(nil) {
+		t.Fatal("nil function should not use runtime caller")
+	}
+	if isRuntimeCallerFunc(nil) {
+		t.Fatal("nil runtime callee should not be treated as runtime caller")
+	}
+
+	plain, _, _ := buildSSAPackageWithFiles(t, `package foo
+func plain() {}
+`)
+	if packageUsesRuntimeCaller(plain) {
+		t.Fatal("plain package should not use runtime caller")
+	}
+
+	ssapkg, _, _ := buildSSAPackageWithFiles(t, `package foo
+import "runtime"
+
+func direct() {
+	_, _, _, _ = runtime.Caller(0)
+}
+
+func nested() {
+	func() { _ = runtime.FuncForPC(0) }()
+}
+
+func nonCaller() {
+	runtime.GC()
+}
+`)
+	if !packageUsesRuntimeCaller(ssapkg) {
+		t.Fatal("package with runtime.Caller should use runtime caller")
+	}
+	if !fnUsesRuntimeCaller(ssapkg.Func("direct")) {
+		t.Fatal("direct runtime.Caller should be detected")
+	}
+	if !fnUsesRuntimeCaller(ssapkg.Func("nested")) {
+		t.Fatal("runtime caller in anon function should be detected")
+	}
+	if fnUsesRuntimeCaller(ssapkg.Func("nonCaller")) {
+		t.Fatal("runtime.GC should not enable runtime caller tracking")
+	}
+}
+
+func TestCallerFrameTrackingPredicates(t *testing.T) {
+	var nilCtx *context
+	if nilCtx.shouldTrackCallerFrames() {
+		t.Fatal("nil context should not track caller frames")
+	}
+
+	for _, pkgPath := range []string{
+		llssa.PkgRuntime,
+		"runtime",
+		"fmt",
+		"github.com/goplus/llgo/runtime/internal/runtime",
+		"github.com/goplus/llgo/runtime/internal/clite",
+	} {
+		if canTrackCallerFramesForPackage(pkgPath) {
+			t.Fatalf("canTrackCallerFramesForPackage(%q) = true, want false", pkgPath)
+		}
+	}
+	for _, pkgPath := range []string{"example.com/mod/pkg", "command-line-arguments"} {
+		if !canTrackCallerFramesForPackage(pkgPath) {
+			t.Fatalf("canTrackCallerFramesForPackage(%q) = false, want true", pkgPath)
+		}
+	}
+	if !isStandardLibraryPackage("fmt") {
+		t.Fatal("fmt should be recognized as standard library")
+	}
+	if isStandardLibraryPackage("command-line-arguments") {
+		t.Fatal("command-line-arguments should not be treated as standard library")
+	}
+
+	prog := newLLSSAProg(t)
+	pkg := prog.NewPackage("foo", "example.com/foo")
+	fn := pkg.NewFunc("f", llssa.NoArgsNoRet, llssa.InGo)
+	ctx := &context{prog: prog, pkg: pkg, fn: fn, trackCallerFrames: true}
+	if !ctx.shouldTrackCallerFrames() {
+		t.Fatal("user package with tracking enabled should track caller frames")
+	}
+
+	ctx.trackCallerFrames = false
+	if ctx.shouldTrackCallerFrames() {
+		t.Fatal("trackCallerFrames=false should disable tracking")
+	}
+	ctx.trackCallerFrames = true
+
+	ctx.pkg = prog.NewPackage("fmt", "fmt")
+	if ctx.shouldTrackCallerFrames() {
+		t.Fatal("standard library package should not track caller frames")
+	}
+	ctx.pkg = pkg
+
+	target := prog.Target()
+	oldTarget, oldGOARCH := target.Target, target.GOARCH
+	target.Target = "esp32"
+	if ctx.shouldTrackCallerFrames() {
+		t.Fatal("-target builds should not track caller frames")
+	}
+	target.Target = ""
+	target.GOARCH = "wasm"
+	if ctx.shouldTrackCallerFrames() {
+		t.Fatal("wasm builds should not track caller frames")
+	}
+	target.Target, target.GOARCH = oldTarget, oldGOARCH
+}
+
+func TestCallerFrameFileHelpers(t *testing.T) {
+	root := t.TempDir()
+	original := filepath.Join(root, "src", "main.go")
+	fset := token.NewFileSet()
+	file := fset.AddFile(original, -1, 64)
+	pos := file.Pos(1)
+	ctx := &context{fset: fset}
+
+	if got := runtimeFrameName("command-line-arguments.main"); got != "main.main" {
+		t.Fatalf("runtimeFrameName command-line-arguments = %q", got)
+	}
+	if got := runtimeFrameName("example.com/foo.f"); got != "example.com/foo.f" {
+		t.Fatalf("runtimeFrameName ordinary package = %q", got)
+	}
+	ctx.pushCallerFrame(nil, nil)
+	if got := ctx.callerFrameFile(pos, ""); got != "??" {
+		t.Fatalf("empty caller frame filename = %q", got)
+	}
+	if got := ctx.callerFrameFile(pos, original); got != original {
+		t.Fatalf("same caller frame filename = %q, want %q", got, original)
+	}
+
+	inside := filepath.Join(root, "src", "generated", "caller.go")
+	if got := ctx.callerFrameFile(pos, inside); got != "generated/caller.go" {
+		t.Fatalf("relative caller frame filename = %q", got)
+	}
+	outside := filepath.Join(root, "other", "caller.go")
+	if got := ctx.callerFrameFile(pos, outside); got != outside {
+		t.Fatalf("outside caller frame filename = %q, want %q", got, outside)
+	}
+
+	if _, ok := relativeLineDirectiveFile(original, filepath.Dir(original)); ok {
+		t.Fatal("relativeLineDirectiveFile should reject same directory")
+	}
+	if _, ok := relativeLineDirectiveFile(filepath.Join(root, "src", "main.go"), root); ok {
+		t.Fatal("relativeLineDirectiveFile should reject parent directory")
+	}
+	if _, ok := relativeLineDirectiveFile(original, outside); ok {
+		t.Fatal("relativeLineDirectiveFile should reject paths outside the original directory")
+	}
+}
+
+func TestCompileRuntimeCallerFrameInstrumentation(t *testing.T) {
+	ir := compileLLPkgFromSrcPathIR(t, "example.com/foo", `package foo
+import "runtime"
+
+func marker() {}
+
+func f() {
+//line generated/caller_frame.go:42
+	_, _, _, _ = runtime.Caller(0)
+	marker()
+}
+`)
+	for _, want := range []string{
+		"PushCallerFrame",
+		"SetCallerLocation",
+		"PopCallerFrame",
+		"generated/caller_frame.go",
+	} {
+		if !strings.Contains(ir, want) {
+			t.Fatalf("instrumented IR missing %q:\n%s", want, ir)
+		}
+	}
+
+	plainIR := compileLLPkgFromSrcPathIR(t, "example.com/plain", `package plain
+func marker() {}
+func f() { marker() }
+`)
+	for _, unwanted := range []string{"PushCallerFrame", "SetCallerLocation", "PopCallerFrame"} {
+		if strings.Contains(plainIR, unwanted) {
+			t.Fatalf("plain package IR unexpectedly contains %q:\n%s", unwanted, plainIR)
+		}
+	}
+}

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -627,6 +627,9 @@ func (p *context) compileBlock(b llssa.Builder, block *ssa.BasicBlock, n int, do
 	var instrs = block.Instrs[n:]
 	var ret = fn.Block(block.Index)
 	b.SetBlock(ret)
+	if block.Index == 0 && p.shouldTrackCallerFrames() {
+		p.pushCallerFrame(b, block.Parent())
+	}
 	if block.Index == 0 && enableCallTracing && !strings.HasPrefix(fn.Name(), "github.com/goplus/llgo/runtime/internal/runtime.Print") {
 		b.Printf("call " + fn.Name() + "\n\x00")
 	}
@@ -1382,6 +1385,9 @@ func (p *context) compileInstr(b llssa.Builder, instr ssa.Instruction) {
 		}
 		if p.returnNeedsImplicitRunDefers(v) {
 			b.RunDefers()
+		}
+		if p.shouldTrackCallerFrames() {
+			p.popCallerFrame(b)
 		}
 		b.Return(results...)
 	case *ssa.If:

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -199,6 +199,8 @@ type context struct {
 	rewrites   map[string]string
 	embedMap   goembed.VarMap
 	embedInits []embedInit
+
+	trackCallerFrames bool
 }
 
 func (p *context) rewriteValue(name string) (string, bool) {
@@ -212,6 +214,63 @@ func (p *context) rewriteValue(name string) (string, bool) {
 	varName := name[dot+1:]
 	val, ok := p.rewrites[varName]
 	return val, ok
+}
+
+func filesUseRuntimeCaller(files []*ast.File) bool {
+	for _, file := range files {
+		runtimeNames := make(map[string]struct{})
+		var dotRuntime bool
+		for _, imp := range file.Imports {
+			path, err := strconv.Unquote(imp.Path.Value)
+			if err != nil || path != "runtime" {
+				continue
+			}
+			name := "runtime"
+			if imp.Name != nil {
+				switch imp.Name.Name {
+				case ".":
+					dotRuntime = true
+					continue
+				case "_":
+					continue
+				default:
+					name = imp.Name.Name
+				}
+			}
+			runtimeNames[name] = struct{}{}
+		}
+		if len(runtimeNames) == 0 && !dotRuntime {
+			continue
+		}
+		found := false
+		ast.Inspect(file, func(n ast.Node) bool {
+			if found {
+				return false
+			}
+			switch n := n.(type) {
+			case *ast.SelectorExpr:
+				if !isRuntimeCallerName(n.Sel.Name) {
+					return true
+				}
+				if ident, ok := n.X.(*ast.Ident); ok {
+					if _, ok := runtimeNames[ident.Name]; ok {
+						found = true
+						return false
+					}
+				}
+			case *ast.Ident:
+				if dotRuntime && isRuntimeCallerName(n.Name) {
+					found = true
+					return false
+				}
+			}
+			return true
+		})
+		if found {
+			return true
+		}
+	}
+	return false
 }
 
 // isStringPtrType checks if typ is a pointer to the basic string type (*string).
@@ -1733,6 +1792,8 @@ func newPackageEx(prog llssa.Program, patches Patches, rewrites map[string]strin
 		},
 		cgoSymbols: make([]string, 0, 128),
 		rewrites:   rewrites,
+
+		trackCallerFrames: filesUseRuntimeCaller(files) || packageUsesRuntimeCaller(pkg),
 	}
 	if embedMap != nil {
 		ctx.embedMap = *embedMap

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -24,6 +24,7 @@ import (
 	"go/types"
 	"log"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -873,20 +874,25 @@ func (p *context) pushCallerFrame(b llssa.Builder, fn *ssa.Function) {
 		p.pkg.RuntimeFunc("PushCallerFrame"),
 		entry,
 		b.Str(runtimeFrameName(p.fn.Name())),
-		b.Str(pos.Filename),
+		b.Str(p.callerFrameFile(fn.Pos(), pos.Filename)),
 		p.prog.IntVal(uint64(pos.Line), p.prog.Int()),
 	)
 }
 
-func (p *context) setCallerLine(b llssa.Builder, pos token.Pos) {
+func (p *context) setCallerLocation(b llssa.Builder, pos token.Pos) {
 	if !p.shouldTrackCallerFrames() {
 		return
 	}
-	line := p.fset.Position(pos).Line
+	position := p.fset.Position(pos)
+	line := position.Line
 	if line <= 0 {
 		return
 	}
-	b.Call(p.pkg.RuntimeFunc("SetCallerLine"), p.prog.IntVal(uint64(line), p.prog.Int()))
+	b.Call(
+		p.pkg.RuntimeFunc("SetCallerLocation"),
+		b.Str(p.callerFrameFile(pos, position.Filename)),
+		p.prog.IntVal(uint64(line), p.prog.Int()),
+	)
 }
 
 func (p *context) popCallerFrame(b llssa.Builder) {
@@ -899,6 +905,31 @@ func runtimeFrameName(name string) string {
 		return "main." + name[len(commandLineArguments):]
 	}
 	return name
+}
+
+func (p *context) callerFrameFile(pos token.Pos, filename string) string {
+	if filename == "" {
+		return "??"
+	}
+	original := p.fset.PositionFor(pos, false).Filename
+	if original == "" || original == filename {
+		return filename
+	}
+	if rel, ok := relativeLineDirectiveFile(original, filename); ok {
+		return rel
+	}
+	return filename
+}
+
+func relativeLineDirectiveFile(original, adjusted string) (string, bool) {
+	rel, err := filepath.Rel(filepath.Dir(original), adjusted)
+	if err != nil || rel == "." || rel == ".." {
+		return "", false
+	}
+	if strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return filepath.ToSlash(rel), true
 }
 
 // -----------------------------------------------------------------------------
@@ -941,7 +972,7 @@ func (p *context) deferStackOwner(fn *ssa.Function) llssa.Function {
 }
 
 func (p *context) emitDo(b llssa.Builder, act llssa.DoAction, pos token.Pos, ds *explicitDeferStack, fn llssa.Expr, buildCall func(llssa.Builder, llssa.Expr, ...llssa.Expr) llssa.Expr, args ...llssa.Expr) llssa.Expr {
-	p.setCallerLine(b, pos)
+	p.setCallerLocation(b, pos)
 	if ds != nil {
 		b.DeferTo(ds.owner, ds.stack, fn, buildCall, args...)
 		return llssa.Nil

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -853,6 +853,54 @@ func (p *context) sourceLine(filename string, line int) (string, bool) {
 	return lines[line-1], true
 }
 
+func (p *context) shouldTrackCallerFrames() bool {
+	if p == nil || p.pkg == nil || p.fn == nil {
+		return false
+	}
+	pkgPath := p.pkg.Path()
+	return pkgPath != llssa.PkgRuntime &&
+		pkgPath != "runtime" &&
+		!strings.HasPrefix(pkgPath, "github.com/goplus/llgo/runtime/internal/")
+}
+
+func (p *context) pushCallerFrame(b llssa.Builder, fn *ssa.Function) {
+	if fn == nil {
+		return
+	}
+	pos := p.fset.Position(fn.Pos())
+	entry := b.Convert(p.prog.Uintptr(), p.fn.Expr)
+	b.Call(
+		p.pkg.RuntimeFunc("PushCallerFrame"),
+		entry,
+		b.Str(runtimeFrameName(p.fn.Name())),
+		b.Str(pos.Filename),
+		p.prog.IntVal(uint64(pos.Line), p.prog.Int()),
+	)
+}
+
+func (p *context) setCallerLine(b llssa.Builder, pos token.Pos) {
+	if !p.shouldTrackCallerFrames() {
+		return
+	}
+	line := p.fset.Position(pos).Line
+	if line <= 0 {
+		return
+	}
+	b.Call(p.pkg.RuntimeFunc("SetCallerLine"), p.prog.IntVal(uint64(line), p.prog.Int()))
+}
+
+func (p *context) popCallerFrame(b llssa.Builder) {
+	b.Call(p.pkg.RuntimeFunc("PopCallerFrame"))
+}
+
+func runtimeFrameName(name string) string {
+	const commandLineArguments = "command-line-arguments."
+	if strings.HasPrefix(name, commandLineArguments) {
+		return "main." + name[len(commandLineArguments):]
+	}
+	return name
+}
+
 // -----------------------------------------------------------------------------
 
 type explicitDeferStack struct {
@@ -892,7 +940,8 @@ func (p *context) deferStackOwner(fn *ssa.Function) llssa.Function {
 	return owner
 }
 
-func (p *context) emitDo(b llssa.Builder, act llssa.DoAction, ds *explicitDeferStack, fn llssa.Expr, buildCall func(llssa.Builder, llssa.Expr, ...llssa.Expr) llssa.Expr, args ...llssa.Expr) llssa.Expr {
+func (p *context) emitDo(b llssa.Builder, act llssa.DoAction, pos token.Pos, ds *explicitDeferStack, fn llssa.Expr, buildCall func(llssa.Builder, llssa.Expr, ...llssa.Expr) llssa.Expr, args ...llssa.Expr) llssa.Expr {
+	p.setCallerLine(b, pos)
 	if ds != nil {
 		b.DeferTo(ds.owner, ds.stack, fn, buildCall, args...)
 		return llssa.Nil
@@ -1059,7 +1108,7 @@ func (p *context) callEx(b llssa.Builder, act llssa.DoAction, call *ssa.CallComm
 			hasVArg = fnHasVArg
 		}
 		args := p.compileValues(b, call.Args, hasVArg)
-		ret = p.emitDo(b, act, ds, fn, llssa.Builder.Call, args...)
+		ret = p.emitDo(b, act, call.Pos(), ds, fn, llssa.Builder.Call, args...)
 		b.EmitReflectTypeMethodCheckedLoad(ret, reflectCheck)
 		return
 	}
@@ -1090,7 +1139,7 @@ func (p *context) callEx(b llssa.Builder, act llssa.DoAction, call *ssa.CallComm
 			}
 		}
 		args := p.compileValues(b, args, kind)
-		ret = p.emitDo(b, act, ds, llssa.Builtin(fn), llssa.Builder.Call, args...)
+		ret = p.emitDo(b, act, call.Pos(), ds, llssa.Builtin(fn), llssa.Builder.Call, args...)
 	case *ssa.Function:
 		aFn, pyFn, ftype := p.compileFunction(cv)
 		// TODO(xsw): check ca != llssa.Call
@@ -1099,13 +1148,13 @@ func (p *context) callEx(b llssa.Builder, act llssa.DoAction, call *ssa.CallComm
 			p.inCFunc = true
 			args := p.compileValues(b, args, kind)
 			p.inCFunc = false
-			ret = p.emitDo(b, act, ds, aFn.Expr, llssa.Builder.Call, args...)
+			ret = p.emitDo(b, act, call.Pos(), ds, aFn.Expr, llssa.Builder.Call, args...)
 		case goFunc:
 			args := p.compileValues(b, args, kind)
-			ret = p.emitDo(b, act, ds, aFn.Expr, llssa.Builder.Call, args...)
+			ret = p.emitDo(b, act, call.Pos(), ds, aFn.Expr, llssa.Builder.Call, args...)
 		case pyFunc:
 			args := p.compileValues(b, args, kind)
-			ret = p.emitDo(b, act, ds, pyFn.Expr, llssa.Builder.Call, args...)
+			ret = p.emitDo(b, act, call.Pos(), ds, pyFn.Expr, llssa.Builder.Call, args...)
 		case llgoPyList:
 			args := p.compileValues(b, args, fnHasVArg)
 			ret = b.PyList(args...)
@@ -1179,33 +1228,33 @@ func (p *context) callEx(b llssa.Builder, act llssa.DoAction, call *ssa.CallComm
 			b.Unreachable()
 		case llgoAtomicLoad:
 			args := p.compileValues(b, args, kind)
-			ret = p.emitDo(b, act, ds, llssa.Nil, func(b llssa.Builder, _ llssa.Expr, args ...llssa.Expr) llssa.Expr {
+			ret = p.emitDo(b, act, call.Pos(), ds, llssa.Nil, func(b llssa.Builder, _ llssa.Expr, args ...llssa.Expr) llssa.Expr {
 				return p.atomicLoad(b, args)
 			}, args...)
 		case llgoAtomicStore:
 			args := p.compileValues(b, args, kind)
-			p.emitDo(b, act, ds, llssa.Nil, func(b llssa.Builder, _ llssa.Expr, args ...llssa.Expr) llssa.Expr {
+			p.emitDo(b, act, call.Pos(), ds, llssa.Nil, func(b llssa.Builder, _ llssa.Expr, args ...llssa.Expr) llssa.Expr {
 				return p.atomicStore(b, args)
 			}, args...)
 		case llgoAtomicCmpXchg:
 			args := p.compileValues(b, args, kind)
-			ret = p.emitDo(b, act, ds, llssa.Nil, func(b llssa.Builder, _ llssa.Expr, args ...llssa.Expr) llssa.Expr {
+			ret = p.emitDo(b, act, call.Pos(), ds, llssa.Nil, func(b llssa.Builder, _ llssa.Expr, args ...llssa.Expr) llssa.Expr {
 				return p.atomicCmpXchg(b, args)
 			}, args...)
 		case llgoAtomicCmpXchgOK:
 			args := p.compileValues(b, args, kind)
-			ret = p.emitDo(b, act, ds, llssa.Nil, func(b llssa.Builder, _ llssa.Expr, args ...llssa.Expr) llssa.Expr {
+			ret = p.emitDo(b, act, call.Pos(), ds, llssa.Nil, func(b llssa.Builder, _ llssa.Expr, args ...llssa.Expr) llssa.Expr {
 				return p.atomicCmpXchgOK(b, args)
 			}, args...)
 		case llgoAtomicAddReturnNew:
 			args := p.compileValues(b, args, kind)
-			ret = p.emitDo(b, act, ds, llssa.Nil, func(b llssa.Builder, _ llssa.Expr, args ...llssa.Expr) llssa.Expr {
+			ret = p.emitDo(b, act, call.Pos(), ds, llssa.Nil, func(b llssa.Builder, _ llssa.Expr, args ...llssa.Expr) llssa.Expr {
 				return b.BinOp(token.ADD, p.atomic(b, llssa.OpAdd, args), args[1])
 			}, args...)
 		default:
 			if ftype >= llgoAtomicOpBase && ftype <= llgoAtomicOpLast {
 				args := p.compileValues(b, args, kind)
-				ret = p.emitDo(b, act, ds, llssa.Nil, func(b llssa.Builder, _ llssa.Expr, args ...llssa.Expr) llssa.Expr {
+				ret = p.emitDo(b, act, call.Pos(), ds, llssa.Nil, func(b llssa.Builder, _ llssa.Expr, args ...llssa.Expr) llssa.Expr {
 					return p.atomic(b, llssa.AtomicOp(ftype-llgoAtomicOpBase), args)
 				}, args...)
 			} else {
@@ -1215,7 +1264,7 @@ func (p *context) callEx(b llssa.Builder, act llssa.DoAction, call *ssa.CallComm
 	default:
 		fn := p.compileValue(b, cv)
 		args := p.compileValues(b, args, kind)
-		ret = p.emitDo(b, act, ds, fn, llssa.Builder.Call, args...)
+		ret = p.emitDo(b, act, call.Pos(), ds, fn, llssa.Builder.Call, args...)
 	}
 	return
 }

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -855,13 +855,80 @@ func (p *context) sourceLine(filename string, line int) (string, bool) {
 }
 
 func (p *context) shouldTrackCallerFrames() bool {
-	if p == nil || p.pkg == nil || p.fn == nil {
+	if p == nil || p.pkg == nil || p.fn == nil || !p.trackCallerFrames {
+		return false
+	}
+	if target := p.prog.Target(); target != nil && (target.Target != "" || target.GOARCH == "wasm") {
 		return false
 	}
 	pkgPath := p.pkg.Path()
+	return canTrackCallerFramesForPackage(pkgPath)
+}
+
+func canTrackCallerFramesForPackage(pkgPath string) bool {
 	return pkgPath != llssa.PkgRuntime &&
 		pkgPath != "runtime" &&
+		!isStandardLibraryPackage(pkgPath) &&
 		!strings.HasPrefix(pkgPath, "github.com/goplus/llgo/runtime/internal/")
+}
+
+func isStandardLibraryPackage(pkgPath string) bool {
+	return pkgPath != "command-line-arguments" && !strings.Contains(pkgPath, ".")
+}
+
+func packageUsesRuntimeCaller(pkg *ssa.Package) bool {
+	if pkg == nil {
+		return false
+	}
+	for _, member := range pkg.Members {
+		fn, ok := member.(*ssa.Function)
+		if ok && fnUsesRuntimeCaller(fn) {
+			return true
+		}
+	}
+	return false
+}
+
+func fnUsesRuntimeCaller(fn *ssa.Function) bool {
+	if fn == nil {
+		return false
+	}
+	for _, block := range fn.Blocks {
+		for _, instr := range block.Instrs {
+			call, ok := instr.(ssa.CallInstruction)
+			if !ok {
+				continue
+			}
+			if isRuntimeCallerFunc(call.Common().StaticCallee()) {
+				return true
+			}
+		}
+	}
+	for _, anon := range fn.AnonFuncs {
+		if fnUsesRuntimeCaller(anon) {
+			return true
+		}
+	}
+	return false
+}
+
+func isRuntimeCallerFunc(fn *ssa.Function) bool {
+	if fn == nil || fn.Pkg == nil || fn.Pkg.Pkg == nil {
+		return false
+	}
+	if fn.Pkg.Pkg.Path() != "runtime" {
+		return false
+	}
+	return isRuntimeCallerName(fn.Name())
+}
+
+func isRuntimeCallerName(name string) bool {
+	switch name {
+	case "Caller", "Callers", "CallersFrames", "FuncForPC":
+		return true
+	default:
+		return false
+	}
 }
 
 func (p *context) pushCallerFrame(b llssa.Builder, fn *ssa.Function) {

--- a/cl/rewrite_internal_test.go
+++ b/cl/rewrite_internal_test.go
@@ -328,8 +328,8 @@ func TestEmitDoWithExplicitDeferStack(t *testing.T) {
 	b.SetBlockEx(owner.Block(0), llssa.BeforeLast, true)
 
 	ctx := &context{}
-	ctx.emitDo(b, llssa.DeferInLoop, &explicitDeferStack{stack: stack, owner: owner}, callee.Expr, llssa.Builder.Call)
-	ctx.emitDo(b, llssa.DeferAlways, nil, callee.Expr, llssa.Builder.Call)
+	ctx.emitDo(b, llssa.DeferInLoop, token.NoPos, &explicitDeferStack{stack: stack, owner: owner}, callee.Expr, llssa.Builder.Call)
+	ctx.emitDo(b, llssa.DeferAlways, token.NoPos, nil, callee.Expr, llssa.Builder.Call)
 	b.DeferStackDrain()
 	b.RunDefers()
 	b.Return()
@@ -465,7 +465,7 @@ func TestEmitDoWithoutExplicitDeferStack(t *testing.T) {
 	b := fn.MakeBody(1)
 
 	ctx := &context{}
-	got := ctx.emitDo(b, llssa.Call, nil, callee.Expr, llssa.Builder.Call)
+	got := ctx.emitDo(b, llssa.Call, token.NoPos, nil, callee.Expr, llssa.Builder.Call)
 	if got.IsNil() {
 		t.Fatal("emitDo without explicit defer stack should return direct call result")
 	}

--- a/runtime/internal/lib/runtime/extern.go
+++ b/runtime/internal/lib/runtime/extern.go
@@ -6,21 +6,23 @@ package runtime
 
 import (
 	clitedebug "github.com/goplus/llgo/runtime/internal/clite/debug"
+	rtdebug "github.com/goplus/llgo/runtime/internal/runtime"
 )
 
 func Caller(skip int) (pc uintptr, file string, line int, ok bool) {
-	// llgo currently doesn't have reliable source file/line mapping from PC.
-	// Return a stable placeholder location so stdlib log/testing can proceed.
-	var pcs [1]uintptr
-	if Callers(skip+1, pcs[:]) < 1 {
+	frame, ok := rtdebug.Caller(skip)
+	if !ok {
 		return 0, "", 0, false
 	}
-	return pcs[0], "???", 1, true
+	return frame.PC, frame.File, frame.Line, true
 }
 
 func Callers(skip int, pc []uintptr) int {
 	if len(pc) == 0 {
 		return 0
+	}
+	if n := rtdebug.Callers(skip, pc); n > 0 {
+		return n
 	}
 	n := 0
 	clitedebug.StackTrace(skip, func(fr *clitedebug.Frame) bool {

--- a/runtime/internal/lib/runtime/pprof_runtime_stub_llgo.go
+++ b/runtime/internal/lib/runtime/pprof_runtime_stub_llgo.go
@@ -85,5 +85,5 @@ func NumGoroutine() int {
 func SetCPUProfileRate(hz int) {}
 
 func FuncForPC(pc uintptr) *Func {
-	return nil
+	return funcForPC(pc)
 }

--- a/runtime/internal/lib/runtime/symtab.go
+++ b/runtime/internal/lib/runtime/symtab.go
@@ -5,10 +5,12 @@
 package runtime
 
 import (
+	"strings"
 	"unsafe"
 
 	c "github.com/goplus/llgo/runtime/internal/clite"
 	clitedebug "github.com/goplus/llgo/runtime/internal/clite/debug"
+	rtdebug "github.com/goplus/llgo/runtime/internal/runtime"
 )
 
 // Frames may be used to get function/file/line information for a
@@ -119,6 +121,19 @@ func (ci *Frames) Next() (frame Frame, more bool) {
 		} else {
 			pc, ci.callers = ci.callers[0], ci.callers[1:]
 		}
+		if known, ok := rtdebug.FrameForPC(pc); ok {
+			fn := newFunc(known.Function, known.Entry, known.File, known.StartLine)
+			ci.frames = append(ci.frames, Frame{
+				PC:        pc,
+				Func:      fn,
+				Function:  known.Function,
+				File:      known.File,
+				Line:      known.Line,
+				startLine: known.StartLine,
+				Entry:     known.Entry,
+			})
+			continue
+		}
 		info := &clitedebug.Info{}
 		if clitedebug.Addrinfo(unsafe.Pointer(pc), info) == 0 {
 			ci.frames = append(ci.frames, Frame{
@@ -135,8 +150,10 @@ func (ci *Frames) Next() (frame Frame, more bool) {
 		if fn == "" {
 			fn = unknownFunctionName(pc)
 		}
+		fn = normalizeLLGoSymbolName(fn)
 		ci.frames = append(ci.frames, Frame{
 			PC:        pc,
+			Func:      newFunc(fn, uintptr(info.Saddr), "", 0),
 			Function:  fn,
 			File:      "",
 			Line:      0,
@@ -176,11 +193,69 @@ func CallersFrames(callers []uintptr) *Frames {
 
 // A Func represents a Go function in the running binary.
 type Func struct {
-	opaque struct{} // unexported field to disallow conversions
+	name      string
+	entry     uintptr
+	file      string
+	startLine int
 }
 
 func (f *Func) Name() string {
-	panic("todo")
+	if f == nil {
+		return ""
+	}
+	return f.name
+}
+
+func (f *Func) Entry() uintptr {
+	if f == nil {
+		return 0
+	}
+	return f.entry
+}
+
+func (f *Func) FileLine(pc uintptr) (file string, line int) {
+	if f == nil {
+		return "", 0
+	}
+	if frame, ok := rtdebug.FrameForPC(pc); ok {
+		return frame.File, frame.Line
+	}
+	return f.file, f.startLine
+}
+
+func newFunc(name string, entry uintptr, file string, startLine int) *Func {
+	return &Func{name: name, entry: entry, file: file, startLine: startLine}
+}
+
+func funcForPC(pc uintptr) *Func {
+	if frame, ok := rtdebug.FrameForPC(pc); ok {
+		return newFunc(frame.Function, frame.Entry, frame.File, frame.StartLine)
+	}
+	if pc > 0 {
+		if frame, ok := rtdebug.FrameForPC(pc - 1); ok {
+			return newFunc(frame.Function, frame.Entry, frame.File, frame.StartLine)
+		}
+	}
+	if frame, ok := rtdebug.FrameForPC(pc + 1); ok {
+		return newFunc(frame.Function, frame.Entry, frame.File, frame.StartLine)
+	}
+	info := &clitedebug.Info{}
+	if clitedebug.Addrinfo(unsafe.Pointer(pc), info) == 0 {
+		return nil
+	}
+	fn := safeGoString(info.Sname, "")
+	if fn == "" {
+		return nil
+	}
+	return newFunc(normalizeLLGoSymbolName(fn), uintptr(info.Saddr), "", 0)
+}
+
+func normalizeLLGoSymbolName(name string) string {
+	const commandLineArguments = "command-line-arguments."
+	if strings.HasPrefix(name, commandLineArguments) {
+		return "main." + name[len(commandLineArguments):]
+	}
+	return name
 }
 
 func (f *Func) FileLine(pc uintptr) (file string, line int) {

--- a/runtime/internal/lib/runtime/symtab.go
+++ b/runtime/internal/lib/runtime/symtab.go
@@ -257,14 +257,6 @@ func normalizeLLGoSymbolName(name string) string {
 	return name
 }
 
-func (f *Func) FileLine(pc uintptr) (file string, line int) {
-	var info clitedebug.Info
-	if pc == 0 || clitedebug.Addrinfo(unsafe.Pointer(pc), &info) == 0 {
-		return "", 0
-	}
-	return safeGoString(info.Fname, ""), 0
-}
-
 // moduledata records information about the layout of the executable
 // image. It is written by the linker. Any changes here must be
 // matched changes to the code in cmd/link/internal/ld/symtab.go:symtab.

--- a/runtime/internal/lib/runtime/symtab.go
+++ b/runtime/internal/lib/runtime/symtab.go
@@ -5,7 +5,6 @@
 package runtime
 
 import (
-	"strings"
 	"unsafe"
 
 	c "github.com/goplus/llgo/runtime/internal/clite"
@@ -252,7 +251,7 @@ func funcForPC(pc uintptr) *Func {
 
 func normalizeLLGoSymbolName(name string) string {
 	const commandLineArguments = "command-line-arguments."
-	if strings.HasPrefix(name, commandLineArguments) {
+	if len(name) >= len(commandLineArguments) && name[:len(commandLineArguments)] == commandLineArguments {
 		return "main." + name[len(commandLineArguments):]
 	}
 	return name

--- a/runtime/internal/runtime/caller.go
+++ b/runtime/internal/runtime/caller.go
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import "unsafe"
+
+type CallerFrame struct {
+	PC        uintptr
+	Entry     uintptr
+	Function  string
+	File      string
+	Line      int
+	StartLine int
+}
+
+var (
+	callerFrames []CallerFrame
+	pcFrames     []*CallerFrame
+)
+
+var (
+	runtimeCallersFrame = CallerFrame{Function: "runtime.Callers"}
+	runtimeMainFrame    = CallerFrame{Function: "runtime.main"}
+	runtimeGoexitFrame  = CallerFrame{Function: "runtime.goexit"}
+)
+
+func PushCallerFrame(entry uintptr, name, file string, startLine int) {
+	callerFrames = append(callerFrames, CallerFrame{
+		PC:        entry,
+		Entry:     entry,
+		Function:  name,
+		File:      file,
+		Line:      startLine,
+		StartLine: startLine,
+	})
+}
+
+func SetCallerLine(line int) {
+	if line <= 0 || len(callerFrames) == 0 {
+		return
+	}
+	callerFrames[len(callerFrames)-1].Line = line
+}
+
+func PopCallerFrame() {
+	if len(callerFrames) == 0 {
+		return
+	}
+	callerFrames = callerFrames[:len(callerFrames)-1]
+}
+
+func Caller(skip int) (CallerFrame, bool) {
+	if skip < 0 {
+		return CallerFrame{}, false
+	}
+	if skip < len(callerFrames) {
+		return captureFrame(callerFrames[len(callerFrames)-1-skip], false), true
+	}
+	switch skip - len(callerFrames) {
+	case 0:
+		return captureFrame(runtimeMainFrame, false), true
+	case 1:
+		return captureFrame(runtimeGoexitFrame, false), true
+	default:
+		return CallerFrame{}, false
+	}
+}
+
+func Callers(skip int, pcs []uintptr) int {
+	if skip < 0 {
+		skip = 0
+	}
+	n := 0
+	add := func(frame CallerFrame) bool {
+		if skip > 0 {
+			skip--
+			return true
+		}
+		if n >= len(pcs) {
+			return false
+		}
+		pcs[n] = captureFrame(frame, true).PC
+		n++
+		return true
+	}
+	if !add(runtimeCallersFrame) {
+		return n
+	}
+	for i := len(callerFrames) - 1; i >= 0; i-- {
+		if !add(callerFrames[i]) {
+			return n
+		}
+	}
+	_ = add(runtimeMainFrame)
+	_ = add(runtimeGoexitFrame)
+	return n
+}
+
+func FrameForPC(pc uintptr) (CallerFrame, bool) {
+	if pc == 0 {
+		return CallerFrame{}, false
+	}
+	for _, frame := range pcFrames {
+		if uintptr(unsafe.Pointer(frame)) == pc || uintptr(unsafe.Pointer(frame))+1 == pc {
+			return *frame, true
+		}
+	}
+	return CallerFrame{}, false
+}
+
+func captureFrame(frame CallerFrame, callersPC bool) CallerFrame {
+	rec := new(CallerFrame)
+	*rec = frame
+	pc := uintptr(unsafe.Pointer(rec))
+	if callersPC {
+		pc++
+	}
+	rec.PC = pc
+	if rec.Entry == 0 {
+		rec.Entry = pc
+	}
+	pcFrames = append(pcFrames, rec)
+	return *rec
+}

--- a/runtime/internal/runtime/caller.go
+++ b/runtime/internal/runtime/caller.go
@@ -56,6 +56,15 @@ func SetCallerLine(line int) {
 	callerFrames[len(callerFrames)-1].Line = line
 }
 
+func SetCallerLocation(file string, line int) {
+	if line <= 0 || len(callerFrames) == 0 {
+		return
+	}
+	frame := &callerFrames[len(callerFrames)-1]
+	frame.File = file
+	frame.Line = line
+}
+
 func PopCallerFrame() {
 	if len(callerFrames) == 0 {
 		return

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -802,6 +802,10 @@ func (p Package) rtFunc(fnName string) Expr {
 	return p.NewFunc(name, sig, InGo).Expr
 }
 
+func (p Package) RuntimeFunc(fnName string) Expr {
+	return p.rtFunc(fnName)
+}
+
 func (p Package) cFunc(fullName string, sig *types.Signature) Expr {
 	return p.NewFunc(fullName, sig, InC).Expr
 }

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -2451,4 +2451,7 @@ func TestRtFuncResolvesLinkname(t *testing.T) {
 	if got := pkg.rtFunc("Sigsetjmp").impl.Name(); got != "sigsetjmp" {
 		t.Fatalf("rtFunc linkname = %q, want %q", got, "sigsetjmp")
 	}
+	if got := pkg.RuntimeFunc("Sigsetjmp").impl.Name(); got != "sigsetjmp" {
+		t.Fatalf("RuntimeFunc linkname = %q, want %q", got, "sigsetjmp")
+	}
 }

--- a/test/go/runtime_caller_test.go
+++ b/test/go/runtime_caller_test.go
@@ -1,0 +1,117 @@
+package gotest
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+type runtimeCallerSnapshot struct {
+	pc   uintptr
+	file string
+	line int
+	ok   bool
+}
+
+func TestRuntimeCallerMetadata(t *testing.T) {
+	tests := []struct {
+		skip       int
+		nameSuffix string
+		line       int
+	}{
+		{0, ".runtimeCallerLeaf", 101},
+		{1, ".runtimeCallerMid", 111},
+		{2, ".runtimeCallerTop", 121},
+	}
+	for _, tt := range tests {
+		got := runtimeCallerTop(tt.skip)
+		if !got.ok {
+			t.Fatalf("runtime.Caller(%d) failed", tt.skip)
+		}
+		if !strings.HasSuffix(got.file, "runtime_caller_metadata.go") {
+			t.Fatalf("runtime.Caller(%d) file = %q", tt.skip, got.file)
+		}
+		if got.line != tt.line {
+			t.Fatalf("runtime.Caller(%d) line = %d, want %d", tt.skip, got.line, tt.line)
+		}
+		fn := runtime.FuncForPC(got.pc)
+		if fn == nil {
+			t.Fatalf("FuncForPC(runtime.Caller(%d) pc) = nil", tt.skip)
+		}
+		if name := fn.Name(); !strings.HasSuffix(name, tt.nameSuffix) {
+			t.Fatalf("FuncForPC(runtime.Caller(%d) pc).Name = %q, want suffix %q", tt.skip, name, tt.nameSuffix)
+		}
+	}
+}
+
+func TestRuntimeCallersFramesMetadata(t *testing.T) {
+	frames := runtimeCallersTop(0)
+	want := []struct {
+		nameSuffix string
+		line       int
+	}{
+		{"runtime.Callers", 0},
+		{".runtimeCallersLeaf", 202},
+		{".runtimeCallersMid", 211},
+		{".runtimeCallersTop", 221},
+	}
+	if len(frames) < len(want) {
+		t.Fatalf("runtime.CallersFrames returned %d frames, want at least %d: %#v", len(frames), len(want), frames)
+	}
+	for i, tt := range want {
+		if name := frames[i].Function; !strings.HasSuffix(name, tt.nameSuffix) {
+			t.Fatalf("frame %d function = %q, want suffix %q", i, name, tt.nameSuffix)
+		}
+		if tt.line != 0 && frames[i].Line != tt.line {
+			t.Fatalf("frame %d line = %d, want %d", i, frames[i].Line, tt.line)
+		}
+		if frames[i].Func == nil {
+			continue
+		}
+		if name := frames[i].Func.Name(); !strings.HasSuffix(name, tt.nameSuffix) {
+			t.Fatalf("frame %d Func.Name = %q, want suffix %q", i, name, tt.nameSuffix)
+		}
+	}
+}
+
+//line runtime_caller_metadata.go:100
+func runtimeCallerLeaf(skip int) runtimeCallerSnapshot {
+	pc, file, line, ok := runtime.Caller(skip)
+	return runtimeCallerSnapshot{pc: pc, file: file, line: line, ok: ok}
+}
+
+//line runtime_caller_metadata.go:110
+func runtimeCallerMid(skip int) runtimeCallerSnapshot {
+	return runtimeCallerLeaf(skip)
+}
+
+//line runtime_caller_metadata.go:120
+func runtimeCallerTop(skip int) runtimeCallerSnapshot {
+	return runtimeCallerMid(skip)
+}
+
+//line runtime_callers_metadata.go:200
+func runtimeCallersLeaf(skip int) []runtime.Frame {
+	var pcs [16]uintptr
+	n := runtime.Callers(skip, pcs[:])
+	frames := runtime.CallersFrames(pcs[:n])
+	var out []runtime.Frame
+	for {
+		frame, more := frames.Next()
+		out = append(out, frame)
+		if !more {
+			break
+		}
+	}
+	return out
+}
+
+//line runtime_callers_metadata.go:210
+func runtimeCallersMid(skip int) []runtime.Frame {
+	return runtimeCallersLeaf(skip)
+}
+
+//line runtime_callers_metadata.go:220
+func runtimeCallersTop(skip int) []runtime.Frame {
+	return runtimeCallersMid(skip)
+}

--- a/test/go/runtime_caller_test.go
+++ b/test/go/runtime_caller_test.go
@@ -74,6 +74,62 @@ func TestRuntimeCallersFramesMetadata(t *testing.T) {
 	}
 }
 
+func TestRuntimeCallerLineDirectiveCallSites(t *testing.T) {
+	got := runtimeCallerLineDirectiveChecks()
+	want := []struct {
+		file string
+		line int
+	}{
+		{"/foo/bar.go", 123},
+		{"c:/foo/bar.go", 987},
+		{"??", 1},
+		{"foo.go", 1},
+		{"bar.go", 10},
+		{"bar.go", 11},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d caller snapshots, want %d", len(got), len(want))
+	}
+	for i, tt := range want {
+		if !got[i].ok {
+			t.Fatalf("snapshot %d runtime.Caller failed", i)
+		}
+		if got[i].file != tt.file || got[i].line != tt.line {
+			t.Fatalf("snapshot %d = %s:%d, want %s:%d", i, got[i].file, got[i].line, tt.file, tt.line)
+		}
+		fn := runtime.FuncForPC(got[i].pc)
+		if fn == nil {
+			t.Fatalf("snapshot %d FuncForPC = nil", i)
+		}
+		file, line := fn.FileLine(got[i].pc)
+		if file != tt.file || line != tt.line {
+			t.Fatalf("snapshot %d FuncForPC.FileLine = %s:%d, want %s:%d", i, file, line, tt.file, tt.line)
+		}
+	}
+}
+
+func runtimeCallerLineDirectiveChecks() []runtimeCallerSnapshot {
+	var out []runtimeCallerSnapshot
+//line /foo/bar.go:123
+	out = append(out, runtimeCallerAtCallSite())
+//line c:/foo/bar.go:987
+	out = append(out, runtimeCallerAtCallSite())
+//line :1
+	out = append(out, runtimeCallerAtCallSite())
+//line foo.go:1
+	out = append(out, runtimeCallerAtCallSite())
+//line bar.go:10:20
+	out = append(out, runtimeCallerAtCallSite())
+//line :11:22
+	out = append(out, runtimeCallerAtCallSite())
+	return out
+}
+
+func runtimeCallerAtCallSite() runtimeCallerSnapshot {
+	pc, file, line, ok := runtime.Caller(1)
+	return runtimeCallerSnapshot{pc: pc, file: file, line: line, ok: ok}
+}
+
 //line runtime_caller_metadata.go:100
 func runtimeCallerLeaf(skip int) runtimeCallerSnapshot {
 	pc, file, line, ok := runtime.Caller(skip)

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -2129,19 +2129,11 @@ xfails:
     reason: latest main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
-    case: fixedbugs/issue18149.go
-    reason: latest main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
     case: fixedbugs/issue21879.go
     reason: latest main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
     case: fixedbugs/issue22083.go
-    reason: latest main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
-    case: fixedbugs/issue22662.go
     reason: latest main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -2634,16 +2634,6 @@ xfails:
   - version: go1.24
     platform: darwin/arm64
     directive: run
-    case: inline_caller.go
-    reason: go1.24 goroot ci-mode run failure on darwin/arm64
-  - version: go1.24
-    platform: darwin/arm64
-    directive: run
-    case: inline_callers.go
-    reason: go1.24 goroot ci-mode run failure on darwin/arm64
-  - version: go1.24
-    platform: darwin/arm64
-    directive: run
     case: maymorestack.go
     reason: go1.24 goroot ci-mode run failure on darwin/arm64
   - version: go1.25


### PR DESCRIPTION
## Summary
- preserve adjusted call-site filenames, not only lines, in LLGo caller-frame metadata
- normalize package-loader-expanded relative `//line` filenames back to Go runtime spelling (`foo.go`, `c:/foo/bar.go`) and map empty directive filenames to `??`
- add stable `test/go` coverage for runtime.Caller / FuncForPC.FileLine under absolute, Windows-style, relative, and empty filename line directives
- remove only the verified darwin/arm64 xfails for `fixedbugs/issue18149.go` and `fixedbugs/issue22662.go`

## Stack note
This branch includes the caller-frame metadata commit from PR #1884 because these fixedbugs exercise `runtime.Caller`; without that dependency, the current mainline placeholder returns `???:1`. The second commit is the scoped line-directive/source-position fix.

## Testing
- Reproduced with xfail disabled before the scoped fix:
  - `go test ./test/goroot -count=1 -run TestGoRootRunCases -args -goroot "$(go env GOROOT)" -dirs fixedbugs -case '^fixedbugs/(issue18149|issue22662)\\.go$' -xfail /tmp/llgo-no-xfail.yaml -run-timeout 30s`
  - after the caller-frame baseline, LLGo reported the physical/package-relative files instead of the directive files
- `go test ./test/go -run 'TestRuntimeCaller' -count=1`
- `go build -tags=dev -o /tmp/llgo-linedir-test ./cmd/llgo`
- `LLGO_ROOT=$PWD /tmp/llgo-linedir-test test ./test/go/runtime_caller_test.go`
- `go test ./cl -run 'TestEmitDo|TestExplicitDefer|Test.*Rewrite|TestOffsetOfHelpersAndSourceLineCache' -count=1`
- `go test ./ssa -run 'TestFuncCall|TestSetBlockEx|TestClosureFuncPtrValue' -count=1`
- `(cd runtime && go test ./internal/runtime -count=1)`
- `go test ./test/goroot -count=1 -run TestGoRootRunCases -args -goroot "$(go env GOROOT)" -llgo /tmp/llgo-linedir-test -dirs fixedbugs -case '^fixedbugs/(issue18149|issue22662)\\.go$' -xfail /tmp/llgo-no-xfail.yaml -run-timeout 30s`
- `go test ./test/goroot -count=1 -run TestGoRootRunCases -args -goroot "$(go env GOROOT)" -llgo /tmp/llgo-linedir-test -dirs fixedbugs -case '^fixedbugs/(issue18149|issue22662)\\.go$' -run-timeout 30s`

GOROOT CI is slow/disabled in this repo, so this PR relies on the targeted GOROOT runs above plus normal PR CI from the fork branch. I did not push any branch to `xgo-dev/llgo`; the head branch is on `cpunion/llgo`.
