### PR TITLE
ssa: handle recursive pointer type names

### DIFF
--- a/test/go/recursive_pointer_type_test.go
+++ b/test/go/recursive_pointer_type_test.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gotest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const recursivePointerTypeProbe = `package main
+
+type Link *Link
+
+func box(v Link) *Link {
+	p := new(Link)
+	*p = v
+	return p
+}
+
+func unbox(p *Link) Link {
+	return *p
+}
+
+func main() {
+	sentinel := Link(new(Link))
+	p := box(sentinel)
+	if unbox(p) != sentinel {
+		panic("recursive pointer type lost value")
+	}
+}
+`
+
+func TestRecursivePointerTypeBuilds(t *testing.T) {
+	dir := t.TempDir()
+	mainFile := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(mainFile, []byte(recursivePointerTypeProbe), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	runGoCmd(t, dir, "run", mainFile)
+
+	root := findLLGoRoot(t)
+	t.Setenv("LLGO_ROOT", root)
+	runGoCmd(t, root, "run", "./cmd/llgo", "run", mainFile)
+}

--- a/test/go/recursive_pointer_type_test.go
+++ b/test/go/recursive_pointer_type_test.go
@@ -25,6 +25,7 @@ import (
 const recursivePointerTypeProbe = `package main
 
 type Link *Link
+type Peano *Peano
 
 func box(v Link) *Link {
 	p := new(Link)
@@ -36,11 +37,38 @@ func unbox(p *Link) Link {
 	return *p
 }
 
+func makePeano(n int) *Peano {
+	if n == 0 {
+		return nil
+	}
+	p := Peano(makePeano(n - 1))
+	return &p
+}
+
+var countArg Peano
+var countResult int
+
+func countPeano() {
+	if countArg == nil {
+		countResult = 0
+		return
+	}
+	countArg = *countArg
+	countPeano()
+	countResult++
+}
+
 func main() {
 	sentinel := Link(new(Link))
 	p := box(sentinel)
 	if unbox(p) != sentinel {
 		panic("recursive pointer type lost value")
+	}
+
+	countArg = makePeano(4096)
+	countPeano()
+	if countResult != 4096 {
+		panic("recursive Peano pointer count failed")
 	}
 }
 `

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -2216,10 +2216,6 @@ xfails:
     reason: latest main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
-    case: peano.go
-    reason: latest main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
     case: recover.go
     reason: latest main goroot run failure on darwin/arm64
   - platform: darwin/arm64
@@ -3307,10 +3303,6 @@ xfails:
   - platform: linux/amd64
     directive: run
     case: nilptr.go
-    reason: current main goroot run failure on linux/amd64
-  - platform: linux/amd64
-    directive: run
-    case: peano.go
     reason: current main goroot run failure on linux/amd64
   - platform: linux/amd64
     directive: run

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -3159,10 +3159,6 @@ xfails:
     reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
-    case: fixedbugs/issue4316.go
-    reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
     case: fixedbugs/issue43835.go
     reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64
@@ -3251,10 +3247,6 @@ xfails:
   - platform: linux/amd64
     directive: run
     case: fixedbugs/issue38496.go
-    reason: current main goroot run failure on linux/amd64
-  - platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue4316.go
     reason: current main goroot run failure on linux/amd64
   - platform: linux/amd64
     directive: run


### PR DESCRIPTION
## Summary
- avoid recursively resolving the LLVM element type for Go pointer types, which fixes self-referential named pointer types such as `type Number *Number`
- add `test/go` coverage that runs a recursive named pointer type through llgo, including a 4096-deep Peano construction/count matching `fixedbugs/issue4316.go`
- remove the now-covered `peano.go` and `fixedbugs/issue4316.go` goroot xfails for darwin/arm64 and linux/amd64

## Scope
- Covered: recursive named pointer / Peano / recursion lowering cases.
- Not covered here: nil/chan/print/recover/GC/liveness/finalizer/goroutine domains; those remain out of scope for this PR.

## Tests
- `go test ./test/goroot -count=1 -run TestGoRootRunCases -timeout 10m -args -goroot "$(go env GOROOT)" -dirs fixedbugs -case '^fixedbugs/issue4316\.go$' -xfail /dev/null -run-timeout 2m`
- `go test ./test/goroot -count=1 -run TestGoRootRunCases -timeout 10m -args -goroot "$(go env GOROOT)" -dirs . -case '^peano\.go$' -xfail /dev/null -run-timeout 2m`
- `go test ./test/goroot -count=1 -run TestGoRootRunCases -timeout 15m -args -goroot "$(go env GOROOT)" -dirs .,fixedbugs -case '^(peano\.go|fixedbugs/issue4316\.go)$' -xfail /dev/null -run-timeout 2m`
- `go test ./test/go -run TestRecursivePointerTypeBuilds -count=1`
- `go test ./test/go -count=1`
- `go test ./ssa -count=1`
- `go test ./cl -list .`
- `go test ./cl -run TestRunAndTestFromTestgo -count=1 -timeout 5m`

## Local test notes
- `go test ./cl -count=1` was also attempted locally and was terminated after 428s without a Peano/named-pointer failure.
- `go test ./cl -run 'TestRunAndTestFromTestgo|TestRunAndTestFromTestrt' -count=1 -timeout 5m` timed out in `TestRunAndTestFromTestrt/index`; this is outside the recursive named pointer / Peano scope.
