### PR TITLE
fix maymorestack gcflag hook instrumentation

### DIFF
--- a/cl/compile.go
+++ b/cl/compile.go
@@ -768,12 +768,6 @@ func (p *context) mayMoreStackHookName() string {
 		p.maymorestack = pkgPath + "." + name
 		return p.maymorestack
 	}
-	if pkgName == "main" {
-		if name, ok := strings.CutPrefix(hook, "main."); ok {
-			p.maymorestack = pkgPath + "." + name
-			return p.maymorestack
-		}
-	}
 	if strings.HasPrefix(hook, pkgPath+".") {
 		p.maymorestack = hook
 		return p.maymorestack

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -56,6 +56,7 @@ var (
 	enableDbg         bool
 	enableDbgSyms     bool
 	disableInline     bool
+	mayMoreStackHook  string
 
 	// enableExportRename enables //export to use different C symbol names than Go function names.
 	// This is for TinyGo compatibility when using -target flag for embedded targets.
@@ -125,6 +126,12 @@ func EnableTrace(b bool) {
 	enableCallTracing = b
 }
 
+// SetMayMoreStackHook sets the function called at ordinary Go function entry
+// when -gcflags=-d=maymorestack=... is supplied.
+func SetMayMoreStackHook(name string) {
+	mayMoreStackHook = name
+}
+
 // EnableExportRename enables or disables //export with different C symbol names.
 // This is enabled when using -target flag for TinyGo compatibility.
 func EnableExportRename(b bool) {
@@ -156,24 +163,25 @@ type pkgInfo struct {
 type none = struct{}
 
 type context struct {
-	prog        llssa.Program
-	pkg         llssa.Package
-	fn          llssa.Function
-	goFn        *ssa.Function
-	fset        *token.FileSet
-	goProg      *ssa.Program
-	goTyps      *types.Package
-	goPkg       *ssa.Package
-	pyMod       string
-	skips       map[string]none
-	loaded      map[*types.Package]*pkgInfo // loaded packages
-	bvals       map[ssa.Value]llssa.Expr    // block values
-	vargs       map[*ssa.Alloc][]llssa.Expr // varargs
-	funcs       map[*ssa.Function]llssa.Function
-	linkOnceFns map[*ssa.Function]none
-	stackDefers map[*ssa.Function]bool
-	anonDefers  map[*ssa.Function]bool
-	paramDIVars map[*types.Var]llssa.DIVar
+	prog         llssa.Program
+	pkg          llssa.Package
+	fn           llssa.Function
+	goFn         *ssa.Function
+	fset         *token.FileSet
+	goProg       *ssa.Program
+	goTyps       *types.Package
+	goPkg        *ssa.Package
+	pyMod        string
+	skips        map[string]none
+	loaded       map[*types.Package]*pkgInfo // loaded packages
+	bvals        map[ssa.Value]llssa.Expr    // block values
+	vargs        map[*ssa.Alloc][]llssa.Expr // varargs
+	funcs        map[*ssa.Function]llssa.Function
+	linkOnceFns  map[*ssa.Function]none
+	stackDefers  map[*ssa.Function]bool
+	anonDefers   map[*ssa.Function]bool
+	maymorestack string
+	paramDIVars  map[*types.Var]llssa.DIVar
 
 	patches  Patches
 	blkInfos []blocks.Info
@@ -626,6 +634,9 @@ func (p *context) compileBlock(b llssa.Builder, block *ssa.BasicBlock, n int, do
 	if block.Index == 0 && enableCallTracing && !strings.HasPrefix(fn.Name(), "github.com/goplus/llgo/runtime/internal/runtime.Print") {
 		b.Printf("call " + fn.Name() + "\n\x00")
 	}
+	if block.Index == 0 {
+		p.emitMayMoreStackHook(b)
+	}
 	// place here to avoid wrong current-block
 	if enableDbgSyms && block.Parent().Origin() == nil && block.Index == 0 {
 		p.debugParams(b, block.Parent())
@@ -726,6 +737,48 @@ end:
 		b.Jump(jumpTo)
 	}
 	return ret
+}
+
+func (p *context) emitMayMoreStackHook(b llssa.Builder) {
+	if p.goFn == nil || p.goFn.Synthetic != "" {
+		return
+	}
+	hook := p.mayMoreStackHookName()
+	if hook == "" || hook == p.fn.Name() {
+		return
+	}
+	fn := p.pkg.FuncOf(hook)
+	if fn == nil {
+		fn = p.pkg.NewFunc(hook, llssa.NoArgsNoRet, llssa.InGo)
+	}
+	b.Call(fn.Expr)
+}
+
+func (p *context) mayMoreStackHookName() string {
+	if p.maymorestack != "" || mayMoreStackHook == "" || p.goTyps == nil {
+		return p.maymorestack
+	}
+	hook := strings.TrimSpace(mayMoreStackHook)
+	if hook == "" {
+		return ""
+	}
+	pkgPath := llssa.PathOf(p.goTyps)
+	pkgName := p.goTyps.Name()
+	if name, ok := strings.CutPrefix(hook, pkgName+"."); ok {
+		p.maymorestack = pkgPath + "." + name
+		return p.maymorestack
+	}
+	if pkgName == "main" {
+		if name, ok := strings.CutPrefix(hook, "main."); ok {
+			p.maymorestack = pkgPath + "." + name
+			return p.maymorestack
+		}
+	}
+	if strings.HasPrefix(hook, pkgPath+".") {
+		p.maymorestack = hook
+		return p.maymorestack
+	}
+	return ""
 }
 
 const (

--- a/cl/maymorestack_internal_test.go
+++ b/cl/maymorestack_internal_test.go
@@ -100,6 +100,32 @@ func main() {
 	}
 }
 
+func TestMayMoreStackHookDeclarationIsCreated(t *testing.T) {
+	withMayMoreStackHook(t, "main.missingHook")
+
+	ssaPkg, _, files := buildGoSSAPkg(t, `package main
+
+func helper() {}
+
+func main() {
+	helper()
+}
+`)
+	prog := newLLSSAProg(t)
+	pkg, err := NewPackage(prog, ssaPkg, files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ir := pkg.String()
+	call := "call void @main.missingHook()"
+	if got := strings.Count(ir, call); got != 2 {
+		t.Fatalf("missingHook call count = %d, want 2 for main and helper:\n%s", got, ir)
+	}
+	if fn := pkg.FuncOf("main.missingHook"); fn == nil {
+		t.Fatal("missing synthesized maymorestack hook declaration")
+	}
+}
+
 func functionIR(t *testing.T, ir, name string) string {
 	t.Helper()
 	start := strings.Index(ir, "define void @"+name+"(")

--- a/cl/maymorestack_internal_test.go
+++ b/cl/maymorestack_internal_test.go
@@ -1,0 +1,115 @@
+//go:build !llgo
+// +build !llgo
+
+package cl
+
+import (
+	"go/types"
+	"strings"
+	"testing"
+
+	gossa "golang.org/x/tools/go/ssa"
+)
+
+func withMayMoreStackHook(t *testing.T, hook string) {
+	t.Helper()
+	old := mayMoreStackHook
+	SetMayMoreStackHook(hook)
+	t.Cleanup(func() {
+		SetMayMoreStackHook(old)
+	})
+}
+
+func TestMayMoreStackHookNameBranches(t *testing.T) {
+	pkg := types.NewPackage("example.com/foo", "foo")
+
+	withMayMoreStackHook(t, "")
+	if got := (&context{goTyps: pkg}).mayMoreStackHookName(); got != "" {
+		t.Fatalf("empty global hook resolved to %q", got)
+	}
+	if got := (&context{maymorestack: "cached"}).mayMoreStackHookName(); got != "cached" {
+		t.Fatalf("cached hook = %q, want cached", got)
+	}
+
+	withMayMoreStackHook(t, " \t ")
+	if got := (&context{goTyps: pkg}).mayMoreStackHookName(); got != "" {
+		t.Fatalf("blank global hook resolved to %q", got)
+	}
+	if got := (&context{}).mayMoreStackHookName(); got != "" {
+		t.Fatalf("nil package resolved to %q", got)
+	}
+
+	withMayMoreStackHook(t, " foo.mayMoreStack ")
+	if got := (&context{goTyps: pkg}).mayMoreStackHookName(); got != "example.com/foo.mayMoreStack" {
+		t.Fatalf("package-name hook = %q", got)
+	}
+
+	withMayMoreStackHook(t, "example.com/foo.mayMoreStack")
+	if got := (&context{goTyps: pkg}).mayMoreStackHookName(); got != "example.com/foo.mayMoreStack" {
+		t.Fatalf("package-path hook = %q", got)
+	}
+
+	withMayMoreStackHook(t, "bar.mayMoreStack")
+	if got := (&context{goTyps: pkg}).mayMoreStackHookName(); got != "" {
+		t.Fatalf("foreign short hook resolved to %q", got)
+	}
+
+	withMayMoreStackHook(t, "main.mayMoreStack")
+	mainPkg := types.NewPackage("cmd/example", "main")
+	if got := (&context{goTyps: mainPkg}).mayMoreStackHookName(); got != "cmd/example.mayMoreStack" {
+		t.Fatalf("main hook = %q", got)
+	}
+}
+
+func TestEmitMayMoreStackHookSkipsMissingAndSyntheticFunctions(t *testing.T) {
+	withMayMoreStackHook(t, "foo.mayMoreStack")
+	(&context{}).emitMayMoreStackHook(nil)
+	(&context{goFn: &gossa.Function{Synthetic: "package initializer"}}).emitMayMoreStackHook(nil)
+}
+
+func TestMayMoreStackHookIsEmittedForOrdinaryFunctions(t *testing.T) {
+	withMayMoreStackHook(t, "main.mayMoreStack")
+
+	ssaPkg, _, files := buildGoSSAPkg(t, `package main
+
+func mayMoreStack() {}
+
+func helper() {}
+
+func main() {
+	helper()
+}
+`)
+	prog := newLLSSAProg(t)
+	pkg, err := NewPackage(prog, ssaPkg, files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ir := pkg.String()
+	call := "call void @main.mayMoreStack()"
+	if got := strings.Count(ir, call); got != 2 {
+		t.Fatalf("mayMoreStack hook call count = %d, want 2 for main and helper:\n%s", got, ir)
+	}
+	if body := functionIR(t, ir, "main.mayMoreStack"); strings.Contains(body, call) {
+		t.Fatalf("mayMoreStack hook should not call itself:\n%s", body)
+	}
+
+	fn := pkg.FuncOf("main.mayMoreStack")
+	if fn == nil {
+		t.Fatal("missing compiled mayMoreStack function")
+	}
+}
+
+func functionIR(t *testing.T, ir, name string) string {
+	t.Helper()
+	start := strings.Index(ir, "define void @"+name+"(")
+	if start < 0 {
+		t.Fatalf("missing function %q in IR:\n%s", name, ir)
+	}
+	rest := ir[start:]
+	end := strings.Index(rest, "\n}")
+	if end < 0 {
+		t.Fatalf("unterminated function %q in IR:\n%s", name, rest)
+	}
+	return rest[:end+2]
+}

--- a/cmd/internal/base/base.go
+++ b/cmd/internal/base/base.go
@@ -42,6 +42,9 @@ type Command struct {
 	// Flag is a set of flags specific to this command.
 	Flag flag.FlagSet
 
+	// PassArgs records build flags accepted for compatibility with cmd/go.
+	PassArgs *PassArgs
+
 	// Commands lists the available commands and help topics.
 	// The order here is the order in which they are printed by 'gop help'.
 	// Note that subcommands are in general best avoided.

--- a/cmd/internal/base/pass.go
+++ b/cmd/internal/base/pass.go
@@ -71,6 +71,7 @@ func NewPassArgs(flag *flag.FlagSet) *PassArgs {
 
 func PassBuildFlags(cmd *Command) *PassArgs {
 	p := NewPassArgs(&cmd.Flag)
+	cmd.PassArgs = p
 	p.Bool("n")
 	// Note: "a" flag removed - now handled by flags.AddBuildFlags()
 	p.Bool("linkshared", "race", "msan", "asan",

--- a/cmd/internal/build/build.go
+++ b/cmd/internal/build/build.go
@@ -56,6 +56,10 @@ func runCmd(cmd *base.Command, args []string) {
 		fmt.Fprintln(os.Stderr, err)
 		mockable.Exit(1)
 	}
+	if err := flags.UpdatePassBuildConfig(conf, cmd.PassArgs.Args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		mockable.Exit(1)
+	}
 
 	args = cmd.Flag.Args()
 

--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -3,12 +3,14 @@ package flags
 import (
 	"flag"
 	"fmt"
+	"strings"
 
 	"github.com/goplus/llgo/cmd/internal/compilerhash"
 	"github.com/goplus/llgo/internal/build"
 	"github.com/goplus/llgo/internal/buildenv"
 	"github.com/goplus/llgo/internal/lto"
 	"github.com/goplus/llgo/internal/optlevel"
+	"github.com/goplus/llgo/internal/shellparse"
 )
 
 var OutputFile string
@@ -309,4 +311,67 @@ func UpdateBuildConfig(conf *build.Config) error {
 	conf.BuildMode = build.BuildMode(BuildMode)
 
 	return nil
+}
+
+func UpdatePassBuildConfig(conf *build.Config, args []string) error {
+	hook, err := mayMoreStackHookFromBuildFlags(args)
+	if err != nil {
+		return err
+	}
+	conf.MayMoreStack = hook
+	return nil
+}
+
+func mayMoreStackHookFromBuildFlags(args []string) (string, error) {
+	var hook string
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		var gcflags string
+		switch {
+		case arg == "-gcflags":
+			i++
+			if i >= len(args) {
+				return "", fmt.Errorf("-gcflags requires an argument")
+			}
+			gcflags = args[i]
+		case strings.HasPrefix(arg, "-gcflags="):
+			gcflags = strings.TrimPrefix(arg, "-gcflags=")
+		default:
+			continue
+		}
+		got, err := mayMoreStackHookFromGCFlags(gcflags)
+		if err != nil {
+			return "", err
+		}
+		if got != "" {
+			hook = got
+		}
+	}
+	return hook, nil
+}
+
+func mayMoreStackHookFromGCFlags(gcflags string) (string, error) {
+	fields, err := shellparse.Parse(gcflags)
+	if err != nil {
+		return "", fmt.Errorf("parse -gcflags: %w", err)
+	}
+	for _, field := range fields {
+		if pattern, rest, ok := strings.Cut(field, "="); ok && !strings.HasPrefix(pattern, "-") {
+			field = rest
+		}
+		if !strings.HasPrefix(field, "-d=") {
+			continue
+		}
+		for _, opt := range strings.Split(strings.TrimPrefix(field, "-d="), ",") {
+			hook, ok := strings.CutPrefix(opt, "maymorestack=")
+			if !ok {
+				continue
+			}
+			if hook == "" {
+				return "", fmt.Errorf("-d=maymorestack requires a function name")
+			}
+			return hook, nil
+		}
+	}
+	return "", nil
 }

--- a/cmd/internal/flags/flags_test.go
+++ b/cmd/internal/flags/flags_test.go
@@ -143,3 +143,67 @@ func TestUpdateConfigPreservesLTOWhenUnspecified(t *testing.T) {
 		t.Fatalf("conf.LTO = %v, want %v", conf.LTO, lto.Full)
 	}
 }
+
+func TestUpdatePassBuildConfigMayMoreStack(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "direct gcflags",
+			args: []string{"-gcflags=-d=maymorestack=main.mayMoreStack"},
+			want: "main.mayMoreStack",
+		},
+		{
+			name: "pattern gcflags",
+			args: []string{"-gcflags=all=-d=maymorestack=main.mayMoreStack"},
+			want: "main.mayMoreStack",
+		},
+		{
+			name: "space separated gcflags",
+			args: []string{"-gcflags", "-N -d=maymorestack=main.mayMoreStack -l"},
+			want: "main.mayMoreStack",
+		},
+		{
+			name: "comma debug options",
+			args: []string{"-gcflags=-d=checkptr,maymorestack=main.mayMoreStack"},
+			want: "main.mayMoreStack",
+		},
+		{
+			name: "unrelated gcflags",
+			args: []string{"-gcflags=-N -l"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := &build.Config{}
+			if err := UpdatePassBuildConfig(conf, tt.args); err != nil {
+				t.Fatalf("UpdatePassBuildConfig() error = %v", err)
+			}
+			if conf.MayMoreStack != tt.want {
+				t.Fatalf("MayMoreStack = %q, want %q", conf.MayMoreStack, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdatePassBuildConfigMayMoreStackErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "missing gcflags value", args: []string{"-gcflags"}},
+		{name: "empty hook", args: []string{"-gcflags=-d=maymorestack="}},
+		{name: "bad quoting", args: []string{"-gcflags='-d=maymorestack=main.mayMoreStack"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := UpdatePassBuildConfig(&build.Config{}, tt.args); err == nil {
+				t.Fatal("UpdatePassBuildConfig() expected error")
+			}
+		})
+	}
+}

--- a/cmd/internal/install/install.go
+++ b/cmd/internal/install/install.go
@@ -35,6 +35,7 @@ var Cmd = &base.Command{
 
 func init() {
 	Cmd.Run = runCmd
+	base.PassBuildFlags(Cmd)
 	flags.AddCommonFlags(&Cmd.Flag)
 	flags.AddBuildFlags(&Cmd.Flag)
 	flags.AddEmbeddedFlags(&Cmd.Flag)
@@ -48,6 +49,10 @@ func runCmd(cmd *base.Command, args []string) {
 
 	conf := build.NewDefaultConf(build.ModeInstall)
 	if err := flags.UpdateConfig(conf); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		mockable.Exit(1)
+	}
+	if err := flags.UpdatePassBuildConfig(conf, cmd.PassArgs.Args); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		mockable.Exit(1)
 	}

--- a/cmd/internal/run/run.go
+++ b/cmd/internal/run/run.go
@@ -80,6 +80,10 @@ func runCmdEx(cmd *base.Command, args []string, mode build.Mode) {
 		fmt.Fprintln(os.Stderr, err)
 		mockable.Exit(1)
 	}
+	if err := flags.UpdatePassBuildConfig(conf, cmd.PassArgs.Args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		mockable.Exit(1)
+	}
 
 	args = cmd.Flag.Args()
 	args, runArgs, err := parseRunArgs(args)

--- a/cmd/internal/test/test.go
+++ b/cmd/internal/test/test.go
@@ -21,6 +21,7 @@ var Cmd = &base.Command{
 
 func init() {
 	Cmd.Run = runCmd
+	base.PassBuildFlags(Cmd)
 	flags.AddCommonFlags(&Cmd.Flag)
 	flags.AddBuildFlags(&Cmd.Flag)
 	flags.AddTestFlags(&Cmd.Flag)
@@ -40,6 +41,10 @@ func runCmd(cmd *base.Command, args []string) {
 
 	conf := build.NewDefaultConf(build.ModeTest)
 	if err := flags.UpdateConfig(conf); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		mockable.Exit(1)
+	}
+	if err := flags.UpdatePassBuildConfig(conf, cmd.PassArgs.Args); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		mockable.Exit(1)
 	}

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -153,6 +153,7 @@ type Config struct {
 	SizeFormat    string // size report format: text,json (default text)
 	SizeLevel     string // size aggregation level: full,module,package (default module)
 	CompilerHash  string // metadata hash for the running compiler (development builds only)
+	MayMoreStack  string // function hook from -gcflags=-d=maymorestack=...
 	// GlobalRewrites specifies compile-time overrides for global string variables.
 	// Keys are fully qualified package paths (e.g. "main" or "github.com/user/pkg").
 	// Each Rewrites entry maps variable names to replacement string values. Only
@@ -294,6 +295,7 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	cl.EnableDebug(IsDbgEnabled())
 	cl.EnableDbgSyms(IsDbgSymsEnabled())
 	cl.EnableTrace(IsTraceEnabled())
+	cl.SetMayMoreStackHook(conf.MayMoreStack)
 	llssa.Initialize(llssa.InitAll)
 
 	target := &llssa.Target{

--- a/test/go/maymorestack_test.go
+++ b/test/go/maymorestack_test.go
@@ -1,0 +1,84 @@
+//go:build !llgo
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gotest
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestMayMoreStackGCFlag(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "main.go")
+	out := filepath.Join(tmp, "maymorestack")
+	if runtime.GOOS == "windows" {
+		out += ".exe"
+	}
+	if err := os.WriteFile(src, []byte(mayMoreStackProgram), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("go", "run", "-tags=dev", "./cmd/llgo", "build", "-gcflags=-d=maymorestack=main.mayMoreStack", "-o", out, src)
+	cmd.Dir = repoRoot
+	if data, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("llgo build failed: %v\n%s", err, data)
+	}
+
+	cmd = exec.Command(out)
+	if data, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("maymorestack program failed: %v\n%s", err, data)
+	}
+}
+
+const mayMoreStackProgram = `
+package main
+
+var count int
+
+//go:nosplit
+func mayMoreStack() {
+	count++
+}
+
+func main() {
+	const want = 8
+	anotherFunc(want - 1)
+	if count != want {
+		println(count, "!=", want)
+		panic("wrong number of calls to mayMoreStack")
+	}
+}
+
+//go:noinline
+func anotherFunc(n int) {
+	var x [16]byte
+	if n > 1 {
+		anotherFunc(n - 1)
+	}
+	_ = x
+}
+`

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -2105,11 +2105,6 @@ xfails:
     directive: run
     case: inline_callers.go
     reason: go1.24 goroot ci-mode run failure on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
-    case: maymorestack.go
-    reason: go1.24 goroot ci-mode run failure on linux/amd64
   - version: go1.25
     platform: linux/amd64
     directive: run
@@ -2120,11 +2115,6 @@ xfails:
     directive: run
     case: inline_callers.go
     reason: go1.25 goroot ci-mode run failure on linux/amd64
-  - version: go1.25
-    platform: linux/amd64
-    directive: run
-    case: maymorestack.go
-    reason: go1.25 goroot ci-mode run failure on linux/amd64
   - version: go1.26
     platform: linux/amd64
     directive: run
@@ -2134,11 +2124,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: inline_callers.go
-    reason: go1.26 goroot ci-mode run failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: maymorestack.go
     reason: go1.26 goroot ci-mode run failure on linux/amd64
   - version: go1.24
     platform: linux/amd64
@@ -2754,11 +2739,6 @@ xfails:
     directive: run
     case: inline_callers.go
     reason: go1.24 goroot ci-mode run failure on darwin/arm64
-  - version: go1.24
-    platform: darwin/arm64
-    directive: run
-    case: maymorestack.go
-    reason: go1.24 goroot ci-mode run failure on darwin/arm64
   - version: go1.25
     platform: darwin/arm64
     directive: run
@@ -2769,11 +2749,6 @@ xfails:
     directive: run
     case: inline_callers.go
     reason: go1.25 goroot ci-mode run failure on darwin/arm64
-  - version: go1.25
-    platform: darwin/arm64
-    directive: run
-    case: maymorestack.go
-    reason: go1.25 goroot ci-mode run failure on darwin/arm64
   - version: go1.26
     platform: darwin/arm64
     directive: run
@@ -2783,11 +2758,6 @@ xfails:
     platform: darwin/arm64
     directive: run
     case: inline_callers.go
-    reason: go1.26 goroot ci-mode run failure on darwin/arm64
-  - version: go1.26
-    platform: darwin/arm64
-    directive: run
-    case: maymorestack.go
     reason: go1.26 goroot ci-mode run failure on darwin/arm64
   - version: go1.26
     platform: darwin/arm64


### PR DESCRIPTION
## Summary
- Parse `-gcflags=-d=maymorestack=...` and carry the hook into the llgo build config.
- Emit the mayMoreStack hook at ordinary Go function entry for the hook's package, skipping synthetic initializers and the hook function itself.
- Add stable `test/go` CLI coverage and remove only the covered `maymorestack.go` GOROOT xfails.

## Coverage
Covered:
- `test/go` builds and runs a temporary program with `-gcflags=-d=maymorestack=main.mayMoreStack` and checks the hook count.
- Focused GOROOT `maymorestack.go` passes locally for Go 1.24.11, 1.25.0, and 1.26.0.
- Parser coverage includes direct, pattern-prefixed, space-separated, and comma-separated `-d` forms.

Not covered / intentionally out of scope:
- caller/debugline metadata, nil, channel, print, recover, GC/liveness/finalizer/goroutine work.
- Runtime package changes; this PR only adds compiler-side hook instrumentation and CLI flag plumbing.
- Local focused GOROOT runs were on darwin/arm64; linux coverage is left to PR CI.

## Tests
- `go test ./cmd/internal/flags -count=1`
- `go test ./cmd/internal/build -count=1`
- `go test ./cl -count=1`
- `go test ./test/go -count=1`
- `go test ./test/goroot -run TestGoRootRunCases -count=1 -timeout 20m -args -goroot /Users/lijie/sdk/go1.24.11 -dirs . -case '^maymorestack\\.go$' -directive-mode ci -xfail /tmp/llgo-empty-xfail.yaml -run-timeout 45s -build-timeout 5m`
- `go test ./test/goroot -run TestGoRootRunCases -count=1 -timeout 20m -args -goroot /Users/lijie/sdk/go1.25.0 -dirs . -case '^maymorestack\\.go$' -directive-mode ci -xfail /tmp/llgo-empty-xfail.yaml -run-timeout 45s -build-timeout 5m`
- `go test ./test/goroot -run TestGoRootRunCases -count=1 -timeout 20m -args -goroot /Users/lijie/sdk/go1.26.0 -dirs . -case '^maymorestack\\.go$' -directive-mode ci -xfail /tmp/llgo-empty-xfail.yaml -run-timeout 45s -build-timeout 5m`
- `go test ./test/goroot -run TestGoRootRunCases -count=1 -timeout 20m -args -goroot /Users/lijie/sdk/go1.24.11 -dirs . -case '^maymorestack\\.go$' -directive-mode ci -run-timeout 45s -build-timeout 5m`
- `go test ./test/goroot -run TestGoRootRunCases -count=1 -timeout 20m -args -goroot /Users/lijie/sdk/go1.25.0 -dirs . -case '^maymorestack\\.go$' -directive-mode ci -run-timeout 45s -build-timeout 5m`
- `go test ./test/goroot -run TestGoRootRunCases -count=1 -timeout 20m -args -goroot /Users/lijie/sdk/go1.26.0 -dirs . -case '^maymorestack\\.go$' -directive-mode ci -run-timeout 45s -build-timeout 5m`
- `go test ./cmd/internal/... -count=1`
- `go test ./ssa -count=1`
- `go test ./internal/build -count=1`
