### PR TITLE
fix(build): default non-constant untyped shifts

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1657,27 +1657,22 @@ func toTypeList(args *types.TypeList) []types.Type {
 // is an untyped constant, it is first implicitly converted to the type it would assume
 // if the shift expression were replaced by its left operand alone."
 //
-// This causes go/ssa sanity check to fail when the type remains untyped.
+// Parent expressions can inherit that untyped result. This causes go/ssa sanity
+// check to fail when a non-constant instruction result remains untyped.
 // See: https://github.com/golang/go/issues/77067
 func fixUntypedShiftTypes(p *packages.Package) {
-	// First pass: identify expressions needing fixes
-	// (avoid modifying map during iteration)
 	var toFix []ast.Expr
 	for expr, tv := range p.TypesInfo.Types {
-		switch e := expr.(type) {
-		case *ast.BinaryExpr:
-			if e.Op != token.SHL && e.Op != token.SHR {
-				break
-			}
-			basic, ok := tv.Type.(*types.Basic)
-			if !ok || basic.Info()&types.IsUntyped == 0 {
-				break
-			}
-			toFix = append(toFix, expr)
+		if tv.Value != nil {
+			continue
 		}
+		basic, ok := tv.Type.(*types.Basic)
+		if !ok || basic.Info()&types.IsUntyped == 0 {
+			continue
+		}
+		toFix = append(toFix, expr)
 	}
 
-	// Second pass: apply fixes
 	for _, expr := range toFix {
 		tv := p.TypesInfo.Types[expr]
 		p.TypesInfo.Types[expr] = types.TypeAndValue{

--- a/test/go/shift_untyped_test.go
+++ b/test/go/shift_untyped_test.go
@@ -85,3 +85,68 @@ func TestNestedShiftEdgeCases(t *testing.T) {
 		t.Errorf("nestedShift (shift by 8): got %d, want 256", r)
 	}
 }
+
+// issue12133F1 covers a non-constant shift whose left operand is an
+// untyped constant. go/types can leave parent expressions untyped, which
+// must be defaulted before building SSA.
+func issue12133F1(v1 uint) uint {
+	return v1 >> ((1 >> v1) + (1 >> v1))
+}
+
+func TestGorootIssue12133UnsignedShiftCount(t *testing.T) {
+	if got := issue12133F1(48); got != 48 {
+		t.Fatalf("issue12133F1(48) = %d, want 48", got)
+	}
+}
+
+func issue15175Bool(v bool) bool {
+	return v
+}
+
+func issue15175F1(a1 uint, a2 int8, a3 int8, a4 int8, a5 uint8, a6 int, a7 bool) uint8 {
+	a5--
+	a4 += (a2 << a1 << 2) | (a4 ^ a4<<(a1&a1)) - a3
+	a6 -= a6 >> (2 + uint32(a2)>>3)
+	a1 += a1
+	a3 *= a4 << (a1 | a1) << (uint16(3) >> 2 & (1 - 0) & (uint16(1) << a5 << 3))
+	_ = issue15175Bool(a7) || (a2 == a4) || (a5 == 0)
+	return a5 >> a1
+}
+
+func issue15175F2(a1 uint8) uint8 {
+	a1--
+	a1--
+	a1 -= a1 + (a1 << 1) - (a1*a1*a1)<<(2-0+(3|3)-1)
+	v1 := 0 * ((2 * 1) ^ 1) & ((uint(0) >> a1) + (2+0)*(uint(2)+0))
+	_ = v1
+	return a1 >> (((2 ^ 2) >> (v1 | 2)) + 0)
+}
+
+func issue15175F3(a1 bool, a2 uint, a3 int64) uint8 {
+	a3--
+	v1 := 1 & (2 & 1 * (1 ^ 2) & (uint8(3*1) >> 0))
+	_ = v1
+	v1 += v1 - (v1 >> a2) + (v1 << (a2 ^ a2) & v1)
+	v1 *= v1
+	a3--
+	v1 += v1 & v1
+	v1--
+	v1 = ((v1 << 0) | v1>>0) + v1
+	return v1 >> 0
+}
+
+func TestGorootIssue15175UnsignedNarrowShiftResults(t *testing.T) {
+	a6 := uint8(253)
+	if got := a6 >> 0; got != 253 {
+		t.Fatalf("uint8(253) >> 0 = %d, want 253", got)
+	}
+	if got := issue15175F1(0, 2, 1, 0, 0, 1, true); got != 255 {
+		t.Fatalf("issue15175F1(...) = %d, want 255", got)
+	}
+	if got := issue15175F2(1); got != 242 {
+		t.Fatalf("issue15175F2(1) = %d, want 242", got)
+	}
+	if got := issue15175F3(false, 0, 0); got != 254 {
+		t.Fatalf("issue15175F3(false, 0, 0) = %d, want 254", got)
+	}
+}

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -3135,15 +3135,7 @@ xfails:
     reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
-    case: fixedbugs/issue12133.go
-    reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
     case: fixedbugs/issue13169.go
-    reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
-    case: fixedbugs/issue15175.go
     reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
@@ -3231,14 +3223,6 @@ xfails:
   - platform: linux/amd64
     directive: run
     case: fixedbugs/bug273.go
-    reason: current main goroot run failure on linux/amd64
-  - platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue12133.go
-    reason: current main goroot run failure on linux/amd64
-  - platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue15175.go
     reason: current main goroot run failure on linux/amd64
   - platform: linux/amd64
     directive: run


### PR DESCRIPTION
## Summary
- default non-constant untyped basic expressions before go/ssa build so shift-derived parent expressions do not fail sanity checks
- add stable test/go coverage for fixedbugs/issue12133.go and fixedbugs/issue15175.go semantics
- remove the covered goroot xfails for darwin/arm64 and linux/amd64

## Tests
- go test ./test/goroot -run TestGoRootRunCases -count=1 -args -goroot /opt/homebrew/Cellar/go@1.24/1.24.11/libexec -dirs fixedbugs -case '^(fixedbugs/issue12133.go|fixedbugs/issue15175.go)$'
- go test ./test/go -count=1
- go test ./internal/build -count=1
- /tmp/llgo-shift test ./test/go


CI dependency note: Depends on #1892 for the shared `ifaceprom` / nointerface method-table behavior in the LLGo demo job; this PR intentionally keeps the untyped-shift fix scoped.
