### PR TITLE
cl: guard zero-sized interface deref

### DIFF
--- a/cl/compile.go
+++ b/cl/compile.go
@@ -95,6 +95,10 @@ func (p *context) isLargeNonPointerValue(t llssa.Type) bool {
 	return sizes.Sizeof(raw) > maxDirectDerefSize
 }
 
+func (p *context) isZeroSizedValue(t llssa.Type) bool {
+	return p.prog.SizeOf(t) == 0
+}
+
 func dbgGoSSADump(f interface {
 	WriteTo(io.Writer) (int64, error)
 }) {
@@ -988,7 +992,7 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 		t := p.type_(v.Type(), llssa.InGo)
 		if unop, ok := v.X.(*ssa.UnOp); ok && unop.Op == token.MUL {
 			if vt := p.type_(unop.Type(), llssa.InGo); vt.RawType() != nil {
-				if p.isLargeNonPointerValue(vt) {
+				if p.isLargeNonPointerValue(vt) || p.isZeroSizedValue(vt) {
 					if ptr := p.compileValue(b, unop.X); ptr.Type != nil {
 						p.assertNilDerefBase(b, unop.X)
 						ret = b.MakeInterfaceFromPtr(t, ptr)

--- a/test/go/nil_pointer_interface_test.go
+++ b/test/go/nil_pointer_interface_test.go
@@ -4,6 +4,8 @@ import "testing"
 
 type nilPointerInterfaceLarge [1 << 21]byte
 
+type nilPointerInterfaceZero struct{}
+
 type nilPointerInterfaceLargeStruct struct {
 	data [1 << 21]byte
 }
@@ -28,6 +30,13 @@ func expectNilPointerInterfacePanic(t *testing.T, f func()) {
 func TestNilPointerLargeArrayToInterfacePanics(t *testing.T) {
 	expectNilPointerInterfacePanic(t, func() {
 		var p *nilPointerInterfaceLarge
+		nilPointerInterfaceSink = *p
+	})
+}
+
+func TestNilPointerZeroSizedValueToInterfacePanics(t *testing.T) {
+	expectNilPointerInterfacePanic(t, func() {
+		var p *nilPointerInterfaceZero
 		nilPointerInterfaceSink = *p
 	})
 }

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -3616,10 +3616,6 @@ xfails:
     reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
-    case: fixedbugs/issue19246.go
-    reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
     case: fixedbugs/issue23017.go
     reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64
@@ -3811,10 +3807,6 @@ xfails:
   - platform: linux/amd64
     directive: run
     case: fixedbugs/issue15175.go
-    reason: current main goroot run failure on linux/amd64
-  - platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue19246.go
     reason: current main goroot run failure on linux/amd64
   - platform: linux/amd64
     directive: run


### PR DESCRIPTION
## Summary
- guard zero-sized pointer dereferences when they are boxed into interfaces
- add test/go coverage for issue19246 behavior
- remove fixedbugs/issue19246.go xfails for darwin/arm64 and linux/amd64

## Tests
- go test ./test/goroot -run '^TestGoRootRunCases$/fixedbugs/issue19246\.go$' -count=1 -args -goroot "/opt/homebrew/Cellar/go@1.24/1.24.11/libexec" -dirs fixedbugs -case '^fixedbugs/issue19246\.go$' -xfail /tmp/llgo-empty-xfail.yaml -run-timeout 30s
- go test ./test/go -count=1
- go test ./cl ./ssa -count=1 -p=1
- (runtime submodule) go test ./internal/runtime -count=1