### PR TITLE
fix zero-sized deref comparisons

### DIFF
--- a/cl/_testgo/genericembediface/in.go
+++ b/cl/_testgo/genericembediface/in.go
@@ -115,8 +115,9 @@ func main() {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %2, %"{{.*}}/runtime/internal/runtime.String" { ptr @20, i64 58 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 20 })
-// CHECK-NEXT:   %3 = load %"{{.*}}/cl/_testgo/genericembediface.server", ptr %0, align 1
-// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/genericembediface.server.ServerReflectionInfo"(%"{{.*}}/cl/_testgo/genericembediface.server" %3, %"{{.*}}/runtime/internal/runtime.iface" %1)
+// CHECK-NEXT:   %3 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %3)
+// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/genericembediface.server.ServerReflectionInfo"(%"{{.*}}/cl/_testgo/genericembediface.server" zeroinitializer, %"{{.*}}/runtime/internal/runtime.iface" %1)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %4
 // CHECK-NEXT: }
 
@@ -129,8 +130,9 @@ func main() {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @21, i64 58 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 7 })
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/genericembediface.stream", ptr %0, align 1
-// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface.stream.Context"(%"{{.*}}/cl/_testgo/genericembediface.stream" %2)
+// CHECK-NEXT:   %2 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %2)
+// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface.stream.Context"(%"{{.*}}/cl/_testgo/genericembediface.stream" zeroinitializer)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %3
 // CHECK-NEXT: }
 
@@ -175,8 +177,44 @@ func main() {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %12
 // CHECK-NEXT: }
 
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"__llgo_stub.{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response].Context"(ptr %0, %"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response]" %1){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response].Context"(%"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response]" %1)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %2
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"__llgo_stub.{{.*}}/cl/_testgo/genericembediface/streamlib.(*GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response]).Context"(ptr %0, ptr %1){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface/streamlib.(*GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response]).Context"(ptr %1)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %2
+// CHECK-NEXT: }
+
 // CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequal0"(ptr %0, ptr %1, ptr %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.memequal0"(ptr %1, ptr %2)
 // CHECK-NEXT:   ret i1 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.{{.*}}/cl/_testgo/genericembediface.(*server).ServerReflectionInfo"(ptr %0, ptr %1, %"{{.*}}/runtime/internal/runtime.iface" %2){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %3 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/genericembediface.(*server).ServerReflectionInfo"(ptr %1, %"{{.*}}/runtime/internal/runtime.iface" %2)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.{{.*}}/cl/_testgo/genericembediface.server.ServerReflectionInfo"(ptr %0, %"{{.*}}/cl/_testgo/genericembediface.server" %1, %"{{.*}}/runtime/internal/runtime.iface" %2){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %3 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/genericembediface.server.ServerReflectionInfo"(%"{{.*}}/cl/_testgo/genericembediface.server" %1, %"{{.*}}/runtime/internal/runtime.iface" %2)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"__llgo_stub.{{.*}}/cl/_testgo/genericembediface.(*stream).Context"(ptr %0, ptr %1){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface.(*stream).Context"(ptr %1)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %2
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"__llgo_stub.{{.*}}/cl/_testgo/genericembediface.stream.Context"(ptr %0, %"{{.*}}/cl/_testgo/genericembediface.stream" %1){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = tail call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface.stream.Context"(%"{{.*}}/cl/_testgo/genericembediface.stream" %1)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %2
 // CHECK-NEXT: }

--- a/cl/_testgo/ifaceconv/in.go
+++ b/cl/_testgo/ifaceconv/in.go
@@ -111,8 +111,9 @@ func main() {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 46 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 1 })
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/ifaceconv.C1", ptr %0, align 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/ifaceconv.C1.f"(%"{{.*}}/cl/_testgo/ifaceconv.C1" %2)
+// CHECK-NEXT:   %2 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %2)
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/ifaceconv.C1.f"(%"{{.*}}/cl/_testgo/ifaceconv.C1" zeroinitializer)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
@@ -130,8 +131,9 @@ func main() {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 46 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 1 })
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/ifaceconv.C2", ptr %0, align 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/ifaceconv.C2.f"(%"{{.*}}/cl/_testgo/ifaceconv.C2" %2)
+// CHECK-NEXT:   %2 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %2)
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/ifaceconv.C2.f"(%"{{.*}}/cl/_testgo/ifaceconv.C2" zeroinitializer)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
@@ -139,8 +141,9 @@ func main() {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 46 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 1 })
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/ifaceconv.C2", ptr %0, align 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/ifaceconv.C2.g"(%"{{.*}}/cl/_testgo/ifaceconv.C2" %2)
+// CHECK-NEXT:   %2 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %2)
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/ifaceconv.C2.g"(%"{{.*}}/cl/_testgo/ifaceconv.C2" zeroinitializer)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
@@ -478,4 +481,40 @@ func main() {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.memequal0"(ptr %1, ptr %2)
 // CHECK-NEXT:   ret i1 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testgo/ifaceconv.(*C1).f"(ptr %0, ptr %1){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testgo/ifaceconv.(*C1).f"(ptr %1)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testgo/ifaceconv.C1.f"(ptr %0, %"{{.*}}/cl/_testgo/ifaceconv.C1" %1){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testgo/ifaceconv.C1.f"(%"{{.*}}/cl/_testgo/ifaceconv.C1" %1)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testgo/ifaceconv.(*C2).f"(ptr %0, ptr %1){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testgo/ifaceconv.(*C2).f"(ptr %1)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testgo/ifaceconv.(*C2).g"(ptr %0, ptr %1){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testgo/ifaceconv.(*C2).g"(ptr %1)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testgo/ifaceconv.C2.f"(ptr %0, %"{{.*}}/cl/_testgo/ifaceconv.C2" %1){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testgo/ifaceconv.C2.f"(%"{{.*}}/cl/_testgo/ifaceconv.C2" %1)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testgo/ifaceconv.C2.g"(ptr %0, %"{{.*}}/cl/_testgo/ifaceconv.C2" %1){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   tail call void @"{{.*}}/cl/_testgo/ifaceconv.C2.g"(%"{{.*}}/cl/_testgo/ifaceconv.C2" %1)
+// CHECK-NEXT:   ret void
 // CHECK-NEXT: }

--- a/cl/_testgo/ifaceprom/in.go
+++ b/cl/_testgo/ifaceprom/in.go
@@ -150,8 +150,9 @@ func main() {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 48 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 3 })
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/ifaceprom.impl", ptr %0, align 1
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/ifaceprom.impl.one"(%"{{.*}}/cl/_testgo/ifaceprom.impl" %2)
+// CHECK-NEXT:   %2 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %2)
+// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/ifaceprom.impl.one"(%"{{.*}}/cl/_testgo/ifaceprom.impl" zeroinitializer)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
@@ -159,8 +160,9 @@ func main() {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 48 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 3 })
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/ifaceprom.impl", ptr %0, align 1
-// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/ifaceprom.impl.two"(%"{{.*}}/cl/_testgo/ifaceprom.impl" %2)
+// CHECK-NEXT:   %2 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %2)
+// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/ifaceprom.impl.two"(%"{{.*}}/cl/_testgo/ifaceprom.impl" zeroinitializer)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %3
 // CHECK-NEXT: }
 

--- a/cl/_testgo/selects/in.go
+++ b/cl/_testgo/selects/in.go
@@ -111,14 +111,16 @@ func main() {
 // CHECK-NEXT:   %39 = extractvalue { i64, i1 } %38, 0
 // CHECK-NEXT:   %40 = extractvalue { i64, i1 } %38, 1
 // CHECK-NEXT:   %41 = extractvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %26, 1
-// CHECK-NEXT:   %42 = load {}, ptr %41, align 1
+// CHECK-NEXT:   %42 = icmp eq ptr %41, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %42)
 // CHECK-NEXT:   %43 = extractvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %31, 1
-// CHECK-NEXT:   %44 = load {}, ptr %43, align 1
+// CHECK-NEXT:   %44 = icmp eq ptr %43, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %44)
 // CHECK-NEXT:   call void @llvm.stackrestore(ptr %21)
 // CHECK-NEXT:   %45 = insertvalue { i64, i1, {}, {} } undef, i64 %39, 0
 // CHECK-NEXT:   %46 = insertvalue { i64, i1, {}, {} } %45, i1 %40, 1
-// CHECK-NEXT:   %47 = insertvalue { i64, i1, {}, {} } %46, {} %42, 2
-// CHECK-NEXT:   %48 = insertvalue { i64, i1, {}, {} } %47, {} %44, 3
+// CHECK-NEXT:   %47 = insertvalue { i64, i1, {}, {} } %46, {} zeroinitializer, 2
+// CHECK-NEXT:   %48 = insertvalue { i64, i1, {}, {} } %47, {} zeroinitializer, 3
 // CHECK-NEXT:   %49 = extractvalue { i64, i1, {}, {} } %48, 0
 // CHECK-NEXT:   %50 = icmp eq i64 %49, 0
 // CHECK-NEXT:   br i1 %50, label %_llgo_2, label %_llgo_3
@@ -157,7 +159,8 @@ func main() {
 // CHECK-NEXT:   %5 = alloca {}, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %5, i8 0, i64 0, i1 false)
 // CHECK-NEXT:   %6 = call i1 @"{{.*}}/runtime/internal/runtime.ChanRecv"(ptr %3, ptr %5, i64 0)
-// CHECK-NEXT:   %7 = load {}, ptr %5, align 1
+// CHECK-NEXT:   %7 = icmp eq ptr %5, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %7)
 // CHECK-NEXT:   call void @llvm.stackrestore(ptr %4)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 4 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
@@ -191,11 +194,12 @@ func main() {
 // CHECK-NEXT:   %30 = extractvalue { i64, i1 } %29, 0
 // CHECK-NEXT:   %31 = extractvalue { i64, i1 } %29, 1
 // CHECK-NEXT:   %32 = extractvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %22, 1
-// CHECK-NEXT:   %33 = load {}, ptr %32, align 1
+// CHECK-NEXT:   %33 = icmp eq ptr %32, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %33)
 // CHECK-NEXT:   call void @llvm.stackrestore(ptr %12)
 // CHECK-NEXT:   %34 = insertvalue { i64, i1, {} } undef, i64 %30, 0
 // CHECK-NEXT:   %35 = insertvalue { i64, i1, {} } %34, i1 %31, 1
-// CHECK-NEXT:   %36 = insertvalue { i64, i1, {} } %35, {} %33, 2
+// CHECK-NEXT:   %36 = insertvalue { i64, i1, {} } %35, {} zeroinitializer, 2
 // CHECK-NEXT:   %37 = extractvalue { i64, i1, {} } %36, 0
 // CHECK-NEXT:   %38 = icmp eq i64 %37, 0
 // CHECK-NEXT:   br i1 %38, label %_llgo_2, label %_llgo_3

--- a/cl/_testgo/tpnamed/in.go
+++ b/cl/_testgo/tpnamed/in.go
@@ -6,49 +6,107 @@ type Future[T any] func() T
 
 type IO[T any] func() Future[T]
 
-// CHECK-LABEL: define %"{{.*}}tpnamed.IO[error]" @"{{.*}}tpnamed.WriteFile"(%"{{.*}}String" %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/cl/_testgo/tpnamed.IO[error]" @"{{.*}}/cl/_testgo/tpnamed.WriteFile"(%"{{.*}}/runtime/internal/runtime.String" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   ret %"{{.*}}tpnamed.IO[error]" { ptr @"__llgo_stub.{{.*}}tpnamed.WriteFile$1", ptr null }
+// CHECK-NEXT:   ret %"{{.*}}/cl/_testgo/tpnamed.IO[error]" { ptr @"__llgo_stub.{{.*}}/cl/_testgo/tpnamed.WriteFile$1", ptr null }
+// CHECK-NEXT: }
+
 func WriteFile(fileName string) IO[error] {
+
+	// CHECK-LABEL: define %"{{.*}}/cl/_testgo/tpnamed.Future[error]" @"{{.*}}/cl/_testgo/tpnamed.WriteFile$1"(){{.*}} {
+	// CHECK-NEXT: _llgo_0:
+	// CHECK-NEXT:   ret %"{{.*}}/cl/_testgo/tpnamed.Future[error]" { ptr @"__llgo_stub.{{.*}}/cl/_testgo/tpnamed.WriteFile$1$1", ptr null }
+	// CHECK-NEXT: }
+
 	return func() Future[error] {
-		// CHECK-LABEL: define %"{{.*}}tpnamed.Future[error]" @"{{.*}}tpnamed.WriteFile$1"(){{.*}} {
+
+		// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/tpnamed.WriteFile$1$1"(){{.*}} {
 		// CHECK-NEXT: _llgo_0:
-		// CHECK-NEXT:   ret %"{{.*}}tpnamed.Future[error]" { ptr @"__llgo_stub.{{.*}}tpnamed.WriteFile$1$1", ptr null }
+		// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" zeroinitializer
+		// CHECK-NEXT: }
+
+		// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/tpnamed.init"(){{.*}} {
+		// CHECK-NEXT: _llgo_0:
+		// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/tpnamed.init$guard", align 1
+		// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
+		// CHECK-EMPTY:
+		// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+		// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/tpnamed.init$guard", align 1
+		// CHECK-NEXT:   br label %_llgo_2
+		// CHECK-EMPTY:
+		// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+		// CHECK-NEXT:   ret void
+		// CHECK-NEXT: }
+
 		return func() error {
-			// CHECK-LABEL: define %"{{.*}}iface" @"{{.*}}tpnamed.WriteFile$1$1"(){{.*}} {
-			// CHECK-NEXT: _llgo_0:
-			// CHECK-NEXT:   ret %"{{.*}}iface" zeroinitializer
 			return nil
 		}
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}tpnamed.main"(){{.*}} {
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/tpnamed.main"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call [0 x i8] @"{{.*}}/cl/_testgo/tpnamed.RunIO[[0]byte]"(%"{{.*}}/cl/_testgo/tpnamed.IO[[0]byte]" { ptr @"__llgo_stub.{{.*}}/cl/_testgo/tpnamed.main$1", ptr null })
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
 func main() {
-	// CHECK: call [0 x i8] @"{{.*}}tpnamed.RunIO[[0]byte]"(%"{{.*}}tpnamed.IO[[0]byte]" { ptr @"__llgo_stub.{{.*}}tpnamed.main$1", ptr null })
-	// CHECK: ret void
+
+	// CHECK-LABEL: define %"{{.*}}/cl/_testgo/tpnamed.Future[[0]byte]" @"{{.*}}/cl/_testgo/tpnamed.main$1"(){{.*}} {
+	// CHECK-NEXT: _llgo_0:
+	// CHECK-NEXT:   ret %"{{.*}}/cl/_testgo/tpnamed.Future[[0]byte]" { ptr @"__llgo_stub.{{.*}}/cl/_testgo/tpnamed.main$1$1", ptr null }
+	// CHECK-NEXT: }
+
 	RunIO[Void](func() Future[Void] {
-		// CHECK-LABEL: define %"{{.*}}tpnamed.Future[[0]byte]" @"{{.*}}tpnamed.main$1"(){{.*}} {
+
+		// CHECK-LABEL: define [0 x i8] @"{{.*}}/cl/_testgo/tpnamed.main$1$1"(){{.*}} {
 		// CHECK-NEXT: _llgo_0:
-		// CHECK-NEXT:   ret %"{{.*}}tpnamed.Future[[0]byte]" { ptr @"__llgo_stub.{{.*}}tpnamed.main$1$1", ptr null }
+		// CHECK-NEXT:   ret [0 x i8] zeroinitializer
+		// CHECK-NEXT: }
+
 		return func() (ret Void) {
-			// CHECK-LABEL: define [0 x i8] @"{{.*}}tpnamed.main$1$1"(){{.*}} {
-			// CHECK-NEXT: _llgo_0:
-			// CHECK-NEXT:   ret [0 x i8] zeroinitializer
 			return
 		}
 	})
 }
 
-// CHECK-LABEL: define linkonce [0 x i8] @"{{.*}}tpnamed.RunIO[[0]byte]"(%"{{.*}}tpnamed.IO[[0]byte]" %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = extractvalue %"{{.*}}tpnamed.IO[[0]byte]" %0, 1
-// CHECK-NEXT:   %2 = extractvalue %"{{.*}}tpnamed.IO[[0]byte]" %0, 0
-// CHECK-NEXT:   %3 = call %"{{.*}}tpnamed.Future[[0]byte]" %2(ptr %1)
-// CHECK-NEXT:   %4 = extractvalue %"{{.*}}tpnamed.Future[[0]byte]" %3, 1
-// CHECK-NEXT:   %5 = extractvalue %"{{.*}}tpnamed.Future[[0]byte]" %3, 0
-// CHECK-NEXT:   %6 = call [0 x i8] %5(ptr %4)
-// CHECK-NEXT:   ret [0 x i8] %6
 func RunIO[T any](call IO[T]) T {
 	return call()()
 }
+
+// CHECK-LABEL: define linkonce %"{{.*}}/cl/_testgo/tpnamed.Future[error]" @"__llgo_stub.{{.*}}/cl/_testgo/tpnamed.WriteFile$1"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = tail call %"{{.*}}/cl/_testgo/tpnamed.Future[error]" @"{{.*}}/cl/_testgo/tpnamed.WriteFile$1"()
+// CHECK-NEXT:   ret %"{{.*}}/cl/_testgo/tpnamed.Future[error]" %1
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"__llgo_stub.{{.*}}/cl/_testgo/tpnamed.WriteFile$1$1"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = tail call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/tpnamed.WriteFile$1$1"()
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %1
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce %"{{.*}}/cl/_testgo/tpnamed.Future[[0]byte]" @"__llgo_stub.{{.*}}/cl/_testgo/tpnamed.main$1"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = tail call %"{{.*}}/cl/_testgo/tpnamed.Future[[0]byte]" @"{{.*}}/cl/_testgo/tpnamed.main$1"()
+// CHECK-NEXT:   ret %"{{.*}}/cl/_testgo/tpnamed.Future[[0]byte]" %1
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce [0 x i8] @"{{.*}}/cl/_testgo/tpnamed.RunIO[[0]byte]"(%"{{.*}}/cl/_testgo/tpnamed.IO[[0]byte]" %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = extractvalue %"{{.*}}/cl/_testgo/tpnamed.IO[[0]byte]" %0, 1
+// CHECK-NEXT:   %2 = extractvalue %"{{.*}}/cl/_testgo/tpnamed.IO[[0]byte]" %0, 0
+// CHECK-NEXT:   %3 = call %"{{.*}}/cl/_testgo/tpnamed.Future[[0]byte]" %2(ptr %1)
+// CHECK-NEXT:   %4 = extractvalue %"{{.*}}/cl/_testgo/tpnamed.Future[[0]byte]" %3, 1
+// CHECK-NEXT:   %5 = extractvalue %"{{.*}}/cl/_testgo/tpnamed.Future[[0]byte]" %3, 0
+// CHECK-NEXT:   %6 = icmp eq ptr %5, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %6)
+// CHECK-NEXT:   %7 = call [0 x i8] %5(ptr %4)
+// CHECK-NEXT:   ret [0 x i8] %7
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce [0 x i8] @"__llgo_stub.{{.*}}/cl/_testgo/tpnamed.main$1$1"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = tail call [0 x i8] @"{{.*}}/cl/_testgo/tpnamed.main$1$1"()
+// CHECK-NEXT:   ret [0 x i8] %1
+// CHECK-NEXT: }

--- a/cl/_testrt/closurebound/in.go
+++ b/cl/_testrt/closurebound/in.go
@@ -39,8 +39,9 @@ func main() {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 52 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 6 })
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testrt/closurebound.demo1", ptr %0, align 1
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testrt/closurebound.demo1.encode"(%"{{.*}}/cl/_testrt/closurebound.demo1" %2)
+// CHECK-NEXT:   %2 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %2)
+// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testrt/closurebound.demo1.encode"(%"{{.*}}/cl/_testrt/closurebound.demo1" zeroinitializer)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
@@ -53,8 +54,9 @@ func main() {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp eq ptr %0, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 52 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 6 })
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testrt/closurebound.demo2", ptr %0, align 1
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testrt/closurebound.demo2.encode"(%"{{.*}}/cl/_testrt/closurebound.demo2" %2)
+// CHECK-NEXT:   %2 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %2)
+// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testrt/closurebound.demo2.encode"(%"{{.*}}/cl/_testrt/closurebound.demo2" zeroinitializer)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
@@ -101,16 +103,16 @@ func main() {
 
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/closurebound.demo2.encode$bound"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = load { %"{{.*}}/cl/_testrt/closurebound.demo2" }, ptr %0, align 1
-// CHECK-NEXT:   %2 = extractvalue { %"{{.*}}/cl/_testrt/closurebound.demo2" } %1, 0
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testrt/closurebound.demo2.encode"(%"{{.*}}/cl/_testrt/closurebound.demo2" %2)
-// CHECK-NEXT:   ret i64 %3
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %1)
+// CHECK-NEXT:   %2 = call i64 @"{{.*}}/cl/_testrt/closurebound.demo2.encode"(%"{{.*}}/cl/_testrt/closurebound.demo2" zeroinitializer)
+// CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/closurebound.demo1.encode$bound"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = load { %"{{.*}}/cl/_testrt/closurebound.demo1" }, ptr %0, align 1
-// CHECK-NEXT:   %2 = extractvalue { %"{{.*}}/cl/_testrt/closurebound.demo1" } %1, 0
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testrt/closurebound.demo1.encode"(%"{{.*}}/cl/_testrt/closurebound.demo1" %2)
-// CHECK-NEXT:   ret i64 %3
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %1)
+// CHECK-NEXT:   %2 = call i64 @"{{.*}}/cl/_testrt/closurebound.demo1.encode"(%"{{.*}}/cl/_testrt/closurebound.demo1" zeroinitializer)
+// CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1014,6 +1014,11 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 		if v.Op == token.ARROW {
 			ret = b.Recv(x, v.CommaOk)
 		} else {
+			if v.Op == token.MUL {
+				if t := p.type_(v.Type(), llssa.InGo); t.RawType() != nil && p.prog.SizeOf(t) == 0 {
+					p.assertNilDerefBase(b, v.X)
+				}
+			}
 			ret = b.UnOp(v.Op, x)
 		}
 	case *ssa.ChangeType:

--- a/cl/zero_size_deref_test.go
+++ b/cl/zero_size_deref_test.go
@@ -1,0 +1,25 @@
+//go:build !llgo
+// +build !llgo
+
+package cl
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestZeroSizedFieldDerefEmitsBaseNilGuard(t *testing.T) {
+	const src = `package zeroderef
+type T struct {
+	n int
+	z struct{}
+}
+func Eq(p, q *T) bool {
+	return p.z == q.z
+}
+`
+	ir := compileWithRewrites(t, src, nil)
+	if got := strings.Count(ir, "AssertNilDeref"); got < 4 {
+		t.Fatalf("zero-sized field comparison should guard field bases and loads, got %d guards:\n%s", got, ir)
+	}
+}

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -1190,6 +1190,9 @@ func (b Builder) Call(fn Expr, args ...Expr) (ret Expr) {
 		ctx := types.NewParam(token.NoPos, nil, closureCtx, types.Typ[types.UnsafePointer])
 		sigCtx := FuncAddCtx(ctx, sig)
 		ret.Type = b.Prog.retType(sig)
+		if sig.Results().Len() == 1 && b.Prog.SizeOf(ret.Type) == 0 {
+			b.AssertNilDeref(fn)
+		}
 		ll = b.Prog.FuncDecl(sigCtx, InC).ll
 		ret.impl = llvm.CreateCall(b.impl, ll, fn.impl, llvmParamsEx(data, args, sigCtx.Params(), b))
 		return ret

--- a/ssa/memory.go
+++ b/ssa/memory.go
@@ -357,6 +357,10 @@ func (b Builder) Load(ptr Expr) Expr {
 	}
 	b.assertStaticNilDeref(ptr)
 	telem := b.Prog.Elem(ptr.Type)
+	if b.Prog.SizeOf(telem) == 0 {
+		b.AssertNilDeref(ptr)
+		return b.Prog.Zero(telem)
+	}
 	return Expr{llvm.CreateLoad(b.impl, telem.ll, ptr.impl), telem}
 }
 

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -862,6 +862,33 @@ func TestMakeInterfaceFromPtrKinds(t *testing.T) {
 	}
 }
 
+func TestZeroSizedLoadEmitsNilDerefGuard(t *testing.T) {
+	prog := NewProgram(nil)
+	prog.sizes = types.SizesFor("gc", runtime.GOARCH)
+	prog.SetRuntime(func() *types.Package {
+		pkg, err := importer.For("source", nil).Import(PkgRuntime)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return pkg
+	})
+	pkg := prog.NewPackage("bar", "foo/bar")
+
+	emptyStruct := types.NewStruct(nil, nil)
+	params := types.NewTuple(types.NewVar(0, nil, "p", types.NewPointer(emptyStruct)))
+	results := types.NewTuple(types.NewVar(0, nil, "", emptyStruct))
+	sig := types.NewSignatureType(nil, nil, nil, params, results, false)
+	fn := pkg.NewFunc("loadZero", sig, InGo)
+	b := fn.MakeBody(1)
+	b.Return(b.Load(fn.Param(0)))
+	b.EndBuild()
+
+	ir := pkg.Module().String()
+	if !strings.Contains(ir, "AssertNilDeref") {
+		t.Fatalf("zero-sized Load should emit nil-deref guard, got:\n%s", ir)
+	}
+}
+
 func TestTypeAssertSingleElemArrayUsesInsertValue(t *testing.T) {
 	prog := NewProgram(nil)
 	prog.sizes = types.SizesFor("gc", runtime.GOARCH)

--- a/test/go/zero_size_compare_test.go
+++ b/test/go/zero_size_compare_test.go
@@ -1,0 +1,66 @@
+package gotest
+
+import "testing"
+
+type zeroSizeCompareField struct {
+	n int
+	z struct{}
+}
+
+//go:noinline
+func zeroSizeDerefEqual(p, q *struct{}) bool {
+	return *p == *q
+}
+
+//go:noinline
+func zeroSizeFieldEqual(p, q *zeroSizeCompareField) bool {
+	return p.z == q.z
+}
+
+//go:noinline
+func zeroSizeResultEqual(p, q func() struct{}) bool {
+	return p() == q()
+}
+
+func zeroSizeResultEqualInline(p, q func() struct{}) bool {
+	return p() == q()
+}
+
+func TestZeroSizeNilPointerComparisonPanics(t *testing.T) {
+	expectZeroSizeComparePanic(t, func() {
+		zeroSizeDerefEqual(nil, nil)
+	})
+	expectZeroSizeComparePanic(t, func() {
+		zeroSizeFieldEqual(nil, nil)
+	})
+}
+
+func TestZeroSizeFunctionResultComparisonCallsFunctions(t *testing.T) {
+	n := 0
+	inc := func() struct{} {
+		n++
+		return struct{}{}
+	}
+	if !zeroSizeResultEqual(inc, inc) {
+		t.Fatal("zero-sized results should compare equal")
+	}
+	if n != 2 {
+		t.Fatalf("calls after noinline comparison = %d, want 2", n)
+	}
+	if !zeroSizeResultEqualInline(inc, inc) {
+		t.Fatal("zero-sized results should compare equal")
+	}
+	if n != 4 {
+		t.Fatalf("calls after inline comparison = %d, want 4", n)
+	}
+}
+
+func expectZeroSizeComparePanic(t *testing.T, f func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected nil pointer dereference panic")
+		}
+	}()
+	f()
+}

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -2280,10 +2280,6 @@ xfails:
     reason: latest main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
-    case: fixedbugs/issue23837.go
-    reason: latest main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
     case: fixedbugs/issue24491b.go
     reason: latest main goroot run failure on darwin/arm64
   - platform: darwin/arm64
@@ -2408,11 +2404,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: fixedbugs/issue22662.go
-    reason: go1.25 goroot run failure on linux/amd64
-  - version: go1.25
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue23837.go
     reason: go1.25 goroot run failure on linux/amd64
   - version: go1.25
     platform: linux/amd64
@@ -2736,11 +2727,6 @@ xfails:
     case: fixedbugs/issue21879.go
     reason: go1.24 goroot run failure on linux/amd64
   - version: go1.24
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue23837.go
-    reason: go1.24 goroot run failure on linux/amd64
-  - version: go1.24
     platform: darwin/arm64
     directive: run
     case: fixedbugs/issue25897a.go
@@ -2944,11 +2930,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: fixedbugs/issue21879.go
-    reason: go1.26 goroot run failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue23837.go
     reason: go1.26 goroot run failure on linux/amd64
   - version: go1.26
     platform: darwin/arm64


### PR DESCRIPTION
## Summary
- add nil-deref guards for zero-sized loads and zero-sized field derefs
- keep zero-sized function-result comparisons evaluating calls, including nil function panic behavior
- add focused ssa/cl/test-go coverage and remove fixedbugs/issue23837.go xfail entries

## Validation
- go test ./ssa ./cl -run 'TestZeroSized' -count=1
- go run ./cmd/llgo test -run 'TestZeroSize' ./test/go/zero_size_compare_test.go
- go test ./test/go -run 'TestZeroSize' -count=1
- /Users/lijie/sdk/go1.26.0/bin/go test ./test/goroot -run TestGoRootRunCases -count=1 -args -goroot /Users/lijie/sdk/go1.26.0 -go /Users/lijie/sdk/go1.26.0/bin/go -case 'fixedbugs/issue23837\.go' -xfail /tmp/llgo-empty-xfail.yaml
- also verified the same GOROOT case with Go 1.24.11 and Go 1.25.0 locally

Note: package-wide llgo test -run 'TestZeroSize' ./test/go currently fails at link time on existing generic_local_types symbols; the added zero-size test file passes directly.


CI dependency note: Depends on #1892 for the shared `ifaceprom` / nointerface method-table behavior covered by the Go workflow; this PR intentionally keeps the zero-sized dereference fix scoped.
