### PR TITLE
fix panic for nil value method wrappers

### DIFF
--- a/cl/_testdata/foo/foo.go
+++ b/cl/_testdata/foo/foo.go
@@ -1,14 +1,40 @@
 // LITTEST
 package foo
 
-// CHECK-LABEL: define %"github.com/goplus/llgo/runtime/internal/runtime.eface" @"{{.*}}.Bar"(){{.*}} {
-// CHECK:   ret %"github.com/goplus/llgo/runtime/internal/runtime.eface"
+// CHECK-LINE: @6 = private unnamed_addr constant [43 x i8] c"{{.*}}/cl/_testdata/foo.Foo", align 1
+// CHECK-LINE: @7 = private unnamed_addr constant [2 x i8] c"Pb", align 1
+// CHECK-LINE: @8 = private unnamed_addr constant [4 x i8] c"load", align 1
+
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.eface" @"{{.*}}/cl/_testdata/foo.Bar"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = alloca { i64 }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64 }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   store i64 1, ptr %1, align 8
+// CHECK-NEXT:   %2 = load { i64 }, ptr %0, align 8
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT:   store { i64 } %2, ptr %3, align 8
+// CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_struct$K-dZ9QotZfVPz2a0YdRa9vmZUuDXPTqZOlMShKEDJtk", ptr undef }, ptr %3, 1
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.eface" %4
+// CHECK-NEXT: }
+
 func Bar() any {
 	return struct{ V int }{1}
 }
 
-// CHECK-LABEL: define %"github.com/goplus/llgo/runtime/internal/runtime.eface" @"{{.*}}.F"(){{.*}} {
-// CHECK:   ret %"github.com/goplus/llgo/runtime/internal/runtime.eface"
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.eface" @"{{.*}}/cl/_testdata/foo.F"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = alloca { i64 }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64 }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   store i64 1, ptr %1, align 8
+// CHECK-NEXT:   %2 = load { i64 }, ptr %0, align 8
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT:   store { i64 } %2, ptr %3, align 8
+// CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"{{.*}}/cl/_testdata/foo.struct$MYpsoM99ZwFY087IpUOkIw1zjBA_sgFXVodmn1m-G88", ptr undef }, ptr %3, 1
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.eface" %4
+// CHECK-NEXT: }
+
 func F() any {
 	return struct{ v int }{1}
 }
@@ -18,21 +44,16 @@ type Foo struct {
 	F  float32
 }
 
-// CHECK-LABEL: define ptr @"{{.*}}.Foo.Pb"(%"{{.*}}.Foo" %0){{.*}} {
+// CHECK-LABEL: define ptr @"{{.*}}/cl/_testdata/foo.Foo.Pb"(%"{{.*}}/cl/_testdata/foo.Foo" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = alloca %"{{.*}}.Foo", align 8
+// CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testdata/foo.Foo", align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   store %"{{.*}}.Foo" %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}.Foo", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   store %"{{.*}}/cl/_testdata/foo.Foo" %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testdata/foo.Foo", ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
 // CHECK-NEXT:   ret ptr %3
 // CHECK-NEXT: }
-// CHECK-LABEL: define ptr @"{{.*}}.(*Foo).Pb"(ptr %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = load %"{{.*}}.Foo", ptr %0, align 8
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}.Foo.Pb"(%"{{.*}}.Foo" %1)
-// CHECK-NEXT:   ret ptr %2
-// CHECK-NEXT: }
+
 func (v Foo) Pb() *byte {
 	return v.pb
 }
@@ -48,12 +69,46 @@ type Game struct {
 func (g *Game) initGame() {
 }
 
-// CHECK-LABEL: define void @"{{.*}}.(*Game).Load"(ptr %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}.PrintString"(%"{{.*}}.String" { ptr @6, i64 4 })
-// CHECK-NEXT:   call void @"{{.*}}.PrintByte"(i8 10)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 func (g *Game) Load() {
 	println("load")
 }
+
+// CHECK-LABEL: define ptr @"{{.*}}/cl/_testdata/foo.(*Foo).Pb"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 43 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 2 })
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testdata/foo.Foo", ptr %0, align 8
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/cl/_testdata/foo.Foo.Pb"(%"{{.*}}/cl/_testdata/foo.Foo" %2)
+// CHECK-NEXT:   ret ptr %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/foo.(*Game).Load"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @8, i64 4 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/foo.(*Game).initGame"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/foo.init"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testdata/foo.init$guard", align 1
+// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testdata/foo.init$guard", align 1
+// CHECK-NEXT:   br label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.memequal64"(ptr %1, ptr %2)
+// CHECK-NEXT:   ret i1 %3
+// CHECK-NEXT: }

--- a/cl/_testdata/method/in.go
+++ b/cl/_testdata/method/in.go
@@ -3,19 +3,17 @@ package main
 
 import _ "unsafe"
 
+// CHECK-LINE: @0 = private unnamed_addr constant [44 x i8] c"{{.*}}/cl/_testdata/method.T", align 1
+// CHECK-LINE: @1 = private unnamed_addr constant [3 x i8] c"Add", align 1
+
 type T int
 
-// CHECK-LABEL: define i64 @"{{.*}}.T.Add"(i64 %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testdata/method.T.Add"(i64 %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = add i64 %0, %1
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
-// CHECK-LABEL: define i64 @"{{.*}}.(*T).Add"(ptr %0, i64 %1){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}.T.Add"(i64 %2, i64 %1)
-// CHECK-NEXT:   ret i64 %3
-// CHECK-NEXT: }
+
 func (a T) Add(b T) T {
 	return a + b
 }
@@ -25,13 +23,46 @@ func printf(format *int8, __llgo_va_list ...any)
 
 var format = [...]int8{'H', 'e', 'l', 'l', 'o', ' ', '%', 'd', '\n', 0}
 
-// CHECK-LABEL: define void @"{{.*}}.main"(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call i64 @"{{.*}}.T.Add"(i64 1, i64 2)
-// CHECK-NEXT:   call void (ptr, ...) @printf(ptr @"{{.*}}.format", i64 %0)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 func main() {
 	a := T(1)
 	printf(&format[0], a.Add(2))
 }
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testdata/method.(*T).Add"(ptr %0, i64 %1){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %2 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %2, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 44 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 3 })
+// CHECK-NEXT:   %3 = load i64, ptr %0, align 8
+// CHECK-NEXT:   %4 = call i64 @"{{.*}}/cl/_testdata/method.T.Add"(i64 %3, i64 %1)
+// CHECK-NEXT:   ret i64 %4
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/method.init"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testdata/method.init$guard", align 1
+// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testdata/method.init$guard", align 1
+// CHECK-NEXT:   store i8 72, ptr @"{{.*}}/cl/_testdata/method.format", align 1
+// CHECK-NEXT:   store i8 101, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testdata/method.format", i64 1), align 1
+// CHECK-NEXT:   store i8 108, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testdata/method.format", i64 2), align 1
+// CHECK-NEXT:   store i8 108, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testdata/method.format", i64 3), align 1
+// CHECK-NEXT:   store i8 111, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testdata/method.format", i64 4), align 1
+// CHECK-NEXT:   store i8 32, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testdata/method.format", i64 5), align 1
+// CHECK-NEXT:   store i8 37, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testdata/method.format", i64 6), align 1
+// CHECK-NEXT:   store i8 100, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testdata/method.format", i64 7), align 1
+// CHECK-NEXT:   store i8 10, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testdata/method.format", i64 8), align 1
+// CHECK-NEXT:   store i8 0, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testdata/method.format", i64 9), align 1
+// CHECK-NEXT:   br label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testdata/method.main"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call i64 @"{{.*}}/cl/_testdata/method.T.Add"(i64 1, i64 2)
+// CHECK-NEXT:   call void (ptr, ...) @printf(ptr @"{{.*}}/cl/_testdata/method.format", i64 %0)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }

--- a/cl/_testgo/abimethod/in.go
+++ b/cl/_testgo/abimethod/in.go
@@ -8,210 +8,50 @@ import (
 	"unsafe"
 )
 
-// CHECK: @"*{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8" = weak_odr constant { %"{{.*}}/runtime/abi.PtrType", %"{{.*}}/runtime/abi.UncommonType", [3 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -712860747, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 25 }, ptr null }, ptr @"{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8" }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, i16 3, i16 2, i32 24 }, [3 x %"{{.*}}/runtime/abi.Method"] [%"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo1", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo1" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @9, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo2", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo2" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @11, i64 49 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.demo3", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.demo3" }] }, align 8
-// CHECK: @"{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8" = weak_odr constant { %"{{.*}}/runtime/abi.StructType", %"{{.*}}/runtime/abi.UncommonType", [3 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.StructType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 235980794, i8 9, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"{{.*}}/runtime/internal/runtime.structequal", ptr @"{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8" }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 25 }, ptr @"*{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8$fields", i64 2, i64 2 } }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, i16 3, i16 2, i32 24 }, [3 x %"{{.*}}/runtime/abi.Method"] [%"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo1", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo1" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @9, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo2", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo2" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @11, i64 49 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.demo3", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *{{.*}}/_testgo/abimethod.T}.demo3" }] }, align 8
-// CHECK: @"*_llgo_{{.*}}/_testgo/abimethod.T" = weak_odr constant { %"{{.*}}/runtime/abi.PtrType", %"{{.*}}/runtime/abi.UncommonType", [3 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -908752194, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 6 }, ptr null }, ptr @"_llgo_{{.*}}/_testgo/abimethod.T" }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, i16 3, i16 2, i32 24 }, [3 x %"{{.*}}/runtime/abi.Method"] [%"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.(*T).Demo1", ptr @"{{.*}}/_testgo/abimethod.(*T).Demo1" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @9, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.(*T).Demo2", ptr @"{{.*}}/_testgo/abimethod.(*T).Demo2" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @11, i64 49 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.(*T).demo3", ptr @"{{.*}}/_testgo/abimethod.(*T).demo3" }] }, align 8
-// CHECK: @"_llgo_{{.*}}/_testgo/abimethod.T" = weak_odr constant { %"{{.*}}/runtime/abi.StructType", %"{{.*}}/runtime/abi.UncommonType", [1 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.StructType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 0, i32 -666093743, i8 13, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"{{.*}}/runtime/internal/runtime.structequal", ptr @"_llgo_{{.*}}/_testgo/abimethod.T" }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 6 }, ptr @"*_llgo_{{.*}}/_testgo/abimethod.T" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"{{.*}}/_testgo/abimethod.struct$eovYmOhZg4X0zMSsuscSshndnbbAGvB2E3cyG8E7Y4U$fields", i64 1, i64 1 } }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, i16 1, i16 1, i32 24 }, [1 x %"{{.*}}/runtime/abi.Method"] [%"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.(*T).Demo1", ptr @"{{.*}}/_testgo/abimethod.T.Demo1" }] }, align 8
-// CHECK: @"{{.*}}/_testgo/abimethod.struct$eovYmOhZg4X0zMSsuscSshndnbbAGvB2E3cyG8E7Y4U$fields" = weak_odr constant [1 x %"{{.*}}/runtime/abi.StructField"] [%"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 1 }, ptr @_llgo_int, i64 0, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
-// CHECK: @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 2131144854, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @8, i64 10 }, ptr @"*_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA$out", i64 1, i64 1 } }, align 8
-// CHECK: @"*_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1805835775, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @8, i64 10 }, ptr null }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" }, align 8
-// CHECK: @"{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8$fields" = weak_odr constant [2 x %"{{.*}}/runtime/abi.StructField"] [%"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 1 }, ptr @_llgo_int, i64 0, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @4, i64 1 }, ptr @"*_llgo_{{.*}}/_testgo/abimethod.T", i64 8, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 true }], align 8
-// CHECK: @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc" = weak_odr constant %"{{.*}}/runtime/abi.InterfaceType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 -1807485229, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @12, i64 25 }, ptr @"*_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc$imethods", i64 1, i64 1 } }, align 8
-// CHECK: @"*_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 929086049, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @12, i64 25 }, ptr null }, ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc" }, align 8
-// CHECK: @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc$imethods" = weak_odr constant [1 x %"{{.*}}/runtime/abi.Imethod"] [%"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" }], align 8
-// CHECK: @"{{.*}}/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088" = weak_odr constant { %"{{.*}}/runtime/abi.StructType", %"{{.*}}/runtime/abi.UncommonType", [1 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.StructType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 0, i32 179876865, i8 9, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"{{.*}}/runtime/internal/runtime.structequal", ptr @"{{.*}}/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088" }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @16, i64 24 }, ptr @"*{{.*}}/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"{{.*}}/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088$fields", i64 2, i64 2 } }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, i16 1, i16 1, i32 24 }, [1 x %"{{.*}}/runtime/abi.Method"] [%"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; {{.*}}/_testgo/abimethod.T}.Demo1", ptr @"{{.*}}/_testgo/abimethod.struct{m int; {{.*}}/_testgo/abimethod.T}.Demo1" }] }, align 8
-// CHECK: @"*{{.*}}/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088" = weak_odr constant { %"{{.*}}/runtime/abi.PtrType", %"{{.*}}/runtime/abi.UncommonType", [3 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -343027978, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @16, i64 24 }, ptr null }, ptr @"{{.*}}/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088" }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, i16 3, i16 2, i32 24 }, [3 x %"{{.*}}/runtime/abi.Method"] [%"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; {{.*}}/_testgo/abimethod.T}.Demo1", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; {{.*}}/_testgo/abimethod.T}.Demo1" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @9, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; {{.*}}/_testgo/abimethod.T}.Demo2", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; {{.*}}/_testgo/abimethod.T}.Demo2" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @11, i64 49 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; {{.*}}/_testgo/abimethod.T}.demo3", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; {{.*}}/_testgo/abimethod.T}.demo3" }] }, align 8
-// CHECK: @"{{.*}}/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088$fields" = weak_odr constant [2 x %"{{.*}}/runtime/abi.StructField"] [%"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 1 }, ptr @_llgo_int, i64 0, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @4, i64 1 }, ptr @"_llgo_{{.*}}/_testgo/abimethod.T", i64 8, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 true }], align 8
-// CHECK: @"_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4" = weak_odr constant %"{{.*}}/runtime/abi.InterfaceType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 1090904853, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @19, i64 25 }, ptr @"*_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4$imethods", i64 1, i64 1 } }, align 8
-// CHECK: @"*_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1063382362, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @19, i64 25 }, ptr null }, ptr @"_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4" }, align 8
-// CHECK: @"_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4$imethods" = weak_odr constant [1 x %"{{.*}}/runtime/abi.Imethod"] [%"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @9, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" }], align 8
-// CHECK: @"_llgo_iface$58AxoxqQ6sGUOM73FOqFrXsMlgxkU4HGd-S1Wl-ssYw" = weak_odr constant %"{{.*}}/runtime/abi.InterfaceType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 541709743, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 38 }, ptr @"*_llgo_iface$58AxoxqQ6sGUOM73FOqFrXsMlgxkU4HGd-S1Wl-ssYw" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$58AxoxqQ6sGUOM73FOqFrXsMlgxkU4HGd-S1Wl-ssYw$imethods", i64 2, i64 2 } }, align 8
-// CHECK: @"*_llgo_iface$58AxoxqQ6sGUOM73FOqFrXsMlgxkU4HGd-S1Wl-ssYw" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 945986433, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 38 }, ptr null }, ptr @"_llgo_iface$58AxoxqQ6sGUOM73FOqFrXsMlgxkU4HGd-S1Wl-ssYw" }, align 8
-// CHECK: @"_llgo_iface$58AxoxqQ6sGUOM73FOqFrXsMlgxkU4HGd-S1Wl-ssYw$imethods" = weak_odr constant [2 x %"{{.*}}/runtime/abi.Imethod"] [%"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" }, %"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @9, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" }], align 8
-// CHECK: @"{{.*}}/_testgo/abimethod.iface$kT5SIXt45Cspjl04Bof3DZVSOIltlDo-njpk6KqtZvA" = weak_odr constant %"{{.*}}/runtime/abi.InterfaceType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 -601152795, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @24, i64 56 }, ptr @"*{{.*}}/_testgo/abimethod.iface$kT5SIXt45Cspjl04Bof3DZVSOIltlDo-njpk6KqtZvA" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"{{.*}}/_testgo/abimethod.iface$kT5SIXt45Cspjl04Bof3DZVSOIltlDo-njpk6KqtZvA$imethods", i64 3, i64 3 } }, align 8
-// CHECK: @"*{{.*}}/_testgo/abimethod.iface$kT5SIXt45Cspjl04Bof3DZVSOIltlDo-njpk6KqtZvA" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 162233315, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @24, i64 56 }, ptr null }, ptr @"{{.*}}/_testgo/abimethod.iface$kT5SIXt45Cspjl04Bof3DZVSOIltlDo-njpk6KqtZvA" }, align 8
-// CHECK: @"{{.*}}/_testgo/abimethod.iface$kT5SIXt45Cspjl04Bof3DZVSOIltlDo-njpk6KqtZvA$imethods" = weak_odr constant [3 x %"{{.*}}/runtime/abi.Imethod"] [%"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" }, %"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @9, i64 5 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" }, %"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @11, i64 49 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA" }], align 8
-// CHECK: @"*{{.*}}/_testgo/abimethod.struct$RGW016k7zllXgGPm1CvD5-IBe-9lphOOTCFtYyDGLjY" = weak_odr constant { %"{{.*}}/runtime/abi.PtrType", %"{{.*}}/runtime/abi.UncommonType", [27 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1554050967, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @27, i64 31 }, ptr null }, ptr @"{{.*}}/_testgo/abimethod.struct$RGW016k7zllXgGPm1CvD5-IBe-9lphOOTCFtYyDGLjY" }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, i16 27, i16 23, i32 24 }, [27 x %"{{.*}}/runtime/abi.Method"] [%"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @37, i64 9 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Available", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Available" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @38, i64 15 }, ptr @"_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.AvailableBuffer", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.AvailableBuffer" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @40, i64 5 }, ptr @"_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Bytes", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Bytes" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @41, i64 3 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Cap", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Cap" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @42, i64 4 }, ptr @"_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Grow", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Grow" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @44, i64 3 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Len", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Len" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @45, i64 4 }, ptr @"_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Next", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Next" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @47, i64 4 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Read", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Read" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @52, i64 8 }, ptr @"_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadByte", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadByte" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @54, i64 9 }, ptr @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadBytes", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadBytes" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @56, i64 8 }, ptr @"_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadFrom", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadFrom" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @60, i64 8 }, ptr @"_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadRune", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadRune" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @63, i64 10 }, ptr @"_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadString", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadString" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @65, i64 5 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Reset", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Reset" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @67, i64 6 }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.String", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.String" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @68, i64 8 }, ptr @"_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Truncate", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Truncate" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @69, i64 10 }, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadByte", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadByte" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @71, i64 10 }, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadRune", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadRune" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @72, i64 5 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Write", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Write" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @73, i64 9 }, ptr @"_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteByte", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteByte" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @75, i64 9 }, ptr @"_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteRune", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteRune" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @77, i64 11 }, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteString", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteString" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @79, i64 7 }, ptr @"_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteTo", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteTo" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @83, i64 11 }, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.empty", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.empty" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @87, i64 10 }, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.grow", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.grow" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @90, i64 15 }, ptr @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.readSlice", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.readSlice" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @92, i64 22 }, ptr @"_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.tryGrowByReslice", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.tryGrowByReslice" }] }, align 8
-// CHECK: @"{{.*}}/_testgo/abimethod.struct$RGW016k7zllXgGPm1CvD5-IBe-9lphOOTCFtYyDGLjY" = weak_odr constant { %"{{.*}}/runtime/abi.StructType", %"{{.*}}/runtime/abi.UncommonType", [27 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.StructType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 -1137763463, i8 9, i8 8, i8 8, i8 25, { ptr, ptr } { ptr @"{{.*}}/runtime/internal/runtime.structequal", ptr @"{{.*}}/_testgo/abimethod.struct$RGW016k7zllXgGPm1CvD5-IBe-9lphOOTCFtYyDGLjY" }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @27, i64 31 }, ptr @"*{{.*}}/_testgo/abimethod.struct$RGW016k7zllXgGPm1CvD5-IBe-9lphOOTCFtYyDGLjY" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"{{.*}}/_testgo/abimethod.struct$RGW016k7zllXgGPm1CvD5-IBe-9lphOOTCFtYyDGLjY$fields", i64 2, i64 2 } }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, i16 27, i16 23, i32 24 }, [27 x %"{{.*}}/runtime/abi.Method"] [%"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @37, i64 9 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Available", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Available" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @38, i64 15 }, ptr @"_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.AvailableBuffer", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.AvailableBuffer" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @40, i64 5 }, ptr @"_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Bytes", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Bytes" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @41, i64 3 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Cap", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Cap" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @42, i64 4 }, ptr @"_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Grow", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Grow" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @44, i64 3 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Len", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Len" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @45, i64 4 }, ptr @"_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Next", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Next" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @47, i64 4 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Read", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Read" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @52, i64 8 }, ptr @"_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadByte", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadByte" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @54, i64 9 }, ptr @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadBytes", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadBytes" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @56, i64 8 }, ptr @"_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadFrom", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadFrom" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @60, i64 8 }, ptr @"_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadRune", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadRune" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @63, i64 10 }, ptr @"_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadString", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadString" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @65, i64 5 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Reset", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Reset" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @67, i64 6 }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.String", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.String" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @68, i64 8 }, ptr @"_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Truncate", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Truncate" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @69, i64 10 }, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadByte", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.UnreadByte" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @71, i64 10 }, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadRune", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.UnreadRune" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @72, i64 5 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Write", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Write" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @73, i64 9 }, ptr @"_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteByte", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteByte" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @75, i64 9 }, ptr @"_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteRune", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteRune" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @77, i64 11 }, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteString", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteString" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @79, i64 7 }, ptr @"_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteTo", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteTo" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @83, i64 11 }, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.empty", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.empty" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @87, i64 10 }, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.grow", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.grow" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @90, i64 15 }, ptr @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.readSlice", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.readSlice" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @92, i64 22 }, ptr @"_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M", ptr @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.tryGrowByReslice", ptr @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.tryGrowByReslice" }] }, align 8
-// CHECK: @"*_llgo_bytes.Buffer" = weak_odr constant { %"{{.*}}/runtime/abi.PtrType", %"{{.*}}/runtime/abi.UncommonType", [27 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 258663788, i8 11, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @29, i64 12 }, ptr null }, ptr @_llgo_bytes.Buffer }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @30, i64 5 }, i16 27, i16 23, i32 24 }, [27 x %"{{.*}}/runtime/abi.Method"] [%"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @37, i64 9 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"bytes.(*Buffer).Available", ptr @"bytes.(*Buffer).Available" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @38, i64 15 }, ptr @"_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY", ptr @"bytes.(*Buffer).AvailableBuffer", ptr @"bytes.(*Buffer).AvailableBuffer" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @40, i64 5 }, ptr @"_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY", ptr @"bytes.(*Buffer).Bytes", ptr @"bytes.(*Buffer).Bytes" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @41, i64 3 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"bytes.(*Buffer).Cap", ptr @"bytes.(*Buffer).Cap" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @42, i64 4 }, ptr @"_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA", ptr @"bytes.(*Buffer).Grow", ptr @"bytes.(*Buffer).Grow" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @44, i64 3 }, ptr @"_llgo_func$ETeB8WwW04JEq0ztcm-XPTJtuYvtpkjIsAc0-2NT9zA", ptr @"bytes.(*Buffer).Len", ptr @"bytes.(*Buffer).Len" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @45, i64 4 }, ptr @"_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY", ptr @"bytes.(*Buffer).Next", ptr @"bytes.(*Buffer).Next" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @47, i64 4 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk", ptr @"bytes.(*Buffer).Read", ptr @"bytes.(*Buffer).Read" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @52, i64 8 }, ptr @"_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ", ptr @"bytes.(*Buffer).ReadByte", ptr @"bytes.(*Buffer).ReadByte" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @54, i64 9 }, ptr @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0", ptr @"bytes.(*Buffer).ReadBytes", ptr @"bytes.(*Buffer).ReadBytes" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @56, i64 8 }, ptr @"_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8", ptr @"bytes.(*Buffer).ReadFrom", ptr @"bytes.(*Buffer).ReadFrom" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @60, i64 8 }, ptr @"_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y", ptr @"bytes.(*Buffer).ReadRune", ptr @"bytes.(*Buffer).ReadRune" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @63, i64 10 }, ptr @"_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o", ptr @"bytes.(*Buffer).ReadString", ptr @"bytes.(*Buffer).ReadString" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @65, i64 5 }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac", ptr @"bytes.(*Buffer).Reset", ptr @"bytes.(*Buffer).Reset" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @67, i64 6 }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to", ptr @"bytes.(*Buffer).String", ptr @"bytes.(*Buffer).String" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @68, i64 8 }, ptr @"_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA", ptr @"bytes.(*Buffer).Truncate", ptr @"bytes.(*Buffer).Truncate" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @69, i64 10 }, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", ptr @"bytes.(*Buffer).UnreadByte", ptr @"bytes.(*Buffer).UnreadByte" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @71, i64 10 }, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w", ptr @"bytes.(*Buffer).UnreadRune", ptr @"bytes.(*Buffer).UnreadRune" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @72, i64 5 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk", ptr @"bytes.(*Buffer).Write", ptr @"bytes.(*Buffer).Write" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @73, i64 9 }, ptr @"_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg", ptr @"bytes.(*Buffer).WriteByte", ptr @"bytes.(*Buffer).WriteByte" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @75, i64 9 }, ptr @"_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw", ptr @"bytes.(*Buffer).WriteRune", ptr @"bytes.(*Buffer).WriteRune" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @77, i64 11 }, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw", ptr @"bytes.(*Buffer).WriteString", ptr @"bytes.(*Buffer).WriteString" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @79, i64 7 }, ptr @"_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M", ptr @"bytes.(*Buffer).WriteTo", ptr @"bytes.(*Buffer).WriteTo" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @83, i64 11 }, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk", ptr @"bytes.(*Buffer).empty", ptr @"bytes.(*Buffer).empty" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @87, i64 10 }, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU", ptr @"bytes.(*Buffer).grow", ptr @"bytes.(*Buffer).grow" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @90, i64 15 }, ptr @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0", ptr @"bytes.(*Buffer).readSlice", ptr @"bytes.(*Buffer).readSlice" }, %"{{.*}}/runtime/abi.Method" { %"{{.*}}/runtime/internal/runtime.String" { ptr @92, i64 22 }, ptr @"_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M", ptr @"bytes.(*Buffer).tryGrowByReslice", ptr @"bytes.(*Buffer).tryGrowByReslice" }] }, align 8
-// CHECK: @_llgo_bytes.Buffer = weak_odr constant { %"{{.*}}/runtime/abi.StructType", %"{{.*}}/runtime/abi.UncommonType", [0 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.StructType" { %"{{.*}}/runtime/abi.Type" { i64 40, i64 0, i32 661676552, i8 5, i8 8, i8 8, i8 25, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @29, i64 12 }, ptr @"*_llgo_bytes.Buffer" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @30, i64 5 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"bytes.struct$8M6lRFZ7Fk2XCr2laNI9Y7uQtk2A8VDBrezMuq2Fkuo$fields", i64 3, i64 3 } }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @30, i64 5 }, i16 0, i16 0, i32 24 }, [0 x %"{{.*}}/runtime/abi.Method"] zeroinitializer }, align 8
-// CHECK: @"[]_llgo_uint8" = weak_odr constant %"{{.*}}/runtime/abi.SliceType" { %"{{.*}}/runtime/abi.Type" { i64 24, i64 8, i32 370346748, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @32, i64 7 }, ptr @"*[]_llgo_uint8" }, ptr @_llgo_uint8 }, align 8
-// CHECK: @"*[]_llgo_uint8" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -2143776929, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @32, i64 7 }, ptr null }, ptr @"[]_llgo_uint8" }, align 8
-// CHECK: @_llgo_uint8 = weak_odr constant %"{{.*}}/runtime/abi.Type" { i64 1, i64 0, i32 269156761, i8 12, i8 1, i8 1, i8 8, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequal8", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @33, i64 5 }, ptr @"*_llgo_uint8" }, align 8
-// CHECK: @"*_llgo_uint8" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1277858201, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @33, i64 5 }, ptr null }, ptr @_llgo_uint8 }, align 8
-// CHECK: @_llgo_bytes.readOp = weak_odr constant { %"{{.*}}/runtime/abi.Type", %"{{.*}}/runtime/abi.UncommonType", [0 x %"{{.*}}/runtime/abi.Method"] } { %"{{.*}}/runtime/abi.Type" { i64 1, i64 0, i32 1507423333, i8 13, i8 1, i8 1, i8 3, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequal8", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @36, i64 12 }, ptr @"*_llgo_bytes.readOp" }, %"{{.*}}/runtime/abi.UncommonType" { %"{{.*}}/runtime/internal/runtime.String" { ptr @30, i64 5 }, i16 0, i16 0, i32 24 }, [0 x %"{{.*}}/runtime/abi.Method"] zeroinitializer }, align 8
-// CHECK: @"*_llgo_bytes.readOp" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1082688598, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @36, i64 12 }, ptr null }, ptr @_llgo_bytes.readOp }, align 8
-// CHECK: @"bytes.struct$8M6lRFZ7Fk2XCr2laNI9Y7uQtk2A8VDBrezMuq2Fkuo$fields" = weak_odr constant [3 x %"{{.*}}/runtime/abi.StructField"] [%"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @31, i64 3 }, ptr @"[]_llgo_uint8", i64 0, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @34, i64 3 }, ptr @_llgo_int, i64 24, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @35, i64 8 }, ptr @_llgo_bytes.readOp, i64 32, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
-// CHECK: @"_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -153447421, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @39, i64 14 }, ptr @"*_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY" }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY$out", i64 1, i64 1 } }, align 8
-// CHECK: @"*_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1574747178, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @39, i64 14 }, ptr null }, ptr @"_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY" }, align 8
-// CHECK: @"_llgo_func$Z_-7GWzB37LCYRTQLsSYmEihg_hqBK8o_GbT88pqnPY$out" = weak_odr constant [1 x ptr] [ptr @"[]_llgo_uint8"], align 8
-// CHECK: @"_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -637187458, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @43, i64 9 }, ptr @"*_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer }, align 8
-// CHECK: @"*_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 735356155, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @43, i64 9 }, ptr null }, ptr @"_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA" }, align 8
-// CHECK: @"_llgo_func$VZ-8VPNF1RaLICwxc1Ghn7BbgyFX3v762OCdx127EkA$in" = weak_odr constant [1 x ptr] [ptr @_llgo_int], align 8
-// CHECK: @"_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -875118098, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @46, i64 17 }, ptr @"*_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY$out", i64 1, i64 1 } }, align 8
-// CHECK: @"*_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1809495648, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @46, i64 17 }, ptr null }, ptr @"_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY" }, align 8
-// CHECK: @"_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY$in" = weak_odr constant [1 x ptr] [ptr @_llgo_int], align 8
-// CHECK: @"_llgo_func$d4kMA_oCkLwnd1j8nVlv1hwRarEVuCIrDCpnHhDz9UY$out" = weak_odr constant [1 x ptr] [ptr @"[]_llgo_uint8"], align 8
-// CHECK: @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -58533757, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @48, i64 26 }, ptr @"*_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk$out", i64 2, i64 2 } }, align 8
-// CHECK: @"*_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1244675479, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @48, i64 26 }, ptr null }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk" }, align 8
-// CHECK: @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk$in" = weak_odr constant [1 x ptr] [ptr @"[]_llgo_uint8"], align 8
-// CHECK: @_llgo_error = weak_odr constant %"{{.*}}/runtime/abi.InterfaceType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 -1462738452, i8 4, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @49, i64 5 }, ptr @"*_llgo_error" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU$imethods", i64 1, i64 1 } }, align 8
-// CHECK: @"*_llgo_error" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1621558991, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @49, i64 5 }, ptr null }, ptr @_llgo_error }, align 8
-// CHECK: @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1419376263, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @51, i64 13 }, ptr @"*_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to$out", i64 1, i64 1 } }, align 8
-// CHECK: @"*_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1900367307, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @51, i64 13 }, ptr null }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" }, align 8
-// CHECK: @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to$out" = weak_odr constant [1 x ptr] [ptr @_llgo_string], align 8
-// CHECK: @"_llgo_iface$Fh8eUJ-Gw4e6TYuajcFIOSCuqSPKAt5nS4ow7xeGXEU$imethods" = weak_odr constant [1 x %"{{.*}}/runtime/abi.Imethod"] [%"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @50, i64 5 }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" }], align 8
-// CHECK: @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk$out" = weak_odr constant [2 x ptr] [ptr @_llgo_int, ptr @_llgo_error], align 8
-// CHECK: @"_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1499372428, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @53, i64 21 }, ptr @"*_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ" }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ$out", i64 2, i64 2 } }, align 8
-// CHECK: @"*_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1164205677, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @53, i64 21 }, ptr null }, ptr @"_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ" }, align 8
-// CHECK: @"_llgo_func$lukqSsfDYBoIp_R8GMojGkZnrYDqaq2iHn8RkCjW7iQ$out" = weak_odr constant [2 x ptr] [ptr @_llgo_uint8, ptr @_llgo_error], align 8
-// CHECK: @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1659702664, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @55, i64 28 }, ptr @"*_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0$out", i64 2, i64 2 } }, align 8
-// CHECK: @"*_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 2010891442, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @55, i64 28 }, ptr null }, ptr @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0" }, align 8
-// CHECK: @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0$in" = weak_odr constant [1 x ptr] [ptr @_llgo_uint8], align 8
-// CHECK: @"_llgo_func$aJkaU3jhXr0Q2QraTe2_TTdupeMMW2MD66UwBxynRM0$out" = weak_odr constant [2 x ptr] [ptr @"[]_llgo_uint8", ptr @_llgo_error], align 8
-// CHECK: @"_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1635781323, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @57, i64 30 }, ptr @"*_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8$out", i64 2, i64 2 } }, align 8
-// CHECK: @"*_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1930979199, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @57, i64 30 }, ptr null }, ptr @"_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8" }, align 8
-// CHECK: @_llgo_io.Reader = weak_odr constant %"{{.*}}/runtime/abi.InterfaceType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 -1885455791, i8 4, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @58, i64 9 }, ptr @"*_llgo_io.Reader" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw$imethods", i64 1, i64 1 } }, align 8
-// CHECK: @"*_llgo_io.Reader" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 760453616, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @58, i64 9 }, ptr null }, ptr @_llgo_io.Reader }, align 8
-// CHECK: @"_llgo_iface$uycIKA3bbxRhudEjW1hHKWKdLqHQsCVy8NdW1bkQmNw$imethods" = weak_odr constant [1 x %"{{.*}}/runtime/abi.Imethod"] [%"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @47, i64 4 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk" }], align 8
-// CHECK: @"_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8$in" = weak_odr constant [1 x ptr] [ptr @_llgo_io.Reader], align 8
-// CHECK: @_llgo_int64 = weak_odr constant %"{{.*}}/runtime/abi.Type" { i64 8, i64 0, i32 394795202, i8 12, i8 8, i8 8, i8 6, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequal64", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @59, i64 5 }, ptr @"*_llgo_int64" }, align 8
-// CHECK: @"*_llgo_int64" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1901231210, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @59, i64 5 }, ptr null }, ptr @_llgo_int64 }, align 8
-// CHECK: @"_llgo_func$uVmBDI0DMcrui3Q9y-g_hbtVN8JckQ18V2wmO5_G7A8$out" = weak_odr constant [2 x ptr] [ptr @_llgo_int64, ptr @_llgo_error], align 8
-// CHECK: @"_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1043083527, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @61, i64 26 }, ptr @"*_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y" }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y$out", i64 3, i64 3 } }, align 8
-// CHECK: @"*_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 746645372, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @61, i64 26 }, ptr null }, ptr @"_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y" }, align 8
-// CHECK: @_llgo_int32 = weak_odr constant %"{{.*}}/runtime/abi.Type" { i64 4, i64 0, i32 1448558410, i8 12, i8 4, i8 4, i8 5, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequal32", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @62, i64 5 }, ptr @"*_llgo_int32" }, align 8
-// CHECK: @"*_llgo_int32" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -38689692, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @62, i64 5 }, ptr null }, ptr @_llgo_int32 }, align 8
-// CHECK: @"_llgo_func$q-bw-_pPYBCXnr1TXIF8sOD4fVVzzIlpHqD-A13AB4Y$out" = weak_odr constant [3 x ptr] [ptr @_llgo_int32, ptr @_llgo_int, ptr @_llgo_error], align 8
-// CHECK: @"_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 2138446355, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @64, i64 27 }, ptr @"*_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o$out", i64 2, i64 2 } }, align 8
-// CHECK: @"*_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1932918037, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @64, i64 27 }, ptr null }, ptr @"_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o" }, align 8
-// CHECK: @"_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o$in" = weak_odr constant [1 x ptr] [ptr @_llgo_uint8], align 8
-// CHECK: @"_llgo_func$TBlCn7YTQdraI1HMiBWmkrqIGG-8UgD1UVyJy62Z_0o$out" = weak_odr constant [2 x ptr] [ptr @_llgo_string, ptr @_llgo_error], align 8
-// CHECK: @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1790696805, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @66, i64 6 }, ptr @"*_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac" }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer }, align 8
-// CHECK: @"*_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -130179135, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @66, i64 6 }, ptr null }, ptr @"_llgo_func$2_iS07vIlF2_rZqWB5eU0IvP_9HviM4MYZNkXZDvbac" }, align 8
-// CHECK: @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1183719404, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @70, i64 12 }, ptr @"*_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w" }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w$out", i64 1, i64 1 } }, align 8
-// CHECK: @"*_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1571491799, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @70, i64 12 }, ptr null }, ptr @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w" }, align 8
-// CHECK: @"_llgo_func$8rsrSd_r3UHd_2DiYTyaOKR7BYkei4zw5ysG35KF38w$out" = weak_odr constant [1 x ptr] [ptr @_llgo_error], align 8
-// CHECK: @"_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1226479232, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @74, i64 17 }, ptr @"*_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg$out", i64 1, i64 1 } }, align 8
-// CHECK: @"*_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 513101056, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @74, i64 17 }, ptr null }, ptr @"_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg" }, align 8
-// CHECK: @"_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg$in" = weak_odr constant [1 x ptr] [ptr @_llgo_uint8], align 8
-// CHECK: @"_llgo_func$w4tN9iibS_UimF5vLUWoKP0uAk2tJZF26VqETo_8LVg$out" = weak_odr constant [1 x ptr] [ptr @_llgo_error], align 8
-// CHECK: @"_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1027172853, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @76, i64 24 }, ptr @"*_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw$out", i64 2, i64 2 } }, align 8
-// CHECK: @"*_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -841225112, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @76, i64 24 }, ptr null }, ptr @"_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw" }, align 8
-// CHECK: @"_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw$in" = weak_odr constant [1 x ptr] [ptr @_llgo_int32], align 8
-// CHECK: @"_llgo_func$uf8yw1UkUdbDuCneSpNKIq_NThWIEVE7f1IYfJGz_bw$out" = weak_odr constant [2 x ptr] [ptr @_llgo_int, ptr @_llgo_error], align 8
-// CHECK: @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -183202291, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @78, i64 25 }, ptr @"*_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw$out", i64 2, i64 2 } }, align 8
-// CHECK: @"*_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1229992101, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @78, i64 25 }, ptr null }, ptr @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw" }, align 8
-// CHECK: @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw$in" = weak_odr constant [1 x ptr] [ptr @_llgo_string], align 8
-// CHECK: @"_llgo_func$thH5FBpdXzJNnCpSfiLU5ItTntFU6LWp0RJhDm2XJjw$out" = weak_odr constant [2 x ptr] [ptr @_llgo_int, ptr @_llgo_error], align 8
-// CHECK: @"_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1753174026, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @80, i64 30 }, ptr @"*_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M$out", i64 2, i64 2 } }, align 8
-// CHECK: @"*_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1055881531, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @80, i64 30 }, ptr null }, ptr @"_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M" }, align 8
-// CHECK: @_llgo_io.Writer = weak_odr constant %"{{.*}}/runtime/abi.InterfaceType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 1423852385, i8 4, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @81, i64 9 }, ptr @"*_llgo_io.Writer" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$kr1iSWwMezh0B9LdQN0MhEZUNZvBlHPhlst95jAyxE0$imethods", i64 1, i64 1 } }, align 8
-// CHECK: @"*_llgo_io.Writer" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1477879550, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @81, i64 9 }, ptr null }, ptr @_llgo_io.Writer }, align 8
-// CHECK: @"_llgo_iface$kr1iSWwMezh0B9LdQN0MhEZUNZvBlHPhlst95jAyxE0$imethods" = weak_odr constant [1 x %"{{.*}}/runtime/abi.Imethod"] [%"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @72, i64 5 }, ptr @"_llgo_func$G2hch9Iy9DrhKKsg70PbL54bK-XSl-1IUUORN17J2Dk" }], align 8
-// CHECK: @"_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M$in" = weak_odr constant [1 x ptr] [ptr @_llgo_io.Writer], align 8
-// CHECK: @"_llgo_func$vSv85k0UY6JWccAc3T-lvdCx9J-4GM-oZC9zGLrxW1M$out" = weak_odr constant [2 x ptr] [ptr @_llgo_int64, ptr @_llgo_error], align 8
-// CHECK: @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -541022001, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @84, i64 11 }, ptr @"*_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk" }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk$out", i64 1, i64 1 } }, align 8
-// CHECK: @"*_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -367308996, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @84, i64 11 }, ptr null }, ptr @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk" }, align 8
-// CHECK: @_llgo_bool = weak_odr constant %"{{.*}}/runtime/abi.Type" { i64 1, i64 0, i32 554183389, i8 12, i8 1, i8 1, i8 1, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequal8", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @85, i64 4 }, ptr @"*_llgo_bool" }, align 8
-// CHECK: @"*_llgo_bool" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1896950390, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @85, i64 4 }, ptr null }, ptr @_llgo_bool }, align 8
-// CHECK: @"_llgo_func$YHeRw3AOvQtzv982-ZO3Yn8vh3Fx89RM3VvI8E4iKVk$out" = weak_odr constant [1 x ptr] [ptr @_llgo_bool], align 8
-// CHECK: @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1134531106, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @88, i64 13 }, ptr @"*_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU$out", i64 1, i64 1 } }, align 8
-// CHECK: @"*_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1763581361, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @88, i64 13 }, ptr null }, ptr @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU" }, align 8
-// CHECK: @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU$in" = weak_odr constant [1 x ptr] [ptr @_llgo_int], align 8
-// CHECK: @"_llgo_func$ekGNsrYBSzltfAjxbl6T8H6Yq8j16wzqS3nDj2xxGMU$out" = weak_odr constant [1 x ptr] [ptr @_llgo_int], align 8
-// CHECK: @"_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 559523889, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @93, i64 21 }, ptr @"*_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M$out", i64 2, i64 2 } }, align 8
-// CHECK: @"*_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1842714480, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @93, i64 21 }, ptr null }, ptr @"_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M" }, align 8
-// CHECK: @"_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M$in" = weak_odr constant [1 x ptr] [ptr @_llgo_int], align 8
-// CHECK: @"_llgo_func$qVJ5SH6qhXP_h0AM41vpBGzQEMp-fQIfvwQEJy5NI8M$out" = weak_odr constant [2 x ptr] [ptr @_llgo_int, ptr @_llgo_bool], align 8
-// CHECK: @"{{.*}}/_testgo/abimethod.struct$RGW016k7zllXgGPm1CvD5-IBe-9lphOOTCFtYyDGLjY$fields" = weak_odr constant [2 x %"{{.*}}/runtime/abi.StructField"] [%"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 1 }, ptr @_llgo_int, i64 0, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @28, i64 6 }, ptr @"*_llgo_bytes.Buffer", i64 8, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 true }], align 8
-// CHECK: @"_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U" = weak_odr constant %"{{.*}}/runtime/abi.InterfaceType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 -195205541, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @94, i64 29 }, ptr @"*_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U$imethods", i64 1, i64 1 } }, align 8
-// CHECK: @"*_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 876051709, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @94, i64 29 }, ptr null }, ptr @"_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U" }, align 8
-// CHECK: @"_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U$imethods" = weak_odr constant [1 x %"{{.*}}/runtime/abi.Imethod"] [%"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @67, i64 6 }, ptr @"_llgo_func$zNDVRsWTIpUPKouNUS805RGX--IV9qVK8B31IZbg5to" }], align 8
-// CHECK: @"*_llgo_{{.*}}/_testgo/abimethod.Pointer[any]" = weak_odr constant { %"{{.*}}/runtime/abi.PtrType", %"{{.*}}/runtime/abi.UncommonType", [2 x %"{{.*}}/runtime/abi.Method"] }
-// CHECK: ptr @"{{.*}}/_testgo/abimethod.(*Pointer[any]).Load"
-// CHECK: ptr @"{{.*}}/_testgo/abimethod.(*Pointer[any]).Store"
-// CHECK: @"_llgo_{{.*}}/_testgo/abimethod.Pointer[any]" = weak_odr constant { %"{{.*}}/runtime/abi.StructType", %"{{.*}}/runtime/abi.UncommonType", [0 x %"{{.*}}/runtime/abi.Method"] }
-// CHECK: @"[0]*_llgo_any" = weak_odr constant %"{{.*}}/runtime/abi.ArrayType" { %"{{.*}}/runtime/abi.Type" { i64 0, i64 0, i32 -1235244625, i8 8, i8 8, i8 8, i8 17, { ptr, ptr } { ptr @"{{.*}}/runtime/internal/runtime.arrayequal", ptr @"[0]*_llgo_any" }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @98, i64 16 }, ptr @"*[0]*_llgo_any" }, ptr @"*_llgo_any", ptr @"[]*_llgo_any", i64 0 }, align 8
-// CHECK: @"*[0]*_llgo_any" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1487017406, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @98, i64 16 }, ptr null }, ptr @"[0]*_llgo_any" }, align 8
-// CHECK: @"*_llgo_any" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1741196194, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @99, i64 12 }, ptr null }, ptr @_llgo_any }, align 8
-// CHECK: @_llgo_any = weak_odr constant %"{{.*}}/runtime/abi.InterfaceType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 1376530322, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.nilinterequal", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @99, i64 12 }, ptr @"*_llgo_any" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer }, align 8
-// CHECK: @"[]*_llgo_any" = weak_odr constant %"{{.*}}/runtime/abi.SliceType" { %"{{.*}}/runtime/abi.Type" { i64 24, i64 8, i32 1393026359, i8 0, i8 8, i8 8, i8 23, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @100, i64 15 }, ptr @"*[]*_llgo_any" }, ptr @"*_llgo_any" }, align 8
-// CHECK: @"*[]*_llgo_any" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1459791968, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @100, i64 15 }, ptr null }, ptr @"[]*_llgo_any" }, align 8
-// CHECK: @_llgo_Pointer = weak_odr constant %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 507576105, i8 12, i8 8, i8 8, i8 58, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @102, i64 14 }, ptr @"*_llgo_Pointer" }, align 8
-// CHECK: @"*_llgo_Pointer" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1134390089, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @102, i64 14 }, ptr null }, ptr @_llgo_Pointer }, align 8
-// CHECK: @"{{.*}}/_testgo/abimethod.struct$WF_Ikp6H-8IyobSlL849gp6AslXPTyT8oKnkzqHD2NA$fields" = weak_odr constant [2 x %"{{.*}}/runtime/abi.StructField"] [%"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @97, i64 1 }, ptr @"[0]*_llgo_any", i64 0, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 false }, %"{{.*}}/runtime/abi.StructField" { %"{{.*}}/runtime/internal/runtime.String" { ptr @101, i64 1 }, ptr @_llgo_Pointer, i64 0, %"{{.*}}/runtime/internal/runtime.String" zeroinitializer, i1 false }], align 8
-// CHECK: @"_llgo_func$oqZ09zjnrQRdlivNw60EomwRoboDQbCk5_Y4MGDpQMQ" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 1908794164, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @104, i64 20 }, ptr @"*_llgo_func$oqZ09zjnrQRdlivNw60EomwRoboDQbCk5_Y4MGDpQMQ" }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$oqZ09zjnrQRdlivNw60EomwRoboDQbCk5_Y4MGDpQMQ$out", i64 1, i64 1 } }, align 8
-// CHECK: @"*_llgo_func$oqZ09zjnrQRdlivNw60EomwRoboDQbCk5_Y4MGDpQMQ" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 709309578, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @104, i64 20 }, ptr null }, ptr @"_llgo_func$oqZ09zjnrQRdlivNw60EomwRoboDQbCk5_Y4MGDpQMQ" }, align 8
-// CHECK: @"_llgo_func$oqZ09zjnrQRdlivNw60EomwRoboDQbCk5_Y4MGDpQMQ$out" = weak_odr constant [1 x ptr] [ptr @"*_llgo_any"], align 8
-// CHECK: @"_llgo_func$Y8Pl6IHgSDuynhMRTXPlqFo9zl71SSTuMe0Wi5m8eWw" = weak_odr constant %"{{.*}}/runtime/abi.FuncType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1005812159, i8 0, i8 8, i8 8, i8 51, { ptr, ptr } zeroinitializer, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @106, i64 19 }, ptr @"*_llgo_func$Y8Pl6IHgSDuynhMRTXPlqFo9zl71SSTuMe0Wi5m8eWw" }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_func$Y8Pl6IHgSDuynhMRTXPlqFo9zl71SSTuMe0Wi5m8eWw$in", i64 1, i64 1 }, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer }, align 8
-// CHECK: @"*_llgo_func$Y8Pl6IHgSDuynhMRTXPlqFo9zl71SSTuMe0Wi5m8eWw" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -1778721426, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @106, i64 19 }, ptr null }, ptr @"_llgo_func$Y8Pl6IHgSDuynhMRTXPlqFo9zl71SSTuMe0Wi5m8eWw" }, align 8
-// CHECK: @"_llgo_func$Y8Pl6IHgSDuynhMRTXPlqFo9zl71SSTuMe0Wi5m8eWw$in" = weak_odr constant [1 x ptr] [ptr @"*_llgo_any"], align 8
-// CHECK: @"_llgo_iface$uinGjIxPTfzB5e5h5gH-0VIvLl5rQdJ_yx2UsrxQqds" = weak_odr constant %"{{.*}}/runtime/abi.InterfaceType" { %"{{.*}}/runtime/abi.Type" { i64 16, i64 16, i32 414101712, i8 0, i8 8, i8 8, i8 20, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @107, i64 56 }, ptr @"*_llgo_iface$uinGjIxPTfzB5e5h5gH-0VIvLl5rQdJ_yx2UsrxQqds" }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 43 }, %"{{.*}}/runtime/internal/runtime.Slice" { ptr @"_llgo_iface$uinGjIxPTfzB5e5h5gH-0VIvLl5rQdJ_yx2UsrxQqds$imethods", i64 2, i64 2 } }, align 8
-// CHECK: @"*_llgo_iface$uinGjIxPTfzB5e5h5gH-0VIvLl5rQdJ_yx2UsrxQqds" = weak_odr constant %"{{.*}}/runtime/abi.PtrType" { %"{{.*}}/runtime/abi.Type" { i64 8, i64 8, i32 -756921395, i8 10, i8 8, i8 8, i8 54, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequalptr", ptr null }, ptr null, %"{{.*}}/runtime/internal/runtime.String" { ptr @107, i64 56 }, ptr null }, ptr @"_llgo_iface$uinGjIxPTfzB5e5h5gH-0VIvLl5rQdJ_yx2UsrxQqds" }, align 8
-// CHECK: @"_llgo_iface$uinGjIxPTfzB5e5h5gH-0VIvLl5rQdJ_yx2UsrxQqds$imethods" = weak_odr constant [2 x %"{{.*}}/runtime/abi.Imethod"] [%"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @103, i64 4 }, ptr @"_llgo_func$oqZ09zjnrQRdlivNw60EomwRoboDQbCk5_Y4MGDpQMQ" }, %"{{.*}}/runtime/abi.Imethod" { %"{{.*}}/runtime/internal/runtime.String" { ptr @105, i64 5 }, ptr @"_llgo_func$Y8Pl6IHgSDuynhMRTXPlqFo9zl71SSTuMe0Wi5m8eWw" }], align 8
+// CHECK-LINE: @0 = private unnamed_addr constant [45 x i8] c"{{.*}}/cl/_testgo/abimethod.T", align 1
+// CHECK-LINE: @1 = private unnamed_addr constant [5 x i8] c"Demo1", align 1
+// CHECK-LINE: @14 = private unnamed_addr constant [20 x i8] c"testAnonymous1 error", align 1
+// CHECK-LINE: @16 = private unnamed_addr constant [20 x i8] c"testAnonymous2 error", align 1
+// CHECK-LINE: @18 = private unnamed_addr constant [20 x i8] c"testAnonymous3 error", align 1
+// CHECK-LINE: @19 = private unnamed_addr constant [20 x i8] c"testAnonymous4 error", align 1
+// CHECK-LINE: @21 = private unnamed_addr constant [20 x i8] c"testAnonymous5 error", align 1
+// CHECK-LINE: @22 = private unnamed_addr constant [20 x i8] c"testAnonymous6 error", align 1
+// CHECK-LINE: @24 = private unnamed_addr constant [20 x i8] c"testAnonymous7 error", align 1
+// CHECK-LINE: @26 = private unnamed_addr constant [20 x i8] c"testAnonymous8 error", align 1
+// CHECK-LINE: @27 = private unnamed_addr constant [5 x i8] c"hello", align 1
+// CHECK-LINE: @96 = private unnamed_addr constant [25 x i8] c"testAnonymousBuffer error", align 1
+// CHECK-LINE: @109 = private unnamed_addr constant [40 x i8] c"type assertion interface{} -> int failed", align 1
+// CHECK-LINE: @110 = private unnamed_addr constant [17 x i8] c"testGeneric error", align 1
+// CHECK-LINE: @111 = private unnamed_addr constant [16 x i8] c"testNamed1 error", align 1
+// CHECK-LINE: @112 = private unnamed_addr constant [16 x i8] c"testNamed2 error", align 1
+// CHECK-LINE: @113 = private unnamed_addr constant [16 x i8] c"testNamed4 error", align 1
 
 type T struct {
 	n int
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.T.Demo1"(%"{{.*}}/_testgo/abimethod.T" %0){{.*}} {
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.T.Demo1"(%"{{.*}}/cl/_testgo/abimethod.T" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = alloca %"{{.*}}/_testgo/abimethod.T", align 8
+// CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/abimethod.T", align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   store %"{{.*}}/_testgo/abimethod.T" %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/abimethod.T" %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load i64, ptr %2, align 8
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.(*T).Demo1"(ptr %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = load %"{{.*}}/_testgo/abimethod.T", ptr %0, align 8
-// CHECK-NEXT:   %2 = call i64 @"{{.*}}/_testgo/abimethod.T.Demo1"(%"{{.*}}/_testgo/abimethod.T" %1)
-// CHECK-NEXT:   ret i64 %2
-// CHECK-NEXT: }
 func (t T) Demo1() int {
 	return t.n
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.(*T).Demo2"(ptr %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:  %1 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %0, i32 0, i32 0
-// CHECK-NEXT:  %2 = load i64, ptr %1, align 8
-// CHECK-NEXT:  ret i64 %2
-// CHECK-NEXT: }
 func (t *T) Demo2() int {
 	return t.n
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.(*T).demo3"(ptr %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:  %1 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %0, i32 0, i32 0
-// CHECK-NEXT:  %2 = load i64, ptr %1, align 8
-// CHECK-NEXT:  ret i64 %2
-// CHECK-NEXT: }
 func (t *T) demo3() int {
 	return t.n
 }
 
-// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.main"(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testGeneric"()
-// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testNamed1"()
-// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testNamed2"()
-// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testNamed3"()
-// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testAnonymous1"()
-// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testAnonymous2"()
-// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testAnonymous3"()
-// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testAnonymous4"()
-// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testAnonymous5"()
-// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testAnonymous6"()
-// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testAnonymous7"()
-// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testAnonymous8"()
-// CHECK-NEXT:   call void @"{{.*}}/_testgo/abimethod.testAnonymousBuffer"()
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 func main() {
 	testGeneric()
 	testNamed1()
@@ -228,41 +68,6 @@ func main() {
 	testAnonymousBuffer()
 }
 
-// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testAnonymous1"(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %3, i32 0, i32 0
-// CHECK-NEXT:   store i64 100, ptr %4, align 8
-// CHECK-NEXT:   store i64 10, ptr %1, align 8
-// CHECK-NEXT:   store ptr %3, ptr %2, align 8
-// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"*{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8")
-// CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %5, 0
-// CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %6, ptr %0, 1
-// CHECK-NEXT:   %8 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %7)
-// CHECK-NEXT:   %9 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %7, 0
-// CHECK-NEXT:   %10 = getelementptr ptr, ptr %9, i64 3
-// CHECK-NEXT:   %11 = load ptr, ptr %10, align 8
-// CHECK-NEXT:   %12 = insertvalue { ptr, ptr } undef, ptr %11, 0
-// CHECK-NEXT:   %13 = insertvalue { ptr, ptr } %12, ptr %8, 1
-// CHECK-NEXT:   %14 = extractvalue { ptr, ptr } %13, 1
-// CHECK-NEXT:   %15 = extractvalue { ptr, ptr } %13, 0
-// CHECK-NEXT:   %16 = call i64 %15(ptr %14)
-// CHECK-NEXT:   %17 = icmp ne i64 %16, 100
-// CHECK-NEXT:   br i1 %17, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %18 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @13, i64 20 }, ptr %18, align 8
-// CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %18, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %19)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 func testAnonymous1() {
 	var s I = &struct {
 		m int
@@ -273,45 +78,6 @@ func testAnonymous1() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testAnonymous2"(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %3, i32 0, i32 0
-// CHECK-NEXT:   store i64 100, ptr %4, align 8
-// CHECK-NEXT:   store i64 10, ptr %1, align 8
-// CHECK-NEXT:   store ptr %3, ptr %2, align 8
-// CHECK-NEXT:   %5 = load { i64, ptr }, ptr %0, align 8
-// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store { i64, ptr } %5, ptr %6, align 8
-// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8")
-// CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %7, 0
-// CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %8, ptr %6, 1
-// CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
-// CHECK-NEXT:   %11 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
-// CHECK-NEXT:   %12 = getelementptr ptr, ptr %11, i64 3
-// CHECK-NEXT:   %13 = load ptr, ptr %12, align 8
-// CHECK-NEXT:   %14 = insertvalue { ptr, ptr } undef, ptr %13, 0
-// CHECK-NEXT:   %15 = insertvalue { ptr, ptr } %14, ptr %10, 1
-// CHECK-NEXT:   %16 = extractvalue { ptr, ptr } %15, 1
-// CHECK-NEXT:   %17 = extractvalue { ptr, ptr } %15, 0
-// CHECK-NEXT:   %18 = call i64 %17(ptr %16)
-// CHECK-NEXT:   %19 = icmp ne i64 %18, 100
-// CHECK-NEXT:   br i1 %19, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @15, i64 20 }, ptr %20, align 8
-// CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %20, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %21)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 func testAnonymous2() {
 	var s I = struct {
 		m int
@@ -322,43 +88,6 @@ func testAnonymous2() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testAnonymous3"(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = alloca { i64, %"{{.*}}/_testgo/abimethod.T" }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/_testgo/abimethod.T" }, ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %2 = getelementptr inbounds { i64, %"{{.*}}/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %2, i32 0, i32 0
-// CHECK-NEXT:   store i64 10, ptr %1, align 8
-// CHECK-NEXT:   store i64 100, ptr %3, align 8
-// CHECK-NEXT:   %4 = load { i64, %"{{.*}}/_testgo/abimethod.T" }, ptr %0, align 8
-// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store { i64, %"{{.*}}/_testgo/abimethod.T" } %4, ptr %5, align 8
-// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"{{.*}}/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088")
-// CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %6, 0
-// CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %7, ptr %5, 1
-// CHECK-NEXT:   %9 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %8)
-// CHECK-NEXT:   %10 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %8, 0
-// CHECK-NEXT:   %11 = getelementptr ptr, ptr %10, i64 3
-// CHECK-NEXT:   %12 = load ptr, ptr %11, align 8
-// CHECK-NEXT:   %13 = insertvalue { ptr, ptr } undef, ptr %12, 0
-// CHECK-NEXT:   %14 = insertvalue { ptr, ptr } %13, ptr %9, 1
-// CHECK-NEXT:   %15 = extractvalue { ptr, ptr } %14, 1
-// CHECK-NEXT:   %16 = extractvalue { ptr, ptr } %14, 0
-// CHECK-NEXT:   %17 = call i64 %16(ptr %15)
-// CHECK-NEXT:   %18 = icmp ne i64 %17, 100
-// CHECK-NEXT:   br i1 %18, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %19 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @17, i64 20 }, ptr %19, align 8
-// CHECK-NEXT:   %20 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %19, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %20)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 func testAnonymous3() {
 	var s I = struct {
 		m int
@@ -369,39 +98,6 @@ func testAnonymous3() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testAnonymous4"(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/_testgo/abimethod.T" }, ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %2 = getelementptr inbounds { i64, %"{{.*}}/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %2, i32 0, i32 0
-// CHECK-NEXT:   store i64 10, ptr %1, align 8
-// CHECK-NEXT:   store i64 100, ptr %3, align 8
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"*{{.*}}/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088")
-// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %4, 0
-// CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %5, ptr %0, 1
-// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %6)
-// CHECK-NEXT:   %8 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %6, 0
-// CHECK-NEXT:   %9 = getelementptr ptr, ptr %8, i64 3
-// CHECK-NEXT:   %10 = load ptr, ptr %9, align 8
-// CHECK-NEXT:   %11 = insertvalue { ptr, ptr } undef, ptr %10, 0
-// CHECK-NEXT:   %12 = insertvalue { ptr, ptr } %11, ptr %7, 1
-// CHECK-NEXT:   %13 = extractvalue { ptr, ptr } %12, 1
-// CHECK-NEXT:   %14 = extractvalue { ptr, ptr } %12, 0
-// CHECK-NEXT:   %15 = call i64 %14(ptr %13)
-// CHECK-NEXT:   %16 = icmp ne i64 %15, 100
-// CHECK-NEXT:   br i1 %16, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %17 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @18, i64 20 }, ptr %17, align 8
-// CHECK-NEXT:   %18 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %17, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %18)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 func testAnonymous4() {
 	var s I = &struct {
 		m int
@@ -412,39 +108,6 @@ func testAnonymous4() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testAnonymous5"(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/_testgo/abimethod.T" }, ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %2 = getelementptr inbounds { i64, %"{{.*}}/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %2, i32 0, i32 0
-// CHECK-NEXT:   store i64 10, ptr %1, align 8
-// CHECK-NEXT:   store i64 100, ptr %3, align 8
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4", ptr @"*{{.*}}/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088")
-// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %4, 0
-// CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %5, ptr %0, 1
-// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %6)
-// CHECK-NEXT:   %8 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %6, 0
-// CHECK-NEXT:   %9 = getelementptr ptr, ptr %8, i64 3
-// CHECK-NEXT:   %10 = load ptr, ptr %9, align 8
-// CHECK-NEXT:   %11 = insertvalue { ptr, ptr } undef, ptr %10, 0
-// CHECK-NEXT:   %12 = insertvalue { ptr, ptr } %11, ptr %7, 1
-// CHECK-NEXT:   %13 = extractvalue { ptr, ptr } %12, 1
-// CHECK-NEXT:   %14 = extractvalue { ptr, ptr } %12, 0
-// CHECK-NEXT:   %15 = call i64 %14(ptr %13)
-// CHECK-NEXT:   %16 = icmp ne i64 %15, 100
-// CHECK-NEXT:   br i1 %16, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %17 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @20, i64 20 }, ptr %17, align 8
-// CHECK-NEXT:   %18 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %17, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %18)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 func testAnonymous5() {
 	var s I2 = &struct {
 		m int
@@ -455,45 +118,6 @@ func testAnonymous5() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testAnonymous6"(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %3, i32 0, i32 0
-// CHECK-NEXT:   store i64 100, ptr %4, align 8
-// CHECK-NEXT:   store i64 10, ptr %1, align 8
-// CHECK-NEXT:   store ptr %3, ptr %2, align 8
-// CHECK-NEXT:   %5 = load { i64, ptr }, ptr %0, align 8
-// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store { i64, ptr } %5, ptr %6, align 8
-// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4", ptr @"{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8")
-// CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %7, 0
-// CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %8, ptr %6, 1
-// CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
-// CHECK-NEXT:   %11 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
-// CHECK-NEXT:   %12 = getelementptr ptr, ptr %11, i64 3
-// CHECK-NEXT:   %13 = load ptr, ptr %12, align 8
-// CHECK-NEXT:   %14 = insertvalue { ptr, ptr } undef, ptr %13, 0
-// CHECK-NEXT:   %15 = insertvalue { ptr, ptr } %14, ptr %10, 1
-// CHECK-NEXT:   %16 = extractvalue { ptr, ptr } %15, 1
-// CHECK-NEXT:   %17 = extractvalue { ptr, ptr } %15, 0
-// CHECK-NEXT:   %18 = call i64 %17(ptr %16)
-// CHECK-NEXT:   %19 = icmp ne i64 %18, 100
-// CHECK-NEXT:   br i1 %19, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @21, i64 20 }, ptr %20, align 8
-// CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %20, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %21)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 func testAnonymous6() {
 	var s I2 = struct {
 		m int
@@ -504,65 +128,6 @@ func testAnonymous6() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testAnonymous7"(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %3, i32 0, i32 0
-// CHECK-NEXT:   store i64 100, ptr %4, align 8
-// CHECK-NEXT:   store i64 10, ptr %1, align 8
-// CHECK-NEXT:   store ptr %3, ptr %2, align 8
-// CHECK-NEXT:   %5 = load { i64, ptr }, ptr %0, align 8
-// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store { i64, ptr } %5, ptr %6, align 8
-// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$58AxoxqQ6sGUOM73FOqFrXsMlgxkU4HGd-S1Wl-ssYw", ptr @"{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8")
-// CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %7, 0
-// CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %8, ptr %6, 1
-// CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
-// CHECK-NEXT:   %11 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
-// CHECK-NEXT:   %12 = getelementptr ptr, ptr %11, i64 3
-// CHECK-NEXT:   %13 = load ptr, ptr %12, align 8
-// CHECK-NEXT:   %14 = insertvalue { ptr, ptr } undef, ptr %13, 0
-// CHECK-NEXT:   %15 = insertvalue { ptr, ptr } %14, ptr %10, 1
-// CHECK-NEXT:   %16 = extractvalue { ptr, ptr } %15, 1
-// CHECK-NEXT:   %17 = extractvalue { ptr, ptr } %15, 0
-// CHECK-NEXT:   %18 = call i64 %17(ptr %16)
-// CHECK-NEXT:   %19 = icmp ne i64 %18, 100
-// CHECK-NEXT:   br i1 %19, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @23, i64 20 }, ptr %20, align 8
-// CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %20, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %21)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %22 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
-// CHECK-NEXT:   %23 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
-// CHECK-NEXT:   %24 = getelementptr ptr, ptr %23, i64 4
-// CHECK-NEXT:   %25 = load ptr, ptr %24, align 8
-// CHECK-NEXT:   %26 = insertvalue { ptr, ptr } undef, ptr %25, 0
-// CHECK-NEXT:   %27 = insertvalue { ptr, ptr } %26, ptr %22, 1
-// CHECK-NEXT:   %28 = extractvalue { ptr, ptr } %27, 1
-// CHECK-NEXT:   %29 = extractvalue { ptr, ptr } %27, 0
-// CHECK-NEXT:   %30 = call i64 %29(ptr %28)
-// CHECK-NEXT:   %31 = icmp ne i64 %30, 100
-// CHECK-NEXT:   br i1 %31, label %_llgo_3, label %_llgo_4
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %32 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @23, i64 20 }, ptr %32, align 8
-// CHECK-NEXT:   %33 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %32, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %33)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 func testAnonymous7() {
 	var s interface {
 		Demo1() int
@@ -579,85 +144,6 @@ func testAnonymous7() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testAnonymous8"(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %3, i32 0, i32 0
-// CHECK-NEXT:   store i64 100, ptr %4, align 8
-// CHECK-NEXT:   store i64 10, ptr %1, align 8
-// CHECK-NEXT:   store ptr %3, ptr %2, align 8
-// CHECK-NEXT:   %5 = load { i64, ptr }, ptr %0, align 8
-// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store { i64, ptr } %5, ptr %6, align 8
-// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/_testgo/abimethod.iface$kT5SIXt45Cspjl04Bof3DZVSOIltlDo-njpk6KqtZvA", ptr @"{{.*}}/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8")
-// CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %7, 0
-// CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %8, ptr %6, 1
-// CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
-// CHECK-NEXT:   %11 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
-// CHECK-NEXT:   %12 = getelementptr ptr, ptr %11, i64 3
-// CHECK-NEXT:   %13 = load ptr, ptr %12, align 8
-// CHECK-NEXT:   %14 = insertvalue { ptr, ptr } undef, ptr %13, 0
-// CHECK-NEXT:   %15 = insertvalue { ptr, ptr } %14, ptr %10, 1
-// CHECK-NEXT:   %16 = extractvalue { ptr, ptr } %15, 1
-// CHECK-NEXT:   %17 = extractvalue { ptr, ptr } %15, 0
-// CHECK-NEXT:   %18 = call i64 %17(ptr %16)
-// CHECK-NEXT:   %19 = icmp ne i64 %18, 100
-// CHECK-NEXT:   br i1 %19, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @25, i64 20 }, ptr %20, align 8
-// CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %20, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %21)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %22 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
-// CHECK-NEXT:   %23 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
-// CHECK-NEXT:   %24 = getelementptr ptr, ptr %23, i64 4
-// CHECK-NEXT:   %25 = load ptr, ptr %24, align 8
-// CHECK-NEXT:   %26 = insertvalue { ptr, ptr } undef, ptr %25, 0
-// CHECK-NEXT:   %27 = insertvalue { ptr, ptr } %26, ptr %22, 1
-// CHECK-NEXT:   %28 = extractvalue { ptr, ptr } %27, 1
-// CHECK-NEXT:   %29 = extractvalue { ptr, ptr } %27, 0
-// CHECK-NEXT:   %30 = call i64 %29(ptr %28)
-// CHECK-NEXT:   %31 = icmp ne i64 %30, 100
-// CHECK-NEXT:   br i1 %31, label %_llgo_3, label %_llgo_4
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %32 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @25, i64 20 }, ptr %32, align 8
-// CHECK-NEXT:   %33 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %32, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %33)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %34 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
-// CHECK-NEXT:   %35 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
-// CHECK-NEXT:   %36 = getelementptr ptr, ptr %35, i64 5
-// CHECK-NEXT:   %37 = load ptr, ptr %36, align 8
-// CHECK-NEXT:   %38 = insertvalue { ptr, ptr } undef, ptr %37, 0
-// CHECK-NEXT:   %39 = insertvalue { ptr, ptr } %38, ptr %34, 1
-// CHECK-NEXT:   %40 = extractvalue { ptr, ptr } %39, 1
-// CHECK-NEXT:   %41 = extractvalue { ptr, ptr } %39, 0
-// CHECK-NEXT:   %42 = call i64 %41(ptr %40)
-// CHECK-NEXT:   %43 = icmp ne i64 %42, 100
-// CHECK-NEXT:   br i1 %43, label %_llgo_5, label %_llgo_6
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_4
-// CHECK-NEXT:   %44 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @25, i64 20 }, ptr %44, align 8
-// CHECK-NEXT:   %45 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %44, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %45)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_4
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 func testAnonymous8() {
 	var s interface {
 		Demo1() int
@@ -678,40 +164,6 @@ func testAnonymous8() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testAnonymousBuffer"(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
-// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %3 = call ptr @bytes.NewBufferString(%"{{.*}}/runtime/internal/runtime.String" { ptr @26, i64 5 })
-// CHECK-NEXT:   store i64 10, ptr %1, align 8
-// CHECK-NEXT:   store ptr %3, ptr %2, align 8
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U", ptr @"*{{.*}}/_testgo/abimethod.struct$RGW016k7zllXgGPm1CvD5-IBe-9lphOOTCFtYyDGLjY")
-// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %4, 0
-// CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %5, ptr %0, 1
-// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %6)
-// CHECK-NEXT:   %8 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %6, 0
-// CHECK-NEXT:   %9 = getelementptr ptr, ptr %8, i64 3
-// CHECK-NEXT:   %10 = load ptr, ptr %9, align 8
-// CHECK-NEXT:   %11 = insertvalue { ptr, ptr } undef, ptr %10, 0
-// CHECK-NEXT:   %12 = insertvalue { ptr, ptr } %11, ptr %7, 1
-// CHECK-NEXT:   %13 = extractvalue { ptr, ptr } %12, 1
-// CHECK-NEXT:   %14 = extractvalue { ptr, ptr } %12, 0
-// CHECK-NEXT:   %15 = call %"{{.*}}/runtime/internal/runtime.String" %14(ptr %13)
-// CHECK-NEXT:   %16 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %15, %"{{.*}}/runtime/internal/runtime.String" { ptr @26, i64 5 })
-// CHECK-NEXT:   %17 = xor i1 %16, true
-// CHECK-NEXT:   br i1 %17, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %18 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @95, i64 25 }, ptr %18, align 8
-// CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %18, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %19)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 func testAnonymousBuffer() {
 	var s fmt.Stringer = &struct {
 		m int
@@ -722,69 +174,6 @@ func testAnonymousBuffer() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testGeneric"(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uinGjIxPTfzB5e5h5gH-0VIvLl5rQdJ_yx2UsrxQqds", ptr @"*_llgo_{{.*}}/_testgo/abimethod.Pointer[any]")
-// CHECK-NEXT:   %2 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %1, 0
-// CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %2, ptr %0, 1
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/_testgo/abimethod.testGeneric$1"()
-// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %3)
-// CHECK-NEXT:   %6 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %3, 0
-// CHECK-NEXT:   %7 = getelementptr ptr, ptr %6, i64 4
-// CHECK-NEXT:   %8 = load ptr, ptr %7, align 8
-// CHECK-NEXT:   %9 = insertvalue { ptr, ptr } undef, ptr %8, 0
-// CHECK-NEXT:   %10 = insertvalue { ptr, ptr } %9, ptr %5, 1
-// CHECK-NEXT:   %11 = extractvalue { ptr, ptr } %10, 1
-// CHECK-NEXT:   %12 = extractvalue { ptr, ptr } %10, 0
-// CHECK-NEXT:   call void %12(ptr %11, ptr %4)
-// CHECK-NEXT:   %13 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %3)
-// CHECK-NEXT:   %14 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %3, 0
-// CHECK-NEXT:   %15 = getelementptr ptr, ptr %14, i64 3
-// CHECK-NEXT:   %16 = load ptr, ptr %15, align 8
-// CHECK-NEXT:   %17 = insertvalue { ptr, ptr } undef, ptr %16, 0
-// CHECK-NEXT:   %18 = insertvalue { ptr, ptr } %17, ptr %13, 1
-// CHECK-NEXT:   %19 = extractvalue { ptr, ptr } %18, 1
-// CHECK-NEXT:   %20 = extractvalue { ptr, ptr } %18, 0
-// CHECK-NEXT:   %21 = call ptr %20(ptr %19)
-// CHECK-NEXT:   %22 = load %"{{.*}}/runtime/internal/runtime.eface", ptr %21, align 8
-// CHECK-NEXT:   %23 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %22, 0
-// CHECK-NEXT:   %24 = icmp eq ptr %23, @_llgo_int
-// CHECK-NEXT:   br i1 %24, label %_llgo_3, label %_llgo_4
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_3
-// CHECK-NEXT:   %25 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @109, i64 17 }, ptr %25, align 8
-// CHECK-NEXT:   %26 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %25, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %26)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_3
-// CHECK-NEXT:   ret void
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %27 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %22, 1
-// CHECK-NEXT:   %28 = load i64, ptr %27, align 8
-// CHECK-NEXT:   %29 = icmp ne i64 %28, 100
-// CHECK-NEXT:   br i1 %29, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %30 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @108, i64 40 }, ptr %30, align 8
-// CHECK-NEXT:   %31 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %30, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %31)
-// CHECK-NEXT:   unreachable
-// CHECK-NEXT: }
-
-// CHECK-LABEL: define ptr @"{{.*}}/_testgo/abimethod.testGeneric$1"(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store i64 100, ptr %1, align 8
-// CHECK-NEXT:   %2 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %1, 1
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %2, ptr %0, align 8
-// CHECK-NEXT:   ret ptr %0
-// CHECK-NEXT: }
 func testGeneric() {
 	var p IP = &Pointer[any]{}
 	p.Store(func() *any {
@@ -796,36 +185,6 @@ func testGeneric() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testNamed1"(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %0, i32 0, i32 0
-// CHECK-NEXT:   store i64 100, ptr %1, align 8
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"*_llgo_{{.*}}/_testgo/abimethod.T")
-// CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %2, 0
-// CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %3, ptr %0, 1
-// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %4)
-// CHECK-NEXT:   %6 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %4, 0
-// CHECK-NEXT:   %7 = getelementptr ptr, ptr %6, i64 3
-// CHECK-NEXT:   %8 = load ptr, ptr %7, align 8
-// CHECK-NEXT:   %9 = insertvalue { ptr, ptr } undef, ptr %8, 0
-// CHECK-NEXT:   %10 = insertvalue { ptr, ptr } %9, ptr %5, 1
-// CHECK-NEXT:   %11 = extractvalue { ptr, ptr } %10, 1
-// CHECK-NEXT:   %12 = extractvalue { ptr, ptr } %10, 0
-// CHECK-NEXT:   %13 = call i64 %12(ptr %11)
-// CHECK-NEXT:   %14 = icmp ne i64 %13, 100
-// CHECK-NEXT:   br i1 %14, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %15 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @110, i64 16 }, ptr %15, align 8
-// CHECK-NEXT:   %16 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %15, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %16)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 func testNamed1() {
 	var a I = &T{100}
 	if a.Demo1() != 100 {
@@ -833,40 +192,6 @@ func testNamed1() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testNamed2"(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = alloca %"{{.*}}/_testgo/abimethod.T", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %0, i32 0, i32 0
-// CHECK-NEXT:   store i64 100, ptr %1, align 8
-// CHECK-NEXT:   %2 = load %"{{.*}}/_testgo/abimethod.T", ptr %0, align 8
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
-// CHECK-NEXT:   store %"{{.*}}/_testgo/abimethod.T" %2, ptr %3, align 8
-// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"_llgo_{{.*}}/_testgo/abimethod.T")
-// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %4, 0
-// CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %5, ptr %3, 1
-// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %6)
-// CHECK-NEXT:   %8 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %6, 0
-// CHECK-NEXT:   %9 = getelementptr ptr, ptr %8, i64 3
-// CHECK-NEXT:   %10 = load ptr, ptr %9, align 8
-// CHECK-NEXT:   %11 = insertvalue { ptr, ptr } undef, ptr %10, 0
-// CHECK-NEXT:   %12 = insertvalue { ptr, ptr } %11, ptr %7, 1
-// CHECK-NEXT:   %13 = extractvalue { ptr, ptr } %12, 1
-// CHECK-NEXT:   %14 = extractvalue { ptr, ptr } %12, 0
-// CHECK-NEXT:   %15 = call i64 %14(ptr %13)
-// CHECK-NEXT:   %16 = icmp ne i64 %15, 100
-// CHECK-NEXT:   br i1 %16, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %17 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @111, i64 16 }, ptr %17, align 8
-// CHECK-NEXT:   %18 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %17, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %18)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 func testNamed2() {
 	var a I = T{100}
 	if a.Demo1() != 100 {
@@ -874,36 +199,6 @@ func testNamed2() {
 	}
 }
 
-// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.testNamed3"(){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.T", ptr %0, i32 0, i32 0
-// CHECK-NEXT:   store i64 100, ptr %1, align 8
-// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4", ptr @"*_llgo_{{.*}}/_testgo/abimethod.T")
-// CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %2, 0
-// CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %3, ptr %0, 1
-// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %4)
-// CHECK-NEXT:   %6 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %4, 0
-// CHECK-NEXT:   %7 = getelementptr ptr, ptr %6, i64 3
-// CHECK-NEXT:   %8 = load ptr, ptr %7, align 8
-// CHECK-NEXT:   %9 = insertvalue { ptr, ptr } undef, ptr %8, 0
-// CHECK-NEXT:   %10 = insertvalue { ptr, ptr } %9, ptr %5, 1
-// CHECK-NEXT:   %11 = extractvalue { ptr, ptr } %10, 1
-// CHECK-NEXT:   %12 = extractvalue { ptr, ptr } %10, 0
-// CHECK-NEXT:   %13 = call i64 %12(ptr %11)
-// CHECK-NEXT:   %14 = icmp ne i64 %13, 100
-// CHECK-NEXT:   br i1 %14, label %_llgo_1, label %_llgo_2
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %15 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @112, i64 16 }, ptr %15, align 8
-// CHECK-NEXT:   %16 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %15, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %16)
-// CHECK-NEXT:   unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 func testNamed3() {
 	var a I2 = &T{100}
 	if a.Demo2() != 100 {
@@ -938,99 +233,726 @@ type I2 interface {
 	Demo2() int
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo1"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.(*T).Demo1"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 45 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 5 })
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/abimethod.T", ptr %0, align 8
+// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/abimethod.T.Demo1"(%"{{.*}}/cl/_testgo/abimethod.T" %2)
+// CHECK-NEXT:   ret i64 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.(*T).Demo2"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = load i64, ptr %1, align 8
+// CHECK-NEXT:   ret i64 %2
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.(*T).demo3"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = load i64, ptr %1, align 8
+// CHECK-NEXT:   ret i64 %2
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.init"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/abimethod.init$guard", align 1
+// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/abimethod.init$guard", align 1
+// CHECK-NEXT:   call void @bytes.init()
+// CHECK-NEXT:   call void @fmt.init()
+// CHECK-NEXT:   call void @"sync/atomic.init"()
+// CHECK-NEXT:   br label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.main"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testGeneric"()
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testNamed1"()
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testNamed2"()
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testNamed3"()
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testAnonymous1"()
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testAnonymous2"()
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testAnonymous3"()
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testAnonymous4"()
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testAnonymous5"()
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testAnonymous6"()
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testAnonymous7"()
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testAnonymous8"()
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/abimethod.testAnonymousBuffer"()
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testAnonymous1"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %3, i32 0, i32 0
+// CHECK-NEXT:   store i64 100, ptr %4, align 8
+// CHECK-NEXT:   store i64 10, ptr %1, align 8
+// CHECK-NEXT:   store ptr %3, ptr %2, align 8
+// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"*{{.*}}/cl/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8")
+// CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %5, 0
+// CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %6, ptr %0, 1
+// CHECK-NEXT:   %8 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %7)
+// CHECK-NEXT:   %9 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %7, 0
+// CHECK-NEXT:   %10 = getelementptr ptr, ptr %9, i64 3
+// CHECK-NEXT:   %11 = load ptr, ptr %10, align 8
+// CHECK-NEXT:   %12 = insertvalue { ptr, ptr } undef, ptr %11, 0
+// CHECK-NEXT:   %13 = insertvalue { ptr, ptr } %12, ptr %8, 1
+// CHECK-NEXT:   %14 = extractvalue { ptr, ptr } %13, 1
+// CHECK-NEXT:   %15 = extractvalue { ptr, ptr } %13, 0
+// CHECK-NEXT:   %16 = call i64 %15(ptr %14)
+// CHECK-NEXT:   %17 = icmp ne i64 %16, 100
+// CHECK-NEXT:   br i1 %17, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %18 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @14, i64 20 }, ptr %18, align 8
+// CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %18, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %19)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testAnonymous2"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %3, i32 0, i32 0
+// CHECK-NEXT:   store i64 100, ptr %4, align 8
+// CHECK-NEXT:   store i64 10, ptr %1, align 8
+// CHECK-NEXT:   store ptr %3, ptr %2, align 8
+// CHECK-NEXT:   %5 = load { i64, ptr }, ptr %0, align 8
+// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store { i64, ptr } %5, ptr %6, align 8
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"{{.*}}/cl/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8")
+// CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %7, 0
+// CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %8, ptr %6, 1
+// CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
+// CHECK-NEXT:   %11 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
+// CHECK-NEXT:   %12 = getelementptr ptr, ptr %11, i64 3
+// CHECK-NEXT:   %13 = load ptr, ptr %12, align 8
+// CHECK-NEXT:   %14 = insertvalue { ptr, ptr } undef, ptr %13, 0
+// CHECK-NEXT:   %15 = insertvalue { ptr, ptr } %14, ptr %10, 1
+// CHECK-NEXT:   %16 = extractvalue { ptr, ptr } %15, 1
+// CHECK-NEXT:   %17 = extractvalue { ptr, ptr } %15, 0
+// CHECK-NEXT:   %18 = call i64 %17(ptr %16)
+// CHECK-NEXT:   %19 = icmp ne i64 %18, 100
+// CHECK-NEXT:   br i1 %19, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @16, i64 20 }, ptr %20, align 8
+// CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %20, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %21)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testAnonymous3"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = alloca { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   store i64 10, ptr %1, align 8
+// CHECK-NEXT:   store i64 100, ptr %3, align 8
+// CHECK-NEXT:   %4 = load { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %0, align 8
+// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store { i64, %"{{.*}}/cl/_testgo/abimethod.T" } %4, ptr %5, align 8
+// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"{{.*}}/cl/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088")
+// CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %6, 0
+// CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %7, ptr %5, 1
+// CHECK-NEXT:   %9 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %8)
+// CHECK-NEXT:   %10 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %8, 0
+// CHECK-NEXT:   %11 = getelementptr ptr, ptr %10, i64 3
+// CHECK-NEXT:   %12 = load ptr, ptr %11, align 8
+// CHECK-NEXT:   %13 = insertvalue { ptr, ptr } undef, ptr %12, 0
+// CHECK-NEXT:   %14 = insertvalue { ptr, ptr } %13, ptr %9, 1
+// CHECK-NEXT:   %15 = extractvalue { ptr, ptr } %14, 1
+// CHECK-NEXT:   %16 = extractvalue { ptr, ptr } %14, 0
+// CHECK-NEXT:   %17 = call i64 %16(ptr %15)
+// CHECK-NEXT:   %18 = icmp ne i64 %17, 100
+// CHECK-NEXT:   br i1 %18, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %19 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @18, i64 20 }, ptr %19, align 8
+// CHECK-NEXT:   %20 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %19, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %20)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testAnonymous4"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   store i64 10, ptr %1, align 8
+// CHECK-NEXT:   store i64 100, ptr %3, align 8
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"*{{.*}}/cl/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088")
+// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %4, 0
+// CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %5, ptr %0, 1
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %6)
+// CHECK-NEXT:   %8 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %6, 0
+// CHECK-NEXT:   %9 = getelementptr ptr, ptr %8, i64 3
+// CHECK-NEXT:   %10 = load ptr, ptr %9, align 8
+// CHECK-NEXT:   %11 = insertvalue { ptr, ptr } undef, ptr %10, 0
+// CHECK-NEXT:   %12 = insertvalue { ptr, ptr } %11, ptr %7, 1
+// CHECK-NEXT:   %13 = extractvalue { ptr, ptr } %12, 1
+// CHECK-NEXT:   %14 = extractvalue { ptr, ptr } %12, 0
+// CHECK-NEXT:   %15 = call i64 %14(ptr %13)
+// CHECK-NEXT:   %16 = icmp ne i64 %15, 100
+// CHECK-NEXT:   br i1 %16, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %17 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @19, i64 20 }, ptr %17, align 8
+// CHECK-NEXT:   %18 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %17, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %18)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testAnonymous5"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   store i64 10, ptr %1, align 8
+// CHECK-NEXT:   store i64 100, ptr %3, align 8
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4", ptr @"*{{.*}}/cl/_testgo/abimethod.struct$F3FioEGWwXQRUdV6xoxVUEDjRNgBQIpL0XIyBECp088")
+// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %4, 0
+// CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %5, ptr %0, 1
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %6)
+// CHECK-NEXT:   %8 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %6, 0
+// CHECK-NEXT:   %9 = getelementptr ptr, ptr %8, i64 3
+// CHECK-NEXT:   %10 = load ptr, ptr %9, align 8
+// CHECK-NEXT:   %11 = insertvalue { ptr, ptr } undef, ptr %10, 0
+// CHECK-NEXT:   %12 = insertvalue { ptr, ptr } %11, ptr %7, 1
+// CHECK-NEXT:   %13 = extractvalue { ptr, ptr } %12, 1
+// CHECK-NEXT:   %14 = extractvalue { ptr, ptr } %12, 0
+// CHECK-NEXT:   %15 = call i64 %14(ptr %13)
+// CHECK-NEXT:   %16 = icmp ne i64 %15, 100
+// CHECK-NEXT:   br i1 %16, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %17 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @21, i64 20 }, ptr %17, align 8
+// CHECK-NEXT:   %18 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %17, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %18)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testAnonymous6"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %3, i32 0, i32 0
+// CHECK-NEXT:   store i64 100, ptr %4, align 8
+// CHECK-NEXT:   store i64 10, ptr %1, align 8
+// CHECK-NEXT:   store ptr %3, ptr %2, align 8
+// CHECK-NEXT:   %5 = load { i64, ptr }, ptr %0, align 8
+// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store { i64, ptr } %5, ptr %6, align 8
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4", ptr @"{{.*}}/cl/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8")
+// CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %7, 0
+// CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %8, ptr %6, 1
+// CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
+// CHECK-NEXT:   %11 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
+// CHECK-NEXT:   %12 = getelementptr ptr, ptr %11, i64 3
+// CHECK-NEXT:   %13 = load ptr, ptr %12, align 8
+// CHECK-NEXT:   %14 = insertvalue { ptr, ptr } undef, ptr %13, 0
+// CHECK-NEXT:   %15 = insertvalue { ptr, ptr } %14, ptr %10, 1
+// CHECK-NEXT:   %16 = extractvalue { ptr, ptr } %15, 1
+// CHECK-NEXT:   %17 = extractvalue { ptr, ptr } %15, 0
+// CHECK-NEXT:   %18 = call i64 %17(ptr %16)
+// CHECK-NEXT:   %19 = icmp ne i64 %18, 100
+// CHECK-NEXT:   br i1 %19, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 20 }, ptr %20, align 8
+// CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %20, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %21)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testAnonymous7"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %3, i32 0, i32 0
+// CHECK-NEXT:   store i64 100, ptr %4, align 8
+// CHECK-NEXT:   store i64 10, ptr %1, align 8
+// CHECK-NEXT:   store ptr %3, ptr %2, align 8
+// CHECK-NEXT:   %5 = load { i64, ptr }, ptr %0, align 8
+// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store { i64, ptr } %5, ptr %6, align 8
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$58AxoxqQ6sGUOM73FOqFrXsMlgxkU4HGd-S1Wl-ssYw", ptr @"{{.*}}/cl/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8")
+// CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %7, 0
+// CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %8, ptr %6, 1
+// CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
+// CHECK-NEXT:   %11 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
+// CHECK-NEXT:   %12 = getelementptr ptr, ptr %11, i64 3
+// CHECK-NEXT:   %13 = load ptr, ptr %12, align 8
+// CHECK-NEXT:   %14 = insertvalue { ptr, ptr } undef, ptr %13, 0
+// CHECK-NEXT:   %15 = insertvalue { ptr, ptr } %14, ptr %10, 1
+// CHECK-NEXT:   %16 = extractvalue { ptr, ptr } %15, 1
+// CHECK-NEXT:   %17 = extractvalue { ptr, ptr } %15, 0
+// CHECK-NEXT:   %18 = call i64 %17(ptr %16)
+// CHECK-NEXT:   %19 = icmp ne i64 %18, 100
+// CHECK-NEXT:   br i1 %19, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @24, i64 20 }, ptr %20, align 8
+// CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %20, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %21)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %22 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
+// CHECK-NEXT:   %23 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
+// CHECK-NEXT:   %24 = getelementptr ptr, ptr %23, i64 4
+// CHECK-NEXT:   %25 = load ptr, ptr %24, align 8
+// CHECK-NEXT:   %26 = insertvalue { ptr, ptr } undef, ptr %25, 0
+// CHECK-NEXT:   %27 = insertvalue { ptr, ptr } %26, ptr %22, 1
+// CHECK-NEXT:   %28 = extractvalue { ptr, ptr } %27, 1
+// CHECK-NEXT:   %29 = extractvalue { ptr, ptr } %27, 0
+// CHECK-NEXT:   %30 = call i64 %29(ptr %28)
+// CHECK-NEXT:   %31 = icmp ne i64 %30, 100
+// CHECK-NEXT:   br i1 %31, label %_llgo_3, label %_llgo_4
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_2
+// CHECK-NEXT:   %32 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @24, i64 20 }, ptr %32, align 8
+// CHECK-NEXT:   %33 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %32, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %33)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testAnonymous8"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = alloca { i64, ptr }, align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %3, i32 0, i32 0
+// CHECK-NEXT:   store i64 100, ptr %4, align 8
+// CHECK-NEXT:   store i64 10, ptr %1, align 8
+// CHECK-NEXT:   store ptr %3, ptr %2, align 8
+// CHECK-NEXT:   %5 = load { i64, ptr }, ptr %0, align 8
+// CHECK-NEXT:   %6 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store { i64, ptr } %5, ptr %6, align 8
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"{{.*}}/cl/_testgo/abimethod.iface$kT5SIXt45Cspjl04Bof3DZVSOIltlDo-njpk6KqtZvA", ptr @"{{.*}}/cl/_testgo/abimethod.struct$mRfo5gQx8vKF1DvrL24XRoyvI_ttVDcwc1JYMRxWfb8")
+// CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %7, 0
+// CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %8, ptr %6, 1
+// CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
+// CHECK-NEXT:   %11 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
+// CHECK-NEXT:   %12 = getelementptr ptr, ptr %11, i64 3
+// CHECK-NEXT:   %13 = load ptr, ptr %12, align 8
+// CHECK-NEXT:   %14 = insertvalue { ptr, ptr } undef, ptr %13, 0
+// CHECK-NEXT:   %15 = insertvalue { ptr, ptr } %14, ptr %10, 1
+// CHECK-NEXT:   %16 = extractvalue { ptr, ptr } %15, 1
+// CHECK-NEXT:   %17 = extractvalue { ptr, ptr } %15, 0
+// CHECK-NEXT:   %18 = call i64 %17(ptr %16)
+// CHECK-NEXT:   %19 = icmp ne i64 %18, 100
+// CHECK-NEXT:   br i1 %19, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @26, i64 20 }, ptr %20, align 8
+// CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %20, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %21)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %22 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
+// CHECK-NEXT:   %23 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
+// CHECK-NEXT:   %24 = getelementptr ptr, ptr %23, i64 4
+// CHECK-NEXT:   %25 = load ptr, ptr %24, align 8
+// CHECK-NEXT:   %26 = insertvalue { ptr, ptr } undef, ptr %25, 0
+// CHECK-NEXT:   %27 = insertvalue { ptr, ptr } %26, ptr %22, 1
+// CHECK-NEXT:   %28 = extractvalue { ptr, ptr } %27, 1
+// CHECK-NEXT:   %29 = extractvalue { ptr, ptr } %27, 0
+// CHECK-NEXT:   %30 = call i64 %29(ptr %28)
+// CHECK-NEXT:   %31 = icmp ne i64 %30, 100
+// CHECK-NEXT:   br i1 %31, label %_llgo_3, label %_llgo_4
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_2
+// CHECK-NEXT:   %32 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @26, i64 20 }, ptr %32, align 8
+// CHECK-NEXT:   %33 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %32, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %33)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
+// CHECK-NEXT:   %34 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
+// CHECK-NEXT:   %35 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
+// CHECK-NEXT:   %36 = getelementptr ptr, ptr %35, i64 5
+// CHECK-NEXT:   %37 = load ptr, ptr %36, align 8
+// CHECK-NEXT:   %38 = insertvalue { ptr, ptr } undef, ptr %37, 0
+// CHECK-NEXT:   %39 = insertvalue { ptr, ptr } %38, ptr %34, 1
+// CHECK-NEXT:   %40 = extractvalue { ptr, ptr } %39, 1
+// CHECK-NEXT:   %41 = extractvalue { ptr, ptr } %39, 0
+// CHECK-NEXT:   %42 = call i64 %41(ptr %40)
+// CHECK-NEXT:   %43 = icmp ne i64 %42, 100
+// CHECK-NEXT:   br i1 %43, label %_llgo_5, label %_llgo_6
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_4
+// CHECK-NEXT:   %44 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @26, i64 20 }, ptr %44, align 8
+// CHECK-NEXT:   %45 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %44, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %45)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_4
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testAnonymousBuffer"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = call ptr @bytes.NewBufferString(%"{{.*}}/runtime/internal/runtime.String" { ptr @27, i64 5 })
+// CHECK-NEXT:   store i64 10, ptr %1, align 8
+// CHECK-NEXT:   store ptr %3, ptr %2, align 8
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$O6rEVxIuA5O1E0KWpQBCgGx26X5gYhJ_nnJnHVL8_7U", ptr @"*{{.*}}/cl/_testgo/abimethod.struct$RGW016k7zllXgGPm1CvD5-IBe-9lphOOTCFtYyDGLjY")
+// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %4, 0
+// CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %5, ptr %0, 1
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %6)
+// CHECK-NEXT:   %8 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %6, 0
+// CHECK-NEXT:   %9 = getelementptr ptr, ptr %8, i64 3
+// CHECK-NEXT:   %10 = load ptr, ptr %9, align 8
+// CHECK-NEXT:   %11 = insertvalue { ptr, ptr } undef, ptr %10, 0
+// CHECK-NEXT:   %12 = insertvalue { ptr, ptr } %11, ptr %7, 1
+// CHECK-NEXT:   %13 = extractvalue { ptr, ptr } %12, 1
+// CHECK-NEXT:   %14 = extractvalue { ptr, ptr } %12, 0
+// CHECK-NEXT:   %15 = call %"{{.*}}/runtime/internal/runtime.String" %14(ptr %13)
+// CHECK-NEXT:   %16 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %15, %"{{.*}}/runtime/internal/runtime.String" { ptr @27, i64 5 })
+// CHECK-NEXT:   %17 = xor i1 %16, true
+// CHECK-NEXT:   br i1 %17, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %18 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @96, i64 25 }, ptr %18, align 8
+// CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %18, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %19)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testGeneric"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uinGjIxPTfzB5e5h5gH-0VIvLl5rQdJ_yx2UsrxQqds", ptr @"*_llgo_{{.*}}/cl/_testgo/abimethod.Pointer[any]")
+// CHECK-NEXT:   %2 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %1, 0
+// CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %2, ptr %0, 1
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/cl/_testgo/abimethod.testGeneric$1"()
+// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %3)
+// CHECK-NEXT:   %6 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %3, 0
+// CHECK-NEXT:   %7 = getelementptr ptr, ptr %6, i64 4
+// CHECK-NEXT:   %8 = load ptr, ptr %7, align 8
+// CHECK-NEXT:   %9 = insertvalue { ptr, ptr } undef, ptr %8, 0
+// CHECK-NEXT:   %10 = insertvalue { ptr, ptr } %9, ptr %5, 1
+// CHECK-NEXT:   %11 = extractvalue { ptr, ptr } %10, 1
+// CHECK-NEXT:   %12 = extractvalue { ptr, ptr } %10, 0
+// CHECK-NEXT:   call void %12(ptr %11, ptr %4)
+// CHECK-NEXT:   %13 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %3)
+// CHECK-NEXT:   %14 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %3, 0
+// CHECK-NEXT:   %15 = getelementptr ptr, ptr %14, i64 3
+// CHECK-NEXT:   %16 = load ptr, ptr %15, align 8
+// CHECK-NEXT:   %17 = insertvalue { ptr, ptr } undef, ptr %16, 0
+// CHECK-NEXT:   %18 = insertvalue { ptr, ptr } %17, ptr %13, 1
+// CHECK-NEXT:   %19 = extractvalue { ptr, ptr } %18, 1
+// CHECK-NEXT:   %20 = extractvalue { ptr, ptr } %18, 0
+// CHECK-NEXT:   %21 = call ptr %20(ptr %19)
+// CHECK-NEXT:   %22 = load %"{{.*}}/runtime/internal/runtime.eface", ptr %21, align 8
+// CHECK-NEXT:   %23 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %22, 0
+// CHECK-NEXT:   %24 = icmp eq ptr %23, @_llgo_int
+// CHECK-NEXT:   br i1 %24, label %_llgo_3, label %_llgo_4
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_3
+// CHECK-NEXT:   %25 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @110, i64 17 }, ptr %25, align 8
+// CHECK-NEXT:   %26 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %25, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %26)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_3
+// CHECK-NEXT:   ret void
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %27 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %22, 1
+// CHECK-NEXT:   %28 = load i64, ptr %27, align 8
+// CHECK-NEXT:   %29 = icmp ne i64 %28, 100
+// CHECK-NEXT:   br i1 %29, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %30 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @109, i64 40 }, ptr %30, align 8
+// CHECK-NEXT:   %31 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %30, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %31)
+// CHECK-NEXT:   unreachable
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define ptr @"{{.*}}/cl/_testgo/abimethod.testGeneric$1"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT:   store i64 100, ptr %1, align 8
+// CHECK-NEXT:   %2 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_int, ptr undef }, ptr %1, 1
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %2, ptr %0, align 8
+// CHECK-NEXT:   ret ptr %0
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testNamed1"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   store i64 100, ptr %1, align 8
+// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"*_llgo_{{.*}}/cl/_testgo/abimethod.T")
+// CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %2, 0
+// CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %3, ptr %0, 1
+// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %4)
+// CHECK-NEXT:   %6 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %4, 0
+// CHECK-NEXT:   %7 = getelementptr ptr, ptr %6, i64 3
+// CHECK-NEXT:   %8 = load ptr, ptr %7, align 8
+// CHECK-NEXT:   %9 = insertvalue { ptr, ptr } undef, ptr %8, 0
+// CHECK-NEXT:   %10 = insertvalue { ptr, ptr } %9, ptr %5, 1
+// CHECK-NEXT:   %11 = extractvalue { ptr, ptr } %10, 1
+// CHECK-NEXT:   %12 = extractvalue { ptr, ptr } %10, 0
+// CHECK-NEXT:   %13 = call i64 %12(ptr %11)
+// CHECK-NEXT:   %14 = icmp ne i64 %13, 100
+// CHECK-NEXT:   br i1 %14, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %15 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @111, i64 16 }, ptr %15, align 8
+// CHECK-NEXT:   %16 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %15, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %16)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testNamed2"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = alloca %"{{.*}}/cl/_testgo/abimethod.T", align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   store i64 100, ptr %1, align 8
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/abimethod.T", ptr %0, align 8
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/abimethod.T" %2, ptr %3, align 8
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$WkyTd7mXEW0USaC6FIo7OG9IdUUyjAJl_h3PFrMEtHc", ptr @"_llgo_{{.*}}/cl/_testgo/abimethod.T")
+// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %4, 0
+// CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %5, ptr %3, 1
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %6)
+// CHECK-NEXT:   %8 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %6, 0
+// CHECK-NEXT:   %9 = getelementptr ptr, ptr %8, i64 3
+// CHECK-NEXT:   %10 = load ptr, ptr %9, align 8
+// CHECK-NEXT:   %11 = insertvalue { ptr, ptr } undef, ptr %10, 0
+// CHECK-NEXT:   %12 = insertvalue { ptr, ptr } %11, ptr %7, 1
+// CHECK-NEXT:   %13 = extractvalue { ptr, ptr } %12, 1
+// CHECK-NEXT:   %14 = extractvalue { ptr, ptr } %12, 0
+// CHECK-NEXT:   %15 = call i64 %14(ptr %13)
+// CHECK-NEXT:   %16 = icmp ne i64 %15, 100
+// CHECK-NEXT:   br i1 %16, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %17 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @112, i64 16 }, ptr %17, align 8
+// CHECK-NEXT:   %18 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %17, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %18)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testNamed3"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   store i64 100, ptr %1, align 8
+// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$GIQLduxo5T_xLwYbboAKy8LzikHgsGzb7WxrkOH3Lr4", ptr @"*_llgo_{{.*}}/cl/_testgo/abimethod.T")
+// CHECK-NEXT:   %3 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %2, 0
+// CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %3, ptr %0, 1
+// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %4)
+// CHECK-NEXT:   %6 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %4, 0
+// CHECK-NEXT:   %7 = getelementptr ptr, ptr %6, i64 3
+// CHECK-NEXT:   %8 = load ptr, ptr %7, align 8
+// CHECK-NEXT:   %9 = insertvalue { ptr, ptr } undef, ptr %8, 0
+// CHECK-NEXT:   %10 = insertvalue { ptr, ptr } %9, ptr %5, 1
+// CHECK-NEXT:   %11 = extractvalue { ptr, ptr } %10, 1
+// CHECK-NEXT:   %12 = extractvalue { ptr, ptr } %10, 0
+// CHECK-NEXT:   %13 = call i64 %12(ptr %11)
+// CHECK-NEXT:   %14 = icmp ne i64 %13, 100
+// CHECK-NEXT:   br i1 %14, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %15 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @113, i64 16 }, ptr %15, align 8
+// CHECK-NEXT:   %16 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %15, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %16)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.Demo1"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
-// CHECK-NEXT:   %3 = load %"{{.*}}/_testgo/abimethod.T", ptr %2, align 8
-// CHECK-NEXT:   %4 = call i64 @"{{.*}}/_testgo/abimethod.T.Demo1"(%"{{.*}}/_testgo/abimethod.T" %3)
+// CHECK-NEXT:   %3 = load %"{{.*}}/cl/_testgo/abimethod.T", ptr %2, align 8
+// CHECK-NEXT:   %4 = call i64 @"{{.*}}/cl/_testgo/abimethod.T.Demo1"(%"{{.*}}/cl/_testgo/abimethod.T" %3)
 // CHECK-NEXT:   ret i64 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo2"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.Demo2"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/_testgo/abimethod.(*T).Demo2"(ptr %2)
+// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/abimethod.(*T).Demo2"(ptr %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.*struct{m int; *{{.*}}/_testgo/abimethod.T}.demo3"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.demo3"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/_testgo/abimethod.(*T).demo3"(ptr %2)
+// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/abimethod.(*T).demo3"(ptr %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo1"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.Demo1"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
-// CHECK-NEXT:   %4 = load %"{{.*}}/_testgo/abimethod.T", ptr %3, align 8
-// CHECK-NEXT:   %5 = call i64 @"{{.*}}/_testgo/abimethod.T.Demo1"(%"{{.*}}/_testgo/abimethod.T" %4)
+// CHECK-NEXT:   %4 = load %"{{.*}}/cl/_testgo/abimethod.T", ptr %3, align 8
+// CHECK-NEXT:   %5 = call i64 @"{{.*}}/cl/_testgo/abimethod.T.Demo1"(%"{{.*}}/cl/_testgo/abimethod.T" %4)
 // CHECK-NEXT:   ret i64 %5
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.struct{m int; *{{.*}}/_testgo/abimethod.T}.Demo2"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.Demo2"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
-// CHECK-NEXT:   %4 = call i64 @"{{.*}}/_testgo/abimethod.(*T).Demo2"(ptr %3)
+// CHECK-NEXT:   %4 = call i64 @"{{.*}}/cl/_testgo/abimethod.(*T).Demo2"(ptr %3)
 // CHECK-NEXT:   ret i64 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.struct{m int; *{{.*}}/_testgo/abimethod.T}.demo3"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.demo3"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
-// CHECK-NEXT:   %4 = call i64 @"{{.*}}/_testgo/abimethod.(*T).demo3"(ptr %3)
+// CHECK-NEXT:   %4 = call i64 @"{{.*}}/cl/_testgo/abimethod.(*T).demo3"(ptr %3)
 // CHECK-NEXT:   ret i64 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.struct{m int; {{.*}}/_testgo/abimethod.T}.Demo1"({ i64, %"{{.*}}/_testgo/abimethod.T" } %0){{.*}} {
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = alloca { i64, %"{{.*}}/_testgo/abimethod.T" }, align 8
+// CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.memequal64"(ptr %1, ptr %2)
+// CHECK-NEXT:   ret i1 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.interequal"(ptr %1, ptr %2)
+// CHECK-NEXT:   ret i1 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; {{.*}}/cl/_testgo/abimethod.T}.Demo1"({ i64, %"{{.*}}/cl/_testgo/abimethod.T" } %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   store { i64, %"{{.*}}/_testgo/abimethod.T" } %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds { i64, %"{{.*}}/_testgo/abimethod.T" }, ptr %1, i32 0, i32 1
-// CHECK-NEXT:   %3 = load %"{{.*}}/_testgo/abimethod.T", ptr %2, align 8
-// CHECK-NEXT:   %4 = call i64 @"{{.*}}/_testgo/abimethod.T.Demo1"(%"{{.*}}/_testgo/abimethod.T" %3)
+// CHECK-NEXT:   store { i64, %"{{.*}}/cl/_testgo/abimethod.T" } %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %1, i32 0, i32 1
+// CHECK-NEXT:   %3 = load %"{{.*}}/cl/_testgo/abimethod.T", ptr %2, align 8
+// CHECK-NEXT:   %4 = call i64 @"{{.*}}/cl/_testgo/abimethod.T.Demo1"(%"{{.*}}/cl/_testgo/abimethod.T" %3)
 // CHECK-NEXT:   ret i64 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.*struct{m int; {{.*}}/_testgo/abimethod.T}.Demo1"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; {{.*}}/cl/_testgo/abimethod.T}.Demo1"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %2 = load %"{{.*}}/_testgo/abimethod.T", ptr %1, align 8
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/_testgo/abimethod.T.Demo1"(%"{{.*}}/_testgo/abimethod.T" %2)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/abimethod.T", ptr %1, align 8
+// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/abimethod.T.Demo1"(%"{{.*}}/cl/_testgo/abimethod.T" %2)
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.*struct{m int; {{.*}}/_testgo/abimethod.T}.Demo2"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; {{.*}}/cl/_testgo/abimethod.T}.Demo2"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %2 = call i64 @"{{.*}}/_testgo/abimethod.(*T).Demo2"(ptr %1)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = call i64 @"{{.*}}/cl/_testgo/abimethod.(*T).Demo2"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.*struct{m int; {{.*}}/_testgo/abimethod.T}.demo3"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; {{.*}}/cl/_testgo/abimethod.T}.demo3"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
-// CHECK-NEXT:   %2 = call i64 @"{{.*}}/_testgo/abimethod.(*T).demo3"(ptr %1)
+// CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = call i64 @"{{.*}}/cl/_testgo/abimethod.(*T).demo3"(ptr %1)
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Available"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Available"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1038,7 +960,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.AvailableBuffer"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.AvailableBuffer"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1046,7 +968,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Bytes"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Bytes"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1054,7 +976,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Cap"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Cap"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1062,7 +984,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Grow"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Grow"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1070,7 +992,7 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Len"(ptr %0){{.*}} {
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Len"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1078,7 +1000,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Next"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Next"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1086,7 +1008,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Read"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Read"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1098,7 +1020,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadByte"(ptr %0){{.*}} {
+// CHECK-LABEL: define { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadByte"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1110,7 +1032,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i8, %"{{.*}}/runtime/internal/runtime.iface" } %7
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadBytes"(ptr %0, i8 %1){{.*}} {
+// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadBytes"(ptr %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1122,7 +1044,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadFrom"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadFrom"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1134,7 +1056,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadRune"(ptr %0){{.*}} {
+// CHECK-LABEL: define { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadRune"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1148,7 +1070,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadString"(ptr %0, i8 %1){{.*}} {
+// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.ReadString"(ptr %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1160,7 +1082,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Reset"(ptr %0){{.*}} {
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Reset"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1168,7 +1090,7 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.String"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.String"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1176,7 +1098,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Truncate"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Truncate"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1184,7 +1106,7 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadByte"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadByte"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1192,7 +1114,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadRune"(ptr %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.UnreadRune"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1200,7 +1122,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Write"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.Write"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1212,7 +1134,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteByte"(ptr %0, i8 %1){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteByte"(ptr %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1220,7 +1142,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteRune"(ptr %0, i32 %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteRune"(ptr %0, i32 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1232,7 +1154,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteString"(ptr %0, %"{{.*}}/runtime/internal/runtime.String" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteString"(ptr %0, %"{{.*}}/runtime/internal/runtime.String" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1244,7 +1166,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteTo"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.WriteTo"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1256,7 +1178,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i1 @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.empty"(ptr %0){{.*}} {
+// CHECK-LABEL: define i1 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.empty"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load ptr, ptr %1, align 8
@@ -1264,7 +1186,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.grow"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.grow"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1272,7 +1194,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i64 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.readSlice"(ptr %0, i8 %1){{.*}} {
+// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.readSlice"(ptr %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1284,7 +1206,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, i1 } @"{{.*}}/_testgo/abimethod.*struct{m int; *bytes.Buffer}.tryGrowByReslice"(ptr %0, i64 %1){{.*}} {
+// CHECK-LABEL: define { i64, i1 } @"{{.*}}/cl/_testgo/abimethod.*struct{m int; *bytes.Buffer}.tryGrowByReslice"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1296,7 +1218,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, i1 } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Available"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Available"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1307,7 +1229,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i64 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.AvailableBuffer"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.AvailableBuffer"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1318,7 +1240,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Bytes"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Bytes"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1329,7 +1251,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Cap"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Cap"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1340,7 +1262,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i64 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Grow"({ i64, ptr } %0, i64 %1){{.*}} {
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Grow"({ i64, ptr } %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1351,7 +1273,7 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Len"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Len"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1362,7 +1284,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i64 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Next"({ i64, ptr } %0, i64 %1){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Next"({ i64, ptr } %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1373,7 +1295,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %5
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Read"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Read"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1388,7 +1310,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadByte"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadByte"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1403,7 +1325,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i8, %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadBytes"({ i64, ptr } %0, i8 %1){{.*}} {
+// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadBytes"({ i64, ptr } %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1418,7 +1340,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadFrom"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadFrom"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1433,7 +1355,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadRune"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadRune"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1450,7 +1372,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } %10
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadString"({ i64, ptr } %0, i8 %1){{.*}} {
+// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadString"({ i64, ptr } %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1465,7 +1387,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Reset"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Reset"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1476,7 +1398,7 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.String"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.String"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1487,7 +1409,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Truncate"({ i64, ptr } %0, i64 %1){{.*}} {
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Truncate"({ i64, ptr } %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1498,7 +1420,7 @@ type I2 interface {
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.UnreadByte"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.UnreadByte"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1509,7 +1431,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.UnreadRune"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.UnreadRune"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1520,7 +1442,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.Write"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Write"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1535,7 +1457,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteByte"({ i64, ptr } %0, i8 %1){{.*}} {
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteByte"({ i64, ptr } %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1546,7 +1468,7 @@ type I2 interface {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %5
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteRune"({ i64, ptr } %0, i32 %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteRune"({ i64, ptr } %0, i32 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1561,7 +1483,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteString"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.String" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteString"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.String" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1576,7 +1498,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteTo"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
+// CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteTo"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1591,7 +1513,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i1 @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.empty"({ i64, ptr } %0){{.*}} {
+// CHECK-LABEL: define i1 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.empty"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
@@ -1602,7 +1524,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i1 %4
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.grow"({ i64, ptr } %0, i64 %1){{.*}} {
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.grow"({ i64, ptr } %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1613,7 +1535,7 @@ type I2 interface {
 // CHECK-NEXT:   ret i64 %5
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.readSlice"({ i64, ptr } %0, i8 %1){{.*}} {
+// CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.readSlice"({ i64, ptr } %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1628,7 +1550,7 @@ type I2 interface {
 // CHECK-NEXT:   ret { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define { i64, i1 } @"{{.*}}/_testgo/abimethod.struct{m int; *bytes.Buffer}.tryGrowByReslice"({ i64, ptr } %0, i64 %1){{.*}} {
+// CHECK-LABEL: define { i64, i1 } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.tryGrowByReslice"({ i64, ptr } %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
@@ -1643,16 +1565,28 @@ type I2 interface {
 // CHECK-NEXT:   ret { i64, i1 } %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce ptr @"{{.*}}/_testgo/abimethod.(*Pointer[any]).Load"(ptr %0){{.*}} {
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.Pointer[any]", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.memequal8"(ptr %1, ptr %2)
+// CHECK-NEXT:   ret i1 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce ptr @"{{.*}}/cl/_testgo/abimethod.(*Pointer[any]).Load"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.Pointer[any]", ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %2 = load atomic ptr, ptr %1 seq_cst, align 8
 // CHECK-NEXT:   ret ptr %2
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"{{.*}}/_testgo/abimethod.(*Pointer[any]).Store"(ptr %0, ptr %1){{.*}} {
+// CHECK-LABEL: define linkonce void @"{{.*}}/cl/_testgo/abimethod.(*Pointer[any]).Store"(ptr %0, ptr %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/_testgo/abimethod.Pointer[any]", ptr %0, i32 0, i32 1
+// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.Pointer[any]", ptr %0, i32 0, i32 1
 // CHECK-NEXT:   store atomic ptr %1, ptr %2 seq_cst, align 8
 // CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.nilinterequal"(ptr %0, ptr %1, ptr %2){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.nilinterequal"(ptr %1, ptr %2)
+// CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }

--- a/cl/_testgo/closureall/in.go
+++ b/cl/_testgo/closureall/in.go
@@ -8,6 +8,10 @@ import "github.com/goplus/lib/c"
 //go:linkname cSqrt C.sqrt
 func cSqrt(x c.Double) c.Double
 
+// CHECK-LINE: @0 = private unnamed_addr constant [46 x i8] c"{{.*}}/cl/_testgo/closureall.S", align 1
+// CHECK-LINE: @1 = private unnamed_addr constant [3 x i8] c"Inc", align 1
+// CHECK-LINE: @9 = private unnamed_addr constant [72 x i8] c"type assertion interface{Add(int) int} -> interface{Add(int) int} failed", align 1
+
 // llgo:link cAbs C.abs
 func cAbs(x c.Int) c.Int { return 0 }
 
@@ -30,6 +34,7 @@ type S struct {
 // CHECK-NEXT:   %5 = add i64 %4, %1
 // CHECK-NEXT:   ret i64 %5
 // CHECK-NEXT: }
+
 func (s S) Inc(x int) int {
 	return s.v + x
 }
@@ -41,15 +46,62 @@ func (s S) Inc(x int) int {
 // CHECK-NEXT:   %4 = add i64 %3, %1
 // CHECK-NEXT:   ret i64 %4
 // CHECK-NEXT: }
+
 func (s *S) Add(x int) int {
 	return s.v + x
 }
 
+func callCallback(cb CCallback, v c.Int) c.Int {
+	return cb(v)
+}
+
+func globalAdd(x, y int) int {
+	return x + y
+}
+
+func main() {
+	nf := makeNoFree()
+	wf := makeWithFree(3)
+	_ = nf(1)
+	_ = wf(2)
+
+	g := globalAdd
+	_ = g(1, 2)
+
+	s := &S{v: 5}
+	mv := s.Add
+	_ = mv(7)
+	me := (*S).Add
+	_ = me(s, 8)
+
+	var i interface{ Add(int) int } = s
+	im := i.Add
+	_ = im(9)
+
+	cs := cSqrt
+	_ = cs(4)
+	ca := cAbs
+	_ = ca(-3)
+
+	cb := CCallback(func(x c.Int) c.Int { return x + 1 })
+	_ = callCallback(cb, 7)
+}
+
+func makeNoFree() Fn {
+	return func(x int) int { return x + 1 }
+}
+
+func makeWithFree(base int) Fn {
+	return func(x int) int { return x + base }
+}
+
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/closureall.(*S).Inc"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/closureall.S", ptr %0, align 8
-// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/closureall.S.Inc"(%"{{.*}}/cl/_testgo/closureall.S" %2, i64 %1)
-// CHECK-NEXT:   ret i64 %3
+// CHECK-NEXT:   %2 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %2, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 46 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 3 })
+// CHECK-NEXT:   %3 = load %"{{.*}}/cl/_testgo/closureall.S", ptr %0, align 8
+// CHECK-NEXT:   %4 = call i64 @"{{.*}}/cl/_testgo/closureall.S.Inc"(%"{{.*}}/cl/_testgo/closureall.S" %3, i64 %1)
+// CHECK-NEXT:   ret i64 %4
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define i32 @"{{.*}}/cl/_testgo/closureall.callCallback"(ptr %0, i32 %1){{.*}} {
@@ -57,18 +109,25 @@ func (s *S) Add(x int) int {
 // CHECK-NEXT:   %2 = call i32 %0(i32 %1)
 // CHECK-NEXT:   ret i32 %2
 // CHECK-NEXT: }
-func callCallback(cb CCallback, v c.Int) c.Int {
-	return cb(v)
-}
 
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/closureall.globalAdd"(i64 %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = add i64 %0, %1
 // CHECK-NEXT:   ret i64 %2
 // CHECK-NEXT: }
-func globalAdd(x, y int) int {
-	return x + y
-}
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/closureall.init"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/closureall.init$guard", align 1
+// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/closureall.init$guard", align 1
+// CHECK-NEXT:   br label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/closureall.main"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
@@ -114,38 +173,17 @@ func globalAdd(x, y int) int {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %32 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @8, i64 72 }, ptr %32, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @9, i64 72 }, ptr %32, align 8
 // CHECK-NEXT:   %33 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %32, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %33)
 // CHECK-NEXT:   unreachable
 // CHECK-NEXT: }
-func main() {
-	nf := makeNoFree()
-	wf := makeWithFree(3)
-	_ = nf(1)
-	_ = wf(2)
 
-	g := globalAdd
-	_ = g(1, 2)
-
-	s := &S{v: 5}
-	mv := s.Add
-	_ = mv(7)
-	me := (*S).Add
-	_ = me(s, 8)
-
-	var i interface{ Add(int) int } = s
-	im := i.Add
-	_ = im(9)
-
-	cs := cSqrt
-	_ = cs(4)
-	ca := cAbs
-	_ = ca(-3)
-
-	cb := CCallback(func(x c.Int) c.Int { return x + 1 })
-	_ = callCallback(cb, 7)
-}
+// CHECK-LABEL: define i32 @"{{.*}}/cl/_testgo/closureall.main$1"(i32 %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = add i32 %0, 1
+// CHECK-NEXT:   ret i32 %1
+// CHECK-NEXT: }
 
 // CHECK-LABEL: define %"{{.*}}/cl/_testgo/closureall.Fn" @"{{.*}}/cl/_testgo/closureall.makeNoFree"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
@@ -157,9 +195,6 @@ func main() {
 // CHECK-NEXT:   %1 = add i64 %0, 1
 // CHECK-NEXT:   ret i64 %1
 // CHECK-NEXT: }
-func makeNoFree() Fn {
-	return func(x int) int { return x + 1 }
-}
 
 // CHECK-LABEL: define %"{{.*}}/cl/_testgo/closureall.Fn" @"{{.*}}/cl/_testgo/closureall.makeWithFree"(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
@@ -183,9 +218,6 @@ func makeNoFree() Fn {
 // CHECK-NEXT:   %5 = add i64 %1, %4
 // CHECK-NEXT:   ret i64 %5
 // CHECK-NEXT: }
-func makeWithFree(base int) Fn {
-	return func(x int) int { return x + base }
-}
 
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/closureall.(*S).Add$bound"(ptr %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
@@ -199,6 +231,18 @@ func makeWithFree(base int) Fn {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = call i64 @"{{.*}}/cl/_testgo/closureall.(*S).Add"(ptr %0, i64 %1)
 // CHECK-NEXT:   ret i64 %2
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.memequal64"(ptr %1, ptr %2)
+// CHECK-NEXT:   ret i1 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.interequal"(ptr %1, ptr %2)
+// CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/closureall.interface{Add(int) int}.Add$bound"(ptr %0, i64 %1){{.*}} {

--- a/cl/_testgo/cursor/in.go
+++ b/cl/_testgo/cursor/in.go
@@ -9,6 +9,11 @@ import (
 
 // CHECK-LINE: @0 = private unnamed_addr constant [36 x i8] c"iterator call did not preserve panic", align 1
 // CHECK-LINE: @2 = private unnamed_addr constant [43 x i8] c"yield function called after range loop exit", align 1
+// CHECK-LINE: @3 = private unnamed_addr constant [47 x i8] c"{{.*}}/cl/_testgo/cursor.Cursor", align 1
+// CHECK-LINE: @4 = private unnamed_addr constant [8 x i8] c"FindNode", align 1
+// CHECK-LINE: @5 = private unnamed_addr constant [4 x i8] c"Node", align 1
+// CHECK-LINE: @6 = private unnamed_addr constant [8 x i8] c"Preorder", align 1
+// CHECK-LINE: @7 = private unnamed_addr constant [7 x i8] c"indices", align 1
 
 func main() {
 	c := &Cursor{in: &Inspector{}}
@@ -732,38 +737,46 @@ const (
 
 // CHECK-LABEL: define { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } @"{{.*}}/cl/_testgo/cursor.(*Cursor).FindNode"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %0, align 8
-// CHECK-NEXT:   %3 = call { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } @"{{.*}}/cl/_testgo/cursor.Cursor.FindNode"(%"{{.*}}/cl/_testgo/cursor.Cursor" %2, %"{{.*}}/runtime/internal/runtime.iface" %1)
-// CHECK-NEXT:   %4 = extractvalue { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } %3, 0
-// CHECK-NEXT:   %5 = extractvalue { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } %3, 1
-// CHECK-NEXT:   %6 = insertvalue { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } undef, %"{{.*}}/cl/_testgo/cursor.Cursor" %4, 0
-// CHECK-NEXT:   %7 = insertvalue { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } %6, i1 %5, 1
-// CHECK-NEXT:   ret { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } %7
+// CHECK-NEXT:   %2 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %2, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 47 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @4, i64 8 })
+// CHECK-NEXT:   %3 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %0, align 8
+// CHECK-NEXT:   %4 = call { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } @"{{.*}}/cl/_testgo/cursor.Cursor.FindNode"(%"{{.*}}/cl/_testgo/cursor.Cursor" %3, %"{{.*}}/runtime/internal/runtime.iface" %1)
+// CHECK-NEXT:   %5 = extractvalue { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } %4, 0
+// CHECK-NEXT:   %6 = extractvalue { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } %4, 1
+// CHECK-NEXT:   %7 = insertvalue { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } undef, %"{{.*}}/cl/_testgo/cursor.Cursor" %5, 0
+// CHECK-NEXT:   %8 = insertvalue { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } %7, i1 %6, 1
+// CHECK-NEXT:   ret { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } %8
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/cursor.(*Cursor).Node"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %0, align 8
-// CHECK-NEXT:   %2 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/cursor.Cursor.Node"(%"{{.*}}/cl/_testgo/cursor.Cursor" %1)
-// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %2
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 47 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 4 })
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %0, align 8
+// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/cursor.Cursor.Node"(%"{{.*}}/cl/_testgo/cursor.Cursor" %2)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %3
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define %"iter.Seq[{{.*}}/cl/_testgo/cursor.Cursor]" @"{{.*}}/cl/_testgo/cursor.(*Cursor).Preorder"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %0, align 8
-// CHECK-NEXT:   %3 = call %"iter.Seq[{{.*}}/cl/_testgo/cursor.Cursor]" @"{{.*}}/cl/_testgo/cursor.Cursor.Preorder"(%"{{.*}}/cl/_testgo/cursor.Cursor" %2, %"{{.*}}/runtime/internal/runtime.Slice" %1)
-// CHECK-NEXT:   ret %"iter.Seq[{{.*}}/cl/_testgo/cursor.Cursor]" %3
+// CHECK-NEXT:   %2 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %2, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 47 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 8 })
+// CHECK-NEXT:   %3 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %0, align 8
+// CHECK-NEXT:   %4 = call %"iter.Seq[{{.*}}/cl/_testgo/cursor.Cursor]" @"{{.*}}/cl/_testgo/cursor.Cursor.Preorder"(%"{{.*}}/cl/_testgo/cursor.Cursor" %3, %"{{.*}}/runtime/internal/runtime.Slice" %1)
+// CHECK-NEXT:   ret %"iter.Seq[{{.*}}/cl/_testgo/cursor.Cursor]" %4
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define { i32, i32 } @"{{.*}}/cl/_testgo/cursor.(*Cursor).indices"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %0, align 8
-// CHECK-NEXT:   %2 = call { i32, i32 } @"{{.*}}/cl/_testgo/cursor.Cursor.indices"(%"{{.*}}/cl/_testgo/cursor.Cursor" %1)
-// CHECK-NEXT:   %3 = extractvalue { i32, i32 } %2, 0
-// CHECK-NEXT:   %4 = extractvalue { i32, i32 } %2, 1
-// CHECK-NEXT:   %5 = insertvalue { i32, i32 } undef, i32 %3, 0
-// CHECK-NEXT:   %6 = insertvalue { i32, i32 } %5, i32 %4, 1
-// CHECK-NEXT:   ret { i32, i32 } %6
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 47 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 7 })
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %0, align 8
+// CHECK-NEXT:   %3 = call { i32, i32 } @"{{.*}}/cl/_testgo/cursor.Cursor.indices"(%"{{.*}}/cl/_testgo/cursor.Cursor" %2)
+// CHECK-NEXT:   %4 = extractvalue { i32, i32 } %3, 0
+// CHECK-NEXT:   %5 = extractvalue { i32, i32 } %3, 1
+// CHECK-NEXT:   %6 = insertvalue { i32, i32 } undef, i32 %4, 0
+// CHECK-NEXT:   %7 = insertvalue { i32, i32 } %6, i32 %5, 1
+// CHECK-NEXT:   ret { i32, i32 } %7
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/cursor.init"(){{.*}} {

--- a/cl/_testgo/genericembediface/in.go
+++ b/cl/_testgo/genericembediface/in.go
@@ -5,9 +5,12 @@ import (
 	"github.com/goplus/llgo/cl/_testgo/genericembediface/streamlib"
 )
 
+// CHECK-LINE: @2 = private unnamed_addr constant [20 x i8] c"ServerReflectionInfo", align 1
 // CHECK-LINE: @5 = private unnamed_addr constant [7 x i8] c"Context", align 1
 // CHECK-LINE: @10 = private unnamed_addr constant [97 x i8] c"type assertion any -> {{.*}}/cl/_testgo/genericembediface.ReflectionServer failed", align 1
 // CHECK-LINE: @19 = private unnamed_addr constant [4 x i8] c"pass", align 1
+// CHECK-LINE: @20 = private unnamed_addr constant [58 x i8] c"{{.*}}/cl/_testgo/genericembediface.server", align 1
+// CHECK-LINE: @21 = private unnamed_addr constant [58 x i8] c"{{.*}}/cl/_testgo/genericembediface.stream", align 1
 
 type Request struct{}
 type Response struct{}
@@ -50,6 +53,20 @@ type ReflectionServer interface {
 // CHECK-NEXT:   %23 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %22, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %23)
 // CHECK-NEXT:   unreachable
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/genericembediface.init"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/genericembediface.init$guard", align 1
+// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/genericembediface.init$guard", align 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/genericembediface/streamlib.init"()
+// CHECK-NEXT:   br label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+// CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
 func handler(srv any, stream streamlib.ServerStream) error {
@@ -96,9 +113,11 @@ func main() {
 
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/genericembediface.(*server).ServerReflectionInfo"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/genericembediface.server", ptr %0, align 1
-// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/genericembediface.server.ServerReflectionInfo"(%"{{.*}}/cl/_testgo/genericembediface.server" %2, %"{{.*}}/runtime/internal/runtime.iface" %1)
-// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %3
+// CHECK-NEXT:   %2 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %2, %"{{.*}}/runtime/internal/runtime.String" { ptr @20, i64 58 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 20 })
+// CHECK-NEXT:   %3 = load %"{{.*}}/cl/_testgo/genericembediface.server", ptr %0, align 1
+// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/genericembediface.server.ServerReflectionInfo"(%"{{.*}}/cl/_testgo/genericembediface.server" %3, %"{{.*}}/runtime/internal/runtime.iface" %1)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %4
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface.stream.Context"(%"{{.*}}/cl/_testgo/genericembediface.stream" %0){{.*}} {
@@ -108,9 +127,11 @@ func main() {
 
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface.(*stream).Context"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = load %"{{.*}}/cl/_testgo/genericembediface.stream", ptr %0, align 1
-// CHECK-NEXT:   %2 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface.stream.Context"(%"{{.*}}/cl/_testgo/genericembediface.stream" %1)
-// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %2
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @21, i64 58 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 7 })
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/genericembediface.stream", ptr %0, align 1
+// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface.stream.Context"(%"{{.*}}/cl/_testgo/genericembediface.stream" %2)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %3
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2){{.*}} {
@@ -152,4 +173,10 @@ func main() {
 // CHECK-NEXT:   %11 = extractvalue { ptr, ptr } %9, 0
 // CHECK-NEXT:   %12 = call %"{{.*}}/runtime/internal/runtime.String" %11(ptr %10)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %12
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequal0"(ptr %0, ptr %1, ptr %2){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.memequal0"(ptr %1, ptr %2)
+// CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }

--- a/cl/_testgo/ifaceconv/in.go
+++ b/cl/_testgo/ifaceconv/in.go
@@ -3,6 +3,23 @@ package main
 
 // Tests of interface conversions and type assertions.
 
+// CHECK-LINE: @0 = private unnamed_addr constant [46 x i8] c"{{.*}}/cl/_testgo/ifaceconv.C1", align 1
+// CHECK-LINE: @1 = private unnamed_addr constant [1 x i8] c"f", align 1
+// CHECK-LINE: @2 = private unnamed_addr constant [46 x i8] c"{{.*}}/cl/_testgo/ifaceconv.C2", align 1
+// CHECK-LINE: @3 = private unnamed_addr constant [1 x i8] c"g", align 1
+// CHECK-LINE: @6 = private unnamed_addr constant [21 x i8] c"nil i0.(I0) succeeded", align 1
+// CHECK-LINE: @11 = private unnamed_addr constant [21 x i8] c"nil i1.(I1) succeeded", align 1
+// CHECK-LINE: @14 = private unnamed_addr constant [21 x i8] c"nil i2.(I2) succeeded", align 1
+// CHECK-LINE: @17 = private unnamed_addr constant [17 x i8] c"C1 i1.(I0) failed", align 1
+// CHECK-LINE: @19 = private unnamed_addr constant [17 x i8] c"C1 i1.(I1) failed", align 1
+// CHECK-LINE: @20 = private unnamed_addr constant [20 x i8] c"C1 i1.(I2) succeeded", align 1
+// CHECK-LINE: @22 = private unnamed_addr constant [17 x i8] c"C2 i1.(I0) failed", align 1
+// CHECK-LINE: @23 = private unnamed_addr constant [17 x i8] c"C2 i1.(I1) failed", align 1
+// CHECK-LINE: @24 = private unnamed_addr constant [17 x i8] c"C2 i1.(I2) failed", align 1
+// CHECK-LINE: @25 = private unnamed_addr constant [17 x i8] c"C1 I0(i1) was nil", align 1
+// CHECK-LINE: @26 = private unnamed_addr constant [17 x i8] c"C1 I1(i1) was nil", align 1
+// CHECK-LINE: @27 = private unnamed_addr constant [4 x i8] c"pass", align 1
+
 type I0 interface {
 }
 type I1 interface {
@@ -21,15 +38,83 @@ type C1 struct{}
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceconv.(*C1).f"(ptr %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = load %"{{.*}}/cl/_testgo/ifaceconv.C1", ptr %0, align 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/ifaceconv.C1.f"(%"{{.*}}/cl/_testgo/ifaceconv.C1" %1)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 func (C1) f() {}
 
 type C2 struct{}
+
+func (C2) f() {}
+func (C2) g() {}
+
+func main() {
+	var i0 I0
+	var i1 I1
+	var i2 I2
+
+	// Nil always causes a type assertion to fail, even to the
+	// same type.
+	if _, ok := i0.(I0); ok {
+		panic("nil i0.(I0) succeeded")
+	}
+	if _, ok := i1.(I1); ok {
+		panic("nil i1.(I1) succeeded")
+	}
+	if _, ok := i2.(I2); ok {
+		panic("nil i2.(I2) succeeded")
+	}
+
+	// Conversions can't fail, even with nil.
+	_ = I0(i0)
+
+	_ = I0(i1)
+	_ = I1(i1)
+
+	_ = I0(i2)
+	_ = I1(i2)
+	_ = I2(i2)
+
+	// Non-nil type assertions pass or fail based on the concrete type.
+	i1 = C1{}
+	if _, ok := i1.(I0); !ok {
+		panic("C1 i1.(I0) failed")
+	}
+	if _, ok := i1.(I1); !ok {
+		panic("C1 i1.(I1) failed")
+	}
+	if _, ok := i1.(I2); ok {
+		panic("C1 i1.(I2) succeeded")
+	}
+
+	i1 = C2{}
+	if _, ok := i1.(I0); !ok {
+		panic("C2 i1.(I0) failed")
+	}
+	if _, ok := i1.(I1); !ok {
+		panic("C2 i1.(I1) failed")
+	}
+	if _, ok := i1.(I2); !ok {
+		panic("C2 i1.(I2) failed")
+	}
+
+	// Conversions can't fail.
+	i1 = C1{}
+	if I0(i1) == nil {
+		panic("C1 I0(i1) was nil")
+	}
+	if I1(i1) == nil {
+		panic("C1 I1(i1) was nil")
+	}
+
+	println("pass")
+}
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceconv.(*C1).f"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 46 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 1 })
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/ifaceconv.C1", ptr %0, align 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/ifaceconv.C1.f"(%"{{.*}}/cl/_testgo/ifaceconv.C1" %2)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceconv.C2.f"(%"{{.*}}/cl/_testgo/ifaceconv.C2" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
@@ -43,19 +128,34 @@ type C2 struct{}
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceconv.(*C2).f"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = load %"{{.*}}/cl/_testgo/ifaceconv.C2", ptr %0, align 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/ifaceconv.C2.f"(%"{{.*}}/cl/_testgo/ifaceconv.C2" %1)
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 46 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 1 })
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/ifaceconv.C2", ptr %0, align 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/ifaceconv.C2.f"(%"{{.*}}/cl/_testgo/ifaceconv.C2" %2)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceconv.(*C2).g"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = load %"{{.*}}/cl/_testgo/ifaceconv.C2", ptr %0, align 1
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/ifaceconv.C2.g"(%"{{.*}}/cl/_testgo/ifaceconv.C2" %1)
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 46 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 1 })
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/ifaceconv.C2", ptr %0, align 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/ifaceconv.C2.g"(%"{{.*}}/cl/_testgo/ifaceconv.C2" %2)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
-func (C2) f() {}
-func (C2) g() {}
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceconv.init"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/ifaceconv.init$guard", align 1
+// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/ifaceconv.init$guard", align 1
+// CHECK-NEXT:   br label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceconv.main"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
@@ -63,7 +163,7 @@ func (C2) g() {}
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_25
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 21 }, ptr %0, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 21 }, ptr %0, align 8
 // CHECK-NEXT:   %1 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %0, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %1)
 // CHECK-NEXT:   unreachable
@@ -75,7 +175,7 @@ func (C2) g() {}
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_28
 // CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 21 }, ptr %4, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @11, i64 21 }, ptr %4, align 8
 // CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %4, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %5)
 // CHECK-NEXT:   unreachable
@@ -87,7 +187,7 @@ func (C2) g() {}
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_31
 // CHECK-NEXT:   %8 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @10, i64 21 }, ptr %8, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @14, i64 21 }, ptr %8, align 8
 // CHECK-NEXT:   %9 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %8, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %9)
 // CHECK-NEXT:   unreachable
@@ -114,7 +214,7 @@ func (C2) g() {}
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_34
 // CHECK-NEXT:   %26 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @14, i64 17 }, ptr %26, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @17, i64 17 }, ptr %26, align 8
 // CHECK-NEXT:   %27 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %26, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %27)
 // CHECK-NEXT:   unreachable
@@ -126,7 +226,7 @@ func (C2) g() {}
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_9:                                          ; preds = %_llgo_37
 // CHECK-NEXT:   %30 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @16, i64 17 }, ptr %30, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @19, i64 17 }, ptr %30, align 8
 // CHECK-NEXT:   %31 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %30, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %31)
 // CHECK-NEXT:   unreachable
@@ -138,7 +238,7 @@ func (C2) g() {}
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_11:                                         ; preds = %_llgo_40
 // CHECK-NEXT:   %34 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @17, i64 20 }, ptr %34, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @20, i64 20 }, ptr %34, align 8
 // CHECK-NEXT:   %35 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %34, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %35)
 // CHECK-NEXT:   unreachable
@@ -155,7 +255,7 @@ func (C2) g() {}
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_13:                                         ; preds = %_llgo_43
 // CHECK-NEXT:   %42 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @20, i64 17 }, ptr %42, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 17 }, ptr %42, align 8
 // CHECK-NEXT:   %43 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %42, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %43)
 // CHECK-NEXT:   unreachable
@@ -167,7 +267,7 @@ func (C2) g() {}
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_15:                                         ; preds = %_llgo_46
 // CHECK-NEXT:   %46 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @21, i64 17 }, ptr %46, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @23, i64 17 }, ptr %46, align 8
 // CHECK-NEXT:   %47 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %46, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %47)
 // CHECK-NEXT:   unreachable
@@ -179,7 +279,7 @@ func (C2) g() {}
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_17:                                         ; preds = %_llgo_49
 // CHECK-NEXT:   %50 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 17 }, ptr %50, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @24, i64 17 }, ptr %50, align 8
 // CHECK-NEXT:   %51 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %50, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %51)
 // CHECK-NEXT:   unreachable
@@ -199,7 +299,7 @@ func (C2) g() {}
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_19:                                         ; preds = %_llgo_18
 // CHECK-NEXT:   %61 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @23, i64 17 }, ptr %61, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @25, i64 17 }, ptr %61, align 8
 // CHECK-NEXT:   %62 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %61, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %62)
 // CHECK-NEXT:   unreachable
@@ -217,13 +317,13 @@ func (C2) g() {}
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_21:                                         ; preds = %_llgo_20
 // CHECK-NEXT:   %71 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @24, i64 17 }, ptr %71, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @26, i64 17 }, ptr %71, align 8
 // CHECK-NEXT:   %72 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %71, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %72)
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_22:                                         ; preds = %_llgo_20
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @25, i64 4 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @27, i64 4 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
@@ -361,64 +461,21 @@ func (C2) g() {}
 // CHECK-NEXT:   %125 = extractvalue { %"{{.*}}/runtime/internal/runtime.iface", i1 } %123, 1
 // CHECK-NEXT:   br i1 %125, label %_llgo_18, label %_llgo_17
 // CHECK-NEXT: }
-func main() {
-	var i0 I0
-	var i1 I1
-	var i2 I2
 
-	// Nil always causes a type assertion to fail, even to the
-	// same type.
-	if _, ok := i0.(I0); ok {
-		panic("nil i0.(I0) succeeded")
-	}
-	if _, ok := i1.(I1); ok {
-		panic("nil i1.(I1) succeeded")
-	}
-	if _, ok := i2.(I2); ok {
-		panic("nil i2.(I2) succeeded")
-	}
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.nilinterequal"(ptr %0, ptr %1, ptr %2){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.nilinterequal"(ptr %1, ptr %2)
+// CHECK-NEXT:   ret i1 %3
+// CHECK-NEXT: }
 
-	// Conversions can't fail, even with nil.
-	_ = I0(i0)
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.interequal"(ptr %1, ptr %2)
+// CHECK-NEXT:   ret i1 %3
+// CHECK-NEXT: }
 
-	_ = I0(i1)
-	_ = I1(i1)
-
-	_ = I0(i2)
-	_ = I1(i2)
-	_ = I2(i2)
-
-	// Non-nil type assertions pass or fail based on the concrete type.
-	i1 = C1{}
-	if _, ok := i1.(I0); !ok {
-		panic("C1 i1.(I0) failed")
-	}
-	if _, ok := i1.(I1); !ok {
-		panic("C1 i1.(I1) failed")
-	}
-	if _, ok := i1.(I2); ok {
-		panic("C1 i1.(I2) succeeded")
-	}
-
-	i1 = C2{}
-	if _, ok := i1.(I0); !ok {
-		panic("C2 i1.(I0) failed")
-	}
-	if _, ok := i1.(I1); !ok {
-		panic("C2 i1.(I1) failed")
-	}
-	if _, ok := i1.(I2); !ok {
-		panic("C2 i1.(I2) failed")
-	}
-
-	// Conversions can't fail.
-	i1 = C1{}
-	if I0(i1) == nil {
-		panic("C1 I0(i1) was nil")
-	}
-	if I1(i1) == nil {
-		panic("C1 I1(i1) was nil")
-	}
-
-	println("pass")
-}
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequal0"(ptr %0, ptr %1, ptr %2){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.memequal0"(ptr %1, ptr %2)
+// CHECK-NEXT:   ret i1 %3
+// CHECK-NEXT: }

--- a/cl/_testgo/ifaceprom/in.go
+++ b/cl/_testgo/ifaceprom/in.go
@@ -5,9 +5,65 @@ package main
 // struct.  In particular, this test exercises that the correct
 // method is called.
 
+// CHECK-LINE: @0 = private unnamed_addr constant [3 x i8] c"two", align 1
+// CHECK-LINE: @1 = private unnamed_addr constant [48 x i8] c"{{.*}}/cl/_testgo/ifaceprom.impl", align 1
+// CHECK-LINE: @2 = private unnamed_addr constant [3 x i8] c"one", align 1
+// CHECK-LINE: @13 = private unnamed_addr constant [116 x i8] c"type assertion {{.*}}/cl/_testgo/ifaceprom.I -> {{.*}}/cl/_testgo/ifaceprom.I failed", align 1
+// CHECK-LINE: @14 = private unnamed_addr constant [4 x i8] c"pass", align 1
+
 type I interface {
 	one() int
 	two() string
+}
+
+type S struct {
+	I
+}
+
+type impl struct{}
+
+func (impl) one() int {
+	return 1
+}
+
+func (impl) two() string {
+	return "two"
+}
+
+func main() {
+	var s S
+	s.I = impl{}
+	if one := s.I.one(); one != 1 {
+		panic(one)
+	}
+	if one := s.one(); one != 1 {
+		panic(one)
+	}
+	closOne := s.I.one
+	if one := closOne(); one != 1 {
+		panic(one)
+	}
+	closOne = s.one
+	if one := closOne(); one != 1 {
+		panic(one)
+	}
+
+	if two := s.I.two(); two != "two" {
+		panic(two)
+	}
+	if two := s.two(); two != "two" {
+		panic(two)
+	}
+	closTwo := s.I.two
+	if two := closTwo(); two != "two" {
+		panic(two)
+	}
+	closTwo = s.two
+	if two := closTwo(); two != "two" {
+		panic(two)
+	}
+
+	println("pass")
 }
 
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/ifaceprom.S.one"(%"{{.*}}/cl/_testgo/ifaceprom.S" %0){{.*}} {
@@ -47,27 +103,79 @@ type I interface {
 // CHECK-NEXT:   %12 = call %"{{.*}}/runtime/internal/runtime.String" %11(ptr %10)
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %12
 // CHECK-NEXT: }
-type S struct {
-	I
-}
 
-type impl struct{}
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/ifaceprom.(*S).one"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %1, align 8
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %2)
+// CHECK-NEXT:   %4 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %2, 0
+// CHECK-NEXT:   %5 = getelementptr ptr, ptr %4, i64 3
+// CHECK-NEXT:   %6 = load ptr, ptr %5, align 8
+// CHECK-NEXT:   %7 = insertvalue { ptr, ptr } undef, ptr %6, 0
+// CHECK-NEXT:   %8 = insertvalue { ptr, ptr } %7, ptr %3, 1
+// CHECK-NEXT:   %9 = extractvalue { ptr, ptr } %8, 1
+// CHECK-NEXT:   %10 = extractvalue { ptr, ptr } %8, 0
+// CHECK-NEXT:   %11 = call i64 %10(ptr %9)
+// CHECK-NEXT:   ret i64 %11
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/ifaceprom.(*S).two"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %1, align 8
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %2)
+// CHECK-NEXT:   %4 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %2, 0
+// CHECK-NEXT:   %5 = getelementptr ptr, ptr %4, i64 4
+// CHECK-NEXT:   %6 = load ptr, ptr %5, align 8
+// CHECK-NEXT:   %7 = insertvalue { ptr, ptr } undef, ptr %6, 0
+// CHECK-NEXT:   %8 = insertvalue { ptr, ptr } %7, ptr %3, 1
+// CHECK-NEXT:   %9 = extractvalue { ptr, ptr } %8, 1
+// CHECK-NEXT:   %10 = extractvalue { ptr, ptr } %8, 0
+// CHECK-NEXT:   %11 = call %"{{.*}}/runtime/internal/runtime.String" %10(ptr %9)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %11
+// CHECK-NEXT: }
 
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/ifaceprom.impl.one"(%"{{.*}}/cl/_testgo/ifaceprom.impl" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret i64 1
 // CHECK-NEXT: }
-func (impl) one() int {
-	return 1
-}
 
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/ifaceprom.impl.two"(%"{{.*}}/cl/_testgo/ifaceprom.impl" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 3 }
 // CHECK-NEXT: }
-func (impl) two() string {
-	return "two"
-}
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/ifaceprom.(*impl).one"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 48 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 3 })
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/ifaceprom.impl", ptr %0, align 1
+// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/ifaceprom.impl.one"(%"{{.*}}/cl/_testgo/ifaceprom.impl" %2)
+// CHECK-NEXT:   ret i64 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/ifaceprom.(*impl).two"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 48 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 3 })
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/ifaceprom.impl", ptr %0, align 1
+// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/ifaceprom.impl.two"(%"{{.*}}/cl/_testgo/ifaceprom.impl" %2)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceprom.init"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/ifaceprom.init$guard", align 1
+// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/ifaceprom.init$guard", align 1
+// CHECK-NEXT:   br label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceprom.main"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
@@ -226,7 +334,7 @@ func (impl) two() string {
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_16:                                         ; preds = %_llgo_23
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @13, i64 4 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @14, i64 4 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   ret void
 // CHECK-EMPTY:
@@ -243,7 +351,7 @@ func (impl) two() string {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_18:                                         ; preds = %_llgo_4
 // CHECK-NEXT:   %95 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @12, i64 116 }, ptr %95, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @13, i64 116 }, ptr %95, align 8
 // CHECK-NEXT:   %96 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %95, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %96)
 // CHECK-NEXT:   unreachable
@@ -261,7 +369,7 @@ func (impl) two() string {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_20:                                         ; preds = %_llgo_6
 // CHECK-NEXT:   %104 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @12, i64 116 }, ptr %104, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @13, i64 116 }, ptr %104, align 8
 // CHECK-NEXT:   %105 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %104, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %105)
 // CHECK-NEXT:   unreachable
@@ -280,7 +388,7 @@ func (impl) two() string {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_22:                                         ; preds = %_llgo_12
 // CHECK-NEXT:   %114 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @12, i64 116 }, ptr %114, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @13, i64 116 }, ptr %114, align 8
 // CHECK-NEXT:   %115 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %114, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %115)
 // CHECK-NEXT:   unreachable
@@ -299,43 +407,58 @@ func (impl) two() string {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_24:                                         ; preds = %_llgo_14
 // CHECK-NEXT:   %124 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @12, i64 116 }, ptr %124, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @13, i64 116 }, ptr %124, align 8
 // CHECK-NEXT:   %125 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %124, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %125)
 // CHECK-NEXT:   unreachable
 // CHECK-NEXT: }
-func main() {
-	var s S
-	s.I = impl{}
-	if one := s.I.one(); one != 1 {
-		panic(one)
-	}
-	if one := s.one(); one != 1 {
-		panic(one)
-	}
-	closOne := s.I.one
-	if one := closOne(); one != 1 {
-		panic(one)
-	}
-	closOne = s.one
-	if one := closOne(); one != 1 {
-		panic(one)
-	}
 
-	if two := s.I.two(); two != "two" {
-		panic(two)
-	}
-	if two := s.two(); two != "two" {
-		panic(two)
-	}
-	closTwo := s.I.two
-	if two := closTwo(); two != "two" {
-		panic(two)
-	}
-	closTwo = s.two
-	if two := closTwo(); two != "two" {
-		panic(two)
-	}
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequal0"(ptr %0, ptr %1, ptr %2){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.memequal0"(ptr %1, ptr %2)
+// CHECK-NEXT:   ret i1 %3
+// CHECK-NEXT: }
 
-	println("pass")
-}
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.memequal64"(ptr %1, ptr %2)
+// CHECK-NEXT:   ret i1 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.interequal"(ptr %1, ptr %2)
+// CHECK-NEXT:   ret i1 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/ifaceprom.I.one$bound"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = load { %"{{.*}}/runtime/internal/runtime.iface" }, ptr %0, align 8
+// CHECK-NEXT:   %2 = extractvalue { %"{{.*}}/runtime/internal/runtime.iface" } %1, 0
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %2)
+// CHECK-NEXT:   %4 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %2, 0
+// CHECK-NEXT:   %5 = getelementptr ptr, ptr %4, i64 3
+// CHECK-NEXT:   %6 = load ptr, ptr %5, align 8
+// CHECK-NEXT:   %7 = insertvalue { ptr, ptr } undef, ptr %6, 0
+// CHECK-NEXT:   %8 = insertvalue { ptr, ptr } %7, ptr %3, 1
+// CHECK-NEXT:   %9 = extractvalue { ptr, ptr } %8, 1
+// CHECK-NEXT:   %10 = extractvalue { ptr, ptr } %8, 0
+// CHECK-NEXT:   %11 = call i64 %10(ptr %9)
+// CHECK-NEXT:   ret i64 %11
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/ifaceprom.I.two$bound"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = load { %"{{.*}}/runtime/internal/runtime.iface" }, ptr %0, align 8
+// CHECK-NEXT:   %2 = extractvalue { %"{{.*}}/runtime/internal/runtime.iface" } %1, 0
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %2)
+// CHECK-NEXT:   %4 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %2, 0
+// CHECK-NEXT:   %5 = getelementptr ptr, ptr %4, i64 4
+// CHECK-NEXT:   %6 = load ptr, ptr %5, align 8
+// CHECK-NEXT:   %7 = insertvalue { ptr, ptr } undef, ptr %6, 0
+// CHECK-NEXT:   %8 = insertvalue { ptr, ptr } %7, ptr %3, 1
+// CHECK-NEXT:   %9 = extractvalue { ptr, ptr } %8, 1
+// CHECK-NEXT:   %10 = extractvalue { ptr, ptr } %8, 0
+// CHECK-NEXT:   %11 = call %"{{.*}}/runtime/internal/runtime.String" %10(ptr %9)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %11
+// CHECK-NEXT: }

--- a/cl/_testgo/invoke/in.go
+++ b/cl/_testgo/invoke/in.go
@@ -1,47 +1,53 @@
 // LITTEST
 package main
 
+// CHECK-LINE: @0 = private unnamed_addr constant [6 x i8] c"invoke", align 1
+// CHECK-LINE: @1 = private unnamed_addr constant [42 x i8] c"{{.*}}/cl/_testgo/invoke.T", align 1
+// CHECK-LINE: @2 = private unnamed_addr constant [6 x i8] c"Invoke", align 1
+// CHECK-LINE: @3 = private unnamed_addr constant [7 x i8] c"invoke1", align 1
+// CHECK-LINE: @4 = private unnamed_addr constant [43 x i8] c"{{.*}}/cl/_testgo/invoke.T1", align 1
+// CHECK-LINE: @5 = private unnamed_addr constant [7 x i8] c"invoke2", align 1
+// CHECK-LINE: @6 = private unnamed_addr constant [43 x i8] c"{{.*}}/cl/_testgo/invoke.T2", align 1
+// CHECK-LINE: @7 = private unnamed_addr constant [7 x i8] c"invoke3", align 1
+// CHECK-LINE: @8 = private unnamed_addr constant [7 x i8] c"invoke4", align 1
+// CHECK-LINE: @9 = private unnamed_addr constant [43 x i8] c"{{.*}}/cl/_testgo/invoke.T4", align 1
+// CHECK-LINE: @10 = private unnamed_addr constant [7 x i8] c"invoke5", align 1
+// CHECK-LINE: @11 = private unnamed_addr constant [43 x i8] c"{{.*}}/cl/_testgo/invoke.T5", align 1
+// CHECK-LINE: @12 = private unnamed_addr constant [7 x i8] c"invoke6", align 1
+// CHECK-LINE: @13 = private unnamed_addr constant [43 x i8] c"{{.*}}/cl/_testgo/invoke.T6", align 1
+// CHECK-LINE: @14 = private unnamed_addr constant [5 x i8] c"hello", align 1
+// CHECK-LINE: @36 = private unnamed_addr constant [5 x i8] c"world", align 1
+// CHECK-LINE: @38 = private unnamed_addr constant [71 x i8] c"type assertion any -> {{.*}}/cl/_testgo/invoke.I failed", align 1
+// CHECK-LINE: @40 = private unnamed_addr constant [32 x i8] c"type assertion any -> any failed", align 1
+// CHECK-LINE: @41 = private unnamed_addr constant [52 x i8] c"type assertion any -> interface{Invoke() int} failed", align 1
+
 type T struct {
 	s string
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}invoke.T.Invoke"(%"{{.*}}invoke.T" %0){{.*}} {
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.T.Invoke"(%"{{.*}}/cl/_testgo/invoke.T" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = alloca %"{{.*}}invoke.T", align 8
+// CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/invoke.T", align 8
 // CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
-// CHECK-NEXT:   store %"{{.*}}invoke.T" %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}invoke.T", ptr %1, i32 0, i32 0
-// CHECK-NEXT:   %3 = load %"{{.*}}String", ptr %2, align 8
-// CHECK-NEXT:   call void @"{{.*}}PrintString"(%"{{.*}}String" { ptr @{{[0-9]+}}, i64 6 })
-// CHECK-NEXT:   call void @"{{.*}}PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}PrintString"(%"{{.*}}String" %3)
-// CHECK-NEXT:   call void @"{{.*}}PrintByte"(i8 10)
+// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/invoke.T" %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/invoke.T", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.String", ptr %2, align 8
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 6 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %3)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   ret i64 0
+// CHECK-NEXT: }
+
 func (t T) Invoke() int {
 	println("invoke", t.s)
 	return 0
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}invoke.(*T).Invoke"(ptr %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = load %"{{.*}}invoke.T", ptr %0, align 8
-// CHECK-NEXT:   %2 = call i64 @"{{.*}}invoke.T.Invoke"(%"{{.*}}invoke.T" %1)
-// CHECK-NEXT:   ret i64 %2
-
-// CHECK-LABEL: define void @"{{.*}}invoke.(*T).Method"(ptr %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   ret void
 func (t *T) Method() {}
 
 type T1 int
 
-// CHECK-LABEL: define i64 @"{{.*}}invoke.T1.Invoke"(i64 %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}PrintString"(%"{{.*}}String" { ptr @{{[0-9]+}}, i64 7 })
-// CHECK-NEXT:   call void @"{{.*}}PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}PrintInt"(i64 %0)
-// CHECK-NEXT:   call void @"{{.*}}PrintByte"(i8 10)
-// CHECK-NEXT:   ret i64 1
 func (t T1) Invoke() int {
 	println("invoke1", t)
 	return 1
@@ -49,13 +55,6 @@ func (t T1) Invoke() int {
 
 type T2 float64
 
-// CHECK-LABEL: define i64 @"{{.*}}invoke.T2.Invoke"(double %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   call void @"{{.*}}PrintString"(%"{{.*}}String" { ptr @{{[0-9]+}}, i64 7 })
-// CHECK-NEXT:   call void @"{{.*}}PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}PrintFloat"(double %0)
-// CHECK-NEXT:   call void @"{{.*}}PrintByte"(i8 10)
-// CHECK-NEXT:   ret i64 2
 func (t T2) Invoke() int {
 	println("invoke2", t)
 	return 2
@@ -63,15 +62,6 @@ func (t T2) Invoke() int {
 
 type T3 int8
 
-// CHECK-LABEL: define i64 @"{{.*}}invoke.(*T3).Invoke"(ptr %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = load i8, ptr %0, align 1
-// CHECK-NEXT:   call void @"{{.*}}PrintString"(%"{{.*}}String" { ptr @{{[0-9]+}}, i64 7 })
-// CHECK-NEXT:   call void @"{{.*}}PrintByte"(i8 32)
-// CHECK-NEXT:   %2 = sext i8 %1 to i64
-// CHECK-NEXT:   call void @"{{.*}}PrintInt"(i64 %2)
-// CHECK-NEXT:   call void @"{{.*}}PrintByte"(i8 10)
-// CHECK-NEXT:   ret i64 3
 func (t *T3) Invoke() int {
 	println("invoke3", *t)
 	return 3
@@ -79,19 +69,6 @@ func (t *T3) Invoke() int {
 
 type T4 [1]int
 
-// CHECK-LABEL: define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.T4.Invoke"([1 x i64] %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = alloca [1 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   store [1 x i64] %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds i64, ptr %1, i64 0
-// CHECK-NEXT:   %3 = load i64, ptr %2, align 8
-// CHECK-NEXT:   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @4, i64 7 })
-// CHECK-NEXT:   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %3)
-// CHECK-NEXT:   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   ret i64 4
-// CHECK-NEXT: }
 func (t T4) Invoke() int {
 	println("invoke4", t[0])
 	return 4
@@ -101,19 +78,6 @@ type T5 struct {
 	n int
 }
 
-// CHECK-LABEL: define i64 @"github.com/goplus/llgo/cl/_testgo/invoke.T5.Invoke"(%"github.com/goplus/llgo/cl/_testgo/invoke.T5" %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = alloca %"github.com/goplus/llgo/cl/_testgo/invoke.T5", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
-// CHECK-NEXT:   store %"github.com/goplus/llgo/cl/_testgo/invoke.T5" %0, ptr %1, align 8
-// CHECK-NEXT:   %2 = getelementptr inbounds %"github.com/goplus/llgo/cl/_testgo/invoke.T5", ptr %1, i32 0, i32 0
-// CHECK-NEXT:   %3 = load i64, ptr %2, align 8
-// CHECK-NEXT:   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintString"(%"github.com/goplus/llgo/runtime/internal/runtime.String" { ptr @5, i64 7 })
-// CHECK-NEXT:   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintInt"(i64 %3)
-// CHECK-NEXT:   call void @"github.com/goplus/llgo/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   ret i64 5
-// CHECK-NEXT: }
 func (t T5) Invoke() int {
 	println("invoke5", t.n)
 	return 5
@@ -121,16 +85,6 @@ func (t T5) Invoke() int {
 
 type T6 func() int
 
-// CHECK-LABEL: define i64 @"{{.*}}invoke.T6.Invoke"(%"{{.*}}invoke.T6" %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = extractvalue %"{{.*}}invoke.T6" %0, 1
-// CHECK-NEXT:   %2 = extractvalue %"{{.*}}invoke.T6" %0, 0
-// CHECK-NEXT:   %3 = call i64 %2(ptr %1)
-// CHECK-NEXT:   call void @"{{.*}}PrintString"(%"{{.*}}String" { ptr @{{[0-9]+}}, i64 7 })
-// CHECK-NEXT:   call void @"{{.*}}PrintByte"(i8 32)
-// CHECK-NEXT:   call void @"{{.*}}PrintInt"(i64 %3)
-// CHECK-NEXT:   call void @"{{.*}}PrintByte"(i8 10)
-// CHECK-NEXT:   ret i64 6
 func (t T6) Invoke() int {
 	println("invoke6", t())
 	return 6
@@ -144,22 +98,6 @@ func invoke(i I) {
 	println(i.Invoke())
 }
 
-// CHECK-LABEL: define void @"{{.*}}invoke.invoke"(%"{{.*}}iface" %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = call ptr @"{{.*}}IfacePtrData"(%"{{.*}}iface" %0)
-// CHECK-NEXT:   %2 = extractvalue %"{{.*}}iface" %0, 0
-// CHECK-NEXT:   %3 = getelementptr ptr, ptr %2, i64 3
-// CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
-// CHECK-NEXT:   %5 = insertvalue { ptr, ptr } undef, ptr %4, 0
-// CHECK-NEXT:   %6 = insertvalue { ptr, ptr } %5, ptr %1, 1
-// CHECK-NEXT:   %7 = extractvalue { ptr, ptr } %6, 1
-// CHECK-NEXT:   %8 = extractvalue { ptr, ptr } %6, 0
-// CHECK-NEXT:   %9 = call i64 %8(ptr %7)
-// CHECK-NEXT:   call void @"{{.*}}PrintInt"(i64 %9)
-// CHECK-NEXT:   call void @"{{.*}}PrintByte"(i8 10)
-// CHECK-NEXT:   ret void
-
-// CHECK-LABEL: define void @"{{.*}}invoke.main"(){{.*}} {
 func main() {
 	var t = T{"hello"}
 	var t1 = T1(100)
@@ -169,92 +107,45 @@ func main() {
 	var t5 = T5{300}
 	var t6 = T6(func() int { return 400 })
 
-	// CHECK: call ptr @"{{.*}}AllocU"(i64 16)
-	// CHECK: store %"{{.*}}invoke.T" %{{[0-9]+}}, ptr %{{[0-9]+}}, align 8
-	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr @"_llgo_{{.*}}invoke.T")
-	// CHECK: call void @"{{.*}}invoke.invoke"(%"{{.*}}iface" %{{[0-9]+}})
 	invoke(t)
 
-	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr @"*_llgo_{{.*}}invoke.T")
-	// CHECK: call void @"{{.*}}invoke.invoke"(%"{{.*}}iface" %{{[0-9]+}})
 	invoke(&t)
 
-	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr @"_llgo_{{.*}}invoke.T1")
-	// CHECK: call void @"{{.*}}invoke.invoke"(%"{{.*}}iface" %{{[0-9]+}})
 	invoke(t1)
 
-	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr @"*_llgo_{{.*}}invoke.T1")
-	// CHECK: call void @"{{.*}}invoke.invoke"(%"{{.*}}iface" %{{[0-9]+}})
 	invoke(&t1)
 
-	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr @"_llgo_{{.*}}invoke.T2")
-	// CHECK: call void @"{{.*}}invoke.invoke"(%"{{.*}}iface" %{{[0-9]+}})
 	invoke(t2)
 
-	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr @"*_llgo_{{.*}}invoke.T2")
-	// CHECK: call void @"{{.*}}invoke.invoke"(%"{{.*}}iface" %{{[0-9]+}})
 	invoke(&t2)
 
-	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr @"*_llgo_{{.*}}invoke.T3")
-	// CHECK: call void @"{{.*}}invoke.invoke"(%"{{.*}}iface" %{{[0-9]+}})
 	invoke(&t3)
 
-	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr @"_llgo_{{.*}}invoke.T4")
-	// CHECK: call void @"{{.*}}invoke.invoke"(%"{{.*}}iface" %{{[0-9]+}})
 	invoke(t4)
 
-	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr @"*_llgo_{{.*}}invoke.T4")
-	// CHECK: call void @"{{.*}}invoke.invoke"(%"{{.*}}iface" %{{[0-9]+}})
 	invoke(&t4)
 
-	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr @"_llgo_{{.*}}invoke.T5")
-	// CHECK: call void @"{{.*}}invoke.invoke"(%"{{.*}}iface" %{{[0-9]+}})
 	invoke(t5)
 
-	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr @"*_llgo_{{.*}}invoke.T5")
-	// CHECK: call void @"{{.*}}invoke.invoke"(%"{{.*}}iface" %{{[0-9]+}})
 	invoke(&t5)
 
-	// CHECK: call ptr @"{{.*}}AllocU"(i64 16)
-	// CHECK: store %"{{.*}}invoke.T6" %{{[0-9]+}}, ptr %{{[0-9]+}}, align 8
-	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr @"_llgo_{{.*}}invoke.T6")
-	// CHECK: call void @"{{.*}}invoke.invoke"(%"{{.*}}iface" %{{[0-9]+}})
 	invoke(t6)
 
-	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr @"*_llgo_{{.*}}invoke.T6")
-	// CHECK: call void @"{{.*}}invoke.invoke"(%"{{.*}}iface" %{{[0-9]+}})
 	invoke(&t6)
 
 	var m M
 	var i I = m
 
-	// CHECK: call ptr @"{{.*}}IfaceType"(%"{{.*}}iface" zeroinitializer)
-	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr %{{[0-9]+}})
-	// CHECK: call void @"{{.*}}PrintIface"(%"{{.*}}iface" %{{[0-9]+}})
-	// CHECK-NEXT: call void @"{{.*}}PrintByte"(i8 32)
-	// CHECK-NEXT: call void @"{{.*}}PrintIface"(%"{{.*}}iface" zeroinitializer)
-	// CHECK-NEXT: call void @"{{.*}}PrintByte"(i8 10)
 	println(i, m)
 
 	m = &t
 
-	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr @"*_llgo_{{.*}}invoke.T")
-	// CHECK: call ptr @"{{.*}}IfaceType"(%"{{.*}}iface" %{{[0-9]+}})
-	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr %{{[0-9]+}})
-	// CHECK: call void @"{{.*}}invoke.invoke"(%"{{.*}}iface" %{{[0-9]+}})
 	invoke(m)
 
 	var a any = T{"world"}
 
-	// CHECK: call i1 @"{{.*}}Implements"(ptr @"_llgo_{{.*}}invoke.I", ptr %{{[0-9]+}})
-	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr %{{[0-9]+}})
-	// CHECK: call void @"{{.*}}invoke.invoke"(%"{{.*}}iface" %{{[0-9]+}})
 	invoke(a.(I))
 
-	// CHECK: call i1 @"{{.*}}Implements"(ptr @"{{.*}}iface{{.*}}", ptr %{{[0-9]+}})
-	// CHECK: call ptr @"{{.*}}NewItab"(ptr @"{{.*}}iface{{.*}}", ptr %{{[0-9]+}})
-	// CHECK: call void @"{{.*}}invoke.invoke"(%"{{.*}}iface" %{{[0-9]+}})
-	// CHECK: ret void
 	invoke(a.(interface{}).(interface{ Invoke() int }))
 
 	//panic
@@ -266,6 +157,363 @@ type M interface {
 	Method()
 }
 
-// CHECK-LABEL: define i64 @"{{.*}}invoke.main$1"(){{.*}} {
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.(*T).Invoke"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 42 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 6 })
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/invoke.T", ptr %0, align 8
+// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/invoke.T.Invoke"(%"{{.*}}/cl/_testgo/invoke.T" %2)
+// CHECK-NEXT:   ret i64 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/invoke.(*T).Method"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.T1.Invoke"(i64 %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 7 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %0)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   ret i64 1
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.(*T1).Invoke"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @4, i64 43 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 6 })
+// CHECK-NEXT:   %2 = load i64, ptr %0, align 8
+// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/invoke.T1.Invoke"(i64 %2)
+// CHECK-NEXT:   ret i64 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.T2.Invoke"(double %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 7 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintFloat"(double %0)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   ret i64 2
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.(*T2).Invoke"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 43 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 6 })
+// CHECK-NEXT:   %2 = load double, ptr %0, align 8
+// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/invoke.T2.Invoke"(double %2)
+// CHECK-NEXT:   ret i64 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.(*T3).Invoke"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = load i8, ptr %0, align 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 7 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
+// CHECK-NEXT:   %2 = sext i8 %1 to i64
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %2)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   ret i64 3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.T4.Invoke"([1 x i64] %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca [1 x i64], align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   store [1 x i64] %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds i64, ptr %1, i64 0
+// CHECK-NEXT:   %3 = load i64, ptr %2, align 8
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @8, i64 7 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %3)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   ret i64 4
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.(*T4).Invoke"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @9, i64 43 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 6 })
+// CHECK-NEXT:   %2 = load [1 x i64], ptr %0, align 8
+// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/invoke.T4.Invoke"([1 x i64] %2)
+// CHECK-NEXT:   ret i64 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.T5.Invoke"(%"{{.*}}/cl/_testgo/invoke.T5" %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/invoke.T5", align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/invoke.T5" %0, ptr %1, align 8
+// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/invoke.T5", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   %3 = load i64, ptr %2, align 8
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @10, i64 7 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %3)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   ret i64 5
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.(*T5).Invoke"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @11, i64 43 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 6 })
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/invoke.T5", ptr %0, align 8
+// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/invoke.T5.Invoke"(%"{{.*}}/cl/_testgo/invoke.T5" %2)
+// CHECK-NEXT:   ret i64 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.T6.Invoke"(%"{{.*}}/cl/_testgo/invoke.T6" %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = extractvalue %"{{.*}}/cl/_testgo/invoke.T6" %0, 1
+// CHECK-NEXT:   %2 = extractvalue %"{{.*}}/cl/_testgo/invoke.T6" %0, 0
+// CHECK-NEXT:   %3 = call i64 %2(ptr %1)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @12, i64 7 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %3)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   ret i64 6
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.(*T6).Invoke"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @13, i64 43 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 6 })
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/invoke.T6", ptr %0, align 8
+// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testgo/invoke.T6.Invoke"(%"{{.*}}/cl/_testgo/invoke.T6" %2)
+// CHECK-NEXT:   ret i64 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/invoke.init"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/invoke.init$guard", align 1
+// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/invoke.init$guard", align 1
+// CHECK-NEXT:   br label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %0)
+// CHECK-NEXT:   %2 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %0, 0
+// CHECK-NEXT:   %3 = getelementptr ptr, ptr %2, i64 3
+// CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
+// CHECK-NEXT:   %5 = insertvalue { ptr, ptr } undef, ptr %4, 0
+// CHECK-NEXT:   %6 = insertvalue { ptr, ptr } %5, ptr %1, 1
+// CHECK-NEXT:   %7 = extractvalue { ptr, ptr } %6, 1
+// CHECK-NEXT:   %8 = extractvalue { ptr, ptr } %6, 0
+// CHECK-NEXT:   %9 = call i64 %8(ptr %7)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %9)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/invoke.main"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/invoke.T", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @14, i64 5 }, ptr %1, align 8
+// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   store i64 100, ptr %2, align 8
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   store double 1.001000e+02, ptr %3, align 8
+// CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 1)
+// CHECK-NEXT:   store i8 127, ptr %4, align 1
+// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %6 = getelementptr inbounds i64, ptr %5, i64 0
+// CHECK-NEXT:   store i64 200, ptr %6, align 8
+// CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
+// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/cl/_testgo/invoke.T5", ptr %7, i32 0, i32 0
+// CHECK-NEXT:   store i64 300, ptr %8, align 8
+// CHECK-NEXT:   %9 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/invoke.T6" { ptr @"__llgo_stub.{{.*}}/cl/_testgo/invoke.main$1", ptr null }, ptr %9, align 8
+// CHECK-NEXT:   %10 = load %"{{.*}}/cl/_testgo/invoke.T", ptr %0, align 8
+// CHECK-NEXT:   %11 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/invoke.T" %10, ptr %11, align 8
+// CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"_llgo_{{.*}}/cl/_testgo/invoke.T")
+// CHECK-NEXT:   %13 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %12, 0
+// CHECK-NEXT:   %14 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %13, ptr %11, 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %14)
+// CHECK-NEXT:   %15 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"*_llgo_{{.*}}/cl/_testgo/invoke.T")
+// CHECK-NEXT:   %16 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %15, 0
+// CHECK-NEXT:   %17 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %16, ptr %0, 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %17)
+// CHECK-NEXT:   %18 = load i64, ptr %2, align 8
+// CHECK-NEXT:   %19 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT:   store i64 %18, ptr %19, align 8
+// CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"_llgo_{{.*}}/cl/_testgo/invoke.T1")
+// CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %20, 0
+// CHECK-NEXT:   %22 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %21, ptr %19, 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %22)
+// CHECK-NEXT:   %23 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"*_llgo_{{.*}}/cl/_testgo/invoke.T1")
+// CHECK-NEXT:   %24 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %23, 0
+// CHECK-NEXT:   %25 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %24, ptr %2, 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %25)
+// CHECK-NEXT:   %26 = load double, ptr %3, align 8
+// CHECK-NEXT:   %27 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT:   store double %26, ptr %27, align 8
+// CHECK-NEXT:   %28 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"_llgo_{{.*}}/cl/_testgo/invoke.T2")
+// CHECK-NEXT:   %29 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %28, 0
+// CHECK-NEXT:   %30 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %29, ptr %27, 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %30)
+// CHECK-NEXT:   %31 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"*_llgo_{{.*}}/cl/_testgo/invoke.T2")
+// CHECK-NEXT:   %32 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %31, 0
+// CHECK-NEXT:   %33 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %32, ptr %3, 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %33)
+// CHECK-NEXT:   %34 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"*_llgo_{{.*}}/cl/_testgo/invoke.T3")
+// CHECK-NEXT:   %35 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %34, 0
+// CHECK-NEXT:   %36 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %35, ptr %4, 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %36)
+// CHECK-NEXT:   %37 = load [1 x i64], ptr %5, align 8
+// CHECK-NEXT:   %38 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT:   store [1 x i64] %37, ptr %38, align 8
+// CHECK-NEXT:   %39 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"_llgo_{{.*}}/cl/_testgo/invoke.T4")
+// CHECK-NEXT:   %40 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %39, 0
+// CHECK-NEXT:   %41 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %40, ptr %38, 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %41)
+// CHECK-NEXT:   %42 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"*_llgo_{{.*}}/cl/_testgo/invoke.T4")
+// CHECK-NEXT:   %43 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %42, 0
+// CHECK-NEXT:   %44 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %43, ptr %5, 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %44)
+// CHECK-NEXT:   %45 = load %"{{.*}}/cl/_testgo/invoke.T5", ptr %7, align 8
+// CHECK-NEXT:   %46 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 8)
+// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/invoke.T5" %45, ptr %46, align 8
+// CHECK-NEXT:   %47 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"_llgo_{{.*}}/cl/_testgo/invoke.T5")
+// CHECK-NEXT:   %48 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %47, 0
+// CHECK-NEXT:   %49 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %48, ptr %46, 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %49)
+// CHECK-NEXT:   %50 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"*_llgo_{{.*}}/cl/_testgo/invoke.T5")
+// CHECK-NEXT:   %51 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %50, 0
+// CHECK-NEXT:   %52 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %51, ptr %7, 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %52)
+// CHECK-NEXT:   %53 = load %"{{.*}}/cl/_testgo/invoke.T6", ptr %9, align 8
+// CHECK-NEXT:   %54 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/invoke.T6" %53, ptr %54, align 8
+// CHECK-NEXT:   %55 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"_llgo_{{.*}}/cl/_testgo/invoke.T6")
+// CHECK-NEXT:   %56 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %55, 0
+// CHECK-NEXT:   %57 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %56, ptr %54, 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %57)
+// CHECK-NEXT:   %58 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr @"*_llgo_{{.*}}/cl/_testgo/invoke.T6")
+// CHECK-NEXT:   %59 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %58, 0
+// CHECK-NEXT:   %60 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %59, ptr %9, 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %60)
+// CHECK-NEXT:   %61 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" zeroinitializer)
+// CHECK-NEXT:   %62 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr %61)
+// CHECK-NEXT:   %63 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %62, 0
+// CHECK-NEXT:   %64 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %63, ptr null, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintIface"(%"{{.*}}/runtime/internal/runtime.iface" %64)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintIface"(%"{{.*}}/runtime/internal/runtime.iface" zeroinitializer)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   %65 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$jwmSdgh1zvY_TDIgLzCkvkbiyrdwl9N806DH0JGcyMI", ptr @"*_llgo_{{.*}}/cl/_testgo/invoke.T")
+// CHECK-NEXT:   %66 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %65, 0
+// CHECK-NEXT:   %67 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %66, ptr %0, 1
+// CHECK-NEXT:   %68 = call ptr @"{{.*}}/runtime/internal/runtime.IfaceType"(%"{{.*}}/runtime/internal/runtime.iface" %67)
+// CHECK-NEXT:   %69 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %67, 1
+// CHECK-NEXT:   %70 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr %68)
+// CHECK-NEXT:   %71 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %70, 0
+// CHECK-NEXT:   %72 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %71, ptr %69, 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %72)
+// CHECK-NEXT:   %73 = alloca %"{{.*}}/cl/_testgo/invoke.T", align 8
+// CHECK-NEXT:   call void @llvm.memset(ptr %73, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   %74 = getelementptr inbounds %"{{.*}}/cl/_testgo/invoke.T", ptr %73, i32 0, i32 0
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @36, i64 5 }, ptr %74, align 8
+// CHECK-NEXT:   %75 = load %"{{.*}}/cl/_testgo/invoke.T", ptr %73, align 8
+// CHECK-NEXT:   %76 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/cl/_testgo/invoke.T" %75, ptr %76, align 8
+// CHECK-NEXT:   %77 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testgo/invoke.T", ptr undef }, ptr %76, 1
+// CHECK-NEXT:   %78 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %77, 0
+// CHECK-NEXT:   %79 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @"_llgo_{{.*}}/cl/_testgo/invoke.I", ptr %78)
+// CHECK-NEXT:   br i1 %79, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %80 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %77, 1
+// CHECK-NEXT:   %81 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr %78)
+// CHECK-NEXT:   %82 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %81, 0
+// CHECK-NEXT:   %83 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %82, ptr %80, 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %83)
+// CHECK-NEXT:   %84 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %77, 0
+// CHECK-NEXT:   %85 = icmp ne ptr %84, null
+// CHECK-NEXT:   br i1 %85, label %_llgo_3, label %_llgo_4
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %86 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @38, i64 71 }, ptr %86, align 8
+// CHECK-NEXT:   %87 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %86, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %87)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_1
+// CHECK-NEXT:   %88 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %77, 0
+// CHECK-NEXT:   %89 = call i1 @"{{.*}}/runtime/internal/runtime.Implements"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr %88)
+// CHECK-NEXT:   br i1 %89, label %_llgo_5, label %_llgo_6
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_1
+// CHECK-NEXT:   %90 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @40, i64 32 }, ptr %90, align 8
+// CHECK-NEXT:   %91 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %90, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %91)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_3
+// CHECK-NEXT:   %92 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %77, 1
+// CHECK-NEXT:   %93 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$uRUteI7wmSy7y7ODhGzk0FdDaxGKMhVSSu6HZEv9aa0", ptr %88)
+// CHECK-NEXT:   %94 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %93, 0
+// CHECK-NEXT:   %95 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %94, ptr %92, 1
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %95)
+// CHECK-NEXT:   ret void
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_3
+// CHECK-NEXT:   %96 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @41, i64 52 }, ptr %96, align 8
+// CHECK-NEXT:   %97 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %96, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %97)
+// CHECK-NEXT:   unreachable
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.main$1"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   ret i64 400
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce i64 @"__llgo_stub.{{.*}}/cl/_testgo/invoke.main$1"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = tail call i64 @"{{.*}}/cl/_testgo/invoke.main$1"()
+// CHECK-NEXT:   ret i64 %1
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.memequal64"(ptr %1, ptr %2)
+// CHECK-NEXT:   ret i1 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.interequal"(ptr %1, ptr %2)
+// CHECK-NEXT:   ret i1 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.f64equal"(ptr %0, ptr %1, ptr %2){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.f64equal"(ptr %1, ptr %2)
+// CHECK-NEXT:   ret i1 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequal8"(ptr %0, ptr %1, ptr %2){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.memequal8"(ptr %1, ptr %2)
+// CHECK-NEXT:   ret i1 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.nilinterequal"(ptr %0, ptr %1, ptr %2){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.nilinterequal"(ptr %1, ptr %2)
+// CHECK-NEXT:   ret i1 %3
+// CHECK-NEXT: }

--- a/cl/_testgo/reader/in.go
+++ b/cl/_testgo/reader/in.go
@@ -5,17 +5,21 @@ import (
 	"unicode/utf8"
 )
 
+// CHECK-LINE: @2 = private unnamed_addr constant [7 x i8] c"WriteTo", align 1
+// CHECK-LINE: @17 = private unnamed_addr constant [5 x i8] c"Close", align 1
 // CHECK-LINE: @28 = private unnamed_addr constant [3 x i8] c"EOF", align 1
 // CHECK-LINE: @29 = private unnamed_addr constant [11 x i8] c"short write", align 1
 // CHECK-LINE: @30 = private unnamed_addr constant [11 x i8] c"hello world", align 1
-// CHECK-LINE: @53 = private unnamed_addr constant [122 x i8] c"type assertion {{.*}}/cl/_testgo/reader.Reader -> {{.*}}/cl/_testgo/reader.WriterTo failed", align 1
-// CHECK-LINE: @54 = private unnamed_addr constant [37 x i8] c"stringsReader.ReadAt: negative offset", align 1
-// CHECK-LINE: @55 = private unnamed_addr constant [34 x i8] c"stringsReader.Seek: invalid whence", align 1
-// CHECK-LINE: @56 = private unnamed_addr constant [37 x i8] c"stringsReader.Seek: negative position", align 1
-// CHECK-LINE: @57 = private unnamed_addr constant [48 x i8] c"stringsReader.UnreadByte: at beginning of string", align 1
-// CHECK-LINE: @58 = private unnamed_addr constant [49 x i8] c"strings.Reader.UnreadRune: at beginning of string", align 1
-// CHECK-LINE: @59 = private unnamed_addr constant [62 x i8] c"strings.Reader.UnreadRune: previous operation was not ReadRune", align 1
-// CHECK-LINE: @60 = private unnamed_addr constant [48 x i8] c"stringsReader.WriteTo: invalid WriteString count", align 1
+// CHECK-LINE: @53 = private unnamed_addr constant [50 x i8] c"{{.*}}/cl/_testgo/reader.nopCloser", align 1
+// CHECK-LINE: @54 = private unnamed_addr constant [122 x i8] c"type assertion {{.*}}/cl/_testgo/reader.Reader -> {{.*}}/cl/_testgo/reader.WriterTo failed", align 1
+// CHECK-LINE: @55 = private unnamed_addr constant [58 x i8] c"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", align 1
+// CHECK-LINE: @56 = private unnamed_addr constant [37 x i8] c"stringsReader.ReadAt: negative offset", align 1
+// CHECK-LINE: @57 = private unnamed_addr constant [34 x i8] c"stringsReader.Seek: invalid whence", align 1
+// CHECK-LINE: @58 = private unnamed_addr constant [37 x i8] c"stringsReader.Seek: negative position", align 1
+// CHECK-LINE: @59 = private unnamed_addr constant [48 x i8] c"stringsReader.UnreadByte: at beginning of string", align 1
+// CHECK-LINE: @60 = private unnamed_addr constant [49 x i8] c"strings.Reader.UnreadRune: at beginning of string", align 1
+// CHECK-LINE: @61 = private unnamed_addr constant [62 x i8] c"strings.Reader.UnreadRune: previous operation was not ReadRune", align 1
+// CHECK-LINE: @62 = private unnamed_addr constant [48 x i8] c"stringsReader.WriteTo: invalid WriteString count", align 1
 
 type Reader interface {
 	Read(p []byte) (n int, err error)
@@ -598,9 +602,11 @@ func main() {
 
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.(*nopCloser).Close"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = load %"{{.*}}/cl/_testgo/reader.nopCloser", ptr %0, align 8
-// CHECK-NEXT:   %2 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.nopCloser.Close"(%"{{.*}}/cl/_testgo/reader.nopCloser" %1)
-// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %2
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @53, i64 50 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @17, i64 5 })
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/reader.nopCloser", ptr %0, align 8
+// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.nopCloser.Close"(%"{{.*}}/cl/_testgo/reader.nopCloser" %2)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %3
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.(*nopCloser).Read"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
@@ -684,7 +690,7 @@ func main() {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %24 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @53, i64 122 }, ptr %24, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @54, i64 122 }, ptr %24, align 8
 // CHECK-NEXT:   %25 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %24, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %25)
 // CHECK-NEXT:   unreachable
@@ -692,9 +698,11 @@ func main() {
 
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.(*nopCloserWriterTo).Close"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = load %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", ptr %0, align 8
-// CHECK-NEXT:   %2 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.nopCloserWriterTo.Close"(%"{{.*}}/cl/_testgo/reader.nopCloserWriterTo" %1)
-// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %2
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @55, i64 58 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @17, i64 5 })
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", ptr %0, align 8
+// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.nopCloserWriterTo.Close"(%"{{.*}}/cl/_testgo/reader.nopCloserWriterTo" %2)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %3
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.(*nopCloserWriterTo).Read"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
@@ -719,13 +727,15 @@ func main() {
 
 // CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.(*nopCloserWriterTo).WriteTo"(ptr %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", ptr %0, align 8
-// CHECK-NEXT:   %3 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.nopCloserWriterTo.WriteTo"(%"{{.*}}/cl/_testgo/reader.nopCloserWriterTo" %2, %"{{.*}}/runtime/internal/runtime.iface" %1)
-// CHECK-NEXT:   %4 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3, 0
-// CHECK-NEXT:   %5 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %3, 1
-// CHECK-NEXT:   %6 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } undef, i64 %4, 0
-// CHECK-NEXT:   %7 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %6, %"{{.*}}/runtime/internal/runtime.iface" %5, 1
-// CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %7
+// CHECK-NEXT:   %2 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %2, %"{{.*}}/runtime/internal/runtime.String" { ptr @55, i64 58 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 7 })
+// CHECK-NEXT:   %3 = load %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", ptr %0, align 8
+// CHECK-NEXT:   %4 = call { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.nopCloserWriterTo.WriteTo"(%"{{.*}}/cl/_testgo/reader.nopCloserWriterTo" %3, %"{{.*}}/runtime/internal/runtime.iface" %1)
+// CHECK-NEXT:   %5 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %4, 0
+// CHECK-NEXT:   %6 = extractvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %4, 1
+// CHECK-NEXT:   %7 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } undef, i64 %5, 0
+// CHECK-NEXT:   %8 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } %7, %"{{.*}}/runtime/internal/runtime.iface" %6, 1
+// CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %8
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/reader.(*stringReader).Len"(ptr %0){{.*}} {
@@ -794,7 +804,7 @@ func main() {
 // CHECK-NEXT:   br i1 %3, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.newError"(%"{{.*}}/runtime/internal/runtime.String" { ptr @54, i64 37 })
+// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.newError"(%"{{.*}}/runtime/internal/runtime.String" { ptr @56, i64 37 })
 // CHECK-NEXT:   %5 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } { i64 0, %"{{.*}}/runtime/internal/runtime.iface" undef }, %"{{.*}}/runtime/internal/runtime.iface" %4, 1
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %5
 // CHECK-EMPTY:
@@ -980,12 +990,12 @@ func main() {
 // CHECK-NEXT:   br i1 %15, label %_llgo_5, label %_llgo_7
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_6
-// CHECK-NEXT:   %16 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.newError"(%"{{.*}}/runtime/internal/runtime.String" { ptr @55, i64 34 })
+// CHECK-NEXT:   %16 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.newError"(%"{{.*}}/runtime/internal/runtime.String" { ptr @57, i64 34 })
 // CHECK-NEXT:   %17 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } { i64 0, %"{{.*}}/runtime/internal/runtime.iface" undef }, %"{{.*}}/runtime/internal/runtime.iface" %16, 1
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %17
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_1
-// CHECK-NEXT:   %18 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.newError"(%"{{.*}}/runtime/internal/runtime.String" { ptr @56, i64 37 })
+// CHECK-NEXT:   %18 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.newError"(%"{{.*}}/runtime/internal/runtime.String" { ptr @58, i64 37 })
 // CHECK-NEXT:   %19 = insertvalue { i64, %"{{.*}}/runtime/internal/runtime.iface" } { i64 0, %"{{.*}}/runtime/internal/runtime.iface" undef }, %"{{.*}}/runtime/internal/runtime.iface" %18, 1
 // CHECK-NEXT:   ret { i64, %"{{.*}}/runtime/internal/runtime.iface" } %19
 // CHECK-EMPTY:
@@ -1013,7 +1023,7 @@ func main() {
 // CHECK-NEXT:   br i1 %3, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.newError"(%"{{.*}}/runtime/internal/runtime.String" { ptr @57, i64 48 })
+// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.newError"(%"{{.*}}/runtime/internal/runtime.String" { ptr @59, i64 48 })
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %4
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
@@ -1035,7 +1045,7 @@ func main() {
 // CHECK-NEXT:   br i1 %3, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.newError"(%"{{.*}}/runtime/internal/runtime.String" { ptr @58, i64 49 })
+// CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.newError"(%"{{.*}}/runtime/internal/runtime.String" { ptr @60, i64 49 })
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %4
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
@@ -1045,7 +1055,7 @@ func main() {
 // CHECK-NEXT:   br i1 %7, label %_llgo_3, label %_llgo_4
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_2
-// CHECK-NEXT:   %8 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.newError"(%"{{.*}}/runtime/internal/runtime.String" { ptr @59, i64 62 })
+// CHECK-NEXT:   %8 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/reader.newError"(%"{{.*}}/runtime/internal/runtime.String" { ptr @61, i64 62 })
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %8
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
@@ -1089,7 +1099,7 @@ func main() {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_2
 // CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @60, i64 48 }, ptr %20, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @62, i64 48 }, ptr %20, align 8
 // CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %20, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %21)
 // CHECK-NEXT:   unreachable

--- a/cl/_testgo/reflectmk/in.go
+++ b/cl/_testgo/reflectmk/in.go
@@ -7,20 +7,21 @@ import (
 )
 
 // CHECK-LINE: @1 = private unnamed_addr constant [7 x i8] c"(%v,%v)", align 1
-// CHECK-LINE: @6 = private unnamed_addr constant [6 x i8] c"String", align 1
-// CHECK-LINE: @11 = private unnamed_addr constant [13 x i8] c"arrayOf error", align 1
-// CHECK-LINE: @12 = private unnamed_addr constant [12 x i8] c"chanOf error", align 1
-// CHECK-LINE: @13 = private unnamed_addr constant [12 x i8] c"funcOf error", align 1
-// CHECK-LINE: @14 = private unnamed_addr constant [11 x i8] c"mapOf error", align 1
-// CHECK-LINE: @15 = private unnamed_addr constant [15 x i8] c"pointerTo error", align 1
-// CHECK-LINE: @16 = private unnamed_addr constant [13 x i8] c"sliceOf error", align 1
-// CHECK-LINE: @17 = private unnamed_addr constant [1 x i8] c"T", align 1
-// CHECK-LINE: @18 = private unnamed_addr constant [14 x i8] c"structOf error", align 1
-// CHECK-LINE: @19 = private unnamed_addr constant [12 x i8] c"method error", align 1
-// CHECK-LINE: @20 = private unnamed_addr constant [18 x i8] c"methodByName error", align 1
-// CHECK-LINE: @21 = private unnamed_addr constant [5 x i8] c"(1,2)", align 1
-// CHECK-LINE: @22 = private unnamed_addr constant [18 x i8] c"value.Method error", align 1
-// CHECK-LINE: @23 = private unnamed_addr constant [24 x i8] c"value.MethodByName error", align 1
+// CHECK-LINE: @2 = private unnamed_addr constant [49 x i8] c"{{.*}}/cl/_testgo/reflectmk.Point", align 1
+// CHECK-LINE: @3 = private unnamed_addr constant [6 x i8] c"String", align 1
+// CHECK-LINE: @12 = private unnamed_addr constant [13 x i8] c"arrayOf error", align 1
+// CHECK-LINE: @13 = private unnamed_addr constant [12 x i8] c"chanOf error", align 1
+// CHECK-LINE: @14 = private unnamed_addr constant [12 x i8] c"funcOf error", align 1
+// CHECK-LINE: @15 = private unnamed_addr constant [11 x i8] c"mapOf error", align 1
+// CHECK-LINE: @16 = private unnamed_addr constant [15 x i8] c"pointerTo error", align 1
+// CHECK-LINE: @17 = private unnamed_addr constant [13 x i8] c"sliceOf error", align 1
+// CHECK-LINE: @18 = private unnamed_addr constant [1 x i8] c"T", align 1
+// CHECK-LINE: @19 = private unnamed_addr constant [14 x i8] c"structOf error", align 1
+// CHECK-LINE: @20 = private unnamed_addr constant [12 x i8] c"method error", align 1
+// CHECK-LINE: @21 = private unnamed_addr constant [18 x i8] c"methodByName error", align 1
+// CHECK-LINE: @22 = private unnamed_addr constant [5 x i8] c"(1,2)", align 1
+// CHECK-LINE: @23 = private unnamed_addr constant [18 x i8] c"value.Method error", align 1
+// CHECK-LINE: @24 = private unnamed_addr constant [24 x i8] c"value.MethodByName error", align 1
 
 type Point struct {
 	x int
@@ -130,9 +131,11 @@ func methodByName(name string) {
 
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/reflectmk.(*Point).String"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = load %"{{.*}}/cl/_testgo/reflectmk.Point", ptr %0, align 8
-// CHECK-NEXT:   %2 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/reflectmk.Point.String"(%"{{.*}}/cl/_testgo/reflectmk.Point" %1)
-// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %2
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 49 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 6 })
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/reflectmk.Point", ptr %0, align 8
+// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/reflectmk.Point.String"(%"{{.*}}/cl/_testgo/reflectmk.Point" %2)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.String" %3
 // CHECK-NEXT: }
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/reflectmk.init"(){{.*}} {
@@ -186,7 +189,7 @@ func methodByName(name string) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %30 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @11, i64 13 }, ptr %30, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @12, i64 13 }, ptr %30, align 8
 // CHECK-NEXT:   %31 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %30, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %31)
 // CHECK-NEXT:   unreachable
@@ -216,7 +219,7 @@ func methodByName(name string) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_2
 // CHECK-NEXT:   %52 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @12, i64 12 }, ptr %52, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @13, i64 12 }, ptr %52, align 8
 // CHECK-NEXT:   %53 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %52, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %53)
 // CHECK-NEXT:   unreachable
@@ -258,7 +261,7 @@ func methodByName(name string) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_7, %_llgo_4
 // CHECK-NEXT:   %84 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @13, i64 12 }, ptr %84, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @14, i64 12 }, ptr %84, align 8
 // CHECK-NEXT:   %85 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %84, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %85)
 // CHECK-NEXT:   unreachable
@@ -310,7 +313,7 @@ func methodByName(name string) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_10, %_llgo_6
 // CHECK-NEXT:   %125 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @14, i64 11 }, ptr %125, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @15, i64 11 }, ptr %125, align 8
 // CHECK-NEXT:   %126 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %125, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %126)
 // CHECK-NEXT:   unreachable
@@ -362,7 +365,7 @@ func methodByName(name string) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_11:                                         ; preds = %_llgo_9
 // CHECK-NEXT:   %166 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @15, i64 15 }, ptr %166, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @16, i64 15 }, ptr %166, align 8
 // CHECK-NEXT:   %167 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %166, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %167)
 // CHECK-NEXT:   unreachable
@@ -392,7 +395,7 @@ func methodByName(name string) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_13:                                         ; preds = %_llgo_12
 // CHECK-NEXT:   %188 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @16, i64 13 }, ptr %188, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @17, i64 13 }, ptr %188, align 8
 // CHECK-NEXT:   %189 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %188, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %189)
 // CHECK-NEXT:   unreachable
@@ -402,7 +405,7 @@ func methodByName(name string) {
 // CHECK-NEXT:   %191 = getelementptr inbounds %reflect.StructField, ptr %190, i64 0
 // CHECK-NEXT:   %192 = getelementptr inbounds %reflect.StructField, ptr %191, i32 0, i32 0
 // CHECK-NEXT:   %193 = getelementptr inbounds %reflect.StructField, ptr %191, i32 0, i32 2
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @17, i64 1 }, ptr %192, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @18, i64 1 }, ptr %192, align 8
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %9, ptr %193, align 8
 // CHECK-NEXT:   %194 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %190, 0
 // CHECK-NEXT:   %195 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %194, i64 1, 1
@@ -432,7 +435,7 @@ func methodByName(name string) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_15:                                         ; preds = %_llgo_14
 // CHECK-NEXT:   %218 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @18, i64 14 }, ptr %218, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @19, i64 14 }, ptr %218, align 8
 // CHECK-NEXT:   %219 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %218, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %219)
 // CHECK-NEXT:   unreachable
@@ -452,13 +455,13 @@ func methodByName(name string) {
 // CHECK-NEXT:   store %reflect.Method %229, ptr %220, align 8
 // CHECK-NEXT:   %230 = getelementptr inbounds %reflect.Method, ptr %220, i32 0, i32 0
 // CHECK-NEXT:   %231 = load %"{{.*}}/runtime/internal/runtime.String", ptr %230, align 8
-// CHECK-NEXT:   %232 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %231, %"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 6 })
+// CHECK-NEXT:   %232 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %231, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 6 })
 // CHECK-NEXT:   %233 = xor i1 %232, true
 // CHECK-NEXT:   br i1 %233, label %_llgo_17, label %_llgo_18
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_17:                                         ; preds = %_llgo_16
 // CHECK-NEXT:   %234 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @19, i64 12 }, ptr %234, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @20, i64 12 }, ptr %234, align 8
 // CHECK-NEXT:   %235 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %234, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %235)
 // CHECK-NEXT:   unreachable
@@ -474,7 +477,7 @@ func methodByName(name string) {
 // CHECK-NEXT:   %242 = insertvalue { ptr, ptr } %241, ptr %237, 1
 // CHECK-NEXT:   %243 = extractvalue { ptr, ptr } %242, 1
 // CHECK-NEXT:   %244 = extractvalue { ptr, ptr } %242, 0
-// CHECK-NEXT:   %245 = call { %reflect.Method, i1 } %244(ptr %243, %"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 6 })
+// CHECK-NEXT:   %245 = call { %reflect.Method, i1 } %244(ptr %243, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 6 })
 // CHECK-NEXT:   %246 = extractvalue { %reflect.Method, i1 } %245, 0
 // CHECK-NEXT:   store %reflect.Method %246, ptr %236, align 8
 // CHECK-NEXT:   %247 = extractvalue { %reflect.Method, i1 } %245, 1
@@ -482,7 +485,7 @@ func methodByName(name string) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_19:                                         ; preds = %_llgo_21, %_llgo_18
 // CHECK-NEXT:   %248 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @20, i64 18 }, ptr %248, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @21, i64 18 }, ptr %248, align 8
 // CHECK-NEXT:   %249 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %248, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %249)
 // CHECK-NEXT:   unreachable
@@ -504,26 +507,26 @@ func methodByName(name string) {
 // CHECK-NEXT:   %260 = getelementptr inbounds %reflect.Value, ptr %257, i64 0
 // CHECK-NEXT:   %261 = load %reflect.Value, ptr %260, align 8
 // CHECK-NEXT:   %262 = call %"{{.*}}/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %261)
-// CHECK-NEXT:   %263 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %262, %"{{.*}}/runtime/internal/runtime.String" { ptr @21, i64 5 })
+// CHECK-NEXT:   %263 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %262, %"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 5 })
 // CHECK-NEXT:   %264 = xor i1 %263, true
 // CHECK-NEXT:   br i1 %264, label %_llgo_22, label %_llgo_23
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_21:                                         ; preds = %_llgo_18
 // CHECK-NEXT:   %265 = getelementptr inbounds %reflect.Method, ptr %236, i32 0, i32 0
 // CHECK-NEXT:   %266 = load %"{{.*}}/runtime/internal/runtime.String", ptr %265, align 8
-// CHECK-NEXT:   %267 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %266, %"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 6 })
+// CHECK-NEXT:   %267 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %266, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 6 })
 // CHECK-NEXT:   %268 = xor i1 %267, true
 // CHECK-NEXT:   br i1 %268, label %_llgo_19, label %_llgo_20
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_22:                                         ; preds = %_llgo_20
 // CHECK-NEXT:   %269 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 18 }, ptr %269, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @23, i64 18 }, ptr %269, align 8
 // CHECK-NEXT:   %270 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %269, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %270)
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_23:                                         ; preds = %_llgo_20
-// CHECK-NEXT:   %271 = call %reflect.Value @reflect.Value.MethodByName(%reflect.Value %254, %"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 6 })
+// CHECK-NEXT:   %271 = call %reflect.Value @reflect.Value.MethodByName(%reflect.Value %254, %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 6 })
 // CHECK-NEXT:   %272 = call %"{{.*}}/runtime/internal/runtime.Slice" @reflect.Value.Call(%reflect.Value %271, %"{{.*}}/runtime/internal/runtime.Slice" zeroinitializer)
 // CHECK-NEXT:   %273 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %272, 0
 // CHECK-NEXT:   %274 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %272, 1
@@ -532,20 +535,20 @@ func methodByName(name string) {
 // CHECK-NEXT:   %276 = getelementptr inbounds %reflect.Value, ptr %273, i64 0
 // CHECK-NEXT:   %277 = load %reflect.Value, ptr %276, align 8
 // CHECK-NEXT:   %278 = call %"{{.*}}/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %277)
-// CHECK-NEXT:   %279 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %278, %"{{.*}}/runtime/internal/runtime.String" { ptr @21, i64 5 })
+// CHECK-NEXT:   %279 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %278, %"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 5 })
 // CHECK-NEXT:   %280 = xor i1 %279, true
 // CHECK-NEXT:   br i1 %280, label %_llgo_24, label %_llgo_25
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_24:                                         ; preds = %_llgo_23
 // CHECK-NEXT:   %281 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @23, i64 24 }, ptr %281, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @24, i64 24 }, ptr %281, align 8
 // CHECK-NEXT:   %282 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %281, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %282)
 // CHECK-NEXT:   unreachable
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_25:                                         ; preds = %_llgo_23
 // CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/reflectmk.method"(i64 1)
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/reflectmk.methodByName"(%"{{.*}}/runtime/internal/runtime.String" { ptr @6, i64 6 })
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/reflectmk.methodByName"(%"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 6 })
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
@@ -567,13 +570,13 @@ func methodByName(name string) {
 // CHECK-NEXT:   %11 = getelementptr inbounds %reflect.Value, ptr %8, i64 0
 // CHECK-NEXT:   %12 = load %reflect.Value, ptr %11, align 8
 // CHECK-NEXT:   %13 = call %"{{.*}}/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %12)
-// CHECK-NEXT:   %14 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %13, %"{{.*}}/runtime/internal/runtime.String" { ptr @21, i64 5 })
+// CHECK-NEXT:   %14 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %13, %"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 5 })
 // CHECK-NEXT:   %15 = xor i1 %14, true
 // CHECK-NEXT:   br i1 %15, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %16 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 18 }, ptr %16, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @23, i64 18 }, ptr %16, align 8
 // CHECK-NEXT:   %17 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %16, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %17)
 // CHECK-NEXT:   unreachable
@@ -600,13 +603,13 @@ func methodByName(name string) {
 // CHECK-NEXT:   %11 = getelementptr inbounds %reflect.Value, ptr %8, i64 0
 // CHECK-NEXT:   %12 = load %reflect.Value, ptr %11, align 8
 // CHECK-NEXT:   %13 = call %"{{.*}}/runtime/internal/runtime.String" @reflect.Value.String(%reflect.Value %12)
-// CHECK-NEXT:   %14 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %13, %"{{.*}}/runtime/internal/runtime.String" { ptr @21, i64 5 })
+// CHECK-NEXT:   %14 = call i1 @"{{.*}}/runtime/internal/runtime.StringEqual"(%"{{.*}}/runtime/internal/runtime.String" %13, %"{{.*}}/runtime/internal/runtime.String" { ptr @22, i64 5 })
 // CHECK-NEXT:   %15 = xor i1 %14, true
 // CHECK-NEXT:   br i1 %15, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %16 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @23, i64 24 }, ptr %16, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @24, i64 24 }, ptr %16, align 8
 // CHECK-NEXT:   %17 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %16, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %17)
 // CHECK-NEXT:   unreachable

--- a/cl/_testrt/closurebound/in.go
+++ b/cl/_testrt/closurebound/in.go
@@ -1,6 +1,11 @@
 // LITTEST
 package main
 
+// CHECK-LINE: @0 = private unnamed_addr constant [52 x i8] c"{{.*}}/cl/_testrt/closurebound.demo1", align 1
+// CHECK-LINE: @1 = private unnamed_addr constant [6 x i8] c"encode", align 1
+// CHECK-LINE: @2 = private unnamed_addr constant [52 x i8] c"{{.*}}/cl/_testrt/closurebound.demo2", align 1
+// CHECK-LINE: @3 = private unnamed_addr constant [5 x i8] c"error", align 1
+
 var my = demo2{}.encode
 
 type demo1 struct {
@@ -11,18 +16,33 @@ type demo1 struct {
 // CHECK-NEXT:   ret i64 1
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/closurebound.(*demo1).encode"(ptr %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = load %"{{.*}}/cl/_testrt/closurebound.demo1", ptr %0, align 1
-// CHECK-NEXT:   %2 = call i64 @"{{.*}}/cl/_testrt/closurebound.demo1.encode"(%"{{.*}}/cl/_testrt/closurebound.demo1" %1)
-// CHECK-NEXT:   ret i64 %2
-// CHECK-NEXT: }
 func (se demo1) encode() int {
 	return 1
 }
 
 type demo2 struct {
 }
+
+func (se demo2) encode() int {
+	return 2
+}
+
+func main() {
+	se := demo1{}
+	f := se.encode
+	if f() != 1 {
+		panic("error")
+	}
+}
+
+// CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/closurebound.(*demo1).encode"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 52 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 6 })
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testrt/closurebound.demo1", ptr %0, align 1
+// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testrt/closurebound.demo1.encode"(%"{{.*}}/cl/_testrt/closurebound.demo1" %2)
+// CHECK-NEXT:   ret i64 %3
+// CHECK-NEXT: }
 
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/closurebound.demo2.encode"(%"{{.*}}/cl/_testrt/closurebound.demo2" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
@@ -31,13 +51,30 @@ type demo2 struct {
 
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/closurebound.(*demo2).encode"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = load %"{{.*}}/cl/_testrt/closurebound.demo2", ptr %0, align 1
-// CHECK-NEXT:   %2 = call i64 @"{{.*}}/cl/_testrt/closurebound.demo2.encode"(%"{{.*}}/cl/_testrt/closurebound.demo2" %1)
-// CHECK-NEXT:   ret i64 %2
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 52 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 6 })
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testrt/closurebound.demo2", ptr %0, align 1
+// CHECK-NEXT:   %3 = call i64 @"{{.*}}/cl/_testrt/closurebound.demo2.encode"(%"{{.*}}/cl/_testrt/closurebound.demo2" %2)
+// CHECK-NEXT:   ret i64 %3
 // CHECK-NEXT: }
-func (se demo2) encode() int {
-	return 2
-}
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/closurebound.init"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testrt/closurebound.init$guard", align 1
+// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/closurebound.init$guard", align 1
+// CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 0)
+// CHECK-NEXT:   %2 = getelementptr inbounds { %"{{.*}}/cl/_testrt/closurebound.demo2" }, ptr %1, i32 0, i32 0
+// CHECK-NEXT:   store %"{{.*}}/cl/_testrt/closurebound.demo2" zeroinitializer, ptr %2, align 1
+// CHECK-NEXT:   %3 = insertvalue { ptr, ptr } { ptr @"{{.*}}/cl/_testrt/closurebound.demo2.encode$bound", ptr undef }, ptr %1, 1
+// CHECK-NEXT:   store { ptr, ptr } %3, ptr @"{{.*}}/cl/_testrt/closurebound.my", align 8
+// CHECK-NEXT:   br label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/closurebound.main"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
@@ -53,7 +90,7 @@ func (se demo2) encode() int {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %7, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 5 }, ptr %7, align 8
 // CHECK-NEXT:   %8 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %7, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %8)
 // CHECK-NEXT:   unreachable
@@ -61,13 +98,6 @@ func (se demo2) encode() int {
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
-func main() {
-	se := demo1{}
-	f := se.encode
-	if f() != 1 {
-		panic("error")
-	}
-}
 
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/closurebound.demo2.encode$bound"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:

--- a/cl/_testrt/struct/in.go
+++ b/cl/_testrt/struct/in.go
@@ -4,6 +4,9 @@ package main
 import "C"
 import _ "unsafe"
 
+// CHECK-LINE: @0 = private unnamed_addr constant [44 x i8] c"{{.*}}/cl/_testrt/struct.Foo", align 1
+// CHECK-LINE: @1 = private unnamed_addr constant [5 x i8] c"Print", align 1
+
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/struct.Foo.Print"(%"{{.*}}/cl/_testrt/struct.Foo" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testrt/struct.Foo", align 8
@@ -23,12 +26,6 @@ import _ "unsafe"
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/struct.(*Foo).Print"(ptr %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = load %"{{.*}}/cl/_testrt/struct.Foo", ptr %0, align 4
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/struct.Foo.Print"(%"{{.*}}/cl/_testrt/struct.Foo" %1)
-// CHECK-NEXT:   ret void
-// CHECK-NEXT: }
 func (p Foo) Print() {
 	if p.ok {
 		printf(&format[0], p.A)
@@ -38,16 +35,55 @@ func (p Foo) Print() {
 //go:linkname printf C.printf
 func printf(format *int8, __llgo_va_list ...any)
 
-// CHECK-LABEL: define ptr @"{{.*}}/cl/_testrt/struct._Cgo_ptr"(ptr %0){{.*}} {
-// CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   ret ptr %0
-// CHECK-NEXT: }
 type Foo struct {
 	A  C.int
 	ok bool
 }
 
 var format = [...]int8{'H', 'e', 'l', 'l', 'o', ' ', '%', 'd', '\n', 0}
+
+func main() {
+	foo := Foo{100, true}
+	foo.Print()
+}
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/struct.(*Foo).Print"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 44 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 5 })
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testrt/struct.Foo", ptr %0, align 4
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/struct.Foo.Print"(%"{{.*}}/cl/_testrt/struct.Foo" %2)
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define ptr @"{{.*}}/cl/_testrt/struct._Cgo_ptr"(ptr %0){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   ret ptr %0
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/struct.init"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testrt/struct.init$guard", align 1
+// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/struct.init$guard", align 1
+// CHECK-NEXT:   call void @syscall.init()
+// CHECK-NEXT:   store i8 72, ptr @"{{.*}}/cl/_testrt/struct.format", align 1
+// CHECK-NEXT:   store i8 101, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/struct.format", i64 1), align 1
+// CHECK-NEXT:   store i8 108, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/struct.format", i64 2), align 1
+// CHECK-NEXT:   store i8 108, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/struct.format", i64 3), align 1
+// CHECK-NEXT:   store i8 111, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/struct.format", i64 4), align 1
+// CHECK-NEXT:   store i8 32, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/struct.format", i64 5), align 1
+// CHECK-NEXT:   store i8 37, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/struct.format", i64 6), align 1
+// CHECK-NEXT:   store i8 100, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/struct.format", i64 7), align 1
+// CHECK-NEXT:   store i8 10, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/struct.format", i64 8), align 1
+// CHECK-NEXT:   store i8 0, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/struct.format", i64 9), align 1
+// CHECK-NEXT:   br label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/struct.main"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
@@ -61,7 +97,3 @@ var format = [...]int8{'H', 'e', 'l', 'l', 'o', ' ', '%', 'd', '\n', 0}
 // CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/struct.Foo.Print"(%"{{.*}}/cl/_testrt/struct.Foo" %3)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
-func main() {
-	foo := Foo{100, true}
-	foo.Print()
-}

--- a/cl/_testrt/tpabi/in.go
+++ b/cl/_testrt/tpabi/in.go
@@ -3,6 +3,25 @@ package main
 
 import "github.com/goplus/lib/c"
 
+// CHECK-LINE: @0 = private unnamed_addr constant [1 x i8] c"a", align 1
+// CHECK-LINE: @5 = private unnamed_addr constant [4 x i8] c"Info", align 1
+// CHECK-LINE: @10 = private unnamed_addr constant [83 x i8] c"type assertion any -> {{.*}}/cl/_testrt/tpabi.T[string, int] failed", align 1
+// CHECK-LINE: @11 = private unnamed_addr constant [5 x i8] c"hello", align 1
+// CHECK-LINE: @13 = private unnamed_addr constant [54 x i8] c"{{.*}}/cl/_testrt/tpabi.T[string, int]", align 1
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/tpabi.init"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testrt/tpabi.init$guard", align 1
+// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/tpabi.init$guard", align 1
+// CHECK-NEXT:   br label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
 type T[M, N any] struct {
 	m M
 	n N
@@ -38,9 +57,9 @@ func (t *K[N]) Advance(n int) *K[N] {
 // CHECK-NEXT:   %3 = load %"{{.*}}/cl/_testrt/tpabi.T[string,int]", ptr %0, align 8
 // CHECK-NEXT:   %4 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 24)
 // CHECK-NEXT:   store %"{{.*}}/cl/_testrt/tpabi.T[string,int]" %3, ptr %4, align 8
-// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_github.com/goplus/llgo/cl/_testrt/tpabi.T[string,int]", ptr undef }, ptr %4, 1
+// CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/tpabi.T[string,int]", ptr undef }, ptr %4, 1
 // CHECK-NEXT:   %6 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %5, 0
-// CHECK-NEXT:   %7 = icmp eq ptr %6, @"_llgo_github.com/goplus/llgo/cl/_testrt/tpabi.T[string,int]"
+// CHECK-NEXT:   %7 = icmp eq ptr %6, @"_llgo_{{.*}}/cl/_testrt/tpabi.T[string,int]"
 // CHECK-NEXT:   br i1 %7, label %_llgo_1, label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
@@ -54,7 +73,7 @@ func (t *K[N]) Advance(n int) *K[N] {
 // CHECK-NEXT:   %13 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpabi.T[string,int]", ptr %11, i32 0, i32 1
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @11, i64 5 }, ptr %12, align 8
 // CHECK-NEXT:   store i64 100, ptr %13, align 8
-// CHECK-NEXT:   %14 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$BP0p_lUsEd-IbbtJVukGmgrdQkqzcoYzSiwgUvgFvUs", ptr @"*_llgo_github.com/goplus/llgo/cl/_testrt/tpabi.T[string,int]")
+// CHECK-NEXT:   %14 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$BP0p_lUsEd-IbbtJVukGmgrdQkqzcoYzSiwgUvgFvUs", ptr @"*_llgo_{{.*}}/cl/_testrt/tpabi.T[string,int]")
 // CHECK-NEXT:   %15 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %14, 0
 // CHECK-NEXT:   %16 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %15, ptr %11, 1
 // CHECK-NEXT:   %17 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %16)
@@ -90,6 +109,7 @@ func (t *K[N]) Advance(n int) *K[N] {
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %33)
 // CHECK-NEXT:   unreachable
 // CHECK-NEXT: }
+
 func main() {
 	var a any = T[string, int]{"a", 1}
 	println(a.(T[string, int]).m)
@@ -132,7 +152,21 @@ func main() {
 
 // CHECK-LABEL: define linkonce void @"{{.*}}/cl/_testrt/tpabi.(*T[string,int]).Info"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = load %"{{.*}}/cl/_testrt/tpabi.T[string,int]", ptr %0, align 8
-// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/tpabi.T[string,int].Info"(%"{{.*}}/cl/_testrt/tpabi.T[string,int]" %1)
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @13, i64 54 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 4 })
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testrt/tpabi.T[string,int]", ptr %0, align 8
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testrt/tpabi.T[string,int].Info"(%"{{.*}}/cl/_testrt/tpabi.T[string,int]" %2)
 // CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.memequal64"(ptr %0, ptr %1, ptr %2){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.memequal64"(ptr %1, ptr %2)
+// CHECK-NEXT:   ret i1 %3
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.interequal"(ptr %1, ptr %2)
+// CHECK-NEXT:   ret i1 %3
 // CHECK-NEXT: }

--- a/cl/_testrt/tpmethod/in.go
+++ b/cl/_testrt/tpmethod/in.go
@@ -1,6 +1,10 @@
 // LITTEST
 package main
 
+// CHECK-LINE: @0 = private unnamed_addr constant [7 x i8] c"foo.txt", align 1
+// CHECK-LINE: @7 = private unnamed_addr constant [3 x i8] c"Get", align 1
+// CHECK-LINE: @16 = private unnamed_addr constant [55 x i8] c"{{.*}}/cl/_testrt/tpmethod.Tuple[error]", align 1
+
 type Tuple[T any] struct {
 	v T
 }
@@ -27,9 +31,10 @@ func Async[T any](fn func(func(T))) Future[T] {
 
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testrt/tpmethod.ReadFile"(%"{{.*}}/runtime/internal/runtime.String" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testrt/tpmethod.Async[github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]]"({ ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/tpmethod.ReadFile$1", ptr null })
+// CHECK-NEXT:   %1 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testrt/tpmethod.Async[{{.*}}/cl/_testrt/tpmethod.Tuple[error]]"({ ptr, ptr } { ptr @"__llgo_stub.{{.*}}/cl/_testrt/tpmethod.ReadFile$1", ptr null })
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %1
 // CHECK-NEXT: }
+
 func ReadFile(fileName string) Future[Tuple[error]] {
 	// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/tpmethod.ReadFile$1"({ ptr, ptr } %0){{.*}} {
 	// CHECK-NEXT: _llgo_0:
@@ -43,6 +48,20 @@ func ReadFile(fileName string) Future[Tuple[error]] {
 	// CHECK-NEXT:   call void %5(ptr %4, %"{{.*}}/cl/_testrt/tpmethod.Tuple[error]" %3)
 	// CHECK-NEXT:   ret void
 	// CHECK-NEXT: }
+
+	// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/tpmethod.init"(){{.*}} {
+	// CHECK-NEXT: _llgo_0:
+	// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testrt/tpmethod.init$guard", align 1
+	// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
+	// CHECK-EMPTY:
+	// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+	// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/tpmethod.init$guard", align 1
+	// CHECK-NEXT:   br label %_llgo_2
+	// CHECK-EMPTY:
+	// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+	// CHECK-NEXT:   ret void
+	// CHECK-NEXT: }
+
 	return Async[Tuple[error]](func(resolve func(Tuple[error])) {
 		resolve(Tuple[error]{v: nil})
 	})
@@ -59,9 +78,10 @@ func ReadFile(fileName string) Future[Tuple[error]] {
 // CHECK-NEXT:   %6 = insertvalue { ptr, ptr } %5, ptr %1, 1
 // CHECK-NEXT:   %7 = extractvalue { ptr, ptr } %6, 1
 // CHECK-NEXT:   %8 = extractvalue { ptr, ptr } %6, 0
-// CHECK-NEXT:   call void %8(ptr %7, { ptr, ptr } { ptr @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/tpmethod.main$1", ptr null })
+// CHECK-NEXT:   call void %8(ptr %7, { ptr, ptr } { ptr @"__llgo_stub.{{.*}}/cl/_testrt/tpmethod.main$1", ptr null })
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
+
 func main() {
 	// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/tpmethod.main$1"(%"{{.*}}/cl/_testrt/tpmethod.Tuple[error]" %0){{.*}} {
 	// CHECK-NEXT: _llgo_0:
@@ -70,29 +90,30 @@ func main() {
 	// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 	// CHECK-NEXT:   ret void
 	// CHECK-NEXT: }
+
 	ReadFile("foo.txt").Then(func(v Tuple[error]) {
 		println(v.Get())
 	})
 }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testrt/tpmethod.Async[github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]]"({ ptr, ptr } %0){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testrt/tpmethod.Async[{{.*}}/cl/_testrt/tpmethod.Tuple[error]]"({ ptr, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmethod.future[github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]]", ptr %1, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmethod.future[{{.*}}/cl/_testrt/tpmethod.Tuple[error]]", ptr %1, i32 0, i32 0
 // CHECK-NEXT:   store { ptr, ptr } %0, ptr %2, align 8
-// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$S25w7h931TxiY5HCyBzDrZdIDRx-V5waLTlYXjrsYWc", ptr @"*_llgo_github.com/goplus/llgo/cl/_testrt/tpmethod.future[github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]]")
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.NewItab"(ptr @"_llgo_iface$S25w7h931TxiY5HCyBzDrZdIDRx-V5waLTlYXjrsYWc", ptr @"*_llgo_{{.*}}/cl/_testrt/tpmethod.future[{{.*}}/cl/_testrt/tpmethod.Tuple[error]]")
 // CHECK-NEXT:   %4 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" undef, ptr %3, 0
 // CHECK-NEXT:   %5 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %4, ptr %1, 1
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %5
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/tpmethod.ReadFile$1"(ptr %0, { ptr, ptr } %1){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testrt/tpmethod.ReadFile$1"(ptr %0, { ptr, ptr } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   tail call void @"{{.*}}/cl/_testrt/tpmethod.ReadFile$1"({ ptr, ptr } %1)
 // CHECK-NEXT:   ret void
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"__llgo_stub.github.com/goplus/llgo/cl/_testrt/tpmethod.main$1"(ptr %0, %"{{.*}}/cl/_testrt/tpmethod.Tuple[error]" %1){{.*}} {
+// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/cl/_testrt/tpmethod.main$1"(ptr %0, %"{{.*}}/cl/_testrt/tpmethod.Tuple[error]" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   tail call void @"{{.*}}/cl/_testrt/tpmethod.main$1"(%"{{.*}}/cl/_testrt/tpmethod.Tuple[error]" %1)
 // CHECK-NEXT:   ret void
@@ -108,9 +129,9 @@ func main() {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce void @"{{.*}}/cl/_testrt/tpmethod.(*future[github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]]).Then"(ptr %0, { ptr, ptr } %1){{.*}} {
+// CHECK-LABEL: define linkonce void @"{{.*}}/cl/_testrt/tpmethod.(*future[{{.*}}/cl/_testrt/tpmethod.Tuple[error]]).Then"(ptr %0, { ptr, ptr } %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmethod.future[github.com/goplus/llgo/cl/_testrt/tpmethod.Tuple[error]]", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmethod.future[{{.*}}/cl/_testrt/tpmethod.Tuple[error]]", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %3 = load { ptr, ptr }, ptr %2, align 8
 // CHECK-NEXT:   %4 = extractvalue { ptr, ptr } %3, 1
 // CHECK-NEXT:   %5 = extractvalue { ptr, ptr } %3, 0
@@ -120,12 +141,14 @@ func main() {
 
 // CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testrt/tpmethod.(*Tuple[error]).Get"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = load %"{{.*}}/cl/_testrt/tpmethod.Tuple[error]", ptr %0, align 8
-// CHECK-NEXT:   %2 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testrt/tpmethod.Tuple[error].Get"(%"{{.*}}/cl/_testrt/tpmethod.Tuple[error]" %1)
-// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %2
+// CHECK-NEXT:   %1 = icmp eq ptr %0, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PanicWrapNilPointer"(i1 %1, %"{{.*}}/runtime/internal/runtime.String" { ptr @16, i64 55 }, %"{{.*}}/runtime/internal/runtime.String" { ptr @7, i64 3 })
+// CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testrt/tpmethod.Tuple[error]", ptr %0, align 8
+// CHECK-NEXT:   %3 = call %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testrt/tpmethod.Tuple[error].Get"(%"{{.*}}/cl/_testrt/tpmethod.Tuple[error]" %2)
+// CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %3
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce i1 @"__llgo_stub.github.com/goplus/llgo/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2){{.*}} {
+// CHECK-LABEL: define linkonce i1 @"__llgo_stub.{{.*}}/runtime/internal/runtime.interequal"(ptr %0, ptr %1, ptr %2){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %3 = tail call i1 @"{{.*}}/runtime/internal/runtime.interequal"(ptr %1, ptr %2)
 // CHECK-NEXT:   ret i1 %3

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -868,9 +868,11 @@ func (p *context) callEx(b llssa.Builder, act llssa.DoAction, call *ssa.CallComm
 	switch cv := cv.(type) {
 	case *ssa.Builtin:
 		fn := cv.Name()
-		if fn == "ssa:wrapnilchk" { // TODO(xsw): check nil ptr
-			arg := args[0]
-			ret = p.compileValue(b, arg)
+		if fn == "ssa:wrapnilchk" {
+			ptr := p.compileValue(b, args[0])
+			recvType := p.compileValue(b, args[1])
+			methodName := p.compileValue(b, args[2])
+			ret = b.WrapNilCheck(ptr, recvType, methodName)
 			return
 		} else if fn == "Offsetof" && act == llssa.Call {
 			if offset, ok := p.offsetOfBuiltinArg(args[0]); ok {

--- a/runtime/internal/runtime/z_error.go
+++ b/runtime/internal/runtime/z_error.go
@@ -67,6 +67,40 @@ func AssertNilDeref(b bool) {
 	}
 }
 
+func PanicWrapNilPointer(b bool, recvType, methodName string) {
+	if b {
+		recvType = panicWrapRecvType(recvType)
+		panic(plainError("value method " + recvType + "." + methodName + " called using nil *" + panicWrapTypeName(recvType) + " pointer"))
+	}
+}
+
+func panicWrapRecvType(recvType string) string {
+	const commandLineArguments = "command-line-arguments."
+	if len(recvType) > len(commandLineArguments) && recvType[:len(commandLineArguments)] == commandLineArguments {
+		return "main." + recvType[len(commandLineArguments):]
+	}
+	return recvType
+}
+
+func panicWrapTypeName(recvType string) string {
+	depth := 0
+	for i := len(recvType) - 1; i >= 0; i-- {
+		switch recvType[i] {
+		case ']':
+			depth++
+		case '[':
+			if depth > 0 {
+				depth--
+			}
+		case '.':
+			if depth == 0 {
+				return recvType[i+1:]
+			}
+		}
+	}
+	return recvType
+}
+
 // printany prints an argument passed to panic.
 // If panic is called with a value that has a String or Error method,
 // it has already been converted into a string by preprintpanics.

--- a/ssa/memory.go
+++ b/ssa/memory.go
@@ -337,6 +337,12 @@ func (b Builder) AssertNilDeref(ptr Expr) {
 	b.InlineCall(b.Pkg.rtFunc("AssertNilDeref"), isNil)
 }
 
+func (b Builder) WrapNilCheck(ptr, recvType, methodName Expr) Expr {
+	isNil := b.BinOp(token.EQL, ptr, b.Prog.Nil(ptr.Type))
+	b.Call(b.Pkg.rtFunc("PanicWrapNilPointer"), isNil, recvType, methodName)
+	return ptr
+}
+
 // Load returns the value at the pointer ptr.
 func (b Builder) Load(ptr Expr) Expr {
 	dbgInstrf("Load %v\n", ptr.impl)

--- a/test/go/panicwrap_method_test.go
+++ b/test/go/panicwrap_method_test.go
@@ -1,0 +1,35 @@
+package gotest
+
+import "testing"
+
+type panicWrapT int
+
+func (panicWrapT) PanicWrapValueMethod() {}
+
+type panicWrapI interface {
+	PanicWrapValueMethod()
+}
+
+var (
+	panicWrapPtr *panicWrapT
+	panicWrapItf panicWrapI = panicWrapPtr
+)
+
+func TestValueMethodWrapperNilPointerPanic(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected value method wrapper panic")
+		}
+		err, ok := r.(error)
+		if !ok {
+			t.Fatalf("panic type = %T, want error", r)
+		}
+		const want = "value method github.com/goplus/llgo/test/go.panicWrapT.PanicWrapValueMethod called using nil *panicWrapT pointer"
+		if got := err.Error(); got != want {
+			t.Fatalf("panic text = %q, want %q", got, want)
+		}
+	}()
+
+	panicWrapItf.PanicWrapValueMethod()
+}

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1836,10 +1836,6 @@ xfails:
     reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
-    case: fixedbugs/issue19040.go
-    reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
     case: fixedbugs/issue22881.go
     reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64
@@ -1970,11 +1966,6 @@ xfails:
   - version: go1.24
     platform: linux/amd64
     directive: run
-    case: fixedbugs/issue19040.go
-    reason: go1.24 goroot run failure on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
     case: fixedbugs/issue22881.go
     reason: go1.24 goroot run failure on linux/amd64
   - version: go1.24
@@ -2076,11 +2067,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: fixedbugs/issue16130.go
-    reason: go1.25 goroot run failure on linux/amd64
-  - version: go1.25
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue19040.go
     reason: go1.25 goroot run failure on linux/amd64
   - version: go1.25
     platform: linux/amd64
@@ -2191,11 +2177,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: fixedbugs/issue16130.go
-    reason: go1.26 goroot run failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue19040.go
     reason: go1.26 goroot run failure on linux/amd64
   - version: go1.26
     platform: linux/amd64


### PR DESCRIPTION
Fixes the remaining fixedbugs/issue19040.go panic text mismatch by implementing the compiler-generated wrapnilchk path for value-method wrappers invoked through nil pointers.

Coverage:
- Adds test/go coverage for nil *T assigned to an interface and calling a value receiver method.
- Removes the fixedbugs/issue19040.go xfail entries for Darwin and Linux Go 1.24/1.25/1.26.
- Refreshes affected LITTEST IR goldens for generated wrapper nil checks.

Local validation:
- go test ./cl ./ssa -count=1
- go test ./test/go -run TestValueMethodWrapperNilPointerPanic -count=1
- go run ./cmd/llgo run "$(go env GOROOT)/test/fixedbugs/issue19040.go"
- go test ./test/goroot -run TestGoRootRunCases -count=1 -timeout 30m -args -goroot "$(go env GOROOT)" -case "fixedbugs/issue19040\.go" -xfail <empty xfail> -progress 30s