### PR TITLE
fix recursive named pointer types

### DIFF
--- a/ssa/type.go
+++ b/ssa/type.go
@@ -388,8 +388,10 @@ func (p Program) toType(raw types.Type) Type {
 			return &aType{p.tyVoidPtr(), typ, vkPtr}
 		}
 	case *types.Pointer:
-		elem := p.rawType(t.Elem())
-		return &aType{llvm.PointerType(elem.ll, 0), typ, vkPtr}
+		// LLVM pointers are opaque, so the element LLVM type is not needed here.
+		// Avoid expanding it eagerly: legal Go recursive types often close their
+		// cycle through a pointer.
+		return &aType{p.tyVoidPtr(), typ, vkPtr}
 	case *types.Interface:
 		if t.Empty() {
 			return &aType{p.rtEface(), typ, vkEface}

--- a/ssa/type_patch_test.go
+++ b/ssa/type_patch_test.go
@@ -119,6 +119,29 @@ func TestToLLVMFuncPtrUsesVoidPtr(t *testing.T) {
 	}
 }
 
+func TestPointerTypeDoesNotExpandRecursiveNamedElement(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "recursive.go", `package p
+
+type T18 *[10]T19
+type T19 T18
+`, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkg := types.NewPackage("example.com/p", "p")
+	if err := types.NewChecker(&types.Config{}, fset, pkg, nil).Files([]*ast.File{f}); err != nil {
+		t.Fatal(err)
+	}
+
+	prog := NewProgram(nil)
+	prog.TypeSizes(types.SizesFor("gc", runtime.GOARCH))
+	t18 := pkg.Scope().Lookup("T18").Type()
+	if got, want := prog.Type(t18, InGo).ll.String(), prog.tyVoidPtr().String(); got != want {
+		t.Fatalf("recursive named pointer LLVM type = %q, want %q", got, want)
+	}
+}
+
 func TestNamedStructLayoutEquivalent(t *testing.T) {
 	prog := NewProgram(nil)
 	prog.TypeSizes(types.SizesFor("gc", runtime.GOARCH))

--- a/test/go/recursive_named_types_test.go
+++ b/test/go/recursive_named_types_test.go
@@ -1,0 +1,91 @@
+package gotest
+
+import "testing"
+
+type recursiveNamedT1 struct {
+	Next *recursiveNamedT2
+}
+
+type recursiveNamedT2 recursiveNamedT1
+
+type recursiveNamedT3 struct {
+	Next *recursiveNamedT4
+}
+
+type recursiveNamedT4 recursiveNamedT5
+type recursiveNamedT5 recursiveNamedT6
+type recursiveNamedT6 recursiveNamedT7
+type recursiveNamedT7 recursiveNamedT8
+type recursiveNamedT8 recursiveNamedT9
+type recursiveNamedT9 recursiveNamedT3
+
+type recursiveNamedT10 struct {
+	x struct {
+		y ***struct {
+			z *struct {
+				Next *recursiveNamedT11
+			}
+		}
+	}
+}
+
+type recursiveNamedT11 recursiveNamedT10
+
+type recursiveNamedT12 struct {
+	F1 *recursiveNamedT15
+	F2 *recursiveNamedT13
+	F3 *recursiveNamedT16
+}
+
+type recursiveNamedT13 recursiveNamedT14
+type recursiveNamedT14 recursiveNamedT15
+type recursiveNamedT15 recursiveNamedT16
+type recursiveNamedT16 recursiveNamedT17
+type recursiveNamedT17 recursiveNamedT12
+
+type recursiveNamedT18 *[10]recursiveNamedT19
+type recursiveNamedT19 recursiveNamedT18
+
+func TestRecursiveNamedTypeLiterals(t *testing.T) {
+	_ = &recursiveNamedT1{&recursiveNamedT2{}}
+	_ = &recursiveNamedT2{&recursiveNamedT2{}}
+	_ = &recursiveNamedT3{&recursiveNamedT4{}}
+	_ = &recursiveNamedT4{&recursiveNamedT4{}}
+	_ = &recursiveNamedT5{&recursiveNamedT4{}}
+	_ = &recursiveNamedT6{&recursiveNamedT4{}}
+	_ = &recursiveNamedT7{&recursiveNamedT4{}}
+	_ = &recursiveNamedT8{&recursiveNamedT4{}}
+	_ = &recursiveNamedT9{&recursiveNamedT4{}}
+	_ = &recursiveNamedT12{&recursiveNamedT15{}, &recursiveNamedT13{}, &recursiveNamedT16{}}
+
+	var (
+		tn struct{ Next *recursiveNamedT11 }
+		tz struct {
+			z *struct{ Next *recursiveNamedT11 }
+		}
+		tpz *struct {
+			z *struct{ Next *recursiveNamedT11 }
+		}
+		tppz **struct {
+			z *struct{ Next *recursiveNamedT11 }
+		}
+		tpppz ***struct {
+			z *struct{ Next *recursiveNamedT11 }
+		}
+		ty struct {
+			y ***struct {
+				z *struct{ Next *recursiveNamedT11 }
+			}
+		}
+	)
+	tn.Next = &recursiveNamedT11{}
+	tz.z = &tn
+	tpz = &tz
+	tppz = &tpz
+	tpppz = &tppz
+	ty.y = tpppz
+	_ = &recursiveNamedT10{ty}
+
+	t19s := &[10]recursiveNamedT19{}
+	_ = recursiveNamedT18(t19s)
+}

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1828,10 +1828,6 @@ xfails:
     reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
-    case: fixedbugs/bug336.go
-    reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
     case: fixedbugs/issue16130.go
     reason: current main goroot run failure on darwin/arm64
   - platform: darwin/arm64
@@ -1960,11 +1956,6 @@ xfails:
   - version: go1.24
     platform: linux/amd64
     directive: run
-    case: fixedbugs/bug336.go
-    reason: go1.24 goroot run failure on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
     case: fixedbugs/issue16130.go
     reason: go1.24 goroot run failure on linux/amd64
   - version: go1.24
@@ -2066,11 +2057,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: zerodivide.go
-    reason: go1.25 goroot run failure on linux/amd64
-  - version: go1.25
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/bug336.go
     reason: go1.25 goroot run failure on linux/amd64
   - version: go1.25
     platform: linux/amd64
@@ -2181,11 +2167,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: zerodivide.go
-    reason: go1.26 goroot run failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/bug336.go
     reason: go1.26 goroot run failure on linux/amd64
   - version: go1.26
     platform: linux/amd64


### PR DESCRIPTION
## Summary
- avoid eager LLVM element type expansion for opaque pointers
- cover recursive and mutually recursive named type literals in test/go
- remove the goroot xfail for fixedbugs/bug336.go

## Verification
- go test ./test/go -count=1
- LLGO_ROOT="/Users/lijie/source/goplus/llgo-wt-goroot-fixedbugs-recursive-types" /tmp/llgo-recursive-types-fixed test ./test/go -run TestRecursiveNamedTypeLiterals -count=1
- go test ./test/goroot -run TestGoRootRunCases -count=1 -timeout 30m -args -goroot "/opt/homebrew/Cellar/go@1.24/1.24.11/libexec" -dirs fixedbugs -case '^fixedbugs/bug336\.go$' -xfail /tmp/llgo-empty-xfail-does-not-exist.yaml -run-timeout 2m -build-timeout 5m
- go test ./ssa -count=1
- go test ./ssa -run TestPointerTypeDoesNotExpandRecursiveNamedElement -count=1
- go test ./cl -run '^TestRunAndTestFromTestgo$/^typerecur$' -count=1