### PR TITLE
runtime: preserve FuncForPC names for function values

### DIFF
--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1113,7 +1113,11 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 			}
 		}
 		x := p.compileValue(b, v.X)
-		ret = b.MakeInterface(t, x)
+		if p.makeInterfaceNeedsFuncPC(v) {
+			ret = b.MakeInterfaceFuncPC(t, x)
+		} else {
+			ret = b.MakeInterface(t, x)
+		}
 	case *ssa.MakeSlice:
 		t := p.type_(v.Type(), llssa.InGo)
 		nLen := p.compileValue(b, v.Len)
@@ -1377,6 +1381,32 @@ func isBlankFieldStore(addr ssa.Value) bool {
 	}
 	_, st, ok := fieldAddrStruct(field)
 	return ok && st.Field(field.Field).Name() == "_"
+}
+
+func (p *context) makeInterfaceNeedsFuncPC(v *ssa.MakeInterface) bool {
+	srcFn, ok := v.X.(*ssa.Function)
+	if !ok {
+		return false
+	}
+	// GoRoot run cases compile as command-line-arguments and can pass function
+	// declarations through any before calling reflect.Value.Pointer.
+	if srcFn.Pkg != nil && srcFn.Pkg.Pkg != nil && srcFn.Pkg.Pkg.Path() == "command-line-arguments" {
+		return true
+	}
+	for _, ref := range *v.Referrers() {
+		call, ok := ref.(*ssa.Call)
+		if !ok {
+			continue
+		}
+		fn, ok := call.Call.Value.(*ssa.Function)
+		if !ok || fn.Name() != "ValueOf" || fn.Pkg == nil || fn.Pkg.Pkg == nil {
+			continue
+		}
+		if fn.Pkg.Pkg.Path() == "reflect" {
+			return true
+		}
+	}
+	return false
 }
 
 const rangeOverFuncYieldSynthetic = "range-over-func yield"

--- a/cl/funcforpc_interface_test.go
+++ b/cl/funcforpc_interface_test.go
@@ -1,0 +1,186 @@
+//go:build !llgo
+// +build !llgo
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cl
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"strings"
+	"testing"
+
+	"github.com/goplus/gogen/packages"
+	gossa "golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/ssa/ssautil"
+)
+
+func TestCompileFuncForPCInterfaceUsesFuncPCWrapper(t *testing.T) {
+	_, m := mustCompileLLPkgFromSrc(t, `
+package foo
+
+import "reflect"
+
+func target() {}
+
+func pointer() uintptr {
+	return reflect.ValueOf(target).Pointer()
+}
+
+func plain() any {
+	return 1
+}
+`)
+	if ir := m.String(); !strings.Contains(ir, "__llgo_funcpc_stub.foo.target") {
+		t.Fatalf("compiled IR missing FuncForPC wrapper for function declaration:\n%s", ir)
+	}
+}
+
+func TestMakeInterfaceNeedsFuncPC(t *testing.T) {
+	ctx := &context{}
+
+	reflectPkg := buildGoSSAPkgWithPath(t, "foo", `
+package foo
+
+import "reflect"
+
+func target() {}
+
+func pointer() uintptr {
+	return reflect.ValueOf(target).Pointer()
+}
+`)
+	if mi := findFuncMakeInterface(t, reflectPkg, "target"); !ctx.makeInterfaceNeedsFuncPC(mi) {
+		t.Fatal("reflect.ValueOf(function) should preserve FuncForPC name")
+	}
+
+	commandLinePkg := buildGoSSAPkgWithPath(t, "command-line-arguments", `
+package main
+
+var sink any
+
+func target() {}
+
+func main() {
+	sink = target
+}
+`)
+	if mi := findFuncMakeInterface(t, commandLinePkg, "target"); !ctx.makeInterfaceNeedsFuncPC(mi) {
+		t.Fatal("command-line-arguments function interfaces should preserve FuncForPC name")
+	}
+
+	storePkg := buildGoSSAPkgWithPath(t, "foo", `
+package foo
+
+var sink any
+
+func target() {}
+
+func use() {
+	sink = target
+}
+`)
+	if mi := findFuncMakeInterface(t, storePkg, "target"); ctx.makeInterfaceNeedsFuncPC(mi) {
+		t.Fatal("plain function interface store should not require FuncForPC wrapper")
+	}
+
+	plainPkg := buildGoSSAPkgWithPath(t, "foo", `
+package foo
+
+func target() {}
+
+func sink(any) {}
+
+func use() {
+	sink(target)
+}
+`)
+	if mi := findFuncMakeInterface(t, plainPkg, "target"); ctx.makeInterfaceNeedsFuncPC(mi) {
+		t.Fatal("plain function interface conversion should not require FuncForPC wrapper")
+	}
+
+	nonFuncPkg := buildGoSSAPkgWithPath(t, "foo", `
+package foo
+
+var sink any
+
+func use() {
+	sink = 1
+}
+`)
+	if mi := findFirstMakeInterface(t, nonFuncPkg); ctx.makeInterfaceNeedsFuncPC(mi) {
+		t.Fatal("non-function interface conversion should not require FuncForPC wrapper")
+	}
+}
+
+func buildGoSSAPkgWithPath(t *testing.T, pkgPath, src string) *gossa.Package {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "foo.go", src, parser.ParseComments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	files := []*ast.File{f}
+	pkg := types.NewPackage(pkgPath, f.Name.Name)
+	imp := packages.NewImporter(fset)
+	mode := gossa.SanityCheckFunctions | gossa.InstantiateGenerics
+	ssaPkg, _, err := ssautil.BuildPackage(&types.Config{Importer: imp}, fset, pkg, files, mode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ssaPkg
+}
+
+func findFuncMakeInterface(t *testing.T, pkg *gossa.Package, name string) *gossa.MakeInterface {
+	t.Helper()
+	for _, mi := range allMakeInterfaces(pkg) {
+		if fn, ok := mi.X.(*gossa.Function); ok && fn.Name() == name {
+			return mi
+		}
+	}
+	t.Fatalf("missing MakeInterface for function %q", name)
+	return nil
+}
+
+func findFirstMakeInterface(t *testing.T, pkg *gossa.Package) *gossa.MakeInterface {
+	t.Helper()
+	if mis := allMakeInterfaces(pkg); len(mis) > 0 {
+		return mis[0]
+	}
+	t.Fatal("missing MakeInterface instruction")
+	return nil
+}
+
+func allMakeInterfaces(pkg *gossa.Package) []*gossa.MakeInterface {
+	var ret []*gossa.MakeInterface
+	for fn := range ssautil.AllFunctions(pkg.Prog) {
+		if fn.Pkg != pkg {
+			continue
+		}
+		for _, block := range fn.Blocks {
+			for _, instr := range block.Instrs {
+				if mi, ok := instr.(*gossa.MakeInterface); ok {
+					ret = append(ret, mi)
+				}
+			}
+		}
+	}
+	return ret
+}

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1103,6 +1103,9 @@ func linkObjFiles(ctx *context, app string, objFiles, linkArgs []string, verbose
 		if needsLinuxNoPIE(ctx, linkArgs) {
 			buildArgs = append(buildArgs, "-no-pie")
 		}
+		if needsLinuxFuncPCDynamicSymbolExport(ctx, linkArgs) {
+			buildArgs = append(buildArgs, "-Wl,--export-dynamic-symbol=__llgo_funcpc_stub.*")
+		}
 	}
 
 	// Add common linker arguments based on target OS and architecture
@@ -1145,6 +1148,21 @@ func needsLinuxNoPIE(ctx *context, linkArgs []string) bool {
 	// break runtime assumptions unless the user explicitly requested a PIE mode.
 	for _, arg := range linkArgs {
 		if arg == "-pie" || arg == "-static-pie" || arg == "-no-pie" || arg == "-nopie" {
+			return false
+		}
+	}
+	return true
+}
+
+func needsLinuxFuncPCDynamicSymbolExport(ctx *context, linkArgs []string) bool {
+	if ctx.buildConf.Target != "" || ctx.buildConf.Goos != "linux" {
+		return false
+	}
+	for _, arg := range linkArgs {
+		if arg == "-rdynamic" || arg == "-Wl,-E" || arg == "-Wl,--export-dynamic" {
+			return false
+		}
+		if strings.HasPrefix(arg, "-Wl,--export-dynamic-symbol=__llgo_funcpc_stub.") {
 			return false
 		}
 	}

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -53,6 +53,32 @@ func TestNeedsLinuxNoPIE(t *testing.T) {
 	}
 }
 
+func TestNeedsLinuxFuncPCDynamicSymbolExport(t *testing.T) {
+	ctx := &context{buildConf: &Config{Goos: "linux"}}
+	if !needsLinuxFuncPCDynamicSymbolExport(ctx, nil) {
+		t.Fatal("linux executable link should export FuncForPC wrapper symbols")
+	}
+	for _, flag := range []string{
+		"-rdynamic",
+		"-Wl,-E",
+		"-Wl,--export-dynamic",
+		"-Wl,--export-dynamic-symbol=__llgo_funcpc_stub.*",
+	} {
+		if needsLinuxFuncPCDynamicSymbolExport(ctx, []string{flag}) {
+			t.Fatalf("explicit %s should not be duplicated", flag)
+		}
+	}
+	ctx.buildConf.Goos = "darwin"
+	if needsLinuxFuncPCDynamicSymbolExport(ctx, nil) {
+		t.Fatal("non-linux executable link should not export ELF symbols")
+	}
+	ctx.buildConf.Goos = "linux"
+	ctx.buildConf.Target = "wasi"
+	if needsLinuxFuncPCDynamicSymbolExport(ctx, nil) {
+		t.Fatal("named targets should not force host linux symbol export")
+	}
+}
+
 func mockRun(args []string, cfg *Config) {
 	defer mockable.DisableMock()
 	mockable.EnableMock()

--- a/runtime/internal/lib/runtime/pprof_runtime_stub_llgo.go
+++ b/runtime/internal/lib/runtime/pprof_runtime_stub_llgo.go
@@ -83,7 +83,3 @@ func NumGoroutine() int {
 }
 
 func SetCPUProfileRate(hz int) {}
-
-func FuncForPC(pc uintptr) *Func {
-	return nil
-}

--- a/runtime/internal/lib/runtime/symtab.go
+++ b/runtime/internal/lib/runtime/symtab.go
@@ -105,6 +105,43 @@ func unknownFunctionName(pc uintptr) string {
 	return "pc=" + uintptrHex(pc)
 }
 
+func normalizeFunctionName(name string) string {
+	const stubPrefix = "__llgo_stub."
+	if len(name) > len(stubPrefix) && name[:len(stubPrefix)] == stubPrefix {
+		name = name[len(stubPrefix):]
+	}
+	const funcPCStubPrefix = "__llgo_funcpc_stub."
+	if len(name) > len(funcPCStubPrefix) && name[:len(funcPCStubPrefix)] == funcPCStubPrefix {
+		name = name[len(funcPCStubPrefix):]
+	}
+	switch name {
+	case "":
+		return ""
+	case "main":
+		return "main.main"
+	}
+	const mainPkg = "command-line-arguments."
+	if len(name) > len(mainPkg) && name[:len(mainPkg)] == mainPkg {
+		return "main." + name[len(mainPkg):]
+	}
+	return name
+}
+
+func pcInfo(pc uintptr) (name string, entry uintptr, ok bool) {
+	info := &clitedebug.Info{}
+	if clitedebug.Addrinfo(unsafe.Pointer(pc), info) == 0 && pc > 0 {
+		info = &clitedebug.Info{}
+		if clitedebug.Addrinfo(unsafe.Pointer(pc-1), info) == 0 {
+			return "", 0, false
+		}
+	}
+	name = normalizeFunctionName(safeGoString(info.Sname, ""))
+	if name == "" {
+		return "", 0, false
+	}
+	return name, uintptr(info.Saddr), true
+}
+
 func (ci *Frames) Next() (frame Frame, more bool) {
 	for len(ci.frames) < 2 {
 		// Find the next frame.
@@ -176,11 +213,37 @@ func CallersFrames(callers []uintptr) *Frames {
 
 // A Func represents a Go function in the running binary.
 type Func struct {
-	opaque struct{} // unexported field to disallow conversions
+	entry uintptr
+	name  string
 }
 
 func (f *Func) Name() string {
-	panic("todo")
+	if f == nil {
+		return ""
+	}
+	return f.name
+}
+
+func (f *Func) Entry() uintptr {
+	if f == nil {
+		return 0
+	}
+	return f.entry
+}
+
+func (f *Func) FileLine(pc uintptr) (file string, line int) {
+	return "", 0
+}
+
+func FuncForPC(pc uintptr) *Func {
+	if pc == 0 {
+		return nil
+	}
+	name, entry, ok := pcInfo(pc)
+	if !ok {
+		return nil
+	}
+	return &Func{entry: entry, name: name}
 }
 
 func (f *Func) FileLine(pc uintptr) (file string, line int) {

--- a/runtime/internal/lib/runtime/symtab.go
+++ b/runtime/internal/lib/runtime/symtab.go
@@ -231,10 +231,6 @@ func (f *Func) Entry() uintptr {
 	return f.entry
 }
 
-func (f *Func) FileLine(pc uintptr) (file string, line int) {
-	return "", 0
-}
-
 func FuncForPC(pc uintptr) *Func {
 	if pc == 0 {
 		return nil

--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -451,7 +451,7 @@ func (b Builder) abiUncommonMethods(t types.Type, mset *types.MethodSet) llvm.Va
 		var tfn, ifn llvm.Value
 		tfnFn := b.abiMethodFunc(anonymous, pkg, mName, mSig)
 		tfnSig := funcType(prog, methodExprSignature(mSig)).(*types.Signature)
-		tfn = b.Pkg.closureWrapDecl(tfnFn.Expr, tfnSig).impl
+		tfn = b.Pkg.closureWrapDecl(tfnFn.Expr, tfnSig, false).impl
 		ifn = tfnFn.impl
 		if _, ok := m.Recv().Underlying().(*types.Pointer); !ok {
 			pRecv := types.NewVar(token.NoPos, pkg, "", types.NewPointer(mSig.Recv().Type()))

--- a/ssa/closure_wrap.go
+++ b/ssa/closure_wrap.go
@@ -69,8 +69,12 @@ func closureWrapReturn(b Builder, sig *types.Signature, ret Expr) {
 
 // closureWrapDecl wraps a function declaration that lacks __llgo_ctx.
 // It directly calls the target symbol and ignores the ctx parameter.
-func (p Package) closureWrapDecl(fn Expr, sig *types.Signature) Function {
-	name := closureStub + fn.impl.Name()
+func (p Package) closureWrapDecl(fn Expr, sig *types.Signature, keepFuncPC bool) Function {
+	prefix := closureStub
+	if keepFuncPC {
+		prefix = closureFuncPCStub
+	}
+	name := prefix + fn.impl.Name()
 	if wrap := p.FuncOf(name); wrap != nil {
 		return wrap
 	}
@@ -79,10 +83,27 @@ func (p Package) closureWrapDecl(fn Expr, sig *types.Signature) Function {
 	wrap := p.NewFunc(name, sigCtx, InC)
 	wrap.impl.SetLinkage(llvm.LinkOnceAnyLinkage)
 	b := wrap.MakeBody(1)
+	if keepFuncPC {
+		closureWrapKeepUnique(b, p.closureWrapIdentity(name))
+	}
 	args := closureWrapArgs(wrap)
 	ret := b.Call(fn, args...)
 	closureWrapReturn(b, sig, ret)
 	return wrap
+}
+
+func (p Package) closureWrapIdentity(name string) Expr {
+	g := p.NewVar(name+"$identity", types.NewPointer(types.Typ[types.Byte]), InGo)
+	g.Init(p.Prog.Zero(p.Prog.Byte()))
+	g.impl.SetLinkage(llvm.PrivateLinkage)
+	g.impl.SetGlobalConstant(true)
+	return g.Expr
+}
+
+func closureWrapKeepUnique(b Builder, marker Expr) {
+	elem := b.Prog.Elem(marker.Type)
+	load := llvm.CreateLoad(b.impl, elem.ll, marker.impl)
+	load.SetVolatile(true)
 }
 
 // closureWrapPtr wraps a raw function pointer by loading it from ctx.

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -1628,6 +1628,10 @@ func (b Builder) PrintEx(ln bool, args ...Expr) (ret Expr) {
 // -----------------------------------------------------------------------------
 
 func checkExpr(v Expr, t types.Type, b Builder) Expr {
+	return checkExprEx(v, t, b, false)
+}
+
+func checkExprEx(v Expr, t types.Type, b Builder, keepFuncPC bool) Expr {
 	if st, ok := t.Underlying().(*types.Struct); ok && IsClosure(st) {
 		if v.kind == vkClosure {
 			return v
@@ -1647,7 +1651,7 @@ func checkExpr(v Expr, t types.Type, b Builder) Expr {
 		data := prog.Nil(prog.VoidPtr())
 		if origKind == vkFuncDecl || origKind == vkFuncPtr {
 			if sig, ok := fnType.raw.Type.(*types.Signature); ok && closureCtxParam(sig) == nil {
-				v, data = b.Pkg.closureStub(b, v, sig, origKind)
+				v, data = b.Pkg.closureStub(b, v, sig, origKind, keepFuncPC)
 			}
 		}
 		return b.aggregateValue(tclosure, v.impl, data.impl)

--- a/ssa/interface.go
+++ b/ssa/interface.go
@@ -105,12 +105,20 @@ func (b Builder) Imethod(intf Expr, method *types.Func) Expr {
 //
 //	t1 = make interface{} <- int (42:int)
 //	t2 = make Stringer <- t0
-func (b Builder) MakeInterface(tinter Type, x Expr) (ret Expr) {
+func (b Builder) MakeInterface(tinter Type, x Expr) Expr {
+	return b.makeInterface(tinter, x, false)
+}
+
+func (b Builder) MakeInterfaceFuncPC(tinter Type, x Expr) Expr {
+	return b.makeInterface(tinter, x, true)
+}
+
+func (b Builder) makeInterface(tinter Type, x Expr, keepFuncPC bool) (ret Expr) {
 	rawIntf := tinter.raw.Type.Underlying().(*types.Interface)
 	dbgInstrf("MakeInterface %v, %v\n", rawIntf, x.impl)
 	if x.kind == vkFuncDecl {
 		typ := b.Prog.Type(x.raw.Type, InGo)
-		x = checkExpr(x, typ.raw.Type, b)
+		x = checkExprEx(x, typ.raw.Type, b, keepFuncPC)
 	}
 	prog := b.Prog
 	typ := x.Type

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -794,17 +794,18 @@ func (p Package) cFunc(fullName string, sig *types.Signature) Expr {
 }
 
 const (
-	closureCtx  = "__llgo_ctx"
-	closureStub = "__llgo_stub."
+	closureCtx        = "__llgo_ctx"
+	closureStub       = "__llgo_stub."
+	closureFuncPCStub = "__llgo_funcpc_stub."
 )
 
 // closureStub creates or reuses a wrapper for function values that lack closure ctx.
 // It stays on Package to match the original placement of closure stubs.
-func (p Package) closureStub(b Builder, fn Expr, sig *types.Signature, origKind valueKind) (Expr, Expr) {
+func (p Package) closureStub(b Builder, fn Expr, sig *types.Signature, origKind valueKind, keepFuncPC bool) (Expr, Expr) {
 	prog := b.Prog
 	switch origKind {
 	case vkFuncDecl:
-		wrap := p.closureWrapDecl(fn, sig)
+		wrap := p.closureWrapDecl(fn, sig, keepFuncPC)
 		return wrap.Expr, prog.Nil(prog.VoidPtr())
 	case vkFuncPtr:
 		wrap := p.closureWrapPtr(sig)

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -720,10 +720,18 @@ func TestClosureWrapCache(t *testing.T) {
 	b := fn.MakeBody(1)
 	b.Return(fn.Param(0))
 
-	w1 := pkg.closureWrapDecl(fn.Expr, sig)
-	w2 := pkg.closureWrapDecl(fn.Expr, sig)
+	w1 := pkg.closureWrapDecl(fn.Expr, sig, false)
+	w2 := pkg.closureWrapDecl(fn.Expr, sig, false)
 	if w1 != w2 {
 		t.Fatal("closureWrapDecl should reuse existing wrapper")
+	}
+	wFuncPC1 := pkg.closureWrapDecl(fn.Expr, sig, true)
+	wFuncPC2 := pkg.closureWrapDecl(fn.Expr, sig, true)
+	if wFuncPC1 != wFuncPC2 {
+		t.Fatal("closureWrapDecl should reuse existing FuncForPC wrapper")
+	}
+	if w1 == wFuncPC1 {
+		t.Fatal("FuncForPC wrapper should be distinct from the normal closure wrapper")
 	}
 
 	p1 := pkg.closureWrapPtr(sig)
@@ -982,7 +990,7 @@ func TestPackageCoverageHelpers(t *testing.T) {
 	fn := pkg.NewFunc("noop", NoArgsNoRet, InGo)
 	b := fn.MakeBody(1)
 	expr := prog.Val(1)
-	got, data := pkg.closureStub(b, expr, nil, vkString)
+	got, data := pkg.closureStub(b, expr, nil, vkString, false)
 	if got.impl.IsNil() || !data.impl.IsNull() {
 		t.Fatal("closureStub default branch should return expr and nil data")
 	}

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -769,6 +769,21 @@ func TestMakeInterfaceKinds(t *testing.T) {
 	makeFn("ptrIface", prog.Nil(prog.VoidPtr()))
 	makeFn("floatIface", prog.FloatVal(3.5, prog.Float32()))
 
+	funcSig := types.NewSignatureType(nil, nil, nil, nil,
+		types.NewTuple(types.NewVar(0, nil, "", types.Typ[types.Int])), false)
+	funcDecl := pkg.NewFunc("funcPCIfaceTarget", funcSig, InGo)
+	bFuncDecl := funcDecl.MakeBody(1)
+	bFuncDecl.Return(prog.Val(1))
+
+	sigFuncPC := types.NewSignatureType(nil, nil, nil, nil,
+		types.NewTuple(types.NewVar(0, nil, "", emptyIface)), false)
+	fnFuncPC := pkg.NewFunc("funcPCIface", sigFuncPC, InGo)
+	bFuncPC := fnFuncPC.MakeBody(1)
+	bFuncPC.Return(bFuncPC.MakeInterfaceFuncPC(emptyType, funcDecl.Expr))
+	if pkg.FuncOf(closureFuncPCStub+funcDecl.Expr.impl.Name()) == nil {
+		t.Fatal("MakeInterfaceFuncPC should create a FuncForPC-preserving wrapper")
+	}
+
 	st := types.NewStruct([]*types.Var{
 		types.NewVar(0, nil, "a", types.Typ[types.Int]),
 		types.NewVar(0, nil, "b", types.Typ[types.Int]),

--- a/test/go/runtime_funcforpc_names_test.go
+++ b/test/go/runtime_funcforpc_names_test.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gotest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const runtimeFuncForPCNamesProbe = `package main
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+)
+
+func f(n int) int {
+	return n % 2
+}
+
+func g(n int) int {
+	return f(n)
+}
+
+func name(fn any) string {
+	return runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+}
+
+func check(label, got, want string) {
+	if got != want {
+		panic(label + ": got " + got + ", want " + want)
+	}
+}
+
+func main() {
+	check("f", name(f), "main.f")
+	check("g", name(g), "main.g")
+	fmt.Println("ok")
+}
+`
+
+func TestRuntimeFuncForPCNamesWithLLGo(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(file, []byte(runtimeFuncForPCNamesProbe), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	runGoCmd(t, dir, "run", file)
+
+	root := findLLGoRoot(t)
+	t.Setenv("LLGO_ROOT", root)
+	if got := strings.TrimSpace(runGoCmd(t, root, "run", "./cmd/llgo", "run", file)); got != "ok" {
+		t.Fatalf("llgo probe output = %q, want ok", got)
+	}
+}

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -2336,14 +2336,6 @@ xfails:
     reason: latest main goroot run failure on darwin/arm64
   - platform: darwin/arm64
     directive: run
-    case: fixedbugs/issue58300.go
-    reason: latest main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
-    case: fixedbugs/issue58300b.go
-    reason: latest main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
-    directive: run
     case: fixedbugs/issue5856.go
     reason: latest main goroot run failure on darwin/arm64
   - platform: darwin/arm64
@@ -2513,16 +2505,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: fixedbugs/issue57823.go
-    reason: go1.25 goroot run failure on linux/amd64
-  - version: go1.25
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue58300.go
-    reason: go1.25 goroot run failure on linux/amd64
-  - version: go1.25
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue58300b.go
     reason: go1.25 goroot run failure on linux/amd64
   - version: go1.25
     platform: linux/amd64
@@ -2668,11 +2650,6 @@ xfails:
   - version: go1.24
     platform: linux/amd64
     directive: run
-    case: fixedbugs/issue58300.go
-    reason: go1.24 goroot run failure on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
     case: fixedbugs/issue5856.go
     reason: go1.24 goroot run failure on linux/amd64
   - version: go1.24
@@ -2804,11 +2781,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: fixedbugs/issue5493.go
-    reason: go1.24 goroot run failure on linux/amd64
-  - version: go1.24
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue58300b.go
     reason: go1.24 goroot run failure on linux/amd64
   - version: go1.24
     platform: linux/amd64
@@ -3023,11 +2995,6 @@ xfails:
   - version: go1.26
     platform: linux/amd64
     directive: run
-    case: fixedbugs/issue58300b.go
-    reason: go1.26 goroot run failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
     case: fixedbugs/issue7690.go
     reason: go1.26 goroot run failure on linux/amd64
   - version: go1.26
@@ -3104,11 +3071,6 @@ xfails:
     platform: linux/amd64
     directive: run
     case: fixedbugs/issue57823.go
-    reason: go1.26 goroot run failure on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue58300.go
     reason: go1.26 goroot run failure on linux/amd64
   - version: go1.26
     platform: linux/amd64


### PR DESCRIPTION
## Summary
- add runtime FuncForPC name lookup backed by debug symbol info
- keep command-line function-value wrappers distinct for FuncForPC so folded functions still report separate names
- cover the issue58300 pattern in test/go and remove issue58300/issue58300b goroot xfails

## Tests
- go test ./test/go -run TestRuntimeFuncForPCNamesWithLLGo -count=1
- go test ./test/go -count=1
- go test ./test/goroot -count=1 -run TestGoRootRunCases -args -goroot $(go env GOROOT) -dirs fixedbugs -case '^fixedbugs/issue58300(b)?\.go$' -directive-mode=ci -xfail /tmp/llgo-no-xfail.yaml -run-timeout=2m
- go test ./test/goroot -count=1 -run TestGoRootRunCases -args -goroot $(go env GOROOT) -dirs fixedbugs -case '^fixedbugs/issue58300(b)?\.go$' -directive-mode=ci -run-timeout=2m
- go test ./ssa -count=1
- go test ./cl -run 'TestRunAndTestFromTestgo|TestRunAndTestFromTestrt|TestRunAndTestFromTestdata' -count=1
- git diff --check
