### PR TITLE
ssa: fix select ops slice header build

### DIFF
--- a/ssa/datastruct.go
+++ b/ssa/datastruct.go
@@ -743,7 +743,7 @@ func (b Builder) selectOpsSlice(t Type, ops []Expr) Expr {
 		b.Store(b.Advance(opPtr, prog.Val(i)), op)
 	}
 	n := llvm.ConstInt(prog.tyInt(), uint64(len(ops)), false)
-	return b.unsafeSlice(opPtr, n, n)
+	return b.unsafeSliceHeader(opPtr, n, n)
 }
 
 func lastParamType(prog Program, fn Expr) Type {


### PR DESCRIPTION
## Summary
- replace the stale `Builder.unsafeSlice` call in select operation slice construction with the current `unsafeSliceHeader` helper
- fixes the build error: `ssa/datastruct.go:746:11: b.unsafeSlice undefined`

## Base
- based on latest `xgo-dev/llgo` main at `95ff512c6`

## Tests
- `go test ./ssa -count=1`
- `go test ./cl -count=1`
