### PR TITLE
ssa: fix ABI layout for function fields

### DIFF
--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -162,7 +162,7 @@ func (b Builder) abiStructFields(t *types.Struct, name string) llvm.Value {
 	g := b.Pkg.VarOf(name)
 	if g == nil {
 		ft := prog.rtType("structfield")
-		typ := prog.rawType(t)
+		typ := prog.Type(t, InGo)
 		fields := make([]llvm.Value, n)
 		for i := 0; i < n; i++ {
 			f := t.Field(i)

--- a/ssa/type.go
+++ b/ssa/type.go
@@ -134,6 +134,9 @@ retry:
 		}
 		typ = t.Underlying()
 		goto retry
+	case *types.Alias:
+		typ = types.Unalias(t)
+		goto retry
 	case *types.Signature:
 		return ptrSize
 	case *types.Struct:

--- a/ssa/type_patch_test.go
+++ b/ssa/type_patch_test.go
@@ -142,6 +142,29 @@ type T19 T18
 	}
 }
 
+func TestGoProgramSizesUnaliasFunctionFieldStruct(t *testing.T) {
+	prog := NewProgram(nil)
+	sizes := prog.TypeSizes(types.SizesFor("gc", runtime.GOARCH))
+
+	sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+	fnStruct := types.NewStruct([]*types.Var{
+		types.NewField(token.NoPos, nil, "Fn", sig, false),
+	}, nil)
+	alias := types.NewAlias(types.NewTypeName(token.NoPos, nil, "FnStruct", nil), fnStruct)
+	fields := []*types.Var{
+		types.NewField(token.NoPos, nil, "A", alias, false),
+		types.NewField(token.NoPos, nil, "B", types.Typ[types.Int], false),
+	}
+
+	want := int64(prog.PointerSize() * 2)
+	if got := sizes.Sizeof(alias); got != want {
+		t.Fatalf("Sizeof(alias to func-field struct) = %d, want %d", got, want)
+	}
+	if got := sizes.Offsetsof(fields)[1]; got != want {
+		t.Fatalf("Offsetsof(field after alias to func-field struct) = %d, want %d", got, want)
+	}
+}
+
 func TestNamedStructLayoutEquivalent(t *testing.T) {
 	prog := NewProgram(nil)
 	prog.TypeSizes(types.SizesFor("gc", runtime.GOARCH))

--- a/test/go/abi_func_fields_test.go
+++ b/test/go/abi_func_fields_test.go
@@ -1,0 +1,120 @@
+package gotest
+
+import (
+	"reflect"
+	"testing"
+)
+
+type abiFastInput struct {
+	Message string
+	Flags   uint8
+}
+
+type abiFastOutput struct {
+	Value int
+}
+
+type abiFastMethods = struct {
+	Flags            uint64
+	Size             func(abiFastInput) abiFastOutput
+	Marshal          func(abiFastInput) abiFastOutput
+	Unmarshal        func(abiFastInput) abiFastOutput
+	Merge            func(abiFastInput) abiFastOutput
+	CheckInitialized func(abiFastInput) abiFastOutput
+	Equal            func(abiFastInput) abiFastOutput
+}
+
+type abiCoderMessageInfo struct {
+	methods abiFastMethods
+	Tail    int
+}
+
+type abiMessageInfo struct {
+	Name string
+	abiCoderMessageInfo
+}
+
+func (mi *abiMessageInfo) initFastMethods() {
+	if mi.methods.Marshal == nil && mi.methods.Size == nil {
+		mi.methods.Flags |= 1
+		mi.methods.Marshal = mi.marshal
+		mi.methods.Size = mi.size
+	}
+	if mi.methods.Unmarshal == nil {
+		mi.methods.Flags |= 2
+		mi.methods.Unmarshal = mi.unmarshal
+	}
+	if mi.methods.CheckInitialized == nil {
+		mi.methods.CheckInitialized = mi.checkInitialized
+	}
+	if mi.methods.Merge == nil {
+		mi.methods.Merge = mi.merge
+	}
+	if mi.methods.Equal == nil {
+		mi.methods.Equal = abiEqual
+	}
+}
+
+func (mi *abiMessageInfo) size(in abiFastInput) abiFastOutput {
+	return abiFastOutput{Value: len(mi.Name) + int(in.Flags) + 10}
+}
+
+func (mi *abiMessageInfo) marshal(in abiFastInput) abiFastOutput {
+	return abiFastOutput{Value: len(mi.Name) + len(in.Message) + 20}
+}
+
+func (mi *abiMessageInfo) unmarshal(in abiFastInput) abiFastOutput {
+	return abiFastOutput{Value: len(mi.Name) + len(in.Message) + 30}
+}
+
+func (mi *abiMessageInfo) merge(in abiFastInput) abiFastOutput {
+	return abiFastOutput{Value: len(mi.Name) + len(in.Message) + 40}
+}
+
+func (mi *abiMessageInfo) checkInitialized(in abiFastInput) abiFastOutput {
+	return abiFastOutput{Value: len(mi.Name) + len(in.Message) + 50}
+}
+
+func abiEqual(in abiFastInput) abiFastOutput {
+	return abiFastOutput{Value: len(in.Message) + 60}
+}
+
+func TestReflectABIDoesNotPolluteFunctionFieldLayout(t *testing.T) {
+	// reflect.TypeOf forces llgo to emit ABI struct-field metadata for the
+	// enclosing named struct before the fast-path function fields are assigned.
+	typ := reflect.TypeOf(abiMessageInfo{})
+	field, ok := typ.FieldByName("abiCoderMessageInfo")
+	if !ok {
+		t.Fatalf("embedded coder field not found in %v", typ)
+	}
+	if field.Offset == 0 {
+		t.Fatalf("embedded coder field offset = 0, want after Name field")
+	}
+
+	mi := &abiMessageInfo{Name: "msg"}
+	mi.initFastMethods()
+
+	if got, want := mi.methods.Flags, uint64(3); got != want {
+		t.Fatalf("method flags = %d, want %d", got, want)
+	}
+	cases := []struct {
+		name string
+		fn   func(abiFastInput) abiFastOutput
+		want int
+	}{
+		{"Size", mi.methods.Size, 18},
+		{"Marshal", mi.methods.Marshal, 26},
+		{"Unmarshal", mi.methods.Unmarshal, 36},
+		{"Merge", mi.methods.Merge, 46},
+		{"CheckInitialized", mi.methods.CheckInitialized, 56},
+		{"Equal", mi.methods.Equal, 63},
+	}
+	for _, tc := range cases {
+		if tc.fn == nil {
+			t.Fatalf("%s function is nil", tc.name)
+		}
+		if got := tc.fn(abiFastInput{Message: "abc", Flags: 5}).Value; got != tc.want {
+			t.Fatalf("%s returned %d, want %d", tc.name, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- prevent ABI struct field metadata generation from materializing named structs with unconverted Go func field layout
- account for type aliases when computing closure extra size
- add a Go/llgo regression test that reflects a struct before initializing fast-path function fields

## Tests
- go test ./test/go -run TestReflectABIDoesNotPolluteFunctionFieldLayout
- /tmp/llgo-pr-test test ./test/go -run TestReflectABIDoesNotPolluteFunctionFieldLayout
- go test ./ssa -run TestGoProgramSizesUnaliasFunctionFieldStruct