### PR TITLE
Fix kube-apiserver link symbols

### DIFF
--- a/cl/compile.go
+++ b/cl/compile.go
@@ -272,11 +272,24 @@ func (p *context) compileType(pkg llssa.Package, t *ssa.Type) {
 }
 
 func (p *context) compileMethods(pkg llssa.Package, typ types.Type) {
+	p.compileMethodsIf(pkg, typ, nil)
+}
+
+func (p *context) compileSyntheticMethods(pkg llssa.Package, typ types.Type) {
+	p.compileMethodsIf(pkg, typ, func(m *ssa.Function) bool {
+		return isWrapperOrInstance(m)
+	})
+}
+
+func (p *context) compileMethodsIf(pkg llssa.Package, typ types.Type, keep func(*ssa.Function) bool) {
 	prog := p.goProg
 	mthds := prog.MethodSets.MethodSet(typ)
 	for i, n := 0, mthds.Len(); i < n; i++ {
 		mthd := mthds.At(i)
 		if ssaMthd := prog.MethodValue(mthd); ssaMthd != nil {
+			if keep != nil && !keep(ssaMthd) {
+				continue
+			}
 			p.compileFuncDecl(pkg, ssaMthd)
 		}
 	}
@@ -351,18 +364,30 @@ func isCgoFuncPtrVar(name string) bool {
 	return strings.HasPrefix(name, "__cgo_")
 }
 
-// isInstance reports whether f is an instance method or generic instantiation.
-func isInstance(f *ssa.Function) bool {
-	if f.Origin() != nil {
-		return true
-	}
-	if recv := f.Type().(*types.Signature).Recv(); recv != nil {
-		if recv.Origin() != recv {
+// isWrapperOrInstance reports whether f may be synthesized in multiple
+// packages and therefore needs linkonce linkage when emitted on demand.
+func isWrapperOrInstance(f *ssa.Function) bool {
+	for ; f != nil; f = f.Parent() {
+		if syn := f.Synthetic; syn != "" {
+			if strings.HasPrefix(syn, "wrapper ") ||
+				strings.HasPrefix(syn, "thunk ") ||
+				strings.HasPrefix(syn, "bound ") ||
+				strings.HasPrefix(syn, "instance ") ||
+				strings.HasPrefix(syn, "instantiation ") {
+				return true
+			}
+		}
+		if f.Origin() != nil {
 			return true
 		}
-		if named := recvNamedOk(recv.Type()); named != nil {
-			if hasTypeArgs(named) {
+		if recv := f.Type().(*types.Signature).Recv(); recv != nil {
+			if recv.Origin() != recv {
 				return true
+			}
+			if named := recvNamedOk(recv.Type()); named != nil {
+				if hasTypeArgs(named) {
+					return true
+				}
 			}
 		}
 	}
@@ -405,7 +430,7 @@ func (p *context) compileFuncDecl(pkg llssa.Package, f *ssa.Function) (llssa.Fun
 		dbgInstrln("==> NewFunc", name, "type:", sig.Recv(), sig, "ftype:", ftype)
 	}
 	if fn == nil {
-		fn = pkg.NewFuncEx(name, sig, llssa.Background(ftype), hasCtx, isInstance(f))
+		fn = pkg.NewFuncEx(name, sig, llssa.Background(ftype), hasCtx, isWrapperOrInstance(f))
 		if disableInline {
 			fn.Inline(llssa.NoInline)
 		}
@@ -1964,20 +1989,22 @@ func (p *context) resolveLinkname(name string) string {
 	return name
 }
 
-// checkCompileMethods ensures that all methods attached to the given type
-// (and to the types it refers to) are compiled and emitted into the
-// current SSA package. Generic named types and struct types are the
-// primary targets; pointer types are followed until a non-pointer is
-// reached. non-generic named have their methods compiled elsewhere.
+// checkCompileMethods ensures that methods referenced from ABI method tables
+// are available to the linker. Generic instances and anonymous structural
+// types are emitted in the current SSA package. Package-level non-generic
+// named types normally have source methods emitted by their defining package,
+// but promoted wrappers can be synthesized only when a use-site asks for a
+// method table, so emit those wrappers on demand.
 func (p *context) checkCompileMethods(pkg llssa.Package, typ types.Type) {
 	nt := typ
 retry:
-	switch t := nt.(type) {
+	switch t := types.Unalias(nt).(type) {
 	case *types.Named:
 		if t.TypeArgs() == nil {
 			obj := t.Obj()
 			// skip package-level type
 			if obj.Parent() == obj.Pkg().Scope() {
+				p.compileSyntheticMethods(pkg, typ)
 				return
 			}
 		}

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -21,6 +21,7 @@ package cl_test
 
 import (
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -315,6 +316,316 @@ func TestGoPkgMath(t *testing.T) {
 	conf := build.NewDefaultConf(build.ModeInstall)
 	_, err := build.Do([]string{"math"}, conf)
 	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildGenericMethodTableSymbols(t *testing.T) {
+	buildTempModule(t, map[string]string{
+		"go.mod": `module repro.methods
+
+go 1.24
+`,
+		"lib/lib.go": `package lib
+
+type Typed[T comparable] struct{}
+
+func (q *Typed[T]) Add(item T) {}
+func (q *Typed[T]) Len() int { return 0 }
+
+type Type = Typed[any]
+
+func NewQueue() *Type { return &Typed[any]{} }
+
+type inner[T any] struct{}
+
+func (i *inner[T]) M() {}
+func (i *inner[T]) N() int { return 1 }
+
+type Outer struct{ *inner[int] }
+
+func NewOuter() *Outer { return &Outer{inner: &inner[int]{}} }
+`,
+		"app/main.go": `package main
+
+import "repro.methods/lib"
+
+type Queue interface {
+	Add(any)
+	Len() int
+}
+
+type Promoted interface {
+	M()
+	N() int
+}
+
+func main() {
+	var q Queue = lib.NewQueue()
+	var p Promoted = lib.NewOuter()
+	_, _ = q, p
+}
+`,
+	})
+}
+
+func TestBuildReflectPrivateLinknames(t *testing.T) {
+	buildTempModule(t, map[string]string{
+		"go.mod": `module repro.reflectlink
+
+go 1.24
+`,
+		"app/main.go": `package main
+
+import (
+	"unsafe"
+	_ "unsafe"
+)
+
+//go:linkname unsafeNew reflect.unsafe_New
+func unsafeNew(unsafe.Pointer) unsafe.Pointer
+
+//go:linkname typedmemmove reflect.typedmemmove
+func typedmemmove(unsafe.Pointer, unsafe.Pointer, unsafe.Pointer)
+
+//go:linkname unsafeNewArray reflect.unsafe_NewArray
+func unsafeNewArray(unsafe.Pointer, int) unsafe.Pointer
+
+//go:linkname makemap reflect.makemap
+func makemap(unsafe.Pointer, int) unsafe.Pointer
+
+//go:linkname mapaccess reflect.mapaccess
+func mapaccess(unsafe.Pointer, unsafe.Pointer, unsafe.Pointer) unsafe.Pointer
+
+//go:linkname mapiterinit reflect.mapiterinit
+func mapiterinit(unsafe.Pointer, unsafe.Pointer, unsafe.Pointer)
+
+//go:linkname mapiternext reflect.mapiternext
+func mapiternext(unsafe.Pointer)
+
+//go:linkname ifaceE2I reflect.ifaceE2I
+func ifaceE2I(unsafe.Pointer, any, unsafe.Pointer)
+
+func main() {
+	_ = unsafeNew(nil)
+	typedmemmove(nil, nil, nil)
+	_ = unsafeNewArray(nil, 0)
+	_ = makemap(nil, 0)
+	_ = mapaccess(nil, nil, nil)
+	mapiterinit(nil, nil, nil)
+	mapiternext(nil)
+	ifaceE2I(nil, nil, nil)
+}
+`,
+	})
+}
+
+func TestBuildReflectValueGo126Symbols(t *testing.T) {
+	buildTempModule(t, map[string]string{
+		"go.mod": `module repro.reflectvalue
+
+go 1.24
+`,
+		"app/main.go": `package main
+
+import (
+	"iter"
+	"reflect"
+	"runtime"
+	"unsafe"
+	_ "unsafe"
+)
+
+type addressableValue struct {
+	reflect.Value
+	forcedAddr bool
+}
+
+//go:linkname valueAbiType reflect.Value.abiType
+func valueAbiType(reflect.Value) unsafe.Pointer
+
+//go:linkname valueAbiTypeSlow reflect.Value.abiTypeSlow
+func valueAbiTypeSlow(reflect.Value) unsafe.Pointer
+
+var _ interface {
+	Fields() iter.Seq2[reflect.StructField, reflect.Value]
+	Methods() iter.Seq2[reflect.Method, reflect.Value]
+} = addressableValue{}
+
+func main() {
+	v := reflect.ValueOf(struct{ A int }{A: 1})
+	_, _ = valueAbiType(v), valueAbiTypeSlow(v)
+	_ = reflect.TypeOf(addressableValue{Value: v})
+	if f := runtime.FuncForPC(0); f != nil {
+		_, _ = f.FileLine(0)
+	}
+}
+`,
+	})
+}
+
+func TestBuildGenericFunctionInstanceLinkOnce(t *testing.T) {
+	buildTempModule(t, map[string]string{
+		"go.mod": `module repro.genericfn
+
+go 1.24
+`,
+		"lib/lib.go": `package lib
+
+func Identity[T any](v T) T { return v }
+`,
+		"a/a.go": `package a
+
+import "repro.genericfn/lib"
+
+func A() string { return lib.Identity("a") }
+`,
+		"b/b.go": `package b
+
+import "repro.genericfn/lib"
+
+func B() string { return lib.Identity("b") }
+`,
+		"app/main.go": `package main
+
+import (
+	"repro.genericfn/a"
+	"repro.genericfn/b"
+)
+
+func main() {
+	_, _ = a.A(), b.B()
+}
+`,
+	})
+}
+
+func TestBuildGenericFunctionClosureLinkOnce(t *testing.T) {
+	buildTempModule(t, map[string]string{
+		"go.mod": `module repro.genericclosure
+
+go 1.24
+`,
+		"lib/lib.go": `package lib
+
+func WithClosure[T any](v T) T {
+	fn := func() T {
+		return v
+	}
+	return fn()
+}
+`,
+		"a/a.go": `package a
+
+import "repro.genericclosure/lib"
+
+func A() string { return lib.WithClosure("a") }
+`,
+		"b/b.go": `package b
+
+import "repro.genericclosure/lib"
+
+func B() string { return lib.WithClosure("b") }
+`,
+		"app/main.go": `package main
+
+import (
+	"repro.genericclosure/a"
+	"repro.genericclosure/b"
+)
+
+func main() {
+	_, _ = a.A(), b.B()
+}
+`,
+	})
+}
+
+func TestBuildXSysUnixRawSyscallNoError(t *testing.T) {
+	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
+		t.Skip("RawSyscallNoError repro uses linux/amd64 x/sys/unix asm")
+	}
+	buildTempModulePatterns(t, build.ModeInstall, []string{"golang.org/x/sys/unix"}, map[string]string{
+		"go.mod": `module repro.xsys
+
+go 1.24
+
+require golang.org/x/sys v0.0.0
+
+replace golang.org/x/sys => ./xsys
+`,
+		"xsys/go.mod": `module golang.org/x/sys
+
+go 1.24
+`,
+		"xsys/unix/syscall_linux_gc.go": `//go:build linux && gc
+
+package unix
+
+func RawSyscallNoError(trap, a1, a2, a3 uintptr) (r1, r2 uintptr)
+func SyscallNoError(trap, a1, a2, a3 uintptr) (r1, r2 uintptr)
+
+func Gettid() int {
+	r1, _ := RawSyscallNoError(186, 0, 0, 0)
+	return int(r1)
+}
+
+func Sync() {
+	SyscallNoError(162, 0, 0, 0)
+}
+`,
+		"xsys/unix/asm_linux_amd64.s": `//go:build linux && gc && amd64
+
+#include "textflag.h"
+
+TEXT ·SyscallNoError(SB),NOSPLIT,$0-48
+	RET
+
+TEXT ·RawSyscallNoError(SB),NOSPLIT,$0-48
+	RET
+`,
+	})
+}
+
+func buildTempModule(t *testing.T, files map[string]string) {
+	t.Helper()
+	buildTempModulePatterns(t, build.ModeBuild, []string{"./app"}, files)
+}
+
+func buildTempModulePatterns(t *testing.T, mode build.Mode, patterns []string, files map[string]string) {
+	t.Helper()
+	dir := t.TempDir()
+	for name, data := range files {
+		path := filepath.Join(dir, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	repoRoot := filepath.Dir(oldWD)
+	t.Setenv("LLGO_ROOT", repoRoot)
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	out := filepath.Join(t.TempDir(), "app")
+	if runtime.GOOS == "windows" {
+		out += ".exe"
+	}
+	conf := build.NewDefaultConf(mode)
+	if mode == build.ModeBuild {
+		conf.OutFile = out
+	}
+	conf.ForceRebuild = true
+	if _, err := build.Do(patterns, conf); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/cl/import.go
+++ b/cl/import.go
@@ -628,7 +628,7 @@ func (p *context) funcName(fn *ssa.Function) (*types.Package, string, int) {
 		if fnPkg := fn.Pkg; fnPkg != nil {
 			pkg = fnPkg.Pkg
 		} else if recv := fn.Type().(*types.Signature).Recv(); recv != nil {
-			if named := recvNamedOk(recv.Type()); named != nil && named.Obj().Pkg() != nil && hasTypeArgs(named) {
+			if named := recvNamedOk(recv.Type()); named != nil && named.Obj().Pkg() != nil && (hasTypeArgs(named) || isWrapperOrInstance(fn)) {
 				pkg = named.Obj().Pkg()
 			} else {
 				pkg = p.goTyps

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -651,7 +651,7 @@ func (p *context) funcOf(fn *ssa.Function) (aFn llssa.Function, pyFn llssa.PyObj
 				return nil, nil, ignoredFunc
 			}
 			sig := p.patchType(fn.Signature).(*types.Signature)
-			aFn = pkg.NewFuncEx(name, sig, llssa.Background(ftype), false, fn.Origin() != nil)
+			aFn = pkg.NewFuncEx(name, sig, llssa.Background(ftype), false, isWrapperOrInstance(fn))
 			if disableInline {
 				aFn.Inline(llssa.NoInline)
 			}

--- a/runtime/internal/lib/golang.org/x/sys/unix/syscall_linux.go
+++ b/runtime/internal/lib/golang.org/x/sys/unix/syscall_linux.go
@@ -1,0 +1,20 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build linux
+
+package unix
+
+// SyscallNoError may be used instead of Syscall for syscalls that don't fail.
+func SyscallNoError(trap, a1, a2, a3 uintptr) (r1, r2 uintptr) {
+	r1, r2, _ = Syscall(trap, a1, a2, a3)
+	return
+}
+
+// RawSyscallNoError may be used instead of RawSyscall for syscalls that don't
+// fail.
+func RawSyscallNoError(trap, a1, a2, a3 uintptr) (r1, r2 uintptr) {
+	r1, r2, _ = RawSyscall(trap, a1, a2, a3)
+	return
+}

--- a/runtime/internal/lib/reflect/value_go126.go
+++ b/runtime/internal/lib/reflect/value_go126.go
@@ -1,0 +1,72 @@
+//go:build go1.26
+// +build go1.26
+
+package reflect
+
+import (
+	"iter"
+	"unsafe"
+
+	"github.com/goplus/llgo/runtime/abi"
+)
+
+func (v Value) abiType() *abi.Type {
+	if v.flag != 0 && v.flag&flagMethod == 0 && !v.typ_.IsClosure() {
+		return v.typ()
+	}
+	return v.abiTypeSlow()
+}
+
+func (v Value) abiTypeSlow() *abi.Type {
+	if v.flag == 0 {
+		panic(&ValueError{"reflect.Value.Type", Invalid})
+	}
+
+	typ := v.typ()
+	if v.typ_.IsClosure() {
+		return &v.closureFunc().Type
+	}
+	if v.flag&flagMethod == 0 {
+		return typ
+	}
+
+	i := int(v.flag) >> flagMethodShift
+	if typ.Kind() == abi.Interface {
+		tt := (*interfaceType)(unsafe.Pointer(typ))
+		if uint(i) >= uint(len(tt.Methods)) {
+			panic("reflect: internal error: invalid method index")
+		}
+		return &tt.Methods[i].Typ_.Type
+	}
+
+	ms := typ.ExportedMethods()
+	if uint(i) >= uint(len(ms)) {
+		panic("reflect: internal error: invalid method index")
+	}
+	return &ms[i].Mtyp_.Type
+}
+
+func (v Value) Fields() iter.Seq2[StructField, Value] {
+	t := v.Type()
+	if t.Kind() != Struct {
+		panic("reflect: Fields of non-struct type " + t.String())
+	}
+	return func(yield func(StructField, Value) bool) {
+		for i := 0; i < v.NumField(); i++ {
+			if !yield(t.Field(i), v.Field(i)) {
+				return
+			}
+		}
+	}
+}
+
+func (v Value) Methods() iter.Seq2[Method, Value] {
+	return func(yield func(Method, Value) bool) {
+		t := v.Type()
+		for i := 0; i < v.NumMethod(); i++ {
+			if !yield(t.Method(i), v.Method(i)) {
+				return
+			}
+		}
+	}
+}

--- a/runtime/internal/lib/runtime/symtab.go
+++ b/runtime/internal/lib/runtime/symtab.go
@@ -183,6 +183,14 @@ func (f *Func) Name() string {
 	panic("todo")
 }
 
+func (f *Func) FileLine(pc uintptr) (file string, line int) {
+	var info clitedebug.Info
+	if pc == 0 || clitedebug.Addrinfo(unsafe.Pointer(pc), &info) == 0 {
+		return "", 0
+	}
+	return safeGoString(info.Fname, ""), 0
+}
+
 // moduledata records information about the layout of the executable
 // image. It is written by the linker. Any changes here must be
 // matched changes to the code in cmd/link/internal/ld/symtab.go:symtab.

--- a/runtime/internal/runtime/reflect_linkname.go
+++ b/runtime/internal/runtime/reflect_linkname.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2024 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"unsafe"
+	_ "unsafe"
+)
+
+//go:linkname reflect_unsafe_New reflect.unsafe_New
+func reflect_unsafe_New(t *Type) unsafe.Pointer {
+	return New(t)
+}
+
+//go:linkname reflect_unsafe_NewArray reflect.unsafe_NewArray
+func reflect_unsafe_NewArray(t *Type, n int) unsafe.Pointer {
+	return NewArray(t, n)
+}
+
+//go:linkname reflect_typedmemmove reflect.typedmemmove
+func reflect_typedmemmove(t *Type, dst, src unsafe.Pointer) {
+	Typedmemmove(t, dst, src)
+}
+
+//go:linkname reflect_makemap reflect.makemap
+func reflect_makemap(t *maptype, cap int) *hmap {
+	return MakeMap(t, cap)
+}
+
+//go:linkname reflect_mapaccess reflect.mapaccess
+func reflect_mapaccess(t *maptype, h *hmap, key unsafe.Pointer) unsafe.Pointer {
+	elem, ok := mapaccess2(t, h, key)
+	if !ok {
+		return nil
+	}
+	return elem
+}
+
+//go:linkname reflect_mapiterinit reflect.mapiterinit
+func reflect_mapiterinit(t *maptype, h *hmap, it *hiter) {
+	mapiterinit(t, h, it)
+}
+
+//go:linkname reflect_mapiternext reflect.mapiternext
+func reflect_mapiternext(it *hiter) {
+	mapiternext(it)
+}
+
+//go:linkname reflect_ifaceE2I reflect.ifaceE2I
+func reflect_ifaceE2I(t *interfacetype, src any, dst unsafe.Pointer) {
+	IfaceE2I(t, *(*eface)(unsafe.Pointer(&src)), (*iface)(dst))
+}


### PR DESCRIPTION
## Summary
- emit synthetic/promoted and generic instance methods with linkonce linkage, including closures nested under generic instances
- add runtime/reflect linkname shims required by reflect2 and Go 1.26 reflect.Value method tables
- patch x/sys/unix NoError syscall helpers and add runtime.Func.FileLine compatibility stub

## Validation
- `go test ./cl -run 'TestBuild(GenericMethodTableSymbols|ReflectPrivateLinknames|ReflectValueGo126Symbols|GenericFunctionInstanceLinkOnce|GenericFunctionClosureLinkOnce|XSysUnixRawSyscallNoError)' -count=1`
- `gentests` (exit 0; no out.ll changes, environment-dependent expect.txt churn was not kept)
- `/tmp/llgo-kube-link-verify/llgo build ./` in `/opt/data/00.Code/godev/kubernetes/cmd/kube-apiserver` with Go 1.26.2 env; elapsed 51:25.78, maxrss 33350324KB

Note: kube-apiserver validation used the prior blocks fix from PR #1936 in a temporary verification tree only. This PR does not include the blocks files.
