### PR TITLE
Fix generic link symbol emission

### DIFF
--- a/cl/compile.go
+++ b/cl/compile.go
@@ -367,7 +367,7 @@ func isCgoFuncPtrVar(name string) bool {
 
 func (p *context) methodValue(sel *types.Selection) *ssa.Function {
 	f := p.goProg.MethodValue(sel)
-	if f != nil && f.Pkg == nil {
+	if f != nil && f.Pkg == nil && hasGenericInstantiation(f) {
 		p.markLinkOnce(f)
 	}
 	return f
@@ -387,19 +387,44 @@ func (p *context) needsLinkOnce(f *ssa.Function) bool {
 		if _, ok := p.linkOnceFns[f]; ok {
 			return true
 		}
-		if f.Origin() != nil {
+		if hasGenericInstantiation(f) {
 			return true
 		}
-		if recv := f.Type().(*types.Signature).Recv(); recv != nil {
-			if recv.Origin() != recv {
-				return true
-			}
-			if named := recvNamedOk(recv.Type()); named != nil {
-				if hasTypeArgs(named) {
-					return true
-				}
-			}
-		}
+	}
+	return false
+}
+
+func hasGenericInstantiation(f *ssa.Function) bool {
+	if f.Origin() != nil || len(f.TypeArgs()) != 0 {
+		return true
+	}
+	if sig, ok := f.Type().(*types.Signature); ok && hasInstantiatedRecv(sig.Recv()) {
+		return true
+	}
+	return hasInstantiatedMethodObject(f)
+}
+
+func hasInstantiatedMethodObject(f *ssa.Function) bool {
+	obj, ok := f.Object().(*types.Func)
+	if !ok {
+		return false
+	}
+	if obj.Origin() != obj {
+		return true
+	}
+	sig, ok := obj.Type().(*types.Signature)
+	return ok && hasInstantiatedRecv(sig.Recv())
+}
+
+func hasInstantiatedRecv(recv *types.Var) bool {
+	if recv == nil {
+		return false
+	}
+	if recv.Origin() != recv {
+		return true
+	}
+	if named := recvNamedOk(recv.Type()); named != nil {
+		return hasTypeArgs(named)
 	}
 	return false
 }

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -170,6 +170,7 @@ type context struct {
 	bvals       map[ssa.Value]llssa.Expr    // block values
 	vargs       map[*ssa.Alloc][]llssa.Expr // varargs
 	funcs       map[*ssa.Function]llssa.Function
+	linkOnceFns map[*ssa.Function]none
 	stackDefers map[*ssa.Function]bool
 	anonDefers  map[*ssa.Function]bool
 	paramDIVars map[*types.Var]llssa.DIVar
@@ -272,11 +273,24 @@ func (p *context) compileType(pkg llssa.Package, t *ssa.Type) {
 }
 
 func (p *context) compileMethods(pkg llssa.Package, typ types.Type) {
+	p.compileMethodsIf(pkg, typ, nil)
+}
+
+func (p *context) compileSyntheticMethods(pkg llssa.Package, typ types.Type) {
+	p.compileMethodsIf(pkg, typ, func(m *ssa.Function) bool {
+		return p.needsLinkOnce(m)
+	})
+}
+
+func (p *context) compileMethodsIf(pkg llssa.Package, typ types.Type, keep func(*ssa.Function) bool) {
 	prog := p.goProg
 	mthds := prog.MethodSets.MethodSet(typ)
 	for i, n := 0, mthds.Len(); i < n; i++ {
 		mthd := mthds.At(i)
-		if ssaMthd := prog.MethodValue(mthd); ssaMthd != nil {
+		if ssaMthd := p.methodValue(mthd); ssaMthd != nil {
+			if keep != nil && !keep(ssaMthd) {
+				continue
+			}
 			p.compileFuncDecl(pkg, ssaMthd)
 		}
 	}
@@ -351,18 +365,39 @@ func isCgoFuncPtrVar(name string) bool {
 	return strings.HasPrefix(name, "__cgo_")
 }
 
-// isInstance reports whether f is an instance method or generic instantiation.
-func isInstance(f *ssa.Function) bool {
-	if f.Origin() != nil {
-		return true
+func (p *context) methodValue(sel *types.Selection) *ssa.Function {
+	f := p.goProg.MethodValue(sel)
+	if f != nil && f.Pkg == nil {
+		p.markLinkOnce(f)
 	}
-	if recv := f.Type().(*types.Signature).Recv(); recv != nil {
-		if recv.Origin() != recv {
+	return f
+}
+
+func (p *context) markLinkOnce(f *ssa.Function) {
+	if p.linkOnceFns == nil {
+		p.linkOnceFns = make(map[*ssa.Function]none)
+	}
+	p.linkOnceFns[f] = none{}
+}
+
+// needsLinkOnce reports whether f may be synthesized in multiple packages and
+// therefore needs linkonce linkage when emitted on demand.
+func (p *context) needsLinkOnce(f *ssa.Function) bool {
+	for ; f != nil; f = f.Parent() {
+		if _, ok := p.linkOnceFns[f]; ok {
 			return true
 		}
-		if named := recvNamedOk(recv.Type()); named != nil {
-			if hasTypeArgs(named) {
+		if f.Origin() != nil {
+			return true
+		}
+		if recv := f.Type().(*types.Signature).Recv(); recv != nil {
+			if recv.Origin() != recv {
 				return true
+			}
+			if named := recvNamedOk(recv.Type()); named != nil {
+				if hasTypeArgs(named) {
+					return true
+				}
 			}
 		}
 	}
@@ -405,7 +440,7 @@ func (p *context) compileFuncDecl(pkg llssa.Package, f *ssa.Function) (llssa.Fun
 		dbgInstrln("==> NewFunc", name, "type:", sig.Recv(), sig, "ftype:", ftype)
 	}
 	if fn == nil {
-		fn = pkg.NewFuncEx(name, sig, llssa.Background(ftype), hasCtx, isInstance(f))
+		fn = pkg.NewFuncEx(name, sig, llssa.Background(ftype), hasCtx, p.needsLinkOnce(f))
 		if disableInline {
 			fn.Inline(llssa.NoInline)
 		}
@@ -1524,16 +1559,17 @@ func newPackageEx(prog llssa.Program, patches Patches, rewrites map[string]strin
 	}
 
 	ctx := &context{
-		prog:    prog,
-		pkg:     ret,
-		fset:    pkgProg.Fset,
-		goProg:  pkgProg,
-		goTyps:  pkgTypes,
-		goPkg:   pkg,
-		patches: patches,
-		skips:   make(map[string]none),
-		vargs:   make(map[*ssa.Alloc][]llssa.Expr),
-		funcs:   make(map[*ssa.Function]llssa.Function),
+		prog:        prog,
+		pkg:         ret,
+		fset:        pkgProg.Fset,
+		goProg:      pkgProg,
+		goTyps:      pkgTypes,
+		goPkg:       pkg,
+		patches:     patches,
+		skips:       make(map[string]none),
+		vargs:       make(map[*ssa.Alloc][]llssa.Expr),
+		funcs:       make(map[*ssa.Function]llssa.Function),
+		linkOnceFns: make(map[*ssa.Function]none),
 		loaded: map[*types.Package]*pkgInfo{
 			types.Unsafe: {kind: PkgDeclOnly}, // TODO(xsw): PkgNoInit or PkgDeclOnly?
 		},
@@ -1969,20 +2005,22 @@ func (p *context) resolveLinkname(name string) string {
 	return name
 }
 
-// checkCompileMethods ensures that all methods attached to the given type
-// (and to the types it refers to) are compiled and emitted into the
-// current SSA package. Generic named types and struct types are the
-// primary targets; pointer types are followed until a non-pointer is
-// reached. non-generic named have their methods compiled elsewhere.
+// checkCompileMethods ensures that methods referenced from ABI method tables
+// are available to the linker. Generic instances and anonymous structural
+// types are emitted in the current SSA package. Package-level non-generic
+// named types normally have source methods emitted by their defining package,
+// but promoted wrappers can be synthesized only when a use-site asks for a
+// method table, so emit those wrappers on demand.
 func (p *context) checkCompileMethods(pkg llssa.Package, typ types.Type) {
 	nt := typ
 retry:
-	switch t := nt.(type) {
+	switch t := types.Unalias(nt).(type) {
 	case *types.Named:
 		if t.TypeArgs() == nil {
 			obj := t.Obj()
 			// skip package-level type
 			if obj.Parent() == obj.Pkg().Scope() {
+				p.compileSyntheticMethods(pkg, typ)
 				return
 			}
 		}

--- a/cl/import.go
+++ b/cl/import.go
@@ -628,7 +628,7 @@ func (p *context) funcName(fn *ssa.Function) (*types.Package, string, int) {
 		if fnPkg := fn.Pkg; fnPkg != nil {
 			pkg = fnPkg.Pkg
 		} else if recv := fn.Type().(*types.Signature).Recv(); recv != nil {
-			if named := recvNamedOk(recv.Type()); named != nil && named.Obj().Pkg() != nil && hasTypeArgs(named) {
+			if named := recvNamedOk(recv.Type()); named != nil && named.Obj().Pkg() != nil && (hasTypeArgs(named) || p.needsLinkOnce(fn)) {
 				pkg = named.Obj().Pkg()
 			} else {
 				pkg = p.goTyps

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -651,7 +651,7 @@ func (p *context) funcOf(fn *ssa.Function) (aFn llssa.Function, pyFn llssa.PyObj
 				return nil, nil, ignoredFunc
 			}
 			sig := p.patchType(fn.Signature).(*types.Signature)
-			aFn = pkg.NewFuncEx(name, sig, llssa.Background(ftype), false, fn.Origin() != nil)
+			aFn = pkg.NewFuncEx(name, sig, llssa.Background(ftype), false, p.needsLinkOnce(fn))
 			if disableInline {
 				aFn.Inline(llssa.NoInline)
 			}

--- a/cl/linkonce_test.go
+++ b/cl/linkonce_test.go
@@ -1,0 +1,113 @@
+//go:build !llgo
+// +build !llgo
+
+package cl
+
+import (
+	"go/ast"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"testing"
+
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/ssa/ssautil"
+)
+
+func buildLinkOnceSSAPackage(t *testing.T, src string) *ssa.Package {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "p.go", src, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkg := types.NewPackage("p", "p")
+	mode := ssa.SanityCheckFunctions | ssa.InstantiateGenerics
+	ssapkg, _, err := ssautil.BuildPackage(&types.Config{Importer: importer.Default()}, fset, pkg, []*ast.File{f}, mode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ssapkg
+}
+
+func linkOnceTestMethodValue(t *testing.T, ssapkg *ssa.Package, recv types.Type, name string) (*context, *ssa.Function) {
+	t.Helper()
+	sel := ssapkg.Prog.MethodSets.MethodSet(recv).Lookup(nil, name)
+	if sel == nil {
+		t.Fatalf("%v has no method %s", recv, name)
+	}
+	ctx := &context{
+		goProg:      ssapkg.Prog,
+		goTyps:      ssapkg.Pkg,
+		linkOnceFns: make(map[*ssa.Function]none),
+	}
+	fn := ctx.methodValue(sel)
+	if fn == nil {
+		t.Fatalf("MethodValue(%v.%s) returned nil", recv, name)
+	}
+	return ctx, fn
+}
+
+func TestNeedsLinkOnceSkipsNonGenericPromotedWrapper(t *testing.T) {
+	ssapkg := buildLinkOnceSSAPackage(t, `package p
+
+type Inner struct{}
+
+func (Inner) M() {}
+
+type Outer struct {
+	Inner
+}
+`)
+	outer := ssapkg.Pkg.Scope().Lookup("Outer").(*types.TypeName).Type()
+	ctx, fn := linkOnceTestMethodValue(t, ssapkg, types.NewPointer(outer), "M")
+	if fn.Pkg != nil || fn.Origin() != nil {
+		t.Fatalf("test expected a non-generic on-demand wrapper, got pkg=%v origin=%v", fn.Pkg, fn.Origin())
+	}
+	if ctx.needsLinkOnce(fn) {
+		t.Fatalf("non-generic promoted wrapper %s should not need linkonce", fn)
+	}
+}
+
+func TestNeedsLinkOnceMarksGenericPromotedWrapper(t *testing.T) {
+	ssapkg := buildLinkOnceSSAPackage(t, `package p
+
+type Inner[T any] struct{}
+
+func (*Inner[T]) M() {}
+
+type Outer struct {
+	*Inner[int]
+}
+`)
+	outer := ssapkg.Pkg.Scope().Lookup("Outer").(*types.TypeName).Type()
+	ctx, fn := linkOnceTestMethodValue(t, ssapkg, types.NewPointer(outer), "M")
+	if fn.Origin() != nil {
+		t.Fatalf("test expected a wrapper around a generic method, got generic instance %s", fn)
+	}
+	if !ctx.needsLinkOnce(fn) {
+		t.Fatalf("generic promoted wrapper %s should need linkonce", fn)
+	}
+}
+
+func TestNeedsLinkOnceMarksGenericMethodInstance(t *testing.T) {
+	ssapkg := buildLinkOnceSSAPackage(t, `package p
+
+type Box[T any] struct{}
+
+func (Box[T]) M() {}
+`)
+	box := ssapkg.Pkg.Scope().Lookup("Box").(*types.TypeName).Type().(*types.Named)
+	boxInt, err := types.Instantiate(nil, box, []types.Type{types.Typ[types.Int]}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, fn := linkOnceTestMethodValue(t, ssapkg, boxInt, "M")
+	if fn.Origin() == nil {
+		t.Fatalf("test expected a generic method instance, got %s", fn)
+	}
+	if !ctx.needsLinkOnce(fn) {
+		t.Fatalf("generic method instance %s should need linkonce", fn)
+	}
+}

--- a/test/go/kube_link_generic_symbols_test.go
+++ b/test/go/kube_link_generic_symbols_test.go
@@ -1,0 +1,42 @@
+package gotest
+
+import (
+	"reflect"
+	"testing"
+
+	methods "github.com/goplus/llgo/test/go/kubelinkmethods"
+	slicesa "github.com/goplus/llgo/test/go/kubelinkslicesa"
+	slicesb "github.com/goplus/llgo/test/go/kubelinkslicesb"
+)
+
+type kubeLinkQueue interface {
+	Add(any)
+	Len() int
+}
+
+type kubeLinkPromoted interface {
+	M()
+	N() int
+}
+
+func TestKubeLinkGenericMethodTableSymbols(t *testing.T) {
+	var q kubeLinkQueue = methods.NewQueue()
+	q.Add("item")
+	if got := q.Len(); got != 1 {
+		t.Fatalf("Len() = %d, want 1", got)
+	}
+
+	var p kubeLinkPromoted = methods.NewOuter()
+	p.M()
+	if got := p.N(); got != 1 {
+		t.Fatalf("N() = %d, want 1", got)
+	}
+}
+
+func TestKubeLinkGenericInstanceClosureLinkOnce(t *testing.T) {
+	got := append(slicesa.A(), slicesb.B()...)
+	want := []string{"a", "aa", "b", "bb"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("combined slices = %v, want %v", got, want)
+	}
+}

--- a/test/go/kubelinkmethods/methods.go
+++ b/test/go/kubelinkmethods/methods.go
@@ -1,0 +1,37 @@
+package kubelinkmethods
+
+type Typed[T comparable] struct {
+	items []T
+}
+
+func (q *Typed[T]) Add(item T) {
+	q.items = append(q.items, item)
+}
+
+func (q *Typed[T]) Len() int {
+	return len(q.items)
+}
+
+type Type = Typed[any]
+
+func NewQueue() *Type {
+	return &Typed[any]{}
+}
+
+type inner[T any] struct {
+	value T
+}
+
+func (i *inner[T]) M() {}
+
+func (i *inner[T]) N() int {
+	return 1
+}
+
+type Outer struct {
+	*inner[int]
+}
+
+func NewOuter() *Outer {
+	return &Outer{inner: &inner[int]{}}
+}

--- a/test/go/kubelinkslicesa/a.go
+++ b/test/go/kubelinkslicesa/a.go
@@ -1,0 +1,9 @@
+package kubelinkslicesa
+
+import "slices"
+
+func A() []string {
+	return slices.AppendSeq([]string{"a"}, func(yield func(string) bool) {
+		yield("aa")
+	})
+}

--- a/test/go/kubelinkslicesb/b.go
+++ b/test/go/kubelinkslicesb/b.go
@@ -1,0 +1,9 @@
+package kubelinkslicesb
+
+import "slices"
+
+func B() []string {
+	return slices.AppendSeq([]string{"b"}, func(yield func(string) bool) {
+		yield("bb")
+	})
+}


### PR DESCRIPTION
## Summary
- record method wrapper functions returned by `ssa.Program.MethodValue` when they are synthesized outside a package (`Pkg == nil`)
- use that recorded function set, plus generic `Origin()` / receiver type-argument metadata, to decide linkonce emission
- make nested closures under generic function instances inherit linkonce linkage through the parent function chain
- resolve package naming for recorded synthetic receiver methods so imported promoted wrappers use the defining package symbol name

This avoids parsing `ssa.Function.Synthetic` descriptions for wrapper/thunk/bound names; LLGo now records the wrapper function objects at the point it obtains them from `MethodValue`.

## Tests
- `go test ./test/go -run 'TestKubeLinkGeneric(MethodTableSymbols|InstanceClosureLinkOnce)' -count=1`
- `go run ./cmd/llgo test ./test/go -run 'TestKubeLinkGeneric(MethodTableSymbols|InstanceClosureLinkOnce)'`

The regression tests live under `test/go` and cover the Kubernetes failures where generic method table symbols were undefined and `slices.AppendSeq$1[[]string,string]` was emitted as a duplicate strong symbol.
