### PR TITLE
Add reflect runtime link symbols

### DIFF
--- a/runtime/internal/lib/reflect/value_go126.go
+++ b/runtime/internal/lib/reflect/value_go126.go
@@ -1,0 +1,72 @@
+//go:build go1.26
+// +build go1.26
+
+package reflect
+
+import (
+	"iter"
+	"unsafe"
+
+	"github.com/goplus/llgo/runtime/abi"
+)
+
+func (v Value) abiType() *abi.Type {
+	if v.flag != 0 && v.flag&flagMethod == 0 && !v.typ_.IsClosure() {
+		return v.typ()
+	}
+	return v.abiTypeSlow()
+}
+
+func (v Value) abiTypeSlow() *abi.Type {
+	if v.flag == 0 {
+		panic(&ValueError{"reflect.Value.Type", Invalid})
+	}
+
+	typ := v.typ()
+	if v.typ_.IsClosure() {
+		return &v.closureFunc().Type
+	}
+	if v.flag&flagMethod == 0 {
+		return typ
+	}
+
+	i := int(v.flag) >> flagMethodShift
+	if typ.Kind() == abi.Interface {
+		tt := (*interfaceType)(unsafe.Pointer(typ))
+		if uint(i) >= uint(len(tt.Methods)) {
+			panic("reflect: internal error: invalid method index")
+		}
+		return &tt.Methods[i].Typ_.Type
+	}
+
+	ms := typ.ExportedMethods()
+	if uint(i) >= uint(len(ms)) {
+		panic("reflect: internal error: invalid method index")
+	}
+	return &ms[i].Mtyp_.Type
+}
+
+func (v Value) Fields() iter.Seq2[StructField, Value] {
+	t := v.Type()
+	if t.Kind() != Struct {
+		panic("reflect: Fields of non-struct type " + t.String())
+	}
+	return func(yield func(StructField, Value) bool) {
+		for i := 0; i < v.NumField(); i++ {
+			if !yield(t.Field(i), v.Field(i)) {
+				return
+			}
+		}
+	}
+}
+
+func (v Value) Methods() iter.Seq2[Method, Value] {
+	return func(yield func(Method, Value) bool) {
+		t := v.Type()
+		for i := 0; i < v.NumMethod(); i++ {
+			if !yield(t.Method(i), v.Method(i)) {
+				return
+			}
+		}
+	}
+}

--- a/runtime/internal/lib/runtime/symtab.go
+++ b/runtime/internal/lib/runtime/symtab.go
@@ -183,6 +183,14 @@ func (f *Func) Name() string {
 	panic("todo")
 }
 
+func (f *Func) FileLine(pc uintptr) (file string, line int) {
+	var info clitedebug.Info
+	if pc == 0 || clitedebug.Addrinfo(unsafe.Pointer(pc), &info) == 0 {
+		return "", 0
+	}
+	return safeGoString(info.Fname, ""), 0
+}
+
 // moduledata records information about the layout of the executable
 // image. It is written by the linker. Any changes here must be
 // matched changes to the code in cmd/link/internal/ld/symtab.go:symtab.

--- a/runtime/internal/runtime/reflect_linkname.go
+++ b/runtime/internal/runtime/reflect_linkname.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2024 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"unsafe"
+	_ "unsafe"
+)
+
+//go:linkname reflect_unsafe_New reflect.unsafe_New
+func reflect_unsafe_New(t *Type) unsafe.Pointer {
+	return New(t)
+}
+
+//go:linkname reflect_unsafe_NewArray reflect.unsafe_NewArray
+func reflect_unsafe_NewArray(t *Type, n int) unsafe.Pointer {
+	return NewArray(t, n)
+}
+
+//go:linkname reflect_typedmemmove reflect.typedmemmove
+func reflect_typedmemmove(t *Type, dst, src unsafe.Pointer) {
+	Typedmemmove(t, dst, src)
+}
+
+//go:linkname reflect_makemap reflect.makemap
+func reflect_makemap(t *maptype, cap int) *hmap {
+	return MakeMap(t, cap)
+}
+
+//go:linkname reflect_mapaccess reflect.mapaccess
+func reflect_mapaccess(t *maptype, h *hmap, key unsafe.Pointer) unsafe.Pointer {
+	elem, ok := mapaccess2(t, h, key)
+	if !ok {
+		return nil
+	}
+	return elem
+}
+
+//go:linkname reflect_mapiterinit reflect.mapiterinit
+func reflect_mapiterinit(t *maptype, h *hmap, it *hiter) {
+	mapiterinit(t, h, it)
+}
+
+//go:linkname reflect_mapiternext reflect.mapiternext
+func reflect_mapiternext(it *hiter) {
+	mapiternext(it)
+}
+
+//go:linkname reflect_ifaceE2I reflect.ifaceE2I
+func reflect_ifaceE2I(t *interfacetype, src any, dst unsafe.Pointer) {
+	IfaceE2I(t, *(*eface)(unsafe.Pointer(&src)), (*iface)(dst))
+}

--- a/test/go/kube_reflect_runtime_symbols_go126_test.go
+++ b/test/go/kube_reflect_runtime_symbols_go126_test.go
@@ -1,0 +1,137 @@
+//go:build go1.26
+// +build go1.26
+
+package gotest
+
+import (
+	"iter"
+	"reflect"
+	"runtime"
+	"testing"
+	"unsafe"
+)
+
+type kubeReflectTypeInterface struct {
+	itab unsafe.Pointer
+	data unsafe.Pointer
+}
+
+func kubeReflectTypeData(t reflect.Type) unsafe.Pointer {
+	return (*kubeReflectTypeInterface)(unsafe.Pointer(&t)).data
+}
+
+//go:linkname kubeReflectUnsafeNew reflect.unsafe_New
+func kubeReflectUnsafeNew(unsafe.Pointer) unsafe.Pointer
+
+//go:linkname kubeReflectTypedmemmove reflect.typedmemmove
+func kubeReflectTypedmemmove(unsafe.Pointer, unsafe.Pointer, unsafe.Pointer)
+
+//go:linkname kubeReflectUnsafeNewArray reflect.unsafe_NewArray
+func kubeReflectUnsafeNewArray(unsafe.Pointer, int) unsafe.Pointer
+
+//go:linkname kubeReflectMakeMap reflect.makemap
+func kubeReflectMakeMap(unsafe.Pointer, int) unsafe.Pointer
+
+//go:linkname kubeReflectMapAccess reflect.mapaccess
+func kubeReflectMapAccess(unsafe.Pointer, unsafe.Pointer, unsafe.Pointer) unsafe.Pointer
+
+//go:linkname kubeReflectMapIterInit reflect.mapiterinit
+func kubeReflectMapIterInit(unsafe.Pointer, unsafe.Pointer, unsafe.Pointer)
+
+//go:linkname kubeReflectMapIterNext reflect.mapiternext
+func kubeReflectMapIterNext(unsafe.Pointer)
+
+//go:linkname kubeReflectIfaceE2I reflect.ifaceE2I
+func kubeReflectIfaceE2I(unsafe.Pointer, any, unsafe.Pointer)
+
+var kubeReflectPrivateSymbolRefs = [...]any{
+	kubeReflectMakeMap,
+	kubeReflectMapAccess,
+	kubeReflectMapIterInit,
+	kubeReflectMapIterNext,
+	kubeReflectIfaceE2I,
+}
+
+func TestKubeReflectPrivateLinknameSymbols(t *testing.T) {
+	intType := kubeReflectTypeData(reflect.TypeOf(int(0)))
+	if intType == nil {
+		t.Fatal("reflect int type data is nil")
+	}
+
+	p := kubeReflectUnsafeNew(intType)
+	if p == nil {
+		t.Fatal("reflect.unsafe_New returned nil")
+	}
+	*(*int)(p) = 42
+	if got := *(*int)(p); got != 42 {
+		t.Fatalf("unsafe_New value = %d, want 42", got)
+	}
+
+	src := 123
+	dst := 0
+	kubeReflectTypedmemmove(intType, unsafe.Pointer(&dst), unsafe.Pointer(&src))
+	if dst != src {
+		t.Fatalf("typedmemmove dst = %d, want %d", dst, src)
+	}
+
+	arr := kubeReflectUnsafeNewArray(intType, 2)
+	if arr == nil {
+		t.Fatal("reflect.unsafe_NewArray returned nil")
+	}
+
+	if len(kubeReflectPrivateSymbolRefs) == 0 {
+		t.Fatal("private reflect symbol refs missing")
+	}
+}
+
+type kubeAddressableValue struct {
+	reflect.Value
+	forcedAddr bool
+}
+
+var _ interface {
+	Fields() iter.Seq2[reflect.StructField, reflect.Value]
+	Methods() iter.Seq2[reflect.Method, reflect.Value]
+} = kubeAddressableValue{}
+
+//go:linkname kubeReflectValueAbiType reflect.Value.abiType
+func kubeReflectValueAbiType(reflect.Value) unsafe.Pointer
+
+//go:linkname kubeReflectValueAbiTypeSlow reflect.Value.abiTypeSlow
+func kubeReflectValueAbiTypeSlow(reflect.Value) unsafe.Pointer
+
+func TestKubeReflectValueGo126PromotedSymbols(t *testing.T) {
+	v := reflect.ValueOf(struct{ A int }{A: 1})
+	if kubeReflectValueAbiType(v) == nil {
+		t.Fatal("reflect.Value.abiType returned nil")
+	}
+	if kubeReflectValueAbiTypeSlow(v) == nil {
+		t.Fatal("reflect.Value.abiTypeSlow returned nil")
+	}
+
+	av := kubeAddressableValue{Value: v}
+	fields := 0
+	for field, value := range av.Fields() {
+		fields++
+		if field.Name != "A" || value.Int() != 1 {
+			t.Fatalf("field = (%s, %v), want (A, 1)", field.Name, value.Interface())
+		}
+	}
+	if fields != 1 {
+		t.Fatalf("Fields yielded %d values, want 1", fields)
+	}
+
+	for range av.Methods() {
+		t.Fatal("unexpected method on anonymous struct value")
+	}
+}
+
+func TestKubeRuntimeFuncFileLineSymbol(t *testing.T) {
+	pc, _, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Skip("runtime.Caller returned no frame")
+	}
+	if fn := runtime.FuncForPC(pc); fn != nil {
+		_, _ = fn.FileLine(pc)
+	}
+}


### PR DESCRIPTION
## Summary
- add LLGo runtime shims for private reflect linknames used by reflect-heavy dependencies
- add Go 1.26 `reflect.Value` compatibility methods required by promoted method tables
- add a minimal `runtime.(*Func).FileLine` symbol for callers that reference the runtime API

## Tests
- `go test ./test/go -run 'TestKube(ReflectPrivateLinknameSymbols|ReflectValueGo126PromotedSymbols|RuntimeFuncFileLineSymbol)' -count=1`
- `go run ./cmd/llgo test ./test/go -run 'TestKube(ReflectPrivateLinknameSymbols|ReflectValueGo126PromotedSymbols|RuntimeFuncFileLineSymbol)'`

The regression tests live under `test/go` and cover the Kubernetes undefined symbols for `reflect.unsafe_New`, `reflect.Value.abiType*`, `reflect.Value.Fields/Methods`, and `runtime.(*Func).FileLine`.
