### PR TITLE
Add xsys unix NoError syscalls

### DIFF
--- a/runtime/internal/lib/golang.org/x/sys/unix/syscall_linux.go
+++ b/runtime/internal/lib/golang.org/x/sys/unix/syscall_linux.go
@@ -1,0 +1,20 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build linux
+
+package unix
+
+// SyscallNoError may be used instead of Syscall for syscalls that don't fail.
+func SyscallNoError(trap, a1, a2, a3 uintptr) (r1, r2 uintptr) {
+	r1, r2, _ = Syscall(trap, a1, a2, a3)
+	return
+}
+
+// RawSyscallNoError may be used instead of RawSyscall for syscalls that don't
+// fail.
+func RawSyscallNoError(trap, a1, a2, a3 uintptr) (r1, r2 uintptr) {
+	r1, r2, _ = RawSyscall(trap, a1, a2, a3)
+	return
+}

--- a/test/go/kube_xsys_unix_noerror_linux_test.go
+++ b/test/go/kube_xsys_unix_noerror_linux_test.go
@@ -1,0 +1,22 @@
+//go:build linux
+// +build linux
+
+package gotest
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestKubeXSysUnixNoErrorSyscalls(t *testing.T) {
+	rawPID, _ := unix.RawSyscallNoError(unix.SYS_GETPID, 0, 0, 0)
+	if rawPID == 0 {
+		t.Fatal("RawSyscallNoError(SYS_GETPID) returned zero pid")
+	}
+
+	sysPID, _ := unix.SyscallNoError(unix.SYS_GETPID, 0, 0, 0)
+	if sysPID != rawPID {
+		t.Fatalf("SyscallNoError pid = %d, want %d", sysPID, rawPID)
+	}
+}


### PR DESCRIPTION
## Summary
- add LLGo runtime patch implementations for `golang.org/x/sys/unix.SyscallNoError`
- add `golang.org/x/sys/unix.RawSyscallNoError` by delegating to the existing syscall wrappers and dropping errno

## Tests
- `go test ./test/go -run 'TestKubeXSysUnixNoErrorSyscalls' -count=1`
- `go run ./cmd/llgo test ./test/go -run 'TestKubeXSysUnixNoErrorSyscalls'`

The regression test lives under `test/go` and directly links the linux x/sys NoError syscall symbols used by Kubernetes dependencies.
