### PR TITLE
Relax litgen function header checks

### DIFF
--- a/chore/litgen/litgen_test.go
+++ b/chore/litgen/litgen_test.go
@@ -46,7 +46,7 @@ func TestProcessPath_SingleFileUsesContainingDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := `// CHECK-LABEL: define void @"{{.*}}/` + filepath.ToSlash(relPath) + `.main"() {`
+	want := `// CHECK-LABEL: define void @"{{.*}}/` + filepath.ToSlash(relPath) + `.main"(){{.*}} {`
 	if !strings.Contains(text, want) {
 		t.Fatalf("missing package-qualified main check:\n%s", text)
 	}

--- a/chore/litgen/rewrite.go
+++ b/chore/litgen/rewrite.go
@@ -60,15 +60,14 @@ type irFunction struct {
 }
 
 var (
-	defineQuotedRE  = regexp.MustCompile(`^define\b.* @"([^"]+)"\(`)
-	definePlainRE   = regexp.MustCompile(`^define\b.* @([^\s(]+)\(`)
-	globalQuotedRE  = regexp.MustCompile(`^@"([^"]+)"\s*=`)
-	globalPlainRE   = regexp.MustCompile(`^@([A-Za-z0-9$._-]+)\s*=`)
-	globalRefRE     = regexp.MustCompile(`@"([^"]+)"|@([A-Za-z0-9$._-]+)`)
-	checkLineRE     = regexp.MustCompile(`^\s*//\s*CHECK(?:-[A-Z]+)?:`)
-	debugMetaRE     = regexp.MustCompile(`, ![A-Za-z0-9_.-]+ ![0-9]+`)
-	attrGroupTailRE = regexp.MustCompile(`\s+#\d+$`)
-	numericNameRE   = regexp.MustCompile(`^\d+$`)
+	defineQuotedRE = regexp.MustCompile(`^define\b.* @"([^"]+)"\(`)
+	definePlainRE  = regexp.MustCompile(`^define\b.* @([^\s(]+)\(`)
+	globalQuotedRE = regexp.MustCompile(`^@"([^"]+)"\s*=`)
+	globalPlainRE  = regexp.MustCompile(`^@([A-Za-z0-9$._-]+)\s*=`)
+	globalRefRE    = regexp.MustCompile(`@"([^"]+)"|@([A-Za-z0-9$._-]+)`)
+	checkLineRE    = regexp.MustCompile(`^\s*//\s*CHECK(?:-[A-Z]+)?:`)
+	debugMetaRE    = regexp.MustCompile(`, ![A-Za-z0-9_.-]+ ![0-9]+`)
+	numericNameRE  = regexp.MustCompile(`^\d+$`)
 )
 
 func generateFile(target resolvedTarget) error {
@@ -426,8 +425,10 @@ func buildFunctionChecks(fn irFunction, modulePath string) []string {
 func generalizeDefineLine(line, modulePath string) string {
 	line = scrubIRLine(line)
 	if idx := strings.LastIndex(line, " {"); idx >= 0 {
-		head := attrGroupTailRE.ReplaceAllString(line[:idx], "")
-		line = head + line[idx:]
+		head := line[:idx]
+		if sigEnd := strings.LastIndex(head, ")"); sigEnd >= 0 {
+			line = head[:sigEnd+1] + "{{.*}}" + line[idx:]
+		}
 	}
 	return generalizeModulePath(line, modulePath)
 }

--- a/chore/litgen/rewrite_test.go
+++ b/chore/litgen/rewrite_test.go
@@ -35,7 +35,7 @@ _llgo_0:
 	if err != nil {
 		t.Fatal(err)
 	}
-	mainCheck := `// CHECK-LABEL: define void @"{{.*}}/p.main"() {`
+	mainCheck := `// CHECK-LABEL: define void @"{{.*}}/p.main"(){{.*}} {`
 	mainDecl := "func main() {"
 	if !strings.Contains(got, mainCheck) {
 		t.Fatalf("main checks not inserted before func main:\n%s", got)
@@ -43,7 +43,7 @@ _llgo_0:
 	if strings.Index(got, mainCheck) > strings.Index(got, mainDecl) {
 		t.Fatalf("main checks should appear before func main:\n%s", got)
 	}
-	closureCheck := "\t// CHECK-LABEL: define void @\"{{.*}}/p.main$1\"() {"
+	closureCheck := "\t// CHECK-LABEL: define void @\"{{.*}}/p.main$1\"(){{.*}} {"
 	closureStmt := "\tfn := func() {}"
 	if !strings.Contains(got, closureCheck) {
 		t.Fatalf("closure checks not inserted before func literal:\n%s", got)
@@ -51,10 +51,10 @@ _llgo_0:
 	if strings.Index(got, closureCheck) > strings.Index(got, closureStmt) {
 		t.Fatalf("closure checks should appear before func literal:\n%s", got)
 	}
-	if !strings.Contains(got, `// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/p.main$1"(ptr %0) {`) {
+	if !strings.Contains(got, `// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/p.main$1"(ptr %0){{.*}} {`) {
 		t.Fatalf("stub checks missing:\n%s", got)
 	}
-	if strings.Index(got, `// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/p.main$1"(ptr %0) {`) < strings.Index(got, "func main()") {
+	if strings.Index(got, `// CHECK-LABEL: define linkonce void @"__llgo_stub.{{.*}}/p.main$1"(ptr %0){{.*}} {`) < strings.Index(got, "func main()") {
 		t.Fatalf("stub checks should be appended after source:\n%s", got)
 	}
 }
@@ -92,7 +92,7 @@ _llgo_0:
 	if err != nil {
 		t.Fatal(err)
 	}
-	initCheck := `// CHECK-LABEL: define void @"{{.*}}/p.init"() {`
+	initCheck := `// CHECK-LABEL: define void @"{{.*}}/p.init"(){{.*}} {`
 	if !strings.Contains(got, initCheck) {
 		t.Fatalf("init checks not inserted before var decl:\n%s", got)
 	}
@@ -139,8 +139,8 @@ _llgo_0:
 	if err != nil {
 		t.Fatal(err)
 	}
-	addCheck := `// CHECK-LABEL: define i64 @"{{.*}}/p.add"(i64 %0, i64 %1) {`
-	initCheck := `// CHECK-LABEL: define void @"{{.*}}/p.init"() {`
+	addCheck := `// CHECK-LABEL: define i64 @"{{.*}}/p.add"(i64 %0, i64 %1){{.*}} {`
+	initCheck := `// CHECK-LABEL: define void @"{{.*}}/p.init"(){{.*}} {`
 	if strings.Index(got, addCheck) < 0 || strings.Index(got, initCheck) < 0 {
 		t.Fatalf("missing checks:\n%s", got)
 	}
@@ -212,8 +212,8 @@ _llgo_0:
 	if err != nil {
 		t.Fatal(err)
 	}
-	firstCheck := `// CHECK-LABEL: define i64 @"{{.*}}/p.init$1"() {`
-	secondCheck := `// CHECK-LABEL: define i64 @"{{.*}}/p.init$2"() {`
+	firstCheck := `// CHECK-LABEL: define i64 @"{{.*}}/p.init$1"(){{.*}} {`
+	secondCheck := `// CHECK-LABEL: define i64 @"{{.*}}/p.init$2"(){{.*}} {`
 	firstVar := "var a = func() int { return 1 }()"
 	secondVar := "var b = func() int { return 2 }()"
 	if strings.Index(got, firstCheck) > strings.Index(got, firstVar) {
@@ -221,6 +221,15 @@ _llgo_0:
 	}
 	if strings.Index(got, secondCheck) > strings.Index(got, secondVar) {
 		t.Fatalf("second init closure should be anchored before second var decl:\n%s", got)
+	}
+}
+
+func TestGeneralizeDefineLine_WildcardsAttrsBeforeBrace(t *testing.T) {
+	line := `define void @"example.com/p.main"() local_unnamed_addr #0 {`
+	got := generalizeDefineLine(line, "example.com")
+	want := `define void @"{{.*}}/p.main"(){{.*}} {`
+	if got != want {
+		t.Fatalf("generalizeDefineLine = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
This updates litgen-generated CHECK-LABEL directives for LLVM function definitions to allow wildcard text between the signature and opening brace.

The wildcard covers attributes such as local_unnamed_addr or attribute groups while preserving the function signature match.

Tests:
- go test ./chore/litgen