### PR TITLE
build: support explicit LTO modes

### DIFF
--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -7,6 +7,7 @@ import (
 	"github.com/goplus/llgo/cmd/internal/compilerhash"
 	"github.com/goplus/llgo/internal/build"
 	"github.com/goplus/llgo/internal/buildenv"
+	"github.com/goplus/llgo/internal/lto"
 	"github.com/goplus/llgo/internal/optlevel"
 )
 
@@ -45,6 +46,39 @@ var SizeLevel string
 var ForceRebuild bool
 var PrintCommands bool
 var OptLevel optlevel.Level
+
+type ltoFlag struct {
+	Specified bool
+	Mode      lto.Mode
+}
+
+func (o *ltoFlag) String() string {
+	return o.Mode.String()
+}
+
+func (o *ltoFlag) Set(v string) error {
+	mode, err := lto.Parse(v)
+	if err != nil {
+		return err
+	}
+	o.Specified = true
+	o.Mode = mode
+	return nil
+}
+
+var LTO ltoFlag
+
+func AddLTOFlag(fs *flag.FlagSet) {
+	LTO = ltoFlag{Mode: lto.Off}
+	fs.Var(&LTO, "lto", "Enable LTO optimization: thin or full (default: off)")
+}
+
+func ResolveLTOMode(defaultValue lto.Mode) lto.Mode {
+	if LTO.Specified {
+		return LTO.Mode
+	}
+	return defaultValue
+}
 
 const DefaultTestTimeout = "10m" // Matches Go's default test timeout
 
@@ -88,6 +122,7 @@ func AddBuildFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&ForceRebuild, "a", false, "Force rebuilding of packages that are already up-to-date")
 	fs.BoolVar(&PrintCommands, "x", false, "Print the commands")
 	AddOptLevelFlags(fs)
+	AddLTOFlag(fs)
 	fs.StringVar(&Tags, "tags", "", "Build tags")
 	fs.StringVar(&BuildEnv, "buildenv", "", "Build environment")
 	if buildenv.Dev {
@@ -218,6 +253,9 @@ func UpdateConfig(conf *build.Config) error {
 	conf.Port = Port
 	conf.BaudRate = BaudRate
 	conf.ForceRebuild = ForceRebuild
+	if LTO.Specified {
+		conf.LTO = LTO.Mode
+	}
 	if SizeReport || SizeFormat != "" || SizeLevel != "" {
 		conf.SizeReport = true
 		if SizeFormat != "" {

--- a/cmd/internal/flags/flags_test.go
+++ b/cmd/internal/flags/flags_test.go
@@ -5,6 +5,8 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/goplus/llgo/internal/build"
+	"github.com/goplus/llgo/internal/lto"
 	"github.com/goplus/llgo/internal/optlevel"
 )
 
@@ -67,5 +69,77 @@ func TestBuildOptimizationFlagsMutuallyExclusive(t *testing.T) {
 				t.Fatalf("Parse(%v) expected conflict error", tt.args)
 			}
 		})
+	}
+}
+
+func TestBuildLTOFlags(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		want      lto.Mode
+		specified bool
+	}{
+		{name: "default off", args: nil, want: lto.Off, specified: false},
+		{name: "thin value", args: []string{"-lto=thin"}, want: lto.Thin, specified: true},
+		{name: "full value", args: []string{"-lto=full"}, want: lto.Full, specified: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := flag.NewFlagSet(tt.name, flag.ContinueOnError)
+			fs.SetOutput(new(bytes.Buffer))
+			AddBuildFlags(fs)
+			if err := fs.Parse(tt.args); err != nil {
+				t.Fatalf("Parse(%v) unexpected error: %v", tt.args, err)
+			}
+			if LTO.Specified != tt.specified {
+				t.Fatalf("LTO.Specified = %v, want %v", LTO.Specified, tt.specified)
+			}
+			if LTO.Mode != tt.want {
+				t.Fatalf("LTO.Mode = %v, want %v", LTO.Mode, tt.want)
+			}
+			conf := &build.Config{}
+			if err := UpdateConfig(conf); err != nil {
+				t.Fatalf("UpdateConfig error: %v", err)
+			}
+			if conf.LTO != tt.want {
+				t.Fatalf("conf.LTO = %v, want %v", conf.LTO, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildLTOFlagInvalid(t *testing.T) {
+	tests := [][]string{
+		{"-lto"},
+		{"-lto=true"},
+		{"-lto=false"},
+		{"-lto=off"},
+		{"-lto=fat"},
+	}
+	for _, args := range tests {
+		fs := flag.NewFlagSet("invalid-lto", flag.ContinueOnError)
+		fs.SetOutput(new(bytes.Buffer))
+		AddBuildFlags(fs)
+		if err := fs.Parse(args); err == nil {
+			t.Fatalf("Parse(%v) expected error", args)
+		}
+	}
+}
+
+func TestUpdateConfigPreservesLTOWhenUnspecified(t *testing.T) {
+	fs := flag.NewFlagSet("lto-unspecified", flag.ContinueOnError)
+	fs.SetOutput(new(bytes.Buffer))
+	AddBuildFlags(fs)
+	if err := fs.Parse(nil); err != nil {
+		t.Fatalf("Parse(nil) unexpected error: %v", err)
+	}
+
+	conf := &build.Config{LTO: lto.Full}
+	if err := UpdateConfig(conf); err != nil {
+		t.Fatalf("UpdateConfig error: %v", err)
+	}
+	if conf.LTO != lto.Full {
+		t.Fatalf("conf.LTO = %v, want %v", conf.LTO, lto.Full)
 	}
 }

--- a/cmd/internal/monitor/monitor.go
+++ b/cmd/internal/monitor/monitor.go
@@ -23,6 +23,7 @@ import (
 	"github.com/goplus/llgo/cmd/internal/base"
 	"github.com/goplus/llgo/cmd/internal/flags"
 	"github.com/goplus/llgo/internal/crosscompile"
+	"github.com/goplus/llgo/internal/lto"
 	"github.com/goplus/llgo/internal/monitor"
 	"github.com/goplus/llgo/internal/optlevel"
 )
@@ -36,6 +37,7 @@ var Cmd = &base.Command{
 func init() {
 	flags.AddCommonFlags(&Cmd.Flag)
 	flags.AddOptLevelFlags(&Cmd.Flag)
+	flags.AddLTOFlag(&Cmd.Flag)
 	flags.AddEmbeddedFlags(&Cmd.Flag)
 	Cmd.Run = runMonitor
 }
@@ -60,7 +62,7 @@ func runMonitor(cmd *base.Command, args []string) {
 		if !level.IsValid() {
 			level = optlevel.Oz
 		}
-		conf, err := crosscompile.UseTarget(flags.Target, level)
+		conf, err := crosscompile.UseTarget(flags.Target, level, flags.ResolveLTOMode(lto.Off))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "llgo monitor: %v\n", err)
 			os.Exit(1)

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -46,6 +46,7 @@ import (
 	"github.com/goplus/llgo/internal/flash"
 	"github.com/goplus/llgo/internal/goembed"
 	"github.com/goplus/llgo/internal/header"
+	"github.com/goplus/llgo/internal/lto"
 	"github.com/goplus/llgo/internal/mockable"
 	"github.com/goplus/llgo/internal/monitor"
 	"github.com/goplus/llgo/internal/optlevel"
@@ -126,6 +127,7 @@ type Config struct {
 	Goarch        string
 	Target        string // target name (e.g., "rp2040", "wasi") - takes precedence over Goos/Goarch
 	OptLevel      optlevel.Level
+	LTO           lto.Mode
 	BinPath       string
 	AppExt        string  // ".exe" on Windows, empty on Unix
 	OutFile       string  // only valid for ModeBuild when len(pkgs) == 1
@@ -203,6 +205,17 @@ func envGOPATH() (string, error) {
 	return filepath.Join(home, "go"), nil
 }
 
+func (c *Config) ltoMode() lto.Mode {
+	if c == nil {
+		return lto.Off
+	}
+	return c.LTO
+}
+
+func (c *Config) ltoEnabled() bool {
+	return c.ltoMode().Enabled()
+}
+
 // -----------------------------------------------------------------------------
 
 const (
@@ -237,7 +250,7 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	conf.OptLevel = effectiveOptLevel(conf)
 	// Handle crosscompile configuration first to set correct GOOS/GOARCH
 	forceEspClang := conf.ForceEspClang || conf.Target != ""
-	export, err := crosscompile.Use(conf.Goos, conf.Goarch, conf.Target, IsWasiThreadsEnabled(), forceEspClang, conf.OptLevel)
+	export, err := crosscompile.Use(conf.Goos, conf.Goarch, conf.Target, IsWasiThreadsEnabled(), forceEspClang, conf.OptLevel, conf.ltoMode())
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup crosscompile: %w", err)
 	}
@@ -1152,8 +1165,8 @@ func needsLinuxNoPIE(ctx *context, linkArgs []string) bool {
 }
 
 // archiver returns the archiving tool to use for the current context.
-// For wasm targets, it prefers llvm-ar because wasm-ld requires archives
-// created with llvm-ar (system ar cannot create valid wasm archive indexes).
+// For wasm targets and LTO builds, it prefers llvm-ar because linkers need
+// LLVM-aware archive indexes for wasm objects and bitcode members.
 func (c *context) archiver() string {
 	// First check toolchain directory (for cross-compilation)
 	if c.crossCompile.CC != "" {
@@ -1169,7 +1182,6 @@ func (c *context) archiver() string {
 	if ar := os.Getenv("LLGO_AR"); ar != "" {
 		return ar
 	}
-	// For wasm targets, prefer llvm-ar from PATH (system ar cannot create valid wasm archives)
 	if c.buildConf.Goarch == "wasm" || strings.Contains(c.crossCompile.LLVMTarget, "wasm") {
 		if llvmAr, err := exec.LookPath("llvm-ar"); err == nil {
 			return llvmAr
@@ -1291,7 +1303,7 @@ func buildPkg(ctx *context, aPkg *aPackage, verbose bool) error {
 		mod.SetTarget(ctx.prog.Target().Spec().Triple)
 		pbo := gllvm.NewPassBuilderOptions()
 		defer pbo.Dispose()
-		if err := mod.RunPasses(llvmPassPipeline(ctx.buildConf.OptLevel), ctx.prog.TargetMachine(), pbo); err != nil {
+		if err := mod.RunPasses(llvmPassPipeline(ctx.buildConf.OptLevel, ctx.buildConf.ltoMode()), ctx.prog.TargetMachine(), pbo); err != nil {
 			return fmt.Errorf("run LLVM passes failed for %v: %v", pkgPath, err)
 		}
 	}
@@ -1411,9 +1423,24 @@ func exportObjectInMemory(ctx *context, pkgPath string, exportFile string, pkg l
 			return "", err
 		}
 	}
-	buf, err := ctx.prog.TargetMachine().EmitToMemoryBuffer(pkg.Module(), gllvm.ObjectFile)
-	if err != nil {
-		return "", err
+	ltoMode := ctx.buildConf.ltoMode()
+	var (
+		buf  gllvm.MemoryBuffer
+		err  error
+		kind = "in-memory LLVM object emission"
+	)
+	switch ltoMode {
+	case lto.Full:
+		buf = gllvm.WriteBitcodeToMemoryBuffer(pkg.Module())
+		kind = "in-memory LLVM full LTO bitcode emission"
+	case lto.Thin:
+		buf = gllvm.WriteThinLTOBitcodeToMemoryBuffer(pkg.Module())
+		kind = "in-memory LLVM ThinLTO bitcode emission"
+	default:
+		buf, err = ctx.prog.TargetMachine().EmitToMemoryBuffer(pkg.Module(), gllvm.ObjectFile)
+		if err != nil {
+			return "", err
+		}
 	}
 	defer buf.Dispose()
 
@@ -1425,7 +1452,7 @@ func exportObjectInMemory(ctx *context, pkgPath string, exportFile string, pkg l
 	objFileName := objFile.Name()
 	if ctx.shouldPrintCommands(false) {
 		fmt.Fprintf(os.Stderr, "# compiling %s for pkg: %s\n", objFileName, pkgPath)
-		fmt.Fprintln(os.Stderr, "# using in-memory LLVM object emission")
+		fmt.Fprintf(os.Stderr, "# using %s\n", kind)
 	}
 	if _, err := objFile.Write(buf.Bytes()); err != nil {
 		objFile.Close()
@@ -1818,8 +1845,15 @@ func effectiveOptLevel(conf *Config) optlevel.Level {
 	return optlevel.O2
 }
 
-func llvmPassPipeline(level optlevel.Level) string {
-	return "default<" + level.Name() + ">"
+func llvmPassPipeline(level optlevel.Level, ltoMode lto.Mode) string {
+	switch ltoMode {
+	case lto.Full:
+		return "lto-pre-link<" + level.Name() + ">"
+	case lto.Thin:
+		return "thinlto-pre-link<" + level.Name() + ">"
+	default:
+		return "default<" + level.Name() + ">"
+	}
 }
 
 func IsWasiThreadsEnabled() bool {

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/goplus/llgo/internal/lto"
 	"github.com/goplus/llgo/internal/mockable"
 	"github.com/goplus/llgo/internal/packages"
 	llssa "github.com/goplus/llgo/ssa"
@@ -361,5 +362,34 @@ func Sigsetjmp()
 	}})
 	if got, ok := prog.Linkname(llssa.PkgRuntime + ".Sigsetjmp"); !ok || got != "C.sigsetjmp" {
 		t.Fatalf("pre-collected runtime linkname = (%q,%v), want (%q,%v)", got, ok, "C.sigsetjmp", true)
+	}
+}
+
+func TestLTOEnabledDefault(t *testing.T) {
+	host := &Config{Target: ""}
+	if host.ltoEnabled() {
+		t.Fatal("expected LTO disabled by default for non-target builds")
+	}
+
+	target := &Config{Target: "rp2040"}
+	if target.ltoEnabled() {
+		t.Fatal("expected LTO disabled by default for target builds")
+	}
+}
+
+func TestLTOEnabledExplicitOverride(t *testing.T) {
+	hostOn := &Config{Target: "", LTO: lto.Thin}
+	if !hostOn.ltoEnabled() {
+		t.Fatal("expected explicit LTO=thin to enable LTO for non-target build")
+	}
+
+	hostFull := &Config{Target: "", LTO: lto.Full}
+	if !hostFull.ltoEnabled() {
+		t.Fatal("expected explicit LTO=full to enable LTO for non-target build")
+	}
+
+	targetOff := &Config{Target: "rp2040", LTO: lto.Off}
+	if targetOff.ltoEnabled() {
+		t.Fatal("expected LTO=off to disable LTO for target build")
 	}
 }

--- a/internal/build/optlevel_test.go
+++ b/internal/build/optlevel_test.go
@@ -3,6 +3,7 @@ package build
 import (
 	"testing"
 
+	"github.com/goplus/llgo/internal/lto"
 	"github.com/goplus/llgo/internal/optlevel"
 )
 
@@ -51,8 +52,9 @@ func TestIsOptimizeEnabledLegacyEnv(t *testing.T) {
 
 func TestLLVMPassPipeline(t *testing.T) {
 	tests := []struct {
-		level optlevel.Level
-		want  string
+		level   optlevel.Level
+		ltoMode lto.Mode
+		want    string
 	}{
 		{level: optlevel.O0, want: "default<O0>"},
 		{level: optlevel.O1, want: "default<O1>"},
@@ -60,10 +62,12 @@ func TestLLVMPassPipeline(t *testing.T) {
 		{level: optlevel.O3, want: "default<O3>"},
 		{level: optlevel.Os, want: "default<Os>"},
 		{level: optlevel.Oz, want: "default<Oz>"},
+		{level: optlevel.O2, ltoMode: lto.Full, want: "lto-pre-link<O2>"},
+		{level: optlevel.Oz, ltoMode: lto.Thin, want: "thinlto-pre-link<Oz>"},
 	}
 	for _, tt := range tests {
-		if got := llvmPassPipeline(tt.level); got != tt.want {
-			t.Fatalf("llvmPassPipeline(%v) = %q, want %q", tt.level, got, tt.want)
+		if got := llvmPassPipeline(tt.level, tt.ltoMode); got != tt.want {
+			t.Fatalf("llvmPassPipeline(%v, %v) = %q, want %q", tt.level, tt.ltoMode, got, tt.want)
 		}
 	}
 }

--- a/internal/crosscompile/crosscompile.go
+++ b/internal/crosscompile/crosscompile.go
@@ -13,6 +13,7 @@ import (
 	"github.com/goplus/llgo/internal/crosscompile/compile"
 	"github.com/goplus/llgo/internal/env"
 	"github.com/goplus/llgo/internal/flash"
+	"github.com/goplus/llgo/internal/lto"
 	"github.com/goplus/llgo/internal/optlevel"
 	"github.com/goplus/llgo/internal/targets"
 	"github.com/goplus/llgo/internal/xtool/llvm"
@@ -198,7 +199,7 @@ func compileWithConfig(
 	return
 }
 
-func use(goos, goarch string, wasiThreads, forceEspClang bool, level optlevel.Level) (export Export, err error) {
+func use(goos, goarch string, wasiThreads, forceEspClang bool, level optlevel.Level, ltoMode lto.Mode) (export Export, err error) {
 	targetTriple := llvm.GetTargetTriple(goos, goarch)
 	llgoRoot := env.LLGoROOT()
 
@@ -226,8 +227,10 @@ func use(goos, goarch string, wasiThreads, forceEspClang bool, level optlevel.Le
 			"-Wl,--error-limit=0",
 			"-fuse-ld=lld",
 			// Enable ICF (Identical Code Folding) to reduce binary size
-			"-Xlinker",
-			"--icf=safe",
+			"-Wl,--icf=safe",
+		}
+		if ltoMode.Enabled() {
+			export.LDFLAGS = append(export.LDFLAGS, ltoMode.ClangFlag(), "-Wl,--lto"+level.Flag())
 		}
 		if clangRoot != "" {
 			clangLib := filepath.Join(clangRoot, "lib")
@@ -249,8 +252,12 @@ func use(goos, goarch string, wasiThreads, forceEspClang bool, level optlevel.Le
 		}
 		export.CCFLAGS = []string{
 			level.Flag(),
+			"-target", targetTriple,
 			"-Qunused-arguments",
 			"-Wno-unused-command-line-argument",
+		}
+		if ltoMode.Enabled() {
+			export.CCFLAGS = append(export.CCFLAGS, ltoMode.ClangFlag())
 		}
 
 		// Add sysroot for macOS only
@@ -428,7 +435,7 @@ func use(goos, goarch string, wasiThreads, forceEspClang bool, level optlevel.Le
 }
 
 // UseTarget loads configuration from a target name (e.g., "rp2040", "wasi")
-func UseTarget(targetName string, level optlevel.Level) (export Export, err error) {
+func UseTarget(targetName string, level optlevel.Level, ltoMode lto.Mode) (export Export, err error) {
 	resolver := targets.NewDefaultResolver()
 
 	config, err := resolver.Resolve(targetName)
@@ -503,6 +510,12 @@ func UseTarget(targetName string, level optlevel.Level) (export Export, err erro
 	expandedCFlags := env.ExpandEnvSlice(config.CFlags, envs)
 	cflags = append(cflags, expandedCFlags...)
 
+	if config.Linker == "ld.lld" && ltoMode.Enabled() {
+		ldflags = append(ldflags, "--lto"+level.Flag())
+		cflags = append(cflags, ltoMode.ClangFlag())
+		ccflags = append(ccflags, ltoMode.ClangFlag())
+	}
+
 	// The following parameters are inspired by tinygo/builder/library.go
 	// Handle CPU configuration
 	if cpu != "" {
@@ -549,6 +562,8 @@ func UseTarget(targetName string, level optlevel.Level) (export Export, err erro
 		ccflags = append(ccflags, "-fforce-enable-int128")
 	case "riscv64":
 		ccflags = append(ccflags, "-march=rv64gc")
+		// codegen option should be added to ldflags for lto
+		ldflags = append(ldflags, "-mllvm", "-march=rv64gc")
 	case "mips":
 		ccflags = append(ccflags, "-fno-pic")
 	}
@@ -578,9 +593,17 @@ func UseTarget(targetName string, level optlevel.Level) (export Export, err erro
 	// Handle code generation configuration
 	if config.CodeModel != "" {
 		ccflags = append(ccflags, "-mcmodel="+config.CodeModel)
+		if ltoMode.Enabled() {
+			// codegen option should be added to ldflags for lto
+			ldflags = append(ldflags, "-mllvm", "-code-model="+config.CodeModel)
+		}
 	}
 	if config.TargetABI != "" {
 		ccflags = append(ccflags, "-mabi="+config.TargetABI)
+		if ltoMode.Enabled() {
+			// codegen option should be added to ldflags for lto
+			ldflags = append(ldflags, "-mllvm", "-target-abi="+config.TargetABI)
+		}
 	}
 	if config.RelocationModel != "" {
 		switch config.RelocationModel {
@@ -662,9 +685,9 @@ func UseTarget(targetName string, level optlevel.Level) (export Export, err erro
 
 // Use extends the original Use function to support target-based configuration
 // If targetName is provided, it takes precedence over goos/goarch
-func Use(goos, goarch, targetName string, wasiThreads, forceEspClang bool, level optlevel.Level) (export Export, err error) {
+func Use(goos, goarch, targetName string, wasiThreads, forceEspClang bool, level optlevel.Level, ltoMode lto.Mode) (export Export, err error) {
 	if targetName != "" && !strings.HasPrefix(targetName, "wasm") && !strings.HasPrefix(targetName, "wasi") {
-		return UseTarget(targetName, level)
+		return UseTarget(targetName, level, ltoMode)
 	}
-	return use(goos, goarch, wasiThreads, forceEspClang, level)
+	return use(goos, goarch, wasiThreads, forceEspClang, level, ltoMode)
 }

--- a/internal/crosscompile/crosscompile_test.go
+++ b/internal/crosscompile/crosscompile_test.go
@@ -7,9 +7,12 @@ import (
 	"os"
 	"runtime"
 	"slices"
+	"strings"
 	"testing"
 
+	"github.com/goplus/llgo/internal/lto"
 	"github.com/goplus/llgo/internal/optlevel"
+	"github.com/goplus/llgo/internal/xtool/llvm"
 )
 
 const (
@@ -78,7 +81,7 @@ func TestUseCrossCompileSDK(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			export, err := use(tc.goos, tc.goarch, false, false, optlevel.O2)
+			export, err := use(tc.goos, tc.goarch, false, false, optlevel.O2, lto.Off)
 
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
@@ -233,7 +236,7 @@ func TestUseTarget(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			export, err := UseTarget(tc.targetName, optlevel.Oz)
+			export, err := UseTarget(tc.targetName, optlevel.Oz, lto.Thin)
 
 			if tc.expectError {
 				if err == nil {
@@ -313,7 +316,7 @@ func TestUseTarget(t *testing.T) {
 
 func TestUseWithTarget(t *testing.T) {
 	// Test target-based configuration takes precedence
-	export, err := Use("linux", "amd64", "esp32", false, true, optlevel.Oz)
+	export, err := Use("linux", "amd64", "esp32", false, true, optlevel.Oz, lto.Thin)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -325,7 +328,7 @@ func TestUseWithTarget(t *testing.T) {
 	}
 
 	// Test fallback to goos/goarch when no target specified
-	export, err = Use(runtime.GOOS, runtime.GOARCH, "", false, false, optlevel.O2)
+	export, err = Use(runtime.GOOS, runtime.GOARCH, "", false, false, optlevel.O2, lto.Thin)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -337,7 +340,7 @@ func TestUseWithTarget(t *testing.T) {
 }
 
 func TestOptimizationFlagPlacement(t *testing.T) {
-	export, err := UseTarget("rp2040", optlevel.Oz)
+	export, err := UseTarget("rp2040", optlevel.Oz, lto.Off)
 	if err != nil {
 		t.Fatalf("UseTargetWithOptLevel(rp2040) failed: %v", err)
 	}
@@ -345,11 +348,120 @@ func TestOptimizationFlagPlacement(t *testing.T) {
 		t.Fatalf("target CCFLAGS = %v, want first flag -Oz", export.CCFLAGS)
 	}
 
-	export, err = Use(runtime.GOOS, runtime.GOARCH, "", false, false, optlevel.O3)
+	export, err = Use(runtime.GOOS, runtime.GOARCH, "", false, false, optlevel.O3, lto.Off)
 	if err != nil {
 		t.Fatalf("UseWithOptLevel(host, O3) failed: %v", err)
 	}
 	if !slices.Contains(export.CCFLAGS, "-O3") {
 		t.Fatalf("host CCFLAGS = %v, want -O3", export.CCFLAGS)
+	}
+	if !hasFlagValue(export.CCFLAGS, "-target", llvm.GetTargetTriple(runtime.GOOS, runtime.GOARCH)) {
+		t.Fatalf("host CCFLAGS = %v, want native -target", export.CCFLAGS)
+	}
+	if !hasFlagValue(export.LDFLAGS, "-target", llvm.GetTargetTriple(runtime.GOOS, runtime.GOARCH)) {
+		t.Fatalf("host LDFLAGS = %v, want native -target", export.LDFLAGS)
+	}
+}
+
+func TestUseLTOFlagsControlledByOption(t *testing.T) {
+	export, err := use(runtime.GOOS, runtime.GOARCH, false, false, optlevel.O2, lto.Off)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	for _, flag := range export.CCFLAGS {
+		if strings.HasPrefix(flag, "-flto") {
+			t.Fatalf("unexpected LTO ccflag when disabled: %q", flag)
+		}
+	}
+	for _, flag := range export.LDFLAGS {
+		if strings.Contains(flag, "lto-") {
+			t.Fatalf("unexpected LTO ldflag when disabled: %q", flag)
+		}
+	}
+
+	thin, err := use(runtime.GOOS, runtime.GOARCH, false, false, optlevel.O2, lto.Thin)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !slices.Contains(thin.CCFLAGS, "-flto=thin") {
+		t.Fatalf("missing thin LTO ccflag: %v", thin.CCFLAGS)
+	}
+	if !slices.Contains(thin.LDFLAGS, "-flto=thin") {
+		t.Fatalf("missing thin LTO link driver flag: %v", thin.LDFLAGS)
+	}
+	if !slices.Contains(thin.LDFLAGS, "-Wl,--lto-O2") {
+		t.Fatalf("missing thin LTO linker opt flag: %v", thin.LDFLAGS)
+	}
+
+	full, err := use(runtime.GOOS, runtime.GOARCH, false, false, optlevel.O2, lto.Full)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !slices.Contains(full.CCFLAGS, "-flto=full") {
+		t.Fatalf("missing full LTO ccflag: %v", full.CCFLAGS)
+	}
+	if !slices.Contains(full.LDFLAGS, "-flto=full") {
+		t.Fatalf("missing full LTO link driver flag: %v", full.LDFLAGS)
+	}
+}
+
+func hasMllvmOption(flags []string, opt string) bool {
+	for i := 0; i+1 < len(flags); i++ {
+		if flags[i] == "-mllvm" && flags[i+1] == opt {
+			return true
+		}
+	}
+	return false
+}
+
+func hasFlagValue(flags []string, flag, value string) bool {
+	for i := 0; i+1 < len(flags); i++ {
+		if flags[i] == flag && flags[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+func TestUseTargetCodegenFlagsOnlyAddedToLDFlagsWithLTO(t *testing.T) {
+	const target = "k210"
+
+	noLTO, err := UseTarget(target, optlevel.Oz, lto.Off)
+	if err != nil {
+		t.Fatalf("UseTarget(%q, off) error: %v", target, err)
+	}
+	if hasMllvmOption(noLTO.LDFLAGS, "-code-model=medium") {
+		t.Fatalf("unexpected -mllvm -code-model=medium in LDFLAGS when LTO disabled: %v", noLTO.LDFLAGS)
+	}
+	if hasMllvmOption(noLTO.LDFLAGS, "-target-abi=lp64") {
+		t.Fatalf("unexpected -mllvm -target-abi=lp64 in LDFLAGS when LTO disabled: %v", noLTO.LDFLAGS)
+	}
+	if !slices.Contains(noLTO.CCFLAGS, "-mcmodel=medium") {
+		t.Fatalf("missing -mcmodel=medium in CCFLAGS: %v", noLTO.CCFLAGS)
+	}
+	if !slices.Contains(noLTO.CCFLAGS, "-mabi=lp64") {
+		t.Fatalf("missing -mabi=lp64 in CCFLAGS: %v", noLTO.CCFLAGS)
+	}
+
+	withLTO, err := UseTarget(target, optlevel.Oz, lto.Thin)
+	if err != nil {
+		t.Fatalf("UseTarget(%q, thin) error: %v", target, err)
+	}
+	if !slices.Contains(withLTO.CCFLAGS, "-flto=thin") {
+		t.Fatalf("missing thin LTO ccflag: %v", withLTO.CCFLAGS)
+	}
+	if !hasMllvmOption(withLTO.LDFLAGS, "-code-model=medium") {
+		t.Fatalf("missing -mllvm -code-model=medium in LDFLAGS when LTO enabled: %v", withLTO.LDFLAGS)
+	}
+	if !hasMllvmOption(withLTO.LDFLAGS, "-target-abi=lp64") {
+		t.Fatalf("missing -mllvm -target-abi=lp64 in LDFLAGS when LTO enabled: %v", withLTO.LDFLAGS)
+	}
+
+	fullLTO, err := UseTarget(target, optlevel.Oz, lto.Full)
+	if err != nil {
+		t.Fatalf("UseTarget(%q, full) error: %v", target, err)
+	}
+	if !slices.Contains(fullLTO.CCFLAGS, "-flto=full") {
+		t.Fatalf("missing full LTO ccflag: %v", fullLTO.CCFLAGS)
 	}
 }

--- a/internal/lto/lto.go
+++ b/internal/lto/lto.go
@@ -1,0 +1,53 @@
+package lto
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Mode uint8
+
+const (
+	Off Mode = iota
+	Full
+	Thin
+)
+
+func Parse(value string) (Mode, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "thin":
+		return Thin, nil
+	case "full":
+		return Full, nil
+	default:
+		return Off, fmt.Errorf("invalid LTO mode %q, want thin or full", value)
+	}
+}
+
+func (m Mode) String() string {
+	switch m {
+	case Off:
+		return "off"
+	case Full:
+		return "full"
+	case Thin:
+		return "thin"
+	default:
+		return fmt.Sprintf("Mode(%d)", m)
+	}
+}
+
+func (m Mode) Enabled() bool {
+	return m == Full || m == Thin
+}
+
+func (m Mode) ClangFlag() string {
+	switch m {
+	case Full:
+		return "-flto=full"
+	case Thin:
+		return "-flto=thin"
+	default:
+		return ""
+	}
+}

--- a/internal/lto/lto_test.go
+++ b/internal/lto/lto_test.go
@@ -1,0 +1,76 @@
+package lto
+
+import "testing"
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		value string
+		want  Mode
+	}{
+		{"thin", Thin},
+		{"full", Full},
+	}
+	for _, tt := range tests {
+		got, err := Parse(tt.value)
+		if err != nil {
+			t.Fatalf("Parse(%q) error: %v", tt.value, err)
+		}
+		if got != tt.want {
+			t.Fatalf("Parse(%q) = %v, want %v", tt.value, got, tt.want)
+		}
+	}
+}
+
+func TestParseInvalid(t *testing.T) {
+	for _, value := range []string{"", "true", "false", "off", "thinlto", "fulllto", "fat"} {
+		if _, err := Parse(value); err == nil {
+			t.Fatalf("Parse(%q) expected error", value)
+		}
+	}
+}
+
+func TestModeString(t *testing.T) {
+	tests := []struct {
+		mode Mode
+		want string
+	}{
+		{Off, "off"},
+		{Full, "full"},
+		{Thin, "thin"},
+		{Mode(99), "Mode(99)"},
+	}
+	for _, tt := range tests {
+		if got := tt.mode.String(); got != tt.want {
+			t.Fatalf("%v.String() = %q, want %q", tt.mode, got, tt.want)
+		}
+	}
+}
+
+func TestModeEnabled(t *testing.T) {
+	tests := []struct {
+		mode Mode
+		want bool
+	}{
+		{Off, false},
+		{Full, true},
+		{Thin, true},
+		{Mode(99), false},
+	}
+	for _, tt := range tests {
+		if got := tt.mode.Enabled(); got != tt.want {
+			t.Fatalf("%v.Enabled() = %t, want %t", tt.mode, got, tt.want)
+		}
+	}
+}
+
+func TestClangFlag(t *testing.T) {
+	if got := Off.ClangFlag(); got != "" {
+		t.Fatalf("Off.ClangFlag() = %q, want empty", got)
+	}
+	if got := Full.ClangFlag(); got != "-flto=full" {
+		t.Fatalf("Full.ClangFlag() = %q, want -flto=full", got)
+	}
+	if got := Thin.ClangFlag(); got != "-flto=thin" {
+		t.Fatalf("Thin.ClangFlag() = %q, want -flto=thin", got)
+	}
+}

--- a/internal/xtool/llvm/llvm.go
+++ b/internal/xtool/llvm/llvm.go
@@ -18,14 +18,9 @@ func GetTargetTriple(goos, goarch string) string {
 	case "arm64":
 		llvmarch = "aarch64"
 	case "arm":
-		switch goarch {
-		case "5":
-			llvmarch = "armv5"
-		case "6":
-			llvmarch = "armv6"
-		default:
-			llvmarch = "armv7"
-		}
+		// Keep the default in sync with ssa.Target.Spec when GOARM is not
+		// explicitly modeled by this helper.
+		llvmarch = "armv7"
 	case "wasm":
 		llvmarch = "wasm32"
 	default:
@@ -51,5 +46,11 @@ func GetTargetTriple(goos, goarch string) string {
 	// Target triples (which actually have four components, but are called
 	// triples for historical reasons) have the form:
 	//   arch-vendor-os-environment
-	return llvmarch + "-" + llvmvendor + "-" + llvmos
+	triple := llvmarch + "-" + llvmvendor + "-" + llvmos
+	if llvmos == "windows" {
+		triple += "-gnu"
+	} else if goarch == "arm" {
+		triple += "-gnueabihf"
+	}
+	return triple
 }

--- a/internal/xtool/llvm/llvm_test.go
+++ b/internal/xtool/llvm/llvm_test.go
@@ -141,10 +141,10 @@ func TestGetTargetTriple(t *testing.T) {
 	checkTriple(t, "linux/amd64", "linux", "amd64", "x86_64-unknown-linux")
 	checkTriple(t, "linux/386", "linux", "386", "i386-unknown-linux")
 	checkTriple(t, "linux/arm64", "linux", "arm64", "aarch64-unknown-linux")
-	checkTriple(t, "linux/arm", "linux", "arm", "armv7-unknown-linux")
+	checkTriple(t, "linux/arm", "linux", "arm", "armv7-unknown-linux-gnueabihf")
 	checkTriple(t, "darwin/amd64", "darwin", "amd64", "x86_64-apple-macosx")
 	checkTriple(t, "darwin/arm64", "darwin", "arm64", "arm64-apple-macosx")
-	checkTriple(t, "windows/amd64", "windows", "amd64", "x86_64-unknown-windows")
-	checkTriple(t, "windows/386", "windows", "386", "i386-unknown-windows")
+	checkTriple(t, "windows/amd64", "windows", "amd64", "x86_64-unknown-windows-gnu")
+	checkTriple(t, "windows/386", "windows", "386", "i386-unknown-windows-gnu")
 	checkTriple(t, "js/wasm", "js", "wasm", "wasm32-unknown-js")
 }


### PR DESCRIPTION
## Summary
- keep LTO disabled by default and only enable it through `-lto=thin` or `-lto=full`
- thread the selected LTO mode through build and crosscompile configuration
- emit full or ThinLTO bitcode from the in-memory LLVM path and use the matching pre-link optimization pipeline

## Tests
- `GOROOT=/opt/tools/go1.26.2.linux-amd64/go/ go test -count=1 ./internal/lto ./cmd/internal/flags ./internal/crosscompile ./cmd/internal/monitor`
- `GOROOT=/opt/tools/go1.26.2.linux-amd64/go/ go test -count=1 ./internal/build -run 'TestLTO|TestArchiver|TestEffectiveOptLevel|TestLLVMPassPipeline'`