### PR TITLE
test: use LLVM FileCheck for LITTEST

### DIFF
--- a/chore/litgen/rewrite.go
+++ b/chore/litgen/rewrite.go
@@ -401,7 +401,7 @@ func buildGlobalChecks(prog irProgram, modulePath string) []string {
 		if !needed[symbol] {
 			continue
 		}
-		lines = append(lines, "// CHECK-LINE: "+generalizeIRLine(defs[symbol], modulePath))
+		lines = append(lines, "// CHECK: {{^}}"+generalizeIRLine(defs[symbol], modulePath)+"{{$}}")
 	}
 	return lines
 }

--- a/chore/litgen/rewrite_test.go
+++ b/chore/litgen/rewrite_test.go
@@ -170,16 +170,16 @@ _llgo_0:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(got, `// CHECK-LINE: @0 = private unnamed_addr constant [4 x i8] c"Hi\0A\00", align 1`) {
+	if !strings.Contains(got, `// CHECK: {{^}}@0 = private unnamed_addr constant [4 x i8] c"Hi\0A\00", align 1{{$}}`) {
 		t.Fatalf("missing numeric global @0:\n%s", got)
 	}
-	if !strings.Contains(got, `// CHECK-LINE: @1 = private unnamed_addr constant [3 x i8] c"%s\00", align 1`) {
+	if !strings.Contains(got, `// CHECK: {{^}}@1 = private unnamed_addr constant [3 x i8] c"%s\00", align 1{{$}}`) {
 		t.Fatalf("missing numeric global @1:\n%s", got)
 	}
-	if strings.Contains(got, `// CHECK-LINE: @"{{.*}}/p.named" = global i64 1`) {
+	if strings.Contains(got, `// CHECK: {{^}}@"{{.*}}/p.named" = global i64 1{{$}}`) {
 		t.Fatalf("named globals should not be emitted by default:\n%s", got)
 	}
-	if strings.Index(got, `// CHECK-LINE: @0 = private unnamed_addr constant [4 x i8] c"Hi\0A\00", align 1`) > strings.Index(got, "func main()") {
+	if strings.Index(got, `// CHECK: {{^}}@0 = private unnamed_addr constant [4 x i8] c"Hi\0A\00", align 1{{$}}`) > strings.Index(got, "func main()") {
 		t.Fatalf("global checks should be placed before first declaration:\n%s", got)
 	}
 }

--- a/cl/_testdata/cpkg/in.go
+++ b/cl/_testdata/cpkg/in.go
@@ -1,7 +1,7 @@
 // LITTEST
 package C
 
-// CHECK-LINE: @llvm.compiler.used = appending global [2 x ptr] [ptr @Double, ptr @add], section "llvm.metadata"
+// CHECK: {{^}}@llvm.compiler.used = appending global [2 x ptr] [ptr @Double, ptr @add], section "llvm.metadata"{{$}}
 
 // CHECK-LABEL: define double @Double(double %0){{.*}} {
 // CHECK-NEXT: _llgo_0:

--- a/cl/_testdata/foo/foo.go
+++ b/cl/_testdata/foo/foo.go
@@ -1,9 +1,9 @@
 // LITTEST
 package foo
 
-// CHECK-LINE: @6 = private unnamed_addr constant [43 x i8] c"{{.*}}/cl/_testdata/foo.Foo", align 1
-// CHECK-LINE: @7 = private unnamed_addr constant [2 x i8] c"Pb", align 1
-// CHECK-LINE: @8 = private unnamed_addr constant [4 x i8] c"load", align 1
+// CHECK: {{^}}@6 = private unnamed_addr constant [43 x i8] c"{{.*}}/cl/_testdata/foo.Foo", align 1{{$}}
+// CHECK: {{^}}@7 = private unnamed_addr constant [2 x i8] c"Pb", align 1{{$}}
+// CHECK: {{^}}@8 = private unnamed_addr constant [4 x i8] c"load", align 1{{$}}
 
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.eface" @"{{.*}}/cl/_testdata/foo.Bar"(){{.*}} {
 // CHECK-NEXT: _llgo_0:

--- a/cl/_testdata/method/in.go
+++ b/cl/_testdata/method/in.go
@@ -3,8 +3,8 @@ package main
 
 import _ "unsafe"
 
-// CHECK-LINE: @0 = private unnamed_addr constant [44 x i8] c"{{.*}}/cl/_testdata/method.T", align 1
-// CHECK-LINE: @1 = private unnamed_addr constant [3 x i8] c"Add", align 1
+// CHECK: {{^}}@0 = private unnamed_addr constant [44 x i8] c"{{.*}}/cl/_testdata/method.T", align 1{{$}}
+// CHECK: {{^}}@1 = private unnamed_addr constant [3 x i8] c"Add", align 1{{$}}
 
 type T int
 

--- a/cl/_testdata/print/in.go
+++ b/cl/_testdata/print/in.go
@@ -7,21 +7,21 @@ import (
 	"github.com/goplus/lib/c"
 )
 
-// CHECK-LINE: @0 = private unnamed_addr constant [3 x i8] c"%c\00", align 1
-// CHECK-LINE: @1 = private unnamed_addr constant [4 x i8] c"llgo", align 1
-// CHECK-LINE: @4 = private unnamed_addr constant [10 x i8] c"check bool", align 1
-// CHECK-LINE: @7 = private unnamed_addr constant [8 x i8] c"check &^", align 1
-// CHECK-LINE: @21 = private unnamed_addr constant [1 x i8] c"(", align 1
-// CHECK-LINE: @22 = private unnamed_addr constant [2 x i8] c"i)", align 1
-// CHECK-LINE: @23 = private unnamed_addr constant [4 x i8] c"true", align 1
-// CHECK-LINE: @24 = private unnamed_addr constant [5 x i8] c"false", align 1
-// CHECK-LINE: @25 = private unnamed_addr constant [3 x i8] c"NaN", align 1
-// CHECK-LINE: @26 = private unnamed_addr constant [4 x i8] c"+Inf", align 1
-// CHECK-LINE: @27 = private unnamed_addr constant [4 x i8] c"-Inf", align 1
-// CHECK-LINE: @28 = private unnamed_addr constant [16 x i8] c"0123456789abcdef", align 1
-// CHECK-LINE: @29 = private unnamed_addr constant [1 x i8] c"-", align 1
-// CHECK-LINE: @30 = private unnamed_addr constant [1 x i8] c" ", align 1
-// CHECK-LINE: @31 = private unnamed_addr constant [1 x i8] c"\0A", align 1
+// CHECK: {{^}}@0 = private unnamed_addr constant [3 x i8] c"%c\00", align 1{{$}}
+// CHECK: {{^}}@1 = private unnamed_addr constant [4 x i8] c"llgo", align 1{{$}}
+// CHECK: {{^}}@4 = private unnamed_addr constant [10 x i8] c"check bool", align 1{{$}}
+// CHECK: {{^}}@7 = private unnamed_addr constant [8 x i8] c"check &^", align 1{{$}}
+// CHECK: {{^}}@21 = private unnamed_addr constant [1 x i8] c"(", align 1{{$}}
+// CHECK: {{^}}@22 = private unnamed_addr constant [2 x i8] c"i)", align 1{{$}}
+// CHECK: {{^}}@23 = private unnamed_addr constant [4 x i8] c"true", align 1{{$}}
+// CHECK: {{^}}@24 = private unnamed_addr constant [5 x i8] c"false", align 1{{$}}
+// CHECK: {{^}}@25 = private unnamed_addr constant [3 x i8] c"NaN", align 1{{$}}
+// CHECK: {{^}}@26 = private unnamed_addr constant [4 x i8] c"+Inf", align 1{{$}}
+// CHECK: {{^}}@27 = private unnamed_addr constant [4 x i8] c"-Inf", align 1{{$}}
+// CHECK: {{^}}@28 = private unnamed_addr constant [16 x i8] c"0123456789abcdef", align 1{{$}}
+// CHECK: {{^}}@29 = private unnamed_addr constant [1 x i8] c"-", align 1{{$}}
+// CHECK: {{^}}@30 = private unnamed_addr constant [1 x i8] c" ", align 1{{$}}
+// CHECK: {{^}}@31 = private unnamed_addr constant [1 x i8] c"\0A", align 1{{$}}
 
 var minhexdigits = 0
 

--- a/cl/_testdata/vargs/in.go
+++ b/cl/_testdata/vargs/in.go
@@ -3,8 +3,8 @@ package main
 
 import "github.com/goplus/lib/c"
 
-// CHECK-LINE: @0 = private unnamed_addr constant [3 x i8] c"int", align 1
-// CHECK-LINE: @1 = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 1
+// CHECK: @0 = private unnamed_addr constant [3 x i8] c"int", align 1
+// CHECK: @1 = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 1
 
 func main() {
 	test(1, 2, 3)

--- a/cl/_testgo/abimethod/in.go
+++ b/cl/_testgo/abimethod/in.go
@@ -678,7 +678,7 @@ type I2 interface {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %18 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr [[ANON_BUF_ERR]], i64 25 }, ptr %18, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @96, i64 25 }, ptr %18, align 8
 // CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %18, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %19)
 // CHECK-NEXT:   unreachable

--- a/cl/_testgo/abimethod/in.go
+++ b/cl/_testgo/abimethod/in.go
@@ -8,23 +8,23 @@ import (
 	"unsafe"
 )
 
-// CHECK-LINE: @0 = private unnamed_addr constant [45 x i8] c"{{.*}}/cl/_testgo/abimethod.T", align 1
-// CHECK-LINE: @1 = private unnamed_addr constant [5 x i8] c"Demo1", align 1
-// CHECK-LINE: @5 = private unnamed_addr constant [3 x i8] c"int", align 1
-// CHECK-LINE: @14 = private unnamed_addr constant [20 x i8] c"testAnonymous1 error", align 1
-// CHECK-LINE: @16 = private unnamed_addr constant [20 x i8] c"testAnonymous2 error", align 1
-// CHECK-LINE: @18 = private unnamed_addr constant [20 x i8] c"testAnonymous3 error", align 1
-// CHECK-LINE: @19 = private unnamed_addr constant [20 x i8] c"testAnonymous4 error", align 1
-// CHECK-LINE: @21 = private unnamed_addr constant [20 x i8] c"testAnonymous5 error", align 1
-// CHECK-LINE: @22 = private unnamed_addr constant [20 x i8] c"testAnonymous6 error", align 1
-// CHECK-LINE: @24 = private unnamed_addr constant [20 x i8] c"testAnonymous7 error", align 1
-// CHECK-LINE: @26 = private unnamed_addr constant [20 x i8] c"testAnonymous8 error", align 1
-// CHECK-LINE: @27 = private unnamed_addr constant [5 x i8] c"hello", align 1
-// CHECK-LINE: @96 = private unnamed_addr constant [25 x i8] c"testAnonymousBuffer error", align 1
-// CHECK-LINE: @109 = private unnamed_addr constant [17 x i8] c"testGeneric error", align 1
-// CHECK-LINE: @110 = private unnamed_addr constant [16 x i8] c"testNamed1 error", align 1
-// CHECK-LINE: @111 = private unnamed_addr constant [16 x i8] c"testNamed2 error", align 1
-// CHECK-LINE: @112 = private unnamed_addr constant [16 x i8] c"testNamed4 error", align 1
+// CHECK: @0 = private unnamed_addr constant [45 x i8] c"{{.*}}/cl/_testgo/abimethod.T", align 1
+// CHECK: @1 = private unnamed_addr constant [5 x i8] c"Demo1", align 1
+// CHECK: @5 = private unnamed_addr constant [3 x i8] c"int", align 1
+// CHECK: @14 = private unnamed_addr constant [20 x i8] c"testAnonymous1 error", align 1
+// CHECK: @16 = private unnamed_addr constant [20 x i8] c"testAnonymous2 error", align 1
+// CHECK: @18 = private unnamed_addr constant [20 x i8] c"testAnonymous3 error", align 1
+// CHECK: @19 = private unnamed_addr constant [20 x i8] c"testAnonymous4 error", align 1
+// CHECK: @21 = private unnamed_addr constant [20 x i8] c"testAnonymous5 error", align 1
+// CHECK: @22 = private unnamed_addr constant [20 x i8] c"testAnonymous6 error", align 1
+// CHECK: @24 = private unnamed_addr constant [20 x i8] c"testAnonymous7 error", align 1
+// CHECK: @26 = private unnamed_addr constant [20 x i8] c"testAnonymous8 error", align 1
+// CHECK: @27 = private unnamed_addr constant [5 x i8] c"hello", align 1
+// CHECK: @96 = private unnamed_addr constant [25 x i8] c"testAnonymousBuffer error", align 1
+// CHECK: @109 = private unnamed_addr constant [17 x i8] c"testGeneric error", align 1
+// CHECK: @110 = private unnamed_addr constant [16 x i8] c"testNamed1 error", align 1
+// CHECK: @111 = private unnamed_addr constant [16 x i8] c"testNamed2 error", align 1
+// CHECK: @112 = private unnamed_addr constant [16 x i8] c"testNamed4 error", align 1
 
 type T struct {
 	n int
@@ -678,7 +678,7 @@ type I2 interface {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %18 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @96, i64 25 }, ptr %18, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr [[ANON_BUF_ERR]], i64 25 }, ptr %18, align 8
 // CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %18, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %19)
 // CHECK-NEXT:   unreachable

--- a/cl/_testgo/closureall/in.go
+++ b/cl/_testgo/closureall/in.go
@@ -5,10 +5,10 @@ import _ "unsafe" // for go:linkname
 
 import "github.com/goplus/lib/c"
 
-// CHECK-LINE: @0 = private unnamed_addr constant [46 x i8] c"{{.*}}/cl/_testgo/closureall.S", align 1
-// CHECK-LINE: @1 = private unnamed_addr constant [3 x i8] c"Inc", align 1
-// CHECK-LINE: @7 = private unnamed_addr constant [3 x i8] c"Add", align 1
-// CHECK-LINE: @9 = private unnamed_addr constant [23 x i8] c"interface{Add(int) int}", align 1
+// CHECK: @0 = private unnamed_addr constant [46 x i8] c"{{.*}}/cl/_testgo/closureall.S", align 1
+// CHECK: @1 = private unnamed_addr constant [3 x i8] c"Inc", align 1
+// CHECK: @7 = private unnamed_addr constant [3 x i8] c"Add", align 1
+// CHECK: @9 = private unnamed_addr constant [23 x i8] c"interface{Add(int) int}", align 1
 
 //go:linkname cSqrt C.sqrt
 func cSqrt(x c.Double) c.Double

--- a/cl/_testgo/cursor/in.go
+++ b/cl/_testgo/cursor/in.go
@@ -7,13 +7,13 @@ import (
 	"math"
 )
 
-// CHECK-LINE: @0 = private unnamed_addr constant [36 x i8] c"iterator call did not preserve panic", align 1
-// CHECK-LINE: @2 = private unnamed_addr constant [43 x i8] c"yield function called after range loop exit", align 1
-// CHECK-LINE: @3 = private unnamed_addr constant [47 x i8] c"{{.*}}/cl/_testgo/cursor.Cursor", align 1
-// CHECK-LINE: @4 = private unnamed_addr constant [8 x i8] c"FindNode", align 1
-// CHECK-LINE: @5 = private unnamed_addr constant [4 x i8] c"Node", align 1
-// CHECK-LINE: @6 = private unnamed_addr constant [8 x i8] c"Preorder", align 1
-// CHECK-LINE: @7 = private unnamed_addr constant [7 x i8] c"indices", align 1
+// CHECK: {{^}}@0 = private unnamed_addr constant [36 x i8] c"iterator call did not preserve panic", align 1{{$}}
+// CHECK: {{^}}@2 = private unnamed_addr constant [43 x i8] c"yield function called after range loop exit", align 1{{$}}
+// CHECK: {{^}}@3 = private unnamed_addr constant [47 x i8] c"{{.*}}/cl/_testgo/cursor.Cursor", align 1{{$}}
+// CHECK: {{^}}@4 = private unnamed_addr constant [8 x i8] c"FindNode", align 1{{$}}
+// CHECK: {{^}}@5 = private unnamed_addr constant [4 x i8] c"Node", align 1{{$}}
+// CHECK: {{^}}@6 = private unnamed_addr constant [8 x i8] c"Preorder", align 1{{$}}
+// CHECK: {{^}}@7 = private unnamed_addr constant [7 x i8] c"indices", align 1{{$}}
 
 func main() {
 	c := &Cursor{in: &Inspector{}}

--- a/cl/_testgo/genericembediface/in.go
+++ b/cl/_testgo/genericembediface/in.go
@@ -5,12 +5,12 @@ import (
 	"github.com/goplus/llgo/cl/_testgo/genericembediface/streamlib"
 )
 
-// CHECK-LINE: @2 = private unnamed_addr constant [20 x i8] c"ServerReflectionInfo", align 1
-// CHECK-LINE: @5 = private unnamed_addr constant [7 x i8] c"Context", align 1
-// CHECK-LINE: @10 = private unnamed_addr constant [68 x i8] c"{{.*}}/cl/_testgo/genericembediface.ReflectionServer", align 1
-// CHECK-LINE: @19 = private unnamed_addr constant [4 x i8] c"pass", align 1
-// CHECK-LINE: @20 = private unnamed_addr constant [58 x i8] c"{{.*}}/cl/_testgo/genericembediface.server", align 1
-// CHECK-LINE: @21 = private unnamed_addr constant [58 x i8] c"{{.*}}/cl/_testgo/genericembediface.stream", align 1
+// CHECK: @2 = private unnamed_addr constant [20 x i8] c"ServerReflectionInfo", align 1
+// CHECK: @5 = private unnamed_addr constant [7 x i8] c"Context", align 1
+// CHECK: @10 = private unnamed_addr constant [68 x i8] c"{{.*}}/cl/_testgo/genericembediface.ReflectionServer", align 1
+// CHECK: @19 = private unnamed_addr constant [4 x i8] c"pass", align 1
+// CHECK: @20 = private unnamed_addr constant [58 x i8] c"{{.*}}/cl/_testgo/genericembediface.server", align 1
+// CHECK: @21 = private unnamed_addr constant [58 x i8] c"{{.*}}/cl/_testgo/genericembediface.stream", align 1
 
 type Request struct{}
 type Response struct{}

--- a/cl/_testgo/genericiter/in.go
+++ b/cl/_testgo/genericiter/in.go
@@ -1,8 +1,8 @@
 // LITTEST
 package main
 
-// CHECK-LINE: @0 = private unnamed_addr constant [17 x i8] c"bad Ascend result", align 1
-// CHECK-LINE: @2 = private unnamed_addr constant [2 x i8] c"ok", align 1
+// CHECK: {{^}}@0 = private unnamed_addr constant [17 x i8] c"bad Ascend result", align 1{{$}}
+// CHECK: {{^}}@2 = private unnamed_addr constant [2 x i8] c"ok", align 1{{$}}
 
 type IteratorG[T any] func(T) bool
 

--- a/cl/_testgo/ifaceconv/in.go
+++ b/cl/_testgo/ifaceconv/in.go
@@ -3,22 +3,22 @@ package main
 
 // Tests of interface conversions and type assertions.
 
-// CHECK-LINE: @0 = private unnamed_addr constant [46 x i8] c"{{.*}}/cl/_testgo/ifaceconv.C1", align 1
-// CHECK-LINE: @1 = private unnamed_addr constant [1 x i8] c"f", align 1
-// CHECK-LINE: @2 = private unnamed_addr constant [46 x i8] c"{{.*}}/cl/_testgo/ifaceconv.C2", align 1
-// CHECK-LINE: @3 = private unnamed_addr constant [1 x i8] c"g", align 1
-// CHECK-LINE: @6 = private unnamed_addr constant [21 x i8] c"nil i0.(I0) succeeded", align 1
-// CHECK-LINE: @11 = private unnamed_addr constant [21 x i8] c"nil i1.(I1) succeeded", align 1
-// CHECK-LINE: @14 = private unnamed_addr constant [21 x i8] c"nil i2.(I2) succeeded", align 1
-// CHECK-LINE: @17 = private unnamed_addr constant [17 x i8] c"C1 i1.(I0) failed", align 1
-// CHECK-LINE: @19 = private unnamed_addr constant [17 x i8] c"C1 i1.(I1) failed", align 1
-// CHECK-LINE: @20 = private unnamed_addr constant [20 x i8] c"C1 i1.(I2) succeeded", align 1
-// CHECK-LINE: @22 = private unnamed_addr constant [17 x i8] c"C2 i1.(I0) failed", align 1
-// CHECK-LINE: @23 = private unnamed_addr constant [17 x i8] c"C2 i1.(I1) failed", align 1
-// CHECK-LINE: @24 = private unnamed_addr constant [17 x i8] c"C2 i1.(I2) failed", align 1
-// CHECK-LINE: @25 = private unnamed_addr constant [17 x i8] c"C1 I0(i1) was nil", align 1
-// CHECK-LINE: @26 = private unnamed_addr constant [17 x i8] c"C1 I1(i1) was nil", align 1
-// CHECK-LINE: @27 = private unnamed_addr constant [4 x i8] c"pass", align 1
+// CHECK: {{^}}@0 = private unnamed_addr constant [46 x i8] c"{{.*}}/cl/_testgo/ifaceconv.C1", align 1{{$}}
+// CHECK: {{^}}@1 = private unnamed_addr constant [1 x i8] c"f", align 1{{$}}
+// CHECK: {{^}}@2 = private unnamed_addr constant [46 x i8] c"{{.*}}/cl/_testgo/ifaceconv.C2", align 1{{$}}
+// CHECK: {{^}}@3 = private unnamed_addr constant [1 x i8] c"g", align 1{{$}}
+// CHECK: {{^}}@6 = private unnamed_addr constant [21 x i8] c"nil i0.(I0) succeeded", align 1{{$}}
+// CHECK: {{^}}@11 = private unnamed_addr constant [21 x i8] c"nil i1.(I1) succeeded", align 1{{$}}
+// CHECK: {{^}}@14 = private unnamed_addr constant [21 x i8] c"nil i2.(I2) succeeded", align 1{{$}}
+// CHECK: {{^}}@17 = private unnamed_addr constant [17 x i8] c"C1 i1.(I0) failed", align 1{{$}}
+// CHECK: {{^}}@19 = private unnamed_addr constant [17 x i8] c"C1 i1.(I1) failed", align 1{{$}}
+// CHECK: {{^}}@20 = private unnamed_addr constant [20 x i8] c"C1 i1.(I2) succeeded", align 1{{$}}
+// CHECK: {{^}}@22 = private unnamed_addr constant [17 x i8] c"C2 i1.(I0) failed", align 1{{$}}
+// CHECK: {{^}}@23 = private unnamed_addr constant [17 x i8] c"C2 i1.(I1) failed", align 1{{$}}
+// CHECK: {{^}}@24 = private unnamed_addr constant [17 x i8] c"C2 i1.(I2) failed", align 1{{$}}
+// CHECK: {{^}}@25 = private unnamed_addr constant [17 x i8] c"C1 I0(i1) was nil", align 1{{$}}
+// CHECK: {{^}}@26 = private unnamed_addr constant [17 x i8] c"C1 I1(i1) was nil", align 1{{$}}
+// CHECK: {{^}}@27 = private unnamed_addr constant [4 x i8] c"pass", align 1{{$}}
 
 type I0 interface {
 }

--- a/cl/_testgo/ifaceprom/in.go
+++ b/cl/_testgo/ifaceprom/in.go
@@ -5,11 +5,11 @@ package main
 // struct.  In particular, this test exercises that the correct
 // method is called.
 
-// CHECK-LINE: @0 = private unnamed_addr constant [3 x i8] c"two", align 1
-// CHECK-LINE: @1 = private unnamed_addr constant [48 x i8] c"{{.*}}/cl/_testgo/ifaceprom.impl", align 1
-// CHECK-LINE: @2 = private unnamed_addr constant [3 x i8] c"one", align 1
-// CHECK-LINE: @13 = private unnamed_addr constant [45 x i8] c"{{.*}}/cl/_testgo/ifaceprom.I", align 1
-// CHECK-LINE: @14 = private unnamed_addr constant [4 x i8] c"pass", align 1
+// CHECK: @0 = private unnamed_addr constant [3 x i8] c"two", align 1
+// CHECK: @1 = private unnamed_addr constant [48 x i8] c"{{.*}}/cl/_testgo/ifaceprom.impl", align 1
+// CHECK: @2 = private unnamed_addr constant [3 x i8] c"one", align 1
+// CHECK: @13 = private unnamed_addr constant [45 x i8] c"{{.*}}/cl/_testgo/ifaceprom.I", align 1
+// CHECK: @14 = private unnamed_addr constant [4 x i8] c"pass", align 1
 
 type I interface {
 	one() int

--- a/cl/_testgo/invoke/in.go
+++ b/cl/_testgo/invoke/in.go
@@ -1,25 +1,25 @@
 // LITTEST
 package main
 
-// CHECK-LINE: @0 = private unnamed_addr constant [6 x i8] c"invoke", align 1
-// CHECK-LINE: @1 = private unnamed_addr constant [42 x i8] c"{{.*}}/cl/_testgo/invoke.T", align 1
-// CHECK-LINE: @2 = private unnamed_addr constant [6 x i8] c"Invoke", align 1
-// CHECK-LINE: @3 = private unnamed_addr constant [7 x i8] c"invoke1", align 1
-// CHECK-LINE: @4 = private unnamed_addr constant [43 x i8] c"{{.*}}/cl/_testgo/invoke.T1", align 1
-// CHECK-LINE: @5 = private unnamed_addr constant [7 x i8] c"invoke2", align 1
-// CHECK-LINE: @6 = private unnamed_addr constant [43 x i8] c"{{.*}}/cl/_testgo/invoke.T2", align 1
-// CHECK-LINE: @7 = private unnamed_addr constant [7 x i8] c"invoke3", align 1
-// CHECK-LINE: @8 = private unnamed_addr constant [7 x i8] c"invoke4", align 1
-// CHECK-LINE: @9 = private unnamed_addr constant [43 x i8] c"{{.*}}/cl/_testgo/invoke.T4", align 1
-// CHECK-LINE: @10 = private unnamed_addr constant [7 x i8] c"invoke5", align 1
-// CHECK-LINE: @11 = private unnamed_addr constant [43 x i8] c"{{.*}}/cl/_testgo/invoke.T5", align 1
-// CHECK-LINE: @12 = private unnamed_addr constant [7 x i8] c"invoke6", align 1
-// CHECK-LINE: @13 = private unnamed_addr constant [43 x i8] c"{{.*}}/cl/_testgo/invoke.T6", align 1
-// CHECK-LINE: @14 = private unnamed_addr constant [5 x i8] c"hello", align 1
-// CHECK-LINE: @36 = private unnamed_addr constant [5 x i8] c"world", align 1
-// CHECK-LINE: @38 = private unnamed_addr constant [42 x i8] c"{{.*}}/cl/_testgo/invoke.I", align 1
-// CHECK-LINE: @40 = private unnamed_addr constant [3 x i8] c"any", align 1
-// CHECK-LINE: @41 = private unnamed_addr constant [23 x i8] c"interface{Invoke() int}", align 1
+// CHECK: @0 = private unnamed_addr constant [6 x i8] c"invoke", align 1
+// CHECK: @1 = private unnamed_addr constant [42 x i8] c"{{.*}}/cl/_testgo/invoke.T", align 1
+// CHECK: @2 = private unnamed_addr constant [6 x i8] c"Invoke", align 1
+// CHECK: @3 = private unnamed_addr constant [7 x i8] c"invoke1", align 1
+// CHECK: @4 = private unnamed_addr constant [43 x i8] c"{{.*}}/cl/_testgo/invoke.T1", align 1
+// CHECK: @5 = private unnamed_addr constant [7 x i8] c"invoke2", align 1
+// CHECK: @6 = private unnamed_addr constant [43 x i8] c"{{.*}}/cl/_testgo/invoke.T2", align 1
+// CHECK: @7 = private unnamed_addr constant [7 x i8] c"invoke3", align 1
+// CHECK: @8 = private unnamed_addr constant [7 x i8] c"invoke4", align 1
+// CHECK: @9 = private unnamed_addr constant [43 x i8] c"{{.*}}/cl/_testgo/invoke.T4", align 1
+// CHECK: @10 = private unnamed_addr constant [7 x i8] c"invoke5", align 1
+// CHECK: @11 = private unnamed_addr constant [43 x i8] c"{{.*}}/cl/_testgo/invoke.T5", align 1
+// CHECK: @12 = private unnamed_addr constant [7 x i8] c"invoke6", align 1
+// CHECK: @13 = private unnamed_addr constant [43 x i8] c"{{.*}}/cl/_testgo/invoke.T6", align 1
+// CHECK: @14 = private unnamed_addr constant [5 x i8] c"hello", align 1
+// CHECK: @36 = private unnamed_addr constant [5 x i8] c"world", align 1
+// CHECK: @38 = private unnamed_addr constant [42 x i8] c"{{.*}}/cl/_testgo/invoke.I", align 1
+// CHECK: @40 = private unnamed_addr constant [3 x i8] c"any", align 1
+// CHECK: @41 = private unnamed_addr constant [23 x i8] c"interface{Invoke() int}", align 1
 
 type T struct {
 	s string

--- a/cl/_testgo/reader/in.go
+++ b/cl/_testgo/reader/in.go
@@ -5,21 +5,21 @@ import (
 	"unicode/utf8"
 )
 
-// CHECK-LINE: @2 = private unnamed_addr constant [7 x i8] c"WriteTo", align 1
-// CHECK-LINE: @17 = private unnamed_addr constant [5 x i8] c"Close", align 1
-// CHECK-LINE: @28 = private unnamed_addr constant [3 x i8] c"EOF", align 1
-// CHECK-LINE: @29 = private unnamed_addr constant [11 x i8] c"short write", align 1
-// CHECK-LINE: @30 = private unnamed_addr constant [11 x i8] c"hello world", align 1
-// CHECK-LINE: @53 = private unnamed_addr constant [50 x i8] c"{{.*}}/cl/_testgo/reader.nopCloser", align 1
-// CHECK-LINE: @54 = private unnamed_addr constant [49 x i8] c"{{.*}}/cl/_testgo/reader.WriterTo", align 1
-// CHECK-LINE: @55 = private unnamed_addr constant [58 x i8] c"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", align 1
-// CHECK-LINE: @56 = private unnamed_addr constant [37 x i8] c"stringsReader.ReadAt: negative offset", align 1
-// CHECK-LINE: @57 = private unnamed_addr constant [34 x i8] c"stringsReader.Seek: invalid whence", align 1
-// CHECK-LINE: @58 = private unnamed_addr constant [37 x i8] c"stringsReader.Seek: negative position", align 1
-// CHECK-LINE: @59 = private unnamed_addr constant [48 x i8] c"stringsReader.UnreadByte: at beginning of string", align 1
-// CHECK-LINE: @60 = private unnamed_addr constant [49 x i8] c"strings.Reader.UnreadRune: at beginning of string", align 1
-// CHECK-LINE: @61 = private unnamed_addr constant [62 x i8] c"strings.Reader.UnreadRune: previous operation was not ReadRune", align 1
-// CHECK-LINE: @62 = private unnamed_addr constant [48 x i8] c"stringsReader.WriteTo: invalid WriteString count", align 1
+// CHECK: @2 = private unnamed_addr constant [7 x i8] c"WriteTo", align 1
+// CHECK: @17 = private unnamed_addr constant [5 x i8] c"Close", align 1
+// CHECK: @28 = private unnamed_addr constant [3 x i8] c"EOF", align 1
+// CHECK: @29 = private unnamed_addr constant [11 x i8] c"short write", align 1
+// CHECK: @30 = private unnamed_addr constant [11 x i8] c"hello world", align 1
+// CHECK: @53 = private unnamed_addr constant [50 x i8] c"{{.*}}/cl/_testgo/reader.nopCloser", align 1
+// CHECK: @54 = private unnamed_addr constant [49 x i8] c"{{.*}}/cl/_testgo/reader.WriterTo", align 1
+// CHECK: @55 = private unnamed_addr constant [58 x i8] c"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", align 1
+// CHECK: @56 = private unnamed_addr constant [37 x i8] c"stringsReader.ReadAt: negative offset", align 1
+// CHECK: @57 = private unnamed_addr constant [34 x i8] c"stringsReader.Seek: invalid whence", align 1
+// CHECK: @58 = private unnamed_addr constant [37 x i8] c"stringsReader.Seek: negative position", align 1
+// CHECK: @59 = private unnamed_addr constant [48 x i8] c"stringsReader.UnreadByte: at beginning of string", align 1
+// CHECK: @60 = private unnamed_addr constant [49 x i8] c"strings.Reader.UnreadRune: at beginning of string", align 1
+// CHECK: @61 = private unnamed_addr constant [62 x i8] c"strings.Reader.UnreadRune: previous operation was not ReadRune", align 1
+// CHECK: @62 = private unnamed_addr constant [48 x i8] c"stringsReader.WriteTo: invalid WriteString count", align 1
 
 type Reader interface {
 	Read(p []byte) (n int, err error)

--- a/cl/_testgo/recoverthenpanic/in.go
+++ b/cl/_testgo/recoverthenpanic/in.go
@@ -1,9 +1,9 @@
 // LITTEST
 package main
 
-// CHECK-LINE: @0 = private unnamed_addr constant [19 x i8] c"will panic in defer", align 1
-// CHECK-LINE: @1 = private unnamed_addr constant [3 x i8] c"end", align 1
-// CHECK-LINE: @2 = private unnamed_addr constant [13 x i8] c"panic in main", align 1
+// CHECK: @0 = private unnamed_addr constant [19 x i8] c"will panic in defer", align 1
+// CHECK: @1 = private unnamed_addr constant [3 x i8] c"end", align 1
+// CHECK: @2 = private unnamed_addr constant [13 x i8] c"panic in main", align 1
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/recoverthenpanic.End"(){{.*}} {
 // CHECK-NEXT: _llgo_0:

--- a/cl/_testgo/reflect/in.go
+++ b/cl/_testgo/reflect/in.go
@@ -6,22 +6,22 @@ import (
 	"unsafe"
 )
 
-// CHECK-LINE: @0 = private unnamed_addr constant [11 x i8] c"call.method", align 1
-// CHECK-LINE: @2 = private unnamed_addr constant [3 x i8] c"int", align 1
-// CHECK-LINE: @6 = private unnamed_addr constant [7 x i8] c"closure", align 1
-// CHECK-LINE: @7 = private unnamed_addr constant [5 x i8] c"error", align 1
-// CHECK-LINE: @9 = private unnamed_addr constant [12 x i8] c"call.closure", align 1
-// CHECK-LINE: @10 = private unnamed_addr constant [4 x i8] c"func", align 1
-// CHECK-LINE: @11 = private unnamed_addr constant [9 x i8] c"call.func", align 1
-// CHECK-LINE: @17 = private unnamed_addr constant [7 x i8] c"imethod", align 1
-// CHECK-LINE: @18 = private unnamed_addr constant [6 x i8] c"method", align 1
-// CHECK-LINE: @22 = private unnamed_addr constant [10 x i8] c"call.slice", align 1
-// CHECK-LINE: @36 = private unnamed_addr constant [5 x i8] c"hello", align 1
-// CHECK-LINE: @37 = private unnamed_addr constant [5 x i8] c"world", align 1
-// CHECK-LINE: @38 = private unnamed_addr constant [14 x i8] c"MapIndex error", align 1
-// CHECK-LINE: @39 = private unnamed_addr constant [4 x i8] c"todo", align 1
-// CHECK-LINE: @40 = private unnamed_addr constant [12 x i8] c"must invalid", align 1
-// CHECK-LINE: @41 = private unnamed_addr constant [13 x i8] c"MapIter error", align 1
+// CHECK: @0 = private unnamed_addr constant [11 x i8] c"call.method", align 1
+// CHECK: @2 = private unnamed_addr constant [3 x i8] c"int", align 1
+// CHECK: @6 = private unnamed_addr constant [7 x i8] c"closure", align 1
+// CHECK: @7 = private unnamed_addr constant [5 x i8] c"error", align 1
+// CHECK: @9 = private unnamed_addr constant [12 x i8] c"call.closure", align 1
+// CHECK: @10 = private unnamed_addr constant [4 x i8] c"func", align 1
+// CHECK: @11 = private unnamed_addr constant [9 x i8] c"call.func", align 1
+// CHECK: @17 = private unnamed_addr constant [7 x i8] c"imethod", align 1
+// CHECK: @18 = private unnamed_addr constant [6 x i8] c"method", align 1
+// CHECK: @22 = private unnamed_addr constant [10 x i8] c"call.slice", align 1
+// CHECK: @36 = private unnamed_addr constant [5 x i8] c"hello", align 1
+// CHECK: @37 = private unnamed_addr constant [5 x i8] c"world", align 1
+// CHECK: @38 = private unnamed_addr constant [14 x i8] c"MapIndex error", align 1
+// CHECK: @39 = private unnamed_addr constant [4 x i8] c"todo", align 1
+// CHECK: @40 = private unnamed_addr constant [12 x i8] c"must invalid", align 1
+// CHECK: @41 = private unnamed_addr constant [13 x i8] c"MapIter error", align 1
 
 func main() {
 	callSlice()
@@ -119,7 +119,7 @@ type T struct {
 // CHECK-NEXT:   %8 = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %6)
 // CHECK-NEXT:   %9 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %8)
 // CHECK-NEXT:   %10 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %8, 0
-// CHECK-NEXT:   %11 = getelementptr ptr, ptr %10, i64 37
+// CHECK-NEXT:   %11 = getelementptr ptr, ptr %10, i64 {{(37|41)}}
 // CHECK-NEXT:   %12 = load ptr, ptr %11, align 8
 // CHECK-NEXT:   %13 = insertvalue { ptr, ptr } undef, ptr %12, 0
 // CHECK-NEXT:   %14 = insertvalue { ptr, ptr } %13, ptr %9, 1
@@ -209,7 +209,7 @@ type T struct {
 // CHECK-NEXT:   %4 = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %2)
 // CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %4)
 // CHECK-NEXT:   %6 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %4, 0
-// CHECK-NEXT:   %7 = getelementptr ptr, ptr %6, i64 37
+// CHECK-NEXT:   %7 = getelementptr ptr, ptr %6, i64 {{(37|41)}}
 // CHECK-NEXT:   %8 = load ptr, ptr %7, align 8
 // CHECK-NEXT:   %9 = insertvalue { ptr, ptr } undef, ptr %8, 0
 // CHECK-NEXT:   %10 = insertvalue { ptr, ptr } %9, ptr %5, 1
@@ -335,7 +335,7 @@ func callMethod() {
 // CHECK-NEXT:   %12 = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %10)
 // CHECK-NEXT:   %13 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %12)
 // CHECK-NEXT:   %14 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %12, 0
-// CHECK-NEXT:   %15 = getelementptr ptr, ptr %14, i64 37
+// CHECK-NEXT:   %15 = getelementptr ptr, ptr %14, i64 {{(37|41)}}
 // CHECK-NEXT:   %16 = load ptr, ptr %15, align 8
 // CHECK-NEXT:   %17 = insertvalue { ptr, ptr } undef, ptr %16, 0
 // CHECK-NEXT:   %18 = insertvalue { ptr, ptr } %17, ptr %13, 1
@@ -437,7 +437,7 @@ func callMethod() {
 // CHECK-NEXT:   %6 = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %4)
 // CHECK-NEXT:   %7 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %6)
 // CHECK-NEXT:   %8 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %6, 0
-// CHECK-NEXT:   %9 = getelementptr ptr, ptr %8, i64 37
+// CHECK-NEXT:   %9 = getelementptr ptr, ptr %8, i64 {{(37|41)}}
 // CHECK-NEXT:   %10 = load ptr, ptr %9, align 8
 // CHECK-NEXT:   %11 = insertvalue { ptr, ptr } undef, ptr %10, 0
 // CHECK-NEXT:   %12 = insertvalue { ptr, ptr } %11, ptr %7, 1
@@ -854,7 +854,7 @@ func callIMethod() {
 // CHECK-NEXT:   %43 = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %6)
 // CHECK-NEXT:   %44 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %43)
 // CHECK-NEXT:   %45 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %43, 0
-// CHECK-NEXT:   %46 = getelementptr ptr, ptr %45, i64 20
+// CHECK-NEXT:   %46 = getelementptr ptr, ptr %45, i64 {{(20|22)}}
 // CHECK-NEXT:   %47 = load ptr, ptr %46, align 8
 // CHECK-NEXT:   %48 = insertvalue { ptr, ptr } undef, ptr %47, 0
 // CHECK-NEXT:   %49 = insertvalue { ptr, ptr } %48, ptr %44, 1
@@ -1051,7 +1051,7 @@ func mapDemo1() {
 // CHECK-NEXT:   %56 = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.Value.Type(%reflect.Value %7)
 // CHECK-NEXT:   %57 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %56)
 // CHECK-NEXT:   %58 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %56, 0
-// CHECK-NEXT:   %59 = getelementptr ptr, ptr %58, i64 20
+// CHECK-NEXT:   %59 = getelementptr ptr, ptr %58, i64 {{(20|22)}}
 // CHECK-NEXT:   %60 = load ptr, ptr %59, align 8
 // CHECK-NEXT:   %61 = insertvalue { ptr, ptr } undef, ptr %60, 0
 // CHECK-NEXT:   %62 = insertvalue { ptr, ptr } %61, ptr %57, 1

--- a/cl/_testgo/reflectmk/in.go
+++ b/cl/_testgo/reflectmk/in.go
@@ -6,22 +6,22 @@ import (
 	"reflect"
 )
 
-// CHECK-LINE: @1 = private unnamed_addr constant [7 x i8] c"(%v,%v)", align 1
-// CHECK-LINE: @2 = private unnamed_addr constant [49 x i8] c"{{.*}}/cl/_testgo/reflectmk.Point", align 1
-// CHECK-LINE: @3 = private unnamed_addr constant [6 x i8] c"String", align 1
-// CHECK-LINE: @12 = private unnamed_addr constant [13 x i8] c"arrayOf error", align 1
-// CHECK-LINE: @13 = private unnamed_addr constant [12 x i8] c"chanOf error", align 1
-// CHECK-LINE: @14 = private unnamed_addr constant [12 x i8] c"funcOf error", align 1
-// CHECK-LINE: @15 = private unnamed_addr constant [11 x i8] c"mapOf error", align 1
-// CHECK-LINE: @16 = private unnamed_addr constant [15 x i8] c"pointerTo error", align 1
-// CHECK-LINE: @17 = private unnamed_addr constant [13 x i8] c"sliceOf error", align 1
-// CHECK-LINE: @18 = private unnamed_addr constant [1 x i8] c"T", align 1
-// CHECK-LINE: @19 = private unnamed_addr constant [14 x i8] c"structOf error", align 1
-// CHECK-LINE: @20 = private unnamed_addr constant [12 x i8] c"method error", align 1
-// CHECK-LINE: @21 = private unnamed_addr constant [18 x i8] c"methodByName error", align 1
-// CHECK-LINE: @22 = private unnamed_addr constant [5 x i8] c"(1,2)", align 1
-// CHECK-LINE: @23 = private unnamed_addr constant [18 x i8] c"value.Method error", align 1
-// CHECK-LINE: @24 = private unnamed_addr constant [24 x i8] c"value.MethodByName error", align 1
+// CHECK: {{^}}@1 = private unnamed_addr constant [7 x i8] c"(%v,%v)", align 1{{$}}
+// CHECK: {{^}}@2 = private unnamed_addr constant [49 x i8] c"{{.*}}/cl/_testgo/reflectmk.Point", align 1{{$}}
+// CHECK: {{^}}@3 = private unnamed_addr constant [6 x i8] c"String", align 1{{$}}
+// CHECK: {{^}}@12 = private unnamed_addr constant [13 x i8] c"arrayOf error", align 1{{$}}
+// CHECK: {{^}}@13 = private unnamed_addr constant [12 x i8] c"chanOf error", align 1{{$}}
+// CHECK: {{^}}@14 = private unnamed_addr constant [12 x i8] c"funcOf error", align 1{{$}}
+// CHECK: {{^}}@15 = private unnamed_addr constant [11 x i8] c"mapOf error", align 1{{$}}
+// CHECK: {{^}}@16 = private unnamed_addr constant [15 x i8] c"pointerTo error", align 1{{$}}
+// CHECK: {{^}}@17 = private unnamed_addr constant [13 x i8] c"sliceOf error", align 1{{$}}
+// CHECK: {{^}}@18 = private unnamed_addr constant [1 x i8] c"T", align 1{{$}}
+// CHECK: {{^}}@19 = private unnamed_addr constant [14 x i8] c"structOf error", align 1{{$}}
+// CHECK: {{^}}@20 = private unnamed_addr constant [12 x i8] c"method error", align 1{{$}}
+// CHECK: {{^}}@21 = private unnamed_addr constant [18 x i8] c"methodByName error", align 1{{$}}
+// CHECK: {{^}}@22 = private unnamed_addr constant [5 x i8] c"(1,2)", align 1{{$}}
+// CHECK: {{^}}@23 = private unnamed_addr constant [18 x i8] c"value.Method error", align 1{{$}}
+// CHECK: {{^}}@24 = private unnamed_addr constant [24 x i8] c"value.MethodByName error", align 1{{$}}
 
 type Point struct {
 	x int
@@ -240,7 +240,7 @@ func methodByName(name string) {
 // CHECK-NEXT:   %64 = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.FuncOf(%"{{.*}}/runtime/internal/runtime.Slice" %58, %"{{.*}}/runtime/internal/runtime.Slice" %63, i1 false)
 // CHECK-NEXT:   %65 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %64)
 // CHECK-NEXT:   %66 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %64, 0
-// CHECK-NEXT:   %67 = getelementptr ptr, ptr %66, i64 18
+// CHECK-NEXT:   %67 = getelementptr ptr, ptr %66, i64 {{(18|19)}}
 // CHECK-NEXT:   %68 = load ptr, ptr %67, align 8
 // CHECK-NEXT:   %69 = insertvalue { ptr, ptr } undef, ptr %68, 0
 // CHECK-NEXT:   %70 = insertvalue { ptr, ptr } %69, ptr %65, 1
@@ -270,7 +270,7 @@ func methodByName(name string) {
 // CHECK-NEXT:   %86 = call %"{{.*}}/runtime/internal/runtime.iface" @reflect.MapOf(%"{{.*}}/runtime/internal/runtime.iface" %9, %"{{.*}}/runtime/internal/runtime.iface" %9)
 // CHECK-NEXT:   %87 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %86)
 // CHECK-NEXT:   %88 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %86, 0
-// CHECK-NEXT:   %89 = getelementptr ptr, ptr %88, i64 20
+// CHECK-NEXT:   %89 = getelementptr ptr, ptr %88, i64 {{(20|22)}}
 // CHECK-NEXT:   %90 = load ptr, ptr %89, align 8
 // CHECK-NEXT:   %91 = insertvalue { ptr, ptr } undef, ptr %90, 0
 // CHECK-NEXT:   %92 = insertvalue { ptr, ptr } %91, ptr %87, 1
@@ -292,7 +292,7 @@ func methodByName(name string) {
 // CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_4
 // CHECK-NEXT:   %106 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %64)
 // CHECK-NEXT:   %107 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %64, 0
-// CHECK-NEXT:   %108 = getelementptr ptr, ptr %107, i64 30
+// CHECK-NEXT:   %108 = getelementptr ptr, ptr %107, i64 {{(30|33)}}
 // CHECK-NEXT:   %109 = load ptr, ptr %108, align 8
 // CHECK-NEXT:   %110 = insertvalue { ptr, ptr } undef, ptr %109, 0
 // CHECK-NEXT:   %111 = insertvalue { ptr, ptr } %110, ptr %106, 1
@@ -445,7 +445,7 @@ func methodByName(name string) {
 // CHECK-NEXT:   call void @llvm.memset(ptr %220, i8 0, i64 80, i1 false)
 // CHECK-NEXT:   %221 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
 // CHECK-NEXT:   %222 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
-// CHECK-NEXT:   %223 = getelementptr ptr, ptr %222, i64 23
+// CHECK-NEXT:   %223 = getelementptr ptr, ptr %222, i64 {{(23|25)}}
 // CHECK-NEXT:   %224 = load ptr, ptr %223, align 8
 // CHECK-NEXT:   %225 = insertvalue { ptr, ptr } undef, ptr %224, 0
 // CHECK-NEXT:   %226 = insertvalue { ptr, ptr } %225, ptr %221, 1
@@ -471,7 +471,7 @@ func methodByName(name string) {
 // CHECK-NEXT:   call void @llvm.memset(ptr %236, i8 0, i64 80, i1 false)
 // CHECK-NEXT:   %237 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
 // CHECK-NEXT:   %238 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
-// CHECK-NEXT:   %239 = getelementptr ptr, ptr %238, i64 24
+// CHECK-NEXT:   %239 = getelementptr ptr, ptr %238, i64 {{(24|26)}}
 // CHECK-NEXT:   %240 = load ptr, ptr %239, align 8
 // CHECK-NEXT:   %241 = insertvalue { ptr, ptr } undef, ptr %240, 0
 // CHECK-NEXT:   %242 = insertvalue { ptr, ptr } %241, ptr %237, 1

--- a/cl/_testgo/selects/in.go
+++ b/cl/_testgo/selects/in.go
@@ -1,13 +1,13 @@
 // LITTEST
 package main
 
-// CHECK-LINE: @0 = private unnamed_addr constant [4 x i8] c"c1<-", align 1
-// CHECK-LINE: @1 = private unnamed_addr constant [4 x i8] c"<-c2", align 1
-// CHECK-LINE: @2 = private unnamed_addr constant [4 x i8] c"<-c4", align 1
-// CHECK-LINE: @3 = private unnamed_addr constant [31 x i8] c"blocking select matched no case", align 1
-// CHECK-LINE: @5 = private unnamed_addr constant [4 x i8] c"<-c1", align 1
-// CHECK-LINE: @6 = private unnamed_addr constant [4 x i8] c"c2<-", align 1
-// CHECK-LINE: @7 = private unnamed_addr constant [4 x i8] c"<-c3", align 1
+// CHECK: {{^}}@0 = private unnamed_addr constant [4 x i8] c"c1<-", align 1{{$}}
+// CHECK: {{^}}@1 = private unnamed_addr constant [4 x i8] c"<-c2", align 1{{$}}
+// CHECK: {{^}}@2 = private unnamed_addr constant [4 x i8] c"<-c4", align 1{{$}}
+// CHECK: {{^}}@3 = private unnamed_addr constant [31 x i8] c"blocking select matched no case", align 1{{$}}
+// CHECK: {{^}}@5 = private unnamed_addr constant [4 x i8] c"<-c1", align 1{{$}}
+// CHECK: {{^}}@6 = private unnamed_addr constant [4 x i8] c"c2<-", align 1{{$}}
+// CHECK: {{^}}@7 = private unnamed_addr constant [4 x i8] c"<-c3", align 1{{$}}
 
 func main() {
 	c1 := make(chan struct{}, 1)

--- a/cl/_testgo/tpinst/main.go
+++ b/cl/_testgo/tpinst/main.go
@@ -1,9 +1,9 @@
 // LITTEST
 package main
 
-// CHECK-LINE: @6 = private unnamed_addr constant [5 x i8] c"value", align 1
-// CHECK-LINE: @9 = private unnamed_addr constant [5 x i8] c"error", align 1
-// CHECK-LINE: @16 = private unnamed_addr constant [22 x i8] c"interface{value() int}", align 1
+// CHECK: @6 = private unnamed_addr constant [5 x i8] c"value", align 1
+// CHECK: @9 = private unnamed_addr constant [5 x i8] c"error", align 1
+// CHECK: @16 = private unnamed_addr constant [22 x i8] c"interface{value() int}", align 1
 
 type M[T interface{}] struct {
 	v T

--- a/cl/_testgo/tpnamed/in.go
+++ b/cl/_testgo/tpnamed/in.go
@@ -46,15 +46,15 @@ func WriteFile(fileName string) IO[error] {
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/tpnamed.main"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call [0 x i8] @"{{.*}}/cl/_testgo/tpnamed.RunIO[[0]byte]"(%"{{.*}}/cl/_testgo/tpnamed.IO[[0]byte]" { ptr @"__llgo_stub.{{.*}}/cl/_testgo/tpnamed.main$1", ptr null })
-// CHECK-NEXT:   ret void
+// CHECK-NEXT:  %0 = call [0 x i8] @"{{.*}}/cl/_testgo/tpnamed.RunIO{{\[\[0\]byte\]}}"(%"{{.*}}/cl/_testgo/tpnamed.IO{{\[\[0\]byte\]}}" { ptr @"__llgo_stub.{{.*}}/cl/_testgo/tpnamed.main$1", ptr null })
+// CHECK-NEXT:  ret void
 // CHECK-NEXT: }
 
 func main() {
 
-	// CHECK-LABEL: define %"{{.*}}/cl/_testgo/tpnamed.Future[[0]byte]" @"{{.*}}/cl/_testgo/tpnamed.main$1"(){{.*}} {
+	// CHECK-LABEL: define %"{{.*}}/cl/_testgo/tpnamed.Future{{\[\[0\]byte\]}}" @"{{.*}}/cl/_testgo/tpnamed.main$1"()
 	// CHECK-NEXT: _llgo_0:
-	// CHECK-NEXT:   ret %"{{.*}}/cl/_testgo/tpnamed.Future[[0]byte]" { ptr @"__llgo_stub.{{.*}}/cl/_testgo/tpnamed.main$1$1", ptr null }
+	// CHECK-NEXT:   ret %"{{.*}}/cl/_testgo/tpnamed.Future{{\[\[0\]byte\]}}" { ptr @"__llgo_stub.{{.*}}/cl/_testgo/tpnamed.main$1$1", ptr null }
 	// CHECK-NEXT: }
 
 	RunIO[Void](func() Future[Void] {
@@ -86,19 +86,19 @@ func RunIO[T any](call IO[T]) T {
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.iface" %1
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/cl/_testgo/tpnamed.Future[[0]byte]" @"__llgo_stub.{{.*}}/cl/_testgo/tpnamed.main$1"(ptr %0){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/cl/_testgo/tpnamed.Future{{\[\[0\]byte\]}}" @"__llgo_stub.{{.*}}/cl/_testgo/tpnamed.main$1"(ptr %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = tail call %"{{.*}}/cl/_testgo/tpnamed.Future[[0]byte]" @"{{.*}}/cl/_testgo/tpnamed.main$1"()
-// CHECK-NEXT:   ret %"{{.*}}/cl/_testgo/tpnamed.Future[[0]byte]" %1
+// CHECK-NEXT:   %1 = tail call %"{{.*}}/cl/_testgo/tpnamed.Future{{\[\[0\]byte\]}}" @"{{.*}}/cl/_testgo/tpnamed.main$1"()
+// CHECK-NEXT:   ret %"{{.*}}/cl/_testgo/tpnamed.Future{{\[\[0\]byte\]}}" %1
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce [0 x i8] @"{{.*}}/cl/_testgo/tpnamed.RunIO[[0]byte]"(%"{{.*}}/cl/_testgo/tpnamed.IO[[0]byte]" %0){{.*}} {
+// CHECK-LABEL: define linkonce [0 x i8] @"{{.*}}/cl/_testgo/tpnamed.RunIO{{\[\[0\]byte\]}}"(%"{{.*}}/cl/_testgo/tpnamed.IO{{\[\[0\]byte\]}}" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %1 = extractvalue %"{{.*}}/cl/_testgo/tpnamed.IO[[0]byte]" %0, 1
-// CHECK-NEXT:   %2 = extractvalue %"{{.*}}/cl/_testgo/tpnamed.IO[[0]byte]" %0, 0
-// CHECK-NEXT:   %3 = call %"{{.*}}/cl/_testgo/tpnamed.Future[[0]byte]" %2(ptr %1)
-// CHECK-NEXT:   %4 = extractvalue %"{{.*}}/cl/_testgo/tpnamed.Future[[0]byte]" %3, 1
-// CHECK-NEXT:   %5 = extractvalue %"{{.*}}/cl/_testgo/tpnamed.Future[[0]byte]" %3, 0
+// CHECK-NEXT:   %1 = extractvalue %"{{.*}}/cl/_testgo/tpnamed.IO{{\[\[0\]byte\]}}" %0, 1
+// CHECK-NEXT:   %2 = extractvalue %"{{.*}}/cl/_testgo/tpnamed.IO{{\[\[0\]byte\]}}" %0, 0
+// CHECK-NEXT:   %3 = call %"{{.*}}/cl/_testgo/tpnamed.Future{{\[\[0\]byte\]}}" %2(ptr %1)
+// CHECK-NEXT:   %4 = extractvalue %"{{.*}}/cl/_testgo/tpnamed.Future{{\[\[0\]byte\]}}" %3, 1
+// CHECK-NEXT:   %5 = extractvalue %"{{.*}}/cl/_testgo/tpnamed.Future{{\[\[0\]byte\]}}" %3, 0
 // CHECK-NEXT:   %6 = icmp eq ptr %5, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %6)
 // CHECK-NEXT:   %7 = call [0 x i8] %5(ptr %4)

--- a/cl/_testgo/tprecur/in.go
+++ b/cl/_testgo/tprecur/in.go
@@ -1,7 +1,7 @@
 // LITTEST
 package main
 
-// CHECK-LINE: @0 = private unnamed_addr constant [5 x i8] c"error", align 1
+// CHECK: {{^}}@0 = private unnamed_addr constant [5 x i8] c"error", align 1{{$}}
 
 func main() {
 	recursive()

--- a/cl/_testgo/tptypes/in.go
+++ b/cl/_testgo/tptypes/in.go
@@ -1,7 +1,7 @@
 // LITTEST
 package main
 
-// CHECK-LINE: @0 = private unnamed_addr constant [5 x i8] c"hello", align 1
+// CHECK: {{^}}@0 = private unnamed_addr constant [5 x i8] c"hello", align 1{{$}}
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/tptypes.init"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
@@ -96,7 +96,7 @@ type (
 // CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %17, 0
 // CHECK-NEXT:   %20 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %19, i64 1, 1
 // CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %20, i64 1, 2
-// CHECK-NEXT:   %22 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/tptypes.(*Slice[[]int,int]).Append"(ptr %16, %"{{.*}}/runtime/internal/runtime.Slice" %21)
+// CHECK-NEXT:   %22 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/tptypes.(*Slice{{\[\[\]int,int\]}}).Append"(ptr %16, %"{{.*}}/runtime/internal/runtime.Slice" %21)
 // CHECK-NEXT:   %23 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
 // CHECK-NEXT:   %24 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   %25 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.String", ptr %24, i64 0
@@ -104,7 +104,7 @@ type (
 // CHECK-NEXT:   %26 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %24, 0
 // CHECK-NEXT:   %27 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %26, i64 1, 1
 // CHECK-NEXT:   %28 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %27, i64 1, 2
-// CHECK-NEXT:   %29 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/tptypes.(*Slice[[]string,string]).Append"(ptr %23, %"{{.*}}/runtime/internal/runtime.Slice" %28)
+// CHECK-NEXT:   %29 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/tptypes.(*Slice{{\[\[\]string,string\]}}).Append"(ptr %23, %"{{.*}}/runtime/internal/runtime.Slice" %28)
 // CHECK-NEXT:   %30 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 24)
 // CHECK-NEXT:   %31 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 32)
 // CHECK-NEXT:   %32 = getelementptr inbounds i64, ptr %31, i64 0
@@ -118,7 +118,7 @@ type (
 // CHECK-NEXT:   %36 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %31, 0
 // CHECK-NEXT:   %37 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %36, i64 4, 1
 // CHECK-NEXT:   %38 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %37, i64 4, 2
-// CHECK-NEXT:   %39 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/tptypes.(*Slice[[]int,int]).Append"(ptr %30, %"{{.*}}/runtime/internal/runtime.Slice" %38)
+// CHECK-NEXT:   %39 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/tptypes.(*Slice{{\[\[\]int,int\]}}).Append"(ptr %30, %"{{.*}}/runtime/internal/runtime.Slice" %38)
 // CHECK-NEXT:   %40 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 32)
 // CHECK-NEXT:   %41 = getelementptr inbounds i64, ptr %40, i64 0
 // CHECK-NEXT:   store i64 1, ptr %41, align 8
@@ -131,10 +131,10 @@ type (
 // CHECK-NEXT:   %45 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %40, 0
 // CHECK-NEXT:   %46 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %45, i64 4, 1
 // CHECK-NEXT:   %47 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %46, i64 4, 2
-// CHECK-NEXT:   %48 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/tptypes.(*Slice[[]int,int]).Append2"(ptr %30, %"{{.*}}/runtime/internal/runtime.Slice" %47)
-// CHECK-NEXT:   %49 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice[[]int,int]", ptr %16, i32 0, i32 0
+// CHECK-NEXT:   %48 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/tptypes.(*Slice{{\[\[\]int,int\]}}).Append2"(ptr %30, %"{{.*}}/runtime/internal/runtime.Slice" %47)
+// CHECK-NEXT:   %49 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]int,int\]}}", ptr %16, i32 0, i32 0
 // CHECK-NEXT:   %50 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %49, align 8
-// CHECK-NEXT:   %51 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice[[]int,int]", ptr %16, i32 0, i32 0
+// CHECK-NEXT:   %51 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]int,int\]}}", ptr %16, i32 0, i32 0
 // CHECK-NEXT:   %52 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %51, align 8
 // CHECK-NEXT:   %53 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %52, 0
 // CHECK-NEXT:   %54 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %52, 1
@@ -146,9 +146,9 @@ type (
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %57)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %58 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice[[]string,string]", ptr %23, i32 0, i32 0
+// CHECK-NEXT:   %58 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]string,string\]}}", ptr %23, i32 0, i32 0
 // CHECK-NEXT:   %59 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %58, align 8
-// CHECK-NEXT:   %60 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice[[]string,string]", ptr %23, i32 0, i32 0
+// CHECK-NEXT:   %60 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]string,string\]}}", ptr %23, i32 0, i32 0
 // CHECK-NEXT:   %61 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %60, align 8
 // CHECK-NEXT:   %62 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %61, 0
 // CHECK-NEXT:   %63 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %61, 1
@@ -160,9 +160,9 @@ type (
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 32)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %66)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %67 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice[[]int,int]", ptr %30, i32 0, i32 0
+// CHECK-NEXT:   %67 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]int,int\]}}", ptr %30, i32 0, i32 0
 // CHECK-NEXT:   %68 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %67, align 8
-// CHECK-NEXT:   %69 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice[[]int,int]", ptr %30, i32 0, i32 0
+// CHECK-NEXT:   %69 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]int,int\]}}", ptr %30, i32 0, i32 0
 // CHECK-NEXT:   %70 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %69, align 8
 // CHECK-NEXT:   %71 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %70, 0
 // CHECK-NEXT:   %72 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %70, 1
@@ -202,44 +202,44 @@ func main() {
 	println(v3.Data, v3.Data[0])
 }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/tptypes.(*Slice[[]int,int]).Append"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/tptypes.(*Slice{{\[\[\]int,int\]}}).Append"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice[[]int,int]", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]int,int\]}}", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %2, align 8
 // CHECK-NEXT:   %4 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %1, 0
 // CHECK-NEXT:   %5 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %1, 1
 // CHECK-NEXT:   %6 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.SliceAppend"(%"{{.*}}/runtime/internal/runtime.Slice" %3, ptr %4, i64 %5, i64 8)
-// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice[[]int,int]", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]int,int\]}}", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.Slice" %6, ptr %7, align 8
-// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice[[]int,int]", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]int,int\]}}", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %9 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %8, align 8
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/tptypes.(*Slice[[]string,string]).Append"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/tptypes.(*Slice{{\[\[\]string,string\]}}).Append"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice[[]string,string]", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]string,string\]}}", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %2, align 8
 // CHECK-NEXT:   %4 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %1, 0
 // CHECK-NEXT:   %5 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %1, 1
 // CHECK-NEXT:   %6 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.SliceAppend"(%"{{.*}}/runtime/internal/runtime.Slice" %3, ptr %4, i64 %5, i64 16)
-// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice[[]string,string]", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]string,string\]}}", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.Slice" %6, ptr %7, align 8
-// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice[[]string,string]", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]string,string\]}}", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %9 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %8, align 8
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %9
 // CHECK-NEXT: }
 
-// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/tptypes.(*Slice[[]int,int]).Append2"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
+// CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/tptypes.(*Slice{{\[\[\]int,int\]}}).Append2"(ptr %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice[[]int,int]", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]int,int\]}}", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %2, align 8
 // CHECK-NEXT:   %4 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %1, 0
 // CHECK-NEXT:   %5 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %1, 1
 // CHECK-NEXT:   %6 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.SliceAppend"(%"{{.*}}/runtime/internal/runtime.Slice" %3, ptr %4, i64 %5, i64 8)
-// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice[[]int,int]", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]int,int\]}}", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.Slice" %6, ptr %7, align 8
-// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice[[]int,int]", ptr %0, i32 0, i32 0
+// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Slice{{\[\[\]int,int\]}}", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %9 = load %"{{.*}}/runtime/internal/runtime.Slice", ptr %8, align 8
 // CHECK-NEXT:   ret %"{{.*}}/runtime/internal/runtime.Slice" %9
 // CHECK-NEXT: }

--- a/cl/_testpy/callpy/in.go
+++ b/cl/_testpy/callpy/in.go
@@ -8,10 +8,10 @@ import (
 	"github.com/goplus/lib/py/os"
 )
 
-// CHECK-LINE: @0 = private unnamed_addr constant [16 x i8] c"sqrt(2) = %.6f\0A\00", align 1
-// CHECK-LINE: @1 = private unnamed_addr constant [13 x i8] c"cwd ok = %d\0A\00", align 1
-// CHECK-LINE: @2 = private unnamed_addr constant [5 x i8] c"sqrt\00", align 1
-// CHECK-LINE: @3 = private unnamed_addr constant [7 x i8] c"getcwd\00", align 1
+// CHECK: @0 = private unnamed_addr constant [16 x i8] c"sqrt(2) = %.6f\0A\00", align 1
+// CHECK: @1 = private unnamed_addr constant [13 x i8] c"cwd ok = %d\0A\00", align 1
+// CHECK: @2 = private unnamed_addr constant [5 x i8] c"sqrt\00", align 1
+// CHECK: @3 = private unnamed_addr constant [7 x i8] c"getcwd\00", align 1
 
 func main() {
 	x := math.Sqrt(py.Float(2))

--- a/cl/_testpy/list/in.go
+++ b/cl/_testpy/list/in.go
@@ -10,14 +10,14 @@ import (
 	"github.com/goplus/lib/py/std"
 )
 
-// CHECK-LINE: @0 = private unnamed_addr constant [5 x i8] c"world", align 1
-// CHECK-LINE: @1 = private unnamed_addr constant [5 x i8] c"hello", align 1
-// CHECK-LINE: @2 = private unnamed_addr constant [3 x i8] c"pi\00", align 1
-// CHECK-LINE: @3 = private unnamed_addr constant [14 x i8] c"lens = %d %d\0A\00", align 1
-// CHECK-LINE: @4 = private unnamed_addr constant [14 x i8] c"ptrs = %d %d\0A\00", align 1
-// CHECK-LINE: @5 = private unnamed_addr constant [12 x i8] c"pi = %.15g\0A\00", align 1
-// CHECK-LINE: @6 = private unnamed_addr constant [4 x i8] c"abs\00", align 1
-// CHECK-LINE: @7 = private unnamed_addr constant [6 x i8] c"print\00", align 1
+// CHECK: @0 = private unnamed_addr constant [5 x i8] c"world", align 1
+// CHECK: @1 = private unnamed_addr constant [5 x i8] c"hello", align 1
+// CHECK: @2 = private unnamed_addr constant [3 x i8] c"pi\00", align 1
+// CHECK: @3 = private unnamed_addr constant [14 x i8] c"lens = %d %d\0A\00", align 1
+// CHECK: @4 = private unnamed_addr constant [14 x i8] c"ptrs = %d %d\0A\00", align 1
+// CHECK: @5 = private unnamed_addr constant [12 x i8] c"pi = %.15g\0A\00", align 1
+// CHECK: @6 = private unnamed_addr constant [4 x i8] c"abs\00", align 1
+// CHECK: @7 = private unnamed_addr constant [6 x i8] c"print\00", align 1
 
 func main() {
 	v := 100

--- a/cl/_testrt/alloca/in.go
+++ b/cl/_testrt/alloca/in.go
@@ -5,8 +5,8 @@ import (
 	"github.com/goplus/lib/c"
 )
 
-// CHECK-LINE: @0 = private unnamed_addr constant [4 x i8] c"Hi\0A\00", align 1
-// CHECK-LINE: @1 = private unnamed_addr constant [3 x i8] c"%s\00", align 1
+// CHECK: {{^}}@0 = private unnamed_addr constant [4 x i8] c"Hi\0A\00", align 1{{$}}
+// CHECK: {{^}}@1 = private unnamed_addr constant [3 x i8] c"%s\00", align 1{{$}}
 // CHECK-LABEL: define void @"{{.*}}alloca.main"(){{.*}} {
 func main() {
 	s := c.Str("Hi\n")

--- a/cl/_testrt/allocstr/in.go
+++ b/cl/_testrt/allocstr/in.go
@@ -5,8 +5,8 @@ import (
 	"github.com/goplus/lib/c"
 )
 
-// CHECK-LINE: %"{{.*}}/runtime/internal/runtime.String" = type { ptr, i64 }
-// CHECK-LINE: @0 = private unnamed_addr constant [12 x i8] c"Hello world\0A", align 1
+// CHECK: {{^}}%"{{.*}}/runtime/internal/runtime.String" = type { ptr, i64 }{{$}}
+// CHECK: {{^}}@0 = private unnamed_addr constant [12 x i8] c"Hello world\0A", align 1{{$}}
 
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testrt/allocstr.hello"(){{.*}} {
 // CHECK-NEXT: _llgo_0:

--- a/cl/_testrt/any/in.go
+++ b/cl/_testrt/any/in.go
@@ -5,10 +5,10 @@ import (
 	"github.com/goplus/lib/c"
 )
 
-// CHECK-LINE: @1 = private unnamed_addr constant [29 x i8] c"*github.com/goplus/lib/c.Char", align 1
-// CHECK-LINE: @2 = private unnamed_addr constant [3 x i8] c"int", align 1
-// CHECK-LINE: @3 = private unnamed_addr constant [7 x i8] c"%s %d\0A\00", align 1
-// CHECK-LINE: @4 = private unnamed_addr constant [6 x i8] c"Hello\00", align 1
+// CHECK: @1 = private unnamed_addr constant [29 x i8] c"*github.com/goplus/lib/c.Char", align 1
+// CHECK: @2 = private unnamed_addr constant [3 x i8] c"int", align 1
+// CHECK: @3 = private unnamed_addr constant [7 x i8] c"%s %d\0A\00", align 1
+// CHECK: @4 = private unnamed_addr constant [6 x i8] c"Hello\00", align 1
 
 // CHECK-LABEL: define ptr @"{{.*}}/cl/_testrt/any.hi"(%"{{.*}}/runtime/internal/runtime.eface" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:

--- a/cl/_testrt/builtin/in.go
+++ b/cl/_testrt/builtin/in.go
@@ -5,13 +5,13 @@ import (
 	"unsafe"
 )
 
-// CHECK-LINE: @0 = private unnamed_addr constant [5 x i8] c"hello", align 1
-// CHECK-LINE: @1 = private unnamed_addr constant [3 x i8] c"def", align 1
-// CHECK-LINE: @3 = private unnamed_addr constant [4 x i8] c"ABCD", align 1
-// CHECK-LINE: @4 = private unnamed_addr constant [7 x i8] c"\E4\B8\ADabcd", align 1
-// CHECK-LINE: @5 = private unnamed_addr constant [3 x i8] c"abc", align 1
-// CHECK-LINE: @6 = private unnamed_addr constant [3 x i8] c"abd", align 1
-// CHECK-LINE: @7 = private unnamed_addr constant [2 x i8] c"fn", align 1
+// CHECK: {{^}}@0 = private unnamed_addr constant [5 x i8] c"hello", align 1{{$}}
+// CHECK: {{^}}@1 = private unnamed_addr constant [3 x i8] c"def", align 1{{$}}
+// CHECK: {{^}}@3 = private unnamed_addr constant [4 x i8] c"ABCD", align 1{{$}}
+// CHECK: {{^}}@4 = private unnamed_addr constant [7 x i8] c"\E4\B8\ADabcd", align 1{{$}}
+// CHECK: {{^}}@5 = private unnamed_addr constant [3 x i8] c"abc", align 1{{$}}
+// CHECK: {{^}}@6 = private unnamed_addr constant [3 x i8] c"abd", align 1{{$}}
+// CHECK: {{^}}@7 = private unnamed_addr constant [2 x i8] c"fn", align 1{{$}}
 
 var a int64 = 1<<63 - 1
 var b int64 = -1 << 63

--- a/cl/_testrt/cast/in.go
+++ b/cl/_testrt/cast/in.go
@@ -3,7 +3,7 @@ package main
 
 //"github.com/goplus/lib/c"
 
-// CHECK-LINE: @0 = private unnamed_addr constant [5 x i8] c"error", align 1
+// CHECK: @0 = private unnamed_addr constant [5 x i8] c"error", align 1
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/cast.cvt32Fto32"(float %0, i32 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:

--- a/cl/_testrt/closurebound/in.go
+++ b/cl/_testrt/closurebound/in.go
@@ -1,10 +1,10 @@
 // LITTEST
 package main
 
-// CHECK-LINE: @0 = private unnamed_addr constant [52 x i8] c"{{.*}}/cl/_testrt/closurebound.demo1", align 1
-// CHECK-LINE: @1 = private unnamed_addr constant [6 x i8] c"encode", align 1
-// CHECK-LINE: @2 = private unnamed_addr constant [52 x i8] c"{{.*}}/cl/_testrt/closurebound.demo2", align 1
-// CHECK-LINE: @3 = private unnamed_addr constant [5 x i8] c"error", align 1
+// CHECK: {{^}}@0 = private unnamed_addr constant [52 x i8] c"{{.*}}/cl/_testrt/closurebound.demo1", align 1{{$}}
+// CHECK: {{^}}@1 = private unnamed_addr constant [6 x i8] c"encode", align 1{{$}}
+// CHECK: {{^}}@2 = private unnamed_addr constant [52 x i8] c"{{.*}}/cl/_testrt/closurebound.demo2", align 1{{$}}
+// CHECK: {{^}}@3 = private unnamed_addr constant [5 x i8] c"error", align 1{{$}}
 
 var my = demo2{}.encode
 

--- a/cl/_testrt/cstr/in.go
+++ b/cl/_testrt/cstr/in.go
@@ -3,7 +3,7 @@ package main
 
 import _ "unsafe"
 
-// CHECK-LINE: @0 = private unnamed_addr constant [14 x i8] c"Hello, world\0A\00", align 1
+// CHECK: {{^}}@0 = private unnamed_addr constant [14 x i8] c"Hello, world\0A\00", align 1{{$}}
 
 //go:linkname cstr llgo.cstr
 func cstr(string) *int8

--- a/cl/_testrt/cvar/in.go
+++ b/cl/_testrt/cvar/in.go
@@ -3,7 +3,7 @@ package main
 
 import _ "unsafe"
 
-// CHECK-LINE: @_bar_x = external global { [16 x i8], [2 x ptr] }, align 8
+// CHECK: {{^}}@_bar_x = external global { [16 x i8], [2 x ptr] }, align 8{{$}}
 //
 //go:linkname barX _bar_x
 var barX struct {
@@ -11,7 +11,7 @@ var barX struct {
 	Callbacks [2]func()
 }
 
-// CHECK-LINE: @_bar_y = external global { [16 x i8] }, align 1
+// CHECK: {{^}}@_bar_y = external global { [16 x i8] }, align 1{{$}}
 //
 //go:linkname barY _bar_y
 var barY struct {

--- a/cl/_testrt/fprintf/in.go
+++ b/cl/_testrt/fprintf/in.go
@@ -3,7 +3,7 @@ package main
 
 import "unsafe"
 
-// CHECK-LINE: @0 = private unnamed_addr constant [10 x i8] c"Hello %d\0A\00", align 1
+// CHECK: {{^}}@0 = private unnamed_addr constant [10 x i8] c"Hello %d\0A\00", align 1{{$}}
 //
 //go:linkname cstr llgo.cstr
 func cstr(string) *int8

--- a/cl/_testrt/funcdecl/in.go
+++ b/cl/_testrt/funcdecl/in.go
@@ -5,9 +5,9 @@ import (
 	"unsafe"
 )
 
-// CHECK-LINE: @4 = private unnamed_addr constant [39 x i8] c"struct{$f func(); $data unsafe.Pointer}", align 1
-// CHECK-LINE: @5 = private unnamed_addr constant [4 x i8] c"demo", align 1
-// CHECK-LINE: @6 = private unnamed_addr constant [5 x i8] c"hello", align 1
+// CHECK: @4 = private unnamed_addr constant [39 x i8] c"struct{$f func(); $data unsafe.Pointer}", align 1
+// CHECK: @5 = private unnamed_addr constant [4 x i8] c"demo", align 1
+// CHECK: @6 = private unnamed_addr constant [5 x i8] c"hello", align 1
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/funcdecl.check"({ ptr, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:

--- a/cl/_testrt/hello/in.go
+++ b/cl/_testrt/hello/in.go
@@ -3,7 +3,7 @@ package main
 
 import "github.com/goplus/llgo/cl/_testrt/hello/libc"
 
-// CHECK-LINE: @"{{.*}}/cl/_testrt/hello.format" = global [10 x i8] zeroinitializer, align 1
+// CHECK: {{^}}@"{{.*}}/cl/_testrt/hello.format" = global [10 x i8] zeroinitializer, align 1{{$}}
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/hello.init"(){{.*}} {
 // CHECK-NEXT: _llgo_0:

--- a/cl/_testrt/index/in.go
+++ b/cl/_testrt/index/in.go
@@ -1,7 +1,7 @@
 // LITTEST
 package main
 
-// CHECK-LINE: @0 = private unnamed_addr constant [6 x i8] c"123456", align 1
+// CHECK: @0 = private unnamed_addr constant [6 x i8] c"123456", align 1
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/index.init"(){{.*}} {
 // CHECK-NEXT: _llgo_0:

--- a/cl/_testrt/makemap/in.go
+++ b/cl/_testrt/makemap/in.go
@@ -1,16 +1,16 @@
 // LITTEST
 package main
 
-// CHECK-LINE: @16 = private unnamed_addr constant [5 x i8] c"hello", align 1
-// CHECK-LINE: @17 = private unnamed_addr constant [5 x i8] c"world", align 1
-// CHECK-LINE: @18 = private unnamed_addr constant [4 x i8] c"llgo", align 1
-// CHECK-LINE: @19 = private unnamed_addr constant [1 x i8] c":", align 1
-// CHECK-LINE: @22 = private unnamed_addr constant [2 x i8] c"go", align 1
-// CHECK-LINE: @23 = private unnamed_addr constant [7 x i8] c"bad key", align 1
-// CHECK-LINE: @24 = private unnamed_addr constant [7 x i8] c"bad len", align 1
-// CHECK-LINE: @32 = private unnamed_addr constant [44 x i8] c"{{.*}}/cl/_testrt/makemap.N1", align 1
-// CHECK-LINE: @39 = private unnamed_addr constant [43 x i8] c"{{.*}}/cl/_testrt/makemap.K", align 1
-// CHECK-LINE: @42 = private unnamed_addr constant [44 x i8] c"{{.*}}/cl/_testrt/makemap.K2", align 1
+// CHECK: @16 = private unnamed_addr constant [5 x i8] c"hello", align 1
+// CHECK: @17 = private unnamed_addr constant [5 x i8] c"world", align 1
+// CHECK: @18 = private unnamed_addr constant [4 x i8] c"llgo", align 1
+// CHECK: @19 = private unnamed_addr constant [1 x i8] c":", align 1
+// CHECK: @22 = private unnamed_addr constant [2 x i8] c"go", align 1
+// CHECK: @23 = private unnamed_addr constant [7 x i8] c"bad key", align 1
+// CHECK: @24 = private unnamed_addr constant [7 x i8] c"bad len", align 1
+// CHECK: @32 = private unnamed_addr constant [44 x i8] c"{{.*}}/cl/_testrt/makemap.N1", align 1
+// CHECK: @39 = private unnamed_addr constant [43 x i8] c"{{.*}}/cl/_testrt/makemap.K", align 1
+// CHECK: @42 = private unnamed_addr constant [44 x i8] c"{{.*}}/cl/_testrt/makemap.K2", align 1
 
 func main() {
 	make1()

--- a/cl/_testrt/slicelen/in.go
+++ b/cl/_testrt/slicelen/in.go
@@ -5,9 +5,9 @@ import (
 	"unsafe"
 )
 
-// CHECK-LINE: @0 = private unnamed_addr constant [30 x i8] c"unsafe.Slice: len out of range", align 1
-// CHECK-LINE: @1 = private unnamed_addr constant [46 x i8] c"unsafe.Slice: nil pointer with non-zero length", align 1
-// CHECK-LINE: @2 = private unnamed_addr constant [7 x i8] c"len > 0", align 1
+// CHECK: {{^}}@0 = private unnamed_addr constant [30 x i8] c"unsafe.Slice: len out of range", align 1{{$}}
+// CHECK: {{^}}@1 = private unnamed_addr constant [46 x i8] c"unsafe.Slice: nil pointer with non-zero length", align 1{{$}}
+// CHECK: {{^}}@2 = private unnamed_addr constant [7 x i8] c"len > 0", align 1{{$}}
 
 func main() {
 	var s *int

--- a/cl/_testrt/struct/in.go
+++ b/cl/_testrt/struct/in.go
@@ -4,8 +4,8 @@ package main
 import "C"
 import _ "unsafe"
 
-// CHECK-LINE: @0 = private unnamed_addr constant [44 x i8] c"{{.*}}/cl/_testrt/struct.Foo", align 1
-// CHECK-LINE: @1 = private unnamed_addr constant [5 x i8] c"Print", align 1
+// CHECK: {{^}}@0 = private unnamed_addr constant [44 x i8] c"{{.*}}/cl/_testrt/struct.Foo", align 1{{$}}
+// CHECK: {{^}}@1 = private unnamed_addr constant [5 x i8] c"Print", align 1{{$}}
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/struct.Foo.Print"(%"{{.*}}/cl/_testrt/struct.Foo" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:

--- a/cl/_testrt/tpabi/in.go
+++ b/cl/_testrt/tpabi/in.go
@@ -3,10 +3,10 @@ package main
 
 import "github.com/goplus/lib/c"
 
-// CHECK-LINE: @0 = private unnamed_addr constant [1 x i8] c"a", align 1
-// CHECK-LINE: @5 = private unnamed_addr constant [4 x i8] c"Info", align 1
-// CHECK-LINE: @10 = private unnamed_addr constant [54 x i8] c"{{.*}}/cl/_testrt/tpabi.T[string, int]", align 1
-// CHECK-LINE: @11 = private unnamed_addr constant [5 x i8] c"hello", align 1
+// CHECK: @0 = private unnamed_addr constant [1 x i8] c"a", align 1
+// CHECK: @5 = private unnamed_addr constant [4 x i8] c"Info", align 1
+// CHECK: @10 = private unnamed_addr constant [54 x i8] c"{{.*}}/cl/_testrt/tpabi.T[string, int]", align 1
+// CHECK: @11 = private unnamed_addr constant [5 x i8] c"hello", align 1
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/tpabi.init"(){{.*}} {
 // CHECK-NEXT: _llgo_0:

--- a/cl/_testrt/tpmethod/in.go
+++ b/cl/_testrt/tpmethod/in.go
@@ -1,9 +1,9 @@
 // LITTEST
 package main
 
-// CHECK-LINE: @0 = private unnamed_addr constant [7 x i8] c"foo.txt", align 1
-// CHECK-LINE: @7 = private unnamed_addr constant [3 x i8] c"Get", align 1
-// CHECK-LINE: @16 = private unnamed_addr constant [55 x i8] c"{{.*}}/cl/_testrt/tpmethod.Tuple[error]", align 1
+// CHECK: {{^}}@0 = private unnamed_addr constant [7 x i8] c"foo.txt", align 1{{$}}
+// CHECK: {{^}}@7 = private unnamed_addr constant [3 x i8] c"Get", align 1{{$}}
+// CHECK: {{^}}@16 = private unnamed_addr constant [55 x i8] c"{{.*}}/cl/_testrt/tpmethod.Tuple[error]", align 1{{$}}
 
 type Tuple[T any] struct {
 	v T

--- a/cl/_testrt/typed/in.go
+++ b/cl/_testrt/typed/in.go
@@ -1,8 +1,8 @@
 // LITTEST
 package main
 
-// CHECK-LINE: @0 = private unnamed_addr constant [5 x i8] c"hello", align 1
-// CHECK-LINE: @3 = private unnamed_addr constant [41 x i8] c"{{.*}}/cl/_testrt/typed.T", align 1
+// CHECK: @0 = private unnamed_addr constant [5 x i8] c"hello", align 1
+// CHECK: @3 = private unnamed_addr constant [41 x i8] c"{{.*}}/cl/_testrt/typed.T", align 1
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/typed.init"(){{.*}} {
 // CHECK-NEXT: _llgo_0:

--- a/cl/_testrt/unsafe/in.go
+++ b/cl/_testrt/unsafe/in.go
@@ -7,13 +7,13 @@ import (
 	"github.com/goplus/lib/c"
 )
 
-// CHECK-LINE: @0 = private unnamed_addr constant [5 x i8] c"error", align 1
-// CHECK-LINE: @2 = private unnamed_addr constant [4 x i8] c"abc\00", align 1
-// CHECK-LINE: @3 = private unnamed_addr constant [31 x i8] c"unsafe.String: len out of range", align 1
-// CHECK-LINE: @4 = private unnamed_addr constant [47 x i8] c"unsafe.String: nil pointer with non-zero length", align 1
-// CHECK-LINE: @5 = private unnamed_addr constant [3 x i8] c"abc", align 1
-// CHECK-LINE: @6 = private unnamed_addr constant [30 x i8] c"unsafe.Slice: len out of range", align 1
-// CHECK-LINE: @7 = private unnamed_addr constant [46 x i8] c"unsafe.Slice: nil pointer with non-zero length", align 1
+// CHECK: {{^}}@0 = private unnamed_addr constant [5 x i8] c"error", align 1{{$}}
+// CHECK: {{^}}@2 = private unnamed_addr constant [4 x i8] c"abc\00", align 1{{$}}
+// CHECK: {{^}}@3 = private unnamed_addr constant [31 x i8] c"unsafe.String: len out of range", align 1{{$}}
+// CHECK: {{^}}@4 = private unnamed_addr constant [47 x i8] c"unsafe.String: nil pointer with non-zero length", align 1{{$}}
+// CHECK: {{^}}@5 = private unnamed_addr constant [3 x i8] c"abc", align 1{{$}}
+// CHECK: {{^}}@6 = private unnamed_addr constant [30 x i8] c"unsafe.Slice: len out of range", align 1{{$}}
+// CHECK: {{^}}@7 = private unnamed_addr constant [46 x i8] c"unsafe.Slice: nil pointer with non-zero length", align 1{{$}}
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/unsafe.init"(){{.*}} {
 // CHECK-NEXT: _llgo_0:

--- a/internal/filecheck/filecheck.go
+++ b/internal/filecheck/filecheck.go
@@ -17,339 +17,68 @@
 package filecheck
 
 import (
+	"bytes"
 	"fmt"
-	"regexp"
 	"strings"
+
+	"github.com/goplus/llgo/xtool/env/llvm"
 )
 
-type kind string
-
-const (
-	kindCheck kind = "CHECK"
-	kindLine  kind = "CHECK-LINE"
-	kindNext  kind = "CHECK-NEXT"
-	kindSame  kind = "CHECK-SAME"
-	kindNot   kind = "CHECK-NOT"
-	kindLabel kind = "CHECK-LABEL"
-	kindEmpty kind = "CHECK-EMPTY"
-)
-
-type directive struct {
-	kind    kind
-	pattern string
-	re      *regexp.Regexp
-	line    int
-}
-
-type pos struct {
-	line int
-	col  int
-}
-
-type match struct {
-	start pos
-	end   pos
+var supportedDirectives = []string{
+	"CHECK:",
+	"CHECK-NEXT:",
+	"CHECK-SAME:",
+	"CHECK-NOT:",
+	"CHECK-LABEL:",
+	"CHECK-EMPTY:",
+	"CHECK-DAG:",
+	"CHECK-COUNT-",
 }
 
 func HasDirectives(text string) (bool, error) {
-	lines := splitLines(text)
-	for _, line := range lines {
-		_, hasDirective, ok, err := parseDirectiveLine(line)
-		if err != nil {
-			return false, err
+	for _, line := range splitLines(text) {
+		bodyStart, ok := directiveBody(line)
+		if !ok {
+			continue
 		}
-		if hasDirective && ok {
-			return true, nil
+		body := line[bodyStart:]
+		for _, directive := range supportedDirectives {
+			if strings.HasPrefix(body, directive) {
+				return true, nil
+			}
 		}
 	}
 	return false, nil
 }
 
-func Match(filename, checks, input string) error {
-	directives, err := parseDirectives(filename, checks)
+func Match(filename, input string) error {
+	cmd, err := llvm.New("").FileCheck(filename)
 	if err != nil {
 		return err
 	}
-	lines := splitLines(input)
-	if len(lines) == 0 {
-		lines = []string{""}
-	}
-	cur := pos{line: 0, col: 0}
-	prev := match{}
-	hasPrev := false
-	var pendingNot []directive
-	for _, dir := range directives {
-		switch dir.kind {
-		case kindNot:
-			pendingNot = append(pendingNot, dir)
-			continue
-		case kindEmpty:
-			if !hasPrev {
-				return fmt.Errorf("%s:%d: CHECK-EMPTY requires a prior positive match", filename, dir.line)
-			}
-			target := pos{line: prev.start.line + 1, col: 0}
-			if target.line >= len(lines) {
-				return fmt.Errorf("%s:%d: CHECK-EMPTY expected an empty line after input:%d", filename, dir.line, prev.start.line+1)
-			}
-			if err := checkPendingNot(filename, pendingNot, lines, cur, target); err != nil {
-				return err
-			}
-			if lines[target.line] != "" {
-				return fmt.Errorf("%s:%d: CHECK-EMPTY expected input:%d to be empty", filename, dir.line, target.line+1)
-			}
-			pendingNot = nil
-			prev = match{start: target, end: target}
-			cur = target
-			hasPrev = true
-			continue
+	cmd.Stdin = strings.NewReader(input)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if stderr.Len() > 0 {
+			return fmt.Errorf("%w\n%s", err, strings.TrimRight(stderr.String(), "\n"))
 		}
-
-		var found match
-		var ok bool
-		switch dir.kind {
-		case kindCheck:
-			found, ok = findForward(lines, cur, dir.re)
-		case kindLine, kindLabel:
-			found, ok = findForwardFullLine(lines, cur, dir.re)
-		case kindNext:
-			if !hasPrev {
-				return fmt.Errorf("%s:%d: CHECK-NEXT requires a prior positive match", filename, dir.line)
-			}
-			found, ok = findLine(lines, prev.start.line+1, 0, dir.re)
-		case kindSame:
-			if !hasPrev {
-				return fmt.Errorf("%s:%d: CHECK-SAME requires a prior positive match", filename, dir.line)
-			}
-			found, ok = findLine(lines, prev.start.line, prev.end.col, dir.re)
-		default:
-			return fmt.Errorf("%s:%d: unsupported directive %s", filename, dir.line, dir.kind)
-		}
-		if !ok {
-			switch dir.kind {
-			case kindNext:
-				return fmt.Errorf("%s:%d: CHECK-NEXT %q did not match input:%d, input: %s", filename, dir.line, dir.pattern, prev.start.line+2, input)
-			case kindSame:
-				return fmt.Errorf("%s:%d: CHECK-SAME %q did not match input:%d, input: %s", filename, dir.line, dir.pattern, prev.start.line+1, input)
-			default:
-				return fmt.Errorf("%s:%d: %s %q was not found", filename, dir.line, dir.kind, dir.pattern)
-			}
-		}
-		if err := checkPendingNot(filename, pendingNot, lines, cur, found.start); err != nil {
-			return err
-		}
-		pendingNot = nil
-		prev = found
-		cur = found.end
-		if dir.kind == kindLabel {
-			cur = pos{line: min(found.start.line+1, len(lines)-1), col: 0}
-		}
-		hasPrev = true
-	}
-
-	end := pos{line: len(lines) - 1, col: len(lines[len(lines)-1])}
-	if err := checkPendingNot(filename, pendingNot, lines, cur, end); err != nil {
 		return err
 	}
 	return nil
 }
 
-func parseDirectives(filename, checks string) ([]directive, error) {
-	lines := splitLines(checks)
-	var directives []directive
-	for idx, line := range lines {
-		dir, hasDirective, ok, err := parseDirectiveLine(line)
-		if err != nil {
-			return nil, fmt.Errorf("%s:%d: %w", filename, idx+1, err)
-		}
-		if hasDirective && ok {
-			dir.line = idx + 1
-			directives = append(directives, dir)
-		}
+func directiveBody(line string) (int, bool) {
+	trimmed := strings.TrimLeft(line, " \t")
+	if !strings.HasPrefix(trimmed, "//") {
+		return 0, false
 	}
-	if len(directives) == 0 {
-		return nil, fmt.Errorf("%s: no FileCheck directives found", filename)
-	}
-	return directives, nil
+	indent := len(line) - len(trimmed)
+	return indent + 2 + lenLeftTrim(trimmed[2:], " \t"), true
 }
 
-func parseDirectiveLine(line string) (directive, bool, bool, error) {
-	rest := strings.TrimLeft(line, " \t")
-	if !strings.HasPrefix(rest, "//") {
-		return directive{}, false, false, nil
-	}
-	rest = strings.TrimLeft(rest[2:], " \t")
-	if strings.HasPrefix(rest, "CHECK:") {
-		pattern := trimDirectivePattern(strings.TrimPrefix(rest, "CHECK:"))
-		re, err := compilePattern(pattern)
-		if err != nil {
-			return directive{}, true, false, err
-		}
-		return directive{kind: kindCheck, pattern: pattern, re: re}, true, true, nil
-	}
-	if !strings.HasPrefix(rest, "CHECK-") {
-		return directive{}, false, false, nil
-	}
-	suffixRest := strings.TrimPrefix(rest, "CHECK-")
-	colon := strings.IndexByte(suffixRest, ':')
-	if colon < 0 {
-		return directive{}, true, false, fmt.Errorf("missing ':' in directive")
-	}
-	suffix := suffixRest[:colon]
-	pattern := trimDirectivePattern(suffixRest[colon+1:])
-	k, ok := parseKind(suffix)
-	if !ok {
-		return directive{}, true, false, fmt.Errorf("unknown directive CHECK-%s", suffix)
-	}
-	if k == kindEmpty {
-		if pattern != "" {
-			return directive{}, true, false, fmt.Errorf("CHECK-EMPTY must not have a pattern")
-		}
-		return directive{kind: k}, true, true, nil
-	}
-	re, err := compilePattern(pattern)
-	if err != nil {
-		return directive{}, true, false, err
-	}
-	return directive{kind: k, pattern: pattern, re: re}, true, true, nil
-}
-
-func parseKind(suffix string) (kind, bool) {
-	switch suffix {
-	case "LINE":
-		return kindLine, true
-	case "NEXT":
-		return kindNext, true
-	case "SAME":
-		return kindSame, true
-	case "NOT":
-		return kindNot, true
-	case "LABEL":
-		return kindLabel, true
-	case "EMPTY":
-		return kindEmpty, true
-	default:
-		return "", false
-	}
-}
-
-func compilePattern(pattern string) (*regexp.Regexp, error) {
-	if pattern == "" {
-		return nil, fmt.Errorf("empty pattern")
-	}
-	var b strings.Builder
-	for {
-		idx := strings.Index(pattern, "{{")
-		if idx < 0 {
-			b.WriteString(regexp.QuoteMeta(pattern))
-			break
-		}
-		b.WriteString(regexp.QuoteMeta(pattern[:idx]))
-		pattern = pattern[idx+2:]
-		end := strings.Index(pattern, "}}")
-		if end < 0 {
-			return nil, fmt.Errorf("unterminated '{{' in pattern")
-		}
-		b.WriteString("(?:")
-		b.WriteString(pattern[:end])
-		b.WriteString(")")
-		pattern = pattern[end+2:]
-	}
-	re, err := regexp.Compile(b.String())
-	if err != nil {
-		return nil, err
-	}
-	return re, nil
-}
-
-func findForward(lines []string, start pos, re *regexp.Regexp) (match, bool) {
-	for lineIdx := start.line; lineIdx < len(lines); lineIdx++ {
-		col := 0
-		if lineIdx == start.line {
-			col = start.col
-		}
-		if col > len(lines[lineIdx]) {
-			col = len(lines[lineIdx])
-		}
-		if loc := re.FindStringIndex(lines[lineIdx][col:]); loc != nil {
-			return match{
-				start: pos{line: lineIdx, col: col + loc[0]},
-				end:   pos{line: lineIdx, col: col + loc[1]},
-			}, true
-		}
-	}
-	return match{}, false
-}
-
-func findLine(lines []string, lineIdx, startCol int, re *regexp.Regexp) (match, bool) {
-	if lineIdx < 0 || lineIdx >= len(lines) {
-		return match{}, false
-	}
-	if startCol > len(lines[lineIdx]) {
-		startCol = len(lines[lineIdx])
-	}
-	if loc := re.FindStringIndex(lines[lineIdx][startCol:]); loc != nil {
-		return match{
-			start: pos{line: lineIdx, col: startCol + loc[0]},
-			end:   pos{line: lineIdx, col: startCol + loc[1]},
-		}, true
-	}
-	return match{}, false
-}
-
-func findForwardFullLine(lines []string, start pos, re *regexp.Regexp) (match, bool) {
-	lineIdx := start.line
-	if start.col > 0 {
-		lineIdx++
-	}
-	for ; lineIdx < len(lines); lineIdx++ {
-		if loc := re.FindStringIndex(lines[lineIdx]); loc != nil && loc[0] == 0 && loc[1] == len(lines[lineIdx]) {
-			return match{
-				start: pos{line: lineIdx, col: 0},
-				end:   pos{line: lineIdx, col: len(lines[lineIdx])},
-			}, true
-		}
-	}
-	return match{}, false
-}
-
-func checkPendingNot(filename string, pending []directive, lines []string, from, to pos) error {
-	for _, dir := range pending {
-		if at, text, ok := findForbidden(lines, from, to, dir.re); ok {
-			return fmt.Errorf("%s:%d: %s %q matched forbidden text %q at input:%d", filename, dir.line, dir.kind, dir.pattern, text, at.line+1)
-		}
-	}
-	return nil
-}
-
-func findForbidden(lines []string, from, to pos, re *regexp.Regexp) (pos, string, bool) {
-	if before(to, from) {
-		return pos{}, "", false
-	}
-	for lineIdx := from.line; lineIdx <= to.line && lineIdx < len(lines); lineIdx++ {
-		startCol := 0
-		endCol := len(lines[lineIdx])
-		if lineIdx == from.line {
-			startCol = min(startCol+from.col, len(lines[lineIdx]))
-		}
-		if lineIdx == to.line {
-			endCol = min(endCol, to.col)
-		}
-		if startCol > endCol {
-			continue
-		}
-		segment := lines[lineIdx][startCol:endCol]
-		if loc := re.FindStringIndex(segment); loc != nil {
-			return pos{line: lineIdx, col: startCol + loc[0]}, segment[loc[0]:loc[1]], true
-		}
-	}
-	return pos{}, "", false
-}
-
-func before(a, b pos) bool {
-	if a.line != b.line {
-		return a.line < b.line
-	}
-	return a.col < b.col
+func lenLeftTrim(s, cutset string) int {
+	return len(s) - len(strings.TrimLeft(s, cutset))
 }
 
 func splitLines(text string) []string {
@@ -358,14 +87,4 @@ func splitLines(text string) []string {
 		lines[i] = strings.TrimSuffix(line, "\r")
 	}
 	return lines
-}
-
-func trimDirectivePattern(pattern string) string {
-	if pattern == "" {
-		return ""
-	}
-	if pattern[0] == ' ' || pattern[0] == '\t' {
-		return pattern[1:]
-	}
-	return pattern
 }

--- a/internal/filecheck/filecheck_test.go
+++ b/internal/filecheck/filecheck_test.go
@@ -1,12 +1,13 @@
 package filecheck
 
 import (
-	"regexp"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func TestMatchSupportsLabelRegexAndNext(t *testing.T) {
+func TestMatchUsesLLVMFileCheck(t *testing.T) {
 	spec := `// LITTEST
 package main
 
@@ -17,77 +18,41 @@ func main() {
 }
 `
 	input := "func main\nvalue 42\ndone\n"
-	if err := Match("test.go", spec, input); err != nil {
+	if err := Match(writeCheckFile(t, spec), input); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func TestMatchPreservesPatternWhitespace(t *testing.T) {
+func TestMatchSupportsWholeLineAnchors(t *testing.T) {
 	spec := `// LITTEST
 package main
 
-// CHECK:  value 42 
-`
-	input := " value 42 \n"
-	if err := Match("test.go", spec, input); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestMatchSupportsEmptyLine(t *testing.T) {
-	spec := `// LITTEST
-package main
-
-func main() {
-	// CHECK: value 42
-	// CHECK-EMPTY:
-	// CHECK: done
-}
-`
-	input := "value 42\n\ndone\n"
-	if err := Match("test.go", spec, input); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestMatchSupportsWholeLineChecks(t *testing.T) {
-	spec := `// LITTEST
-package main
-
-// CHECK-LINE: begin
-// CHECK-LINE: end
+// CHECK: {{^}}begin{{$}}
+// CHECK: {{^}}end{{$}}
 `
 	input := "begin\nmiddle\nend\n"
-	if err := Match("test.go", spec, input); err != nil {
+	if err := Match(writeCheckFile(t, spec), input); err != nil {
 		t.Fatal(err)
 	}
+
+	err := Match(writeCheckFile(t, "// CHECK: {{^}}begin{{$}}\n"), "prefix begin\n")
+	requireErrContains(t, err, "expected string not found")
 }
 
-func TestCheckLabelRequiresWholeLineMatch(t *testing.T) {
-	spec := `// LITTEST
-package main
-
-// CHECK-LABEL: begin
-`
-	err := Match("test.go", spec, "prefix begin\n")
-	if err == nil {
-		t.Fatal("Match succeeded unexpectedly")
-	}
-}
-
-func TestMatchSupportsSameAndNot(t *testing.T) {
+func TestMatchSupportsSameNotAndEmpty(t *testing.T) {
 	spec := `// LITTEST
 package main
 
 func main() {
 	// CHECK: value
 	// CHECK-SAME: 42
+	// CHECK-EMPTY:
 	// CHECK-NOT: forbidden
 	// CHECK: done
 }
 `
-	input := "value 42\ndone\n"
-	if err := Match("test.go", spec, input); err != nil {
+	input := "value 42\n\ndone\n"
+	if err := Match(writeCheckFile(t, spec), input); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -102,138 +67,11 @@ func main() {
 	// CHECK: done
 }
 `
-	err := Match("test.go", spec, "ok\npanic\ndone\n")
-	requireErrContains(t, err, "forbidden text")
+	err := Match(writeCheckFile(t, spec), "ok\npanic\ndone\n")
+	requireErrContains(t, err, "excluded string found")
 }
 
-func TestMatchDoesNotCarryCheckNotAcrossLabels(t *testing.T) {
-	spec := `// LITTEST
-package main
-
-// CHECK-LABEL: first
-// CHECK: ok
-// CHECK-NOT: panic
-// CHECK-LABEL: second
-// CHECK: panic
-`
-	input := "first\nok\nsecond\npanic\n"
-	if err := Match("test.go", spec, input); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestHasDirectives(t *testing.T) {
-	ok, err := HasDirectives("// CHECK: value\n")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !ok {
-		t.Fatal("HasDirectives returned false")
-	}
-
-	ok, err = HasDirectives("value\n")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ok {
-		t.Fatal("HasDirectives returned true unexpectedly")
-	}
-}
-
-func TestHasDirectivesPropagatesDirectiveErrors(t *testing.T) {
-	_, err := HasDirectives("// CHECK: {{[invalid\n")
-	requireErrContains(t, err, "unterminated '{{' in pattern")
-}
-
-func TestHasDirectivesIgnoresNonSlashSlashComments(t *testing.T) {
-	ok, err := HasDirectives("; CHECK: value\n")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ok {
-		t.Fatal("HasDirectives returned true unexpectedly")
-	}
-}
-
-func TestMatchSupportsCRLF(t *testing.T) {
-	spec := "// LITTEST\r\npackage main\r\n\r\n// CHECK-LABEL: begin\r\n// CHECK-NEXT: done\r\n"
-	input := "begin\r\ndone\r\n"
-	if err := Match("test.go", spec, input); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestMatchReportsDirectiveAndPatternErrors(t *testing.T) {
-	cases := []struct {
-		name string
-		spec string
-		want string
-	}{
-		{
-			name: "empty pattern",
-			spec: "// CHECK:\n",
-			want: "empty pattern",
-		},
-		{
-			name: "unterminated regex",
-			spec: "// CHECK: {{[0-9]+\n",
-			want: "unterminated '{{' in pattern",
-		},
-		{
-			name: "invalid regex",
-			spec: "// CHECK: {{(}}\n",
-			want: "error parsing regexp",
-		},
-		{
-			name: "unknown directive",
-			spec: "// CHECK-BOGUS: value\n",
-			want: "unknown directive CHECK-BOGUS",
-		},
-		{
-			name: "empty pattern not allowed",
-			spec: "// CHECK-EMPTY: value\n",
-			want: "CHECK-EMPTY must not have a pattern",
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := Match("test.go", tc.spec, "")
-			requireErrContains(t, err, tc.want)
-		})
-	}
-}
-
-func TestMatchReportsPreconditionErrors(t *testing.T) {
-	cases := []struct {
-		name string
-		spec string
-		want string
-	}{
-		{
-			name: "next",
-			spec: "// CHECK-NEXT: value\n",
-			want: "CHECK-NEXT requires a prior positive match",
-		},
-		{
-			name: "same",
-			spec: "// CHECK-SAME: value\n",
-			want: "CHECK-SAME requires a prior positive match",
-		},
-		{
-			name: "empty",
-			spec: "// CHECK-EMPTY:\n",
-			want: "CHECK-EMPTY requires a prior positive match",
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := Match("test.go", tc.spec, "value\n")
-			requireErrContains(t, err, tc.want)
-		})
-	}
-}
-
-func TestMatchReportsSearchFailures(t *testing.T) {
+func TestMatchReportsLLVMErrors(t *testing.T) {
 	cases := []struct {
 		name  string
 		spec  string
@@ -241,73 +79,92 @@ func TestMatchReportsSearchFailures(t *testing.T) {
 		want  string
 	}{
 		{
+			name: "empty pattern",
+			spec: "// CHECK:\n",
+			want: "found empty check string",
+		},
+		{
+			name: "unterminated regex",
+			spec: "// CHECK: {{[0-9]+\n",
+			want: "found start of regex string with no end",
+		},
+		{
+			name: "invalid regex",
+			spec: "// CHECK: {{(}}\n",
+			want: "invalid regex",
+		},
+		{
+			name: "unknown directive",
+			spec: "// CHECK-BOGUS: value\n",
+			want: "no check strings found",
+		},
+		{
+			name: "empty pattern not allowed",
+			spec: "// CHECK-EMPTY: value\n",
+			want: "found non-empty check string for empty check",
+		},
+		{
+			name:  "next without previous check",
+			spec:  "// CHECK-NEXT: value\n",
+			input: "value\n",
+			want:  "without previous 'CHECK: line",
+		},
+		{
 			name:  "next wrong line",
 			spec:  "// CHECK: value\n// CHECK-NEXT: done\n",
 			input: "value\nother\n",
-			want:  `CHECK-NEXT "done" did not match`,
-		},
-		{
-			name:  "same wrong line",
-			spec:  "// CHECK: value\n// CHECK-SAME: done\n",
-			input: "value other\n",
-			want:  `CHECK-SAME "done" did not match`,
-		},
-		{
-			name:  "empty non-empty line",
-			spec:  "// CHECK: value\n// CHECK-EMPTY:\n",
-			input: "value\nother\n",
-			want:  "CHECK-EMPTY expected input:2 to be empty",
-		},
-		{
-			name:  "empty past end",
-			spec:  "// CHECK: value\n// CHECK-EMPTY:\n",
-			input: "value",
-			want:  "CHECK-EMPTY expected an empty line after input:1",
-		},
-		{
-			name:  "trailing not checks remaining input",
-			spec:  "// CHECK: value\n// CHECK-NOT: forbidden\n",
-			input: "value\nforbidden\n",
-			want:  "forbidden text",
+			want:  "CHECK-NEXT: expected string not found",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := Match("test.go", tc.spec, tc.input)
+			err := Match(writeCheckFile(t, tc.spec), tc.input)
 			requireErrContains(t, err, tc.want)
 		})
 	}
 }
 
-func TestSearchHelpers(t *testing.T) {
-	re := regexp.MustCompile("x")
+func TestHasDirectives(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{name: "check", text: "// CHECK: value\n", want: true},
+		{name: "check-count", text: "// CHECK-COUNT-2: value\n", want: true},
+		{name: "malformed still directive", text: "// CHECK: {{[invalid\n", want: true},
+		{name: "none", text: "value\n", want: false},
+		{name: "non slash slash", text: "; CHECK: value\n", want: false},
+		{name: "string literal", text: `fmt.Println("// CHECK: value")` + "\n", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := HasDirectives(tc.text)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Fatalf("HasDirectives = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
 
-	if got := trimDirectivePattern("\tvalue"); got != "value" {
-		t.Fatalf("trimDirectivePattern(tab) = %q", got)
+func TestMatchSupportsCRLF(t *testing.T) {
+	spec := "// LITTEST\r\npackage main\r\n\r\n// CHECK-LABEL: begin\r\n// CHECK-NEXT: done\r\n"
+	input := "begin\r\ndone\r\n"
+	if err := Match(writeCheckFile(t, spec), input); err != nil {
+		t.Fatal(err)
 	}
-	if got := trimDirectivePattern("value"); got != "value" {
-		t.Fatalf("trimDirectivePattern(plain) = %q", got)
-	}
+}
 
-	if !before(pos{line: 0, col: 1}, pos{line: 1, col: 0}) {
-		t.Fatal("before returned false unexpectedly")
+func writeCheckFile(t *testing.T, spec string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.go")
+	if err := os.WriteFile(path, []byte(spec), 0644); err != nil {
+		t.Fatal(err)
 	}
-	if !before(pos{line: 0, col: 1}, pos{line: 0, col: 2}) {
-		t.Fatal("before returned false unexpectedly")
-	}
-
-	if _, ok := findForward([]string{"ab", "x"}, pos{line: 0, col: 10}, re); !ok {
-		t.Fatal("findForward did not clamp and continue")
-	}
-	if _, ok := findLine([]string{"x"}, -1, 0, re); ok {
-		t.Fatal("findLine matched unexpectedly")
-	}
-	if _, ok := findLine([]string{"x"}, 0, 10, re); ok {
-		t.Fatal("findLine matched unexpectedly")
-	}
-	if _, _, ok := findForbidden([]string{"abc"}, pos{line: 0, col: 2}, pos{line: 0, col: 1}, re); ok {
-		t.Fatal("findForbidden matched unexpectedly")
-	}
+	return path
 }
 
 func requireErrContains(t *testing.T, err error, want string) {

--- a/internal/littest/littest.go
+++ b/internal/littest/littest.go
@@ -67,7 +67,7 @@ func Check(spec Spec, actual string) error {
 	case ModeSkip:
 		return nil
 	case ModeFileCheck:
-		return filecheck.Match(spec.Path, spec.Text, actual)
+		return filecheck.Match(spec.Path, actual)
 	case ModeLiteral:
 		if actual != spec.Text {
 			return fmt.Errorf("%s: literal LLVM IR mismatch", spec.Path)
@@ -103,7 +103,6 @@ func loadSourceSpec(pkgDir string) (Spec, bool, error) {
 	}
 	return Spec{
 		Path: marked,
-		Text: text,
 		Mode: ModeFileCheck,
 	}, true, nil
 }

--- a/internal/littest/littest_test.go
+++ b/internal/littest/littest_test.go
@@ -101,20 +101,25 @@ package main
 	}
 }
 
-func TestLoadSpecReportsMalformedDirective(t *testing.T) {
+func TestCheckReportsMalformedDirective(t *testing.T) {
 	dir := t.TempDir()
-	err := os.WriteFile(filepath.Join(dir, "in.go"), []byte(`// LITTEST
+	path := filepath.Join(dir, "in.go")
+	err := os.WriteFile(path, []byte(`// LITTEST
 // CHECK: {{[invalid
 package main
 `), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = LoadSpec(dir)
-	if err == nil {
-		t.Fatal("LoadSpec succeeded unexpectedly")
+	spec, err := LoadSpec(dir)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), "unterminated '{{' in pattern") {
+	err = Check(spec, "")
+	if err == nil {
+		t.Fatal("Check succeeded unexpectedly")
+	}
+	if !strings.Contains(err.Error(), "found start of regex string with no end") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -204,6 +209,11 @@ func TestHasMarker(t *testing.T) {
 }
 
 func TestCheck(t *testing.T) {
+	checkPath := filepath.Join(t.TempDir(), "check.go")
+	if err := os.WriteFile(checkPath, []byte("// CHECK: ok\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
 	cases := []struct {
 		name string
 		spec Spec
@@ -227,7 +237,7 @@ func TestCheck(t *testing.T) {
 		},
 		{
 			name: "filecheck match",
-			spec: Spec{Path: "check.go", Text: "// CHECK: ok\n", Mode: ModeFileCheck},
+			spec: Spec{Path: checkPath, Mode: ModeFileCheck},
 			text: "ok\n",
 		},
 		{

--- a/xtool/env/llvm/llvm.go
+++ b/xtool/env/llvm/llvm.go
@@ -110,6 +110,15 @@ func (e *Env) InstallNameTool() *install_name_tool.Cmd {
 	return install_name_tool.New(bin)
 }
 
+// FileCheck returns a command to execute LLVM FileCheck with given arguments.
+func (e *Env) FileCheck(args ...string) (*exec.Cmd, error) {
+	path, err := e.toolPath("FileCheck")
+	if err != nil {
+		return nil, err
+	}
+	return exec.Command(path, args...), nil
+}
+
 // Readelf returns a command to execute llvm-readelf with given arguments.
 func (e *Env) Readelf(args ...string) (*exec.Cmd, error) {
 	path, err := e.toolPath("llvm-readelf")


### PR DESCRIPTION
## Summary
- replace the internal LITTEST FileCheck matcher with the LLVM `FileCheck` executable from the configured LLVM toolchain
- add `llvm.Env.FileCheck` lookup and run checks directly against the original marked source file
- convert `cl/_*` `CHECK-LINE` directives to native LLVM FileCheck syntax
- make affected `abimethod`, `reflect`, and `reflectmk` FileCheck expectations stable across Go 1.24 and Go 1.26 generated IR

## Tests
- `go test ./internal/filecheck ./internal/littest ./xtool/env/llvm ./chore/litgen ./chore/gentests`
- `go test ./cl -run 'TestRunAndTestFromTestgo/(abimethod|reflect|reflectmk|tpnamed|tptypes)$' -count=1`
- `GOROOT=/opt/tools/go1.24.5.linux-amd64/go GOTOOLCHAIN=local GOWORK=off go test ./ssa -run 'TestFromTestgo/(abimethod|reflect|reflectmk)$' -count=1`
- `GOROOT=/opt/tools/go1.24.5.linux-amd64/go GOTOOLCHAIN=local GOWORK=off go test ./cl -run 'TestRunAndTestFromTestgo/(reflect|reflectmk)$' -count=1`
- `GOROOT=/opt/tools/go1.26.2.linux-amd64/go go test ./ssa -run 'TestFromTestgo/(abimethod|reflect|reflectmk)$' -count=1`
- `GOROOT=/opt/tools/go1.26.2.linux-amd64/go go test ./cl -run 'TestRunAndTestFromTestgo/(abimethod|reflect|reflectmk)$' -count=1`
- `GOROOT=/opt/tools/go1.26.2.linux-amd64/go go test ./internal/filecheck ./internal/littest -count=1`
- `git diff --check`
