### PR TITLE
test: expect legacy print exponent padding

### DIFF
--- a/test/go/print_builtin_legacy_test.go
+++ b/test/go/print_builtin_legacy_test.go
@@ -69,11 +69,11 @@ func TestBuiltinPrintLegacyExponentWidth(t *testing.T) {
 
 	got := filterPrintProbeOutput(stderr.String())
 	want := "" +
-		"+5.000000e+00 +8.000000e+00\n" +
-		"+1.001000e+02\n" +
-		"(+1.000000e+00+2.000000e+00i)\n" +
-		"(+1.000000e+00+2.000000e+00i)\n" +
-		"(+4.000000e+00+6.000000e+00i)\n"
+		"+5.000000e+000 +8.000000e+000\n" +
+		"+1.001000e+002\n" +
+		"(+1.000000e+000+2.000000e+000i)\n" +
+		"(+1.000000e+000+2.000000e+000i)\n" +
+		"(+4.000000e+000+6.000000e+000i)\n"
 	if got != want {
 		t.Fatalf("builtin print output mismatch:\n got %q\nwant %q", got, want)
 	}

--- a/test/print_builtin_legacy_test.go
+++ b/test/print_builtin_legacy_test.go
@@ -7,7 +7,7 @@ import "testing"
 
 func TestBuiltinPrintLegacyFloatFormat(t *testing.T) {
 	got := runBuiltinPrintProbe(t)
-	wantGC := "" +
+	want := "" +
 		"+1.000000e+007\n" +
 		"(+1.000000e+007-1.000000e+007i)\n" +
 		"(+1.500000e+000+0.000000e+000i)\n" +
@@ -17,17 +17,7 @@ func TestBuiltinPrintLegacyFloatFormat(t *testing.T) {
 		"(+1.000000e+000NaNi)\n" +
 		"(+1.000000e+000+Infi)\n" +
 		"(+1.000000e+000-Infi)\n"
-	wantLLGo := "" +
-		"+1.000000e+07\n" +
-		"(+1.000000e+07-1.000000e+07i)\n" +
-		"(+1.500000e+00+0.000000e+00i)\n" +
-		"NaN\n" +
-		"+Inf\n" +
-		"-Inf\n" +
-		"(+1.000000e+00NaNi)\n" +
-		"(+1.000000e+00+Infi)\n" +
-		"(+1.000000e+00-Infi)\n"
-	if got != wantGC && got != wantLLGo {
-		t.Fatalf("builtin print output mismatch:\n got %q\nwant one of:\n  %q\n  %q", got, wantGC, wantLLGo)
+	if got != want {
+		t.Fatalf("builtin print output mismatch:\n got %q\nwant %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- update the Go <1.26 `test/go` builtin print regression test to expect the three-digit exponent padding emitted by legacy Go builtin print
- tighten the root builtin print legacy test so LLGo on Go <1.26 must match the same legacy exponent width instead of accepting the stale two-digit output
- keep the existing runtime print implementation unchanged

## Verification
- `GOTOOLCHAIN=local go test ./test -run TestBuiltinPrintLegacyFloatFormat -count=1 -v`
- `LLGO_ROOT=$PWD PATH=$PWD/.bin:$PATH GOTOOLCHAIN=local llgo test -timeout=20m github.com/goplus/llgo/test -run TestBuiltinPrintLegacyFloatFormat`
- Docker CI-like Go 1.24.2 linux/amd64:
  - `llgo test -timeout=20m github.com/goplus/llgo/test -run TestBuiltinPrintLegacyFloatFormat`
  - `llgo test -timeout=20m github.com/goplus/llgo/test/go -run TestBuiltinPrintLegacyExponentWidth`

This fixes the latest main CI failure in `TestBuiltinPrintLegacyExponentWidth` on Go 1.24.2 shards.