### PR TITLE
ci: move llama model demo out of PR workflow and fix print expectation

### DIFF
--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -17,24 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  download-model:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - name: Download model file
-        run: |
-          mkdir -p ./_demo/c/llama2-c
-          wget -P ./_demo/c/llama2-c https://huggingface.co/karpathy/tinyllamas/resolve/main/stories15M.bin
-
-      - name: Upload model as artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: llama2-model
-          path: ./_demo/c/llama2-c/stories15M.bin
-          retention-days: 1
-
   llgo:
-    needs: download-model
     continue-on-error: true
     # macOS Intel is much slower than macOS ARM in the "Test demos" step.
     # Observed: macOS ARM about 2m49s vs macOS Intel about 10m26s.
@@ -57,11 +40,6 @@ jobs:
           llvm-version: ${{matrix.llvm}}
       - name: Install embedded dependencies
         uses: ./.github/actions/setup-embed-deps
-      - name: Download model artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: llama2-model
-          path: ./_demo/c/llama2-c/
       - name: Download platform-specific demo libs
         run: |
           if ${{ startsWith(matrix.os, 'macos') }}; then

--- a/.github/workflows/model-demo.yml
+++ b/.github/workflows/model-demo.yml
@@ -1,0 +1,44 @@
+name: Model Demo
+
+on:
+  schedule:
+    - cron: "0 18 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  llama2:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dependencies
+        uses: ./.github/actions/setup-deps
+        with:
+          llvm-version: 19
+
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
+        with:
+          go-version: "1.24.2"
+
+      - name: Install llgo
+        run: |
+          go install ./...
+          echo "LLGO_ROOT=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+
+      - name: Download llama2 model
+        run: |
+          mkdir -p ./_demo/c/llama2-c
+          curl --fail --location --retry 5 --retry-delay 60 --retry-all-errors \
+            --output ./_demo/c/llama2-c/stories15M.bin \
+            https://huggingface.co/karpathy/tinyllamas/resolve/main/stories15M.bin
+
+      - name: Test llama2 demo
+        run: |
+          cd ./_demo/c/llama2-c
+          llgo run .

--- a/.github/workflows/test_demo.sh
+++ b/.github/workflows/test_demo.sh
@@ -206,6 +206,15 @@ should_ignore() {
   return 1
 }
 
+is_model_demo() {
+  case "$1" in
+    ./_demo/c/llama2-c)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 run_dirs=()
 run_targets=()
 run_labels=()
@@ -224,6 +233,10 @@ if [ "$mode" = "embedded" ]; then
   done
 else
   for d in "${cases[@]}"; do
+    if is_model_demo "$d" && [ "${LLGO_RUN_MODEL_DEMOS:-0}" != "1" ]; then
+      echo "SKIP $d (model demo runs in scheduled Model Demo workflow)"
+      continue
+    fi
     run_dirs+=("$d")
     run_targets+=("")
     run_labels+=("$d")

--- a/test/go/print_builtin_legacy_test.go
+++ b/test/go/print_builtin_legacy_test.go
@@ -69,11 +69,11 @@ func TestBuiltinPrintLegacyExponentWidth(t *testing.T) {
 
 	got := filterPrintProbeOutput(stderr.String())
 	want := "" +
-		"+5.000000e+00 +8.000000e+00\n" +
-		"+1.001000e+02\n" +
-		"(+1.000000e+00+2.000000e+00i)\n" +
-		"(+1.000000e+00+2.000000e+00i)\n" +
-		"(+4.000000e+00+6.000000e+00i)\n"
+		"+5.000000e+000 +8.000000e+000\n" +
+		"+1.001000e+002\n" +
+		"(+1.000000e+000+2.000000e+000i)\n" +
+		"(+1.000000e+000+2.000000e+000i)\n" +
+		"(+4.000000e+000+6.000000e+000i)\n"
 	if got != want {
 		t.Fatalf("builtin print output mismatch:\n got %q\nwant %q", got, want)
 	}

--- a/test/print_builtin_legacy_test.go
+++ b/test/print_builtin_legacy_test.go
@@ -7,7 +7,7 @@ import "testing"
 
 func TestBuiltinPrintLegacyFloatFormat(t *testing.T) {
 	got := runBuiltinPrintProbe(t)
-	wantGC := "" +
+	want := "" +
 		"+1.000000e+007\n" +
 		"(+1.000000e+007-1.000000e+007i)\n" +
 		"(+1.500000e+000+0.000000e+000i)\n" +
@@ -17,17 +17,7 @@ func TestBuiltinPrintLegacyFloatFormat(t *testing.T) {
 		"(+1.000000e+000NaNi)\n" +
 		"(+1.000000e+000+Infi)\n" +
 		"(+1.000000e+000-Infi)\n"
-	wantLLGo := "" +
-		"+1.000000e+07\n" +
-		"(+1.000000e+07-1.000000e+07i)\n" +
-		"(+1.500000e+00+0.000000e+00i)\n" +
-		"NaN\n" +
-		"+Inf\n" +
-		"-Inf\n" +
-		"(+1.000000e+00NaNi)\n" +
-		"(+1.000000e+00+Infi)\n" +
-		"(+1.000000e+00-Infi)\n"
-	if got != wantGC && got != wantLLGo {
-		t.Fatalf("builtin print output mismatch:\n got %q\nwant one of:\n  %q\n  %q", got, wantGC, wantLLGo)
+	if got != want {
+		t.Fatalf("builtin print output mismatch:\n got %q\nwant %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- remove the HuggingFace llama model download/artifact dependency from the PR LLGo workflow
- skip `_demo/c/llama2-c` during the normal demo sweep because it requires an external model checkpoint
- add a separate `Model Demo` workflow that runs the llama demo once daily and can also be triggered manually
- fix the Go <1.26 builtin print regression tests to expect legacy three-digit exponent padding

## Verification
- `bash -n .github/workflows/test_demo.sh`
- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/llgo.yml .github/workflows/model-demo.yml`
- `GOTOOLCHAIN=local go test ./test -run TestBuiltinPrintLegacyFloatFormat -count=1`
- Docker CI-like Go 1.24.2 linux/amd64:
  - `llgo test -timeout=20m github.com/goplus/llgo/test -run TestBuiltinPrintLegacyFloatFormat`
  - `llgo test -timeout=20m github.com/goplus/llgo/test/go -run TestBuiltinPrintLegacyExponentWidth`

This prevents PR CI from failing on HuggingFace 429s while preserving scheduled coverage for the model-backed demo, and fixes the current main CI print-format failure.