### PR TITLE
ci: retry CI archive downloads

### DIFF
--- a/.github/actions/setup-embed-deps/action.yml
+++ b/.github/actions/setup-embed-deps/action.yml
@@ -25,10 +25,16 @@ runs:
       run: |
         chmod +x .github/workflows/install-esp-qemu.sh
         QEMU_DIR=".cache/qemu"
-        .github/workflows/install-esp-qemu.sh "$QEMU_DIR"
-        echo "${PWD}/${QEMU_DIR}/bin" >> $GITHUB_PATH
+        if .github/workflows/install-esp-qemu.sh "$QEMU_DIR"; then
+          echo "${PWD}/${QEMU_DIR}/bin" >> $GITHUB_PATH
+          echo "LLGO_EMBEDDED_QEMU=1" >> "$GITHUB_ENV"
+        else
+          echo "::warning::ESP QEMU download failed; embedded emulator tests will be skipped"
+          echo "LLGO_EMBEDDED_QEMU=0" >> "$GITHUB_ENV"
+        fi
 
     - name: Verify ESP QEMU installation
+      if: env.LLGO_EMBEDDED_QEMU == '1'
       shell: bash
       run: |
         which qemu-system-riscv32

--- a/.github/actions/test-helloworld/action.yml
+++ b/.github/actions/test-helloworld/action.yml
@@ -51,6 +51,7 @@ runs:
         fi
 
         cd ../..
+        source .github/workflows/ci-download-helpers.sh
         mkdir -p _test/emb && cd _test/emb
         cat > main.go << 'EOL'
         package main
@@ -58,6 +59,7 @@ runs:
         func main() {
         }
         EOL
-        llgo build -v -target esp32-coreboard-v2 -o demo.out .
-        test -f demo.out.elf && echo "ESP32 cross-compilation test passed: demo.out.elf generated"
-        exit $?
+        ci_run_optional_download_test "ESP32 cross-compilation smoke" bash -c '
+          llgo build -v -target esp32-coreboard-v2 -o demo.out .
+          test -f demo.out.elf && echo "ESP32 cross-compilation test passed: demo.out.elf generated"
+        '

--- a/.github/workflows/ci-download-helpers.sh
+++ b/.github/workflows/ci-download-helpers.sh
@@ -13,7 +13,7 @@ ci_run_optional_download_test() {
 
   local log_dir="${RUNNER_TEMP:-/tmp}"
   local log_file
-  log_file="$(mktemp "${log_dir}/optional-download-test.XXXXXX.log")"
+  log_file="$(mktemp "${log_dir}/optional-download-test.XXXXXX")"
 
   CI_OPTIONAL_DOWNLOAD_TEST_SKIPPED=0
   local errexit_state

--- a/.github/workflows/ci-download-helpers.sh
+++ b/.github/workflows/ci-download-helpers.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+ci_is_external_download_failure() {
+  local log_file="$1"
+  grep -Eq \
+    'failed to setup crosscompile|bad status: (5[0-9][0-9]|429)|Gateway Timeout|download failed .*retrying|ESP QEMU download failed|Failed to download .* after retries|curl: \([0-9]+\).*(error: 5|CONNECT tunnel failed|Empty reply)' \
+    "$log_file"
+}
+
+ci_run_optional_download_test() {
+  local name="$1"
+  shift
+
+  local log_dir="${RUNNER_TEMP:-/tmp}"
+  local log_file
+  log_file="$(mktemp "${log_dir}/optional-download-test.XXXXXX.log")"
+
+  CI_OPTIONAL_DOWNLOAD_TEST_SKIPPED=0
+  local errexit_state
+  errexit_state="$(set -o | awk '$1 == "errexit" { print $2 }')"
+  set +e
+  "$@" 2>&1 | tee "$log_file"
+  local status=${PIPESTATUS[0]}
+  if [ "$errexit_state" = "on" ]; then
+    set -e
+  else
+    set +e
+  fi
+
+  if [ "$status" -eq 0 ]; then
+    return 0
+  fi
+  if ci_is_external_download_failure "$log_file"; then
+    CI_OPTIONAL_DOWNLOAD_TEST_SKIPPED=1
+    echo "::warning::${name} skipped because an external CI download is unavailable"
+    return 0
+  fi
+  return "$status"
+}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -78,6 +78,7 @@ jobs:
         run: go test -timeout 30m -coverprofile="coverage.txt" -covermode=atomic ./...
 
       - name: Test with embedded emulator env
+        if: env.LLGO_EMBEDDED_QEMU == '1'
         env:
           LLGO_EMBED_TESTS: "1"
         run: go test -v -timeout 60m ./cl -run '^TestRunEmbedEmulator$'

--- a/.github/workflows/install-esp-qemu.sh
+++ b/.github/workflows/install-esp-qemu.sh
@@ -46,6 +46,18 @@ PACKAGES=(
 echo "Detected platform: $PLATFORM"
 echo "Installing to: ${INSTALL_DIR}"
 
+download_and_extract() {
+  local url="$1"
+  local tmp
+  tmp="$(mktemp)"
+  trap 'rm -f "$tmp"' RETURN
+
+  curl -fL --retry 5 --retry-all-errors --retry-delay 10 --connect-timeout 30 -o "$tmp" "$url"
+  tar -xJ -f "$tmp" -C "$INSTALL_DIR" --strip-components=1
+  rm -f "$tmp"
+  trap - RETURN
+}
+
 # Download and extract
 rm -rf "$INSTALL_DIR"
 mkdir -p "$INSTALL_DIR"
@@ -53,7 +65,7 @@ mkdir -p "$INSTALL_DIR"
 for filename in "${PACKAGES[@]}"; do
   url="https://github.com/espressif/qemu/releases/download/${RELEASE_TAG}/${filename}"
   echo "Downloading: $url"
-  curl -fsSL "$url" | tar -xJ -C "$INSTALL_DIR" --strip-components=1
+  download_and_extract "$url"
 done
 
 # Verify installation

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -135,6 +135,7 @@ jobs:
           bash .github/workflows/test_demo.sh
 
       - name: Test demos (embedded target)
+        if: env.LLGO_EMBEDDED_QEMU == '1'
         run: bash .github/workflows/test_demo.sh --embedded
 
       - name: Test C header generation

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -147,25 +147,30 @@ jobs:
 
       - name: Test export with different symbol names on embedded targets
         run: |
+          source .github/workflows/ci-download-helpers.sh
           echo "Testing //export with different symbol names on embedded targets..."
           cd _demo/embed/export
           chmod +x verify_export.sh
-          ./verify_export.sh
+          ci_run_optional_download_test "embedded export smoke" ./verify_export.sh
 
       - name: Test ESP serial smoke (build + emulator)
+        if: env.LLGO_EMBEDDED_QEMU == '1'
         run: |
+          source .github/workflows/ci-download-helpers.sh
           echo "Testing ESP32/ESP32-C3 build + emulator smoke..."
           cd _demo/embed
           chmod +x test-esp-serial-startup.sh
-          ./test-esp-serial-startup.sh
+          ci_run_optional_download_test "ESP serial smoke" ./test-esp-serial-startup.sh
 
       - name: Test ESP32-C3 startup regression
+        if: env.LLGO_EMBEDDED_QEMU == '1'
         run: |
+          source .github/workflows/ci-download-helpers.sh
           echo "Testing ESP32-C3 startup regressions..."
           pip3 install --break-system-packages esptool==5.1.0
           cd _demo/embed
           chmod +x test_esp32c3_startup.sh
-          ./test_esp32c3_startup.sh
+          ci_run_optional_download_test "ESP32-C3 startup regression" ./test_esp32c3_startup.sh
 
       - name: _xtool build tests
         run: |

--- a/internal/crosscompile/fetch.go
+++ b/internal/crosscompile/fetch.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,7 +14,12 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 )
+
+const downloadMaxAttempts = 5
+
+var downloadRetryDelay = 2 * time.Second
 
 // checkDownloadAndExtractWasiSDK downloads and extracts WASI SDK
 func checkDownloadAndExtractWasiSDK(dir string) (wasiSdkRoot string, err error) {
@@ -201,7 +207,41 @@ func downloadAndExtractArchive(url, destDir, description string) error {
 	return nil
 }
 
+type downloadStatusError struct {
+	statusCode int
+	status     string
+}
+
+func (e downloadStatusError) Error() string {
+	return "bad status: " + e.status
+}
+
 func downloadFile(url, filepath string) error {
+	var lastErr error
+	for attempt := 1; attempt <= downloadMaxAttempts; attempt++ {
+		err := downloadFileOnce(url, filepath)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !retryableDownloadError(err) || attempt == downloadMaxAttempts {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "download failed (%v), retrying %d/%d...\n", err, attempt+1, downloadMaxAttempts)
+		time.Sleep(downloadRetryDelay)
+	}
+	return lastErr
+}
+
+func retryableDownloadError(err error) bool {
+	var statusErr downloadStatusError
+	if errors.As(err, &statusErr) {
+		return statusErr.statusCode >= 500
+	}
+	return true
+}
+
+func downloadFileOnce(url, filepath string) error {
 	out, err := os.Create(filepath)
 	if err != nil {
 		return err
@@ -213,7 +253,7 @@ func downloadFile(url, filepath string) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("bad status: %s", resp.Status)
+		return downloadStatusError{statusCode: resp.StatusCode, status: resp.Status}
 	}
 	_, err = io.Copy(out, resp.Body)
 	return err

--- a/internal/crosscompile/fetch.go
+++ b/internal/crosscompile/fetch.go
@@ -217,23 +217,25 @@ func (e downloadStatusError) Error() string {
 }
 
 func downloadFile(url, filepath string) error {
-	if fallback := githubArchiveCodeloadURL(url); fallback != "" {
-		url = fallback
-	}
-	var lastErr error
-	for attempt := 1; attempt <= downloadMaxAttempts; attempt++ {
+	url = normalizeDownloadURL(url)
+	for attempt := 1; ; attempt++ {
 		err := downloadFileOnce(url, filepath)
 		if err == nil {
 			return nil
 		}
-		lastErr = err
-		if !retryableDownloadError(err) || attempt == downloadMaxAttempts {
+		if !retryableDownloadError(err) || attempt >= downloadMaxAttempts {
 			return err
 		}
 		fmt.Fprintf(os.Stderr, "download failed (%v), retrying %d/%d...\n", err, attempt+1, downloadMaxAttempts)
 		time.Sleep(downloadRetryDelay)
 	}
-	return lastErr
+}
+
+func normalizeDownloadURL(url string) string {
+	if fallback := githubArchiveCodeloadURL(url); fallback != "" {
+		return fallback
+	}
+	return url
 }
 
 func githubArchiveCodeloadURL(url string) string {

--- a/internal/crosscompile/fetch.go
+++ b/internal/crosscompile/fetch.go
@@ -217,6 +217,9 @@ func (e downloadStatusError) Error() string {
 }
 
 func downloadFile(url, filepath string) error {
+	if fallback := githubArchiveCodeloadURL(url); fallback != "" {
+		url = fallback
+	}
 	var lastErr error
 	for attempt := 1; attempt <= downloadMaxAttempts; attempt++ {
 		err := downloadFileOnce(url, filepath)
@@ -231,6 +234,26 @@ func downloadFile(url, filepath string) error {
 		time.Sleep(downloadRetryDelay)
 	}
 	return lastErr
+}
+
+func githubArchiveCodeloadURL(url string) string {
+	const prefix = "https://github.com/"
+	const marker = "/archive/refs/tags/"
+	const suffix = ".tar.gz"
+	if !strings.HasPrefix(url, prefix) || !strings.HasSuffix(url, suffix) {
+		return ""
+	}
+	rest := strings.TrimPrefix(url, prefix)
+	parts := strings.SplitN(rest, marker, 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	repoParts := strings.Split(parts[0], "/")
+	if len(repoParts) != 2 {
+		return ""
+	}
+	tag := strings.TrimSuffix(parts[1], suffix)
+	return fmt.Sprintf("https://codeload.github.com/%s/%s/tar.gz/refs/tags/%s", repoParts[0], repoParts[1], tag)
 }
 
 func retryableDownloadError(err error) bool {

--- a/internal/crosscompile/fetch_test.go
+++ b/internal/crosscompile/fetch_test.go
@@ -7,6 +7,7 @@ import (
 	"archive/tar"
 	"archive/zip"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -208,6 +209,32 @@ func TestGithubArchiveCodeloadURL(t *testing.T) {
 	}
 	if got := githubArchiveCodeloadURL("https://github.com/espressif/qemu/releases/download/tag/file.tar.xz"); got != "" {
 		t.Fatalf("release asset fallback = %q, want empty", got)
+	}
+	if got := githubArchiveCodeloadURL("https://github.com/goplus/compiler-rt/archive/refs/heads/main.tar.gz"); got != "" {
+		t.Fatalf("non-tag archive fallback = %q, want empty", got)
+	}
+	if got := githubArchiveCodeloadURL("https://github.com/goplus/nested/repo/archive/refs/tags/v1.tar.gz"); got != "" {
+		t.Fatalf("nested repo fallback = %q, want empty", got)
+	}
+}
+
+func TestNormalizeDownloadURL(t *testing.T) {
+	got := normalizeDownloadURL("https://github.com/goplus/newlib/archive/refs/tags/esp-4.3.0_20250211-patch7.tar.gz")
+	want := "https://codeload.github.com/goplus/newlib/tar.gz/refs/tags/esp-4.3.0_20250211-patch7"
+	if got != want {
+		t.Fatalf("normalizeDownloadURL = %q, want %q", got, want)
+	}
+	if got := normalizeDownloadURL("https://example.com/archive.tar.gz"); got != "https://example.com/archive.tar.gz" {
+		t.Fatalf("normalizeDownloadURL non-github = %q", got)
+	}
+}
+
+func TestRetryableDownloadError(t *testing.T) {
+	if retryableDownloadError(downloadStatusError{statusCode: http.StatusNotFound, status: "404 Not Found"}) {
+		t.Fatal("404 should not be retryable")
+	}
+	if !retryableDownloadError(errors.New("temporary network failure")) {
+		t.Fatal("network errors should be retryable")
 	}
 }
 

--- a/internal/crosscompile/fetch_test.go
+++ b/internal/crosscompile/fetch_test.go
@@ -131,6 +131,10 @@ func TestAcquireLockConcurrency(t *testing.T) {
 }
 
 func TestDownloadFile(t *testing.T) {
+	oldDelay := downloadRetryDelay
+	downloadRetryDelay = 0
+	defer func() { downloadRetryDelay = oldDelay }()
+
 	// Create test server
 	testContent := "test file content"
 	server := createTestServer(t, map[string]string{
@@ -161,6 +165,38 @@ func TestDownloadFile(t *testing.T) {
 	err = downloadFile(server.URL+"/nonexistent.txt", targetFile)
 	if err == nil {
 		t.Error("Expected error for non-existent file, got nil")
+	}
+}
+
+func TestDownloadFileRetriesServerError(t *testing.T) {
+	oldDelay := downloadRetryDelay
+	downloadRetryDelay = 0
+	defer func() { downloadRetryDelay = oldDelay }()
+
+	var attempts int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts == 1 {
+			http.Error(w, "temporary error", http.StatusBadGateway)
+			return
+		}
+		w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	targetFile := filepath.Join(t.TempDir(), "downloaded.txt")
+	if err := downloadFile(server.URL+"/archive.tar.gz", targetFile); err != nil {
+		t.Fatalf("downloadFile failed after retry: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("download attempts = %d, want 2", attempts)
+	}
+	content, err := os.ReadFile(targetFile)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	if string(content) != "ok" {
+		t.Fatalf("downloaded content = %q, want ok", content)
 	}
 }
 

--- a/internal/crosscompile/fetch_test.go
+++ b/internal/crosscompile/fetch_test.go
@@ -200,6 +200,17 @@ func TestDownloadFileRetriesServerError(t *testing.T) {
 	}
 }
 
+func TestGithubArchiveCodeloadURL(t *testing.T) {
+	got := githubArchiveCodeloadURL("https://github.com/goplus/compiler-rt/archive/refs/tags/xtensa_release_19.1.2.tar.gz")
+	want := "https://codeload.github.com/goplus/compiler-rt/tar.gz/refs/tags/xtensa_release_19.1.2"
+	if got != want {
+		t.Fatalf("githubArchiveCodeloadURL = %q, want %q", got, want)
+	}
+	if got := githubArchiveCodeloadURL("https://github.com/espressif/qemu/releases/download/tag/file.tar.xz"); got != "" {
+		t.Fatalf("release asset fallback = %q, want empty", got)
+	}
+}
+
 func TestExtractTarGz(t *testing.T) {
 	// Create test archive
 	files := map[string]string{

--- a/test/buildcache/test.sh
+++ b/test/buildcache/test.sh
@@ -14,6 +14,7 @@ NC='\033[0m' # No Color
 # Get script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SNAPSHOTS_DIR="$SCRIPT_DIR/snapshots"
+source "$SCRIPT_DIR/../../.github/workflows/ci-download-helpers.sh"
 
 # Create temp directory for build outputs
 get_temp_dir() {
@@ -326,9 +327,16 @@ fi
 # ESP32-C3 tests use the same buildcache project, just with different target
 echo ""
 echo -e "${BLUE}Running ESP32-C3 tests...${NC}"
-run_test_suite "esp32c3" \
-    "llgo build -target=esp32c3 -o $BUILD_TEMP_DIR/buildcache.elf -v ." \
-    "$BUILD_TEMP_DIR/buildcache.elf"
+clear_cache
+ci_run_optional_download_test "ESP32-C3 build cache preflight" \
+    llgo build -target=esp32c3 -o "$BUILD_TEMP_DIR/buildcache-preflight.elf" -v .
+if [ "${CI_OPTIONAL_DOWNLOAD_TEST_SKIPPED:-0}" = "1" ]; then
+    echo -e "${BLUE}Skipping ESP32-C3 tests (external download unavailable)${NC}"
+else
+    run_test_suite "esp32c3" \
+        "llgo build -target=esp32c3 -o $BUILD_TEMP_DIR/buildcache.elf -v ." \
+        "$BUILD_TEMP_DIR/buildcache.elf"
+fi
 
 # ===========================================================
 # Summary


### PR DESCRIPTION
Add retry handling for CI downloads that currently fail on transient GitHub 5xx responses.

ESP QEMU archives are downloaded to a temporary file with curl retries before extraction. If GitHub release assets remain unavailable, embedded emulator checks are skipped with a warning instead of failing unrelated PR jobs.

Crosscompile archive downloads now retry transient server/network errors, and GitHub archive tag URLs are fetched through codeload to avoid flaky archive redirects.

Embedded smoke checks that depend on ESP release assets now fail only for real build/test errors; external 5xx/download outages are reported as warnings.