### PR TITLE
ssa: avoid branching after panic in deferred calls

### DIFF
--- a/cl/_testgo/cgodefer/cgodefer.go
+++ b/cl/_testgo/cgodefer/cgodefer.go
@@ -89,10 +89,10 @@ import "C"
 // CHECK-NEXT:   %32 = extractvalue { ptr, i64, { ptr, ptr } } %31, 0
 // CHECK-NEXT:   store ptr %32, ptr %18, align 8
 // CHECK-NEXT:   %33 = extractvalue { ptr, i64, { ptr, ptr } } %31, 2
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.FreeDeferNode"(ptr %30)
 // CHECK-NEXT:   %34 = extractvalue { ptr, ptr } %33, 1
 // CHECK-NEXT:   %35 = extractvalue { ptr, ptr } %33, 0
 // CHECK-NEXT:   call void %35(ptr %34)
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.FreeDeferNode"(ptr %30)
 // CHECK-NEXT:   br label %_llgo_8
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_7, %_llgo_2

--- a/cl/_testgo/recoverthenpanic/in.go
+++ b/cl/_testgo/recoverthenpanic/in.go
@@ -27,7 +27,7 @@ package main
 // CHECK-NEXT:   %12 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %5, i32 0, i32 4
 // CHECK-NEXT:   %13 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %5, i32 0, i32 5
 // CHECK-NEXT:   store ptr null, ptr %13, align 8
-// CHECK-NEXT:   %14 = call i32 @__sigsetjmp(ptr %4, i32 0)
+// CHECK-NEXT:   %14 = call i32 @{{.*}}sigsetjmp(ptr %4, i32 0)
 // CHECK-NEXT:   %15 = icmp eq i32 %14, 0
 // CHECK-NEXT:   br i1 %15, label %_llgo_4, label %_llgo_7
 // CHECK-EMPTY:

--- a/cl/_testgo/recoverthenpanic/in.go
+++ b/cl/_testgo/recoverthenpanic/in.go
@@ -1,0 +1,186 @@
+// LITTEST
+package main
+
+// CHECK-LINE: @0 = private unnamed_addr constant [19 x i8] c"will panic in defer", align 1
+// CHECK-LINE: @1 = private unnamed_addr constant [3 x i8] c"end", align 1
+// CHECK-LINE: @2 = private unnamed_addr constant [13 x i8] c"panic in main", align 1
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/recoverthenpanic.End"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call %"{{.*}}/runtime/internal/runtime.eface" @"{{.*}}/runtime/internal/runtime.Recover"()
+// CHECK-NEXT:   %1 = call i1 @"{{.*}}/runtime/internal/runtime.EfaceEqual"(%"{{.*}}/runtime/internal/runtime.eface" %0, %"{{.*}}/runtime/internal/runtime.eface" zeroinitializer)
+// CHECK-NEXT:   %2 = xor i1 %1, true
+// CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.GetThreadDefer"()
+// CHECK-NEXT:   %4 = alloca i8, i64 {{.*}}, align 1
+// CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 48)
+// CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %5, i32 0, i32 0
+// CHECK-NEXT:   store ptr %4, ptr %6, align 8
+// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %5, i32 0, i32 1
+// CHECK-NEXT:   store i64 0, ptr %7, align 8
+// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %5, i32 0, i32 2
+// CHECK-NEXT:   store ptr %3, ptr %8, align 8
+// CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %5, i32 0, i32 3
+// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/recoverthenpanic.End", %_llgo_5), ptr %9, align 8
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.SetThreadDefer"(ptr %5)
+// CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %5, i32 0, i32 1
+// CHECK-NEXT:   %11 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %5, i32 0, i32 3
+// CHECK-NEXT:   %12 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %5, i32 0, i32 4
+// CHECK-NEXT:   %13 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %5, i32 0, i32 5
+// CHECK-NEXT:   store ptr null, ptr %13, align 8
+// CHECK-NEXT:   %14 = call i32 @__sigsetjmp(ptr %4, i32 0)
+// CHECK-NEXT:   %15 = icmp eq i32 %14, 0
+// CHECK-NEXT:   br i1 %15, label %_llgo_4, label %_llgo_7
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_4
+// CHECK-NEXT:   %16 = load i64, ptr %10, align 8
+// CHECK-NEXT:   %17 = or i64 %16, 1
+// CHECK-NEXT:   store i64 %17, ptr %10, align 8
+// CHECK-NEXT:   %18 = load ptr, ptr %13, align 8
+// CHECK-NEXT:   %19 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 32)
+// CHECK-NEXT:   %20 = getelementptr inbounds { ptr, i64, %"{{.*}}/runtime/internal/runtime.eface" }, ptr %19, i32 0, i32 0
+// CHECK-NEXT:   store ptr %18, ptr %20, align 8
+// CHECK-NEXT:   %21 = getelementptr inbounds { ptr, i64, %"{{.*}}/runtime/internal/runtime.eface" }, ptr %19, i32 0, i32 1
+// CHECK-NEXT:   store i64 0, ptr %21, align 8
+// CHECK-NEXT:   %22 = getelementptr inbounds { ptr, i64, %"{{.*}}/runtime/internal/runtime.eface" }, ptr %19, i32 0, i32 2
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.eface" %0, ptr %22, align 8
+// CHECK-NEXT:   store ptr %19, ptr %13, align 8
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 19 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   br label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_4
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @1, i64 3 })
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
+// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/recoverthenpanic.End", %_llgo_8), ptr %12, align 8
+// CHECK-NEXT:   br label %_llgo_5
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_6
+// CHECK-NEXT:   ret void
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   br i1 %2, label %_llgo_1, label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_7, %_llgo_2
+// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/recoverthenpanic.End", %_llgo_6), ptr %11, align 8
+// CHECK-NEXT:   %23 = load i64, ptr %10, align 8
+// CHECK-NEXT:   %24 = and i64 %23, 1
+// CHECK-NEXT:   %25 = icmp ne i64 %24, 0
+// CHECK-NEXT:   br i1 %25, label %_llgo_9, label %_llgo_10
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_6:                                          ; preds = %_llgo_7, %_llgo_10
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Rethrow"(ptr %3)
+// CHECK-NEXT:   br label %_llgo_3
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/recoverthenpanic.End", %_llgo_6), ptr %12, align 8
+// CHECK-NEXT:   %26 = load ptr, ptr %11, align 8
+// CHECK-NEXT:   indirectbr ptr %26, [label %_llgo_6, label %_llgo_5]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_10
+// CHECK-NEXT:   ret void
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_9:                                          ; preds = %_llgo_5
+// CHECK-NEXT:   %27 = load ptr, ptr %13, align 8
+// CHECK-NEXT:   %28 = icmp ne ptr %27, null
+// CHECK-NEXT:   br i1 %28, label %_llgo_11, label %_llgo_12
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_10:                                         ; preds = %_llgo_12, %_llgo_5
+// CHECK-NEXT:   %29 = load %"{{.*}}/runtime/internal/runtime.Defer", ptr %5, align 8
+// CHECK-NEXT:   %30 = extractvalue %"{{.*}}/runtime/internal/runtime.Defer" %29, 2
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.SetThreadDefer"(ptr %30)
+// CHECK-NEXT:   %31 = load ptr, ptr %12, align 8
+// CHECK-NEXT:   indirectbr ptr %31, [label %_llgo_6, label %_llgo_8]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_11:                                         ; preds = %_llgo_9
+// CHECK-NEXT:   %32 = load ptr, ptr %13, align 8
+// CHECK-NEXT:   %33 = load { ptr, i64, %"{{.*}}/runtime/internal/runtime.eface" }, ptr %32, align 8
+// CHECK-NEXT:   %34 = extractvalue { ptr, i64, %"{{.*}}/runtime/internal/runtime.eface" } %33, 0
+// CHECK-NEXT:   store ptr %34, ptr %13, align 8
+// CHECK-NEXT:   %35 = extractvalue { ptr, i64, %"{{.*}}/runtime/internal/runtime.eface" } %33, 2
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.FreeDeferNode"(ptr %32)
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %35)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_12:                                         ; preds = %_llgo_9
+// CHECK-NEXT:   br label %_llgo_10
+// CHECK-NEXT: }
+
+func End() {
+	if recovered := recover(); recovered != nil {
+		// Record but don't stop the panic.
+		defer panic(recovered)
+		println("will panic in defer")
+	}
+	println("end")
+}
+
+func main() {
+	defer End()
+	panic("panic in main")
+}
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/recoverthenpanic.init"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}/cl/_testgo/recoverthenpanic.init$guard", align 1
+// CHECK-NEXT:   br i1 %0, label %_llgo_2, label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testgo/recoverthenpanic.init$guard", align 1
+// CHECK-NEXT:   br label %_llgo_2
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define void @"{{.*}}/cl/_testgo/recoverthenpanic.main"(){{.*}} {
+// CHECK-NEXT: _llgo_0:
+// CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.GetThreadDefer"()
+// CHECK-NEXT:   %1 = alloca i8, i64 {{.*}}, align 1
+// CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 48)
+// CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %2, i32 0, i32 0
+// CHECK-NEXT:   store ptr %1, ptr %3, align 8
+// CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %2, i32 0, i32 1
+// CHECK-NEXT:   store i64 0, ptr %4, align 8
+// CHECK-NEXT:   %5 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %2, i32 0, i32 2
+// CHECK-NEXT:   store ptr %0, ptr %5, align 8
+// CHECK-NEXT:   %6 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %2, i32 0, i32 3
+// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/recoverthenpanic.main", %_llgo_2), ptr %6, align 8
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.SetThreadDefer"(ptr %2)
+// CHECK-NEXT:   %7 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %2, i32 0, i32 1
+// CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %2, i32 0, i32 3
+// CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %2, i32 0, i32 4
+// CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/runtime/internal/runtime.Defer", ptr %2, i32 0, i32 5
+// CHECK-NEXT:   store ptr null, ptr %10, align 8
+// CHECK-NEXT:   %11 = call i32 @{{.*}}sigsetjmp(ptr %1, i32 0)
+// CHECK-NEXT:   %12 = icmp eq i32 %11, 0
+// CHECK-NEXT:   br i1 %12, label %_llgo_4, label %_llgo_5
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_3
+// CHECK-NEXT:   ret void
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_5
+// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/recoverthenpanic.main", %_llgo_3), ptr %8, align 8
+// CHECK-NEXT:   %13 = load i64, ptr %7, align 8
+// CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/recoverthenpanic.End"()
+// CHECK-NEXT:   %14 = load %"{{.*}}/runtime/internal/runtime.Defer", ptr %2, align 8
+// CHECK-NEXT:   %15 = extractvalue %"{{.*}}/runtime/internal/runtime.Defer" %14, 2
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.SetThreadDefer"(ptr %15)
+// CHECK-NEXT:   %16 = load ptr, ptr %9, align 8
+// CHECK-NEXT:   indirectbr ptr %16, [label %_llgo_3]
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_5, %_llgo_2
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Rethrow"(ptr %0)
+// CHECK-NEXT:   br label %_llgo_1
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   %17 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 13 }, ptr %17, align 8
+// CHECK-NEXT:   %18 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %17, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %18)
+// CHECK-NEXT:   unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_0
+// CHECK-NEXT:   store ptr blockaddress(@"{{.*}}/cl/_testgo/recoverthenpanic.main", %_llgo_3), ptr %9, align 8
+// CHECK-NEXT:   %19 = load ptr, ptr %8, align 8
+// CHECK-NEXT:   indirectbr ptr %19, [label %_llgo_3, label %_llgo_2]
+// CHECK-NEXT: }

--- a/ssa/eh.go
+++ b/ssa/eh.go
@@ -535,8 +535,8 @@ func (b Builder) callDefer(self *aDefer, typ Type, buildCall func(Builder, Expr,
 		for i := 0; i < len(args); i++ {
 			args[i] = b.getField(data, i+offset)
 		}
-		buildCall(b, fn, args...)
 		b.Call(b.Pkg.rtFunc("FreeDeferNode"), ptr)
+		buildCall(b, fn, args...)
 	})
 }
 

--- a/ssa/eh_loop_test.go
+++ b/ssa/eh_loop_test.go
@@ -93,3 +93,41 @@ func TestDeferAtomicInLoopIR(t *testing.T) {
 		t.Fatalf("expected loop defer node free in IR, got:\n%s", ir)
 	}
 }
+
+func TestDeferInLoopMaterializesArgsBeforeFree(t *testing.T) {
+	prog := ssatest.NewProgram(t, nil)
+	pkg := prog.NewPackage("foo", "foo")
+
+	params := types.NewTuple(types.NewParam(token.NoPos, nil, "", types.Typ[types.Int64]))
+	int64ArgSig := types.NewSignatureType(nil, nil, nil, params, nil, false)
+	callee := pkg.NewFunc("callee", int64ArgSig, ssa.InGo)
+	cb := callee.MakeBody(1)
+	cb.Return()
+	cb.EndBuild()
+
+	fn := pkg.NewFunc("main", ssa.NoArgsNoRet, ssa.InGo)
+	b := fn.MakeBody(1)
+	fn.SetRecover(fn.MakeBlock())
+
+	// Ensure entry block has a terminator like real codegen.
+	b.Return()
+	b.SetBlockEx(fn.Block(0), ssa.BeforeLast, true)
+
+	arg := b.Const(constant.MakeInt64(7), prog.Int64())
+	b.Defer(ssa.DeferInLoop, callee.Expr, ssa.Builder.Call, arg)
+	b.EndBuild()
+
+	ir := pkg.Module().String()
+	argExtractIdx := strings.Index(ir, "extractvalue { ptr, i64, i64 }")
+	freeIdx := strings.Index(ir, "FreeDeferNode")
+	callIdx := strings.Index(ir, "call void @callee(i64")
+	if argExtractIdx == -1 || freeIdx == -1 || callIdx == -1 {
+		t.Fatalf("missing deferred arg extraction/free/call in IR, got:\n%s", ir)
+	}
+	if argExtractIdx > freeIdx {
+		t.Fatalf("deferred arg must be materialized before FreeDeferNode, got:\n%s", ir)
+	}
+	if freeIdx > callIdx {
+		t.Fatalf("FreeDeferNode must run before buildCall uses materialized args, got:\n%s", ir)
+	}
+}

--- a/ssa/stmt_builder.go
+++ b/ssa/stmt_builder.go
@@ -228,7 +228,10 @@ func (b Builder) IfThen(cond Expr, then func()) {
 	b.If(cond, blks[0], blks[1])
 	b.SetBlockEx(blks[0], AtEnd, false)
 	then()
-	b.Jump(blks[1])
+	lastInst := b.impl.GetInsertBlock().LastInstruction()
+	if lastInst.IsNil() || lastInst.IsAUnreachableInst().IsNil() {
+		b.Jump(blks[1])
+	}
 	b.SetBlockEx(blks[1], AtEnd, false)
 	b.blk.last = blks[1].last
 }

--- a/test/go/defer_ir_regression_test.go
+++ b/test/go/defer_ir_regression_test.go
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gotest
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const recoverThenDeferredPanicProbe = `package main
+
+func end() {
+	if recovered := recover(); recovered != nil {
+		defer panic(recovered)
+		println("will panic in defer")
+	}
+	println("end")
+}
+
+func main() {
+	defer end()
+	panic("panic in main")
+}
+`
+
+const cgoDeferredFreeProbe = `package main
+
+/*
+#include <stdlib.h>
+*/
+import "C"
+
+func main() {
+	p := C.malloc(8)
+	if p == nil {
+		panic("C.malloc returned nil")
+	}
+	defer C.free(p)
+}
+`
+
+func TestRecoverThenDeferredPanicIRTerminatesBlocks(t *testing.T) {
+	ir := llgoIRFromProbe(t, "recover-then-deferred-panic", recoverThenDeferredPanicProbe)
+	assertNoInstructionsAfterUnreachable(t, ir)
+}
+
+func TestCgoDeferredFreeReleasesNodeBeforeCall(t *testing.T) {
+	if strings.TrimSpace(runGoCmd(t, "", "env", "CGO_ENABLED")) != "1" {
+		t.Skip("cgo is disabled")
+	}
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang is unavailable")
+	}
+
+	ir := llgoIRFromProbe(t, "cgo-deferred-free", cgoDeferredFreeProbe)
+	freeDefer := indexLineContaining(ir, "call void @", "FreeDeferNode")
+	deferredCall := indexLineContaining(ir, "call void %")
+	if freeDefer < 0 {
+		t.Fatalf("missing FreeDeferNode call in IR:\n%s", ir)
+	}
+	if deferredCall < 0 {
+		t.Fatalf("missing deferred indirect call in IR:\n%s", ir)
+	}
+	if freeDefer > deferredCall {
+		t.Fatalf("FreeDeferNode must run before deferred call, got FreeDeferNode line %d after call line %d", freeDefer, deferredCall)
+	}
+}
+
+func llgoIRFromProbe(t *testing.T, name, src string) string {
+	t.Helper()
+
+	root := findLLGoRoot(t)
+	dir, err := os.MkdirTemp(root, "."+name+"-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Logf("remove temp probe dir %s: %v", dir, err)
+		}
+	})
+
+	mainFile := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(mainFile, []byte(src), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	runGoCmd(t, root, "run", "./chore/llgen", filepath.ToSlash(dir))
+	data, err := os.ReadFile(filepath.Join(dir, "llgo_autogen.ll"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func assertNoInstructionsAfterUnreachable(t *testing.T, ir string) {
+	t.Helper()
+
+	lines := strings.Split(ir, "\n")
+	for i := 0; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) != "unreachable" {
+			continue
+		}
+		for j := i + 1; j < len(lines); j++ {
+			trimmed := strings.TrimSpace(lines[j])
+			if trimmed == "" {
+				continue
+			}
+			if trimmed == "}" || isLLVMBasicBlockLabel(trimmed) {
+				break
+			}
+			t.Fatalf("instruction after unreachable at IR line %d: %s", j+1, trimmed)
+		}
+	}
+}
+
+func isLLVMBasicBlockLabel(line string) bool {
+	colon := strings.IndexByte(line, ':')
+	if colon <= 0 {
+		return false
+	}
+	return !strings.ContainsAny(line[:colon], " \t")
+}
+
+func indexLineContaining(s string, parts ...string) int {
+	for i, line := range strings.Split(s, "\n") {
+		ok := true
+		for _, part := range parts {
+			if !strings.Contains(line, part) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return i + 1
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
## Summary
- avoid appending an extra branch after panic-generated unreachable blocks in IfThen
- refresh recoverthenpanic and cgodefer FileCheck expectations under cl/_testgo
- cover recover-then-panic and CGo deferred call IR with valid IR checks

## Tests
- export PATH=/opt/tools/go1.26.2.linux-amd64/go/bin:$PATH; export GOROOT=/opt/tools/go1.26.2.linux-amd64/go/; go test ./cl -run '^TestRunAndTestFromTestgo$/^(cgodefer|recoverthenpanic)$' -count=1 -v
- export PATH=/opt/tools/go1.26.2.linux-amd64/go/bin:$PATH; export GOROOT=/opt/tools/go1.26.2.linux-amd64/go/; go test ./ssa -run '^TestFromTestlibgo$/^mapzero$' -count=1 -v
- export PATH=/opt/tools/go1.26.2.linux-amd64/go/bin:$PATH; export GOROOT=/opt/tools/go1.26.2.linux-amd64/go/; go test ./ssa -run 'Test.*Defer|Test.*IR' -count=1

Note: full go test ./ssa now reaches FileCheck comparisons but fails on existing unrelated _testgo fixture drift (for example abimethod), not on the previous invalid LLVM IR parse error.