### PR TITLE
Integrate ARM plan9asm support in llgo

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1315,10 +1315,12 @@ func buildPkg(ctx *context, aPkg *aPackage, verbose bool) error {
 	}
 	aPkg.ObjFiles = append(aPkg.ObjFiles, cgoLLFiles...)
 	aPkg.ObjFiles = append(aPkg.ObjFiles, concatPkgLinkFiles(ctx, pkg, printCmds)...)
-	if asmObjFiles, err := compilePkgSFiles(ctx, aPkg, pkg, printCmds); err != nil {
-		return err
-	} else {
-		aPkg.ObjFiles = append(aPkg.ObjFiles, asmObjFiles...)
+	if aPkg.AltPkg == nil || llruntime.HasAdditiveAltPkg(pkgPath) {
+		if asmObjFiles, err := compilePkgSFiles(ctx, aPkg, pkg, printCmds); err != nil {
+			return err
+		} else {
+			aPkg.ObjFiles = append(aPkg.ObjFiles, asmObjFiles...)
+		}
 	}
 	if aliasObjs, err := buildGoCgoAliasObjects(ctx, pkgPath, aPkg.Package.Syntax, printCmds); err != nil {
 		return err

--- a/internal/build/plan9asm.go
+++ b/internal/build/plan9asm.go
@@ -230,6 +230,10 @@ func plan9asmSigsForPkg(ctx *context, pkgPath string) (map[string]struct{}, erro
 		plan9AsmSigCache.Store(key, sigs)
 		return sigs, nil
 	}
+	if hasAltPkgForTarget(ctx.buildConf, pkgPath) && !llruntime.HasAdditiveAltPkg(pkgPath) {
+		plan9AsmSigCache.Store(key, sigs)
+		return sigs, nil
+	}
 
 	var pkg *packages.Package
 	for p := range ctx.pkgs {
@@ -326,6 +330,9 @@ func (ctx *context) plan9asmEnabled(pkgPath string) bool {
 }
 
 func hasAltPkgForTarget(conf *Config, pkgPath string) bool {
+	if pkgPath == "internal/runtime/atomic" {
+		return conf != nil && conf.Goarch == "arm"
+	}
 	if !llruntime.HasAltPkg(pkgPath) {
 		return false
 	}
@@ -359,6 +366,9 @@ func plan9asmEnabledByEnv(pkgPath string) bool {
 func plan9asmEnabledByDefault(conf *Config, pkgPath string) bool {
 	if conf == nil {
 		return false
+	}
+	if pkgPath == "internal/runtime/atomic" {
+		return archSupportsPlan9AsmDefaults(conf.Goarch)
 	}
 	if !archSupportsPlan9AsmDefaults(conf.Goarch) {
 		return false
@@ -432,14 +442,34 @@ func pkgSFiles(ctx *context, pkg *packages.Package) ([]string, error) {
 			return paths, nil
 		}
 	}
-
-	paths := make([]string, 0, len(lp.SFiles))
-	for _, f := range lp.SFiles {
-		if lp.Dir == "" {
-			continue
-		}
-		paths = append(paths, filepath.Join(lp.Dir, f))
+	// Embedded ARM targets currently reuse GOOS=linux metadata, but they do not
+	// have a Linux syscall surface. Skip Linux/ARM syscall asm in that mode so
+	// target-smoke builds can exercise stdlib packages without pulling in
+	// syscall-specific plan9asm frame quirks.
+	if shouldSkipPlan9AsmSFilesForTarget(ctx.buildConf, pkg.PkgPath) {
+		ctx.sfilesCache[pkg.ID] = nil
+		return nil, nil
 	}
+
+	paths := selectedSFiles(lp.Dir, lp.SFiles)
 	ctx.sfilesCache[pkg.ID] = paths
 	return paths, nil
+}
+
+func selectedSFiles(dir string, files []string) []string {
+	if dir == "" || len(files) == 0 {
+		return nil
+	}
+	paths := make([]string, 0, len(files))
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.s") || strings.HasSuffix(f, "_test.S") {
+			continue
+		}
+		paths = append(paths, filepath.Join(dir, f))
+	}
+	return paths
+}
+
+func shouldSkipPlan9AsmSFilesForTarget(conf *Config, pkgPath string) bool {
+	return conf != nil && conf.Target != "" && conf.Goarch == "arm" && pkgPath == "syscall"
 }

--- a/internal/build/plan9asm.go
+++ b/internal/build/plan9asm.go
@@ -230,7 +230,7 @@ func plan9asmSigsForPkg(ctx *context, pkgPath string) (map[string]struct{}, erro
 		plan9AsmSigCache.Store(key, sigs)
 		return sigs, nil
 	}
-	if hasAltPkgForTarget(ctx.buildConf, pkgPath) && !llruntime.HasAdditiveAltPkg(pkgPath) {
+	if hasAltPkgForTarget(ctx.buildConf, pkgPath) && !llruntime.HasAdditiveAltPkgForGOARCH(pkgPath, ctx.buildConf.Goarch) {
 		plan9AsmSigCache.Store(key, sigs)
 		return sigs, nil
 	}
@@ -330,13 +330,10 @@ func (ctx *context) plan9asmEnabled(pkgPath string) bool {
 }
 
 func hasAltPkgForTarget(conf *Config, pkgPath string) bool {
-	if pkgPath == "internal/runtime/atomic" {
-		return conf != nil && conf.Goarch == "arm"
-	}
-	if !llruntime.HasAltPkg(pkgPath) {
+	if conf == nil || !llruntime.HasAltPkgForGOARCH(pkgPath, conf.Goarch) {
 		return false
 	}
-	if llruntime.HasAdditiveAltPkg(pkgPath) {
+	if llruntime.HasAdditiveAltPkgForGOARCH(pkgPath, conf.Goarch) {
 		return true
 	}
 	// When Plan9 asm translation is enabled, avoid also pulling in alt packages
@@ -367,13 +364,10 @@ func plan9asmEnabledByDefault(conf *Config, pkgPath string) bool {
 	if conf == nil {
 		return false
 	}
-	if pkgPath == "internal/runtime/atomic" {
-		return archSupportsPlan9AsmDefaults(conf.Goarch)
-	}
 	if !archSupportsPlan9AsmDefaults(conf.Goarch) {
 		return false
 	}
-	return !llruntime.HasAltPkg(pkgPath) || llruntime.HasAdditiveAltPkg(pkgPath)
+	return !llruntime.HasAltPkgForGOARCH(pkgPath, conf.Goarch) || llruntime.HasAdditiveAltPkgForGOARCH(pkgPath, conf.Goarch)
 }
 
 func pkgSFiles(ctx *context, pkg *packages.Package) ([]string, error) {
@@ -443,9 +437,8 @@ func pkgSFiles(ctx *context, pkg *packages.Package) ([]string, error) {
 		}
 	}
 	// Embedded ARM targets currently reuse GOOS=linux metadata, but they do not
-	// have a Linux syscall surface. Skip Linux/ARM syscall asm in that mode so
-	// target-smoke builds can exercise stdlib packages without pulling in
-	// syscall-specific plan9asm frame quirks.
+	// have a Linux syscall surface. Skip syscall asm in that mode so embedded
+	// builds do not inherit Linux/ARM-specific frame layouts.
 	if shouldSkipPlan9AsmSFilesForTarget(ctx.buildConf, pkg.PkgPath) {
 		ctx.sfilesCache[pkg.ID] = nil
 		return nil, nil

--- a/internal/build/plan9asm_altpkg_test.go
+++ b/internal/build/plan9asm_altpkg_test.go
@@ -18,3 +18,15 @@ func TestHasAltPkgForTarget_AllowsAdditivePatchWithPlan9Asm(t *testing.T) {
 		t.Fatal("internal/runtime/sys should keep its additive alt package even when plan9asm is enabled")
 	}
 }
+
+func TestHasAltPkgForTarget_UsesAtomicFallbackOnArm(t *testing.T) {
+	conf := &Config{Goarch: "arm", AbiMode: cabi.ModeAllFunc}
+	if !hasAltPkgForTarget(conf, "internal/runtime/atomic") {
+		t.Fatal("internal/runtime/atomic should use alt package on arm")
+	}
+
+	conf = &Config{Goarch: "arm64", AbiMode: cabi.ModeAllFunc}
+	if hasAltPkgForTarget(conf, "internal/runtime/atomic") {
+		t.Fatal("internal/runtime/atomic should keep plan9asm/std paths on arm64")
+	}
+}

--- a/internal/build/plan9asm_sfiles_test.go
+++ b/internal/build/plan9asm_sfiles_test.go
@@ -1,0 +1,51 @@
+//go:build !llgo
+// +build !llgo
+
+package build
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestSelectedSFilesSkipsTestAsm(t *testing.T) {
+	dir := "/tmp/pkg"
+	got := selectedSFiles(dir, []string{
+		"abi_test.s",
+		"stub.s",
+		"helper.S",
+		"compare_test.S",
+	})
+	want := []string{
+		filepath.Join(dir, "stub.s"),
+		filepath.Join(dir, "helper.S"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("selectedSFiles() = %#v, want %#v", got, want)
+	}
+}
+
+func TestSelectedSFilesHandlesEmptyInput(t *testing.T) {
+	if got := selectedSFiles("", []string{"stub.s"}); got != nil {
+		t.Fatalf("selectedSFiles(empty dir) = %#v, want nil", got)
+	}
+	if got := selectedSFiles("/tmp/pkg", nil); got != nil {
+		t.Fatalf("selectedSFiles(nil files) = %#v, want nil", got)
+	}
+}
+
+func TestShouldSkipPlan9AsmSFilesForTarget(t *testing.T) {
+	if !shouldSkipPlan9AsmSFilesForTarget(&Config{Target: "cortex-m-qemu", Goarch: "arm"}, "syscall") {
+		t.Fatal("embedded arm syscall asm should be skipped")
+	}
+	if shouldSkipPlan9AsmSFilesForTarget(&Config{Target: "", Goarch: "arm"}, "syscall") {
+		t.Fatal("host arm syscall asm should not be skipped")
+	}
+	if shouldSkipPlan9AsmSFilesForTarget(&Config{Target: "cortex-m-qemu", Goarch: "arm64"}, "syscall") {
+		t.Fatal("arm64 syscall asm should not be skipped by arm-only rule")
+	}
+	if shouldSkipPlan9AsmSFilesForTarget(&Config{Target: "cortex-m-qemu", Goarch: "arm"}, "internal/bytealg") {
+		t.Fatal("only syscall asm should be skipped by embedded arm rule")
+	}
+}

--- a/internal/plan9asm/bytealg_arm_sigs_test.go
+++ b/internal/plan9asm/bytealg_arm_sigs_test.go
@@ -1,0 +1,85 @@
+//go:build !llgo
+// +build !llgo
+
+package plan9asm
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/goplus/llgo/internal/packages"
+	extplan9asm "github.com/goplus/plan9asm"
+)
+
+func loadStdlibInternalBytealgForTarget(t *testing.T, goos, goarch string) *packages.Package {
+	t.Helper()
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedSyntax | packages.NeedTypes | packages.NeedTypesSizes | packages.NeedTypesInfo | packages.NeedImports,
+		Env:  append(os.Environ(), "GOOS="+goos, "GOARCH="+goarch),
+	}
+	pkgs, err := packages.LoadEx(nil, nil, cfg, "internal/bytealg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pkgs) != 1 || pkgs[0].Types == nil {
+		t.Fatalf("load internal/bytealg: got %d pkgs, types=%v", len(pkgs), pkgs[0].Types)
+	}
+	return pkgs[0]
+}
+
+func TestSigsForStdlibInternalBytealgArmHelpers(t *testing.T) {
+	goroot := runtime.GOROOT()
+	if goroot == "" {
+		t.Skip("GOROOT not available")
+	}
+	pkg := loadStdlibInternalBytealgForTarget(t, "linux", "arm")
+
+	tests := map[string]map[string]extplan9asm.FuncSig{
+		filepath.Join(goroot, "src", "internal", "bytealg", "compare_arm.s"): {
+			"internal/bytealg.cmpbody": {
+				Args:    []extplan9asm.LLVMType{extplan9asm.Ptr, "i32", extplan9asm.Ptr, "i32", extplan9asm.Ptr},
+				Ret:     extplan9asm.Void,
+				ArgRegs: []extplan9asm.Reg{"R2", "R0", "R3", "R1", "R7"},
+			},
+		},
+		filepath.Join(goroot, "src", "internal", "bytealg", "count_arm.s"): {
+			"internal/bytealg.countbytebody": {
+				Args:    []extplan9asm.LLVMType{extplan9asm.Ptr, "i32", "i8", extplan9asm.Ptr},
+				Ret:     extplan9asm.Void,
+				ArgRegs: []extplan9asm.Reg{"R0", "R1", "R2", "R7"},
+			},
+		},
+		filepath.Join(goroot, "src", "internal", "bytealg", "equal_arm.s"): {
+			"internal/bytealg.memeqbody": {
+				Args:    []extplan9asm.LLVMType{extplan9asm.Ptr, extplan9asm.Ptr, "i32", extplan9asm.Ptr},
+				Ret:     extplan9asm.Void,
+				ArgRegs: []extplan9asm.Reg{"R0", "R2", "R1", "R7"},
+			},
+		},
+		filepath.Join(goroot, "src", "internal", "bytealg", "indexbyte_arm.s"): {
+			"internal/bytealg.indexbytebody": {
+				Args:    []extplan9asm.LLVMType{extplan9asm.Ptr, "i32", "i8", extplan9asm.Ptr},
+				Ret:     extplan9asm.Void,
+				ArgRegs: []extplan9asm.Reg{"R0", "R1", "R2", "R5"},
+			},
+		},
+	}
+
+	for path, wantSigs := range tests {
+		tr, err := TranslateFileForPkg(pkg, path, "linux", "arm", nil)
+		if err != nil {
+			t.Fatalf("translate %s: %v", path, err)
+		}
+		for name, want := range wantSigs {
+			got, ok := tr.Signatures[name]
+			if !ok {
+				t.Fatalf("missing symbol %s in %s", name, path)
+			}
+			if err := checkSig(got, want); err != nil {
+				t.Fatalf("%s (%s): %v", name, path, err)
+			}
+		}
+	}
+}

--- a/internal/plan9asm/bytealg_arm_sigs_test.go
+++ b/internal/plan9asm/bytealg_arm_sigs_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/goplus/llgo/internal/packages"
-	extplan9asm "github.com/goplus/plan9asm"
+	extplan9asm "github.com/xgo-dev/plan9asm"
 )
 
 func loadStdlibInternalBytealgForTarget(t *testing.T, goos, goarch string) *packages.Package {

--- a/internal/plan9asm/translate.go
+++ b/internal/plan9asm/translate.go
@@ -195,6 +195,27 @@ func extraAsmSigsAndDeclMap(pkgPath string, goarch string) map[string]extplan9as
 	manual := map[string]extplan9asm.FuncSig{}
 	if pkgPath == "internal/bytealg" {
 		switch goarch {
+		case "arm":
+			manual["internal/bytealg.cmpbody"] = extplan9asm.FuncSig{
+				Args:    []extplan9asm.LLVMType{extplan9asm.Ptr, "i32", extplan9asm.Ptr, "i32", extplan9asm.Ptr},
+				Ret:     extplan9asm.Void,
+				ArgRegs: []extplan9asm.Reg{"R2", "R0", "R3", "R1", "R7"},
+			}
+			manual["internal/bytealg.memeqbody"] = extplan9asm.FuncSig{
+				Args:    []extplan9asm.LLVMType{extplan9asm.Ptr, extplan9asm.Ptr, "i32", extplan9asm.Ptr},
+				Ret:     extplan9asm.Void,
+				ArgRegs: []extplan9asm.Reg{"R0", "R2", "R1", "R7"},
+			}
+			manual["internal/bytealg.countbytebody"] = extplan9asm.FuncSig{
+				Args:    []extplan9asm.LLVMType{extplan9asm.Ptr, "i32", extplan9asm.LLVMType("i8"), extplan9asm.Ptr},
+				Ret:     extplan9asm.Void,
+				ArgRegs: []extplan9asm.Reg{"R0", "R1", "R2", "R7"},
+			}
+			manual["internal/bytealg.indexbytebody"] = extplan9asm.FuncSig{
+				Args:    []extplan9asm.LLVMType{extplan9asm.Ptr, "i32", extplan9asm.LLVMType("i8"), extplan9asm.Ptr},
+				Ret:     extplan9asm.Void,
+				ArgRegs: []extplan9asm.Reg{"R0", "R1", "R2", "R5"},
+			}
 		case "arm64":
 			manual["internal/bytealg.cmpbody"] = extplan9asm.FuncSig{Args: []extplan9asm.LLVMType{extplan9asm.Ptr, extplan9asm.I64, extplan9asm.Ptr, extplan9asm.I64}, Ret: extplan9asm.I64}
 			manual["internal/bytealg.memeqbody"] = extplan9asm.FuncSig{Args: []extplan9asm.LLVMType{extplan9asm.Ptr, extplan9asm.Ptr, extplan9asm.I64}, Ret: extplan9asm.I1}

--- a/internal/plan9asm/translate.go
+++ b/internal/plan9asm/translate.go
@@ -207,12 +207,12 @@ func extraAsmSigsAndDeclMap(pkgPath string, goarch string) map[string]extplan9as
 				ArgRegs: []extplan9asm.Reg{"R0", "R2", "R1", "R7"},
 			}
 			manual["internal/bytealg.countbytebody"] = extplan9asm.FuncSig{
-				Args:    []extplan9asm.LLVMType{extplan9asm.Ptr, "i32", extplan9asm.LLVMType("i8"), extplan9asm.Ptr},
+				Args:    []extplan9asm.LLVMType{extplan9asm.Ptr, "i32", "i8", extplan9asm.Ptr},
 				Ret:     extplan9asm.Void,
 				ArgRegs: []extplan9asm.Reg{"R0", "R1", "R2", "R7"},
 			}
 			manual["internal/bytealg.indexbytebody"] = extplan9asm.FuncSig{
-				Args:    []extplan9asm.LLVMType{extplan9asm.Ptr, "i32", extplan9asm.LLVMType("i8"), extplan9asm.Ptr},
+				Args:    []extplan9asm.LLVMType{extplan9asm.Ptr, "i32", "i8", extplan9asm.Ptr},
 				Ret:     extplan9asm.Void,
 				ArgRegs: []extplan9asm.Reg{"R0", "R1", "R2", "R5"},
 			}

--- a/internal/plan9asm/translate_helpers_test.go
+++ b/internal/plan9asm/translate_helpers_test.go
@@ -197,6 +197,18 @@ func TestExtraAsmSigsAndDeclMap(t *testing.T) {
 		t.Fatalf("unexpected manual sigs for scan/arm64: %#v", got)
 	}
 
+	arm := extraAsmSigsAndDeclMap("internal/bytealg", "arm")
+	for _, name := range []string{
+		"internal/bytealg.cmpbody",
+		"internal/bytealg.memeqbody",
+		"internal/bytealg.countbytebody",
+		"internal/bytealg.indexbytebody",
+	} {
+		if _, ok := arm[name]; !ok {
+			t.Fatalf("missing arm manual sig %s", name)
+		}
+	}
+
 	arm64 := extraAsmSigsAndDeclMap("internal/bytealg", "arm64")
 	for _, name := range []string{
 		"internal/bytealg.cmpbody",

--- a/runtime/build.go
+++ b/runtime/build.go
@@ -9,6 +9,23 @@ const (
 	altPkgAdditive
 )
 
+type altPkgSpec struct {
+	mode    altPkgMode
+	goarchs map[string]struct{}
+}
+
+func (s altPkgSpec) enabledFor(goarch string) bool {
+	return len(s.goarchs) == 0 || hasGoarch(s.goarchs, goarch)
+}
+
+func hasGoarch(goarchs map[string]struct{}, goarch string) bool {
+	if goarchs == nil {
+		return false
+	}
+	_, ok := goarchs[goarch]
+	return ok
+}
+
 func SkipToBuild(pkgPath string) bool {
 	if _, ok := altPkgs[pkgPath]; ok {
 		return false
@@ -21,8 +38,33 @@ func HasAltPkg(path string) (b bool) {
 	return
 }
 
+func HasAltPkgForGOARCH(path, goarch string) bool {
+	spec, ok := altPkgs[path]
+	return ok && spec.enabledFor(goarch)
+}
+
 func HasAdditiveAltPkg(path string) bool {
-	return altPkgs[path] == altPkgAdditive
+	return altPkgs[path].mode == altPkgAdditive
+}
+
+func HasAdditiveAltPkgForGOARCH(path, goarch string) bool {
+	spec, ok := altPkgs[path]
+	return ok && spec.mode == altPkgAdditive && spec.enabledFor(goarch)
+}
+
+var altPkgs = map[string]altPkgSpec{
+	"internal/abi":            {mode: altPkgReplace},
+	"internal/runtime/atomic": {mode: altPkgReplace, goarchs: map[string]struct{}{"arm": {}}},
+	"internal/reflectlite":    {mode: altPkgReplace},
+	"internal/runtime/maps":   {mode: altPkgReplace},
+	"internal/runtime/sys":    {mode: altPkgAdditive},
+	"reflect":                 {mode: altPkgReplace},
+	"runtime":                 {mode: altPkgReplace},
+	"sync/atomic":             {mode: altPkgReplace},
+	"syscall/js":              {mode: altPkgReplace},
+	"syscall":                 {mode: altPkgReplace},
+	"unique":                  {mode: altPkgReplace},
+	"golang.org/x/sys/unix":   {mode: altPkgReplace},
 }
 
 func HasSourcePatchPkg(path string) bool {
@@ -37,20 +79,6 @@ func SourcePatchPkgPaths() []string {
 	}
 	sort.Strings(paths)
 	return paths
-}
-
-var altPkgs = map[string]altPkgMode{
-	"internal/abi":          altPkgReplace,
-	"internal/reflectlite":  altPkgReplace,
-	"internal/runtime/maps": altPkgReplace,
-	"internal/runtime/sys":  altPkgAdditive,
-	"reflect":               altPkgReplace,
-	"runtime":               altPkgReplace,
-	"sync/atomic":           altPkgReplace,
-	"syscall/js":            altPkgReplace,
-	"syscall":               altPkgReplace,
-	"unique":                altPkgReplace,
-	"golang.org/x/sys/unix": altPkgReplace,
 }
 
 var sourcePatchPkgs = map[string]struct{}{

--- a/runtime/internal/lib/internal/runtime/atomic/atomic_llgo_arm.go
+++ b/runtime/internal/lib/internal/runtime/atomic/atomic_llgo_arm.go
@@ -1,8 +1,12 @@
-//go:build arm
+//go:build arm && baremetal
 
 package atomic
 
 import "unsafe"
+
+// This file is a single-threaded baremetal fallback for ARM targets that do not
+// provide upstream runtime atomics. These helpers are plain loads/stores and do
+// not provide inter-core atomicity.
 
 // Export some functions via linkname to assembly in sync/atomic.
 //
@@ -233,7 +237,10 @@ func Store64(ptr *uint64, val uint64) {
 	*ptr = val
 }
 
-// StorepNoWB performs *ptr = val atomically and without a write barrier.
+// StorepNoWB performs *ptr = val without a write barrier.
+//
+//go:nosplit
+//go:noinline
 func StorepNoWB(ptr unsafe.Pointer, val unsafe.Pointer) {
 	*(*unsafe.Pointer)(ptr) = val
 }
@@ -358,60 +365,42 @@ func Xaddint64(ptr *int64, delta int64) int64 {
 
 //go:nosplit
 func And32(ptr *uint32, val uint32) uint32 {
-	for {
-		old := *ptr
-		if Cas(ptr, old, old&val) {
-			return old
-		}
-	}
+	old := *ptr
+	*ptr = old & val
+	return old
 }
 
 //go:nosplit
 func Or32(ptr *uint32, val uint32) uint32 {
-	for {
-		old := *ptr
-		if Cas(ptr, old, old|val) {
-			return old
-		}
-	}
+	old := *ptr
+	*ptr = old | val
+	return old
 }
 
 //go:nosplit
 func And64(ptr *uint64, val uint64) uint64 {
-	for {
-		old := *ptr
-		if Cas64(ptr, old, old&val) {
-			return old
-		}
-	}
+	old := *ptr
+	*ptr = old & val
+	return old
 }
 
 //go:nosplit
 func Or64(ptr *uint64, val uint64) uint64 {
-	for {
-		old := *ptr
-		if Cas64(ptr, old, old|val) {
-			return old
-		}
-	}
+	old := *ptr
+	*ptr = old | val
+	return old
 }
 
 //go:nosplit
 func Anduintptr(ptr *uintptr, val uintptr) uintptr {
-	for {
-		old := *ptr
-		if Casuintptr(ptr, old, old&val) {
-			return old
-		}
-	}
+	old := *ptr
+	*ptr = old & val
+	return old
 }
 
 //go:nosplit
 func Oruintptr(ptr *uintptr, val uintptr) uintptr {
-	for {
-		old := *ptr
-		if Casuintptr(ptr, old, old|val) {
-			return old
-		}
-	}
+	old := *ptr
+	*ptr = old | val
+	return old
 }

--- a/runtime/internal/lib/internal/runtime/atomic/atomic_llgo_arm.go
+++ b/runtime/internal/lib/internal/runtime/atomic/atomic_llgo_arm.go
@@ -1,0 +1,417 @@
+//go:build arm
+
+package atomic
+
+import "unsafe"
+
+// Export some functions via linkname to assembly in sync/atomic.
+//
+//go:linkname Load
+//go:linkname Loadp
+//go:linkname Load64
+//go:linkname Loadint32
+//go:linkname Loadint64
+//go:linkname Loaduintptr
+//go:linkname LoadAcq
+//go:linkname LoadAcq64
+//go:linkname LoadAcquintptr
+//go:linkname Load8
+//go:linkname Xadd
+//go:linkname Xaddint32
+//go:linkname Xaddint64
+//go:linkname Xadd64
+//go:linkname Xadduintptr
+//go:linkname Xchg
+//go:linkname Xchg8
+//go:linkname Xchg64
+//go:linkname Xchgint32
+//go:linkname Xchgint64
+//go:linkname Xchguintptr
+//go:linkname Cas
+//go:linkname Cas64
+//go:linkname Casint32
+//go:linkname Casint64
+//go:linkname Casuintptr
+//go:linkname CasRel
+//go:linkname Store
+//go:linkname Store8
+//go:linkname Store64
+//go:linkname Storeint32
+//go:linkname Storeint64
+//go:linkname Storeuintptr
+//go:linkname StoreRel
+//go:linkname StoreRel64
+//go:linkname StoreReluintptr
+//go:linkname And32
+//go:linkname Or32
+//go:linkname And64
+//go:linkname Or64
+//go:linkname Anduintptr
+//go:linkname Oruintptr
+
+//go:nosplit
+//go:noinline
+func Load(ptr *uint32) uint32 {
+	return *ptr
+}
+
+//go:nosplit
+//go:noinline
+func Loadp(ptr unsafe.Pointer) unsafe.Pointer {
+	return *(*unsafe.Pointer)(ptr)
+}
+
+//go:nosplit
+//go:noinline
+func LoadAcq(ptr *uint32) uint32 {
+	return *ptr
+}
+
+//go:nosplit
+//go:noinline
+func LoadAcq64(ptr *uint64) uint64 {
+	return *ptr
+}
+
+//go:nosplit
+//go:noinline
+func LoadAcquintptr(ptr *uintptr) uintptr {
+	return *ptr
+}
+
+//go:nosplit
+//go:noinline
+func Load8(ptr *uint8) uint8 {
+	return *ptr
+}
+
+//go:nosplit
+//go:noinline
+func Load64(ptr *uint64) uint64 {
+	return *ptr
+}
+
+//go:nosplit
+//go:noinline
+func Xadd(ptr *uint32, delta int32) uint32 {
+	new := *ptr + uint32(delta)
+	*ptr = new
+	return new
+}
+
+//go:nosplit
+//go:noinline
+func Xadd64(ptr *uint64, delta int64) uint64 {
+	new := *ptr + uint64(delta)
+	*ptr = new
+	return new
+}
+
+//go:nosplit
+//go:noinline
+func Xadduintptr(ptr *uintptr, delta uintptr) uintptr {
+	new := *ptr + delta
+	*ptr = new
+	return new
+}
+
+//go:nosplit
+//go:noinline
+func Xchg(ptr *uint32, new uint32) uint32 {
+	old := *ptr
+	*ptr = new
+	return old
+}
+
+//go:nosplit
+//go:noinline
+func Xchg8(ptr *uint8, new uint8) uint8 {
+	old := *ptr
+	*ptr = new
+	return old
+}
+
+//go:nosplit
+//go:noinline
+func Xchg64(ptr *uint64, new uint64) uint64 {
+	old := *ptr
+	*ptr = new
+	return old
+}
+
+//go:nosplit
+//go:noinline
+func Xchgint32(ptr *int32, new int32) int32 {
+	old := *ptr
+	*ptr = new
+	return old
+}
+
+//go:nosplit
+//go:noinline
+func Xchgint64(ptr *int64, new int64) int64 {
+	old := *ptr
+	*ptr = new
+	return old
+}
+
+//go:nosplit
+//go:noinline
+func Xchguintptr(ptr *uintptr, new uintptr) uintptr {
+	old := *ptr
+	*ptr = new
+	return old
+}
+
+//go:nosplit
+//go:noinline
+func And8(ptr *uint8, val uint8) {
+	*ptr = *ptr & val
+}
+
+//go:nosplit
+//go:noinline
+func Or8(ptr *uint8, val uint8) {
+	*ptr = *ptr | val
+}
+
+//go:nosplit
+//go:noinline
+func And(ptr *uint32, val uint32) {
+	*ptr = *ptr & val
+}
+
+//go:nosplit
+//go:noinline
+func Or(ptr *uint32, val uint32) {
+	*ptr = *ptr | val
+}
+
+//go:nosplit
+//go:noinline
+func Cas64(ptr *uint64, old, new uint64) bool {
+	if *ptr == old {
+		*ptr = new
+		return true
+	}
+	return false
+}
+
+//go:nosplit
+//go:noinline
+func Store(ptr *uint32, val uint32) {
+	*ptr = val
+}
+
+//go:nosplit
+//go:noinline
+func StoreRel(ptr *uint32, val uint32) {
+	*ptr = val
+}
+
+//go:nosplit
+//go:noinline
+func StoreRel64(ptr *uint64, val uint64) {
+	*ptr = val
+}
+
+//go:nosplit
+//go:noinline
+func StoreReluintptr(ptr *uintptr, val uintptr) {
+	*ptr = val
+}
+
+//go:nosplit
+//go:noinline
+func Store8(ptr *uint8, val uint8) {
+	*ptr = val
+}
+
+//go:nosplit
+//go:noinline
+func Store64(ptr *uint64, val uint64) {
+	*ptr = val
+}
+
+// StorepNoWB performs *ptr = val atomically and without a write barrier.
+func StorepNoWB(ptr unsafe.Pointer, val unsafe.Pointer) {
+	*(*unsafe.Pointer)(ptr) = val
+}
+
+//go:nosplit
+//go:noinline
+func Casint32(ptr *int32, old, new int32) bool {
+	if *ptr == old {
+		*ptr = new
+		return true
+	}
+	return false
+}
+
+//go:nosplit
+//go:noinline
+func Casint64(ptr *int64, old, new int64) bool {
+	if *ptr == old {
+		*ptr = new
+		return true
+	}
+	return false
+}
+
+//go:nosplit
+//go:noinline
+func Cas(ptr *uint32, old, new uint32) bool {
+	if *ptr == old {
+		*ptr = new
+		return true
+	}
+	return false
+}
+
+//go:nosplit
+//go:noinline
+func Casp1(ptr *unsafe.Pointer, old, new unsafe.Pointer) bool {
+	if *ptr == old {
+		*ptr = new
+		return true
+	}
+	return false
+}
+
+//go:nosplit
+//go:noinline
+func Casuintptr(ptr *uintptr, old, new uintptr) bool {
+	if *ptr == old {
+		*ptr = new
+		return true
+	}
+	return false
+}
+
+//go:nosplit
+//go:noinline
+func CasRel(ptr *uint32, old, new uint32) bool {
+	if *ptr == old {
+		*ptr = new
+		return true
+	}
+	return false
+}
+
+//go:nosplit
+//go:noinline
+func Storeint32(ptr *int32, new int32) {
+	*ptr = new
+}
+
+//go:nosplit
+//go:noinline
+func Storeint64(ptr *int64, new int64) {
+	*ptr = new
+}
+
+//go:nosplit
+//go:noinline
+func Storeuintptr(ptr *uintptr, new uintptr) {
+	*ptr = new
+}
+
+//go:nosplit
+//go:noinline
+func Loaduintptr(ptr *uintptr) uintptr {
+	return *ptr
+}
+
+//go:nosplit
+//go:noinline
+func Loaduint(ptr *uint) uint {
+	return *ptr
+}
+
+//go:nosplit
+//go:noinline
+func Loadint32(ptr *int32) int32 {
+	return *ptr
+}
+
+//go:nosplit
+//go:noinline
+func Loadint64(ptr *int64) int64 {
+	return *ptr
+}
+
+//go:nosplit
+//go:noinline
+func Xaddint32(ptr *int32, delta int32) int32 {
+	new := *ptr + delta
+	*ptr = new
+	return new
+}
+
+//go:nosplit
+//go:noinline
+func Xaddint64(ptr *int64, delta int64) int64 {
+	new := *ptr + delta
+	*ptr = new
+	return new
+}
+
+//go:nosplit
+func And32(ptr *uint32, val uint32) uint32 {
+	for {
+		old := *ptr
+		if Cas(ptr, old, old&val) {
+			return old
+		}
+	}
+}
+
+//go:nosplit
+func Or32(ptr *uint32, val uint32) uint32 {
+	for {
+		old := *ptr
+		if Cas(ptr, old, old|val) {
+			return old
+		}
+	}
+}
+
+//go:nosplit
+func And64(ptr *uint64, val uint64) uint64 {
+	for {
+		old := *ptr
+		if Cas64(ptr, old, old&val) {
+			return old
+		}
+	}
+}
+
+//go:nosplit
+func Or64(ptr *uint64, val uint64) uint64 {
+	for {
+		old := *ptr
+		if Cas64(ptr, old, old|val) {
+			return old
+		}
+	}
+}
+
+//go:nosplit
+func Anduintptr(ptr *uintptr, val uintptr) uintptr {
+	for {
+		old := *ptr
+		if Casuintptr(ptr, old, old&val) {
+			return old
+		}
+	}
+}
+
+//go:nosplit
+func Oruintptr(ptr *uintptr, val uintptr) uintptr {
+	for {
+		old := *ptr
+		if Casuintptr(ptr, old, old|val) {
+			return old
+		}
+	}
+}

--- a/runtime/internal/lib/internal/runtime/atomic/types_llgo_arm.go
+++ b/runtime/internal/lib/internal/runtime/atomic/types_llgo_arm.go
@@ -1,4 +1,4 @@
-//go:build arm
+//go:build arm && baremetal
 
 package atomic
 

--- a/runtime/internal/lib/internal/runtime/atomic/types_llgo_arm.go
+++ b/runtime/internal/lib/internal/runtime/atomic/types_llgo_arm.go
@@ -1,0 +1,233 @@
+//go:build arm
+
+package atomic
+
+import "unsafe"
+
+type Int32 struct {
+	noCopy noCopy
+	value  int32
+}
+
+//go:nosplit
+func (i *Int32) Load() int32 { return Loadint32(&i.value) }
+
+//go:nosplit
+func (i *Int32) Store(value int32) { Storeint32(&i.value, value) }
+
+//go:nosplit
+func (i *Int32) CompareAndSwap(old, new int32) bool { return Casint32(&i.value, old, new) }
+
+//go:nosplit
+func (i *Int32) Swap(new int32) int32 { return Xchgint32(&i.value, new) }
+
+//go:nosplit
+func (i *Int32) Add(delta int32) int32 { return Xaddint32(&i.value, delta) }
+
+type Int64 struct {
+	noCopy noCopy
+	_      align64
+	value  int64
+}
+
+//go:nosplit
+func (i *Int64) Load() int64 { return Loadint64(&i.value) }
+
+//go:nosplit
+func (i *Int64) Store(value int64) { Storeint64(&i.value, value) }
+
+//go:nosplit
+func (i *Int64) CompareAndSwap(old, new int64) bool { return Casint64(&i.value, old, new) }
+
+//go:nosplit
+func (i *Int64) Swap(new int64) int64 { return Xchgint64(&i.value, new) }
+
+//go:nosplit
+func (i *Int64) Add(delta int64) int64 { return Xaddint64(&i.value, delta) }
+
+type Uint8 struct {
+	noCopy noCopy
+	value  uint8
+}
+
+//go:nosplit
+func (u *Uint8) Load() uint8 { return Load8(&u.value) }
+
+//go:nosplit
+func (u *Uint8) Store(value uint8) { Store8(&u.value, value) }
+
+//go:nosplit
+func (u *Uint8) And(value uint8) { And8(&u.value, value) }
+
+//go:nosplit
+func (u *Uint8) Or(value uint8) { Or8(&u.value, value) }
+
+type Bool struct {
+	u Uint8
+}
+
+//go:nosplit
+func (b *Bool) Load() bool { return b.u.Load() != 0 }
+
+//go:nosplit
+func (b *Bool) Store(value bool) {
+	s := uint8(0)
+	if value {
+		s = 1
+	}
+	b.u.Store(s)
+}
+
+type Uint32 struct {
+	noCopy noCopy
+	value  uint32
+}
+
+//go:nosplit
+func (u *Uint32) Load() uint32 { return Load(&u.value) }
+
+//go:nosplit
+func (u *Uint32) LoadAcquire() uint32 { return LoadAcq(&u.value) }
+
+//go:nosplit
+func (u *Uint32) Store(value uint32) { Store(&u.value, value) }
+
+//go:nosplit
+func (u *Uint32) StoreRelease(value uint32) { StoreRel(&u.value, value) }
+
+//go:nosplit
+func (u *Uint32) CompareAndSwap(old, new uint32) bool { return Cas(&u.value, old, new) }
+
+//go:nosplit
+func (u *Uint32) CompareAndSwapRelease(old, new uint32) bool { return CasRel(&u.value, old, new) }
+
+//go:nosplit
+func (u *Uint32) Swap(value uint32) uint32 { return Xchg(&u.value, value) }
+
+//go:nosplit
+func (u *Uint32) And(value uint32) { And(&u.value, value) }
+
+//go:nosplit
+func (u *Uint32) Or(value uint32) { Or(&u.value, value) }
+
+//go:nosplit
+func (u *Uint32) Add(delta int32) uint32 { return Xadd(&u.value, delta) }
+
+type Uint64 struct {
+	noCopy noCopy
+	_      align64
+	value  uint64
+}
+
+//go:nosplit
+func (u *Uint64) Load() uint64 { return Load64(&u.value) }
+
+//go:nosplit
+func (u *Uint64) Store(value uint64) { Store64(&u.value, value) }
+
+//go:nosplit
+func (u *Uint64) CompareAndSwap(old, new uint64) bool { return Cas64(&u.value, old, new) }
+
+//go:nosplit
+func (u *Uint64) Swap(value uint64) uint64 { return Xchg64(&u.value, value) }
+
+//go:nosplit
+func (u *Uint64) Add(delta int64) uint64 { return Xadd64(&u.value, delta) }
+
+type Uintptr struct {
+	noCopy noCopy
+	value  uintptr
+}
+
+//go:nosplit
+func (u *Uintptr) Load() uintptr { return Loaduintptr(&u.value) }
+
+//go:nosplit
+func (u *Uintptr) LoadAcquire() uintptr { return LoadAcquintptr(&u.value) }
+
+//go:nosplit
+func (u *Uintptr) Store(value uintptr) { Storeuintptr(&u.value, value) }
+
+//go:nosplit
+func (u *Uintptr) StoreRelease(value uintptr) { StoreReluintptr(&u.value, value) }
+
+//go:nosplit
+func (u *Uintptr) CompareAndSwap(old, new uintptr) bool { return Casuintptr(&u.value, old, new) }
+
+//go:nosplit
+func (u *Uintptr) Swap(value uintptr) uintptr { return Xchguintptr(&u.value, value) }
+
+//go:nosplit
+func (u *Uintptr) Add(delta uintptr) uintptr { return Xadduintptr(&u.value, delta) }
+
+type Float64 struct {
+	u Uint64
+}
+
+//go:nosplit
+func (f *Float64) Load() float64 {
+	r := f.u.Load()
+	return *(*float64)(unsafe.Pointer(&r))
+}
+
+//go:nosplit
+func (f *Float64) Store(value float64) {
+	f.u.Store(*(*uint64)(unsafe.Pointer(&value)))
+}
+
+type UnsafePointer struct {
+	noCopy noCopy
+	value  unsafe.Pointer
+}
+
+//go:nosplit
+func (u *UnsafePointer) Load() unsafe.Pointer { return Loadp(unsafe.Pointer(&u.value)) }
+
+//go:nosplit
+func (u *UnsafePointer) StoreNoWB(value unsafe.Pointer) { StorepNoWB(unsafe.Pointer(&u.value), value) }
+
+func (u *UnsafePointer) Store(value unsafe.Pointer) { storePointer(&u.value, value) }
+
+//go:linkname storePointer
+func storePointer(ptr *unsafe.Pointer, new unsafe.Pointer)
+
+//go:nosplit
+func (u *UnsafePointer) CompareAndSwapNoWB(old, new unsafe.Pointer) bool {
+	return Casp1(&u.value, old, new)
+}
+
+func (u *UnsafePointer) CompareAndSwap(old, new unsafe.Pointer) bool {
+	return casPointer(&u.value, old, new)
+}
+
+//go:linkname casPointer
+func casPointer(ptr *unsafe.Pointer, old, new unsafe.Pointer) bool
+
+type Pointer[T any] struct {
+	u UnsafePointer
+}
+
+//go:nosplit
+func (p *Pointer[T]) Load() *T { return (*T)(p.u.Load()) }
+
+//go:nosplit
+func (p *Pointer[T]) StoreNoWB(value *T) { p.u.StoreNoWB(unsafe.Pointer(value)) }
+
+//go:nosplit
+func (p *Pointer[T]) Store(value *T) { p.u.Store(unsafe.Pointer(value)) }
+
+//go:nosplit
+func (p *Pointer[T]) CompareAndSwapNoWB(old, new *T) bool {
+	return p.u.CompareAndSwapNoWB(unsafe.Pointer(old), unsafe.Pointer(new))
+}
+
+func (p *Pointer[T]) CompareAndSwap(old, new *T) bool {
+	return p.u.CompareAndSwap(unsafe.Pointer(old), unsafe.Pointer(new))
+}
+
+type noCopy struct{}
+
+func (*noCopy) Lock()   {}
+func (*noCopy) Unlock() {}
+
+type align64 struct{}

--- a/runtime/internal/lib/runtime/godebug_baremetal_llgo.go
+++ b/runtime/internal/lib/runtime/godebug_baremetal_llgo.go
@@ -1,25 +1,17 @@
-//go:build !baremetal
+//go:build baremetal
 
 package runtime
 
-import (
-	c "github.com/goplus/llgo/runtime/internal/clite"
-	cliteos "github.com/goplus/llgo/runtime/internal/clite/os"
-	_ "unsafe"
-)
+import _ "unsafe"
 
 var (
-	godebugDefault string // compile-time defaults (empty for now)
+	godebugDefault string
 	godebugEnv     string
 	godebugUpdate  func(string, string)
 )
 
 func godebugGetenv() string {
-	p := cliteos.Getenv(c.AllocaCStr("GODEBUG"))
-	if p == nil {
-		return ""
-	}
-	return c.GoString(p)
+	return ""
 }
 
 func godebugNotify() {
@@ -37,7 +29,6 @@ func godebugEnvChanged(env string) {
 //go:linkname godebug_setUpdate internal/godebug.setUpdate
 func godebug_setUpdate(update func(string, string)) {
 	godebugUpdate = update
-	// Initial sync.
 	godebugEnv = godebugGetenv()
 	godebugNotify()
 }

--- a/runtime/internal/lib/runtime/link_baremetal_llgo.go
+++ b/runtime/internal/lib/runtime/link_baremetal_llgo.go
@@ -1,5 +1,4 @@
-//go:build linux && !baremetal
-// +build linux,!baremetal
+//go:build baremetal
 
 package runtime
 
@@ -7,44 +6,21 @@ import (
 	_ "unsafe"
 
 	c "github.com/goplus/llgo/runtime/internal/clite"
-	cliteos "github.com/goplus/llgo/runtime/internal/clite/os"
 )
 
 //go:linkname os_runtime_args os.runtime_args
 func os_runtime_args() []string {
-	argc := int(c.Argc)
-	if argc <= 0 {
-		return nil
-	}
-	if c.Argv == nil {
-		return nil
-	}
-	args := make([]string, 0, argc)
-	for i := 0; i < argc; i++ {
-		p := c.Index(c.Argv, i)
-		if p == nil {
-			break
-		}
-		args = append(args, c.GoString(p))
-	}
-	return args
+	return nil
 }
-
-//go:linkname c_environ environ
-var c_environ **c.Char
 
 //go:linkname syscall_runtime_envs syscall.runtime_envs
 func syscall_runtime_envs() []string {
-	var out []string
-	for p := c_environ; p != nil && *p != nil; p = c.Advance(p, 1) {
-		out = append(out, c.GoString(*p))
-	}
-	return out
+	return nil
 }
 
 //go:linkname syscall_runtimeSetenv syscall.runtimeSetenv
 func syscall_runtimeSetenv(key, value string) {
-	cliteos.Setenv(c.AllocaCStr(key), c.AllocaCStr(value), 1)
+	_, _ = key, value
 	if key == "GODEBUG" {
 		godebugEnvChanged(value)
 	}
@@ -52,14 +28,15 @@ func syscall_runtimeSetenv(key, value string) {
 
 //go:linkname syscall_runtimeUnsetenv syscall.runtimeUnsetenv
 func syscall_runtimeUnsetenv(key string) {
-	cliteos.Unsetenv(c.AllocaCStr(key))
 	if key == "GODEBUG" {
 		godebugEnvChanged("")
 	}
 }
 
 //go:linkname os_beforeExit os.runtime_beforeExit
-func os_beforeExit(exitCode int) {}
+func os_beforeExit(exitCode int) {
+	_ = exitCode
+}
 
 //go:linkname os_sigpipe os.sigpipe
 func os_sigpipe() {}
@@ -70,18 +47,15 @@ func os_ignoreSIGSYS() {}
 //go:linkname os_restoreSIGSYS os.restoreSIGSYS
 func os_restoreSIGSYS() {}
 
-//go:linkname c_getpagesize C.getpagesize
-func c_getpagesize() c.Int
-
 //go:linkname syscall_Getpagesize syscall.Getpagesize
 func syscall_Getpagesize() int {
-	return int(c_getpagesize())
+	return 4096
 }
 
 //go:linkname syscall_Exit syscall.Exit
 //go:nosplit
 func syscall_Exit(code int) {
-	cliteos.Exit(c.Int(code))
+	c.Exit(c.Int(code))
 }
 
 //go:linkname syscall_runtime_BeforeFork syscall.runtime_BeforeFork
@@ -98,11 +72,3 @@ func syscall_runtime_BeforeExec() {}
 
 //go:linkname syscall_runtime_AfterExec syscall.runtime_AfterExec
 func syscall_runtime_AfterExec() {}
-
-func fcntl(fd int32, cmd int32, arg int32) (int32, int32) {
-	r := cliteos.Fcntl(c.Int(fd), c.Int(cmd), c.Int(arg))
-	if r == -1 {
-		return -1, int32(cliteos.Errno())
-	}
-	return int32(r), 0
-}

--- a/runtime/internal/lib/runtime/poll_baremetal_llgo.go
+++ b/runtime/internal/lib/runtime/poll_baremetal_llgo.go
@@ -1,0 +1,62 @@
+//go:build baremetal
+
+package runtime
+
+import _ "unsafe"
+
+// Minimal internal/poll hooks for baremetal target smoke builds.
+// Embedded targets in this path do not provide a runtime poller.
+
+const (
+	pollNoError        = 0
+	pollErrClosing     = 1
+	pollErrTimeout     = 2
+	pollErrNotPollable = 3
+)
+
+//go:linkname poll_runtime_pollServerInit internal/poll.runtime_pollServerInit
+func poll_runtime_pollServerInit() {}
+
+//go:linkname poll_runtime_pollOpen internal/poll.runtime_pollOpen
+func poll_runtime_pollOpen(fd uintptr) (uintptr, int) {
+	_ = fd
+	return 0, pollErrNotPollable
+}
+
+//go:linkname poll_runtime_pollClose internal/poll.runtime_pollClose
+func poll_runtime_pollClose(ctx uintptr) {
+	_ = ctx
+}
+
+//go:linkname poll_runtime_pollWait internal/poll.runtime_pollWait
+func poll_runtime_pollWait(ctx uintptr, mode int) int {
+	_, _ = ctx, mode
+	return pollErrNotPollable
+}
+
+//go:linkname poll_runtime_pollWaitCanceled internal/poll.runtime_pollWaitCanceled
+func poll_runtime_pollWaitCanceled(ctx uintptr, mode int) {
+	_, _ = ctx, mode
+}
+
+//go:linkname poll_runtime_pollReset internal/poll.runtime_pollReset
+func poll_runtime_pollReset(ctx uintptr, mode int) int {
+	_, _ = ctx, mode
+	return pollErrNotPollable
+}
+
+//go:linkname poll_runtime_pollSetDeadline internal/poll.runtime_pollSetDeadline
+func poll_runtime_pollSetDeadline(ctx uintptr, d int64, mode int) {
+	_, _, _ = ctx, d, mode
+}
+
+//go:linkname poll_runtime_pollUnblock internal/poll.runtime_pollUnblock
+func poll_runtime_pollUnblock(ctx uintptr) {
+	_ = ctx
+}
+
+//go:linkname poll_runtime_isPollServerDescriptor internal/poll.runtime_isPollServerDescriptor
+func poll_runtime_isPollServerDescriptor(fd uintptr) bool {
+	_ = fd
+	return false
+}

--- a/runtime/internal/lib/runtime/poll_linkname_llgo.go
+++ b/runtime/internal/lib/runtime/poll_linkname_llgo.go
@@ -1,4 +1,4 @@
-//go:build darwin || linux
+//go:build (darwin || linux) && !baremetal
 
 package runtime
 

--- a/runtime/internal/lib/runtime/signal_baremetal_llgo.go
+++ b/runtime/internal/lib/runtime/signal_baremetal_llgo.go
@@ -1,0 +1,28 @@
+//go:build baremetal
+
+package runtime
+
+// Baremetal targets do not provide OS signal delivery.
+
+func signal_enable(sig uint32) {
+	_ = sig
+}
+
+func signal_disable(sig uint32) {
+	_ = sig
+}
+
+func signal_ignore(sig uint32) {
+	_ = sig
+}
+
+func signal_ignored(sig uint32) bool {
+	_ = sig
+	return false
+}
+
+func signal_recv() uint32 {
+	return 0
+}
+
+func signalWaitUntilIdle() {}

--- a/runtime/internal/lib/runtime/signal_llgo.go
+++ b/runtime/internal/lib/runtime/signal_llgo.go
@@ -1,3 +1,5 @@
+//go:build !baremetal
+
 package runtime
 
 import (

--- a/runtime/internal/lib/runtime/time_baremetal_legacy_llgo.go
+++ b/runtime/internal/lib/runtime/time_baremetal_legacy_llgo.go
@@ -1,0 +1,89 @@
+//go:build baremetal && !go1.23
+
+package runtime
+
+// Minimal timer hooks for baremetal builds.
+// They keep stdlib packages linkable for target smoke tests but do not
+// provide asynchronous timer delivery.
+
+type runtimeTimer struct {
+	pp       uintptr
+	when     int64
+	period   int64
+	f        func(any, uintptr)
+	arg      any
+	seq      uintptr
+	nextwhen int64
+	status   uint32
+}
+
+func startTimer(r *runtimeTimer) {
+	if r == nil || r.f == nil {
+		return
+	}
+	if r.period == 0 && r.when <= runtimeNano() {
+		r.f(r.arg, r.seq)
+	}
+}
+
+func stopTimer(r *runtimeTimer) bool {
+	return r != nil
+}
+
+func resetTimer(r *runtimeTimer, when int64) bool {
+	if r == nil {
+		return false
+	}
+	r.when = when
+	startTimer(r)
+	return true
+}
+
+func modTimer(r *runtimeTimer, when, period int64, f func(any, uintptr), arg any, seq uintptr) {
+	if r == nil {
+		return
+	}
+	r.when = when
+	r.period = period
+	r.f = f
+	r.arg = arg
+	r.seq = seq
+	startTimer(r)
+}
+
+func resetRuntimeTimer(r *runtimeTimer, when, period int64, f func(any, uintptr), arg any, seq uintptr) bool {
+	if r == nil {
+		return false
+	}
+	modTimer(r, when, period, f, arg, seq)
+	return true
+}
+
+//go:linkname time_now time.now
+func time_now() (sec int64, nsec int32, mono int64) {
+	return 0, 0, 0
+}
+
+//go:linkname time_runtimeNow time.runtimeNow
+func time_runtimeNow() (sec int64, nsec int32, mono int64) {
+	return time_now()
+}
+
+//go:linkname time_runtimeNano time.runtimeNano
+func time_runtimeNano() int64 {
+	return runtimeNano()
+}
+
+//go:linkname time_runtimeIsBubbled time.runtimeIsBubbled
+func time_runtimeIsBubbled() bool {
+	return false
+}
+
+//go:linkname timeSleep time.Sleep
+func timeSleep(ns int64) {
+	_ = ns
+}
+
+func runtimeNano() int64 {
+	return 0
+}

--- a/runtime/internal/lib/runtime/time_baremetal_llgo.go
+++ b/runtime/internal/lib/runtime/time_baremetal_llgo.go
@@ -1,0 +1,108 @@
+//go:build baremetal && go1.23
+
+package runtime
+
+import "unsafe"
+
+// Minimal timer hooks for baremetal builds.
+// They keep stdlib packages linkable for target smoke tests but do not
+// provide asynchronous timer delivery.
+
+type runtimeTimer struct {
+	pp       uintptr
+	when     int64
+	period   int64
+	f        func(any, uintptr, int64)
+	arg      any
+	seq      uintptr
+	nextwhen int64
+	status   uint32
+}
+
+type timeTimer struct {
+	c    unsafe.Pointer
+	init bool
+	r    runtimeTimer
+}
+
+func startRuntimeTimer(r *runtimeTimer) {
+	if r == nil || r.f == nil {
+		return
+	}
+	if r.period == 0 && r.when <= runtimeNano() {
+		r.f(r.arg, r.seq, runtimeNano())
+	}
+}
+
+func stopRuntimeTimer(r *runtimeTimer) bool {
+	return r != nil
+}
+
+func resetRuntimeTimer(r *runtimeTimer, when, period int64, f func(any, uintptr, int64), arg any, seq uintptr) bool {
+	if r == nil {
+		return false
+	}
+	r.when = when
+	r.period = period
+	r.f = f
+	r.arg = arg
+	r.seq = seq
+	startRuntimeTimer(r)
+	return true
+}
+
+//go:linkname time_now time.now
+func time_now() (sec int64, nsec int32, mono int64) {
+	return 0, 0, 0
+}
+
+//go:linkname time_runtimeNow time.runtimeNow
+func time_runtimeNow() (sec int64, nsec int32, mono int64) {
+	return time_now()
+}
+
+//go:linkname time_runtimeNano time.runtimeNano
+func time_runtimeNano() int64 {
+	return runtimeNano()
+}
+
+//go:linkname time_runtimeIsBubbled time.runtimeIsBubbled
+func time_runtimeIsBubbled() bool {
+	return false
+}
+
+//go:linkname timeSleep time.Sleep
+func timeSleep(ns int64) {
+	_ = ns
+}
+
+//go:linkname newTimer time.newTimer
+func newTimer(when, period int64, f func(any, uintptr, int64), arg any, cp unsafe.Pointer) *timeTimer {
+	t := &timeTimer{c: cp, init: true}
+	t.r.when = when
+	t.r.period = period
+	t.r.f = f
+	t.r.arg = arg
+	startRuntimeTimer(&t.r)
+	return t
+}
+
+//go:linkname stopTimer time.stopTimer
+func stopTimer(t *timeTimer) bool {
+	if t == nil {
+		return false
+	}
+	return stopRuntimeTimer(&t.r)
+}
+
+//go:linkname resetTimer time.resetTimer
+func resetTimer(t *timeTimer, when, period int64) bool {
+	if t == nil {
+		return false
+	}
+	return resetRuntimeTimer(&t.r, when, period, t.r.f, t.r.arg, t.r.seq)
+}
+
+func runtimeNano() int64 {
+	return 0
+}

--- a/runtime/internal/lib/runtime/time_llgo.go
+++ b/runtime/internal/lib/runtime/time_llgo.go
@@ -1,5 +1,5 @@
-//go:build !go1.23
-// +build !go1.23
+//go:build !go1.23 && !baremetal
+// +build !go1.23,!baremetal
 
 package runtime
 

--- a/runtime/internal/lib/runtime/time_llgo_go123.go
+++ b/runtime/internal/lib/runtime/time_llgo_go123.go
@@ -1,5 +1,5 @@
-//go:build go1.23
-// +build go1.23
+//go:build go1.23 && !baremetal
+// +build go1.23,!baremetal
 
 package runtime
 


### PR DESCRIPTION
## Summary
- rebase the ARM plan9asm support from #1717 onto the current xgo-dev/llgo main
- add ARM-specific plan9asm integration for internal/bytealg and internal/runtime/atomic
- filter test-only asm inputs and skip Linux/ARM syscall asm for embedded ARM targets
- add baremetal runtime splits for ARM embedded builds

## Testing
- go test ./internal/build ./internal/plan9asm
- go test ./test/goroot -run '^TestGoRootRunCases$' -count=1 -timeout=30m -args -goroot "$(go env GOROOT)" -directive-mode ci -limit=20 -build-timeout=3m -run-timeout=1m -progress=30s
- go build -tags=dev -o /tmp/llgo-pr1717-goroot ./cmd/llgo
- go test ./test/goroot -run '^TestGoRootRunCases$' -count=1 -timeout=30m -args -goroot "$(go env GOROOT)" -llgo /tmp/llgo-pr1717-goroot -dirs fixedbugs -directive-mode ci -limit=20 -build-timeout=3m -run-timeout=1m -progress=30s

## Notes
- Supersedes #1717, which GitHub cannot reopen after the head branch was force-pushed/recreated.
- ARM baremetal targets remain build/integration scope here; this PR does not claim stdlib runtime smoke via emulator.
