### PR TITLE
runtime/internal/lib/reflect: fix named func type

### DIFF
--- a/.github/workflows/test_demo.sh
+++ b/.github/workflows/test_demo.sh
@@ -104,6 +104,7 @@ ignore_esp32=(
   "./_demo/go/reflectmake" # panic: internal/bytealg selected .s files require plan9asm translation
   "./_demo/go/reflectmethod" # panic: internal/bytealg selected .s files require plan9asm translation
   "./_demo/go/reflectname-1412" # panic: internal/bytealg selected .s files require plan9asm translation
+  "./_demo/go/reflectnamedfn" # panic: internal/bytealg selected .s files require plan9asm translation
   "./_demo/go/reflectnew" # panic: internal/bytealg selected .s files require plan9asm translation
   "./_demo/go/reflectpointerto" # panic: internal/bytealg selected .s files require plan9asm translation
   "./_demo/go/reflectpkgpath" # panic: internal/bytealg selected .s files require plan9asm translation
@@ -176,6 +177,7 @@ ignore_esp32c3_basic=(
   "./_demo/go/reflectmethod" # panic: internal/bytealg selected .s files require plan9asm translation
   "./_demo/go/reflectmake" # panic: internal/bytealg selected .s files require plan9asm translation
   "./_demo/go/reflectname-1412" # panic: internal/bytealg selected .s files require plan9asm translation
+  "./_demo/go/reflectnamedfn" # panic: internal/bytealg selected .s files require plan9asm translation
   "./_demo/go/reflectnew" # panic: internal/bytealg selected .s files require plan9asm translation
   "./_demo/go/reflectpointerto" # panic: internal/bytealg selected .s files require plan9asm translation
   "./_demo/go/reflectpkgpath" # panic: internal/bytealg selected .s files require plan9asm translation

--- a/_demo/go/reflectnamedfn/main.go
+++ b/_demo/go/reflectnamedfn/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"reflect"
+)
+
+func demo(n int, s string) (bool, int) {
+	return true, n + len(s)
+}
+
+type T func(n int, s string) (bool, int)
+
+func (t T) Demo() int {
+	return 100
+}
+
+func (t T) Call(s string) (bool, int) {
+	return t(100, s)
+}
+
+func main() {
+	v1 := reflect.ValueOf(demo)
+	typ := reflect.TypeOf((*T)(nil)).Elem()
+	if typ.Kind() != reflect.Func {
+		panic("kind error: " + typ.Kind().String())
+	}
+	if typ.NumIn() != 2 {
+		panic("bad num in")
+	}
+	if typ.NumOut() != 2 {
+		panic("bad num out")
+	}
+	if typ.IsVariadic() {
+		panic("not variadic")
+	}
+	if typ.NumMethod() != 2 {
+		panic("error methods")
+	}
+	v2 := reflect.New(typ).Elem()
+	if v2.Type() != typ {
+		panic("bad type")
+	}
+	v2.Set(v1)
+	check(v2, "named")
+
+	r := v2.Method(1).Call(nil)
+	if r[0].Int() != 100 {
+		panic("error call")
+	}
+	r = v2.MethodByName("Call").Call([]reflect.Value{reflect.ValueOf("hello")})
+	if r[0].Bool() != true {
+		panic("error r[0]")
+	}
+	if r[1].Int() != 100+5 {
+		panic("error r[1]")
+	}
+}
+
+func check(v reflect.Value, s string) {
+	if v.Kind() != reflect.Func {
+		panic("error")
+	}
+	r := v.Call([]reflect.Value{reflect.ValueOf(100), reflect.ValueOf("hello")})
+	if r[0].Bool() != true {
+		panic("error r[0]: " + s)
+	}
+	if r[1].Int() != 100+5 {
+		panic("error r[1]: " + s)
+	}
+}

--- a/_demo/go/reflectnamedfn/main.go
+++ b/_demo/go/reflectnamedfn/main.go
@@ -8,6 +8,9 @@ func demo(n int, s string) (bool, int) {
 	return true, n + len(s)
 }
 
+//llgo:type C
+type CFunc func(n int, s string) (bool, int)
+
 type T func(n int, s string) (bool, int)
 
 func (t T) Demo() int {
@@ -54,6 +57,17 @@ func main() {
 	if r[1].Int() != 100+5 {
 		panic("error r[1]")
 	}
+
+	ctyp := reflect.TypeOf((*CFunc)(nil)).Elem()
+	if ctyp.Kind() != reflect.Func {
+		panic("kind error: " + ctyp.Kind().String())
+	}
+	v3 := reflect.New(ctyp).Elem()
+	if v3.Type() != ctyp {
+		panic("bad c named type")
+	}
+	v3.Set(v1)
+	check(v3, "c named")
 }
 
 func check(v reflect.Value, s string) {

--- a/runtime/internal/lib/reflect/type.go
+++ b/runtime/internal/lib/reflect/type.go
@@ -22,15 +22,14 @@ package reflect
 
 import (
 	"strconv"
+	"sync"
 	"unicode"
 	"unicode/utf8"
 	"unsafe"
 
-	"sync"
-
 	"github.com/goplus/llgo/runtime/abi"
 	clite "github.com/goplus/llgo/runtime/internal/clite"
-	_ "github.com/goplus/llgo/runtime/internal/runtime"
+	"github.com/goplus/llgo/runtime/internal/runtime"
 	"github.com/goplus/llgo/runtime/internal/runtime/goarch"
 )
 
@@ -404,6 +403,10 @@ func toRType(t *abi.Type) *rtype {
 func elem(t *abi.Type) *abi.Type {
 	et := t.Elem()
 	if et != nil {
+		if et.IsClosure() {
+			ft := toFuncType(et.StructType())
+			return &ft.Type
+		}
 		return et
 	}
 	panic("reflect: Elem of invalid type " + stringFor(t))
@@ -841,12 +844,64 @@ func TypeOf(i any) Type {
 	}
 	// check closure type
 	if eface.typ.IsClosure() {
-		ft := eface.typ.StructType().Fields[0].Typ.FuncType()
+		ft := toFuncType(eface.typ.StructType())
 		return toType(&ft.Type)
 	}
 	// Noescape so this doesn't make i to escape. See the comment
 	// at Value.typ for why this is safe.
 	return toType((*abi.Type)(unsafe.Pointer(eface.typ)))
+}
+
+var namedFuncMap sync.Map // map[*abi.StructType]*abi.FuncType
+
+func toFuncType(typ *abi.StructType) *abi.FuncType {
+	if !typ.HasName() {
+		return typ.Fields[0].Typ.FuncType()
+	}
+	if i, ok := namedFuncMap.Load(typ); ok {
+		return i.(*abi.FuncType)
+	}
+	size := unsafe.Sizeof(abi.FuncType{})
+	u := typ.Uncommon()
+	if u != nil {
+		size += unsafe.Sizeof(abi.UncommonType{}) + uintptr(u.Mcount)*unsafe.Sizeof(abi.Method{})
+	}
+	ftyp := typ.Fields[0].Typ.FuncType()
+	ptr := runtime.AllocU(size)
+	t := (*abi.FuncType)(ptr)
+	t.Size_ = ftyp.Size_
+	t.PtrBytes = ftyp.PtrBytes
+	t.Hash = ftyp.Hash
+	t.TFlag = ftyp.TFlag | abi.TFlagNamed
+	t.Align_ = ftyp.Align_
+	t.FieldAlign_ = ftyp.FieldAlign_
+	t.Kind_ = ftyp.Kind_
+	t.Equal = ftyp.Equal
+	t.GCData = ftyp.GCData
+	t.Str_ = typ.Str_
+	t.In = ftyp.In
+	t.Out = ftyp.Out
+	if typ.TFlag&abi.TFlagExtraStar != 0 {
+		t.TFlag |= abi.TFlagExtraStar
+	}
+	if u != nil {
+		t.TFlag |= abi.TFlagUncommon
+		tu := t.Uncommon()
+		tu.PkgPath_ = u.PkgPath_
+		tu.Mcount = u.Mcount
+		tu.Xcount = u.Xcount
+		tu.Moff = u.Moff
+		uptr := add(unsafe.Pointer(u), uintptr(u.Moff), "t.mcount > 0")
+		tptr := add(unsafe.Pointer(tu), uintptr(tu.Moff), "t.mcount > 0")
+
+		for i := 0; i < int(u.Mcount); i++ {
+			uelemPtr := add(uptr, uintptr(i)*unsafe.Sizeof(Method{}), "accessing method element")
+			telemPtr := add(tptr, uintptr(i)*unsafe.Sizeof(Method{}), "accessing method element")
+			*(*Method)(telemPtr) = *(*Method)(uelemPtr)
+		}
+	}
+	tt, _ := namedFuncMap.LoadOrStore(typ, t)
+	return tt.(*abi.FuncType)
 }
 
 // rtypeOf directly extracts the *rtype of the provided value.
@@ -2149,6 +2204,20 @@ var closureLookupCache struct {
 
 // Struct returns a struct type.
 func closureOf(ftyp *abi.FuncType) *abi.Type {
+	if ftyp.HasName() {
+		var t *abi.StructType
+		namedFuncMap.Range(func(key interface{}, value interface{}) bool {
+			if value == ftyp {
+				t = key.(*abi.StructType)
+				return false
+			}
+			return true
+		})
+		if t != nil {
+			return &t.Type
+		}
+	}
+
 	fields := []abi.StructField{
 		abi.StructField{
 			Name_: "$f",

--- a/runtime/internal/lib/reflect/type.go
+++ b/runtime/internal/lib/reflect/type.go
@@ -871,7 +871,7 @@ func toFuncType(typ *abi.StructType) *abi.FuncType {
 	t := (*abi.FuncType)(ptr)
 	t.Size_ = ftyp.Size_
 	t.PtrBytes = ftyp.PtrBytes
-	t.Hash = ftyp.Hash
+	t.Hash = fnv1(typ.Hash, []byte("-funcType")...)
 	t.TFlag = ftyp.TFlag | abi.TFlagNamed
 	t.Align_ = ftyp.Align_
 	t.FieldAlign_ = ftyp.FieldAlign_
@@ -913,7 +913,7 @@ func toClosureType(typ *abi.FuncType) *abi.StructType {
 	ftyp := typ
 	fnstr := funcStr(ftyp)
 	for _, t := range typelist {
-		if t.String() == fnstr {
+		if t.Kind() == abi.Func && t.String() == fnstr {
 			ftyp = t.FuncType()
 			break
 		}
@@ -922,7 +922,7 @@ func toClosureType(typ *abi.FuncType) *abi.StructType {
 	t := (*abi.StructType)(ptr)
 	t.Size_ = ftyp.Size_
 	t.PtrBytes = ftyp.PtrBytes
-	t.Hash = ftyp.Hash
+	t.Hash = fnv1(typ.Hash, []byte("-structType")...)
 	t.TFlag = ftyp.TFlag | abi.TFlagNamed | abi.TFlagClosure
 	t.Align_ = ftyp.Align_
 	t.FieldAlign_ = ftyp.FieldAlign_

--- a/runtime/internal/lib/reflect/type.go
+++ b/runtime/internal/lib/reflect/type.go
@@ -904,6 +904,66 @@ func toFuncType(typ *abi.StructType) *abi.FuncType {
 	return tt.(*abi.FuncType)
 }
 
+func toClosureType(typ *abi.FuncType) *abi.StructType {
+	size := unsafe.Sizeof(abi.StructType{})
+	u := typ.Uncommon()
+	if u != nil {
+		size += unsafe.Sizeof(abi.UncommonType{}) + uintptr(u.Mcount)*unsafe.Sizeof(abi.Method{})
+	}
+	ftyp := typ
+	fnstr := funcStr(ftyp)
+	for _, t := range typelist {
+		if t.String() == fnstr {
+			ftyp = t.FuncType()
+			break
+		}
+	}
+	ptr := runtime.AllocU(size)
+	t := (*abi.StructType)(ptr)
+	t.Size_ = ftyp.Size_
+	t.PtrBytes = ftyp.PtrBytes
+	t.Hash = ftyp.Hash
+	t.TFlag = ftyp.TFlag | abi.TFlagNamed | abi.TFlagClosure
+	t.Align_ = ftyp.Align_
+	t.FieldAlign_ = ftyp.FieldAlign_
+	t.Kind_ = uint8(abi.Struct)
+	t.Equal = ftyp.Equal
+	t.GCData = ftyp.GCData
+	t.Str_ = typ.Str_
+	t.Fields = []abi.StructField{
+		abi.StructField{
+			Name_: "$f",
+			Typ:   &ftyp.Type,
+		}, abi.StructField{
+			Name_:  "$data",
+			Typ:    unsafePointerType,
+			Offset: pointerSize,
+		},
+	}
+	t.PkgPath_ = ""
+	if typ.TFlag&abi.TFlagExtraStar != 0 {
+		t.TFlag |= abi.TFlagExtraStar
+	}
+	if u != nil {
+		t.TFlag |= abi.TFlagUncommon
+		tu := t.Uncommon()
+		tu.PkgPath_ = u.PkgPath_
+		tu.Mcount = u.Mcount
+		tu.Xcount = u.Xcount
+		tu.Moff = u.Moff
+		uptr := add(unsafe.Pointer(u), uintptr(u.Moff), "t.mcount > 0")
+		tptr := add(unsafe.Pointer(tu), uintptr(tu.Moff), "t.mcount > 0")
+
+		for i := 0; i < int(u.Mcount); i++ {
+			uelemPtr := add(uptr, uintptr(i)*unsafe.Sizeof(Method{}), "accessing method element")
+			telemPtr := add(tptr, uintptr(i)*unsafe.Sizeof(Method{}), "accessing method element")
+			*(*Method)(telemPtr) = *(*Method)(uelemPtr)
+		}
+	}
+	namedFuncMap.Store(t, typ)
+	return t
+}
+
 // rtypeOf directly extracts the *rtype of the provided value.
 func rtypeOf(i any) *abi.Type {
 	eface := *(*emptyInterface)(unsafe.Pointer(&i))
@@ -2216,6 +2276,7 @@ func closureOf(ftyp *abi.FuncType) *abi.Type {
 		if t != nil {
 			return &t.Type
 		}
+		return &toClosureType(ftyp).Type
 	}
 
 	fields := []abi.StructField{

--- a/runtime/internal/lib/reflect/value.go
+++ b/runtime/internal/lib/reflect/value.go
@@ -1627,11 +1627,12 @@ func (v Value) typeSlow() Type {
 	}
 
 	typ := v.typ()
-	// closure func
-	if v.typ_.IsClosure() {
-		return toRType(&v.closureFunc().Type)
-	}
+
 	if v.flag&flagMethod == 0 {
+		// closure func
+		if v.typ_.IsClosure() {
+			return toRType(&v.closureFunc().Type)
+		}
 		return toRType(v.typ())
 	}
 
@@ -2430,7 +2431,7 @@ func toFFIRetType(tout []*abi.Type) *ffi.Type {
 }
 
 func (v Value) closureFunc() *abi.FuncType {
-	return v.typ_.StructType().Fields[0].Typ.FuncType()
+	return toFuncType(v.typ_.StructType())
 }
 
 func (v Value) call(op string, in []Value) (out []Value) {
@@ -2443,7 +2444,7 @@ func (v Value) call(op string, in []Value) (out []Value) {
 		ret  unsafe.Pointer
 		ioff int
 	)
-	if v.typ_.IsClosure() {
+	if v.typ_.IsClosure() && v.flag&flagMethod == 0 {
 		ft = v.typ_.StructType().Fields[0].Typ.FuncType()
 		tin = append([]*abi.Type{rtypeOf(unsafe.Pointer(nil))}, ft.In...)
 		tout = ft.Out

--- a/runtime/internal/lib/reflect/value.go
+++ b/runtime/internal/lib/reflect/value.go
@@ -1627,7 +1627,6 @@ func (v Value) typeSlow() Type {
 	}
 
 	typ := v.typ()
-
 	if v.flag&flagMethod == 0 {
 		// closure func
 		if v.typ_.IsClosure() {


### PR DESCRIPTION
fix https://github.com/xgo-dev/llgo/issues/1957

( cached in reflect )
- named closure type => rebuild named func type
```
type T func(int) int   // T is named closure
reflect.TypeOf(T{})   // T rebuild to named func
typ := reflect.TypeOf((*T)(nil)).Elem() // T rebuild to named func
v := reflect.New(typ).Elem() // v.typ is named closure
```
- named c func type => rebuild named closure type
```
//llgo:type C
type T func(int) int   // T is named func
reflect.TypeOf(T{})   
typ := reflect.TypeOf((*T)(nil)).Elem() 
v := reflect.New(typ).Elem() // T rebuild to named closure type
```