### PR TITLE
internal/build: rename -v to -debug for print debug information

### DIFF
--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -30,6 +30,7 @@ func AddOutputFlags(fs *flag.FlagSet) {
 }
 
 var Verbose bool
+var BuildV bool
 var BuildEnv string
 var BuildMode string
 var Tags string
@@ -166,7 +167,7 @@ func ResolveLTOMode(defaultValue lto.Mode) lto.Mode {
 const DefaultTestTimeout = "10m" // Matches Go's default test timeout
 
 func AddCommonFlags(fs *flag.FlagSet) {
-	fs.BoolVar(&Verbose, "v", false, "Verbose output")
+	fs.BoolVar(&Verbose, "debug", false, "Print debug information")
 }
 
 func AddOptLevelFlags(fs *flag.FlagSet) {
@@ -205,6 +206,7 @@ func AddBuildFlags(fs *flag.FlagSet) {
 	PthreadStackSize = 0
 	fs.BoolVar(&ForceRebuild, "a", false, "Force rebuilding of packages that are already up-to-date")
 	fs.BoolVar(&PrintCommands, "x", false, "Print the commands")
+	fs.BoolVar(&BuildV, "v", false, "print the names of packages as they are compiled.")
 	AddOptLevelFlags(fs)
 	AddLTOFlag(fs)
 	AddGlobalDCEFlag(fs)
@@ -333,6 +335,9 @@ func UpdateConfig(conf *build.Config) error {
 	conf.CompilerHash = compilerhash.Value()
 	conf.Tags = Tags
 	conf.Verbose = Verbose
+	if conf.Mode != build.ModeTest {
+		conf.BuildV = BuildV
+	}
 	conf.PrintCommands = PrintCommands
 	conf.OptLevel = OptLevel
 	conf.Target = Target

--- a/cmd/internal/test/test.go
+++ b/cmd/internal/test/test.go
@@ -99,7 +99,7 @@ func buildTestArgs(customArgs []string) []string {
 		}
 	}
 
-	appendBool(flags.Verbose, "-test.v")
+	appendBool(flags.BuildV, "-test.v")
 	appendString(flags.TestRun, "-test.run=")
 	appendString(flags.TestBench, "-test.bench=")
 	appendString(flags.TestList, "-test.list=")

--- a/cmd/internal/test/test_test.go
+++ b/cmd/internal/test/test_test.go
@@ -118,7 +118,7 @@ func TestBuildTestArgs(t *testing.T) {
 		{
 			name: "verbose only",
 			setupFlags: func() {
-				flags.Verbose = true
+				flags.BuildV = true
 			},
 			customArgs:  nil,
 			wantContain: []string{"-test.v"},
@@ -134,7 +134,7 @@ func TestBuildTestArgs(t *testing.T) {
 		{
 			name: "multiple flags",
 			setupFlags: func() {
-				flags.Verbose = true
+				flags.BuildV = true
 				flags.TestRun = "TestFoo"
 				flags.TestTimeout = "30s"
 				flags.TestShort = true

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -146,6 +146,7 @@ type Config struct {
 	AbiMode       AbiMode
 	GenExpect     bool // only valid for ModeCmpTest
 	Verbose       bool
+	BuildV        bool
 	PrintCommands bool
 	GenLL         bool // generate pkg .ll files
 	CheckLLFiles  bool // check .ll files valid
@@ -478,7 +479,7 @@ func Do(args []string, conf *Config) ([]Package, error) {
 
 	allPkgs := append([]*aPackage{}, pkgs...)
 	allPkgs = append(allPkgs, depPkgs...)
-	allPkgs, err = buildAllPkgs(ctx, allPkgs, verbose)
+	allPkgs, err = buildAllPkgs(ctx, allPkgs, verbose, conf.BuildV)
 	if err != nil {
 		return nil, err
 	}
@@ -765,7 +766,7 @@ func normalizeToArchive(ctx *context, aPkg *aPackage, verbose bool) error {
 	return nil
 }
 
-func buildAllPkgs(ctx *context, pkgs []*aPackage, verbose bool) ([]*aPackage, error) {
+func buildAllPkgs(ctx *context, pkgs []*aPackage, verbose bool, buildV bool) ([]*aPackage, error) {
 	built := ctx.built
 
 	// Split packages into runtime tree vs others so we can defer runtime build.
@@ -805,7 +806,7 @@ func buildAllPkgs(ctx *context, pkgs []*aPackage, verbose bool) ([]*aPackage, er
 						fmt.Fprintf(os.Stderr, "CACHE MISS: %s\n", pkg.PkgPath)
 					}
 				}
-				if err := buildPkg(ctx, aPkg, verbose); err != nil {
+				if err := buildPkg(ctx, aPkg, verbose, buildV); err != nil {
 					return err
 				}
 				if !aPkg.CacheHit {
@@ -837,7 +838,7 @@ func buildAllPkgs(ctx *context, pkgs []*aPackage, verbose bool) ([]*aPackage, er
 					fmt.Fprintf(os.Stderr, "CACHE MISS: %s\n", pkg.PkgPath)
 				}
 			}
-			if err := buildPkg(ctx, aPkg, verbose); err != nil {
+			if err := buildPkg(ctx, aPkg, verbose, buildV); err != nil {
 				return err
 			}
 			aPkg.setNeedRuntimeOrPyInit(aPkg.LPkg.NeedRuntime, aPkg.LPkg.NeedPyInit)
@@ -1408,11 +1409,11 @@ func is32Bits(goarch string) bool {
 	return goarch == "386" || goarch == "arm" || goarch == "mips" || goarch == "wasm"
 }
 
-func buildPkg(ctx *context, aPkg *aPackage, verbose bool) error {
+func buildPkg(ctx *context, aPkg *aPackage, verbose bool, buildV bool) error {
 	pkg := aPkg.Package
 	pkgPath := pkg.PkgPath
-	if debugBuild || verbose {
-		fmt.Fprintln(os.Stderr, pkgPath)
+	if debugBuild || verbose || (buildV && !aPkg.CacheHit) {
+		fmt.Fprintln(os.Stderr, aPkg.PkgPath)
 	}
 	if llruntime.SkipToBuild(pkgPath) {
 		pkg.ExportFile = ""

--- a/test/buildcache/test.sh
+++ b/test/buildcache/test.sh
@@ -282,7 +282,7 @@ echo "Snapshots directory: $SNAPSHOTS_DIR"
 echo "Build temp directory: $BUILD_TEMP_DIR"
 
 # Run native tests
-run_test_suite "native" "llgo build -o $BUILD_TEMP_DIR/buildcache.out -v ." ""
+run_test_suite "native" "llgo build -o $BUILD_TEMP_DIR/buildcache.out -debug ." ""
 
 # Run WASM tests - always use iwasm from llgo cache directory
 # Determine cache directory based on platform
@@ -311,7 +311,7 @@ if [ -n "$LLGO_IWASM" ] && [ -f "$LLGO_IWASM" ]; then
     echo ""
     echo -e "${BLUE}Using iwasm: $LLGO_IWASM${NC}"
     run_test_suite "wasm" \
-        "GOOS=wasip1 GOARCH=wasm llgo build -o $BUILD_TEMP_DIR/buildcache.wasm -tags=nogc -v ." \
+        "GOOS=wasip1 GOARCH=wasm llgo build -o $BUILD_TEMP_DIR/buildcache.wasm -tags=nogc -debug ." \
         "$BUILD_TEMP_DIR/buildcache.wasm" \
         "$LLGO_IWASM --stack-size=819200000 --heap-size=800000000 $BUILD_TEMP_DIR/buildcache.wasm"
 else
@@ -327,7 +327,7 @@ fi
 echo ""
 echo -e "${BLUE}Running ESP32-C3 tests...${NC}"
 run_test_suite "esp32c3" \
-    "llgo build -target=esp32c3 -o $BUILD_TEMP_DIR/buildcache.elf -v ." \
+    "llgo build -target=esp32c3 -o $BUILD_TEMP_DIR/buildcache.elf -debug ." \
     "$BUILD_TEMP_DIR/buildcache.elf"
 
 # ===========================================================


### PR DESCRIPTION
`llgo build -v` => `llgo build -debug`

-v flag outputs debug info, which interferes with test -v command output
