### PR TITLE
fix(build): avoid stale main cache for LTO linking

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1196,7 +1196,7 @@ func (c *context) archiver() string {
 	if ar := os.Getenv("LLGO_AR"); ar != "" {
 		return ar
 	}
-	if c.buildConf.Goarch == "wasm" || strings.Contains(c.crossCompile.LLVMTarget, "wasm") {
+	if c.buildConf.ltoEnabled() || c.buildConf.Goarch == "wasm" || strings.Contains(c.crossCompile.LLVMTarget, "wasm") {
 		if llvmAr, err := exec.LookPath("llvm-ar"); err == nil {
 			return llvmAr
 		}

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -395,6 +395,31 @@ func TestLTOEnabledExplicitOverride(t *testing.T) {
 	}
 }
 
+func TestArchiverPrefersLLVMArForLTO(t *testing.T) {
+	td := t.TempDir()
+	llvmAr := filepath.Join(td, "llvm-ar")
+	if err := os.WriteFile(llvmAr, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", td)
+	t.Setenv("LLGO_AR", "")
+
+	if got := (&context{buildConf: &Config{LTO: lto.Off}}).archiver(); got != "ar" {
+		t.Fatalf("archiver without lto = %q, want ar", got)
+	}
+	if got := (&context{buildConf: &Config{LTO: lto.Full}}).archiver(); got != llvmAr {
+		t.Fatalf("archiver with full lto = %q, want %q", got, llvmAr)
+	}
+}
+
+func TestArchiverAllowsLLGOAROverrideForLTO(t *testing.T) {
+	t.Setenv("LLGO_AR", "custom-ar")
+
+	if got := (&context{buildConf: &Config{LTO: lto.Full}}).archiver(); got != "custom-ar" {
+		t.Fatalf("archiver with LLGO_AR = %q, want custom-ar", got)
+	}
+}
+
 func TestDevLTOGlobalDCEDefaultsToFullLTO(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/build/collect.go
+++ b/internal/build/collect.go
@@ -318,6 +318,13 @@ func (c *context) tryLoadFromCache(pkg *aPackage) bool {
 		return false
 	}
 
+	// Main packages are intentionally not written to the build cache because
+	// each executable's entry module is linked against the current main archive.
+	// Do not load stale main archives that may exist from older cache layouts.
+	if pkg.Name == "main" {
+		return false
+	}
+
 	// Skip cache when force rebuild is enabled
 	if c.buildConf.ForceRebuild {
 		return false

--- a/internal/build/collect_test.go
+++ b/internal/build/collect_test.go
@@ -552,6 +552,54 @@ func TestSaveToCache_MainPackage(t *testing.T) {
 	}
 }
 
+func TestTryLoadFromCache_MainPackage(t *testing.T) {
+	td := t.TempDir()
+	oldFunc := cacheRootFunc
+	cacheRootFunc = func() string { return td }
+	defer func() { cacheRootFunc = oldFunc }()
+
+	ctx := &context{
+		conf: &packages.Config{},
+		buildConf: &Config{
+			Goos:   "darwin",
+			Goarch: "arm64",
+		},
+		crossCompile: crosscompile.Export{
+			LLVMTarget: "arm64-apple-darwin",
+		},
+	}
+
+	pkg := &aPackage{
+		Package: &packages.Package{
+			PkgPath: "main",
+			Name:    "main",
+		},
+		Fingerprint: "abc123",
+	}
+
+	cm := ctx.ensureCacheManager()
+	paths := cm.PackagePaths("arm64-apple-darwin", "main", "abc123")
+	if err := cm.EnsureDir(paths); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.Archive, []byte("stale main archive"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.Manifest, []byte("metadata: {}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if ctx.tryLoadFromCache(pkg) {
+		t.Fatal("main package should not be loaded from cache")
+	}
+	if pkg.CacheHit {
+		t.Fatal("main package cache hit should remain false")
+	}
+	if pkg.ArchiveFile != "" {
+		t.Fatalf("main package ArchiveFile = %q, want empty", pkg.ArchiveFile)
+	}
+}
+
 func TestSaveToCache_Success(t *testing.T) {
 	td := t.TempDir()
 	oldFunc := cacheRootFunc


### PR DESCRIPTION
## Summary
- skip build-cache loads for main packages to avoid reusing stale main archives
- prefer llvm-ar for LTO archives while preserving LLGO_AR override
- add tests covering main cache bypass and LTO archiver selection

## Tests
- go test -count=1 -run 'Test(ArchiverPrefersLLVMArForLTO|ArchiverAllowsLLGOAROverrideForLTO|TryLoadFromCache_MainPackage|SaveToCache_MainPackage)' ./internal/build\n- go test -count=1 ./internal/build\n- go test -timeout 30m -count=1 -run '^TestRunAndTestFromTestlto$' ./cl