### PR TITLE
ssa: use overloaded LLVM intrinsics

### DIFF
--- a/cl/_testdata/foo/foo.go
+++ b/cl/_testdata/foo/foo.go
@@ -8,7 +8,7 @@ package foo
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.eface" @"{{.*}}/cl/_testdata/foo.Bar"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca { i64 }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64 }, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store i64 1, ptr %1, align 8
 // CHECK-NEXT:   %2 = load { i64 }, ptr %0, align 8
@@ -25,7 +25,7 @@ func Bar() any {
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.eface" @"{{.*}}/cl/_testdata/foo.F"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca { i64 }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64 }, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store i64 1, ptr %1, align 8
 // CHECK-NEXT:   %2 = load { i64 }, ptr %0, align 8
@@ -47,7 +47,7 @@ type Foo struct {
 // CHECK-LABEL: define ptr @"{{.*}}/cl/_testdata/foo.Foo.Pb"(%"{{.*}}/cl/_testdata/foo.Foo" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testdata/foo.Foo", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store %"{{.*}}/cl/_testdata/foo.Foo" %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testdata/foo.Foo", ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8

--- a/cl/_testdata/llgosyscall/in.go
+++ b/cl/_testdata/llgosyscall/in.go
@@ -12,6 +12,9 @@ func syscall6(fn, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2, err uintptr)
 //go:linkname syscall6X llgo.syscall
 func syscall6X(fn, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2, err uintptr)
 
+//go:linkname syscall5f64 llgo.syscall
+func syscall5f64(fn, a1, a2, a3, a4, a5 uintptr, f1 float64) (r1, r2, err uintptr)
+
 //go:linkname syscallPtr llgo.syscall
 func syscallPtr(fn, a1, a2, a3 uintptr) (r1, r2, err uintptr)
 
@@ -30,6 +33,14 @@ func rawSyscall6(fn, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2, err uintptr)
 // CHECK:   ret i64 %8
 func Use() uintptr {
 	r1, _, _ := syscall(0, 1, 2, 3)
+	return r1
+}
+
+// CHECK-LABEL: define i64 @"{{.*}}/llgosyscall.Use5F64"(i64 %0, double %1){{.*}} {
+// CHECK:   %{{[0-9]+}} = inttoptr i64 %0 to ptr
+// CHECK:   %{{[0-9]+}} = call i64 %{{[0-9]+}}(i64 1, i64 2, i64 3, i64 4, i64 5, double %1)
+func Use5F64(fn uintptr, f float64) uintptr {
+	r1, _, _ := syscall5f64(fn, 1, 2, 3, 4, 5, f)
 	return r1
 }
 

--- a/cl/_testgo/abimethod/in.go
+++ b/cl/_testgo/abimethod/in.go
@@ -20,11 +20,11 @@ import (
 // CHECK: {{^}}@24 = private unnamed_addr constant [20 x i8] c"testAnonymous7 error", align 1{{$}}
 // CHECK: {{^}}@26 = private unnamed_addr constant [20 x i8] c"testAnonymous8 error", align 1{{$}}
 // CHECK: {{^}}@27 = private unnamed_addr constant [5 x i8] c"hello", align 1{{$}}
-// CHECK: {{^}}@96 = private unnamed_addr constant [25 x i8] c"testAnonymousBuffer error", align 1{{$}}
-// CHECK: {{^}}@109 = private unnamed_addr constant [17 x i8] c"testGeneric error", align 1{{$}}
-// CHECK: {{^}}@110 = private unnamed_addr constant [16 x i8] c"testNamed1 error", align 1{{$}}
-// CHECK: {{^}}@111 = private unnamed_addr constant [16 x i8] c"testNamed2 error", align 1{{$}}
-// CHECK: {{^}}@112 = private unnamed_addr constant [16 x i8] c"testNamed4 error", align 1{{$}}
+// CHECK: {{^}}@[[ANONBUF_ERR:[0-9]+]] = private unnamed_addr constant [25 x i8] c"testAnonymousBuffer error", align 1{{$}}
+// CHECK: {{^}}@[[GENERIC_ERR:[0-9]+]] = private unnamed_addr constant [17 x i8] c"testGeneric error", align 1{{$}}
+// CHECK: {{^}}@[[NAMED1_ERR:[0-9]+]] = private unnamed_addr constant [16 x i8] c"testNamed1 error", align 1{{$}}
+// CHECK: {{^}}@[[NAMED2_ERR:[0-9]+]] = private unnamed_addr constant [16 x i8] c"testNamed2 error", align 1{{$}}
+// CHECK: {{^}}@[[NAMED4_ERR:[0-9]+]] = private unnamed_addr constant [16 x i8] c"testNamed4 error", align 1{{$}}
 
 type T struct {
 	n int
@@ -33,7 +33,7 @@ type T struct {
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.T.Demo1"(%"{{.*}}/cl/_testgo/abimethod.T" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/abimethod.T", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   store %"{{.*}}/cl/_testgo/abimethod.T" %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load i64, ptr %2, align 8
@@ -329,7 +329,7 @@ type I2 interface {
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testAnonymous2"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
@@ -369,7 +369,7 @@ type I2 interface {
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testAnonymous3"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %2, i32 0, i32 0
@@ -475,7 +475,7 @@ type I2 interface {
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testAnonymous6"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
@@ -515,7 +515,7 @@ type I2 interface {
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testAnonymous7"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
@@ -575,7 +575,7 @@ type I2 interface {
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testAnonymous8"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %0, i32 0, i32 1
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 8)
@@ -678,7 +678,7 @@ type I2 interface {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %18 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @96, i64 25 }, ptr %18, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @[[ANONBUF_ERR]], i64 25 }, ptr %18, align 8
 // CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %18, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %19)
 // CHECK-NEXT:   unreachable
@@ -719,7 +719,7 @@ type I2 interface {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_3
 // CHECK-NEXT:   %25 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @109, i64 17 }, ptr %25, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @[[GENERIC_ERR]], i64 17 }, ptr %25, align 8
 // CHECK-NEXT:   %26 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %25, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %26)
 // CHECK-NEXT:   unreachable
@@ -770,7 +770,7 @@ type I2 interface {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %15 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @110, i64 16 }, ptr %15, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @[[NAMED1_ERR]], i64 16 }, ptr %15, align 8
 // CHECK-NEXT:   %16 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %15, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %16)
 // CHECK-NEXT:   unreachable
@@ -782,7 +782,7 @@ type I2 interface {
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.testNamed2"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca %"{{.*}}/cl/_testgo/abimethod.T", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/abimethod.T", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store i64 100, ptr %1, align 8
 // CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/abimethod.T", ptr %0, align 8
@@ -805,7 +805,7 @@ type I2 interface {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %17 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @111, i64 16 }, ptr %17, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @[[NAMED2_ERR]], i64 16 }, ptr %17, align 8
 // CHECK-NEXT:   %18 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %17, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %18)
 // CHECK-NEXT:   unreachable
@@ -836,7 +836,7 @@ type I2 interface {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   %15 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @112, i64 16 }, ptr %15, align 8
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @[[NAMED4_ERR]], i64 16 }, ptr %15, align 8
 // CHECK-NEXT:   %16 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %15, 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %16)
 // CHECK-NEXT:   unreachable
@@ -873,7 +873,7 @@ type I2 interface {
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.Demo1"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -885,7 +885,7 @@ type I2 interface {
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.Demo2"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -896,7 +896,7 @@ type I2 interface {
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *{{.*}}/cl/_testgo/abimethod.T}.demo3"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -979,7 +979,7 @@ type I2 interface {
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; {{.*}}/cl/_testgo/abimethod.T}.Demo1"({ i64, %"{{.*}}/cl/_testgo/abimethod.T" } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, %"{{.*}}/cl/_testgo/abimethod.T" } %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, %"{{.*}}/cl/_testgo/abimethod.T" }, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load %"{{.*}}/cl/_testgo/abimethod.T", ptr %2, align 8
@@ -1302,7 +1302,7 @@ type I2 interface {
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Available"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1313,7 +1313,7 @@ type I2 interface {
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.AvailableBuffer"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1324,7 +1324,7 @@ type I2 interface {
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Bytes"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1335,7 +1335,7 @@ type I2 interface {
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Cap"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1346,7 +1346,7 @@ type I2 interface {
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Grow"({ i64, ptr } %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
 // CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
@@ -1357,7 +1357,7 @@ type I2 interface {
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Len"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1368,7 +1368,7 @@ type I2 interface {
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Next"({ i64, ptr } %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
 // CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
@@ -1379,7 +1379,7 @@ type I2 interface {
 // CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Read"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
 // CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
@@ -1394,7 +1394,7 @@ type I2 interface {
 // CHECK-LABEL: define { i8, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadByte"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1409,7 +1409,7 @@ type I2 interface {
 // CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadBytes"({ i64, ptr } %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
 // CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
@@ -1424,7 +1424,7 @@ type I2 interface {
 // CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadFrom"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
 // CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
@@ -1439,7 +1439,7 @@ type I2 interface {
 // CHECK-LABEL: define { i32, i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadRune"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1456,7 +1456,7 @@ type I2 interface {
 // CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.String", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.ReadString"({ i64, ptr } %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
 // CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
@@ -1471,7 +1471,7 @@ type I2 interface {
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Reset"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1482,7 +1482,7 @@ type I2 interface {
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.String"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1493,7 +1493,7 @@ type I2 interface {
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Truncate"({ i64, ptr } %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
 // CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
@@ -1504,7 +1504,7 @@ type I2 interface {
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.UnreadByte"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1515,7 +1515,7 @@ type I2 interface {
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.UnreadRune"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1526,7 +1526,7 @@ type I2 interface {
 // CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.Write"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
 // CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
@@ -1541,7 +1541,7 @@ type I2 interface {
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteByte"({ i64, ptr } %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
 // CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
@@ -1552,7 +1552,7 @@ type I2 interface {
 // CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteRune"({ i64, ptr } %0, i32 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
 // CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
@@ -1567,7 +1567,7 @@ type I2 interface {
 // CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteString"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.String" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
 // CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
@@ -1582,7 +1582,7 @@ type I2 interface {
 // CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.WriteTo"({ i64, ptr } %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
 // CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
@@ -1597,7 +1597,7 @@ type I2 interface {
 // CHECK-LABEL: define i1 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.empty"({ i64, ptr } %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds { i64, ptr }, ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -1608,7 +1608,7 @@ type I2 interface {
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.grow"({ i64, ptr } %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
 // CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
@@ -1619,7 +1619,7 @@ type I2 interface {
 // CHECK-LABEL: define { %"{{.*}}/runtime/internal/runtime.Slice", %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.readSlice"({ i64, ptr } %0, i8 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
 // CHECK-NEXT:   %4 = load ptr, ptr %3, align 8
@@ -1634,7 +1634,7 @@ type I2 interface {
 // CHECK-LABEL: define { i64, i1 } @"{{.*}}/cl/_testgo/abimethod.struct{m int; *bytes.Buffer}.tryGrowByReslice"({ i64, ptr } %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca { i64, ptr }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store { i64, ptr } %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = getelementptr inbounds { i64, ptr }, ptr %2, i32 0, i32 1
 // CHECK-NEXT:   %4 = load ptr, ptr %3, align 8

--- a/cl/_testgo/closureall/in.go
+++ b/cl/_testgo/closureall/in.go
@@ -28,7 +28,7 @@ type S struct {
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/closureall.S.Inc"(%"{{.*}}/cl/_testgo/closureall.S" %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca %"{{.*}}/cl/_testgo/closureall.S", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   store %"{{.*}}/cl/_testgo/closureall.S" %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/closureall.S", ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %4 = load i64, ptr %3, align 8

--- a/cl/_testgo/cursor/in.go
+++ b/cl/_testgo/cursor/in.go
@@ -35,7 +35,7 @@ func (c Cursor) Node() ast.Node {
 // CHECK-LABEL: define { %"{{.*}}/cl/_testgo/cursor.Cursor", i1 } @"{{.*}}/cl/_testgo/cursor.Cursor.FindNode"(%"{{.*}}/cl/_testgo/cursor.Cursor" %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca %"{{.*}}/cl/_testgo/cursor.Cursor", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store %"{{.*}}/cl/_testgo/cursor.Cursor" %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 16)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %1, ptr %3, align 8
@@ -132,7 +132,7 @@ func (c Cursor) Node() ast.Node {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_10:                                         ; preds = %_llgo_9
 // CHECK-NEXT:   %54 = alloca %"{{.*}}/cl/_testgo/cursor.event", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %54, i8 0, i64 32, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %54, i8 0, i64 32, i1 false)
 // CHECK-NEXT:   %55 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %35, 0
 // CHECK-NEXT:   %56 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %35, 1
 // CHECK-NEXT:   %57 = sext i32 %52 to i64
@@ -171,7 +171,7 @@ func (c Cursor) Node() ast.Node {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_14:                                         ; preds = %_llgo_16
 // CHECK-NEXT:   %76 = alloca %"{{.*}}/cl/_testgo/cursor.Cursor", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %76, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %76, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   %77 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %76, i32 0, i32 0
 // CHECK-NEXT:   %78 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %79 = load ptr, ptr %78, align 8
@@ -547,7 +547,7 @@ const (
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testgo/cursor.Cursor.Node"(%"{{.*}}/cl/_testgo/cursor.Cursor" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/cursor.Cursor", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store %"{{.*}}/cl/_testgo/cursor.Cursor" %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load i32, ptr %2, align 4
@@ -618,7 +618,7 @@ const (
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1
 // CHECK-NEXT:   %15 = alloca %"{{.*}}/cl/_testgo/cursor.event", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %15, i8 0, i64 32, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %15, i8 0, i64 32, i1 false)
 // CHECK-NEXT:   %16 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 0
 // CHECK-NEXT:   %17 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %7, 1
 // CHECK-NEXT:   %18 = sext i32 %13 to i64
@@ -671,7 +671,7 @@ const (
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_7:                                          ; preds = %_llgo_4
 // CHECK-NEXT:   %49 = alloca %"{{.*}}/cl/_testgo/cursor.Cursor", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %49, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %49, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   %50 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %49, i32 0, i32 0
 // CHECK-NEXT:   %51 = extractvalue { ptr, ptr } %2, 0
 // CHECK-NEXT:   %52 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %51, i32 0, i32 0
@@ -693,7 +693,7 @@ const (
 // CHECK-LABEL: define { i32, i32 } @"{{.*}}/cl/_testgo/cursor.Cursor.indices"(%"{{.*}}/cl/_testgo/cursor.Cursor" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/cursor.Cursor", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store %"{{.*}}/cl/_testgo/cursor.Cursor" %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/cursor.Cursor", ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load i32, ptr %2, align 4

--- a/cl/_testgo/embedunexport-1598/in.go
+++ b/cl/_testgo/embedunexport-1598/in.go
@@ -11,7 +11,7 @@ type Wrapped struct {
 // CHECK-LABEL: define %"{{.*}}String" @"{{.*}}embedunexport-1598.Wrapped.Name"(%"{{.*}}embedunexport-1598.Wrapped" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca %"{{.*}}embedunexport-1598.Wrapped", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   store %"{{.*}}embedunexport-1598.Wrapped" %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}embedunexport-1598.Wrapped", ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
@@ -21,7 +21,7 @@ type Wrapped struct {
 // CHECK-LABEL: define void @"{{.*}}embedunexport-1598.Wrapped.setName"(%"{{.*}}embedunexport-1598.Wrapped" %0, %"{{.*}}String" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca %"{{.*}}embedunexport-1598.Wrapped", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   store %"{{.*}}embedunexport-1598.Wrapped" %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}embedunexport-1598.Wrapped", ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %4 = load ptr, ptr %3, align 8

--- a/cl/_testgo/equal/in.go
+++ b/cl/_testgo/equal/in.go
@@ -103,7 +103,7 @@ func init() {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/equal.assert"(i1 true)
 // CHECK-NEXT:   %0 = alloca [3 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 24, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 24, i1 false)
 // CHECK-NEXT:   %1 = getelementptr inbounds i64, ptr %0, i64 0
 // CHECK-NEXT:   %2 = getelementptr inbounds i64, ptr %0, i64 1
 // CHECK-NEXT:   %3 = getelementptr inbounds i64, ptr %0, i64 2
@@ -111,7 +111,7 @@ func init() {
 // CHECK-NEXT:   store i64 2, ptr %2, align 8
 // CHECK-NEXT:   store i64 3, ptr %3, align 8
 // CHECK-NEXT:   %4 = alloca [3 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %4, i8 0, i64 24, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %4, i8 0, i64 24, i1 false)
 // CHECK-NEXT:   %5 = getelementptr inbounds i64, ptr %4, i64 0
 // CHECK-NEXT:   %6 = getelementptr inbounds i64, ptr %4, i64 1
 // CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %4, i64 2

--- a/cl/_testgo/genericembediface/in.go
+++ b/cl/_testgo/genericembediface/in.go
@@ -158,7 +158,7 @@ func main() {
 // CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response].Context"(%"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response]" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response]", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store %"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response]" %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/genericembediface/streamlib.GenericServerStream[{{.*}}/cl/_testgo/genericembediface.Request,{{.*}}/cl/_testgo/genericembediface.Response]", ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %2, align 8

--- a/cl/_testgo/ifaceprom/in.go
+++ b/cl/_testgo/ifaceprom/in.go
@@ -69,7 +69,7 @@ func main() {
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/ifaceprom.S.one"(%"{{.*}}/cl/_testgo/ifaceprom.S" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/ifaceprom.S", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store %"{{.*}}/cl/_testgo/ifaceprom.S" %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %2, align 8
@@ -88,7 +88,7 @@ func main() {
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/ifaceprom.S.two"(%"{{.*}}/cl/_testgo/ifaceprom.S" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/ifaceprom.S", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store %"{{.*}}/cl/_testgo/ifaceprom.S" %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %2, align 8
@@ -182,7 +182,7 @@ func main() {
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/ifaceprom.main"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca %"{{.*}}/cl/_testgo/ifaceprom.S", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/ifaceprom.S", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 0)
 // CHECK-NEXT:   store %"{{.*}}/cl/_testgo/ifaceprom.impl" zeroinitializer, ptr %2, align 1

--- a/cl/_testgo/invoke/in.go
+++ b/cl/_testgo/invoke/in.go
@@ -28,7 +28,7 @@ type T struct {
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.T.Invoke"(%"{{.*}}/cl/_testgo/invoke.T" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/invoke.T", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store %"{{.*}}/cl/_testgo/invoke.T" %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/invoke.T", ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.String", ptr %2, align 8
@@ -223,7 +223,7 @@ type M interface {
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.T4.Invoke"([1 x i64] %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca [1 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   store [1 x i64] %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds i64, ptr %1, i64 0
 // CHECK-NEXT:   %3 = load i64, ptr %2, align 8
@@ -246,7 +246,7 @@ type M interface {
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testgo/invoke.T5.Invoke"(%"{{.*}}/cl/_testgo/invoke.T5" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/invoke.T5", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   store %"{{.*}}/cl/_testgo/invoke.T5" %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/invoke.T5", ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load i64, ptr %2, align 8
@@ -423,7 +423,7 @@ type M interface {
 // CHECK-NEXT:   %72 = insertvalue %"{{.*}}/runtime/internal/runtime.iface" %71, ptr %69, 1
 // CHECK-NEXT:   call void @"{{.*}}/cl/_testgo/invoke.invoke"(%"{{.*}}/runtime/internal/runtime.iface" %72)
 // CHECK-NEXT:   %73 = alloca %"{{.*}}/cl/_testgo/invoke.T", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %73, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %73, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   %74 = getelementptr inbounds %"{{.*}}/cl/_testgo/invoke.T", ptr %73, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @36, i64 5 }, ptr %74, align 8
 // CHECK-NEXT:   %75 = load %"{{.*}}/cl/_testgo/invoke.T", ptr %73, align 8

--- a/cl/_testgo/reader/in.go
+++ b/cl/_testgo/reader/in.go
@@ -137,7 +137,7 @@ func WriteString(w Writer, s string) (n int, err error) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_5
 // CHECK-NEXT:   %3 = alloca %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %3, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %3, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", ptr %3, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %0, ptr %4, align 8
 // CHECK-NEXT:   %5 = load %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", ptr %3, align 8
@@ -150,7 +150,7 @@ func WriteString(w Writer, s string) (n int, err error) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_5
 // CHECK-NEXT:   %10 = alloca %"{{.*}}/cl/_testgo/reader.nopCloser", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %10, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %10, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   %11 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.nopCloser", ptr %10, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" %0, ptr %11, align 8
 // CHECK-NEXT:   %12 = load %"{{.*}}/cl/_testgo/reader.nopCloser", ptr %10, align 8
@@ -580,7 +580,7 @@ func main() {
 // CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.nopCloser.Read"(%"{{.*}}/cl/_testgo/reader.nopCloser" %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca %"{{.*}}/cl/_testgo/reader.nopCloser", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store %"{{.*}}/cl/_testgo/reader.nopCloser" %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.nopCloser", ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %4 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %3, align 8
@@ -637,7 +637,7 @@ func main() {
 // CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.nopCloserWriterTo.Read"(%"{{.*}}/cl/_testgo/reader.nopCloserWriterTo" %0, %"{{.*}}/runtime/internal/runtime.Slice" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo" %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %4 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %3, align 8
@@ -660,7 +660,7 @@ func main() {
 // CHECK-LABEL: define { i64, %"{{.*}}/runtime/internal/runtime.iface" } @"{{.*}}/cl/_testgo/reader.nopCloserWriterTo.WriteTo"(%"{{.*}}/cl/_testgo/reader.nopCloserWriterTo" %0, %"{{.*}}/runtime/internal/runtime.iface" %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = alloca %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo" %0, ptr %2, align 8
 // CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testgo/reader.nopCloserWriterTo", ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %4 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %3, align 8

--- a/cl/_testgo/reflectmk/in.go
+++ b/cl/_testgo/reflectmk/in.go
@@ -36,7 +36,7 @@ func (p *Point) Set(x int, y int) {
 // CHECK-LABEL: define %"{{.*}}/runtime/internal/runtime.String" @"{{.*}}/cl/_testgo/reflectmk.Point.String"(%"{{.*}}/cl/_testgo/reflectmk.Point" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testgo/reflectmk.Point", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store %"{{.*}}/cl/_testgo/reflectmk.Point" %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testgo/reflectmk.Point", ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load i64, ptr %2, align 8
@@ -442,7 +442,7 @@ func methodByName(name string) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_16:                                         ; preds = %_llgo_14
 // CHECK-NEXT:   %220 = alloca %reflect.Method, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %220, i8 0, i64 80, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %220, i8 0, i64 80, i1 false)
 // CHECK-NEXT:   %221 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
 // CHECK-NEXT:   %222 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
 // CHECK-NEXT:   %223 = getelementptr ptr, ptr %222, i64 {{(23|25)}}
@@ -468,7 +468,7 @@ func methodByName(name string) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_18:                                         ; preds = %_llgo_16
 // CHECK-NEXT:   %236 = alloca %reflect.Method, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %236, i8 0, i64 80, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %236, i8 0, i64 80, i1 false)
 // CHECK-NEXT:   %237 = call ptr @"{{.*}}/runtime/internal/runtime.IfacePtrData"(%"{{.*}}/runtime/internal/runtime.iface" %9)
 // CHECK-NEXT:   %238 = extractvalue %"{{.*}}/runtime/internal/runtime.iface" %9, 0
 // CHECK-NEXT:   %239 = getelementptr ptr, ptr %238, i64 {{(24|26)}}

--- a/cl/_testgo/selects/in.go
+++ b/cl/_testgo/selects/in.go
@@ -77,24 +77,24 @@ func main() {
 // CHECK-NEXT:   %14 = alloca i8, i64 8, align 1
 // CHECK-NEXT:   %15 = call i32 @"{{.*}}/runtime/internal/runtime.CreateThread"(ptr %14, ptr null, ptr @"{{.*}}/cl/_testgo/selects._llgo_routine$1", ptr %12)
 // CHECK-NEXT:   %16 = load ptr, ptr %0, align 8
-// CHECK-NEXT:   %17 = call ptr @llvm.stacksave()
+// CHECK-NEXT:   %17 = call ptr @llvm.stacksave.p0()
 // CHECK-NEXT:   %18 = alloca {}, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %18, i8 0, i64 0, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %18, i8 0, i64 0, i1 false)
 // CHECK-NEXT:   store {} zeroinitializer, ptr %18, align 1
 // CHECK-NEXT:   %19 = call i1 @"{{.*}}/runtime/internal/runtime.ChanSend"(ptr %16, ptr %18, i64 0)
-// CHECK-NEXT:   call void @llvm.stackrestore(ptr %17)
+// CHECK-NEXT:   call void @llvm.stackrestore.p0(ptr %17)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 4 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %20 = load ptr, ptr %2, align 8
-// CHECK-NEXT:   %21 = call ptr @llvm.stacksave()
+// CHECK-NEXT:   %21 = call ptr @llvm.stacksave.p0()
 // CHECK-NEXT:   %22 = alloca {}, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %22, i8 0, i64 0, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %22, i8 0, i64 0, i1 false)
 // CHECK-NEXT:   %23 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" undef, ptr %20, 0
 // CHECK-NEXT:   %24 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %23, ptr %22, 1
 // CHECK-NEXT:   %25 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %24, i32 0, 2
 // CHECK-NEXT:   %26 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %25, i1 false, 3
 // CHECK-NEXT:   %27 = alloca {}, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %27, i8 0, i64 0, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %27, i8 0, i64 0, i1 false)
 // CHECK-NEXT:   %28 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" undef, ptr %6, 0
 // CHECK-NEXT:   %29 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %28, ptr %27, 1
 // CHECK-NEXT:   %30 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %29, i32 0, 2
@@ -116,7 +116,7 @@ func main() {
 // CHECK-NEXT:   %43 = extractvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %31, 1
 // CHECK-NEXT:   %44 = icmp eq ptr %43, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %44)
-// CHECK-NEXT:   call void @llvm.stackrestore(ptr %21)
+// CHECK-NEXT:   call void @llvm.stackrestore.p0(ptr %21)
 // CHECK-NEXT:   %45 = insertvalue { i64, i1, {}, {} } undef, i64 %39, 0
 // CHECK-NEXT:   %46 = insertvalue { i64, i1, {}, {} } %45, i1 %40, 1
 // CHECK-NEXT:   %47 = insertvalue { i64, i1, {}, {} } %46, {} zeroinitializer, 2
@@ -155,29 +155,29 @@ func main() {
 // CHECK-NEXT:   %1 = load { ptr, ptr, ptr }, ptr %0, align 8
 // CHECK-NEXT:   %2 = extractvalue { ptr, ptr, ptr } %1, 0
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8
-// CHECK-NEXT:   %4 = call ptr @llvm.stacksave()
+// CHECK-NEXT:   %4 = call ptr @llvm.stacksave.p0()
 // CHECK-NEXT:   %5 = alloca {}, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %5, i8 0, i64 0, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %5, i8 0, i64 0, i1 false)
 // CHECK-NEXT:   %6 = call i1 @"{{.*}}/runtime/internal/runtime.ChanRecv"(ptr %3, ptr %5, i64 0)
 // CHECK-NEXT:   %7 = icmp eq ptr %5, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %7)
-// CHECK-NEXT:   call void @llvm.stackrestore(ptr %4)
+// CHECK-NEXT:   call void @llvm.stackrestore.p0(ptr %4)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @5, i64 4 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %8 = extractvalue { ptr, ptr, ptr } %1, 1
 // CHECK-NEXT:   %9 = load ptr, ptr %8, align 8
 // CHECK-NEXT:   %10 = extractvalue { ptr, ptr, ptr } %1, 2
 // CHECK-NEXT:   %11 = load ptr, ptr %10, align 8
-// CHECK-NEXT:   %12 = call ptr @llvm.stacksave()
+// CHECK-NEXT:   %12 = call ptr @llvm.stacksave.p0()
 // CHECK-NEXT:   %13 = alloca {}, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %13, i8 0, i64 0, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %13, i8 0, i64 0, i1 false)
 // CHECK-NEXT:   store {} zeroinitializer, ptr %13, align 1
 // CHECK-NEXT:   %14 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" undef, ptr %9, 0
 // CHECK-NEXT:   %15 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %14, ptr %13, 1
 // CHECK-NEXT:   %16 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %15, i32 0, 2
 // CHECK-NEXT:   %17 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %16, i1 true, 3
 // CHECK-NEXT:   %18 = alloca {}, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %18, i8 0, i64 0, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %18, i8 0, i64 0, i1 false)
 // CHECK-NEXT:   %19 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" undef, ptr %11, 0
 // CHECK-NEXT:   %20 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %19, ptr %18, 1
 // CHECK-NEXT:   %21 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %20, i32 0, 2
@@ -196,7 +196,7 @@ func main() {
 // CHECK-NEXT:   %32 = extractvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %22, 1
 // CHECK-NEXT:   %33 = icmp eq ptr %32, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %33)
-// CHECK-NEXT:   call void @llvm.stackrestore(ptr %12)
+// CHECK-NEXT:   call void @llvm.stackrestore.p0(ptr %12)
 // CHECK-NEXT:   %34 = insertvalue { i64, i1, {} } undef, i64 %30, 0
 // CHECK-NEXT:   %35 = insertvalue { i64, i1, {} } %34, i1 %31, 1
 // CHECK-NEXT:   %36 = insertvalue { i64, i1, {} } %35, {} zeroinitializer, 2

--- a/cl/_testgo/strucintf/in.go
+++ b/cl/_testgo/strucintf/in.go
@@ -6,7 +6,7 @@ import "github.com/goplus/llgo/cl/_testdata/foo"
 // CHECK-LABEL: define %"{{.*}}eface" @"{{.*}}strucintf.Foo"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca { i64 }, align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   %1 = getelementptr inbounds { i64 }, ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store i64 1, ptr %1, align 8
 // CHECK-NEXT:   %2 = load { i64 }, ptr %0, align 8

--- a/cl/_testgo/tptypes/in.go
+++ b/cl/_testgo/tptypes/in.go
@@ -56,7 +56,7 @@ type (
 // CHECK-LABEL: define void @"{{.*}}/cl/_testgo/tptypes.main"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca %"{{.*}}/cl/_testgo/tptypes.Data[int]", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Data[int]", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   store i64 1, ptr %1, align 8
 // CHECK-NEXT:   %2 = load %"{{.*}}/cl/_testgo/tptypes.Data[int]", ptr %0, align 8
@@ -64,7 +64,7 @@ type (
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %3)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %4 = alloca %"{{.*}}/cl/_testgo/tptypes.Data[string]", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %4, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %4, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   %5 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Data[string]", ptr %4, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %5, align 8
 // CHECK-NEXT:   %6 = load %"{{.*}}/cl/_testgo/tptypes.Data[string]", ptr %4, align 8
@@ -72,7 +72,7 @@ type (
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" %7)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %8 = alloca %"{{.*}}/cl/_testgo/tptypes.Data[int]", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %8, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %8, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Data[int]", ptr %8, i32 0, i32 0
 // CHECK-NEXT:   store i64 100, ptr %9, align 8
 // CHECK-NEXT:   %10 = load %"{{.*}}/cl/_testgo/tptypes.Data[int]", ptr %8, align 8
@@ -80,7 +80,7 @@ type (
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %11)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %12 = alloca %"{{.*}}/cl/_testgo/tptypes.Data[string]", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %12, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %12, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   %13 = getelementptr inbounds %"{{.*}}/cl/_testgo/tptypes.Data[string]", ptr %12, i32 0, i32 0
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 }, ptr %13, align 8
 // CHECK-NEXT:   %14 = load %"{{.*}}/cl/_testgo/tptypes.Data[string]", ptr %12, align 8

--- a/cl/_testpy/list/in.go
+++ b/cl/_testpy/list/in.go
@@ -52,7 +52,7 @@ func main() {
 // CHECK-NEXT:   store i64 100, ptr %0, align 8
 // CHECK-NEXT:   %1 = call %"{{.*}}/runtime/internal/runtime.Slice" @"{{.*}}/runtime/internal/runtime.StringToBytes"(%"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 5 })
 // CHECK-NEXT:   %2 = alloca [3 x i8], align 1
-// CHECK-NEXT:   call void @llvm.memset(ptr %2, i8 0, i64 3, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %2, i8 0, i64 3, i1 false)
 // CHECK-NEXT:   %3 = getelementptr inbounds i8, ptr %2, i64 0
 // CHECK-NEXT:   %4 = getelementptr inbounds i8, ptr %2, i64 1
 // CHECK-NEXT:   %5 = getelementptr inbounds i8, ptr %2, i64 2
@@ -84,7 +84,7 @@ func main() {
 // CHECK-NEXT:   %28 = call ptr @PyByteArray_FromStringAndSize(ptr %26, i64 %27)
 // CHECK-NEXT:   %29 = call i32 @PyList_SetItem(ptr %7, i64 9, ptr %28)
 // CHECK-NEXT:   %30 = alloca [3 x i8], align 1
-// CHECK-NEXT:   call void @llvm.memset(ptr %30, i8 0, i64 3, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %30, i8 0, i64 3, i1 false)
 // CHECK-NEXT:   store [3 x i8] %6, ptr %30, align 1
 // CHECK-NEXT:   %31 = getelementptr inbounds ptr, ptr %30, i64 0
 // CHECK-NEXT:   %32 = call ptr @PyBytes_FromStringAndSize(ptr %31, i64 3)

--- a/cl/_testrt/abinamed/in.go
+++ b/cl/_testrt/abinamed/in.go
@@ -38,7 +38,7 @@ import (
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %17)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %18 = alloca %"{{.*}}/runtime/abi.StructField", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %18, i8 0, i64 56, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %18, i8 0, i64 56, i1 false)
 // CHECK-NEXT:   %19 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %20 = load ptr, ptr %19, align 8
 // CHECK-NEXT:   %21 = call ptr @"{{.*}}/runtime/abi.(*Type).StructType"(ptr %20)
@@ -85,7 +85,7 @@ import (
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_2
 // CHECK-NEXT:   %46 = alloca %"{{.*}}/runtime/abi.StructField", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %46, i8 0, i64 56, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %46, i8 0, i64 56, i1 false)
 // CHECK-NEXT:   %47 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %48 = load ptr, ptr %47, align 8
 // CHECK-NEXT:   %49 = call ptr @"{{.*}}/runtime/abi.(*Type).StructType"(ptr %48)
@@ -132,7 +132,7 @@ import (
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_8:                                          ; preds = %_llgo_6
 // CHECK-NEXT:   %74 = alloca %"{{.*}}/runtime/abi.StructField", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %74, i8 0, i64 56, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %74, i8 0, i64 56, i1 false)
 // CHECK-NEXT:   %75 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %76 = load ptr, ptr %75, align 8
 // CHECK-NEXT:   %77 = call ptr @"{{.*}}/runtime/abi.(*Type).StructType"(ptr %76)
@@ -171,7 +171,7 @@ import (
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_10:                                         ; preds = %_llgo_8
 // CHECK-NEXT:   %101 = alloca %"{{.*}}/runtime/abi.StructField", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %101, i8 0, i64 56, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %101, i8 0, i64 56, i1 false)
 // CHECK-NEXT:   %102 = getelementptr inbounds %"{{.*}}/cl/_testrt/abinamed.eface", ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %103 = load ptr, ptr %102, align 8
 // CHECK-NEXT:   %104 = call ptr @"{{.*}}/runtime/abi.(*Type).StructType"(ptr %103)

--- a/cl/_testrt/index/in.go
+++ b/cl/_testrt/index/in.go
@@ -28,9 +28,9 @@ type S []int
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/index.main"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca %"{{.*}}/cl/_testrt/index.point", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   %1 = alloca [3 x %"{{.*}}/cl/_testrt/index.point"], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 48, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 48, i1 false)
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/index.point", ptr %1, i64 0
 // CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testrt/index.point", ptr %2, i32 0, i32 0
 // CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testrt/index.point", ptr %2, i32 0, i32 1
@@ -59,9 +59,9 @@ type S []int
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %17)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %18 = alloca [2 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %18, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %18, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   %19 = alloca [2 x [2 x i64]], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %19, i8 0, i64 32, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %19, i8 0, i64 32, i1 false)
 // CHECK-NEXT:   %20 = getelementptr inbounds [2 x i64], ptr %19, i64 0
 // CHECK-NEXT:   %21 = icmp eq ptr %20, null
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %21)
@@ -93,7 +93,7 @@ type S []int
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintInt"(i64 %36)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %37 = alloca [5 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %37, i8 0, i64 40, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %37, i8 0, i64 40, i1 false)
 // CHECK-NEXT:   %38 = getelementptr inbounds i64, ptr %37, i64 0
 // CHECK-NEXT:   %39 = getelementptr inbounds i64, ptr %37, i64 1
 // CHECK-NEXT:   %40 = getelementptr inbounds i64, ptr %37, i64 2

--- a/cl/_testrt/makemap/in.go
+++ b/cl/_testrt/makemap/in.go
@@ -280,7 +280,7 @@ type N1 [1]int
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %5 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_any]_llgo_int", i64 0)
 // CHECK-NEXT:   %6 = alloca [1 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %6, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %6, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   %7 = getelementptr inbounds i64, ptr %6, i64 0
 // CHECK-NEXT:   store i64 1, ptr %7, align 8
 // CHECK-NEXT:   %8 = load [1 x i64], ptr %6, align 8
@@ -292,7 +292,7 @@ type N1 [1]int
 // CHECK-NEXT:   %12 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %5, ptr %11)
 // CHECK-NEXT:   store i64 100, ptr %12, align 8
 // CHECK-NEXT:   %13 = alloca [1 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %13, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %13, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   %14 = getelementptr inbounds i64, ptr %13, i64 0
 // CHECK-NEXT:   store i64 2, ptr %14, align 8
 // CHECK-NEXT:   %15 = load [1 x i64], ptr %13, align 8
@@ -304,7 +304,7 @@ type N1 [1]int
 // CHECK-NEXT:   %19 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %5, ptr %18)
 // CHECK-NEXT:   store i64 200, ptr %19, align 8
 // CHECK-NEXT:   %20 = alloca [1 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %20, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %20, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   %21 = getelementptr inbounds i64, ptr %20, i64 0
 // CHECK-NEXT:   store i64 3, ptr %21, align 8
 // CHECK-NEXT:   %22 = load [1 x i64], ptr %20, align 8
@@ -316,7 +316,7 @@ type N1 [1]int
 // CHECK-NEXT:   %26 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %5, ptr %25)
 // CHECK-NEXT:   store i64 300, ptr %26, align 8
 // CHECK-NEXT:   %27 = alloca [1 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %27, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %27, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   %28 = getelementptr inbounds i64, ptr %27, i64 0
 // CHECK-NEXT:   store i64 2, ptr %28, align 8
 // CHECK-NEXT:   %29 = load [1 x i64], ptr %27, align 8
@@ -366,7 +366,7 @@ type N1 [1]int
 // CHECK-NEXT:   %49 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %37, 1
 // CHECK-NEXT:   %50 = load [1 x i64], ptr %49, align 8
 // CHECK-NEXT:   %51 = alloca [1 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %51, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %51, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   store [1 x i64] %50, ptr %51, align 8
 // CHECK-NEXT:   %52 = getelementptr inbounds i64, ptr %51, i64 0
 // CHECK-NEXT:   %53 = load i64, ptr %52, align 8
@@ -407,7 +407,7 @@ type K2 [1]*N
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/makemap.make3"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca [1 x %"{{.*}}/cl/_testrt/makemap.N"], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 2, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 2, i1 false)
 // CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %0, i64 0
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %1, i32 0, i32 1
@@ -418,7 +418,7 @@ type K2 [1]*N
 // CHECK-NEXT:   store [1 x %"{{.*}}/cl/_testrt/makemap.N"] %4, ptr %5, align 1
 // CHECK-NEXT:   %6 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.K", ptr undef }, ptr %5, 1
 // CHECK-NEXT:   %7 = alloca [1 x %"{{.*}}/cl/_testrt/makemap.N"], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %7, i8 0, i64 2, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %7, i8 0, i64 2, i1 false)
 // CHECK-NEXT:   %8 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %7, i64 0
 // CHECK-NEXT:   %9 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %8, i32 0, i32 0
 // CHECK-NEXT:   %10 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %8, i32 0, i32 1
@@ -433,7 +433,7 @@ type K2 [1]*N
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %15 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_any]_llgo_int", i64 0)
 // CHECK-NEXT:   %16 = alloca [1 x %"{{.*}}/cl/_testrt/makemap.N"], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %16, i8 0, i64 2, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %16, i8 0, i64 2, i1 false)
 // CHECK-NEXT:   %17 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %16, i64 0
 // CHECK-NEXT:   %18 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %17, i32 0, i32 0
 // CHECK-NEXT:   %19 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %17, i32 0, i32 1
@@ -448,7 +448,7 @@ type K2 [1]*N
 // CHECK-NEXT:   %24 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %15, ptr %23)
 // CHECK-NEXT:   store i64 100, ptr %24, align 8
 // CHECK-NEXT:   %25 = alloca [1 x %"{{.*}}/cl/_testrt/makemap.N"], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %25, i8 0, i64 2, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %25, i8 0, i64 2, i1 false)
 // CHECK-NEXT:   %26 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %25, i64 0
 // CHECK-NEXT:   %27 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %26, i32 0, i32 0
 // CHECK-NEXT:   %28 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %26, i32 0, i32 1
@@ -501,7 +501,7 @@ type K2 [1]*N
 // CHECK-NEXT:   %49 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %37, 1
 // CHECK-NEXT:   %50 = load [1 x %"{{.*}}/cl/_testrt/makemap.N"], ptr %49, align 1
 // CHECK-NEXT:   %51 = alloca [1 x %"{{.*}}/cl/_testrt/makemap.N"], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %51, i8 0, i64 2, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %51, i8 0, i64 2, i1 false)
 // CHECK-NEXT:   store [1 x %"{{.*}}/cl/_testrt/makemap.N"] %50, ptr %51, align 1
 // CHECK-NEXT:   %52 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %51, i64 0
 // CHECK-NEXT:   %53 = load %"{{.*}}/cl/_testrt/makemap.N", ptr %52, align 1
@@ -534,7 +534,7 @@ func make3() {
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/makemap.make4"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca [1 x ptr], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   %1 = getelementptr inbounds ptr, ptr %0, i64 0
 // CHECK-NEXT:   %2 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 2)
 // CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %2, i32 0, i32 0
@@ -546,7 +546,7 @@ func make3() {
 // CHECK-NEXT:   %6 = extractvalue [1 x ptr] %5, 0
 // CHECK-NEXT:   %7 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/makemap.K2", ptr undef }, ptr %6, 1
 // CHECK-NEXT:   %8 = alloca [1 x ptr], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %8, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %8, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   %9 = getelementptr inbounds ptr, ptr %8, i64 0
 // CHECK-NEXT:   %10 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 2)
 // CHECK-NEXT:   %11 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %10, i32 0, i32 0
@@ -562,7 +562,7 @@ func make3() {
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %17 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_any]_llgo_int", i64 0)
 // CHECK-NEXT:   %18 = alloca [1 x ptr], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %18, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %18, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   %19 = getelementptr inbounds ptr, ptr %18, i64 0
 // CHECK-NEXT:   %20 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 2)
 // CHECK-NEXT:   %21 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %20, i32 0, i32 0
@@ -578,7 +578,7 @@ func make3() {
 // CHECK-NEXT:   %27 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_any]_llgo_int", ptr %17, ptr %26)
 // CHECK-NEXT:   store i64 100, ptr %27, align 8
 // CHECK-NEXT:   %28 = alloca [1 x ptr], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %28, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %28, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   %29 = getelementptr inbounds ptr, ptr %28, i64 0
 // CHECK-NEXT:   %30 = call ptr @"{{.*}}/runtime/internal/runtime.AllocZ"(i64 2)
 // CHECK-NEXT:   %31 = getelementptr inbounds %"{{.*}}/cl/_testrt/makemap.N", ptr %30, i32 0, i32 0
@@ -632,7 +632,7 @@ func make3() {
 // CHECK-NEXT:   %53 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %41, 1
 // CHECK-NEXT:   %54 = insertvalue [1 x ptr] undef, ptr %53, 0
 // CHECK-NEXT:   %55 = alloca [1 x ptr], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %55, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %55, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   store [1 x ptr] %54, ptr %55, align 8
 // CHECK-NEXT:   %56 = getelementptr inbounds ptr, ptr %55, i64 0
 // CHECK-NEXT:   %57 = load ptr, ptr %56, align 8

--- a/cl/_testrt/slice2array/in.go
+++ b/cl/_testrt/slice2array/in.go
@@ -62,7 +62,7 @@ package main
 // CHECK-NEXT:   %36 = extractvalue %"{{.*}}/runtime/internal/runtime.Slice" %32, 0
 // CHECK-NEXT:   %37 = load [2 x i8], ptr %36, align 1
 // CHECK-NEXT:   %38 = alloca [2 x i8], align 1
-// CHECK-NEXT:   call void @llvm.memset(ptr %38, i8 0, i64 2, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %38, i8 0, i64 2, i1 false)
 // CHECK-NEXT:   %39 = getelementptr inbounds i8, ptr %38, i64 0
 // CHECK-NEXT:   %40 = getelementptr inbounds i8, ptr %38, i64 1
 // CHECK-NEXT:   store i8 1, ptr %39, align 1

--- a/cl/_testrt/stacksave/in.go
+++ b/cl/_testrt/stacksave/in.go
@@ -11,7 +11,7 @@ func getsp() unsafe.Pointer
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/stacksave.main"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
-// CHECK-NEXT:   %0 = call ptr @llvm.stacksave()
+// CHECK-NEXT:   %0 = call ptr @llvm.stacksave.p0()
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintPointer"(ptr %0)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   ret void

--- a/cl/_testrt/struct/in.go
+++ b/cl/_testrt/struct/in.go
@@ -10,7 +10,7 @@ import _ "unsafe"
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/struct.Foo.Print"(%"{{.*}}/cl/_testrt/struct.Foo" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testrt/struct.Foo", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   store %"{{.*}}/cl/_testrt/struct.Foo" %0, ptr %1, align 4
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/struct.Foo", ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %3 = load i1, ptr %2, align 1
@@ -88,7 +88,7 @@ func main() {
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/struct.main"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca %"{{.*}}/cl/_testrt/struct.Foo", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testrt/struct.Foo", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/struct.Foo", ptr %0, i32 0, i32 1
 // CHECK-NEXT:   store i32 100, ptr %1, align 4

--- a/cl/_testrt/tpabi/in.go
+++ b/cl/_testrt/tpabi/in.go
@@ -48,7 +48,7 @@ func (t *K[N]) Advance(n int) *K[N] {
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/tpabi.main"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = alloca %"{{.*}}/cl/_testrt/tpabi.T[string,int]", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %0, i8 0, i64 24, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %0, i8 0, i64 24, i1 false)
 // CHECK-NEXT:   %1 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpabi.T[string,int]", ptr %0, i32 0, i32 0
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpabi.T[string,int]", ptr %0, i32 0, i32 1
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 1 }, ptr %1, align 8
@@ -120,7 +120,7 @@ func main() {
 // CHECK-LABEL: define linkonce void @"{{.*}}/cl/_testrt/tpabi.T[string,int].Info"(%"{{.*}}/cl/_testrt/tpabi.T[string,int]" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testrt/tpabi.T[string,int]", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 24, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 24, i1 false)
 // CHECK-NEXT:   store %"{{.*}}/cl/_testrt/tpabi.T[string,int]" %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpabi.T[string,int]", ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.String", ptr %2, align 8

--- a/cl/_testrt/tpmap/in.go
+++ b/cl/_testrt/tpmap/in.go
@@ -23,7 +23,7 @@ type cacheKey struct {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = call ptr @"{{.*}}/runtime/internal/runtime.MakeMap"(ptr @"map[_llgo_github.com/goplus/llgo/cl/_testrt/tpmap.cacheKey]_llgo_string", i64 0)
 // CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testrt/tpmap.cacheKey", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 48, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 48, i1 false)
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmap.cacheKey", ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmap.cacheKey", ptr %1, i32 0, i32 1
 // CHECK-NEXT:   %4 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmap.T2", ptr %3, i32 0, i32 0
@@ -45,7 +45,7 @@ type cacheKey struct {
 // CHECK-NEXT:   %13 = call ptr @"{{.*}}/runtime/internal/runtime.MapAssign"(ptr @"map[_llgo_github.com/goplus/llgo/cl/_testrt/tpmap.cacheKey]_llgo_string", ptr %0, ptr %12)
 // CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @29, i64 5 }, ptr %13, align 8
 // CHECK-NEXT:   %14 = alloca %"{{.*}}/cl/_testrt/tpmap.cacheKey", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %14, i8 0, i64 48, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %14, i8 0, i64 48, i1 false)
 // CHECK-NEXT:   %15 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmap.cacheKey", ptr %14, i32 0, i32 0
 // CHECK-NEXT:   %16 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmap.cacheKey", ptr %14, i32 0, i32 1
 // CHECK-NEXT:   %17 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmap.T2", ptr %16, i32 0, i32 0

--- a/cl/_testrt/tpmethod/in.go
+++ b/cl/_testrt/tpmethod/in.go
@@ -39,7 +39,7 @@ func ReadFile(fileName string) Future[Tuple[error]] {
 	// CHECK-LABEL: define void @"{{.*}}/cl/_testrt/tpmethod.ReadFile$1"({ ptr, ptr } %0){{.*}} {
 	// CHECK-NEXT: _llgo_0:
 	// CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testrt/tpmethod.Tuple[error]", align 8
-	// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+	// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 	// CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmethod.Tuple[error]", ptr %1, i32 0, i32 0
 	// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.iface" zeroinitializer, ptr %2, align 8
 	// CHECK-NEXT:   %3 = load %"{{.*}}/cl/_testrt/tpmethod.Tuple[error]", ptr %1, align 8
@@ -122,7 +122,7 @@ func main() {
 // CHECK-LABEL: define linkonce %"{{.*}}/runtime/internal/runtime.iface" @"{{.*}}/cl/_testrt/tpmethod.Tuple[error].Get"(%"{{.*}}/cl/_testrt/tpmethod.Tuple[error]" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testrt/tpmethod.Tuple[error]", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   store %"{{.*}}/cl/_testrt/tpmethod.Tuple[error]" %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/tpmethod.Tuple[error]", ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load %"{{.*}}/runtime/internal/runtime.iface", ptr %2, align 8

--- a/cl/_testrt/typed/in.go
+++ b/cl/_testrt/typed/in.go
@@ -61,7 +61,7 @@ type A [2]int
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintBool"(i1 %14)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
 // CHECK-NEXT:   %15 = alloca [2 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %15, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %15, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   %16 = getelementptr inbounds i64, ptr %15, i64 0
 // CHECK-NEXT:   %17 = getelementptr inbounds i64, ptr %15, i64 1
 // CHECK-NEXT:   store i64 1, ptr %16, align 8
@@ -71,7 +71,7 @@ type A [2]int
 // CHECK-NEXT:   store [2 x i64] %18, ptr %19, align 8
 // CHECK-NEXT:   %20 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @"_llgo_{{.*}}/cl/_testrt/typed.A", ptr undef }, ptr %19, 1
 // CHECK-NEXT:   %21 = alloca [2 x i64], align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %21, i8 0, i64 16, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %21, i8 0, i64 16, i1 false)
 // CHECK-NEXT:   %22 = extractvalue %"{{.*}}/runtime/internal/runtime.eface" %20, 0
 // CHECK-NEXT:   %23 = icmp eq ptr %22, @"_llgo_{{.*}}/cl/_testrt/typed.A"
 // CHECK-NEXT:   br i1 %23, label %_llgo_6, label %_llgo_7

--- a/cl/_testrt/vamethod/in.go
+++ b/cl/_testrt/vamethod/in.go
@@ -10,7 +10,7 @@ import (
 // CHECK-LABEL: define i32 @"{{.*}}/cl/_testrt/vamethod.CFmt.Printf"(%"{{.*}}/cl/_testrt/vamethod.CFmt" %0, ...){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = alloca %"{{.*}}/cl/_testrt/vamethod.CFmt", align 8
-// CHECK-NEXT:   call void @llvm.memset(ptr %1, i8 0, i64 8, i1 false)
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %1, i8 0, i64 8, i1 false)
 // CHECK-NEXT:   store %"{{.*}}/cl/_testrt/vamethod.CFmt" %0, ptr %1, align 8
 // CHECK-NEXT:   %2 = getelementptr inbounds %"{{.*}}/cl/_testrt/vamethod.CFmt", ptr %1, i32 0, i32 0
 // CHECK-NEXT:   %3 = load ptr, ptr %2, align 8

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -436,22 +436,6 @@ func (p *context) syscallFnSigFixed(paramTypes []types.Type) *types.Signature {
 	return types.NewSignatureType(nil, nil, nil, types.NewTuple(params...), types.NewTuple(ret), false)
 }
 
-func (p *context) syscallArg(b llssa.Builder, arg ssa.Value, uptr llssa.Type) (llssa.Expr, types.Type) {
-	expr := p.compileValue(b, arg)
-	if basic, ok := types.Unalias(arg.Type()).Underlying().(*types.Basic); ok {
-		switch basic.Kind() {
-		case types.Float32:
-			return expr, types.Typ[types.Float32]
-		case types.Float64:
-			return expr, types.Typ[types.Float64]
-		}
-		if basic.Info()&types.IsInteger != 0 && p.prog.SizeOf(expr.Type) == p.prog.SizeOf(uptr) {
-			return b.ChangeType(uptr, expr), types.Typ[types.Uintptr]
-		}
-	}
-	return b.Convert(uptr, expr), types.Typ[types.Uintptr]
-}
-
 var errnoSig = types.NewSignatureType(nil, nil, nil, nil,
 	types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Typ[types.Int32])), false)
 
@@ -471,26 +455,26 @@ func (p *context) syscallErrno(b llssa.Builder, r1 llssa.Expr) llssa.Expr {
 
 // syscallIntrinsic implements the llgo.syscall intrinsic for libc-based syscalls.
 // The first argument is treated as a function pointer, called with the remaining
-// arguments (integer and pointer arguments as uintptr, float arguments as their
-// original ABI types), and it returns a (r1, r2, errno) tuple. r2 is always 0
-// and errno is set iff r1 == -1.
+// arguments, and it returns a (r1, r2, errno) tuple. r2 is always 0 and errno is
+// set iff r1 == -1.
 func (p *context) syscallIntrinsic(b llssa.Builder, args []ssa.Value, results *types.Tuple) llssa.Expr {
 	if len(args) < 1 {
 		panic("syscall: missing arguments")
 	}
 	callArgs := make([]llssa.Expr, 0, len(args)-1)
-	callArgTypes := make([]types.Type, 0, len(args)-1)
-	uptr := p.type_(types.Typ[types.Uintptr], llssa.InGo)
 	for _, arg := range args[1:] {
-		expr, typ := p.syscallArg(b, arg, uptr)
-		callArgs = append(callArgs, expr)
-		callArgTypes = append(callArgTypes, typ)
+		callArgs = append(callArgs, p.compileValue(b, arg))
+	}
+	callArgTypes := make([]types.Type, 0, len(callArgs))
+	for _, arg := range callArgs {
+		callArgTypes = append(callArgTypes, arg.RawType())
 	}
 	fnSig := p.syscallFnSigFixed(callArgTypes)
 	fnArg := p.compileValue(b, args[0])
 	fnType := p.type_(fnSig, llssa.InC)
 	fnPtr := b.PtrCast(fnType, b.Convert(p.type_(types.Typ[types.UnsafePointer], llssa.InGo), fnArg))
 	r1 := b.Call(fnPtr, callArgs...)
+	uptr := p.type_(types.Typ[types.Uintptr], llssa.InGo)
 	r2 := p.prog.Zero(uptr)
 	err := p.syscallErrno(b, r1)
 	tuple := p.type_(results, llssa.InGo)

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -425,15 +425,31 @@ func (p *context) syscallFnSig(argc int) *types.Signature {
 	return types.NewSignatureType(nil, nil, nil, types.NewTuple(params...), types.NewTuple(ret), true)
 }
 
-// syscallFnSigFixed returns a non-variadic C signature with argc uintptr
-// parameters and returning a uintptr.
-func (p *context) syscallFnSigFixed(argc int) *types.Signature {
-	params := make([]*types.Var, 0, argc)
-	for i := 0; i < argc; i++ {
-		params = append(params, types.NewParam(token.NoPos, nil, "", types.Typ[types.Uintptr]))
+// syscallFnSigFixed returns a non-variadic C signature with the given parameter
+// types and returning a uintptr.
+func (p *context) syscallFnSigFixed(paramTypes []types.Type) *types.Signature {
+	params := make([]*types.Var, 0, len(paramTypes))
+	for _, typ := range paramTypes {
+		params = append(params, types.NewParam(token.NoPos, nil, "", typ))
 	}
 	ret := types.NewVar(token.NoPos, nil, "", types.Typ[types.Uintptr])
 	return types.NewSignatureType(nil, nil, nil, types.NewTuple(params...), types.NewTuple(ret), false)
+}
+
+func (p *context) syscallArg(b llssa.Builder, arg ssa.Value, uptr llssa.Type) (llssa.Expr, types.Type) {
+	expr := p.compileValue(b, arg)
+	if basic, ok := types.Unalias(arg.Type()).Underlying().(*types.Basic); ok {
+		switch basic.Kind() {
+		case types.Float32:
+			return expr, types.Typ[types.Float32]
+		case types.Float64:
+			return expr, types.Typ[types.Float64]
+		}
+		if basic.Info()&types.IsInteger != 0 && p.prog.SizeOf(expr.Type) == p.prog.SizeOf(uptr) {
+			return b.ChangeType(uptr, expr), types.Typ[types.Uintptr]
+		}
+	}
+	return b.Convert(uptr, expr), types.Typ[types.Uintptr]
 }
 
 var errnoSig = types.NewSignatureType(nil, nil, nil, nil,
@@ -455,22 +471,26 @@ func (p *context) syscallErrno(b llssa.Builder, r1 llssa.Expr) llssa.Expr {
 
 // syscallIntrinsic implements the llgo.syscall intrinsic for libc-based syscalls.
 // The first argument is treated as a function pointer, called with the remaining
-// arguments (as uintptr), and it returns a (r1, r2, errno) tuple. r2 is always 0
+// arguments (integer and pointer arguments as uintptr, float arguments as their
+// original ABI types), and it returns a (r1, r2, errno) tuple. r2 is always 0
 // and errno is set iff r1 == -1.
 func (p *context) syscallIntrinsic(b llssa.Builder, args []ssa.Value, results *types.Tuple) llssa.Expr {
 	if len(args) < 1 {
 		panic("syscall: missing arguments")
 	}
 	callArgs := make([]llssa.Expr, 0, len(args)-1)
+	callArgTypes := make([]types.Type, 0, len(args)-1)
+	uptr := p.type_(types.Typ[types.Uintptr], llssa.InGo)
 	for _, arg := range args[1:] {
-		callArgs = append(callArgs, p.compileValue(b, arg))
+		expr, typ := p.syscallArg(b, arg, uptr)
+		callArgs = append(callArgs, expr)
+		callArgTypes = append(callArgTypes, typ)
 	}
-	fnSig := p.syscallFnSigFixed(len(callArgs))
+	fnSig := p.syscallFnSigFixed(callArgTypes)
 	fnArg := p.compileValue(b, args[0])
 	fnType := p.type_(fnSig, llssa.InC)
 	fnPtr := b.PtrCast(fnType, b.Convert(p.type_(types.Typ[types.UnsafePointer], llssa.InGo), fnArg))
 	r1 := b.Call(fnPtr, callArgs...)
-	uptr := p.type_(types.Typ[types.Uintptr], llssa.InGo)
 	r2 := p.prog.Zero(uptr)
 	err := p.syscallErrno(b, r1)
 	tuple := p.type_(results, llssa.InGo)

--- a/cl/instr_offsetof_test.go
+++ b/cl/instr_offsetof_test.go
@@ -369,9 +369,12 @@ func TestInstrHelperEdges(t *testing.T) {
 		t.Fatal("syscallFnSig should be variadic")
 	}
 
-	sig := ctx.syscallFnSigFixed(2)
+	sig := ctx.syscallFnSigFixed([]types.Type{types.Typ[types.Uintptr], types.Typ[types.Float64]})
 	if got := sig.Params().Len(); got != 2 {
 		t.Fatalf("syscallFnSigFixed params = %d, want 2", got)
+	}
+	if got := sig.Params().At(1).Type(); got != types.Typ[types.Float64] {
+		t.Fatalf("syscallFnSigFixed param 1 = %v, want float64", got)
 	}
 	if got := sig.Results().Len(); got != 1 {
 		t.Fatalf("syscallFnSigFixed results = %d, want 1", got)

--- a/go.mod
+++ b/go.mod
@@ -29,3 +29,5 @@ require (
 )
 
 replace github.com/goplus/llgo/runtime => ./runtime
+
+replace github.com/xgo-dev/llvm => github.com/zhouguangyuan0718/go-llvm v0.0.0-20260627053858-b1a749c0c32f

--- a/go.sum
+++ b/go.sum
@@ -26,10 +26,10 @@ github.com/sigurn/crc16 v0.0.0-20240131213347-83fcde1e29d1 h1:NVK+OqnavpyFmUiKfU
 github.com/sigurn/crc16 v0.0.0-20240131213347-83fcde1e29d1/go.mod h1:9/etS5gpQq9BJsJMWg1wpLbfuSnkm8dPF6FdW2JXVhA=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/xgo-dev/llvm v0.9.2 h1:yLpbwTiVXD49+9pELJF6PFZlloYzyuBXxurjCoQGmf4=
-github.com/xgo-dev/llvm v0.9.2/go.mod h1:42vav2/cI5BAIcL543DZSMO9do8/aCK2z7JERH+AE+M=
 github.com/xgo-dev/plan9asm v0.3.0 h1:8JcpsNa7/B6YUNJPbIezOhpoURvH8VNDbBh8eQwHnnc=
 github.com/xgo-dev/plan9asm v0.3.0/go.mod h1:0yM4CCIp2PyT8h+Ro3Ukro3lHL8ji9mzHEv5yfhOckc=
+github.com/zhouguangyuan0718/go-llvm v0.0.0-20260627053858-b1a749c0c32f h1:DhwlwVGFNlqRCsaycIetxuYTl1HgBf8L245AEV93KjU=
+github.com/zhouguangyuan0718/go-llvm v0.0.0-20260627053858-b1a749c0c32f/go.mod h1:42vav2/cI5BAIcL543DZSMO9do8/aCK2z7JERH+AE+M=
 go.bug.st/serial v1.6.4 h1:7FmqNPgVp3pu2Jz5PoPtbZ9jJO5gnEnZIvnI1lzve8A=
 go.bug.st/serial v1.6.4/go.mod h1:nofMJxTeNVny/m6+KaafC6vJGj3miwQZ6vW4BZUGJPI=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1317,6 +1317,9 @@ func buildPkg(ctx *context, aPkg *aPackage, verbose bool) error {
 		mod.SetTarget(ctx.prog.Target().Spec().Triple)
 		pbo := gllvm.NewPassBuilderOptions()
 		defer pbo.Dispose()
+		if err = gllvm.VerifyModule(mod, gllvm.ReturnStatusAction); err != nil {
+			return err
+		}
 		if err := mod.RunPasses(llvmPassPipeline(ctx.buildConf.OptLevel, ctx.buildConf.ltoMode()), ctx.prog.TargetMachine(), pbo); err != nil {
 			return fmt.Errorf("run LLVM passes failed for %v: %v", pkgPath, err)
 		}

--- a/internal/cabi/cabi.go
+++ b/internal/cabi/cabi.go
@@ -732,29 +732,11 @@ func (p *Transformer) transformCallbackFunc(m llvm.Module, fn llvm.Value) (wrap 
 	return wrapFunc, true
 }
 
-func (p *Transformer) callMemcpy(m llvm.Module, ctx llvm.Context, b llvm.Builder, dst llvm.Value, src llvm.Value, size int) llvm.Value {
-	memcpy := p.getMemcpy(m, ctx)
+func (p *Transformer) callMemcpy(_ llvm.Module, ctx llvm.Context, b llvm.Builder, dst llvm.Value, src llvm.Value, size int) llvm.Value {
 	sz := llvm.ConstInt(ctx.IntType(p.prog.PointerSize()*8), uint64(size), false)
-	return b.CreateCall(memcpy.GlobalValueType(), memcpy, []llvm.Value{
+	return b.CreateIntrinsic(ctx.VoidType(), llvm.LookupIntrinsicID("llvm.memcpy"), []llvm.Value{
 		dst, src, sz, llvm.ConstInt(ctx.Int1Type(), 0, false),
 	}, "")
-}
-
-func (p *Transformer) getMemcpy(m llvm.Module, ctx llvm.Context) llvm.Value {
-	memcpy := m.NamedFunction("llvm.memcpy")
-	if !memcpy.IsNil() {
-		return memcpy
-	}
-	ftyp := llvm.FunctionType(ctx.VoidType(), []llvm.Type{
-		llvm.PointerType(ctx.Int8Type(), 0),
-		llvm.PointerType(ctx.Int8Type(), 0),
-		ctx.IntType(p.prog.PointerSize() * 8),
-		ctx.Int1Type(),
-	}, false)
-	memcpy = llvm.AddFunction(m, "llvm.memcpy", ftyp)
-	memcpy.SetFunctionCallConv(llvm.CCallConv)
-	memcpy.AddFunctionAttr(funcNoUnwind(ctx))
-	return memcpy
 }
 
 func replaceAllocaInstrs(param llvm.Value, nv llvm.Value) {

--- a/ssa/datastruct.go
+++ b/ssa/datastruct.go
@@ -675,6 +675,7 @@ func (b Builder) MakeChan(t Type, size Expr) (ret Expr) {
 	dbgInstrf("MakeChan %v, %v\n", t.RawType(), size.impl)
 	prog := b.Prog
 	eltSize := prog.IntVal(prog.SizeOf(prog.Elem(t)), prog.Int())
+	size = b.FitIntSize(size)
 	ret.Type = t
 	ret.impl = b.InlineCall(b.Pkg.rtFunc("NewChan"), eltSize, size).impl
 	return

--- a/ssa/eh.go
+++ b/ssa/eh.go
@@ -79,14 +79,15 @@ func (b Builder) AllocaSigjmpBuf() Expr {
 
 // declare ptr @llvm.stacksave.p0()
 func (b Builder) StackSave() Expr {
-	fn := b.Pkg.cFunc("llvm.stacksave", b.Prog.tyStacksave())
-	return b.InlineCall(fn)
+	return Expr{
+		b.impl.CreateIntrinsic(b.Prog.VoidPtr().ll, llvm.LookupIntrinsicID("llvm.stacksave"), nil, ""),
+		b.Prog.VoidPtr(),
+	}
 }
 
 // declare void @llvm.stackrestore.p0(ptr)
 func (b Builder) StackRestore(sp Expr) {
-	fn := b.Pkg.cFunc("llvm.stackrestore", b.Prog.tyStackrestore())
-	b.InlineCall(fn, sp)
+	b.impl.CreateIntrinsic(b.Prog.Void().ll, llvm.LookupIntrinsicID("llvm.stackrestore"), []llvm.Value{sp.impl}, "")
 }
 
 // addReturnsTwiceAttr adds the returns_twice attribute to a function.

--- a/ssa/globaldce.go
+++ b/ssa/globaldce.go
@@ -107,26 +107,6 @@ func methodCapabilityKey(method *types.Func) string {
 	return "go.method." + method.Name() + ":" + methodCapabilitySig(method.Type().(*types.Signature))
 }
 
-func (p Program) llvmTypeCheckedLoad(mod llvm.Module) llvm.Value {
-	fn := mod.NamedFunction("llvm.type.checked.load")
-	if !fn.IsNil() {
-		return fn
-	}
-	mdTy := p.ctx.MetadataType()
-	retTy := p.ctx.StructType([]llvm.Type{p.tyVoidPtr(), p.tyInt1()}, false)
-	fnTy := llvm.FunctionType(retTy, []llvm.Type{p.tyVoidPtr(), p.Int32().ll, mdTy}, false)
-	return llvm.AddFunction(mod, "llvm.type.checked.load", fnTy)
-}
-
-func (p Program) llvmAssume(mod llvm.Module) llvm.Value {
-	fn := mod.NamedFunction("llvm.assume")
-	if !fn.IsNil() {
-		return fn
-	}
-	fnTy := llvm.FunctionType(p.tyVoid(), []llvm.Type{p.tyInt1()}, false)
-	return llvm.AddFunction(mod, "llvm.assume", fnTy)
-}
-
 func (p Program) addModuleFlag(mod llvm.Module, behavior uint64, name string, val uint64) {
 	mod.AddNamedMetadataOperand("llvm.module.flags",
 		p.ctx.MDNode([]llvm.Metadata{
@@ -158,15 +138,16 @@ func (p Program) setVCallVisibilityMetadata(global llvm.Value, vis uint64) {
 	global.AddMetadata(kind, node)
 }
 
-func (p Program) methodCheckedLoad(b llvm.Builder, mod llvm.Module, typedesc llvm.Value, typeID string) llvm.Value {
+func (p Program) methodCheckedLoad(b llvm.Builder, typedesc llvm.Value, typeID string) llvm.Value {
 	mdVal := p.ctx.MetadataAsValue(p.ctx.MDString(typeID))
-	res := llvm.CreateCall(b, p.llvmTypeCheckedLoad(mod).GlobalValueType(), p.llvmTypeCheckedLoad(mod), []llvm.Value{
+	retTy := p.ctx.StructType([]llvm.Type{p.tyVoidPtr(), p.tyInt1()}, false)
+	res := b.CreateIntrinsic(retTy, llvm.LookupIntrinsicID("llvm.type.checked.load"), []llvm.Value{
 		typedesc,
 		llvm.ConstInt(p.Int32().ll, 0, false),
 		mdVal,
-	})
+	}, "")
 	ok := llvm.CreateExtractValue(b, res, 1)
-	llvm.CreateCall(b, p.llvmAssume(mod).GlobalValueType(), p.llvmAssume(mod), []llvm.Value{ok})
+	b.CreateIntrinsic(p.tyVoid(), llvm.LookupIntrinsicID("llvm.assume"), []llvm.Value{ok}, "")
 	return llvm.CreateExtractValue(b, res, 0)
 }
 
@@ -174,9 +155,8 @@ func (b Builder) EmitReflectMethodCheckedLoad(ret Expr, reflectKind int) {
 	if !b.Prog.enableGoGlobalDCE || ret.IsNil() || reflectKind&ReflectMethodMask == 0 {
 		return
 	}
-	mod := b.Pkg.Module()
 	checkedLoadValue := func(v Expr, typeID string) {
-		b.Prog.methodCheckedLoad(b.impl, mod, b.Extract(v, reflectValuePtrFieldIndex).impl, typeID)
+		b.Prog.methodCheckedLoad(b.impl, b.Extract(v, reflectValuePtrFieldIndex).impl, typeID)
 	}
 	if reflectKind&reflectTypeMethodMask == 0 {
 		checkedLoadValue(ret, reflectValueMethodTypeID)

--- a/ssa/goroutine.go
+++ b/ssa/goroutine.go
@@ -102,7 +102,10 @@ func (p Package) routine(t Type, fn Expr, buildCall func(Builder, Expr, ...Expr)
 		args[i] = b.getField(data, i+offset)
 	}
 	buildCall(b, fn, args...)
-	b.Return(prog.Nil(prog.VoidPtr()))
+	lastInst := b.impl.GetInsertBlock().LastInstruction()
+	if lastInst.IsNil() || lastInst.IsAUnreachableInst().IsNil() {
+		b.Return(prog.Nil(prog.VoidPtr()))
+	}
 	return routine.Expr
 }
 

--- a/ssa/goroutine_patch_test.go
+++ b/ssa/goroutine_patch_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/goplus/llgo/ssa"
 	"github.com/goplus/llgo/ssa/ssatest"
+	"github.com/xgo-dev/llvm"
 )
 
 func TestGoClosureStartupUsesGCManagedMemory(t *testing.T) {
@@ -45,5 +46,27 @@ func TestGoClosureStartupUsesGCManagedMemory(t *testing.T) {
 	// visible to the runtime GC until the new goroutine consumes them.
 	if got := strings.Count(ir, `"github.com/goplus/llgo/runtime/internal/runtime.AllocU"`); got < 2 {
 		t.Fatalf("expected closure ctx and goroutine startup data to use AllocU, got %d:\n%s", got, ir)
+	}
+}
+
+func TestGoPanicRoutineDoesNotReturnAfterUnreachable(t *testing.T) {
+	prog := ssatest.NewProgram(t, nil)
+	pkg := prog.NewPackage("bar", "foo/bar")
+
+	outer := pkg.NewFunc("outer", ssa.NoArgsNoRet, ssa.InGo)
+	ob := outer.MakeBody(1)
+	ob.Go(ssa.Nil, func(b ssa.Builder, _ ssa.Expr, args ...ssa.Expr) ssa.Expr {
+		b.Panic(args[0])
+		return ssa.Expr{}
+	}, prog.Zero(prog.Any()))
+	ob.Return()
+
+	if err := llvm.VerifyModule(pkg.Module(), llvm.ReturnStatusAction); err != nil {
+		t.Fatal(err)
+	}
+
+	ir := pkg.String()
+	if strings.Contains(ir, "unreachable\n  ret ptr null") {
+		t.Fatalf("goroutine wrapper should not return after unreachable:\n%s", ir)
 	}
 }

--- a/ssa/interface.go
+++ b/ssa/interface.go
@@ -88,7 +88,7 @@ func (b Builder) Imethod(intf Expr, method *types.Func) Expr {
 	if prog.enableGoGlobalDCE {
 		fnType := prog.Elem(pfn.Type)
 		fn = Expr{
-			prog.methodCheckedLoad(b.impl, b.Pkg.Module(), pfn.impl, methodCapabilityKey(method)),
+			prog.methodCheckedLoad(b.impl, pfn.impl, methodCapabilityKey(method)),
 			fnType,
 		}
 	} else {

--- a/ssa/memory.go
+++ b/ssa/memory.go
@@ -259,8 +259,9 @@ func (b Builder) free(ptr Expr) Expr {
 // declare void @llvm.memset.inline.p0.p0i8.i32(ptr <dest>, i8 <val>, i32 <len>, i1 <isvolatile>)
 // declare void @llvm.memset.inline.p0.p0.i64(ptr <dest>, i8 <val>, i64 <len>, i1 <isvolatile>)
 func (b Builder) memset(ptr, val, len, isvolatile Expr) Expr {
-	fn := b.Pkg.cFunc("llvm.memset", b.Prog.tyMemsetInline())
-	b.Call(fn, ptr, val, len, isvolatile)
+	b.impl.CreateIntrinsic(b.Prog.Void().ll, llvm.LookupIntrinsicID("llvm.memset"), []llvm.Value{
+		ptr.impl, val.impl, len.impl, isvolatile.impl,
+	}, "")
 	return ptr
 }
 

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -426,42 +426,6 @@ func TestDevLTOGlobalDCEFakeUseValueInlineAsm(t *testing.T) {
 	}
 }
 
-func TestDevLTOGlobalDCEIntrinsicHelpersReuseDeclarations(t *testing.T) {
-	requireGoGlobalDCE(t)
-
-	prog := NewProgram(nil)
-	pkg := prog.NewPackage("main", "main")
-	mod := pkg.Module()
-
-	helpers := []struct {
-		name string
-		get  func() llvm.Value
-	}{
-		{"llvm.type.checked.load", func() llvm.Value { return prog.llvmTypeCheckedLoad(mod) }},
-		{"llvm.assume", func() llvm.Value { return prog.llvmAssume(mod) }},
-	}
-	for _, helper := range helpers {
-		first := helper.get()
-		second := helper.get()
-		if first.IsNil() || second.IsNil() {
-			t.Fatalf("%s helper returned nil declaration", helper.name)
-		}
-		if first != second {
-			t.Fatalf("%s helper did not reuse the existing declaration", helper.name)
-		}
-		if first.Name() != helper.name {
-			t.Fatalf("helper declaration name = %q, want %q", first.Name(), helper.name)
-		}
-	}
-
-	ir := pkg.String()
-	for _, want := range []string{"@llvm.type.checked.load", "@llvm.assume"} {
-		if strings.Count(ir, want) != 1 {
-			t.Fatalf("expected exactly one %s declaration:\n%s", want, ir)
-		}
-	}
-}
-
 func TestDevLTOGlobalDCEMethodCheckedLoadEmitsIntrinsicAndAssume(t *testing.T) {
 	requireGoGlobalDCE(t)
 
@@ -471,15 +435,21 @@ func TestDevLTOGlobalDCEMethodCheckedLoadEmitsIntrinsicAndAssume(t *testing.T) {
 	sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
 	fn := pkg.NewFunc("Use", sig, InGo)
 	b := fn.MakeBody(1)
-	loaded := prog.methodCheckedLoad(b.impl, pkg.Module(), g.impl, "go.method.M:func()")
+	loaded := prog.methodCheckedLoad(b.impl, g.impl, "go.method.M:func()")
+	prog.methodCheckedLoad(b.impl, g.impl, "go.method.N:func()")
 	prog.fakeUseValueInlineAsm(b.impl, loaded)
 	b.Return()
+
+	if err := llvm.VerifyModule(pkg.Module(), llvm.ReturnStatusAction); err != nil {
+		t.Fatal(err)
+	}
 
 	ir := pkg.String()
 	for _, want := range []string{
 		"@llvm.type.checked.load",
 		"@llvm.assume",
 		`!"go.method.M:func()"`,
+		`!"go.method.N:func()"`,
 	} {
 		if !strings.Contains(ir, want) {
 			t.Fatalf("missing %s in method checked load IR:\n%s", want, ir)


### PR DESCRIPTION
## Summary
- verify LLVM modules before running the pass pipeline
- emit overloaded LLVM intrinsics through `CreateIntrinsic` for memset, memcpy, stacksave/restore, and globaldce type checks
- fit channel capacities to platform `int` and avoid emitting a return after an unreachable goroutine wrapper call
- update FileCheck expectations for mangled intrinsic names under opaque pointers

## Tests
- `go test ./ssa -run '^TestFrom' -count=1`
- `go test ./ssa -count=1`
- `go test ./internal/cabi -count=1`
