### PR TITLE
ssa: emit DCE-safe function metadata

### DIFF
--- a/cl/cltest/cltest.go
+++ b/cl/cltest/cltest.go
@@ -458,7 +458,7 @@ func filterRunOutput(in []byte) []byte {
 	return out.Bytes()
 }
 
-func TestCompileEx(t *testing.T, src any, fname, expected string, dbg bool) {
+func CompileIREx(t *testing.T, src any, fname string, dbg bool, configure func(llssa.Program)) string {
 	t.Helper()
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, fname, src, parser.ParseComments)
@@ -481,13 +481,21 @@ func TestCompileEx(t *testing.T, src any, fname, expected string, dbg bool) {
 	foo.WriteTo(os.Stderr)
 	prog := ssatest.NewProgramEx(t, nil, imp)
 	prog.TypeSizes(types.SizesFor("gc", runtime.GOARCH))
+	if configure != nil {
+		configure(prog)
+	}
 
 	ret, err := cl.NewPackage(prog, foo, files)
 	if err != nil {
 		t.Fatal("cl.NewPackage failed:", err)
 	}
+	return ret.String()
+}
 
-	if v := ret.String(); llssa.StripModuleTarget(v) != expected && expected != ";" { // expected == ";" means skipping out.ll
+func TestCompileEx(t *testing.T, src any, fname, expected string, dbg bool) {
+	t.Helper()
+	v := CompileIREx(t, src, fname, dbg, nil)
+	if llssa.StripModuleTarget(v) != expected && expected != ";" { // expected == ";" means skipping out.ll
 		t.Fatalf("\n==> got:\n%s\n==> expected:\n%s\n", v, expected)
 	}
 }

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -475,6 +475,14 @@ func (p *context) compileFuncDecl(pkg llssa.Package, f *ssa.Function) (llssa.Fun
 	p.funcs[f] = fn
 	isCgo := isCgoExternSymbol(f)
 	if nblk := len(f.Blocks); nblk > 0 {
+		if p.prog.FuncInfoMetadataEnabled() {
+			goName := fn.Name()
+			if pkgTypes != nil {
+				goName = funcName(pkgTypes, f, false)
+			}
+			pos := p.goProg.Fset.Position(f.Pos())
+			pkg.EmitFuncInfo(fn.Name(), goName, pos.Filename, pos.Line, pos.Column)
+		}
 		var childInits []func()
 		if len(f.AnonFuncs) > 0 {
 			parentInits := p.inits

--- a/cl/funcinfo_metadata_test.go
+++ b/cl/funcinfo_metadata_test.go
@@ -1,0 +1,142 @@
+//go:build !llgo
+// +build !llgo
+
+/*
+ * Copyright (c) 2024 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cl_test
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/goplus/llgo/cl/cltest"
+	llssa "github.com/goplus/llgo/ssa"
+)
+
+type funcInfoRecord struct {
+	symbol string
+	name   string
+	file   string
+	line   int
+	column int
+}
+
+func TestFuncInfoMetadataEmission(t *testing.T) {
+	const src = `package foo
+
+type T struct{}
+
+func top() {
+	_ = func() int { return leaf() }()
+}
+
+func leaf() int { return 1 }
+
+func (T) method() {}
+`
+	ir := cltest.CompileIREx(t, src, "foo.go", false, func(prog llssa.Program) {
+		prog.EnableFuncInfoMetadata(true)
+	})
+
+	for _, want := range []string{
+		`!llgo.funcinfo = !{!`,
+		`!"foo.top"`,
+		`!"foo.top$1"`,
+		`!"foo.T.method"`,
+		`!"foo.go"`,
+	} {
+		if !strings.Contains(ir, want) {
+			t.Fatalf("missing funcinfo metadata %s:\n%s", want, ir)
+		}
+	}
+	if strings.Contains(ir, "llvm.compiler.used") {
+		t.Fatalf("funcinfo metadata should not add llvm.compiler.used:\n%s", ir)
+	}
+	if strings.Contains(ir, `ptr @"foo.top"`) || strings.Contains(ir, `ptr @foo.top`) {
+		t.Fatalf("funcinfo metadata should use symbol strings, not function pointers:\n%s", ir)
+	}
+
+	records := parseFuncInfoRecords(t, ir)
+	stackSymbols := []string{"foo.leaf", "foo.top$1", "foo.top"}
+	for _, symbol := range stackSymbols {
+		record, ok := records[symbol]
+		if !ok {
+			t.Fatalf("stack symbol %q not found in funcinfo metadata: %#v", symbol, records)
+		}
+		if record.name == "" || record.file != "foo.go" || record.line <= 0 || record.column <= 0 {
+			t.Fatalf("bad funcinfo for stack symbol %q: %#v", symbol, record)
+		}
+	}
+	if got := records["foo.leaf"].name; got != "foo.leaf" {
+		t.Fatalf("leaf stack frame name = %q, want foo.leaf", got)
+	}
+	if got := records["foo.top$1"].name; got != "foo.top$1" {
+		t.Fatalf("closure stack frame name = %q, want foo.top$1", got)
+	}
+	if got := records["foo.top"].name; got != "foo.top" {
+		t.Fatalf("caller stack frame name = %q, want foo.top", got)
+	}
+}
+
+func parseFuncInfoRecords(t *testing.T, ir string) map[string]funcInfoRecord {
+	t.Helper()
+
+	listRE := regexp.MustCompile(`!llgo\.funcinfo = !\{([^}]*)\}`)
+	listMatch := listRE.FindStringSubmatch(ir)
+	if listMatch == nil {
+		t.Fatalf("missing funcinfo metadata list:\n%s", ir)
+	}
+	refRE := regexp.MustCompile(`!(\d+)`)
+	refs := refRE.FindAllStringSubmatch(listMatch[1], -1)
+	if len(refs) == 0 {
+		t.Fatalf("empty funcinfo metadata list:\n%s", ir)
+	}
+	wantRefs := make(map[string]bool, len(refs))
+	for _, ref := range refs {
+		wantRefs[ref[1]] = true
+	}
+
+	rowRE := regexp.MustCompile(`^!(\d+) = !\{i32 1, !"([^"]+)", !"([^"]+)", !"([^"]*)", i32 ([0-9]+), i32 ([0-9]+)\}$`)
+	records := make(map[string]funcInfoRecord)
+	for _, line := range strings.Split(ir, "\n") {
+		row := rowRE.FindStringSubmatch(line)
+		if row == nil || !wantRefs[row[1]] {
+			continue
+		}
+		lineNo, err := strconv.Atoi(row[5])
+		if err != nil {
+			t.Fatalf("bad funcinfo line in %q: %v", line, err)
+		}
+		column, err := strconv.Atoi(row[6])
+		if err != nil {
+			t.Fatalf("bad funcinfo column in %q: %v", line, err)
+		}
+		records[row[2]] = funcInfoRecord{
+			symbol: row[2],
+			name:   row[3],
+			file:   row[4],
+			line:   lineNo,
+			column: column,
+		}
+	}
+	if len(records) != len(wantRefs) {
+		t.Fatalf("parsed %d funcinfo records, want %d:\n%s", len(records), len(wantRefs), ir)
+	}
+	return records
+}

--- a/ssa/funcinfo.go
+++ b/ssa/funcinfo.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ssa
+
+import "github.com/xgo-dev/llvm"
+
+const (
+	FuncInfoMetadataName = "llgo.funcinfo"
+	funcInfoVersion      = 1
+)
+
+// EnableFuncInfoMetadata controls emission of DCE-safe function source
+// metadata. The metadata intentionally stores symbol names as strings instead
+// of function pointer operands, so it can be consumed before materializing a
+// final runtime line/func table without keeping otherwise-dead functions alive.
+func (p Program) EnableFuncInfoMetadata(enable bool) {
+	p.enableFuncInfoMetadata = enable
+}
+
+func (p Program) FuncInfoMetadataEnabled() bool {
+	return p.enableFuncInfoMetadata
+}
+
+// EmitFuncInfo records a function's linker symbol, Go name, and declaration
+// source position as LLVM named metadata. The row layout is:
+//
+//	!{i32 version, !"symbol", !"go.name", !"file", i32 line, i32 column}
+func (p Package) EmitFuncInfo(symbol, name, file string, line, column int) {
+	if symbol == "" {
+		return
+	}
+	if line < 0 {
+		line = 0
+	}
+	if column < 0 {
+		column = 0
+	}
+	i32 := p.Prog.Int32().ll
+	p.mod.AddNamedMetadataOperand(FuncInfoMetadataName,
+		p.Prog.ctx.MDNode([]llvm.Metadata{
+			llvm.ConstInt(i32, funcInfoVersion, false).ConstantAsMetadata(),
+			p.Prog.ctx.MDString(symbol),
+			p.Prog.ctx.MDString(name),
+			p.Prog.ctx.MDString(file),
+			llvm.ConstInt(i32, uint64(line), false).ConstantAsMetadata(),
+			llvm.ConstInt(i32, uint64(column), false).ConstantAsMetadata(),
+		}),
+	)
+}

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -233,6 +233,8 @@ type aProgram struct {
 	is32Bits bool
 
 	enableGoGlobalDCE bool
+
+	enableFuncInfoMetadata bool
 }
 
 type AbiSymbol struct {

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -200,6 +200,104 @@ func TestNewFuncExLLVMUsed(t *testing.T) {
 	}
 }
 
+func TestFuncInfoMetadataDoesNotPreserveFunctions(t *testing.T) {
+	testFuncInfoMetadataDoesNotPreserveFunctions(t)
+}
+
+func testFuncInfoMetadataDoesNotPreserveFunctions(t *testing.T) {
+	t.Helper()
+
+	prog := NewProgram(nil)
+	if prog.FuncInfoMetadataEnabled() {
+		t.Fatal("funcinfo metadata should be disabled by default")
+	}
+	prog.EnableFuncInfoMetadata(true)
+	if !prog.FuncInfoMetadataEnabled() {
+		t.Fatal("funcinfo metadata should be enabled")
+	}
+
+	pkg := prog.NewPackage("main", "main")
+	sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+
+	pkg.NewFunc("main.unused", sig, InGo)
+	pkg.EmitFuncInfo("", "ignored", "ignored.go", -1, -1)
+	if ir := pkg.String(); strings.Contains(ir, FuncInfoMetadataName) {
+		t.Fatalf("empty symbol should not emit funcinfo metadata:\n%s", ir)
+	}
+
+	pkg.EmitFuncInfo("main.unused", "main.unused", "unused.go", 7, 1)
+	pkg.EmitFuncInfo("main.negative", "main.negative", "negative.go", -7, -1)
+	ir := pkg.String()
+
+	if !strings.Contains(ir, `!llgo.funcinfo = !{!`) {
+		t.Fatalf("missing %s metadata:\n%s", FuncInfoMetadataName, ir)
+	}
+	for _, want := range []string{`!"main.unused"`, `!"unused.go"`, `i32 7`, `!"main.negative"`, `!"negative.go"`, `i32 0`} {
+		if !strings.Contains(ir, want) {
+			t.Fatalf("missing funcinfo field %s:\n%s", want, ir)
+		}
+	}
+	if strings.Contains(ir, "llvm.compiler.used") {
+		t.Fatalf("funcinfo metadata must not preserve symbols with llvm.compiler.used:\n%s", ir)
+	}
+	if strings.Contains(ir, `ptr @"main.unused"`) || strings.Contains(ir, `ptr @main.unused`) {
+		t.Fatalf("funcinfo metadata must not contain function pointer operands:\n%s", ir)
+	}
+}
+
+func TestFuncInfoMetadataDoesNotBlockGlobalDCE(t *testing.T) {
+	testFuncInfoMetadataDoesNotBlockGlobalDCE(t)
+}
+
+func testFuncInfoMetadataDoesNotBlockGlobalDCE(t *testing.T) {
+	t.Helper()
+
+	prog := NewProgram(nil)
+	pkg := prog.NewPackage("main", "main")
+	sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+
+	live := pkg.NewFunc("main.main", sig, InGo)
+	lb := live.MakeBody(1)
+	lb.Return()
+	lb.EndBuild()
+
+	unused := pkg.NewFuncEx("main.unused", sig, InGo, false, true)
+	ub := unused.MakeBody(1)
+	ub.Return()
+	ub.EndBuild()
+	pkg.EmitFuncInfo(unused.Name(), unused.Name(), "unused.go", 7, 1)
+
+	mod := pkg.Module()
+	if mod.NamedFunction("main.unused").IsNil() {
+		t.Fatal("missing main.unused before DCE")
+	}
+	mod.SetDataLayout(prog.DataLayout())
+	mod.SetTarget(prog.Target().Spec().Triple)
+	pbo := llvm.NewPassBuilderOptions()
+	defer pbo.Dispose()
+	if err := llvm.VerifyModule(mod, llvm.ReturnStatusAction); err != nil {
+		t.Fatalf("verify module before DCE: %v", err)
+	}
+	if err := mod.RunPasses("globaldce", prog.TargetMachine(), pbo); err != nil {
+		t.Fatalf("run globaldce: %v", err)
+	}
+	if !mod.NamedFunction("main.unused").IsNil() {
+		t.Fatalf("funcinfo metadata kept main.unused alive:\n%s", mod.String())
+	}
+	if mod.NamedFunction("main.main").IsNil() {
+		t.Fatalf("globaldce removed externally visible live function:\n%s", mod.String())
+	}
+	if ir := mod.String(); !strings.Contains(ir, `!"main.unused"`) {
+		t.Fatalf("funcinfo metadata should remain available for later materialization:\n%s", ir)
+	}
+}
+
+func TestDevLTOGlobalDCEFuncInfoMetadata(t *testing.T) {
+	requireGoGlobalDCE(t)
+	testFuncInfoMetadataDoesNotPreserveFunctions(t)
+	testFuncInfoMetadataDoesNotBlockGlobalDCE(t)
+}
+
 func requireGoGlobalDCE(t *testing.T) {
 	t.Helper()
 }


### PR DESCRIPTION
## Changes
- Add opt-in `llgo.funcinfo` LLVM named metadata rows for functions with bodies.
- Emit the metadata from `cl` when enabled by the compiler pipeline.
- Store function symbols as metadata strings, not function pointer operands, so early metadata does not make otherwise-dead functions live.

## Intended use
This PR emits producer metadata only. `!llgo.funcinfo` is LLVM module metadata, not runtime-visible data, so the runtime cannot read it directly yet.

The intended follow-up is a post-DCE materializer:
1. Run normal LLVM/linker DCE first.
2. Read `!llgo.funcinfo` rows from the surviving module.
3. Filter rows to symbols that still exist after DCE.
4. Emit a runtime-visible table, for example a `__llgo_funcinfo_start/end` section or equivalent global array, containing symbol/name/file/line/column records.
5. Teach `runtime.CallersFrames` / `runtime.FuncForPC` to map a PC or unwound symbol to that table.

## DCE safety
Before DCE, funcinfo rows must remain string-only metadata. They must not contain `ptr @fn` operands and must not add functions to `llvm.compiler.used`.

The materializer must run after DCE/live-set computation and must only emit entries for functions that survived. It must not recreate references to deleted functions.

## Tests
- `go test ./ssa -run 'TestFuncInfoMetadataDoesNot(PreserveFunctions|BlockGlobalDCE)' -count=1`
- `go test -tags=dev ./ssa -run '^TestDevLTOGlobalDCEFuncInfoMetadata$' -count=1`
- `go test -tags=dev -timeout 30m -covermode=atomic -coverprofile=/tmp/coverage-dev-globaldce-unit.txt -run '^TestDevLTOGlobalDCE' ./ssa ./internal/build ./internal/crosscompile ./cmd/internal/flags ./internal/cabi`
- `go test ./cl -run TestFuncInfoMetadataEmission -count=1`
- `go test -timeout 30m -coverprofile=/tmp/ssa.cover ./ssa`

The `cl` test parses emitted metadata into a symbol map and verifies that stack-frame symbols can recover Go function names and source positions. The `ssa` DCE test runs LLVM `globaldce` and verifies metadata for an unused function does not make that function live. The Dev LTO test name covers the same funcinfo paths in the coverage profile uploaded by the Dev LTO GlobalDCE workflow.
