### PR TITLE
fixed:align stripped itab entries with Go runtime

### DIFF
--- a/runtime/internal/runtime/z_face.go
+++ b/runtime/internal/runtime/z_face.go
@@ -142,7 +142,7 @@ func NewItab(inter *InterfaceType, typ *Type) *Itab {
 				// matched but no function pointer (e.g. stripped/unreachable after DCE);
 				// keep itab entry with a placeholder so the itab stays intact
 				// and only panics on call, not at assertion time.
-				fn = abi.Text(uintptr(0))
+				fn = abi.Text(c.Func(unreachableMethod))
 			}
 			*c.Advance(data, i) = uintptr(fn)
 		}
@@ -169,6 +169,12 @@ func findMethod(mthds []abi.Method, im abi.Imethod) (abi.Text, bool) {
 		}
 	}
 	return nil, false
+}
+
+// unreachableMethod matches Go's runtime.unreachableMethod: method entries
+// proven unreachable by link-time DCE are redirected here and should never run.
+func unreachableMethod() {
+	throw("unreachable method called. linker bug?")
 }
 
 func IfaceType(i iface) *abi.Type {


### PR DESCRIPTION
## Summary

This aligns LLGo's itab behavior with Go's runtime handling for unreachable methods.

When `NewItab` finds a matching interface method slot but the concrete method body has been stripped by link-time DCE, we should keep the itab entry structurally valid and install an explicit unreachable-method stub. This mirrors Go's `runtime.unreachableMethod` behavior: interface assertion / itab construction should not fail just because a method body was proven unreachable, but calling that supposedly unreachable method must fail with a clear linker-bug error.

Before this change, the stripped slot was filled with a zero function pointer, which can produce a less intentional nil/invalid call path.

## Changes

- Replace the zero function pointer fallback with `unreachableMethod` in `NewItab`.
- Add `unreachableMethod`, which throws `unreachable method called. linker bug?` when invoked.

## Tests

```sh
go test ./internal/runtime

go test ./cl -run 'TestRunAndTestFromTestgo/abimethod$' -count=1
```
