### PR TITLE
runtime: nanosecond monotonic clock; fix Linux clock IDs

### DIFF
--- a/runtime/internal/lib/runtime/nanotime_darwin_llgo.go
+++ b/runtime/internal/lib/runtime/nanotime_darwin_llgo.go
@@ -1,0 +1,36 @@
+//go:build darwin && !baremetal
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	_ "unsafe"
+)
+
+// Mirrors Go's runtime.nanotime1 on Darwin (sys_darwin.go): read
+// CLOCK_UPTIME_RAW through clock_gettime_nsec_np. Darwin serves
+// clock_gettime(CLOCK_MONOTONIC) with only microsecond granularity, while
+// CLOCK_UPTIME_RAW is mach_absolute_time with full nanosecond resolution.
+const _CLOCK_UPTIME_RAW = 8
+
+//go:linkname c_clock_gettime_nsec_np C.clock_gettime_nsec_np
+func c_clock_gettime_nsec_np(clockID int32) uint64
+
+func nanotime1() int64 {
+	return int64(c_clock_gettime_nsec_np(_CLOCK_UPTIME_RAW))
+}

--- a/runtime/internal/lib/runtime/nanotime_linux_llgo.go
+++ b/runtime/internal/lib/runtime/nanotime_linux_llgo.go
@@ -1,0 +1,40 @@
+//go:build linux && !baremetal
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"unsafe"
+
+	c "github.com/goplus/llgo/runtime/internal/clite"
+	ct "github.com/goplus/llgo/runtime/internal/clite/time"
+)
+
+// Linux CLOCK_MONOTONIC (see <linux/time.h>), which has nanosecond
+// resolution. Deliberately a local constant: ct.CLOCK_MONOTONIC carries
+// Darwin's id (6), which Linux interprets as CLOCK_MONOTONIC_COARSE — a
+// millisecond-granularity clock that quantized every monotonic timestamp
+// the runtime produced.
+const _CLOCK_MONOTONIC = 1
+
+// nanotime1 mirrors Go's runtime.nanotime1 on Linux.
+func nanotime1() int64 {
+	tv := (*ct.Timespec)(c.Alloca(unsafe.Sizeof(ct.Timespec{})))
+	ct.ClockGettime(ct.ClockidT(_CLOCK_MONOTONIC), tv)
+	return int64(tv.Sec)*1e9 + int64(tv.Nsec)
+}

--- a/runtime/internal/lib/runtime/nanotime_llgo.go
+++ b/runtime/internal/lib/runtime/nanotime_llgo.go
@@ -1,0 +1,25 @@
+//go:build !baremetal
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+// runtimeNano mirrors Go's runtime.nanotime: the monotonic clock in
+// nanoseconds, implemented per OS by nanotime1.
+func runtimeNano() int64 {
+	return nanotime1()
+}

--- a/runtime/internal/lib/runtime/nanotime_other_llgo.go
+++ b/runtime/internal/lib/runtime/nanotime_other_llgo.go
@@ -1,0 +1,33 @@
+//go:build !darwin && !linux && !baremetal
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime
+
+import (
+	"unsafe"
+
+	c "github.com/goplus/llgo/runtime/internal/clite"
+	ct "github.com/goplus/llgo/runtime/internal/clite/time"
+)
+
+// nanotime1 keeps the previous behavior on remaining platforms.
+func nanotime1() int64 {
+	tv := (*ct.Timespec)(c.Alloca(unsafe.Sizeof(ct.Timespec{})))
+	ct.ClockGettime(ct.CLOCK_MONOTONIC, tv)
+	return int64(tv.Sec)*1e9 + int64(tv.Nsec)
+}

--- a/runtime/internal/lib/runtime/time_llgo.go
+++ b/runtime/internal/lib/runtime/time_llgo.go
@@ -545,9 +545,3 @@ func timeSleepWake(arg any, _ uintptr) {
 	ch := arg.(chan struct{})
 	ch <- struct{}{}
 }
-
-func runtimeNano() int64 {
-	tv := (*ct.Timespec)(c.Alloca(unsafe.Sizeof(ct.Timespec{})))
-	ct.ClockGettime(ct.CLOCK_MONOTONIC, tv)
-	return int64(tv.Sec)*1e9 + int64(tv.Nsec)
-}

--- a/runtime/internal/lib/runtime/time_llgo_go123.go
+++ b/runtime/internal/lib/runtime/time_llgo_go123.go
@@ -579,9 +579,3 @@ func resetTimer(t *timeTimer, when, period int64) bool {
 	r := &t.r
 	return resetRuntimeTimer(r, when, period, r.f, r.arg, r.seq)
 }
-
-func runtimeNano() int64 {
-	tv := (*ct.Timespec)(c.Alloca(unsafe.Sizeof(ct.Timespec{})))
-	ct.ClockGettime(ct.CLOCK_MONOTONIC, tv)
-	return int64(tv.Sec)*1e9 + int64(tv.Nsec)
-}


### PR DESCRIPTION
The monotonic time source had two independent problems:

- On Linux, `runtimeNano` passed clite's `CLOCK_MONOTONIC`, whose value is Darwin's clock id (6). Linux interprets 6 as `CLOCK_MONOTONIC_COARSE`, a millisecond-granularity clock: consecutive `time.Now()` readings were identical 100% of the time and the smallest nonzero delta was 1ms. Timer precision, sync spin timing and any benchmark that trusts `time.Since` were all millisecond-quantized.
- On Darwin, `clock_gettime(CLOCK_MONOTONIC)` itself only has microsecond granularity (96% identical consecutive readings, 1µs minimum delta).

## Changes

Mirror Go's runtime structure with a per-OS `nanotime1` in the runtime package itself, keeping the hot path free of clite indirection and **clite unchanged**:

- Darwin reads `CLOCK_UPTIME_RAW` through `clock_gettime_nsec_np` — the same clock Go's `nanotime` uses there — via a direct C linkname.
- Linux uses `clock_gettime` with the OS-correct `CLOCK_MONOTONIC` id as a local constant.
- Remaining platforms keep the previous behavior.

## Validation

Consecutive `time.Now()` delta probe (min nonzero delta / fraction of zero deltas), 200k iterations:

| platform | before | after | Go 1.26 |
|---|---|---|---|
| macOS arm64 | 1µs / 96.5% | **41ns / 26%** | 41ns / 22% |
| Linux arm64 (container) | 1ms / 100% | **41ns / 21%** | — |

`time.Sleep` / `Timer` / `Ticker` smoke: 50ms sleep → 51ms, 30ms timer → 31ms, 3×10ms ticker → 32ms, identical before and after. `go test ./test/go -run 'Select|Channel'` passes on macOS; builds and probes verified in the Linux arm64 container.

Found while benchmarking #2012: cold-path metrics on Linux read as 0ns because the monotonic clock could not resolve sub-millisecond durations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)