### PR TITLE
fix: canonicalize patch package path in interface hash

### DIFF
--- a/ssa/abi/abi.go
+++ b/ssa/abi/abi.go
@@ -349,7 +349,7 @@ func (b *Builder) interfaceHash(t *types.Interface) (ret []byte, pkg string) {
 	for i := 0; i < n; i++ {
 		m := t.Method(i)
 		if !m.Exported() && pkg == "" {
-			pkg = m.Pkg().Path()
+			pkg = PathOf(m.Pkg())
 		}
 		ft := b.FuncName(m.Type().(*types.Signature))
 		fmt.Fprintln(h, m.Name(), ft)

--- a/ssa/abi/abi_coverage_test.go
+++ b/ssa/abi/abi_coverage_test.go
@@ -293,6 +293,21 @@ func TestStructInterfaceClosureAndPathCoverage(t *testing.T) {
 	if got := PathOf(patchPkg); got != "runtime" {
 		t.Fatalf("PathOf(patchPkg)=%q, want %q", got, "runtime")
 	}
+	realReflectlite := types.NewPackage("internal/reflectlite", "reflectlite")
+	patchReflectlite := types.NewPackage(PatchPathPrefix+"internal/reflectlite", "reflectlite")
+	realIface := types.NewInterfaceType([]*types.Func{
+		types.NewFunc(token.NoPos, realReflectlite, "common", sig),
+	}, nil)
+	realIface.Complete()
+	patchIface := types.NewInterfaceType([]*types.Func{
+		types.NewFunc(token.NoPos, patchReflectlite, "common", sig),
+	}, nil)
+	patchIface.Complete()
+	realName, _ := b.InterfaceName(realIface)
+	patchName, _ := b.InterfaceName(patchIface)
+	if realName != patchName {
+		t.Fatalf("InterfaceName should canonicalize patch package path: real=%q patch=%q", realName, patchName)
+	}
 	if got := FullName(nil, "X"); got != "X" {
 		t.Fatalf("FullName(nil,\"X\")=%q, want %q", got, "X")
 	}


### PR DESCRIPTION
## Summary

- canonicalize patch package paths when deriving the private-method package prefix for interface hashes
- add coverage ensuring real internal/reflectlite and patched internal/reflectlite interfaces get the same InterfaceName

## Tests

- go test ./ssa/abi -run TestStructInterfaceClosureAndPathCoverage -count=1