### PR TITLE
Refine LTO reflect MethodByName handling

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -143,6 +143,19 @@ jobs:
       - name: Build llgo with dev tag
         run: go install -tags=dev ./cmd/llgo
 
+      - name: Build LTO plugin
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+
+          llvm_config="$(command -v llvm-config || command -v llvm-config-19)"
+          cmake -S ltoplugin -B ltoplugin/build \
+            -DLLVM_DIR="$("${llvm_config}" --cmakedir)" \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build ltoplugin/build --config Release
+
+          echo "LLGO_LTO_PLUGIN=$GITHUB_WORKSPACE/ltoplugin/build/LLGOLTOPlugin.so" >> "$GITHUB_ENV"
+
       - name: Run dev LTO GlobalDCE tests and demos with coverage
         run: |
           set -euo pipefail
@@ -160,6 +173,20 @@ jobs:
             ./cl
           go tool cover -func=coverage-dev-lto-globaldce-cl.txt
 
+          go test -tags=dev -timeout 30m -covermode=atomic \
+            -coverpkg=github.com/goplus/llgo/ssa,github.com/goplus/llgo/internal/build,github.com/goplus/llgo/internal/crosscompile \
+            -coverprofile=coverage-dev-lto-globaldce-symbols.txt \
+            -run '^TestBuildAndCheckSymbolsFromTestlto/globaldce_' \
+            ./cl
+          go tool cover -func=coverage-dev-lto-globaldce-symbols.txt
+
+          go test -tags=dev -timeout 30m -covermode=atomic \
+            -coverpkg=github.com/goplus/llgo/ssa,github.com/goplus/llgo/internal/build,github.com/goplus/llgo/internal/crosscompile \
+            -coverprofile=coverage-dev-lto-plugin-cl.txt \
+            -run '^(TestRunAndTestFromTestltoLTOPlugin|TestBuildAndCheckSymbolsFromTestltoLTOPlugin)' \
+            ./cl
+          go tool cover -func=coverage-dev-lto-plugin-cl.txt
+
           LLGO_DEMO_LLGORUN_FLAGS="-lto=full -globaldce" \
             bash .github/workflows/test_demo.sh
 
@@ -168,5 +195,5 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           token: ${{secrets.CODECOV_TOKEN}}
-          files: coverage-dev-globaldce-unit.txt,coverage-dev-lto-globaldce-cl.txt
+          files: coverage-dev-globaldce-unit.txt,coverage-dev-lto-globaldce-cl.txt,coverage-dev-lto-globaldce-symbols.txt,coverage-dev-lto-plugin-cl.txt
           flags: dev-lto-globaldce

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ _runtime/
 _tinygo/
 _output/
 build.dir/
+ltoplugin/build/
 .vscode/
 .venv/
 

--- a/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin/expect.txt
+++ b/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin/expect.txt
@@ -1,0 +1,2 @@
+keep-a
+keep-a

--- a/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin/in.go
+++ b/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin/in.go
@@ -1,0 +1,49 @@
+// LITTEST
+package main
+
+import (
+	"os"
+	"reflect"
+)
+
+// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin{{.*}}S{{.*}}Drop
+// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin{{.*}}S{{.*}}KeepA
+// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin{{.*}}S{{.*}}KeepB
+// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin{{.*}}S{{.*}}Drop
+
+type S struct{}
+
+//go:noinline
+func (S) KeepA() string {
+	return "keep-a"
+}
+
+//go:noinline
+func (S) KeepB() string {
+	return "keep-b"
+}
+
+//go:noinline
+func (S) Drop() string {
+	panic("Drop should be unreachable")
+}
+
+func methodName() string {
+	name := "KeepA"
+	if os.Args[0] == "" {
+		name = "KeepB"
+	}
+	return name
+}
+
+func main() {
+	out := reflect.ValueOf(S{}).MethodByName(methodName()).Call(nil)
+	println(out[0].String())
+
+	m, ok := reflect.TypeOf(S{}).MethodByName(methodName())
+	if !ok {
+		panic("missing method")
+	}
+	out = m.Func.Call([]reflect.Value{reflect.ValueOf(S{})})
+	println(out[0].String())
+}

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -178,9 +178,11 @@ func TestRunAndTestFromTestgo(t *testing.T) {
 func TestRunAndTestFromTestlto(t *testing.T) {
 	conf := build.NewDefaultConf(build.ModeRun)
 	conf.LTO = lto.Full
-	var ignore []string
+	ignore := []string{
+		"./_testlto/globaldce_reflect_method_by_name_ltoplugin",
+	}
 	if !buildenv.Dev {
-		ignore = []string{
+		ignore = append(ignore,
 			"./_testlto/globaldce_abitype_fakeuse",
 			"./_testlto/globaldce_interface_matrix",
 			"./_testlto/globaldce_interface_slots",
@@ -191,7 +193,7 @@ func TestRunAndTestFromTestlto(t *testing.T) {
 			"./_testlto/globaldce_typeid_dce",
 			"./_testlto/globaldce_unexported_method_identity",
 			"./_testlto/anonymous_alias",
-		}
+		)
 	}
 	cltest.RunAndTestFromDir(t, "", "./_testlto", ignore, cltest.WithRunConfig(conf))
 }
@@ -206,6 +208,10 @@ var testltoSymbolChecks = []string{
 	"globaldce_unexported_method_identity",
 }
 
+var testltoLTOPluginTests = []string{
+	"globaldce_reflect_method_by_name_ltoplugin",
+}
+
 func TestBuildAndCheckSymbolsFromTestlto(t *testing.T) {
 	if !buildenv.Dev {
 		t.Skip("globaldce symbol checks require dev build")
@@ -213,6 +219,36 @@ func TestBuildAndCheckSymbolsFromTestlto(t *testing.T) {
 	conf := build.NewDefaultConf(build.ModeBuild)
 	conf.LTO = lto.Full
 	cltest.BuildAndCheckSymbolsFromDir(t, "", "./_testlto", testltoSymbolChecks, cltest.WithRunConfig(conf))
+}
+
+func testltoLTOPluginConf(t *testing.T, mode build.Mode) *build.Config {
+	t.Helper()
+	if !buildenv.Dev {
+		t.Skip("globaldce plugin tests require dev build")
+	}
+	plugin := os.Getenv("LLGO_LTO_PLUGIN")
+	if plugin == "" {
+		t.Skip("set LLGO_LTO_PLUGIN to the built LLGOLTOPlugin shared library")
+	}
+	conf := build.NewDefaultConf(mode)
+	conf.LTO = lto.Full
+	conf.LTOPlugin = lto.PassPlugin{Path: plugin}
+	return conf
+}
+
+func TestRunAndTestFromTestltoLTOPlugin(t *testing.T) {
+	conf := testltoLTOPluginConf(t, build.ModeRun)
+	cltest.RunAndTestFromDir(t, "ltoplugin", "./_testlto", nil,
+		cltest.WithRunConfig(conf),
+		cltest.WithIRCheck(false),
+	)
+}
+
+func TestBuildAndCheckSymbolsFromTestltoLTOPlugin(t *testing.T) {
+	buildConf := testltoLTOPluginConf(t, build.ModeBuild)
+	cltest.BuildAndCheckSymbolsFromDir(t, "", "./_testlto", testltoLTOPluginTests,
+		cltest.WithRunConfig(buildConf),
+	)
 }
 
 func TestFilterEmulatorOutput(t *testing.T) {

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -1059,7 +1059,13 @@ func (p *context) callEx(b llssa.Builder, act llssa.DoAction, call *ssa.CallComm
 			hasVArg = fnHasVArg
 		}
 		args := p.compileValues(b, call.Args, hasVArg)
+		if reflectCheck.Kind&llssa.ReflectTypeMethodByName != 0 && reflectCheck.Name == "" && len(args) == 1 {
+			reflectCheck.NameArg = args[0]
+		}
 		ret = p.emitDo(b, act, ds, fn, llssa.Builder.Call, args...)
+		if reflectCheck.Kind&llssa.ReflectTypeMethodByName != 0 && reflectCheck.Name == "" {
+			b.MarkReflectTypeMethodByNameExpr(ret)
+		}
 		b.EmitReflectTypeMethodCheckedLoad(ret, reflectCheck)
 		return
 	}

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -1061,7 +1061,7 @@ func (p *context) callEx(b llssa.Builder, act llssa.DoAction, call *ssa.CallComm
 		args := p.compileValues(b, call.Args, hasVArg)
 		ret = p.emitDo(b, act, ds, fn, llssa.Builder.Call, args...)
 		if reflectCheck.Kind&llssa.ReflectTypeMethodByName != 0 && reflectCheck.Name == "" {
-			b.MarkReflectTypeMethodByNameExpr(ret)
+			b.MarkReflectTypeMethodByNameExpr(ret, 1)
 		}
 		b.EmitReflectTypeMethodCheckedLoad(ret, reflectCheck)
 		return

--- a/cl/instr.go
+++ b/cl/instr.go
@@ -1059,9 +1059,6 @@ func (p *context) callEx(b llssa.Builder, act llssa.DoAction, call *ssa.CallComm
 			hasVArg = fnHasVArg
 		}
 		args := p.compileValues(b, call.Args, hasVArg)
-		if reflectCheck.Kind&llssa.ReflectTypeMethodByName != 0 && reflectCheck.Name == "" && len(args) == 1 {
-			reflectCheck.NameArg = args[0]
-		}
 		ret = p.emitDo(b, act, ds, fn, llssa.Builder.Call, args...)
 		if reflectCheck.Kind&llssa.ReflectTypeMethodByName != 0 && reflectCheck.Name == "" {
 			b.MarkReflectTypeMethodByNameExpr(ret)

--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -130,10 +130,13 @@ func (o *ltoFlag) Set(v string) error {
 }
 
 var LTO ltoFlag
+var LTOPluginPath string
 
 func AddLTOFlag(fs *flag.FlagSet) {
 	LTO = ltoFlag{Mode: lto.Off}
+	LTOPluginPath = ""
 	fs.Var(&LTO, "lto", "Enable LTO optimization: thin or full (default: off)")
+	fs.StringVar(&LTOPluginPath, "lto-pass-plugin", "", "Load an LLVM LTO pass plugin during full LTO (ELF lld only)")
 }
 
 var GoGlobalDCE *bool
@@ -339,6 +342,12 @@ func UpdateConfig(conf *build.Config) error {
 	conf.PthreadStackSize = int64(PthreadStackSize)
 	if LTO.Specified {
 		conf.LTO = LTO.Mode
+	}
+	if LTOPluginPath != "" {
+		if conf.LTO != lto.Full {
+			return fmt.Errorf("lto pass plugin can only be enabled with full LTO (-lto=full)")
+		}
+		conf.LTOPlugin = lto.PassPlugin{Path: LTOPluginPath}
 	}
 	if GoGlobalDCE != nil {
 		if *GoGlobalDCE && conf.LTO != lto.Full {

--- a/cmd/internal/flags/flags_test.go
+++ b/cmd/internal/flags/flags_test.go
@@ -169,6 +169,48 @@ func TestBuildPthreadStackSizeFlagRejectsNegative(t *testing.T) {
 	}
 }
 
+func TestBuildLTOPassPluginFlags(t *testing.T) {
+	fs := flag.NewFlagSet("lto-pass-plugin", flag.ContinueOnError)
+	fs.SetOutput(new(bytes.Buffer))
+	AddBuildFlags(fs)
+	args := []string{
+		"-lto=full",
+		"-lto-pass-plugin=/tmp/libLLGOLTOPlugin.so",
+	}
+	if err := fs.Parse(args); err != nil {
+		t.Fatalf("Parse(%v) unexpected error: %v", args, err)
+	}
+
+	conf := &build.Config{}
+	if err := UpdateConfig(conf); err != nil {
+		t.Fatalf("UpdateConfig error: %v", err)
+	}
+	if conf.LTOPlugin.Path != "/tmp/libLLGOLTOPlugin.so" {
+		t.Fatalf("conf.LTOPlugin.Path = %q", conf.LTOPlugin.Path)
+	}
+}
+
+func TestBuildLTOPassPluginRequiresFullLTO(t *testing.T) {
+	tests := [][]string{
+		{"-lto-pass-plugin=/tmp/libLLGOLTOPlugin.so"},
+		{"-lto=thin", "-lto-pass-plugin=/tmp/libLLGOLTOPlugin.so"},
+	}
+
+	for _, args := range tests {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			fs := flag.NewFlagSet("lto-pass-plugin-requires-fulllto", flag.ContinueOnError)
+			fs.SetOutput(new(bytes.Buffer))
+			AddBuildFlags(fs)
+			if err := fs.Parse(args); err != nil {
+				t.Fatalf("Parse(%v) unexpected error: %v", args, err)
+			}
+			if err := UpdateConfig(&build.Config{}); err == nil {
+				t.Fatal("UpdateConfig expected error")
+			}
+		})
+	}
+}
+
 func TestDevLTOGlobalDCEBuildFlags(t *testing.T) {
 	if !buildenv.Dev {
 		fs := flag.NewFlagSet("nodev-globaldce", flag.ContinueOnError)

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -129,6 +129,7 @@ type Config struct {
 	Target        string // target name (e.g., "rp2040", "wasi") - takes precedence over Goos/Goarch
 	OptLevel      optlevel.Level
 	LTO           lto.Mode
+	LTOPlugin     lto.PassPlugin
 	BinPath       string
 	AppExt        string  // ".exe" on Windows, empty on Unix
 	OutFile       string  // only valid for ModeBuild when len(pkgs) == 1
@@ -1127,6 +1128,11 @@ func linkObjFiles(ctx *context, app string, objFiles, linkArgs []string, verbose
 
 	buildArgs := []string{"-o", app}
 	buildArgs = append(buildArgs, linkArgs...)
+	ltoPluginFlags, err := ctx.buildConf.LTOPlugin.LinkerFlags(ctx.buildConf.Goos)
+	if err != nil {
+		return err
+	}
+	buildArgs = append(buildArgs, ltoPluginFlags...)
 
 	// Add build mode specific linker arguments
 	switch ctx.buildConf.BuildMode {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -325,6 +325,7 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	if conf.PthreadStackSize > 0 {
 		prog.SetPthreadStackSize(uint64(conf.PthreadStackSize))
 	}
+	prog.EnableLTOPluginMarkers(conf.LTOPlugin.Enabled())
 	sizes := func(sizes types.Sizes, compiler, arch string) types.Sizes {
 		if arch == "wasm" {
 			sizes = &types.StdSizes{WordSize: 4, MaxAlign: 4}

--- a/internal/cabi/cabi.go
+++ b/internal/cabi/cabi.go
@@ -537,6 +537,7 @@ func (p *Transformer) transformCallInstr(m llvm.Module, ctx llvm.Context, call l
 		return false
 	}
 	nft, attrs := p.transformFuncType(ctx, &info)
+	reflectMethodByNameAttr := call.GetCallSiteStringAttribute(-1, "llgo.reflect.methodbyname")
 	b := ctx.NewBuilder()
 	b.SetInsertPointBefore(call)
 
@@ -587,6 +588,9 @@ func (p *Transformer) transformCallInstr(m llvm.Module, ctx llvm.Context, call l
 	updateCallAttr := func(call llvm.Value) {
 		for i, attr := range attrs {
 			call.AddCallSiteAttribute(i, attr)
+		}
+		if !reflectMethodByNameAttr.IsNil() {
+			call.AddCallSiteAttribute(-1, reflectMethodByNameAttr)
 		}
 	}
 

--- a/internal/cabi/cabi.go
+++ b/internal/cabi/cabi.go
@@ -550,10 +550,19 @@ func (p *Transformer) transformCallInstr(m llvm.Module, ctx llvm.Context, call l
 	}
 
 	operandCount := len(info.Params)
+	returnArgOffset := 0
+	if info.Return.Kind == AttrPointer {
+		returnArgOffset = 1
+	}
+	remappedReflectMethodByNameArgAttrIndex := -1
 	var nparams []llvm.Value
 	for i := 0; i < operandCount; i++ {
 		param := call.Operand(i)
 		ti := info.Params[i]
+		reflectMethodByNameArgAttr := call.GetCallSiteStringAttribute(i+1, "llgo.reflect.methodbyname.name")
+		if !reflectMethodByNameArgAttr.IsNil() {
+			remappedReflectMethodByNameArgAttrIndex = returnArgOffset + len(nparams) + 1
+		}
 		switch ti.Kind {
 		default:
 			nparams = append(nparams, param)
@@ -591,6 +600,11 @@ func (p *Transformer) transformCallInstr(m llvm.Module, ctx llvm.Context, call l
 		}
 		if !reflectMethodByNameAttr.IsNil() {
 			call.AddCallSiteAttribute(-1, reflectMethodByNameAttr)
+		}
+		if remappedReflectMethodByNameArgAttrIndex >= 0 {
+			call.AddCallSiteAttribute(remappedReflectMethodByNameArgAttrIndex, ctx.CreateStringAttribute(
+				"llgo.reflect.methodbyname.name", "1",
+			))
 		}
 	}
 

--- a/internal/cabi/cabi_patch_test.go
+++ b/internal/cabi/cabi_patch_test.go
@@ -4,6 +4,9 @@
 package cabi
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	llssa "github.com/goplus/llgo/ssa"
@@ -139,5 +142,61 @@ func TestRuntimeHeaderWrapAndTypeInfo(t *testing.T) {
 	}
 	if info.Size == 0 || info.Align == 0 {
 		t.Fatalf("GetTypeInfo size/align should be non-zero, got size=%d align=%d", info.Size, info.Align)
+	}
+}
+
+func TestReflectMethodByNameNameArgAttributeRemapped(t *testing.T) {
+	llvm.InitializeAllTargets()
+	llvm.InitializeAllTargetMCs()
+	llvm.InitializeAllTargetInfos()
+
+	const testIR = `
+%String = type { ptr, i64 }
+%Value = type { ptr, ptr, i64 }
+
+declare void @callee(%Value, %String)
+
+define void @caller(%Value %v, %String %name) {
+entry:
+  call void @callee(%Value %v, %String "llgo.reflect.methodbyname.name"="1" %name) #0
+  ret void
+}
+
+attributes #0 = { "llgo.reflect.methodbyname"="value" }
+`
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+
+	tmpfile := filepath.Join(t.TempDir(), "reflect_methodbyname_attr.ll")
+	if err := os.WriteFile(tmpfile, []byte(testIR), 0644); err != nil {
+		t.Fatalf("Failed to write test IR: %v", err)
+	}
+	buf, err := llvm.NewMemoryBufferFromFile(tmpfile)
+	if err != nil {
+		t.Fatalf("Failed to read test IR: %v", err)
+	}
+	mod, err := ctx.ParseIR(buf)
+	if err != nil {
+		t.Fatalf("Failed to parse test IR: %v", err)
+	}
+	defer mod.Dispose()
+
+	prog := llssa.NewProgram(nil)
+	tr := NewTransformer(prog, "", "", ModeAllFunc, true)
+	tr.TransformModule("test", mod)
+
+	caller := mod.NamedFunction("caller")
+	if caller.IsNil() {
+		t.Fatal("caller function not found")
+	}
+	ir := caller.String()
+	if !strings.Contains(mod.String(), `"llgo.reflect.methodbyname"="value"`) {
+		t.Fatalf("reflect MethodByName call marker was not preserved:\n%s", mod.String())
+	}
+	if !strings.Contains(ir, `ptr "llgo.reflect.methodbyname.name"="1"`) {
+		t.Fatalf("reflect MethodByName name marker was not remapped to string data pointer:\n%s", ir)
+	}
+	if strings.Contains(ir, `i64 "llgo.reflect.methodbyname.name"="1"`) {
+		t.Fatalf("reflect MethodByName name marker should not be remapped to string length:\n%s", ir)
 	}
 }

--- a/internal/cabi/cabi_patch_test.go
+++ b/internal/cabi/cabi_patch_test.go
@@ -182,7 +182,7 @@ attributes #0 = { "llgo.reflect.methodbyname"="value" }
 	defer mod.Dispose()
 
 	prog := llssa.NewProgram(nil)
-	tr := NewTransformer(prog, "", "", ModeAllFunc, true)
+	tr := NewTransformer(prog, "amd64-unknown-linux-gnu", "", ModeAllFunc, true)
 	tr.TransformModule("test", mod)
 
 	caller := mod.NamedFunction("caller")

--- a/internal/lto/lto.go
+++ b/internal/lto/lto.go
@@ -51,3 +51,21 @@ func (m Mode) ClangFlag() string {
 		return ""
 	}
 }
+
+type PassPlugin struct {
+	Path string
+}
+
+func (p PassPlugin) Enabled() bool {
+	return p.Path != ""
+}
+
+func (p PassPlugin) LinkerFlags(goos string) ([]string, error) {
+	if !p.Enabled() {
+		return nil, nil
+	}
+	if goos == "darwin" {
+		return nil, fmt.Errorf("LTO pass plugins are not supported on darwin by LLVM 19 ld64.lld or Apple ld64")
+	}
+	return []string{"-Wl,--load-pass-plugin=" + p.Path}, nil
+}

--- a/internal/lto/lto_test.go
+++ b/internal/lto/lto_test.go
@@ -74,3 +74,39 @@ func TestClangFlag(t *testing.T) {
 		t.Fatalf("Thin.ClangFlag() = %q, want -flto=thin", got)
 	}
 }
+
+func TestPassPluginLinkerFlags(t *testing.T) {
+	if got, err := (PassPlugin{}).LinkerFlags("linux"); err != nil || got != nil {
+		t.Fatalf("disabled plugin flags = %v, err = %v; want nil, nil", got, err)
+	}
+
+	if _, err := (PassPlugin{Path: "/tmp/libLLGOLTOPlugin.dylib"}).LinkerFlags("darwin"); err == nil {
+		t.Fatal("darwin plugin flags expected error")
+	}
+
+	if (PassPlugin{}).Enabled() {
+		t.Fatal("empty plugin should be disabled")
+	}
+
+	plugin := PassPlugin{Path: "/tmp/libLLGOLTOPlugin.so"}
+	want := []string{"-Wl,--load-pass-plugin=/tmp/libLLGOLTOPlugin.so"}
+	got, err := plugin.LinkerFlags("linux")
+	if err != nil {
+		t.Fatalf("LinkerFlags() error: %v", err)
+	}
+	if !sameStrings(got, want) {
+		t.Fatalf("LinkerFlags() = %v, want %v", got, want)
+	}
+}
+
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/ltoplugin/CMakeLists.txt
+++ b/ltoplugin/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(LLGOLTOPlugin LANGUAGES CXX)
+
+find_package(LLVM REQUIRED CONFIG)
+
+if(NOT LLVM_VERSION_MAJOR EQUAL 19)
+  message(FATAL_ERROR "LLGo LTO plugin requires LLVM 19.x, found ${LLVM_PACKAGE_VERSION}")
+endif()
+
+message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+
+list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+include(AddLLVM)
+add_definitions(${LLVM_DEFINITIONS})
+
+add_llvm_pass_plugin(LLGOLTOPlugin
+  LLGOLTOPasses.cpp
+)
+
+target_compile_features(LLGOLTOPlugin PRIVATE cxx_std_17)
+target_include_directories(LLGOLTOPlugin PRIVATE ${LLVM_INCLUDE_DIRS})

--- a/ltoplugin/LLGOLTOPasses.cpp
+++ b/ltoplugin/LLGOLTOPasses.cpp
@@ -39,6 +39,10 @@ static constexpr char ReflectTypeMethodTypeIDPrefix[] =
     "go.method.type.reflect.";
 static constexpr unsigned MaxReflectMethodNames = 32;
 
+// Keep the replacement bounded. The pass is only meant to refine cases where
+// optimization has exposed a small finite set of names. If the set grows too
+// large we leave the original generic marker intact, which preserves the old
+// conservative GlobalDCE behavior.
 bool addName(SmallVectorImpl<std::string> &Names, StringRef Name) {
   for (const std::string &Existing : Names) {
     if (Existing == Name)
@@ -50,6 +54,11 @@ bool addName(SmallVectorImpl<std::string> &Names, StringRef Name) {
   return true;
 }
 
+// LLGo strings are lowered as (ptr, len). After LTO optimizations the pointer
+// usually still points into a private global string literal, possibly with a
+// constant GEP offset. Reading through the initializer lets the pass recover
+// names that are no longer visible to the Go SSA builder, for example after
+// inlining and scalar replacement.
 std::optional<std::string> readConstantString(Value *Ptr, Value *Len,
                                               const DataLayout &DL) {
   auto *LenC = dyn_cast<ConstantInt>(Len);
@@ -77,6 +86,12 @@ std::optional<std::string> readConstantString(Value *Ptr, Value *Len,
   return Bytes.substr(Start, Size).str();
 }
 
+// Collect every possible string from a lowered (ptr, len) pair.
+//
+// The pass is intentionally all-or-nothing: it returns false as soon as any
+// incoming value is unknown. That way a partially understood dynamic
+// MethodByName call cannot accidentally lose the generic reflect marker and
+// make GlobalDCE drop a method that may still be reachable at runtime.
 bool collectStringSet(Value *Ptr, Value *Len, const DataLayout &DL,
                       SmallVectorImpl<std::string> &Names,
                       unsigned Depth = 0) {
@@ -127,6 +142,9 @@ bool collectStringSetFromValue(Value *V, const DataLayout &DL,
                                SmallVectorImpl<std::string> &Names,
                                unsigned Depth = 0);
 
+// Some call sites still pass the Go string as an aggregate value before C ABI
+// lowering has fully split it. Rebuild the pair from constant structs or
+// insertvalue chains and then reuse the same ptr/len analysis.
 bool collectStringSetFromStringParts(Value *V, const DataLayout &DL,
                                      SmallVectorImpl<std::string> &Names,
                                      unsigned Depth) {
@@ -170,6 +188,9 @@ bool collectStringSetFromStringParts(Value *V, const DataLayout &DL,
   return collectStringSet(Ptr, Len, DL, Names, Depth + 1);
 }
 
+// Handle aggregate-level selects and phis. This mirrors collectStringSet for
+// split strings, but starts from a value that still represents the whole string
+// object.
 bool collectStringSetFromValue(Value *V, const DataLayout &DL,
                                SmallVectorImpl<std::string> &Names,
                                unsigned Depth) {
@@ -197,6 +218,9 @@ bool collectStringSetFromValue(Value *V, const DataLayout &DL,
   return false;
 }
 
+// A marked MethodByName call may appear either before or after LLGo's C ABI
+// lowering. In the lowered form the final two operands are the string pointer
+// and length; otherwise the final operand is the string aggregate.
 bool collectStringSetFromCallArgs(CallBase *ReflectCall, const DataLayout &DL,
                                   SmallVectorImpl<std::string> &Names) {
   if (ReflectCall->arg_size() >= 2) {
@@ -235,6 +259,16 @@ std::optional<StringRef> checkedLoadTypeID(CallBase *CheckedLoad) {
   return TypeID->getString();
 }
 
+// Remove the original broad marker:
+//
+//   %r = call @llvm.type.checked.load(..., !"go.method.*.reflect")
+//   %ok = extractvalue %r, 1
+//   call @llvm.assume(%ok)
+//
+// The pointer result is intentionally unused in LLGo's GlobalDCE markers, so
+// the pass only erases this pattern when all uses match the marker shape. If a
+// future IR change gives the checked-load result a real data dependency, the
+// pass fails loudly instead of silently changing semantics.
 bool eraseGenericCheckedLoad(CallBase *CheckedLoad) {
   SmallVector<Instruction *, 4> ToErase;
   for (User *U : make_early_inc_range(CheckedLoad->users())) {
@@ -270,6 +304,10 @@ bool eraseGenericCheckedLoad(CallBase *CheckedLoad) {
   return true;
 }
 
+// Replace one generic "some method may be reflected" marker with a disjunction
+// of name-specific markers. The name-specific type IDs are emitted on ABI method
+// slots by LLGo, so GlobalDCE can now keep only methods whose names are proven
+// reachable by this call.
 void insertMethodNameChecks(CallBase *GenericLoad,
                             ArrayRef<std::string> Names, StringRef Prefix) {
   IRBuilder<> B(GenericLoad);
@@ -292,6 +330,9 @@ void insertMethodNameChecks(CallBase *GenericLoad,
   B.CreateIntrinsic(Intrinsic::assume, {}, {AnyOK});
 }
 
+// LLGo emits a generic checked-load near a dynamic MethodByName call. For
+// reflect.Value.MethodByName the checked-load usually consumes a value derived
+// from the call result, so walking the use graph is enough to find it.
 bool isReflectMethodCheckedLoad(CallBase *CheckedLoad, StringRef GenericTypeID) {
   auto TypeID = checkedLoadTypeID(CheckedLoad);
   return TypeID && *TypeID == GenericTypeID;
@@ -322,6 +363,12 @@ void collectReflectMethodCheckedLoads(Value *V, StringRef GenericTypeID,
   }
 }
 
+// reflect.Type.MethodByName returns a pair through the C ABI in some cases. The
+// sret lowering can break the simple use-def chain between the marked call and
+// the generic checked-load. As a fallback, scan a small forward window in the
+// CFG until another marked reflect call is reached. The window keeps the pass
+// local and avoids accidentally rewriting markers that belong to unrelated
+// calls later in the function.
 void addReflectMethodCheckedLoad(CallBase *CheckedLoad, StringRef GenericTypeID,
                                  SmallPtrSetImpl<CallBase *> &SeenLoads,
                                  SmallVectorImpl<CallBase *> &Loads) {
@@ -397,6 +444,10 @@ public:
       if (!KnownNames || Names.empty())
         continue;
 
+      // First try the precise use-def search. Then add the bounded forward CFG
+      // scan so Type.MethodByName after ABI lowering can still be refined. Both
+      // searches target only the generic type ID selected by the call attribute,
+      // keeping reflect.Value and reflect.Type markers independent.
       SmallPtrSet<Value *, 16> Seen;
       SmallVector<CallBase *, 2> GenericLoads;
       collectReflectMethodCheckedLoads(ReflectCall, GenericTypeID, Seen,

--- a/ltoplugin/LLGOLTOPasses.cpp
+++ b/ltoplugin/LLGOLTOPasses.cpp
@@ -140,86 +140,6 @@ bool collectStringSet(Value *Ptr, Value *Len, const DataLayout &DL,
   return false;
 }
 
-bool collectStringSetFromValue(Value *V, const DataLayout &DL,
-                               SmallVectorImpl<std::string> &Names,
-                               unsigned Depth = 0);
-
-// Some call sites still pass the Go string as an aggregate value before C ABI
-// lowering has fully split it. Rebuild the pair from constant structs or
-// insertvalue chains and then reuse the same ptr/len analysis.
-bool collectStringSetFromStringParts(Value *V, const DataLayout &DL,
-                                     SmallVectorImpl<std::string> &Names,
-                                     unsigned Depth) {
-  if (Depth > 8)
-    return false;
-
-  Value *Ptr = nullptr;
-  Value *Len = nullptr;
-
-  if (auto *CS = dyn_cast<ConstantStruct>(V)) {
-    if (CS->getNumOperands() < 2)
-      return false;
-    Ptr = CS->getOperand(0);
-    Len = CS->getOperand(1);
-  } else {
-    Value *Cur = V;
-    while (auto *Insert = dyn_cast<InsertValueInst>(Cur)) {
-      if (Insert->getNumIndices() != 1)
-        return false;
-      unsigned Index = Insert->getIndices()[0];
-      if (Index == 0)
-        Ptr = Insert->getInsertedValueOperand();
-      else if (Index == 1)
-        Len = Insert->getInsertedValueOperand();
-      else
-        return false;
-      Cur = Insert->getAggregateOperand();
-    }
-    if (auto *CS = dyn_cast<ConstantStruct>(Cur)) {
-      if (CS->getNumOperands() < 2)
-        return false;
-      if (!Ptr)
-        Ptr = CS->getOperand(0);
-      if (!Len)
-        Len = CS->getOperand(1);
-    }
-  }
-
-  if (!Ptr || !Len)
-    return false;
-  return collectStringSet(Ptr, Len, DL, Names, Depth + 1);
-}
-
-// Handle aggregate-level selects and phis. This mirrors collectStringSet for
-// split strings, but starts from a value that still represents the whole string
-// object.
-bool collectStringSetFromValue(Value *V, const DataLayout &DL,
-                               SmallVectorImpl<std::string> &Names,
-                               unsigned Depth) {
-  if (Depth > 8)
-    return false;
-
-  if (collectStringSetFromStringParts(V, DL, Names, Depth))
-    return true;
-
-  if (auto *Sel = dyn_cast<SelectInst>(V)) {
-    return collectStringSetFromValue(Sel->getTrueValue(), DL, Names,
-                                     Depth + 1) &&
-           collectStringSetFromValue(Sel->getFalseValue(), DL, Names,
-                                     Depth + 1);
-  }
-
-  if (auto *Phi = dyn_cast<PHINode>(V)) {
-    for (Value *Incoming : Phi->incoming_values()) {
-      if (!collectStringSetFromValue(Incoming, DL, Names, Depth + 1))
-        return false;
-    }
-    return true;
-  }
-
-  return false;
-}
-
 std::optional<unsigned> findReflectMethodNameArg(CallBase *ReflectCall) {
   for (unsigned I = 0, E = ReflectCall->arg_size(); I != E; ++I) {
     Attribute Attr = ReflectCall->getParamAttr(I, ReflectMethodByNameArgAttr);
@@ -229,25 +149,23 @@ std::optional<unsigned> findReflectMethodNameArg(CallBase *ReflectCall) {
   return std::nullopt;
 }
 
-// The call-site function attribute tells us whether this is reflect.Value or
-// reflect.Type. The name operand itself is marked separately with a parameter
-// attribute by LLGo, and the C ABI transformer remaps that attribute when it
-// splits an aggregate string into (ptr, len). Therefore the plugin does not have
-// to infer the argument position from the callee signature or from arg_size().
+// The plugin runs during LTO, after LLGo has applied C ABI lowering to every
+// module that participates in the link. At this point a Go string argument is
+// always split into (ptr, len). LLGo marks the string pointer parameter, and the
+// length is the following parameter produced by the same lowering step.
 bool collectStringSetFromCallArgs(CallBase *ReflectCall, const DataLayout &DL,
                                   SmallVectorImpl<std::string> &Names) {
   std::optional<unsigned> NameArg = findReflectMethodNameArg(ReflectCall);
   if (!NameArg)
     return false;
 
-  Value *Arg = ReflectCall->getArgOperand(*NameArg);
-  if (Arg->getType()->isPointerTy() && *NameArg + 1 < ReflectCall->arg_size()) {
-    Value *Ptr = Arg;
-    Value *Len = ReflectCall->getArgOperand(*NameArg + 1);
-    if (Ptr->getType()->isPointerTy() && Len->getType()->isIntegerTy())
-      return collectStringSet(Ptr, Len, DL, Names);
-  }
-  return collectStringSetFromValue(Arg, DL, Names);
+  if (*NameArg + 1 >= ReflectCall->arg_size())
+    return false;
+  Value *Ptr = ReflectCall->getArgOperand(*NameArg);
+  Value *Len = ReflectCall->getArgOperand(*NameArg + 1);
+  if (!Ptr->getType()->isPointerTy() || !Len->getType()->isIntegerTy())
+    return false;
+  return collectStringSet(Ptr, Len, DL, Names);
 }
 
 bool isTypeCheckedLoad(CallBase *CB) {

--- a/ltoplugin/LLGOLTOPasses.cpp
+++ b/ltoplugin/LLGOLTOPasses.cpp
@@ -29,6 +29,8 @@ namespace {
 static constexpr char LLGOPreGlobalDCEPassName[] = "llgo-lto-pre-globaldce";
 static constexpr char ReflectMethodByNameCallAttr[] =
     "llgo.reflect.methodbyname";
+static constexpr char ReflectMethodByNameArgAttr[] =
+    "llgo.reflect.methodbyname.name";
 static constexpr char ReflectMethodByNameValueKind[] = "value";
 static constexpr char ReflectMethodByNameTypeKind[] = "type";
 static constexpr char ReflectValueMethodTypeID[] = "go.method.value.reflect";
@@ -218,19 +220,34 @@ bool collectStringSetFromValue(Value *V, const DataLayout &DL,
   return false;
 }
 
-// A marked MethodByName call may appear either before or after LLGo's C ABI
-// lowering. In the lowered form the final two operands are the string pointer
-// and length; otherwise the final operand is the string aggregate.
+std::optional<unsigned> findReflectMethodNameArg(CallBase *ReflectCall) {
+  for (unsigned I = 0, E = ReflectCall->arg_size(); I != E; ++I) {
+    Attribute Attr = ReflectCall->getParamAttr(I, ReflectMethodByNameArgAttr);
+    if (Attr.isStringAttribute())
+      return I;
+  }
+  return std::nullopt;
+}
+
+// The call-site function attribute tells us whether this is reflect.Value or
+// reflect.Type. The name operand itself is marked separately with a parameter
+// attribute by LLGo, and the C ABI transformer remaps that attribute when it
+// splits an aggregate string into (ptr, len). Therefore the plugin does not have
+// to infer the argument position from the callee signature or from arg_size().
 bool collectStringSetFromCallArgs(CallBase *ReflectCall, const DataLayout &DL,
                                   SmallVectorImpl<std::string> &Names) {
-  if (ReflectCall->arg_size() >= 2) {
-    Value *Ptr = ReflectCall->getArgOperand(ReflectCall->arg_size() - 2);
-    Value *Len = ReflectCall->getArgOperand(ReflectCall->arg_size() - 1);
+  std::optional<unsigned> NameArg = findReflectMethodNameArg(ReflectCall);
+  if (!NameArg)
+    return false;
+
+  Value *Arg = ReflectCall->getArgOperand(*NameArg);
+  if (Arg->getType()->isPointerTy() && *NameArg + 1 < ReflectCall->arg_size()) {
+    Value *Ptr = Arg;
+    Value *Len = ReflectCall->getArgOperand(*NameArg + 1);
     if (Ptr->getType()->isPointerTy() && Len->getType()->isIntegerTy())
       return collectStringSet(Ptr, Len, DL, Names);
   }
-  return collectStringSetFromValue(
-      ReflectCall->getArgOperand(ReflectCall->arg_size() - 1), DL, Names);
+  return collectStringSetFromValue(Arg, DL, Names);
 }
 
 bool isTypeCheckedLoad(CallBase *CB) {

--- a/ltoplugin/LLGOLTOPasses.cpp
+++ b/ltoplugin/LLGOLTOPasses.cpp
@@ -1,4 +1,16 @@
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Analysis/ValueTracking.h"
 #include "llvm/Config/llvm-config.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/CFG.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InstrTypes.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/Metadata.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Passes/PassBuilder.h"
@@ -7,23 +19,412 @@
 #include "llvm/Support/raw_ostream.h"
 
 #include <cstdlib>
+#include <optional>
+#include <string>
 
 using namespace llvm;
 
 namespace {
 
 static constexpr char LLGOPreGlobalDCEPassName[] = "llgo-lto-pre-globaldce";
+static constexpr char ReflectMethodByNameCallAttr[] =
+    "llgo.reflect.methodbyname";
+static constexpr char ReflectMethodByNameValueKind[] = "value";
+static constexpr char ReflectMethodByNameTypeKind[] = "type";
+static constexpr char ReflectValueMethodTypeID[] = "go.method.value.reflect";
+static constexpr char ReflectTypeMethodTypeID[] = "go.method.type.reflect";
+static constexpr char ReflectValueMethodTypeIDPrefix[] =
+    "go.method.value.reflect.";
+static constexpr char ReflectTypeMethodTypeIDPrefix[] =
+    "go.method.type.reflect.";
+static constexpr unsigned MaxReflectMethodNames = 32;
+
+bool addName(SmallVectorImpl<std::string> &Names, StringRef Name) {
+  for (const std::string &Existing : Names) {
+    if (Existing == Name)
+      return true;
+  }
+  if (Names.size() >= MaxReflectMethodNames)
+    return false;
+  Names.push_back(Name.str());
+  return true;
+}
+
+std::optional<std::string> readConstantString(Value *Ptr, Value *Len,
+                                              const DataLayout &DL) {
+  auto *LenC = dyn_cast<ConstantInt>(Len);
+  if (!LenC || LenC->isNegative())
+    return std::nullopt;
+  uint64_t Size = LenC->getZExtValue();
+
+  int64_t Offset = 0;
+  Value *Base = GetPointerBaseWithConstantOffset(Ptr, Offset, DL);
+  if (!Base || Offset < 0)
+    return std::nullopt;
+
+  auto *GV = dyn_cast<GlobalVariable>(Base->stripPointerCasts());
+  if (!GV || !GV->hasInitializer())
+    return std::nullopt;
+
+  auto *Data = dyn_cast<ConstantDataArray>(GV->getInitializer());
+  if (!Data || !Data->isString())
+    return std::nullopt;
+
+  StringRef Bytes = Data->getAsString();
+  uint64_t Start = static_cast<uint64_t>(Offset);
+  if (Start > Bytes.size() || Size > Bytes.size() - Start)
+    return std::nullopt;
+  return Bytes.substr(Start, Size).str();
+}
+
+bool collectStringSet(Value *Ptr, Value *Len, const DataLayout &DL,
+                      SmallVectorImpl<std::string> &Names,
+                      unsigned Depth = 0) {
+  if (Depth > 8)
+    return false;
+
+  Ptr = Ptr->stripPointerCasts();
+
+  if (auto Name = readConstantString(Ptr, Len, DL))
+    return addName(Names, *Name);
+
+  auto *PtrSel = dyn_cast<SelectInst>(Ptr);
+  auto *LenSel = dyn_cast<SelectInst>(Len);
+  if (PtrSel && LenSel && PtrSel->getCondition() == LenSel->getCondition()) {
+    return collectStringSet(PtrSel->getTrueValue(), LenSel->getTrueValue(), DL,
+                            Names, Depth + 1) &&
+           collectStringSet(PtrSel->getFalseValue(), LenSel->getFalseValue(),
+                            DL, Names, Depth + 1);
+  }
+  if (PtrSel && isa<ConstantInt>(Len)) {
+    return collectStringSet(PtrSel->getTrueValue(), Len, DL, Names,
+                            Depth + 1) &&
+           collectStringSet(PtrSel->getFalseValue(), Len, DL, Names,
+                            Depth + 1);
+  }
+
+  auto *PtrPhi = dyn_cast<PHINode>(Ptr);
+  auto *LenPhi = dyn_cast<PHINode>(Len);
+  if (PtrPhi && LenPhi && PtrPhi->getParent() == LenPhi->getParent() &&
+      PtrPhi->getNumIncomingValues() == LenPhi->getNumIncomingValues()) {
+    for (unsigned I = 0, E = PtrPhi->getNumIncomingValues(); I != E; ++I) {
+      BasicBlock *Incoming = PtrPhi->getIncomingBlock(I);
+      int LenIndex = LenPhi->getBasicBlockIndex(Incoming);
+      if (LenIndex < 0)
+        return false;
+      if (!collectStringSet(PtrPhi->getIncomingValue(I),
+                            LenPhi->getIncomingValue(LenIndex), DL, Names,
+                            Depth + 1))
+        return false;
+    }
+    return true;
+  }
+
+  return false;
+}
+
+bool collectStringSetFromValue(Value *V, const DataLayout &DL,
+                               SmallVectorImpl<std::string> &Names,
+                               unsigned Depth = 0);
+
+bool collectStringSetFromStringParts(Value *V, const DataLayout &DL,
+                                     SmallVectorImpl<std::string> &Names,
+                                     unsigned Depth) {
+  if (Depth > 8)
+    return false;
+
+  Value *Ptr = nullptr;
+  Value *Len = nullptr;
+
+  if (auto *CS = dyn_cast<ConstantStruct>(V)) {
+    if (CS->getNumOperands() < 2)
+      return false;
+    Ptr = CS->getOperand(0);
+    Len = CS->getOperand(1);
+  } else {
+    Value *Cur = V;
+    while (auto *Insert = dyn_cast<InsertValueInst>(Cur)) {
+      if (Insert->getNumIndices() != 1)
+        return false;
+      unsigned Index = Insert->getIndices()[0];
+      if (Index == 0)
+        Ptr = Insert->getInsertedValueOperand();
+      else if (Index == 1)
+        Len = Insert->getInsertedValueOperand();
+      else
+        return false;
+      Cur = Insert->getAggregateOperand();
+    }
+    if (auto *CS = dyn_cast<ConstantStruct>(Cur)) {
+      if (CS->getNumOperands() < 2)
+        return false;
+      if (!Ptr)
+        Ptr = CS->getOperand(0);
+      if (!Len)
+        Len = CS->getOperand(1);
+    }
+  }
+
+  if (!Ptr || !Len)
+    return false;
+  return collectStringSet(Ptr, Len, DL, Names, Depth + 1);
+}
+
+bool collectStringSetFromValue(Value *V, const DataLayout &DL,
+                               SmallVectorImpl<std::string> &Names,
+                               unsigned Depth) {
+  if (Depth > 8)
+    return false;
+
+  if (collectStringSetFromStringParts(V, DL, Names, Depth))
+    return true;
+
+  if (auto *Sel = dyn_cast<SelectInst>(V)) {
+    return collectStringSetFromValue(Sel->getTrueValue(), DL, Names,
+                                     Depth + 1) &&
+           collectStringSetFromValue(Sel->getFalseValue(), DL, Names,
+                                     Depth + 1);
+  }
+
+  if (auto *Phi = dyn_cast<PHINode>(V)) {
+    for (Value *Incoming : Phi->incoming_values()) {
+      if (!collectStringSetFromValue(Incoming, DL, Names, Depth + 1))
+        return false;
+    }
+    return true;
+  }
+
+  return false;
+}
+
+bool collectStringSetFromCallArgs(CallBase *ReflectCall, const DataLayout &DL,
+                                  SmallVectorImpl<std::string> &Names) {
+  if (ReflectCall->arg_size() >= 2) {
+    Value *Ptr = ReflectCall->getArgOperand(ReflectCall->arg_size() - 2);
+    Value *Len = ReflectCall->getArgOperand(ReflectCall->arg_size() - 1);
+    if (Ptr->getType()->isPointerTy() && Len->getType()->isIntegerTy())
+      return collectStringSet(Ptr, Len, DL, Names);
+  }
+  return collectStringSetFromValue(
+      ReflectCall->getArgOperand(ReflectCall->arg_size() - 1), DL, Names);
+}
+
+bool isTypeCheckedLoad(CallBase *CB) {
+  if (!CB)
+    return false;
+  auto *Callee = CB->getCalledFunction();
+  return Callee && Callee->getIntrinsicID() == Intrinsic::type_checked_load;
+}
+
+bool isAssume(CallBase *CB) {
+  if (!CB)
+    return false;
+  auto *Callee = CB->getCalledFunction();
+  return Callee && Callee->getIntrinsicID() == Intrinsic::assume;
+}
+
+std::optional<StringRef> checkedLoadTypeID(CallBase *CheckedLoad) {
+  if (!isTypeCheckedLoad(CheckedLoad) || CheckedLoad->arg_size() < 3)
+    return std::nullopt;
+  auto *MDValue = dyn_cast<MetadataAsValue>(CheckedLoad->getArgOperand(2));
+  if (!MDValue)
+    return std::nullopt;
+  auto *TypeID = dyn_cast<MDString>(MDValue->getMetadata());
+  if (!TypeID)
+    return std::nullopt;
+  return TypeID->getString();
+}
+
+bool eraseGenericCheckedLoad(CallBase *CheckedLoad) {
+  SmallVector<Instruction *, 4> ToErase;
+  for (User *U : make_early_inc_range(CheckedLoad->users())) {
+    auto *Extract = dyn_cast<ExtractValueInst>(U);
+    if (!Extract || Extract->getNumIndices() != 1)
+      return false;
+    unsigned Index = Extract->getIndices()[0];
+    if (Index == 0) {
+      if (!Extract->use_empty())
+        return false;
+      ToErase.push_back(Extract);
+      continue;
+    }
+    if (Index != 1)
+      return false;
+    for (User *EU : make_early_inc_range(Extract->users())) {
+      auto *Assume = dyn_cast<CallBase>(EU);
+      if (!isAssume(Assume))
+        return false;
+      ToErase.push_back(Assume);
+    }
+    ToErase.push_back(Extract);
+  }
+
+  for (Instruction *I : ToErase) {
+    if (!I->use_empty())
+      return false;
+    I->eraseFromParent();
+  }
+  if (!CheckedLoad->use_empty())
+    return false;
+  CheckedLoad->eraseFromParent();
+  return true;
+}
+
+void insertMethodNameChecks(CallBase *GenericLoad,
+                            ArrayRef<std::string> Names, StringRef Prefix) {
+  IRBuilder<> B(GenericLoad);
+  LLVMContext &Ctx = GenericLoad->getContext();
+  SmallVector<Value *, 8> OKs;
+  for (const std::string &Name : Names) {
+    std::string TypeID = (Prefix + Name).str();
+    Value *MDVal = MetadataAsValue::get(Ctx, MDString::get(Ctx, TypeID));
+    CallInst *Checked = B.CreateIntrinsic(
+        Intrinsic::type_checked_load, {},
+        {GenericLoad->getArgOperand(0), GenericLoad->getArgOperand(1), MDVal});
+    OKs.push_back(B.CreateExtractValue(Checked, {1}));
+  }
+  if (OKs.empty())
+    return;
+
+  Value *AnyOK = OKs.front();
+  for (Value *OK : ArrayRef<Value *>(OKs).drop_front())
+    AnyOK = B.CreateOr(AnyOK, OK);
+  B.CreateIntrinsic(Intrinsic::assume, {}, {AnyOK});
+}
+
+bool isReflectMethodCheckedLoad(CallBase *CheckedLoad, StringRef GenericTypeID) {
+  auto TypeID = checkedLoadTypeID(CheckedLoad);
+  return TypeID && *TypeID == GenericTypeID;
+}
+
+void collectReflectMethodCheckedLoads(Value *V, StringRef GenericTypeID,
+                                      SmallPtrSetImpl<Value *> &Seen,
+                                      SmallVectorImpl<CallBase *> &Loads,
+                                      unsigned Depth = 0) {
+  if (!V || Depth > 12 || !Seen.insert(V).second)
+    return;
+
+  for (User *U : V->users()) {
+    if (auto *CB = dyn_cast<CallBase>(U)) {
+      if (isReflectMethodCheckedLoad(CB, GenericTypeID))
+        Loads.push_back(CB);
+      continue;
+    }
+
+    auto *I = dyn_cast<Instruction>(U);
+    if (!I)
+      continue;
+    if (isa<ExtractValueInst>(I) || isa<InsertValueInst>(I) ||
+        isa<PHINode>(I) || isa<SelectInst>(I) || isa<CastInst>(I)) {
+      collectReflectMethodCheckedLoads(I, GenericTypeID, Seen, Loads,
+                                       Depth + 1);
+    }
+  }
+}
+
+void addReflectMethodCheckedLoad(CallBase *CheckedLoad, StringRef GenericTypeID,
+                                 SmallPtrSetImpl<CallBase *> &SeenLoads,
+                                 SmallVectorImpl<CallBase *> &Loads) {
+  if (isReflectMethodCheckedLoad(CheckedLoad, GenericTypeID) &&
+      SeenLoads.insert(CheckedLoad).second)
+    Loads.push_back(CheckedLoad);
+}
+
+void collectForwardReflectMethodCheckedLoads(
+    BasicBlock *BB, BasicBlock::iterator Start, StringRef GenericTypeID,
+    SmallPtrSetImpl<BasicBlock *> &SeenBlocks,
+    SmallPtrSetImpl<CallBase *> &SeenLoads, SmallVectorImpl<CallBase *> &Loads,
+    unsigned Depth = 0) {
+  if (!BB || Depth > 4 || !SeenBlocks.insert(BB).second)
+    return;
+
+  for (auto It = Start, E = BB->end(); It != E; ++It) {
+    auto *CB = dyn_cast<CallBase>(&*It);
+    if (!CB)
+      continue;
+    addReflectMethodCheckedLoad(CB, GenericTypeID, SeenLoads, Loads);
+    if (CB->hasFnAttr(ReflectMethodByNameCallAttr))
+      return;
+  }
+
+  Instruction *Term = BB->getTerminator();
+  if (!Term)
+    return;
+  for (BasicBlock *Succ : successors(Term))
+    collectForwardReflectMethodCheckedLoads(Succ, Succ->begin(), GenericTypeID,
+                                            SeenBlocks, SeenLoads, Loads,
+                                            Depth + 1);
+}
 
 class LLGOLTOPreGlobalDCEPass
     : public PassInfoMixin<LLGOLTOPreGlobalDCEPass> {
 public:
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &) {
-    if (std::getenv("LLGO_LTO_PLUGIN_VERBOSE")) {
-      errs() << "llgo-lto-plugin: running " << LLGOPreGlobalDCEPassName
-             << " on " << M.getModuleIdentifier() << "\n";
+    SmallVector<CallBase *, 16> Calls;
+    for (Function &F : M) {
+      for (BasicBlock &BB : F) {
+        for (Instruction &I : BB) {
+          auto *CB = dyn_cast<CallBase>(&I);
+          if (!CB || !CB->hasFnAttr(ReflectMethodByNameCallAttr))
+            continue;
+          Calls.push_back(CB);
+        }
+      }
     }
 
-    return PreservedAnalyses::all();
+    bool Changed = false;
+    const DataLayout &DL = M.getDataLayout();
+    for (CallBase *ReflectCall : Calls) {
+      Attribute KindAttr = ReflectCall->getFnAttr(ReflectMethodByNameCallAttr);
+      if (!KindAttr.isStringAttribute() || ReflectCall->arg_empty())
+        continue;
+
+      StringRef Prefix;
+      StringRef GenericTypeID;
+      StringRef Kind = KindAttr.getValueAsString();
+      if (Kind == ReflectMethodByNameValueKind) {
+        Prefix = ReflectValueMethodTypeIDPrefix;
+        GenericTypeID = ReflectValueMethodTypeID;
+      } else if (Kind == ReflectMethodByNameTypeKind) {
+        Prefix = ReflectTypeMethodTypeIDPrefix;
+        GenericTypeID = ReflectTypeMethodTypeID;
+      } else {
+        continue;
+      }
+
+      SmallVector<std::string, 4> Names;
+      bool KnownNames = collectStringSetFromCallArgs(ReflectCall, DL, Names);
+      if (!KnownNames || Names.empty())
+        continue;
+
+      SmallPtrSet<Value *, 16> Seen;
+      SmallVector<CallBase *, 2> GenericLoads;
+      collectReflectMethodCheckedLoads(ReflectCall, GenericTypeID, Seen,
+                                       GenericLoads);
+      SmallPtrSet<CallBase *, 4> SeenLoads;
+      for (CallBase *GenericLoad : GenericLoads)
+        SeenLoads.insert(GenericLoad);
+      SmallPtrSet<BasicBlock *, 8> SeenBlocks;
+      collectForwardReflectMethodCheckedLoads(
+          ReflectCall->getParent(), std::next(ReflectCall->getIterator()),
+          GenericTypeID, SeenBlocks, SeenLoads, GenericLoads);
+      for (CallBase *GenericLoad : GenericLoads) {
+        insertMethodNameChecks(GenericLoad, Names, Prefix);
+        if (!eraseGenericCheckedLoad(GenericLoad))
+          report_fatal_error(
+              "llgo-lto-plugin: failed to erase generic MethodByName check");
+        Changed = true;
+      }
+
+      if (!GenericLoads.empty() && std::getenv("LLGO_LTO_PLUGIN_VERBOSE")) {
+        errs() << "llgo-lto-plugin: refined " << Kind << " to";
+        for (const std::string &Name : Names)
+          errs() << " " << Name;
+        errs() << "\n";
+      }
+    }
+
+    return Changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
   }
 };
 
@@ -48,7 +449,6 @@ PassPluginLibraryInfo getLLGOLTOPluginInfo() {
           }};
 }
 
-extern "C" LLVM_ATTRIBUTE_WEAK PassPluginLibraryInfo
-llvmGetPassPluginInfo() {
+extern "C" LLVM_ATTRIBUTE_WEAK PassPluginLibraryInfo llvmGetPassPluginInfo() {
   return getLLGOLTOPluginInfo();
 }

--- a/ltoplugin/LLGOLTOPasses.cpp
+++ b/ltoplugin/LLGOLTOPasses.cpp
@@ -265,45 +265,11 @@ void insertMethodNameChecks(CallBase *GenericLoad,
   B.CreateIntrinsic(Intrinsic::assume, {}, {AnyOK});
 }
 
-// LLGo emits a generic checked-load near a dynamic MethodByName call. For
-// reflect.Value.MethodByName the checked-load usually consumes a value derived
-// from the call result, so walking the use graph is enough to find it.
 bool isReflectMethodCheckedLoad(CallBase *CheckedLoad, StringRef GenericTypeID) {
   auto TypeID = checkedLoadTypeID(CheckedLoad);
   return TypeID && *TypeID == GenericTypeID;
 }
 
-void collectReflectMethodCheckedLoads(Value *V, StringRef GenericTypeID,
-                                      SmallPtrSetImpl<Value *> &Seen,
-                                      SmallVectorImpl<CallBase *> &Loads,
-                                      unsigned Depth = 0) {
-  if (!V || Depth > 12 || !Seen.insert(V).second)
-    return;
-
-  for (User *U : V->users()) {
-    if (auto *CB = dyn_cast<CallBase>(U)) {
-      if (isReflectMethodCheckedLoad(CB, GenericTypeID))
-        Loads.push_back(CB);
-      continue;
-    }
-
-    auto *I = dyn_cast<Instruction>(U);
-    if (!I)
-      continue;
-    if (isa<ExtractValueInst>(I) || isa<InsertValueInst>(I) ||
-        isa<PHINode>(I) || isa<SelectInst>(I) || isa<CastInst>(I)) {
-      collectReflectMethodCheckedLoads(I, GenericTypeID, Seen, Loads,
-                                       Depth + 1);
-    }
-  }
-}
-
-// reflect.Type.MethodByName returns a pair through the C ABI in some cases. The
-// sret lowering can break the simple use-def chain between the marked call and
-// the generic checked-load. As a fallback, scan a small forward window in the
-// CFG until another marked reflect call is reached. The window keeps the pass
-// local and avoids accidentally rewriting markers that belong to unrelated
-// calls later in the function.
 void addReflectMethodCheckedLoad(CallBase *CheckedLoad, StringRef GenericTypeID,
                                  SmallPtrSetImpl<CallBase *> &SeenLoads,
                                  SmallVectorImpl<CallBase *> &Loads) {
@@ -312,6 +278,17 @@ void addReflectMethodCheckedLoad(CallBase *CheckedLoad, StringRef GenericTypeID,
     Loads.push_back(CheckedLoad);
 }
 
+// After C ABI lowering both reflect.Value.MethodByName and
+// reflect.Type.MethodByName have the same ordering property: LLGo emits the
+// marked runtime call first and then emits the generic reflect checked-load that
+// protects the returned method value. Value.MethodByName normally places that
+// checked-load in the same block immediately after the call; Type.MethodByName
+// may place it in the success successor because the returned "ok" flag guards
+// the method value. A bounded forward CFG scan covers both shapes.
+//
+// Stop at the next marked MethodByName call. This keeps the search local to the
+// current reflect call even when several MethodByName calls appear in the same
+// function.
 void collectForwardReflectMethodCheckedLoads(
     BasicBlock *BB, BasicBlock::iterator Start, StringRef GenericTypeID,
     SmallPtrSetImpl<BasicBlock *> &SeenBlocks,
@@ -379,17 +356,8 @@ public:
       if (!KnownNames || Names.empty())
         continue;
 
-      // First try the precise use-def search. Then add the bounded forward CFG
-      // scan so Type.MethodByName after ABI lowering can still be refined. Both
-      // searches target only the generic type ID selected by the call attribute,
-      // keeping reflect.Value and reflect.Type markers independent.
-      SmallPtrSet<Value *, 16> Seen;
       SmallVector<CallBase *, 2> GenericLoads;
-      collectReflectMethodCheckedLoads(ReflectCall, GenericTypeID, Seen,
-                                       GenericLoads);
       SmallPtrSet<CallBase *, 4> SeenLoads;
-      for (CallBase *GenericLoad : GenericLoads)
-        SeenLoads.insert(GenericLoad);
       SmallPtrSet<BasicBlock *, 8> SeenBlocks;
       collectForwardReflectMethodCheckedLoads(
           ReflectCall->getParent(), std::next(ReflectCall->getIterator()),

--- a/ltoplugin/LLGOLTOPasses.cpp
+++ b/ltoplugin/LLGOLTOPasses.cpp
@@ -3,7 +3,6 @@
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/IR/Constants.h"
-#include "llvm/IR/CFG.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstrTypes.h"
@@ -270,6 +269,14 @@ bool isReflectMethodCheckedLoad(CallBase *CheckedLoad, StringRef GenericTypeID) 
   return TypeID && *TypeID == GenericTypeID;
 }
 
+Value *getSRetArg(CallBase *CB) {
+  for (unsigned I = 0, E = CB->arg_size(); I != E; ++I) {
+    if (CB->paramHasAttr(I, Attribute::StructRet))
+      return CB->getArgOperand(I);
+  }
+  return nullptr;
+}
+
 void addReflectMethodCheckedLoad(CallBase *CheckedLoad, StringRef GenericTypeID,
                                  SmallPtrSetImpl<CallBase *> &SeenLoads,
                                  SmallVectorImpl<CallBase *> &Loads) {
@@ -278,41 +285,48 @@ void addReflectMethodCheckedLoad(CallBase *CheckedLoad, StringRef GenericTypeID,
     Loads.push_back(CheckedLoad);
 }
 
-// After C ABI lowering both reflect.Value.MethodByName and
-// reflect.Type.MethodByName have the same ordering property: LLGo emits the
-// marked runtime call first and then emits the generic reflect checked-load that
-// protects the returned method value. Value.MethodByName normally places that
-// checked-load in the same block immediately after the call; Type.MethodByName
-// may place it in the success successor because the returned "ok" flag guards
-// the method value. A bounded forward CFG scan covers both shapes.
+// MethodByName returns through an sret slot after C ABI lowering. LLGo then
+// emits the generic reflect checked-load from the method value extracted out of
+// that slot. This use-def walk is intentionally limited to value-preserving IR
+// around that slot: GEPs into the sret object, loads from those fields, and
+// scalar/aggregate extractions from the loaded values. It avoids a broad CFG
+// scan while still covering both lowered shapes:
 //
-// Stop at the next marked MethodByName call. This keeps the search local to the
-// current reflect call even when several MethodByName calls appear in the same
-// function.
-void collectForwardReflectMethodCheckedLoads(
-    BasicBlock *BB, BasicBlock::iterator Start, StringRef GenericTypeID,
-    SmallPtrSetImpl<BasicBlock *> &SeenBlocks,
+//   reflect.Value.MethodByName:
+//     call @reflect.Value.MethodByName(sret %ret, ...)
+//     %raw = load <2 x ptr>, ptr %ret
+//     %fn = extractelement <2 x ptr> %raw, 1
+//     call @llvm.type.checked.load(ptr %fn, ..., !"go.method.value.reflect")
+//
+//   reflect.Type.MethodByName:
+//     call %methodByName(sret %ret, ...)
+//     ... branch on the ok field ...
+//     %raw = load <2 x ptr>, ptr gep(%ret, method.func)
+//     %fn = extractelement <2 x ptr> %raw, 1
+//     call @llvm.type.checked.load(ptr %fn, ..., !"go.method.type.reflect")
+void collectSRetReflectMethodCheckedLoads(
+    Value *V, StringRef GenericTypeID, SmallPtrSetImpl<Value *> &SeenValues,
     SmallPtrSetImpl<CallBase *> &SeenLoads, SmallVectorImpl<CallBase *> &Loads,
     unsigned Depth = 0) {
-  if (!BB || Depth > 4 || !SeenBlocks.insert(BB).second)
+  if (!V || Depth > 16 || !SeenValues.insert(V).second)
     return;
 
-  for (auto It = Start, E = BB->end(); It != E; ++It) {
-    auto *CB = dyn_cast<CallBase>(&*It);
-    if (!CB)
+  for (User *U : V->users()) {
+    if (auto *CB = dyn_cast<CallBase>(U)) {
+      addReflectMethodCheckedLoad(CB, GenericTypeID, SeenLoads, Loads);
       continue;
-    addReflectMethodCheckedLoad(CB, GenericTypeID, SeenLoads, Loads);
-    if (CB->hasFnAttr(ReflectMethodByNameCallAttr))
-      return;
-  }
+    }
 
-  Instruction *Term = BB->getTerminator();
-  if (!Term)
-    return;
-  for (BasicBlock *Succ : successors(Term))
-    collectForwardReflectMethodCheckedLoads(Succ, Succ->begin(), GenericTypeID,
-                                            SeenBlocks, SeenLoads, Loads,
-                                            Depth + 1);
+    auto *I = dyn_cast<Instruction>(U);
+    if (!I)
+      continue;
+    if (isa<GetElementPtrInst>(I) || isa<LoadInst>(I) ||
+        isa<ExtractElementInst>(I) || isa<ExtractValueInst>(I) ||
+        isa<CastInst>(I) || isa<SelectInst>(I) || isa<PHINode>(I)) {
+      collectSRetReflectMethodCheckedLoads(I, GenericTypeID, SeenValues,
+                                           SeenLoads, Loads, Depth + 1);
+    }
+  }
 }
 
 class LLGOLTOPreGlobalDCEPass
@@ -358,10 +372,10 @@ public:
 
       SmallVector<CallBase *, 2> GenericLoads;
       SmallPtrSet<CallBase *, 4> SeenLoads;
-      SmallPtrSet<BasicBlock *, 8> SeenBlocks;
-      collectForwardReflectMethodCheckedLoads(
-          ReflectCall->getParent(), std::next(ReflectCall->getIterator()),
-          GenericTypeID, SeenBlocks, SeenLoads, GenericLoads);
+      SmallPtrSet<Value *, 16> SeenValues;
+      collectSRetReflectMethodCheckedLoads(getSRetArg(ReflectCall),
+                                           GenericTypeID, SeenValues, SeenLoads,
+                                           GenericLoads);
       for (CallBase *GenericLoad : GenericLoads) {
         insertMethodNameChecks(GenericLoad, Names, Prefix);
         if (!eraseGenericCheckedLoad(GenericLoad))

--- a/ltoplugin/LLGOLTOPasses.cpp
+++ b/ltoplugin/LLGOLTOPasses.cpp
@@ -1,0 +1,54 @@
+#include "llvm/Config/llvm-config.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Support/Compiler.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cstdlib>
+
+using namespace llvm;
+
+namespace {
+
+static constexpr char LLGOPreGlobalDCEPassName[] = "llgo-lto-pre-globaldce";
+
+class LLGOLTOPreGlobalDCEPass
+    : public PassInfoMixin<LLGOLTOPreGlobalDCEPass> {
+public:
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &) {
+    if (std::getenv("LLGO_LTO_PLUGIN_VERBOSE")) {
+      errs() << "llgo-lto-plugin: running " << LLGOPreGlobalDCEPassName
+             << " on " << M.getModuleIdentifier() << "\n";
+    }
+
+    return PreservedAnalyses::all();
+  }
+};
+
+} // namespace
+
+PassPluginLibraryInfo getLLGOLTOPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, "llgo-lto-plugin", LLVM_VERSION_STRING,
+          [](PassBuilder &PB) {
+            PB.registerPipelineParsingCallback(
+                [](StringRef Name, ModulePassManager &MPM,
+                   ArrayRef<PassBuilder::PipelineElement>) {
+                  if (Name != LLGOPreGlobalDCEPassName)
+                    return false;
+                  MPM.addPass(LLGOLTOPreGlobalDCEPass());
+                  return true;
+                });
+
+            PB.registerFullLinkTimeOptimizationEarlyEPCallback(
+                [](ModulePassManager &MPM, OptimizationLevel) {
+                  MPM.addPass(LLGOLTOPreGlobalDCEPass());
+                });
+          }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+  return getLLGOLTOPluginInfo();
+}

--- a/ltoplugin/README.md
+++ b/ltoplugin/README.md
@@ -1,0 +1,30 @@
+# LLGo LTO Plugin
+
+This directory contains the optional LLVM new pass manager plugin used by LLGo
+full LTO builds. It is not required to build or use LLGo.
+
+Build with the same LLVM 19 toolchain used by LLGo:
+
+```sh
+cmake -S ltoplugin -B ltoplugin/build \
+  -DLLVM_DIR=/path/to/llvm-19/lib/cmake/llvm \
+  -DCMAKE_BUILD_TYPE=Release
+cmake --build ltoplugin/build
+```
+
+Load the plugin when building with full LTO on Linux/ELF:
+
+```sh
+llgo build -lto=full -lto-pass-plugin=/path/to/LLGOLTOPlugin.so ./...
+```
+
+On macOS, the built plugin usually uses the `.dylib` suffix.
+
+The plugin registers `llgo-lto-pre-globaldce` and also inserts that pass through
+LLVM's full LTO early extension point, so loading the plugin is enough for the
+pass to run before the normal full LTO optimization pipeline proceeds.
+
+LLGo forwards the plugin path through lld's `--load-pass-plugin` option. LLVM 19
+`ld64.lld` and Apple `ld64` do not expose an equivalent new pass manager LTO
+plugin loading option for Mach-O links, so LLGo rejects `-lto-pass-plugin` for
+Darwin targets until the linker side grows that support.

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -1264,6 +1264,9 @@ func (b Builder) Call(fn Expr, args ...Expr) (ret Expr) {
 	}
 	ret.Type = b.Prog.retType(sig)
 	ret.impl = llvm.CreateCall(b.impl, ll, fn.impl, llvmParamsEx(data, args, sig.Params(), b))
+	if reflectCheck.Kind&ReflectMethodByName != 0 && reflectCheck.Name == "" {
+		b.MarkReflectValueMethodByNameCall(ret.impl)
+	}
 	b.EmitReflectValueMethodCheckedLoad(ret, reflectCheck)
 	return
 }
@@ -1322,7 +1325,8 @@ func (b Builder) checkReflect(fn Expr, args []Expr) (check ReflectMethodCheck) {
 				check.Name = v
 				break
 			}
-			reflectKind = ReflectMethodDynamic
+			reflectKind = ReflectMethodDynamic | ReflectMethodByName
+			check.NameArg = args[1]
 		}
 	}
 	pkg.NeedAbiInit |= reflectKind

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -1326,7 +1326,6 @@ func (b Builder) checkReflect(fn Expr, args []Expr) (check ReflectMethodCheck) {
 				break
 			}
 			reflectKind = ReflectMethodDynamic | ReflectMethodByName
-			check.NameArg = args[1]
 		}
 	}
 	pkg.NeedAbiInit |= reflectKind

--- a/ssa/expr.go
+++ b/ssa/expr.go
@@ -1265,7 +1265,11 @@ func (b Builder) Call(fn Expr, args ...Expr) (ret Expr) {
 	ret.Type = b.Prog.retType(sig)
 	ret.impl = llvm.CreateCall(b.impl, ll, fn.impl, llvmParamsEx(data, args, sig.Params(), b))
 	if reflectCheck.Kind&ReflectMethodByName != 0 && reflectCheck.Name == "" {
-		b.MarkReflectValueMethodByNameCall(ret.impl)
+		nameArgIndex := len(args) - 1
+		if !data.IsNil() {
+			nameArgIndex++
+		}
+		b.MarkReflectValueMethodByNameCall(ret.impl, nameArgIndex)
 	}
 	b.EmitReflectValueMethodCheckedLoad(ret, reflectCheck)
 	return

--- a/ssa/globaldce.go
+++ b/ssa/globaldce.go
@@ -24,9 +24,8 @@ const (
 )
 
 type ReflectMethodCheck struct {
-	Kind    int
-	Name    string
-	NameArg Expr
+	Kind int
+	Name string
 }
 
 func methodCapabilitySig(sig *types.Signature) string {

--- a/ssa/globaldce.go
+++ b/ssa/globaldce.go
@@ -16,13 +16,17 @@ const (
 	reflectValuePtrFieldIndex   = 1
 	reflectMethodFuncFieldIndex = 3
 
-	reflectValueMethodTypeID = "go.method.value.reflect"
-	reflectTypeMethodTypeID  = "go.method.type.reflect"
+	reflectValueMethodTypeID    = "go.method.value.reflect"
+	reflectTypeMethodTypeID     = "go.method.type.reflect"
+	reflectMethodByNameCallAttr = "llgo.reflect.methodbyname"
+	reflectMethodByNameValue    = "value"
+	reflectMethodByNameType     = "type"
 )
 
 type ReflectMethodCheck struct {
-	Kind int
-	Name string
+	Kind    int
+	Name    string
+	NameArg Expr
 }
 
 func methodCapabilitySig(sig *types.Signature) string {
@@ -173,6 +177,34 @@ func (p Program) methodCheckedLoad(b llvm.Builder, typedesc llvm.Value, typeID s
 	ok := llvm.CreateExtractValue(b, res, 1)
 	b.CreateIntrinsic(p.tyVoid(), llvm.LookupIntrinsicID("llvm.assume"), []llvm.Value{ok}, "")
 	return llvm.CreateExtractValue(b, res, 0)
+}
+
+func (b Builder) MarkReflectMethodByNameCall(call llvm.Value, kind string) {
+	if call.IsNil() {
+		return
+	}
+	if !b.Prog.enableLTOPluginMarker {
+		return
+	}
+	if call.IsACallInst().IsNil() && call.IsAInvokeInst().IsNil() {
+		return
+	}
+	call.AddCallSiteAttribute(-1, b.Prog.ctx.CreateStringAttribute(reflectMethodByNameCallAttr, kind))
+}
+
+func (b Builder) MarkReflectValueMethodByNameCall(call llvm.Value) {
+	b.MarkReflectMethodByNameCall(call, reflectMethodByNameValue)
+}
+
+func (b Builder) MarkReflectTypeMethodByNameCall(call llvm.Value) {
+	b.MarkReflectMethodByNameCall(call, reflectMethodByNameType)
+}
+
+func (b Builder) MarkReflectTypeMethodByNameExpr(call Expr) {
+	if call.IsNil() {
+		return
+	}
+	b.MarkReflectTypeMethodByNameCall(call.impl)
 }
 
 func (b Builder) EmitReflectValueMethodCheckedLoad(ret Expr, check ReflectMethodCheck) {

--- a/ssa/globaldce.go
+++ b/ssa/globaldce.go
@@ -19,6 +19,7 @@ const (
 	reflectValueMethodTypeID    = "go.method.value.reflect"
 	reflectTypeMethodTypeID     = "go.method.type.reflect"
 	reflectMethodByNameCallAttr = "llgo.reflect.methodbyname"
+	reflectMethodByNameArgAttr  = "llgo.reflect.methodbyname.name"
 	reflectMethodByNameValue    = "value"
 	reflectMethodByNameType     = "type"
 )
@@ -178,7 +179,7 @@ func (p Program) methodCheckedLoad(b llvm.Builder, typedesc llvm.Value, typeID s
 	return llvm.CreateExtractValue(b, res, 0)
 }
 
-func (b Builder) MarkReflectMethodByNameCall(call llvm.Value, kind string) {
+func (b Builder) MarkReflectMethodByNameCall(call llvm.Value, kind string, nameArgIndex int) {
 	if call.IsNil() {
 		return
 	}
@@ -189,21 +190,22 @@ func (b Builder) MarkReflectMethodByNameCall(call llvm.Value, kind string) {
 		return
 	}
 	call.AddCallSiteAttribute(-1, b.Prog.ctx.CreateStringAttribute(reflectMethodByNameCallAttr, kind))
+	call.AddCallSiteAttribute(nameArgIndex+1, b.Prog.ctx.CreateStringAttribute(reflectMethodByNameArgAttr, "1"))
 }
 
-func (b Builder) MarkReflectValueMethodByNameCall(call llvm.Value) {
-	b.MarkReflectMethodByNameCall(call, reflectMethodByNameValue)
+func (b Builder) MarkReflectValueMethodByNameCall(call llvm.Value, nameArgIndex int) {
+	b.MarkReflectMethodByNameCall(call, reflectMethodByNameValue, nameArgIndex)
 }
 
-func (b Builder) MarkReflectTypeMethodByNameCall(call llvm.Value) {
-	b.MarkReflectMethodByNameCall(call, reflectMethodByNameType)
+func (b Builder) MarkReflectTypeMethodByNameCall(call llvm.Value, nameArgIndex int) {
+	b.MarkReflectMethodByNameCall(call, reflectMethodByNameType, nameArgIndex)
 }
 
-func (b Builder) MarkReflectTypeMethodByNameExpr(call Expr) {
+func (b Builder) MarkReflectTypeMethodByNameExpr(call Expr, nameArgIndex int) {
 	if call.IsNil() {
 		return
 	}
-	b.MarkReflectTypeMethodByNameCall(call.impl)
+	b.MarkReflectTypeMethodByNameCall(call.impl, nameArgIndex)
 }
 
 func (b Builder) EmitReflectValueMethodCheckedLoad(ret Expr, check ReflectMethodCheck) {

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -232,8 +232,9 @@ type aProgram struct {
 
 	is32Bits bool
 
-	enableGoGlobalDCE bool
-	pthreadStackSize  uint64
+	enableGoGlobalDCE     bool
+	pthreadStackSize      uint64
+	enableLTOPluginMarker bool
 }
 
 type AbiSymbol struct {
@@ -331,6 +332,10 @@ func (p Program) EnableGoGlobalDCE(enable bool) {
 
 func (p Program) SetPthreadStackSize(size uint64) {
 	p.pthreadStackSize = size
+}
+
+func (p Program) EnableLTOPluginMarkers(enable bool) {
+	p.enableLTOPluginMarker = enable
 }
 
 // SetRuntime sets the runtime.

--- a/ssa/ssa_test.go
+++ b/ssa/ssa_test.go
@@ -511,6 +511,48 @@ func TestDevLTOGlobalDCEMethodCheckedLoadEmitsIntrinsicAndAssume(t *testing.T) {
 	}
 }
 
+func TestDevLTOGlobalDCEReflectMethodByNameCallMarkers(t *testing.T) {
+	requireGoGlobalDCE(t)
+
+	prog := NewProgram(nil)
+	pkg := prog.NewPackage("main", "main")
+	fn := pkg.NewFunc("UseReflectMethodByName", NoArgsNoRet, InC)
+	b := fn.MakeBody(1)
+	callTy := llvm.FunctionType(prog.tyVoid(), []llvm.Type{
+		prog.tyVoidPtr(),
+		prog.tyVoidPtr(),
+		prog.tyVoidPtr(),
+		prog.Int64().ll,
+	}, false)
+	callee := llvm.AddFunction(pkg.Module(), "reflect.Value.MethodByName", callTy)
+	call := llvm.CreateCall(b.impl, callTy, callee, []llvm.Value{
+		llvm.ConstPointerNull(prog.tyVoidPtr()),
+		llvm.ConstPointerNull(prog.tyVoidPtr()),
+		llvm.ConstPointerNull(prog.tyVoidPtr()),
+		llvm.ConstInt(prog.Int64().ll, 4, false),
+	})
+
+	b.MarkReflectValueMethodByNameCall(call, 2)
+	if attr := call.GetCallSiteStringAttribute(-1, reflectMethodByNameCallAttr); !attr.IsNil() {
+		t.Fatalf("reflect MethodByName call marker should be disabled by default")
+	}
+	if attr := call.GetCallSiteStringAttribute(3, reflectMethodByNameArgAttr); !attr.IsNil() {
+		t.Fatalf("reflect MethodByName name-arg marker should be disabled by default")
+	}
+
+	prog.EnableLTOPluginMarkers(true)
+	b.MarkReflectValueMethodByNameCall(call, 2)
+	if attr := call.GetCallSiteStringAttribute(-1, reflectMethodByNameCallAttr); attr.IsNil() || attr.GetStringValue() != reflectMethodByNameValue {
+		t.Fatalf("reflect MethodByName call marker = %v, want %q", attr, reflectMethodByNameValue)
+	}
+	if attr := call.GetCallSiteStringAttribute(3, reflectMethodByNameArgAttr); attr.IsNil() || attr.GetStringValue() != "1" {
+		t.Fatalf("reflect MethodByName name-arg marker = %v, want 1", attr)
+	}
+
+	b.MarkReflectTypeMethodByNameCall(llvm.ConstPointerNull(prog.tyVoidPtr()), 0)
+	b.Return()
+}
+
 func TestDevLTOGlobalDCEEmitFakeUsesInlineAsmAtEntry(t *testing.T) {
 	requireGoGlobalDCE(t)
 


### PR DESCRIPTION
## Summary
- Add an optional Linux LLVM LTO plugin that runs before LTO GlobalDCE and refines `reflect.Value.MethodByName` / `reflect.Type.MethodByName` reachability after LLVM optimization.
- Mark dynamic `MethodByName` call sites in LLGo IR with a reflect-kind attribute and mark the actual method-name argument separately, then preserve and remap those attributes through C ABI lowering.
- Use the plugin to replace broad dynamic reflect method checks with name-specific `llvm.type.checked.load` checks when optimized IR proves a finite string-name set, so GlobalDCE can remove methods that cannot be reached by those names.
- Keep the existing conservative behavior when the method name cannot be resolved precisely, and extend LTO tests with binary symbol checks to guard the expected removals.

## Implementation Details
The Go side emits two custom attributes only when the optional LTO plugin path is enabled:

- `llgo.reflect.methodbyname` on the call site, with `value` or `type` to distinguish `reflect.Value.MethodByName` from `reflect.Type.MethodByName`.
- `llgo.reflect.methodbyname.name` on the method-name parameter, so later lowering does not need to infer ABI-dependent argument positions.

`internal/cabi` now carries the call-site marker forward and remaps the name-parameter marker onto the lowered string data argument. This keeps the plugin independent of the pre-lowering Go ABI shape while still letting it find the string value precisely after C ABI lowering.

The plugin is built from `ltoplugin/` with CMake against LLVM 19 and registers at `FullLinkTimeOptimizationEarlyEP`. It scans marked reflect calls, derives finite string sets from the optimized IR, traces the call's `sret` result users to find the corresponding generic reflect checked-loads, adds name-specific checked-loads for each proven method name, and erases the generic dynamic check when the replacement is complete.

The reflect modeling still distinguishes Value and Type method metadata, so a `Value.MethodByName` use does not keep the broader `Type.MethodByName` set alive, and vice versa.

## Tests and CI
- Add LTO plugin cl tests for optimized finite-name `MethodByName` flows.
- Add symbol-table checks for GlobalDCE LTO cases, so tests assert that expected unused methods are absent from the final binary.
- Add Go unit coverage for SSA marker emission and C ABI remapping of the method-name parameter marker.
- Extend the dev LTO GlobalDCE GitHub Actions job on Linux to build the plugin and run the plugin-specific LTO tests with coverage output.

## Validation
- `cmake --build /tmp/llgo-ltoplugin-build`
- `LLGO_LTO_PLUGIN=/tmp/llgo-ltoplugin-build/LLGOLTOPlugin.so go test -tags dev ./cl -run '^(TestRunAndTestFromTestltoLTOPlugin|TestBuildAndCheckSymbolsFromTestltoLTOPlugin)' -count=1`
- `go test -tags dev ./cl -run '^TestBuildAndCheckSymbolsFromTestlto/globaldce_' -count=1`
- `LLGO_LTO_PLUGIN=/tmp/llgo-ltoplugin-build/LLGOLTOPlugin.so go test -tags=dev -timeout 30m -covermode=atomic -coverpkg=github.com/goplus/llgo/ssa,github.com/goplus/llgo/internal/build,github.com/goplus/llgo/internal/crosscompile -coverprofile=/tmp/coverage-dev-lto-plugin-cl.txt -run '^(TestRunAndTestFromTestltoLTOPlugin|TestBuildAndCheckSymbolsFromTestltoLTOPlugin)' ./cl`
- `go test -tags dev ./ssa ./internal/cabi -count=1`
- `go test -tags dev -cover ./ssa ./internal/cabi -count=1`
  - `github.com/goplus/llgo/ssa`: 87.5%
  - `github.com/goplus/llgo/internal/cabi`: 82.2%
