### PR TITLE
cltest: share one go-build cache across captured runs

### DIFF
--- a/cl/cltest/cltest.go
+++ b/cl/cltest/cltest.go
@@ -33,6 +33,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/goplus/gogen/packages"
@@ -313,6 +314,21 @@ func testRunAndTestFrom(t *testing.T, pkgDir, relPkg, sel string, opts runOption
 	}
 }
 
+// sharedGoCacheDir returns a per-process go-build cache reused by every
+// captured run. Isolation from the developer cache is preserved (fresh
+// temp dir per test process); sharing across tests avoids re-typechecking
+// the whole dependency graph for each of the ~170 golden dirs.
+var goCacheOnce sync.Once
+var goCacheDir string
+var goCacheErr error
+
+func sharedGoCacheDir() (string, error) {
+	goCacheOnce.Do(func() {
+		goCacheDir, goCacheErr = os.MkdirTemp("", "llgo-gocache-*")
+	})
+	return goCacheDir, goCacheErr
+}
+
 func RunAndCapture(relPkg, pkgDir string) ([]byte, error) {
 	conf := build.NewDefaultConf(build.ModeRun)
 	return RunAndCaptureWithConf(relPkg, pkgDir, conf)
@@ -376,11 +392,10 @@ func runWithConf(relPkg, pkgDir string, conf *build.Config) ([]byte, error) {
 }
 
 func doWithConf(relPkg, pkgDir string, conf *build.Config, action string) ([]byte, error) {
-	cacheDir, err := os.MkdirTemp("", "llgo-gocache-*")
+	cacheDir, err := sharedGoCacheDir()
 	if err != nil {
 		return nil, err
 	}
-	defer os.RemoveAll(cacheDir)
 	oldCache := os.Getenv("GOCACHE")
 	if err := os.Setenv("GOCACHE", cacheDir); err != nil {
 		return nil, err


### PR DESCRIPTION
CI-time investigation follow-up: the stage-5 branches' mac coverage job was running the `cl` package at 37-45 minutes, right at the 45m go-test alarm.

## What this PR does

`RunAndCapture` created a **fresh temp `GOCACHE` per test and deleted it afterwards**, so each of the ~170 golden-dir run tests re-typechecked the whole dependency graph from scratch. This shares one per-process temp cache instead:

- isolation from the developer cache is unchanged (still a fresh temp dir per test process, removed by the OS temp cleaner);
- sharing is **within one test binary only** (`sync.Once` package state) and tests inside a binary run serially, so no new concurrent access surface is introduced across the parallel test processes;
- the go build cache is content+flag keyed, so sharing across build configs is safe.

## Measurements (single-variable A/B: this one-file diff vs its parent, no `-p` flags)

- Local (darwin/arm64, interleaved rounds, heavy run-suites): 348s/308s -> 251s/240s, i.e. **328s -> 245s avg (-25%)**.
- CI coverage jobs vs the parent commit: mac **1508s -> 1061s (-30%)**, ubuntu **1376s -> 779s (-43%)**.
- Full `./cl` and `./ssa` suites green with the change; this PR's CI is green twice (pre- and post-scope-trim).

## What was considered and rejected first

- **Removing the `ssa` `TestFrom*` suites as duplicates of `cl`'s `TestRunAndTestFrom*`**: rejected — they verify the same golden specs, but per-package coverage attribution means they carry the `ssa` package's coverage: 87.5% with them, 51.3% without (measured).
- **`t.Parallel()` on the golden subtests**: rejected for now — `cltest`'s capture path swaps `os.Stdout/Stderr`, `os.Chdir`s, and mutates `GOCACHE` globally, and LLVM installs in-process signal handlers; under a cold cache this reproducibly fails (including a hard `fatal error: semasleep on Darwin signal stack`). Parallelizing needs a capture refactor (explicit `cmd.Dir/Env/Stdout`), tracked separately.

## Scope note

This PR is the cache sharing only. On the much heavier stage-5 branches, warm caches let the four heavy test packages' compile phases overlap fully, and the concurrent clang/lld burst killed 16GB ubuntu runners mid-run; those branches carry a `go test -p 2` mitigation locally. That cap is deliberately NOT part of this PR — it lowers the collision probability rather than provably removing the peak; the structural fix (splitting heavy packages into separate CI jobs) is the tracked follow-up if the deaths reappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
