### PR TITLE
runtime/internal/lib/runtime: add missing type/functions

### DIFF
--- a/runtime/internal/lib/runtime/covercounter.go
+++ b/runtime/internal/lib/runtime/covercounter.go
@@ -1,0 +1,19 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package runtime
+
+import (
+	_ "unsafe"
+)
+
+type covCounterBlob struct {
+	Counters *uint32
+	Len      uint64
+}
+
+//go:linkname coverage_getCovCounterList internal/coverage/cfile.getCovCounterList
+func coverage_getCovCounterList() []covCounterBlob {
+	return nil
+}

--- a/runtime/internal/lib/runtime/debug.go
+++ b/runtime/internal/lib/runtime/debug.go
@@ -10,3 +10,7 @@ func Breakpoint() {
 
 func Gosched() {
 }
+
+func NumCgoCall() int64 {
+	return 0
+}

--- a/runtime/internal/lib/runtime/debug_go125.go
+++ b/runtime/internal/lib/runtime/debug_go125.go
@@ -1,0 +1,7 @@
+//go:build go1.25
+// +build go1.25
+
+package runtime
+
+func SetDefaultGOMAXPROCS() {
+}

--- a/runtime/internal/lib/runtime/error.go
+++ b/runtime/internal/lib/runtime/error.go
@@ -1,0 +1,6 @@
+package runtime
+
+import "github.com/goplus/llgo/runtime/internal/runtime"
+
+type TypeAssertionError = runtime.TypeAssertionError
+type PanicNilError = runtime.PanicNilError

--- a/runtime/internal/lib/runtime/pinner.go
+++ b/runtime/internal/lib/runtime/pinner.go
@@ -1,0 +1,91 @@
+package runtime
+
+import (
+	"unsafe"
+
+	"github.com/goplus/llgo/runtime/abi"
+	"github.com/goplus/llgo/runtime/internal/runtime"
+)
+
+// A Pinner is a set of Go objects each pinned to a fixed location in memory. The
+// [Pinner.Pin] method pins one object, while [Pinner.Unpin] unpins all pinned
+// objects. See their comments for more information.
+type Pinner struct {
+	*pinner
+}
+
+// Pin pins a Go object, preventing it from being moved or freed by the garbage
+// collector until the [Pinner.Unpin] method has been called.
+//
+// A pointer to a pinned object can be directly stored in C memory or can be
+// contained in Go memory passed to C functions. If the pinned object itself
+// contains pointers to Go objects, these objects must be pinned separately if they
+// are going to be accessed from C code.
+//
+// The argument must be a pointer of any type or an [unsafe.Pointer].
+// It's safe to call Pin on non-Go pointers, in which case Pin will do nothing.
+func (p *Pinner) Pin(pointer any) {
+	if p.pinner == nil {
+		p.pinner = new(pinner)
+		p.refs = p.refStore[:0]
+
+		// We set this finalizer once and never clear it. Thus, if the
+		// pinner gets cached, we'll reuse it, along with its finalizer.
+		// This lets us avoid the relatively expensive SetFinalizer call
+		// when reusing from the cache. The finalizer however has to be
+		// resilient to an empty pinner being finalized, which is done
+		// by checking p.refs' length.
+		SetFinalizer(p.pinner, func(i *pinner) {
+			if len(i.refs) != 0 {
+				i.unpin() // only required to make the test idempotent
+				pinnerLeakPanic()
+			}
+		})
+	}
+	ptr := pinnerGetPtr(&pointer)
+	p.refs = append(p.refs, ptr)
+}
+
+// Unpin unpins all pinned objects of the [Pinner].
+func (p *Pinner) Unpin() {
+	p.pinner.unpin()
+}
+
+const (
+	pinnerSize         = 64
+	pinnerRefStoreSize = (pinnerSize - unsafe.Sizeof([]unsafe.Pointer{})) / unsafe.Sizeof(unsafe.Pointer(nil))
+)
+
+type pinner struct {
+	refs     []unsafe.Pointer
+	refStore [pinnerRefStoreSize]unsafe.Pointer
+}
+
+func (p *pinner) unpin() {
+	if p == nil || p.refs == nil {
+		return
+	}
+	// The following two lines make all pointers to references
+	// in p.refs unreachable, either by deleting them or dropping
+	// p.refs' backing store (if it was not backed by refStore).
+	p.refStore = [pinnerRefStoreSize]unsafe.Pointer{}
+	p.refs = p.refStore[:0]
+}
+
+func pinnerGetPtr(i *any) unsafe.Pointer {
+	e := (*eface)(unsafe.Pointer(i))
+	etyp := e._type
+	if etyp == nil {
+		runtime.PanicErrorString("runtime.Pinner: argument is nil")
+	}
+	if kind := etyp.Kind(); kind != abi.Pointer && kind != abi.UnsafePointer {
+		runtime.PanicErrorString("runtime.Pinner: argument is not a pointer: " + etyp.String())
+	}
+	return e.data
+}
+
+// to be able to test that the GC panics when a pinned pointer is leaking, this
+// panic function is a variable, that can be overwritten by a test.
+var pinnerLeakPanic = func() {
+	runtime.PanicErrorString("runtime.Pinner: found leaking pinned pointer; forgot to call Unpin()?")
+}

--- a/runtime/internal/lib/runtime/pprof_runtime_stub_llgo.go
+++ b/runtime/internal/lib/runtime/pprof_runtime_stub_llgo.go
@@ -87,3 +87,11 @@ func SetCPUProfileRate(hz int) {}
 func FuncForPC(pc uintptr) *Func {
 	return nil
 }
+
+func CPUProfile() []byte {
+	panic("CPUProfile no longer available")
+}
+
+func GoroutineProfile(p []StackRecord) (n int, ok bool) {
+	return
+}

--- a/runtime/internal/lib/runtime/runtime.go
+++ b/runtime/internal/lib/runtime/runtime.go
@@ -17,6 +17,7 @@
 package runtime
 
 import (
+	"sync/atomic"
 	"unsafe"
 
 	c "github.com/goplus/llgo/runtime/internal/clite"
@@ -57,3 +58,54 @@ func write(fd uintptr, p unsafe.Pointer, n int32) int32 {
 }
 
 const heapArenaBytes = 1024 * 1024
+
+// panicking is non-zero when crashing the program for an unrecovered panic.
+var panicking atomic.Uint32
+
+// crashFD is an optional file descriptor to use for fatal panics, as
+// set by debug.SetCrashOutput (see #42888). If it is a valid fd (not
+// all ones), writeErr and related functions write to it in addition
+// to standard error.
+//
+// Initialized to -1 in schedinit.
+var crashFD atomic.Uintptr
+
+//go:linkname setCrashFD
+func setCrashFD(fd uintptr) uintptr {
+	// Don't change the crash FD if a crash is already in progress.
+	//
+	// Unlike the case below, this is not required for correctness, but it
+	// is generally nicer to have all of the crash output go to the same
+	// place rather than getting split across two different FDs.
+	if panicking.Load() > 0 {
+		return ^uintptr(0)
+	}
+
+	old := crashFD.Swap(fd)
+
+	// If we are panicking, don't return the old FD to runtime/debug for
+	// closing. writeErrData may have already read the old FD from crashFD
+	// before the swap and closing it would cause the write to be lost [1].
+	// The old FD will never be closed, but we are about to crash anyway.
+	//
+	// On the writeErrData thread, panicking.Add(1) happens-before
+	// crashFD.Load() [2].
+	//
+	// On this thread, swapping old FD for new in crashFD happens-before
+	// panicking.Load() > 0.
+	//
+	// Therefore, if panicking.Load() == 0 here (old FD will be closed), it
+	// is impossible for the writeErrData thread to observe
+	// crashFD.Load() == old FD.
+	//
+	// [1] Or, if really unlucky, another concurrent open could reuse the
+	// FD, sending the write into an unrelated file.
+	//
+	// [2] If gp != nil, it occurs when incrementing gp.m.dying in
+	// startpanic_m. If gp == nil, we read panicking.Load() > 0, so an Add
+	// must have happened-before.
+	if panicking.Load() > 0 {
+		return ^uintptr(0)
+	}
+	return old
+}

--- a/runtime/internal/lib/runtime/trace_stub_llgo.go
+++ b/runtime/internal/lib/runtime/trace_stub_llgo.go
@@ -1,6 +1,8 @@
 package runtime
 
-import _ "unsafe"
+import (
+	"unsafe"
+)
 
 //go:linkname traceAdvance runtime.traceAdvance
 func traceAdvance(stopTrace bool) {}
@@ -22,3 +24,6 @@ func trace_userRegion(id, mode uint64, regionType string) {}
 
 //go:linkname trace_userLog runtime/trace.userLog
 func trace_userLog(id uint64, category, message string) {}
+
+func SetCgoTraceback(version int, traceback, context, symbolizer unsafe.Pointer) {
+}

--- a/runtime/internal/lib/runtime/tracetime_go125.go
+++ b/runtime/internal/lib/runtime/tracetime_go125.go
@@ -1,0 +1,35 @@
+//go:build go1.25
+// +build go1.25
+
+package runtime
+
+import (
+	_ "unsafe"
+)
+
+const (
+	// osHasLowResClockInt is osHasLowResClock but in integer form, so it can be used to create
+	// constants conditionally.
+	osHasLowResClockInt = IsWindows
+
+	// osHasLowResClock indicates that timestamps produced by nanotime on the platform have a
+	// low resolution, typically on the order of 1 ms or more.
+	osHasLowResClock = osHasLowResClockInt > 0
+)
+
+const traceTimeDiv = (1-osHasLowResClockInt)*64 + osHasLowResClockInt*(256-224*(IsPpc64|IsPpc64le))
+
+// traceClockUnitsPerSecond estimates the number of trace clock units per
+// second that elapse.
+//
+//go:linkname traceClockUnitsPerSecond runtime/trace.runtime_traceClockUnitsPerSecond
+func traceClockUnitsPerSecond() uint64 {
+	if osHasLowResClock {
+		// We're using cputicks as our clock, so we need a real estimate.
+		//return uint64(ticksPerSecond() / traceTimeDiv)
+		panic("TODO: ticksPerSecond for windows")
+	}
+	// Our clock is nanotime, so it's just the constant time division.
+	// (trace clock units / nanoseconds) * (1e9 nanoseconds / 1 second)
+	return uint64(1.0 / float64(traceTimeDiv) * 1e9)
+}

--- a/runtime/internal/lib/syscall/syscall_darwin.go
+++ b/runtime/internal/lib/syscall/syscall_darwin.go
@@ -15,6 +15,10 @@ func Syscall6(trap, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err syscall
 	return RawSyscall6(trap, a1, a2, a3, a4, a5, a6)
 }
 
+func Syscall9(trap, a1, a2, a3, a4, a5, a6, a7, a8, a9 uintptr) (r1, r2 uintptr, err syscall.Errno) {
+	return RawSyscall6(trap, a1, a2, a3, a4, a5, a6)
+}
+
 func RawSyscall(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err syscall.Errno) {
 	ret := c_syscall(c.Long(trap), a1, a2, a3)
 	if ret <= -1 {

--- a/runtime/internal/runtime/errors.go
+++ b/runtime/internal/runtime/errors.go
@@ -214,3 +214,21 @@ func pkgpath(t *_type) string {
 	}
 	return ""
 }
+
+// A PanicNilError happens when code calls panic(nil).
+//
+// Before Go 1.21, programs that called panic(nil) observed recover returning nil.
+// Starting in Go 1.21, programs that call panic(nil) observe recover returning a *PanicNilError.
+// Programs can change back to the old behavior by setting GODEBUG=panicnil=1.
+type PanicNilError struct {
+	// This field makes PanicNilError structurally different from
+	// any other struct in this package, and the _ makes it different
+	// from any struct in other packages too.
+	// This avoids any accidental conversions being possible
+	// between this struct and some other struct sharing the same fields,
+	// like happened in go.dev/issue/56603.
+	_ [0]*PanicNilError
+}
+
+func (*PanicNilError) Error() string { return "panic called with nil argument" }
+func (*PanicNilError) RuntimeError() {}

--- a/runtime/internal/runtime/z_error.go
+++ b/runtime/internal/runtime/z_error.go
@@ -63,6 +63,10 @@ func AssertIndexRange(b bool) {
 	}
 }
 
+func PanicErrorString(msg string) {
+	panic(errorString(msg))
+}
+
 func PanicIndex(x int, y int) {
 	panic(boundsError{x: int64(x), signed: true, y: y, code: boundsIndex})
 }

--- a/runtime/internal/runtime/z_rt.go
+++ b/runtime/internal/runtime/z_rt.go
@@ -49,6 +49,9 @@ func Recover() (ret any) {
 
 // Panic panics with a value.
 func Panic(v any) {
+	if v == nil {
+		v = &PanicNilError{}
+	}
 	ptr := c.Malloc(unsafe.Sizeof(v))
 	*(*any)(ptr) = v
 	excepKey.Set(ptr)


### PR DESCRIPTION
implementation
- runtime.Pinner
- runtime.PanicNilError `panic(nil)`
- runtime.TypeAssertionError

no-op implementation
- runtime.NumCgoCall
- runtime.CPUProfile
- runtime.GoroutineProfile
- runtime.coverage_getCovCounterList

   Go 1.25
- runtime.SetDefaultGOMAXPROCS
- runtime.traceClockUnitsPerSecond