### PR TITLE
runtime: add pthread stack size build flag

### DIFF
--- a/cl/_testgo/goroutine/in.go
+++ b/cl/_testgo/goroutine/in.go
@@ -6,14 +6,20 @@ func main() {
 	// CHECK: call ptr @"{{.*}}AllocZ"(i64 1)
 	// CHECK: store i1 false, ptr %0, align 1
 	// CHECK: call ptr @"{{.*}}AllocRoot"(i64 16)
-	// CHECK: call i32 @"{{.*}}CreateThread"(ptr %3, ptr null, ptr @"{{.*}}goroutine._llgo_routine$1", ptr %1)
+	// CHECK: alloca %"{{.*}}pthread.Attr", align 8
+	// CHECK: call i32 @"{{.*}}InitThreadAttr"
+	// CHECK: call i32 @"{{.*}}CreateThread"(ptr {{%[0-9]+}}, ptr {{%[0-9]+}}, ptr @"{{.*}}goroutine._llgo_routine$1", ptr %1)
+	// CHECK: call i32 @"{{.*}}DestroyThreadAttr"
 	done := false
 	go println("hello")
 	go func(s string) {
 		// CHECK: call ptr @"{{.*}}AllocU"(i64 8)
 		// CHECK: { ptr @"{{.*}}goroutine.main$1", ptr undef }
 		// CHECK: call ptr @"{{.*}}AllocRoot"(i64 32)
-		// CHECK: call i32 @"{{.*}}CreateThread"(ptr %11, ptr null, ptr @"{{.*}}goroutine._llgo_routine$2", ptr %8)
+		// CHECK: alloca %"{{.*}}pthread.Attr", align 8
+		// CHECK: call i32 @"{{.*}}InitThreadAttr"
+		// CHECK: call i32 @"{{.*}}CreateThread"(ptr {{%[0-9]+}}, ptr {{%[0-9]+}}, ptr @"{{.*}}goroutine._llgo_routine$2", ptr {{%[0-9]+}})
+		// CHECK: call i32 @"{{.*}}DestroyThreadAttr"
 		// CHECK: call void @"{{.*}}PrintString"(%"{{.*}}String" { ptr @2, i64 1 })
 		// CHECK: ret void
 		// CHECK-LABEL: define void @"{{.*}}goroutine.main$1"(ptr %0, %"{{.*}}String" %1){{.*}} {

--- a/cl/_testgo/selects/in.go
+++ b/cl/_testgo/selects/in.go
@@ -75,55 +75,58 @@ func main() {
 // CHECK-NEXT:   %13 = getelementptr inbounds { { ptr, ptr } }, ptr %12, i32 0, i32 0
 // CHECK-NEXT:   store { ptr, ptr } %11, ptr %13, align 8
 // CHECK-NEXT:   %14 = alloca i8, i64 8, align 1
-// CHECK-NEXT:   %15 = call i32 @"{{.*}}/runtime/internal/runtime.CreateThread"(ptr %14, ptr null, ptr @"{{.*}}/cl/_testgo/selects._llgo_routine$1", ptr %12)
-// CHECK-NEXT:   %16 = load ptr, ptr %0, align 8
-// CHECK-NEXT:   %17 = call ptr @llvm.stacksave.p0()
-// CHECK-NEXT:   %18 = alloca {}, align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %18, i8 0, i64 0, i1 false)
-// CHECK-NEXT:   store {} zeroinitializer, ptr %18, align 1
-// CHECK-NEXT:   %19 = call i1 @"{{.*}}/runtime/internal/runtime.ChanSend"(ptr %16, ptr %18, i64 0)
-// CHECK-NEXT:   call void @llvm.stackrestore.p0(ptr %17)
+// CHECK-NEXT:   %15 = alloca %"{{.*}}/runtime/internal/clite/pthread.Attr", align 8
+// CHECK-NEXT:   %16 = call i32 @"{{.*}}/runtime/internal/runtime.InitThreadAttr"(ptr %15)
+// CHECK-NEXT:   %17 = call i32 @"{{.*}}/runtime/internal/runtime.CreateThread"(ptr %14, ptr %15, ptr @"{{.*}}/cl/_testgo/selects._llgo_routine$1", ptr %12)
+// CHECK-NEXT:   %18 = call i32 @"{{.*}}/runtime/internal/runtime.DestroyThreadAttr"(ptr %15)
+// CHECK-NEXT:   %19 = load ptr, ptr %0, align 8
+// CHECK-NEXT:   %20 = call ptr @llvm.stacksave.p0()
+// CHECK-NEXT:   %21 = alloca {}, align 8
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %21, i8 0, i64 0, i1 false)
+// CHECK-NEXT:   store {} zeroinitializer, ptr %21, align 1
+// CHECK-NEXT:   %22 = call i1 @"{{.*}}/runtime/internal/runtime.ChanSend"(ptr %19, ptr %21, i64 0)
+// CHECK-NEXT:   call void @llvm.stackrestore.p0(ptr %20)
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @0, i64 4 })
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintByte"(i8 10)
-// CHECK-NEXT:   %20 = load ptr, ptr %2, align 8
-// CHECK-NEXT:   %21 = call ptr @llvm.stacksave.p0()
-// CHECK-NEXT:   %22 = alloca {}, align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %22, i8 0, i64 0, i1 false)
-// CHECK-NEXT:   %23 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" undef, ptr %20, 0
-// CHECK-NEXT:   %24 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %23, ptr %22, 1
-// CHECK-NEXT:   %25 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %24, i32 0, 2
-// CHECK-NEXT:   %26 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %25, i1 false, 3
-// CHECK-NEXT:   %27 = alloca {}, align 8
-// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %27, i8 0, i64 0, i1 false)
-// CHECK-NEXT:   %28 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" undef, ptr %6, 0
-// CHECK-NEXT:   %29 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %28, ptr %27, 1
-// CHECK-NEXT:   %30 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %29, i32 0, 2
-// CHECK-NEXT:   %31 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %30, i1 false, 3
-// CHECK-NEXT:   %32 = alloca i8, i64 48, align 1
-// CHECK-NEXT:   %33 = getelementptr %"{{.*}}/runtime/internal/runtime.ChanOp", ptr %32, i64 0
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.ChanOp" %26, ptr %33, align 8
-// CHECK-NEXT:   %34 = getelementptr %"{{.*}}/runtime/internal/runtime.ChanOp", ptr %32, i64 1
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.ChanOp" %31, ptr %34, align 8
-// CHECK-NEXT:   %35 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %32, 0
-// CHECK-NEXT:   %36 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %35, i64 2, 1
-// CHECK-NEXT:   %37 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %36, i64 2, 2
-// CHECK-NEXT:   %38 = call { i64, i1 } @"{{.*}}/runtime/internal/runtime.Select"(%"{{.*}}/runtime/internal/runtime.Slice" %37)
-// CHECK-NEXT:   %39 = extractvalue { i64, i1 } %38, 0
-// CHECK-NEXT:   %40 = extractvalue { i64, i1 } %38, 1
-// CHECK-NEXT:   %41 = extractvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %26, 1
-// CHECK-NEXT:   %42 = icmp eq ptr %41, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %42)
-// CHECK-NEXT:   %43 = extractvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %31, 1
-// CHECK-NEXT:   %44 = icmp eq ptr %43, null
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %44)
-// CHECK-NEXT:   call void @llvm.stackrestore.p0(ptr %21)
-// CHECK-NEXT:   %45 = insertvalue { i64, i1, {}, {} } undef, i64 %39, 0
-// CHECK-NEXT:   %46 = insertvalue { i64, i1, {}, {} } %45, i1 %40, 1
-// CHECK-NEXT:   %47 = insertvalue { i64, i1, {}, {} } %46, {} zeroinitializer, 2
-// CHECK-NEXT:   %48 = insertvalue { i64, i1, {}, {} } %47, {} zeroinitializer, 3
-// CHECK-NEXT:   %49 = extractvalue { i64, i1, {}, {} } %48, 0
-// CHECK-NEXT:   %50 = icmp eq i64 %49, 0
-// CHECK-NEXT:   br i1 %50, label %_llgo_2, label %_llgo_3
+// CHECK-NEXT:   %23 = load ptr, ptr %2, align 8
+// CHECK-NEXT:   %24 = call ptr @llvm.stacksave.p0()
+// CHECK-NEXT:   %25 = alloca {}, align 8
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %25, i8 0, i64 0, i1 false)
+// CHECK-NEXT:   %26 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" undef, ptr %23, 0
+// CHECK-NEXT:   %27 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %26, ptr %25, 1
+// CHECK-NEXT:   %28 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %27, i32 0, 2
+// CHECK-NEXT:   %29 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %28, i1 false, 3
+// CHECK-NEXT:   %30 = alloca {}, align 8
+// CHECK-NEXT:   call void @llvm.memset.p0.i64(ptr %30, i8 0, i64 0, i1 false)
+// CHECK-NEXT:   %31 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" undef, ptr %6, 0
+// CHECK-NEXT:   %32 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %31, ptr %30, 1
+// CHECK-NEXT:   %33 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %32, i32 0, 2
+// CHECK-NEXT:   %34 = insertvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %33, i1 false, 3
+// CHECK-NEXT:   %35 = alloca i8, i64 48, align 1
+// CHECK-NEXT:   %36 = getelementptr %"{{.*}}/runtime/internal/runtime.ChanOp", ptr %35, i64 0
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.ChanOp" %29, ptr %36, align 8
+// CHECK-NEXT:   %37 = getelementptr %"{{.*}}/runtime/internal/runtime.ChanOp", ptr %35, i64 1
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.ChanOp" %34, ptr %37, align 8
+// CHECK-NEXT:   %38 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" undef, ptr %35, 0
+// CHECK-NEXT:   %39 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %38, i64 2, 1
+// CHECK-NEXT:   %40 = insertvalue %"{{.*}}/runtime/internal/runtime.Slice" %39, i64 2, 2
+// CHECK-NEXT:   %41 = call { i64, i1 } @"{{.*}}/runtime/internal/runtime.Select"(%"{{.*}}/runtime/internal/runtime.Slice" %40)
+// CHECK-NEXT:   %42 = extractvalue { i64, i1 } %41, 0
+// CHECK-NEXT:   %43 = extractvalue { i64, i1 } %41, 1
+// CHECK-NEXT:   %44 = extractvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %29, 1
+// CHECK-NEXT:   %45 = icmp eq ptr %44, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %45)
+// CHECK-NEXT:   %46 = extractvalue %"{{.*}}/runtime/internal/runtime.ChanOp" %34, 1
+// CHECK-NEXT:   %47 = icmp eq ptr %46, null
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.AssertNilDeref"(i1 %47)
+// CHECK-NEXT:   call void @llvm.stackrestore.p0(ptr %24)
+// CHECK-NEXT:   %48 = insertvalue { i64, i1, {}, {} } undef, i64 %42, 0
+// CHECK-NEXT:   %49 = insertvalue { i64, i1, {}, {} } %48, i1 %43, 1
+// CHECK-NEXT:   %50 = insertvalue { i64, i1, {}, {} } %49, {} zeroinitializer, 2
+// CHECK-NEXT:   %51 = insertvalue { i64, i1, {}, {} } %50, {} zeroinitializer, 3
+// CHECK-NEXT:   %52 = extractvalue { i64, i1, {}, {} } %51, 0
+// CHECK-NEXT:   %53 = icmp eq i64 %52, 0
+// CHECK-NEXT:   br i1 %53, label %_llgo_2, label %_llgo_3
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_4, %_llgo_2
 // CHECK-NEXT:   ret void
@@ -134,8 +137,8 @@ func main() {
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_3:                                          ; preds = %_llgo_0
-// CHECK-NEXT:   %51 = icmp eq i64 %49, 1
-// CHECK-NEXT:   br i1 %51, label %_llgo_4, label %_llgo_5
+// CHECK-NEXT:   %54 = icmp eq i64 %52, 1
+// CHECK-NEXT:   br i1 %54, label %_llgo_4, label %_llgo_5
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_4:                                          ; preds = %_llgo_3
 // CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.PrintString"(%"{{.*}}/runtime/internal/runtime.String" { ptr @2, i64 4 })
@@ -143,10 +146,10 @@ func main() {
 // CHECK-NEXT:   br label %_llgo_1
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_5:                                          ; preds = %_llgo_3
-// CHECK-NEXT:   %52 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
-// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 31 }, ptr %52, align 8
-// CHECK-NEXT:   %53 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %52, 1
-// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %53)
+// CHECK-NEXT:   %55 = call ptr @"{{.*}}/runtime/internal/runtime.AllocU"(i64 16)
+// CHECK-NEXT:   store %"{{.*}}/runtime/internal/runtime.String" { ptr @3, i64 31 }, ptr %55, align 8
+// CHECK-NEXT:   %56 = insertvalue %"{{.*}}/runtime/internal/runtime.eface" { ptr @_llgo_string, ptr undef }, ptr %55, 1
+// CHECK-NEXT:   call void @"{{.*}}/runtime/internal/runtime.Panic"(%"{{.*}}/runtime/internal/runtime.eface" %56)
 // CHECK-NEXT:   unreachable
 // CHECK-NEXT: }
 

--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/goplus/llgo/cmd/internal/compilerhash"
 	"github.com/goplus/llgo/internal/build"
@@ -46,7 +47,68 @@ var SizeFormat string
 var SizeLevel string
 var ForceRebuild bool
 var PrintCommands bool
+var PthreadStackSize byteSizeFlag
 var OptLevel optlevel.Level
+
+type byteSizeFlag int64
+
+func (p *byteSizeFlag) String() string {
+	if p == nil {
+		return "0"
+	}
+	return strconv.FormatInt(int64(*p), 10)
+}
+
+func (p *byteSizeFlag) Set(v string) error {
+	n, err := parseByteSize(v)
+	if err != nil {
+		return err
+	}
+	*p = byteSizeFlag(n)
+	return nil
+}
+
+func parseByteSize(v string) (int64, error) {
+	s := strings.TrimSpace(v)
+	if s == "" {
+		return 0, fmt.Errorf("empty size")
+	}
+	if strings.HasPrefix(s, "-") {
+		return 0, fmt.Errorf("size must be >= 0")
+	}
+	i := 0
+	for i < len(s) && s[i] >= '0' && s[i] <= '9' {
+		i++
+	}
+	if i == 0 {
+		return 0, fmt.Errorf("invalid size %q", v)
+	}
+	n, err := strconv.ParseUint(s[:i], 10, 63)
+	if err != nil {
+		return 0, err
+	}
+	unit := strings.ToUpper(strings.TrimSpace(s[i:]))
+	mul, ok := map[string]uint64{
+		"":    1,
+		"B":   1,
+		"K":   1024,
+		"KB":  1024,
+		"KIB": 1024,
+		"M":   1024 * 1024,
+		"MB":  1024 * 1024,
+		"MIB": 1024 * 1024,
+		"G":   1024 * 1024 * 1024,
+		"GB":  1024 * 1024 * 1024,
+		"GIB": 1024 * 1024 * 1024,
+	}[unit]
+	if !ok {
+		return 0, fmt.Errorf("invalid size unit %q", strings.TrimSpace(s[i:]))
+	}
+	if n > uint64(^uint64(0)>>1)/mul {
+		return 0, fmt.Errorf("size %q overflows int64", v)
+	}
+	return int64(n * mul), nil
+}
 
 type ltoFlag struct {
 	Specified bool
@@ -137,6 +199,7 @@ func AddOptLevelFlags(fs *flag.FlagSet) {
 }
 
 func AddBuildFlags(fs *flag.FlagSet) {
+	PthreadStackSize = 0
 	fs.BoolVar(&ForceRebuild, "a", false, "Force rebuilding of packages that are already up-to-date")
 	fs.BoolVar(&PrintCommands, "x", false, "Print the commands")
 	AddOptLevelFlags(fs)
@@ -144,6 +207,7 @@ func AddBuildFlags(fs *flag.FlagSet) {
 	AddGlobalDCEFlag(fs)
 	fs.StringVar(&Tags, "tags", "", "Build tags")
 	fs.StringVar(&BuildEnv, "buildenv", "", "Build environment")
+	fs.Var(&PthreadStackSize, "pthread-stack-size", "Stack size for pthread-backed goroutines, e.g. 32MB or 1024KB (0 uses the platform default)")
 	if buildenv.Dev {
 		fs.IntVar(&AbiMode, "abi", 2, "ABI mode (default 2). 0 = none, 1 = cfunc, 2 = allfunc.")
 		fs.BoolVar(&CheckLinkArgs, "check-linkargs", false, "check link args valid")
@@ -272,6 +336,7 @@ func UpdateConfig(conf *build.Config) error {
 	conf.Port = Port
 	conf.BaudRate = BaudRate
 	conf.ForceRebuild = ForceRebuild
+	conf.PthreadStackSize = int64(PthreadStackSize)
 	if LTO.Specified {
 		conf.LTO = LTO.Mode
 	}

--- a/cmd/internal/flags/flags_test.go
+++ b/cmd/internal/flags/flags_test.go
@@ -129,6 +129,46 @@ func TestBuildLTOFlagInvalid(t *testing.T) {
 	}
 }
 
+func TestBuildPthreadStackSizeFlag(t *testing.T) {
+	tests := []struct {
+		arg  string
+		want int64
+	}{
+		{arg: "33554432", want: 33554432},
+		{arg: "32MB", want: 32 * 1024 * 1024},
+		{arg: "1024KB", want: 1024 * 1024},
+		{arg: "1GiB", want: 1024 * 1024 * 1024},
+		{arg: "0", want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.arg, func(t *testing.T) {
+			fs := flag.NewFlagSet("pthread-stack-size", flag.ContinueOnError)
+			fs.SetOutput(new(bytes.Buffer))
+			AddBuildFlags(fs)
+			if err := fs.Parse([]string{"-pthread-stack-size=" + tt.arg}); err != nil {
+				t.Fatalf("Parse unexpected error: %v", err)
+			}
+			conf := &build.Config{}
+			if err := UpdateConfig(conf); err != nil {
+				t.Fatalf("UpdateConfig error: %v", err)
+			}
+			if conf.PthreadStackSize != tt.want {
+				t.Fatalf("conf.PthreadStackSize = %d, want %d", conf.PthreadStackSize, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildPthreadStackSizeFlagRejectsNegative(t *testing.T) {
+	fs := flag.NewFlagSet("pthread-stack-size-negative", flag.ContinueOnError)
+	fs.SetOutput(new(bytes.Buffer))
+	AddBuildFlags(fs)
+	if err := fs.Parse([]string{"-pthread-stack-size=-1"}); err == nil {
+		t.Fatal("Parse expected error")
+	}
+}
+
 func TestDevLTOGlobalDCEBuildFlags(t *testing.T) {
 	if !buildenv.Dev {
 		fs := flag.NewFlagSet("nodev-globaldce", flag.ContinueOnError)

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -155,6 +155,10 @@ type Config struct {
 	SizeLevel     string // size aggregation level: full,module,package (default module)
 	CompilerHash  string // metadata hash for the running compiler (development builds only)
 
+	// PthreadStackSize sets a custom stack size, in bytes, for pthread-backed
+	// goroutines. A zero value keeps the platform pthread default.
+	PthreadStackSize int64
+
 	// DisableGoGlobalDCE disables Go-specific global DCE metadata emission
 	// when it would otherwise be enabled by full LTO.
 	DisableGoGlobalDCE bool
@@ -267,7 +271,6 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup crosscompile: %w", err)
 	}
-
 	// Update GOOS/GOARCH from export if target was used
 	if conf.Target != "" && export.GOOS != "" {
 		conf.Goos = export.GOOS
@@ -318,6 +321,9 @@ func Do(args []string, conf *Config) ([]Package, error) {
 
 	prog := llssa.NewProgram(target)
 	prog.EnableGoGlobalDCE(conf.goGlobalDCEEnabled())
+	if conf.PthreadStackSize > 0 {
+		prog.SetPthreadStackSize(uint64(conf.PthreadStackSize))
+	}
 	sizes := func(sizes types.Sizes, compiler, arch string) types.Sizes {
 		if arch == "wasm" {
 			sizes = &types.StdSizes{WordSize: 4, MaxAlign: 4}

--- a/runtime/internal/clite/pthread/pthread.go
+++ b/runtime/internal/clite/pthread/pthread.go
@@ -73,11 +73,18 @@ func Equal(t1, t2 Thread) c.Int
 // -----------------------------------------------------------------------------
 
 // Attr represents a POSIX thread attributes.
+//
+// pthread_attr_t is opaque and its exact layout varies across libc/OS targets.
+// Keep enough uintptr-aligned storage for the native pthread functions instead
+// of modeling individual fields.
 type Attr struct {
-	Detached byte
-	SsSp     *c.Char
-	SsSize   uintptr
+	_ [16]uintptr
 }
+
+const (
+	CreateJoinable = 0
+	CreateDetached = 1
+)
 
 // llgo:link (*Attr).Init C.pthread_attr_init
 func (attr *Attr) Init() c.Int { return 0 }

--- a/runtime/internal/runtime/z_thread.go
+++ b/runtime/internal/runtime/z_thread.go
@@ -23,6 +23,32 @@ import (
 	"github.com/goplus/llgo/runtime/internal/clite/pthread"
 )
 
+func InitThreadAttr(attr *pthread.Attr) c.Int {
+	if ret := attr.Init(); ret != 0 {
+		return ret
+	}
+	if ret := attr.SetDetached(pthread.CreateDetached); ret != 0 {
+		attr.Destroy()
+		return ret
+	}
+	return 0
+}
+
+func InitThreadAttrWithStack(attr *pthread.Attr, stackSize uintptr) c.Int {
+	if ret := InitThreadAttr(attr); ret != 0 {
+		return ret
+	}
+	if ret := attr.SetStackSize(stackSize); ret != 0 {
+		attr.Destroy()
+		return ret
+	}
+	return 0
+}
+
+func DestroyThreadAttr(attr *pthread.Attr) c.Int {
+	return attr.Destroy()
+}
+
 func CreateThread(th *pthread.Thread, attr *pthread.Attr, routine pthread.RoutineFunc, arg c.Pointer) c.Int {
 	return pthread.Create(th, attr, routine, arg)
 }

--- a/ssa/goroutine.go
+++ b/ssa/goroutine.go
@@ -41,6 +41,15 @@ func (b Builder) pthreadCreate(pp, attr, routine, arg Expr) Expr {
 	return b.Call(fn, pp, attr, routine, arg)
 }
 
+func (b Builder) pthreadAttr() Expr {
+	prog := b.Prog
+	fn := b.Pkg.rtFunc("CreateThread")
+	params := fn.raw.Type.(*types.Signature).Params()
+	attr := prog.rawType(params.At(1).Type())
+	elem := prog.rawType(attr.RawType().(*types.Pointer).Elem())
+	return b.AllocaT(elem)
+}
+
 // -----------------------------------------------------------------------------
 
 // The Go instruction creates a new goroutine and calls the specified
@@ -81,7 +90,15 @@ func (b Builder) Go(fn Expr, buildCall func(Builder, Expr, ...Expr) Expr, args .
 	data := Expr{dataPtr, voidPtr}
 	size := prog.SizeOf(voidPtr)
 	pthd := b.Alloca(prog.IntVal(uint64(size), prog.Uintptr()))
-	b.pthreadCreate(pthd, prog.Nil(voidPtr), pkg.routine(t, fn, buildCall, len(args)), data)
+	attr := b.pthreadAttr()
+	if prog.pthreadStackSize > 0 {
+		stackSize := prog.IntVal(prog.pthreadStackSize, prog.Uintptr())
+		b.Call(pkg.rtFunc("InitThreadAttrWithStack"), attr, stackSize)
+	} else {
+		b.Call(pkg.rtFunc("InitThreadAttr"), attr)
+	}
+	b.pthreadCreate(pthd, attr, pkg.routine(t, fn, buildCall, len(args)), data)
+	b.Call(pkg.rtFunc("DestroyThreadAttr"), attr)
 }
 
 func (p Package) routineName() string {

--- a/ssa/goroutine_patch_test.go
+++ b/ssa/goroutine_patch_test.go
@@ -81,3 +81,53 @@ func TestGoPanicRoutineDoesNotReturnAfterUnreachable(t *testing.T) {
 		t.Fatalf("goroutine wrapper should not return after unreachable:\n%s", ir)
 	}
 }
+
+func TestGoUsesPthreadAttrForDetachedStack(t *testing.T) {
+	prog := ssatest.NewProgram(t, nil)
+	prog.SetPthreadStackSize(32 << 20)
+	pkg := prog.NewPackage("bar", "foo/bar")
+
+	outer := pkg.NewFunc("outer", ssa.NoArgsNoRet, ssa.InGo)
+	ob := outer.MakeBody(1)
+	ob.Go(ssa.Nil, func(b ssa.Builder, _ ssa.Expr, args ...ssa.Expr) ssa.Expr {
+		return ssa.Expr{}
+	})
+	ob.Return()
+
+	ir := pkg.String()
+	initAttr := strings.Index(ir, `"github.com/goplus/llgo/runtime/internal/runtime.InitThreadAttrWithStack"`)
+	createThread := strings.Index(ir, `"github.com/goplus/llgo/runtime/internal/runtime.CreateThread"`)
+	destroyAttr := strings.Index(ir, `"github.com/goplus/llgo/runtime/internal/runtime.DestroyThreadAttr"`)
+	if initAttr < 0 || createThread < 0 || destroyAttr < 0 {
+		t.Fatalf("goroutine should initialize, use, and destroy pthread attrs:\n%s", ir)
+	}
+	if !(initAttr < createThread && createThread < destroyAttr) {
+		t.Fatalf("pthread attr calls should wrap CreateThread:\n%s", ir)
+	}
+	if !strings.Contains(ir, "33554432") {
+		t.Fatalf("goroutine should pass configured pthread stack size:\n%s", ir)
+	}
+	if strings.Contains(ir, "llgo_pthread_create_detached") {
+		t.Fatalf("goroutine should not call detached C wrapper:\n%s", ir)
+	}
+}
+
+func TestGoUsesPthreadAttrWithoutStackByDefault(t *testing.T) {
+	prog := ssatest.NewProgram(t, nil)
+	pkg := prog.NewPackage("bar", "foo/bar")
+
+	outer := pkg.NewFunc("outer", ssa.NoArgsNoRet, ssa.InGo)
+	ob := outer.MakeBody(1)
+	ob.Go(ssa.Nil, func(b ssa.Builder, _ ssa.Expr, args ...ssa.Expr) ssa.Expr {
+		return ssa.Expr{}
+	})
+	ob.Return()
+
+	ir := pkg.String()
+	if !strings.Contains(ir, `"github.com/goplus/llgo/runtime/internal/runtime.InitThreadAttr"`) {
+		t.Fatalf("goroutine should initialize pthread attrs:\n%s", ir)
+	}
+	if strings.Contains(ir, `"github.com/goplus/llgo/runtime/internal/runtime.InitThreadAttrWithStack"`) {
+		t.Fatalf("default goroutine should not request custom pthread stack size:\n%s", ir)
+	}
+}

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -233,6 +233,7 @@ type aProgram struct {
 	is32Bits bool
 
 	enableGoGlobalDCE bool
+	pthreadStackSize  uint64
 }
 
 type AbiSymbol struct {
@@ -326,6 +327,10 @@ func (p Program) SetCompileMethods(check func(Package, types.Type)) {
 
 func (p Program) EnableGoGlobalDCE(enable bool) {
 	p.enableGoGlobalDCE = enable
+}
+
+func (p Program) SetPthreadStackSize(size uint64) {
+	p.pthreadStackSize = size
 }
 
 // SetRuntime sets the runtime.


### PR DESCRIPTION
## Summary
- Add llgo build/test flag `-pthread-stack-size` with human-readable values such as `32MB` and `1024KB`.
- Pass the parsed byte size into SSA code generation instead of exposing a C compiler macro.
- Generate pthread attr setup for goroutine creation in `ssa/goroutine.go`: detached by default, and custom stack size only when requested.
- Use the existing Go pthread `Attr` wrapper; no extra C wrapper is needed.
- Treat `pthread.Attr` as opaque uintptr-aligned storage so native `pthread_attr_init` cannot overwrite llgo stack locals.
- Update `cl/_testgo` IR golden checks for the generated attr init/create/destroy sequence.

## Tests
- `go test ./cl -run 'TestRunAndTestFromTestgo/(goroutine|selects)$' -count=1 -v`
- `go test ./ssa -run 'TestGo.*Pthread|TestGoClosureStartupUsesGCManagedMemory|TestGoPanicRoutineDoesNotReturnAfterUnreachable' -count=1`
- `go test ./cmd/internal/flags -run 'TestBuildPthreadStackSize|TestBuildLTO' -count=1`
- `/opt/data/tmp/llgo-pr-split/llgo-stack test -timeout=20m github.com/goplus/llgo/test/cgo`
- `/opt/data/tmp/llgo-pr-split/llgo-stack test -pthread-stack-size=32MB -timeout=20m github.com/goplus/llgo/test/cgo`
- `/opt/data/tmp/llgo-pr-split/llgo-stack test -a -c -o /opt/data/tmp/llgo-pr-split/test.default ./test`
- `/opt/data/tmp/llgo-pr-split/llgo-stack test -a -pthread-stack-size=32MB -c -o /opt/data/tmp/llgo-pr-split/test.stack32m ./test`
- `nm -n` confirmed the default build references pthread attr init/detach/destroy but not `pthread_attr_setstacksize`; the 32MB build references `pthread_attr_setstacksize`.