### PR TITLE
runtime: serialize sync pool proc pin

### DIFF
--- a/runtime/internal/lib/runtime/sync_runtime_llgo.go
+++ b/runtime/internal/lib/runtime/sync_runtime_llgo.go
@@ -2,9 +2,19 @@
 
 package runtime
 
-import _ "unsafe"
+import (
+	_ "unsafe"
+
+	psync "github.com/goplus/llgo/runtime/internal/clite/pthread/sync"
+)
 
 var poolCleanup func()
+var procPinOnce psync.Once
+var procPinMu psync.Mutex
+
+func initProcPinMu() {
+	procPinMu.Init(nil)
+}
 
 //go:linkname sync_runtime_registerPoolCleanup sync.runtime_registerPoolCleanup
 func sync_runtime_registerPoolCleanup(cleanup func()) {
@@ -13,19 +23,25 @@ func sync_runtime_registerPoolCleanup(cleanup func()) {
 
 //go:linkname sync_runtime_procPin sync.runtime_procPin
 func sync_runtime_procPin() int {
+	procPinOnce.Do(initProcPinMu)
+	procPinMu.Lock()
 	return 0
 }
 
 //go:linkname sync_runtime_procUnpin sync.runtime_procUnpin
-func sync_runtime_procUnpin() {}
+func sync_runtime_procUnpin() {
+	procPinMu.Unlock()
+}
 
 // sync/atomic.Value expects these package-local runtime hooks.
 // In llgo they can share the same no-op pin/unpin behavior as sync.
 //
 //go:linkname atomic_runtime_procPin sync/atomic.runtime_procPin
 func atomic_runtime_procPin() int {
-	return 0
+	return sync_runtime_procPin()
 }
 
 //go:linkname atomic_runtime_procUnpin sync/atomic.runtime_procUnpin
-func atomic_runtime_procUnpin() {}
+func atomic_runtime_procUnpin() {
+	sync_runtime_procUnpin()
+}

--- a/test/syncpool/sync_pool_test.go
+++ b/test/syncpool/sync_pool_test.go
@@ -1,0 +1,41 @@
+package syncpool
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestPoolDoesNotReturnItemConcurrently(t *testing.T) {
+	type item struct {
+		inUse int32
+	}
+
+	var p sync.Pool
+	p.New = func() any {
+		return new(item)
+	}
+
+	var failed int32
+	var wg sync.WaitGroup
+	for g := 0; g < 32; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				x := p.Get().(*item)
+				if !atomic.CompareAndSwapInt32(&x.inUse, 0, 1) {
+					atomic.StoreInt32(&failed, 1)
+					return
+				}
+				atomic.StoreInt32(&x.inUse, 0)
+				p.Put(x)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if atomic.LoadInt32(&failed) != 0 {
+		t.Fatal("sync.Pool returned an item while it was still in use")
+	}
+}


### PR DESCRIPTION
## Summary
- Serialize llgo's sync runtime procPin/procUnpin hooks with a pthread mutex.
- Route sync/atomic.Value procPin/procUnpin through the same hooks.
- Add a concurrent sync.Pool regression that fails if one item is handed to multiple goroutines at once.

## Tests
- `/opt/data/tmp/llgo-pr-split/llgo-syncpool test -timeout=180s ./test/syncpool ./test/std/sync -count=1`