### PR TITLE
Fold static global literal initializers

### DIFF
--- a/cl/_testdata/importpkg/in.go
+++ b/cl/_testdata/importpkg/in.go
@@ -3,6 +3,8 @@ package main
 
 import "github.com/goplus/llgo/cl/_testdata/importpkg/stdio"
 
+// CHECK: @"{{.*}}.hello" = global [7 x i8] c"Hello\0A\00", align 1
+
 // CHECK-LABEL: define void @"{{.*}}.init"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %0 = load i1, ptr @"{{.*}}.init$guard", align 1
@@ -11,13 +13,7 @@ import "github.com/goplus/llgo/cl/_testdata/importpkg/stdio"
 // CHECK-NEXT: _llgo_1:{{.*}}
 // CHECK-NEXT:   store i1 true, ptr @"{{.*}}.init$guard", align 1
 // CHECK-NEXT:   call void @"{{.*}}/stdio.init"()
-// CHECK-NEXT:   store i8 72, ptr @"{{.*}}.hello", align 1
-// CHECK-NEXT:   store i8 101, ptr getelementptr inbounds (i8, ptr @"{{.*}}importpkg.hello", i64 1), align 1
-// CHECK-NEXT:   store i8 108, ptr getelementptr inbounds (i8, ptr @"{{.*}}importpkg.hello", i64 2), align 1
-// CHECK-NEXT:   store i8 108, ptr getelementptr inbounds (i8, ptr @"{{.*}}importpkg.hello", i64 3), align 1
-// CHECK-NEXT:   store i8 111, ptr getelementptr inbounds (i8, ptr @"{{.*}}importpkg.hello", i64 4), align 1
-// CHECK-NEXT:   store i8 10, ptr getelementptr inbounds (i8, ptr @"{{.*}}importpkg.hello", i64 5), align 1
-// CHECK-NEXT:   store i8 0, ptr getelementptr inbounds (i8, ptr @"{{.*}}importpkg.hello", i64 6), align 1
+// CHECK-NEXT:   br label %_llgo_2
 var hello = [...]int8{'H', 'e', 'l', 'l', 'o', '\n', 0}
 
 // CHECK-LABEL: define void @"{{.*}}.main"(){{.*}} {

--- a/cl/_testdata/method/in.go
+++ b/cl/_testdata/method/in.go
@@ -3,8 +3,9 @@ package main
 
 import _ "unsafe"
 
-// CHECK: {{^}}@0 = private unnamed_addr constant [44 x i8] c"{{.*}}/cl/_testdata/method.T", align 1{{$}}
-// CHECK: {{^}}@1 = private unnamed_addr constant [3 x i8] c"Add", align 1{{$}}
+// CHECK-DAG: {{^}}@0 = private unnamed_addr constant [44 x i8] c"{{.*}}/cl/_testdata/method.T", align 1{{$}}
+// CHECK-DAG: {{^}}@1 = private unnamed_addr constant [3 x i8] c"Add", align 1{{$}}
+// CHECK-DAG: @"{{.*}}/cl/_testdata/method.format" = global [10 x i8] c"Hello %d\0A\00", align 1
 
 type T int
 
@@ -44,16 +45,6 @@ func main() {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testdata/method.init$guard", align 1
-// CHECK-NEXT:   store i8 72, ptr @"{{.*}}/cl/_testdata/method.format", align 1
-// CHECK-NEXT:   store i8 101, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testdata/method.format", i64 1), align 1
-// CHECK-NEXT:   store i8 108, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testdata/method.format", i64 2), align 1
-// CHECK-NEXT:   store i8 108, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testdata/method.format", i64 3), align 1
-// CHECK-NEXT:   store i8 111, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testdata/method.format", i64 4), align 1
-// CHECK-NEXT:   store i8 32, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testdata/method.format", i64 5), align 1
-// CHECK-NEXT:   store i8 37, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testdata/method.format", i64 6), align 1
-// CHECK-NEXT:   store i8 100, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testdata/method.format", i64 7), align 1
-// CHECK-NEXT:   store i8 10, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testdata/method.format", i64 8), align 1
-// CHECK-NEXT:   store i8 0, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testdata/method.format", i64 9), align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0

--- a/cl/_testdata/print/in.go
+++ b/cl/_testdata/print/in.go
@@ -109,7 +109,6 @@ func bytes(s string) (ret []byte) {
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testdata/print.init$guard", align 1
-// CHECK-NEXT:   store i64 0, ptr @"{{.*}}/cl/_testdata/print.minhexdigits", align 8
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0

--- a/cl/_testdata/untyped/in.go
+++ b/cl/_testdata/untyped/in.go
@@ -5,7 +5,7 @@ const c = 100
 
 var a float64 = 1
 
-// CHECK: @"{{.*}}/untyped.a" = global double 0.000000e+00, align 8
+// CHECK: @"{{.*}}/untyped.a" = global double 1.000000e+00, align 8
 
 // CHECK-LABEL: define void @"{{.*}}.main"(){{.*}} {
 // CHECK-NEXT: _llgo_0:

--- a/cl/_testdata/utf8/in.go
+++ b/cl/_testdata/utf8/in.go
@@ -5,6 +5,8 @@ import (
 	"unicode/utf8"
 )
 
+// CHECK: @"{{.*}}.array" = global [8 x i8] c"\01\02\03\04\05\06\07\08", align 1
+
 // CHECK-LABEL: define i8 @"{{.*}}.index"(i8 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = sext i8 %0 to i64
@@ -22,7 +24,6 @@ func index(n int8) uint8 {
 
 // CHECK-LABEL: define void @"{{.*}}.init"(){{.*}} {
 // CHECK:   call void @"unicode/utf8.init"()
-// CHECK:   store i8 1, ptr @"{{.*}}.array", align 1
 var array = [...]uint8{
 	1, 2, 3, 4, 5, 6, 7, 8,
 }

--- a/cl/_testrt/gblarray/in.go
+++ b/cl/_testrt/gblarray/in.go
@@ -6,6 +6,8 @@ import (
 	"github.com/goplus/llgo/runtime/abi"
 )
 
+// CHECK: @"{{.*}}/cl/_testrt/gblarray.sizeBasicTypes" = global [25 x i64] [i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 16], align 8
+
 // CHECK-LABEL: define ptr @"{{.*}}/cl/_testrt/gblarray.Basic"(i64 %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %1 = icmp uge i64 %0, 25
@@ -51,7 +53,6 @@ func basicType(kind abi.Kind) *abi.Type {
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/gblarray.init$guard", align 1
 // CHECK-NEXT:   call void @"{{.*}}/runtime/abi.init"()
-// CHECK-NEXT:   store i64 16, ptr getelementptr inbounds (i64, ptr @"{{.*}}/cl/_testrt/gblarray.sizeBasicTypes", i64 24), align 8
 // CHECK-NEXT:   %1 = call ptr @"{{.*}}/cl/_testrt/gblarray.basicType"(i64 24)
 // CHECK-NEXT:   store ptr %1, ptr getelementptr inbounds (ptr, ptr @"{{.*}}/cl/_testrt/gblarray.basicTypes", i64 24), align 8
 // CHECK-NEXT:   br label %_llgo_2

--- a/cl/_testrt/hello/in.go
+++ b/cl/_testrt/hello/in.go
@@ -3,7 +3,7 @@ package main
 
 import "github.com/goplus/llgo/cl/_testrt/hello/libc"
 
-// CHECK: {{^}}@"{{.*}}/cl/_testrt/hello.format" = global [10 x i8] zeroinitializer, align 1{{$}}
+// CHECK: {{^}}@"{{.*}}/cl/_testrt/hello.format" = global [10 x i8] c"Hello %d\0A\00", align 1{{$}}
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/hello.init"(){{.*}} {
 // CHECK-NEXT: _llgo_0:
@@ -12,16 +12,6 @@ import "github.com/goplus/llgo/cl/_testrt/hello/libc"
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/hello.init$guard", align 1
-// CHECK-NEXT:   store i8 72, ptr @"{{.*}}/cl/_testrt/hello.format", align 1
-// CHECK-NEXT:   store i8 101, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/hello.format", i64 1), align 1
-// CHECK-NEXT:   store i8 108, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/hello.format", i64 2), align 1
-// CHECK-NEXT:   store i8 108, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/hello.format", i64 3), align 1
-// CHECK-NEXT:   store i8 111, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/hello.format", i64 4), align 1
-// CHECK-NEXT:   store i8 32, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/hello.format", i64 5), align 1
-// CHECK-NEXT:   store i8 37, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/hello.format", i64 6), align 1
-// CHECK-NEXT:   store i8 100, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/hello.format", i64 7), align 1
-// CHECK-NEXT:   store i8 10, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/hello.format", i64 8), align 1
-// CHECK-NEXT:   store i8 0, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/hello.format", i64 9), align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0

--- a/cl/_testrt/litdemo/in.go
+++ b/cl/_testrt/litdemo/in.go
@@ -3,6 +3,8 @@ package main
 
 var seed = 40
 
+// CHECK: @"{{.*}}/cl/_testrt/litdemo.seed" = global i64 40, align 8
+
 // CHECK-LABEL: define i64 @"{{.*}}/cl/_testrt/litdemo.add"(i64 %0, i64 %1){{.*}} {
 // CHECK-NEXT: _llgo_0:
 // CHECK-NEXT:   %2 = add i64 %0, %1
@@ -16,7 +18,6 @@ var seed = 40
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/litdemo.init$guard", align 1
-// CHECK-NEXT:   store i64 40, ptr @"{{.*}}/cl/_testrt/litdemo.seed", align 8
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0

--- a/cl/_testrt/struct/in.go
+++ b/cl/_testrt/struct/in.go
@@ -4,8 +4,9 @@ package main
 import "C"
 import _ "unsafe"
 
-// CHECK: {{^}}@0 = private unnamed_addr constant [44 x i8] c"{{.*}}/cl/_testrt/struct.Foo", align 1{{$}}
-// CHECK: {{^}}@1 = private unnamed_addr constant [5 x i8] c"Print", align 1{{$}}
+// CHECK-DAG: {{^}}@0 = private unnamed_addr constant [44 x i8] c"{{.*}}/cl/_testrt/struct.Foo", align 1{{$}}
+// CHECK-DAG: {{^}}@1 = private unnamed_addr constant [5 x i8] c"Print", align 1{{$}}
+// CHECK-DAG: @"{{.*}}/cl/_testrt/struct.format" = global [10 x i8] c"Hello %d\0A\00", align 1
 
 // CHECK-LABEL: define void @"{{.*}}/cl/_testrt/struct.Foo.Print"(%"{{.*}}/cl/_testrt/struct.Foo" %0){{.*}} {
 // CHECK-NEXT: _llgo_0:
@@ -69,16 +70,6 @@ func main() {
 // CHECK-NEXT: _llgo_1:                                          ; preds = %_llgo_0
 // CHECK-NEXT:   store i1 true, ptr @"{{.*}}/cl/_testrt/struct.init$guard", align 1
 // CHECK-NEXT:   call void @syscall.init()
-// CHECK-NEXT:   store i8 72, ptr @"{{.*}}/cl/_testrt/struct.format", align 1
-// CHECK-NEXT:   store i8 101, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/struct.format", i64 1), align 1
-// CHECK-NEXT:   store i8 108, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/struct.format", i64 2), align 1
-// CHECK-NEXT:   store i8 108, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/struct.format", i64 3), align 1
-// CHECK-NEXT:   store i8 111, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/struct.format", i64 4), align 1
-// CHECK-NEXT:   store i8 32, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/struct.format", i64 5), align 1
-// CHECK-NEXT:   store i8 37, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/struct.format", i64 6), align 1
-// CHECK-NEXT:   store i8 100, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/struct.format", i64 7), align 1
-// CHECK-NEXT:   store i8 10, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/struct.format", i64 8), align 1
-// CHECK-NEXT:   store i8 0, ptr getelementptr inbounds (i8, ptr @"{{.*}}/cl/_testrt/struct.format", i64 9), align 1
 // CHECK-NEXT:   br label %_llgo_2
 // CHECK-EMPTY:
 // CHECK-NEXT: _llgo_2:                                          ; preds = %_llgo_1, %_llgo_0

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -205,6 +205,9 @@ type context struct {
 
 	trackCallerFrames bool
 	callerFrameMark   llssa.Expr
+
+	staticGlobalInits map[*ssa.Global]llssa.Expr
+	staticInitStores  map[*ssa.Store]none
 }
 
 func (p *context) rewriteValue(name string) (string, bool) {
@@ -399,6 +402,8 @@ func (p *context) compileGlobal(pkg llssa.Package, gbl *ssa.Global) {
 				g.InitNil()
 			}
 		}
+	} else if init, ok := p.staticGlobalInits[gbl]; ok {
+		g.Init(init)
 	} else if define {
 		g.InitNil()
 	}
@@ -1548,6 +1553,9 @@ func (p *context) compileInstr(b llssa.Builder, instr ssa.Instruction) {
 	}
 	switch v := instr.(type) {
 	case *ssa.Store:
+		if _, ok := p.staticInitStores[v]; ok {
+			return
+		}
 		va := v.Addr
 		if va, ok := va.(*ssa.IndexAddr); ok {
 			if args, ok := p.isVArgs(va.X); ok { // varargs: this is a varargs store
@@ -2009,6 +2017,8 @@ func processPkg(ctx *context, ret llssa.Package, pkg *ssa.Package) {
 		name string
 		val  ssa.Member
 	}
+
+	ctx.collectStaticGlobalInits(pkg)
 
 	members := make([]*namedMember, 0, len(pkg.Members))
 	skips := ctx.skips

--- a/cl/rewrite_internal_test.go
+++ b/cl/rewrite_internal_test.go
@@ -5,6 +5,7 @@ package cl
 
 import (
 	"go/ast"
+	"go/constant"
 	"go/parser"
 	"go/token"
 	"go/types"
@@ -44,6 +45,25 @@ func compileWithRewrites(t *testing.T, src string, rewrites map[string]string) s
 		t.Fatalf("NewPackageEx failed: %v", err)
 	}
 	return ret.String()
+}
+
+func assertNoStoreToGlobal(t *testing.T, ir, global string) {
+	t.Helper()
+	for _, line := range strings.Split(ir, "\n") {
+		if strings.Contains(line, "store ") && strings.Contains(line, global) {
+			t.Fatalf("%s initializer store was not folded: %s\n%s", global, line, ir)
+		}
+	}
+}
+
+func assertStoreToGlobal(t *testing.T, ir, global string) {
+	t.Helper()
+	for _, line := range strings.Split(ir, "\n") {
+		if strings.Contains(line, "store ") && strings.Contains(line, global) {
+			return
+		}
+	}
+	t.Fatalf("expected store to %s in IR:\n%s", global, ir)
 }
 
 func TestRewriteGlobalStrings(t *testing.T) {
@@ -101,10 +121,132 @@ func Use() string {
 			t.Fatalf("missing %s in IR:\n%s", want, ir)
 		}
 	}
-	for _, line := range strings.Split(ir, "\n") {
-		if strings.Contains(line, "store ") && strings.Contains(line, "@staticinit.MethodNames") {
-			t.Fatalf("MethodNames initializer store was not folded: %s\n%s", line, ir)
+	assertNoStoreToGlobal(t, ir, "@staticinit.MethodNames")
+}
+
+func TestStaticGlobalScalarAndSparseArrayInit(t *testing.T) {
+	const src = `package staticinit
+
+var StaticBool = true
+var StaticInt int8 = -7
+var StaticUint uint16 = 42
+var StaticFloat = 1.5
+var StaticComplex = complex(2, -3)
+var StaticSparse = [4]int{1: 7, 3: 9}
+
+func Use() (bool, int8, uint16, float64, complex128, int) {
+	return StaticBool, StaticInt, StaticUint, StaticFloat, StaticComplex, StaticSparse[3]
+}
+`
+	ir := compileWithRewrites(t, src, nil)
+	for _, want := range []string{
+		"@staticinit.StaticBool = global i1 true",
+		"@staticinit.StaticInt = global i8 -7",
+		"@staticinit.StaticUint = global i16 42",
+		"@staticinit.StaticFloat = global double 1.500000e+00",
+		"@staticinit.StaticComplex = global { double, double } { double 2.000000e+00, double -3.000000e+00 }",
+		"@staticinit.StaticSparse = global [4 x i64] [i64 0, i64 7, i64 0, i64 9]",
+	} {
+		if !strings.Contains(ir, want) {
+			t.Fatalf("missing static initializer %q in IR:\n%s", want, ir)
 		}
+	}
+	for _, global := range []string{
+		"@staticinit.StaticBool",
+		"@staticinit.StaticInt",
+		"@staticinit.StaticUint",
+		"@staticinit.StaticFloat",
+		"@staticinit.StaticComplex",
+		"@staticinit.StaticSparse",
+	} {
+		assertNoStoreToGlobal(t, ir, global)
+	}
+}
+
+func TestStaticGlobalInitSkipsDynamicGlobal(t *testing.T) {
+	const src = `package staticinit
+
+func value() int { return 3 }
+
+var Dynamic = [2]int{value(), 9}
+
+func Use() int { return Dynamic[0] + Dynamic[1] }
+`
+	ir := compileWithRewrites(t, src, nil)
+	if !strings.Contains(ir, "@staticinit.Dynamic = global [2 x i64] zeroinitializer") {
+		t.Fatalf("dynamic global should keep zero initializer:\n%s", ir)
+	}
+	assertStoreToGlobal(t, ir, "@staticinit.Dynamic")
+}
+
+func TestStaticInitHelperRejectsUnsupportedPaths(t *testing.T) {
+	if _, ok := staticInitConstIndex(nil); ok {
+		t.Fatal("nil index should not be accepted")
+	}
+	if _, ok := staticInitConstIndex(ssa.NewConst(constant.MakeInt64(-1), types.Typ[types.Int])); ok {
+		t.Fatal("negative index should not be accepted")
+	}
+	if _, ok := staticInitStorePath(ssa.NewConst(constant.MakeInt64(0), types.Typ[types.Int])); ok {
+		t.Fatal("non-address value should not produce a static init path")
+	}
+	if global := staticInitRootGlobal(ssa.NewConst(constant.MakeInt64(0), types.Typ[types.Int])); global != nil {
+		t.Fatalf("non-address value should not have root global: %v", global)
+	}
+
+	ssapkg := buildSSAPackage(t, `package foo
+var Array [2]int
+`)
+	arrayGlobal, ok := ssapkg.Members["Array"].(*ssa.Global)
+	if !ok {
+		t.Fatalf("missing Array global: %T", ssapkg.Members["Array"])
+	}
+	if _, ok := staticInitStorePath(&ssa.IndexAddr{X: arrayGlobal, Index: arrayGlobal}); ok {
+		t.Fatal("dynamic index should not produce a static init path")
+	}
+
+	c := ssa.NewConst(constant.MakeInt64(1), types.Typ[types.Int])
+	root := new(staticInitNode)
+	if !root.add(nil, c) {
+		t.Fatal("first root value should be accepted")
+	}
+	if root.add([]staticInitPathElem{{index: 0}}, c) {
+		t.Fatal("child path under scalar value should be rejected")
+	}
+
+	parent := new(staticInitNode)
+	if !parent.add([]staticInitPathElem{{index: 0}}, c) {
+		t.Fatal("first child value should be accepted")
+	}
+	if parent.add(nil, c) {
+		t.Fatal("root value after child path should be rejected")
+	}
+}
+
+func TestStaticInitHelperBuildFailuresAndZeroes(t *testing.T) {
+	prog := ssatest.NewProgram(t, nil)
+	pkg := prog.NewPackage("staticinit", "staticinit")
+	ctx := &context{prog: prog, pkg: pkg}
+
+	if _, ok := ctx.buildStaticInitExpr(types.Typ[types.Int], nil); !ok {
+		t.Fatal("nil node should build a zero initializer")
+	}
+	if _, ok := ctx.staticConstExpr(ssa.NewConst(nil, types.Typ[types.Int]), prog.Int()); !ok {
+		t.Fatal("nil const should build a zero initializer")
+	}
+
+	c := ssa.NewConst(constant.MakeInt64(1), types.Typ[types.Int])
+	scalarWithChild := &staticInitNode{children: map[int]*staticInitNode{
+		0: {value: c},
+	}}
+	if _, ok := ctx.buildStaticInitExpr(types.Typ[types.Int], scalarWithChild); ok {
+		t.Fatal("scalar initializer with children should be rejected")
+	}
+
+	arrayWithOutOfRangeChild := &staticInitNode{children: map[int]*staticInitNode{
+		1: {value: c},
+	}}
+	if _, ok := ctx.buildStaticInitExpr(types.NewArray(types.Typ[types.Int], 1), arrayWithOutOfRangeChild); ok {
+		t.Fatal("array initializer with out-of-range child should be rejected")
 	}
 }
 

--- a/cl/rewrite_internal_test.go
+++ b/cl/rewrite_internal_test.go
@@ -66,6 +66,48 @@ func Use() string { return VarInit + VarPlain }
 	}
 }
 
+func TestStaticGlobalLiteralInit(t *testing.T) {
+	const src = `package staticinit
+
+type Names struct {
+	Value [2]string
+	Nested Nested
+}
+
+type Nested struct {
+	Type [2]string
+}
+
+var MethodNames = Names{
+	Value: [2]string{"KeepValue", "KeepValueAlt"},
+	Nested: Nested{
+		Type: [2]string{"KeepType", "KeepTypeAlt"},
+	},
+}
+
+func Use() string {
+	return MethodNames.Value[0] + MethodNames.Nested.Type[1]
+}
+`
+	ir := compileWithRewrites(t, src, nil)
+	if !strings.Contains(ir, "@staticinit.MethodNames = global %staticinit.Names") {
+		t.Fatalf("missing MethodNames global initializer:\n%s", ir)
+	}
+	if strings.Contains(ir, "@staticinit.MethodNames = global %staticinit.Names zeroinitializer") {
+		t.Fatalf("MethodNames still uses a zero initializer:\n%s", ir)
+	}
+	for _, want := range []string{`c"KeepValue"`, `c"KeepValueAlt"`, `c"KeepType"`, `c"KeepTypeAlt"`} {
+		if !strings.Contains(ir, want) {
+			t.Fatalf("missing %s in IR:\n%s", want, ir)
+		}
+	}
+	for _, line := range strings.Split(ir, "\n") {
+		if strings.Contains(line, "store ") && strings.Contains(line, "@staticinit.MethodNames") {
+			t.Fatalf("MethodNames initializer store was not folded: %s\n%s", line, ir)
+		}
+	}
+}
+
 func TestRewriteSkipsNonConstStores(t *testing.T) {
 	const src = `package rewritepkg
 import "strings"

--- a/cl/rewrite_internal_test.go
+++ b/cl/rewrite_internal_test.go
@@ -4,6 +4,7 @@
 package cl
 
 import (
+	"fmt"
 	"go/ast"
 	"go/constant"
 	"go/parser"
@@ -27,7 +28,7 @@ func init() {
 func compileWithRewrites(t *testing.T, src string, rewrites map[string]string) string {
 	t.Helper()
 	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, "rewrite.go", src, 0)
+	file, err := parser.ParseFile(fset, "rewrite.go", src, parser.ParseComments)
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
@@ -179,6 +180,58 @@ func Use() int { return Dynamic[0] + Dynamic[1] }
 	assertStoreToGlobal(t, ir, "@staticinit.Dynamic")
 }
 
+func TestStaticGlobalInitSkipsExternalGlobal(t *testing.T) {
+	const src = `package staticinit
+
+import _ "unsafe"
+
+//go:linkname External C.external
+var External = 7
+
+func Use() int { return External }
+`
+	ir := compileWithRewrites(t, src, nil)
+	if !strings.Contains(ir, "@C.external = external global i64") {
+		t.Fatalf("linknamed global should remain an external declaration:\n%s", ir)
+	}
+	assertStoreToGlobal(t, ir, "@C.external")
+}
+
+func TestStaticGlobalInitDeterministicOrder(t *testing.T) {
+	const src = `package staticinit
+
+var Zulu = "zulu-static-init"
+var Alpha = "alpha-static-init"
+
+func Use() string { return Zulu + Alpha }
+`
+	ir := compileWithRewrites(t, src, nil)
+	alpha := strings.Index(ir, `c"alpha-static-init"`)
+	zulu := strings.Index(ir, `c"zulu-static-init"`)
+	if alpha < 0 || zulu < 0 {
+		t.Fatalf("missing static string data:\n%s", ir)
+	}
+	if alpha > zulu {
+		t.Fatalf("static initializers were not built in global-name order:\n%s", ir)
+	}
+}
+
+func TestStaticGlobalInitSkipsLargeArray(t *testing.T) {
+	length := maxStaticInitArrayElements + 1
+	src := fmt.Sprintf(`package staticinit
+
+var Large = [%d]byte{%d: 1}
+
+func Use() byte { return Large[%d] }
+`, length, length-1, length-1)
+	ir := compileWithRewrites(t, src, nil)
+	want := fmt.Sprintf("@staticinit.Large = global [%d x i8] zeroinitializer", length)
+	if !strings.Contains(ir, want) {
+		t.Fatalf("large array should keep a zero initializer:\n%s", ir)
+	}
+	assertStoreToGlobal(t, ir, "@staticinit.Large")
+}
+
 func TestStaticInitHelperRejectsUnsupportedPaths(t *testing.T) {
 	if _, ok := staticInitConstIndex(nil); ok {
 		t.Fatal("nil index should not be accepted")
@@ -247,6 +300,140 @@ func TestStaticInitHelperBuildFailuresAndZeroes(t *testing.T) {
 	}}
 	if _, ok := ctx.buildStaticInitExpr(types.NewArray(types.Typ[types.Int], 1), arrayWithOutOfRangeChild); ok {
 		t.Fatal("array initializer with out-of-range child should be rejected")
+	}
+}
+
+func TestStaticInitCollectEarlyExitsAndFilters(t *testing.T) {
+	noInit := buildSSAPackage(t, `package foo
+const A = 1
+`)
+	if initFn := noInit.Func("init"); initFn != nil {
+		initFn.Synthetic = ""
+	}
+	(&context{}).collectStaticGlobalInits(noInit)
+
+	skipped := buildSSAPackage(t, `package foo
+var Skip = 1
+func Use() int { return Skip }
+`)
+	ctx := &context{skips: map[string]none{"Skip": {}}}
+	ctx.collectStaticGlobalInits(skipped)
+	if ctx.staticGlobalInits != nil {
+		t.Fatalf("skipped global should not produce static initializers: %+v", ctx.staticGlobalInits)
+	}
+
+	cgoFuncPtr := buildSSAPackage(t, `package foo
+var __cgo_callback = 1
+func Use() int { return __cgo_callback }
+`)
+	ctx = &context{}
+	ctx.collectStaticGlobalInits(cgoFuncPtr)
+	if ctx.staticGlobalInits != nil {
+		t.Fatalf("__cgo function pointer globals should be ignored: %+v", ctx.staticGlobalInits)
+	}
+
+	nonGlobalStore := buildSSAPackage(t, `package foo
+var G int
+`)
+	initFn := nonGlobalStore.Func("init")
+	if initFn == nil || len(initFn.Blocks) == 0 {
+		t.Fatal("expected package initializer for nonGlobalStore")
+	}
+	initFn.Blocks[0].Instrs = append([]ssa.Instruction{
+		&ssa.Store{
+			Addr: ssa.NewConst(constant.MakeInt64(0), types.Typ[types.Int]),
+			Val:  ssa.NewConst(constant.MakeInt64(1), types.Typ[types.Int]),
+		},
+	}, initFn.Blocks[0].Instrs...)
+	ctx = &context{prog: ssatest.NewProgram(t, nil)}
+	ctx.collectStaticGlobalInits(nonGlobalStore)
+}
+
+func TestStaticInitHelperRejectsNestedUnsupportedPaths(t *testing.T) {
+	badBase := ssa.NewConst(constant.MakeInt64(0), types.Typ[types.Int])
+	if _, ok := staticInitStorePath(&ssa.FieldAddr{X: badBase, Field: 0}); ok {
+		t.Fatal("field path with unsupported base should be rejected")
+	}
+	if _, ok := staticInitStorePath(&ssa.IndexAddr{
+		X:     badBase,
+		Index: ssa.NewConst(constant.MakeInt64(0), types.Typ[types.Int]),
+	}); ok {
+		t.Fatal("index path with unsupported base should be rejected")
+	}
+}
+
+func TestStaticInitHelperBuildAdditionalFailures(t *testing.T) {
+	prog := ssatest.NewProgram(t, nil)
+	pkg := prog.NewPackage("staticinit", "staticinit")
+	ctx := &context{prog: prog, pkg: pkg}
+	c := ssa.NewConst(constant.MakeInt64(1), types.Typ[types.Int])
+
+	if _, ok := ctx.buildStaticGlobalInit(&ssa.Global{}, []staticInitStore{{value: c}}); ok {
+		t.Fatal("global with non-pointer type should be rejected")
+	}
+
+	ssapkg := buildSSAPackage(t, `package foo
+var G int
+`)
+	global, ok := ssapkg.Members["G"].(*ssa.Global)
+	if !ok {
+		t.Fatalf("missing G global: %T", ssapkg.Members["G"])
+	}
+	if _, ok := ctx.buildStaticGlobalInit(global, []staticInitStore{
+		{value: c},
+		{value: c},
+	}); ok {
+		t.Fatal("conflicting root stores should be rejected")
+	}
+
+	scalarWithChild := &staticInitNode{children: map[int]*staticInitNode{
+		0: {value: c},
+	}}
+	structType := types.NewStruct([]*types.Var{
+		types.NewField(token.NoPos, nil, "A", types.Typ[types.Int], false),
+	}, nil)
+	if _, ok := ctx.buildStaticInitExpr(structType, &staticInitNode{
+		children: map[int]*staticInitNode{0: scalarWithChild},
+	}); ok {
+		t.Fatal("struct initializer with invalid field child should be rejected")
+	}
+	if _, ok := ctx.buildStaticInitExpr(structType, &staticInitNode{
+		children: map[int]*staticInitNode{1: {value: c}},
+	}); ok {
+		t.Fatal("struct initializer with out-of-range child should be rejected")
+	}
+	if _, ok := ctx.buildStaticInitExpr(types.NewArray(types.Typ[types.Int], 1), &staticInitNode{
+		children: map[int]*staticInitNode{0: scalarWithChild},
+	}); ok {
+		t.Fatal("array initializer with invalid element child should be rejected")
+	}
+	if _, ok := ctx.buildStaticInitExpr(types.NewPointer(types.Typ[types.Int]), new(staticInitNode)); !ok {
+		t.Fatal("empty unsupported scalar node should build a zero initializer")
+	}
+}
+
+func TestStaticConstExprRejectsUnsupportedConstants(t *testing.T) {
+	prog := ssatest.NewProgram(t, nil)
+	pkg := prog.NewPackage("staticinit", "staticinit")
+	ctx := &context{prog: prog, pkg: pkg}
+
+	if _, ok := ctx.staticConstExpr(&ssa.Const{}, prog.Int()); !ok {
+		t.Fatal("zero ssa.Const should build a zero initializer")
+	}
+	if _, ok := ctx.staticConstExpr(ssa.NewConst(constant.MakeInt64(1), types.Typ[types.Int]), prog.Pointer(prog.Int())); ok {
+		t.Fatal("const for non-basic LLVM type should be rejected")
+	}
+	if _, ok := ctx.staticConstExpr(ssa.NewConst(constant.MakeFloat64(1.25), types.Typ[types.Float64]), prog.Int()); ok {
+		t.Fatal("inexact signed integer constant should be rejected")
+	}
+	if _, ok := ctx.staticConstExpr(ssa.NewConst(constant.MakeInt64(-1), types.Typ[types.Int]), prog.Uint()); ok {
+		t.Fatal("negative unsigned integer constant should be rejected")
+	}
+	if _, ok := ctx.staticConstExpr(
+		ssa.NewConst(constant.MakeInt64(0), types.Typ[types.Int]),
+		ctx.type_(types.Typ[types.UnsafePointer], llssa.InGo),
+	); ok {
+		t.Fatal("unsupported unsafe.Pointer constants should be rejected")
 	}
 }
 

--- a/cl/static_init.go
+++ b/cl/static_init.go
@@ -19,11 +19,16 @@ package cl
 import (
 	"go/constant"
 	"go/types"
+	"sort"
 	"strings"
 
 	llssa "github.com/goplus/llgo/ssa"
 	"golang.org/x/tools/go/ssa"
 )
+
+// Static folding is an optimization. Keep sparse large arrays in the package
+// initializer instead of materializing every zero element as an LLVM constant.
+const maxStaticInitArrayElements = 1 << 16
 
 type staticInitPathElem struct {
 	index int
@@ -60,7 +65,14 @@ func (p *context) collectStaticGlobalInits(pkg *ssa.Package) {
 			continue
 		}
 		if global, ok := member.(*ssa.Global); ok {
-			if _, rewritten := p.rewriteValue(p.globalFullName(global)); rewritten {
+			if isCgoFuncPtrVar(global.Name()) {
+				continue
+			}
+			globalName, vtype, define := p.varName(global.Pkg.Pkg, global)
+			if !define || vtype != goVar {
+				continue
+			}
+			if _, rewritten := p.rewriteValue(globalName); rewritten {
 				continue
 			}
 			globals[global] = none{}
@@ -109,7 +121,16 @@ func (p *context) collectStaticGlobalInits(pkg *ssa.Package) {
 		}
 	}
 
-	for global, candidate := range candidates {
+	orderedGlobals := make([]*ssa.Global, 0, len(candidates))
+	for global := range candidates {
+		orderedGlobals = append(orderedGlobals, global)
+	}
+	sort.Slice(orderedGlobals, func(i, j int) bool {
+		return p.globalFullName(orderedGlobals[i]) < p.globalFullName(orderedGlobals[j])
+	})
+
+	for _, global := range orderedGlobals {
+		candidate := candidates[global]
 		if candidate.invalid || len(candidate.stores) == 0 {
 			continue
 		}
@@ -241,6 +262,9 @@ func (p *context) buildStaticInitExpr(typ types.Type, node *staticInitNode) (lls
 		}
 		return p.prog.ConstStruct(lltyp, values), true
 	case *types.Array:
+		if u.Len() > maxStaticInitArrayElements {
+			return llssa.Expr{}, false
+		}
 		n := int(u.Len())
 		values := make([]llssa.Expr, n)
 		for i := range values {

--- a/cl/static_init.go
+++ b/cl/static_init.go
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cl
+
+import (
+	"go/constant"
+	"go/types"
+	"strings"
+
+	llssa "github.com/goplus/llgo/ssa"
+	"golang.org/x/tools/go/ssa"
+)
+
+type staticInitPathElem struct {
+	index int
+}
+
+type staticInitStore struct {
+	store *ssa.Store
+	path  []staticInitPathElem
+	value *ssa.Const
+}
+
+type staticInitCandidate struct {
+	stores  []staticInitStore
+	invalid bool
+}
+
+type staticInitNode struct {
+	value    *ssa.Const
+	children map[int]*staticInitNode
+}
+
+func (p *context) collectStaticGlobalInits(pkg *ssa.Package) {
+	initFn := pkg.Func("init")
+	if initFn == nil || initFn.Synthetic != "package initializer" {
+		return
+	}
+
+	globals := make(map[*ssa.Global]none)
+	for name, member := range pkg.Members {
+		if _, skip := p.skips[name]; skip {
+			continue
+		}
+		if strings.HasSuffix(name, "init$guard") {
+			continue
+		}
+		if global, ok := member.(*ssa.Global); ok {
+			if _, rewritten := p.rewriteValue(p.globalFullName(global)); rewritten {
+				continue
+			}
+			globals[global] = none{}
+		}
+	}
+	if len(globals) == 0 {
+		return
+	}
+
+	candidates := make(map[*ssa.Global]*staticInitCandidate)
+	candidateOf := func(global *ssa.Global) *staticInitCandidate {
+		candidate := candidates[global]
+		if candidate == nil {
+			candidate = new(staticInitCandidate)
+			candidates[global] = candidate
+		}
+		return candidate
+	}
+
+	for _, block := range initFn.Blocks {
+		for _, instr := range block.Instrs {
+			store, ok := instr.(*ssa.Store)
+			if !ok {
+				continue
+			}
+			global := staticInitRootGlobal(store.Addr)
+			if global == nil {
+				continue
+			}
+			if _, ok := globals[global]; !ok {
+				continue
+			}
+
+			path, ok := staticInitStorePath(store.Addr)
+			value, isConst := store.Val.(*ssa.Const)
+			candidate := candidateOf(global)
+			if !ok || !isConst {
+				candidate.invalid = true
+				continue
+			}
+			candidate.stores = append(candidate.stores, staticInitStore{
+				store: store,
+				path:  path,
+				value: value,
+			})
+		}
+	}
+
+	for global, candidate := range candidates {
+		if candidate.invalid || len(candidate.stores) == 0 {
+			continue
+		}
+		init, ok := p.buildStaticGlobalInit(global, candidate.stores)
+		if !ok {
+			continue
+		}
+		if p.staticGlobalInits == nil {
+			p.staticGlobalInits = make(map[*ssa.Global]llssa.Expr)
+			p.staticInitStores = make(map[*ssa.Store]none)
+		}
+		p.staticGlobalInits[global] = init
+		for _, store := range candidate.stores {
+			p.staticInitStores[store.store] = none{}
+		}
+	}
+}
+
+func staticInitRootGlobal(addr ssa.Value) *ssa.Global {
+	switch addr := addr.(type) {
+	case *ssa.Global:
+		return addr
+	case *ssa.FieldAddr:
+		return staticInitRootGlobal(addr.X)
+	case *ssa.IndexAddr:
+		return staticInitRootGlobal(addr.X)
+	default:
+		return nil
+	}
+}
+
+func staticInitStorePath(addr ssa.Value) ([]staticInitPathElem, bool) {
+	switch addr := addr.(type) {
+	case *ssa.Global:
+		return nil, true
+	case *ssa.FieldAddr:
+		path, ok := staticInitStorePath(addr.X)
+		if !ok {
+			return nil, false
+		}
+		return append(path, staticInitPathElem{index: addr.Field}), true
+	case *ssa.IndexAddr:
+		path, ok := staticInitStorePath(addr.X)
+		if !ok {
+			return nil, false
+		}
+		index, ok := staticInitConstIndex(addr.Index)
+		if !ok {
+			return nil, false
+		}
+		return append(path, staticInitPathElem{index: index}), true
+	default:
+		return nil, false
+	}
+}
+
+func staticInitConstIndex(v ssa.Value) (int, bool) {
+	c, ok := v.(*ssa.Const)
+	if !ok {
+		return 0, false
+	}
+	index, exact := constant.Int64Val(c.Value)
+	if !exact || index < 0 || int64(int(index)) != index {
+		return 0, false
+	}
+	return int(index), true
+}
+
+func (p *context) buildStaticGlobalInit(global *ssa.Global, stores []staticInitStore) (llssa.Expr, bool) {
+	ptr, ok := global.Type().(*types.Pointer)
+	if !ok {
+		return llssa.Expr{}, false
+	}
+
+	root := new(staticInitNode)
+	for _, store := range stores {
+		if !root.add(store.path, store.value) {
+			return llssa.Expr{}, false
+		}
+	}
+	return p.buildStaticInitExpr(ptr.Elem(), root)
+}
+
+func (n *staticInitNode) add(path []staticInitPathElem, value *ssa.Const) bool {
+	if len(path) == 0 {
+		if n.value != nil || len(n.children) != 0 {
+			return false
+		}
+		n.value = value
+		return true
+	}
+	if n.value != nil {
+		return false
+	}
+	head := path[0]
+	child := n.children[head.index]
+	if child == nil {
+		if n.children == nil {
+			n.children = make(map[int]*staticInitNode)
+		}
+		child = new(staticInitNode)
+		n.children[head.index] = child
+	}
+	return child.add(path[1:], value)
+}
+
+func (p *context) buildStaticInitExpr(typ types.Type, node *staticInitNode) (llssa.Expr, bool) {
+	lltyp := p.type_(typ, llssa.InGo)
+	if node == nil {
+		return p.prog.Zero(lltyp), true
+	}
+	if node.value != nil {
+		return p.staticConstExpr(node.value, lltyp)
+	}
+
+	switch u := typ.Underlying().(type) {
+	case *types.Struct:
+		values := make([]llssa.Expr, u.NumFields())
+		for i := range values {
+			child := node.children[i]
+			value, ok := p.buildStaticInitExpr(u.Field(i).Type(), child)
+			if !ok {
+				return llssa.Expr{}, false
+			}
+			values[i] = value
+		}
+		if !staticInitChildrenInRange(node, u.NumFields()) {
+			return llssa.Expr{}, false
+		}
+		return p.prog.ConstStruct(lltyp, values), true
+	case *types.Array:
+		n := int(u.Len())
+		values := make([]llssa.Expr, n)
+		for i := range values {
+			child := node.children[i]
+			value, ok := p.buildStaticInitExpr(u.Elem(), child)
+			if !ok {
+				return llssa.Expr{}, false
+			}
+			values[i] = value
+		}
+		if !staticInitChildrenInRange(node, n) {
+			return llssa.Expr{}, false
+		}
+		return p.prog.ConstArray(lltyp, values), true
+	default:
+		if len(node.children) == 0 {
+			return p.prog.Zero(lltyp), true
+		}
+		return llssa.Expr{}, false
+	}
+}
+
+func staticInitChildrenInRange(node *staticInitNode, n int) bool {
+	for index := range node.children {
+		if index < 0 || index >= n {
+			return false
+		}
+	}
+	return true
+}
+
+func (p *context) staticConstExpr(c *ssa.Const, typ llssa.Type) (llssa.Expr, bool) {
+	if c.Value == nil {
+		return p.prog.Zero(typ), true
+	}
+	raw := typ.RawType().Underlying()
+	basic, ok := raw.(*types.Basic)
+	if !ok {
+		return llssa.Expr{}, false
+	}
+	switch kind := basic.Kind(); {
+	case kind == types.Bool:
+		return p.prog.BoolVal(constant.BoolVal(c.Value)), true
+	case kind >= types.Int && kind <= types.Int64:
+		v, exact := constant.Int64Val(constant.ToInt(c.Value))
+		if !exact {
+			return llssa.Expr{}, false
+		}
+		return p.prog.IntVal(uint64(v), typ), true
+	case kind >= types.Uint && kind <= types.Uintptr:
+		v, exact := constant.Uint64Val(constant.ToInt(c.Value))
+		if !exact {
+			return llssa.Expr{}, false
+		}
+		return p.prog.IntVal(v, typ), true
+	case kind == types.Float32 || kind == types.Float64:
+		v, _ := constant.Float64Val(constant.ToFloat(c.Value))
+		return p.prog.FloatVal(v, typ), true
+	case kind == types.String:
+		return p.pkg.ConstString(constant.StringVal(c.Value)), true
+	case kind == types.Complex64 || kind == types.Complex128:
+		v := constant.ToComplex(c.Value)
+		re, _ := constant.Float64Val(constant.Real(v))
+		im, _ := constant.Float64Val(constant.Imag(v))
+		return p.prog.ComplexVal(complex(re, im), typ), true
+	default:
+		return llssa.Expr{}, false
+	}
+}

--- a/ssa/globals.go
+++ b/ssa/globals.go
@@ -18,6 +18,7 @@ package ssa
 
 import (
 	"fmt"
+	"go/types"
 
 	"github.com/xgo-dev/llvm"
 )
@@ -56,6 +57,28 @@ func (pkg Package) ConstBytes(value []byte) Expr {
 	n := prog.IntVal(uint64(len(value)), prog.Int())
 	cv := llvm.ConstNamedStruct(styp.ll, []llvm.Value{data, n.impl, n.impl})
 	return Expr{cv, styp}
+}
+
+// ConstArray creates an LLVM constant array expression.
+func (prog Program) ConstArray(t Type, values []Expr) Expr {
+	elem := prog.Index(t)
+	fields := make([]llvm.Value, len(values))
+	for i, value := range values {
+		fields[i] = value.impl
+	}
+	return Expr{llvm.ConstArray(elem.ll, fields), t}
+}
+
+// ConstStruct creates an LLVM constant struct expression.
+func (prog Program) ConstStruct(t Type, values []Expr) Expr {
+	fields := make([]llvm.Value, len(values))
+	for i, value := range values {
+		fields[i] = value.impl
+	}
+	if _, ok := t.raw.Type.(*types.Named); ok {
+		return Expr{llvm.ConstNamedStruct(t.ll, fields), t}
+	}
+	return Expr{prog.ctx.ConstStruct(fields, false), t}
 }
 
 // Undefined global string var by names


### PR DESCRIPTION
## Summary

This PR teaches the LLGo code generator to fold package-level pure literal initializers into LLVM global initializers when the package initializer only writes compile-time constants into fixed global slots.

The change adds a small static-initializer collection pass in `cl` that:
- scans the synthetic package initializer for stores into package globals;
- accepts only stores with constant values and fixed `FieldAddr` / `IndexAddr` paths;
- rejects a global if any package-initializer store to that global is not statically representable;
- initializes the LLVM global directly and skips the now-redundant package-init stores.

It also adds `ssa.Program.ConstArray` and `ssa.Program.ConstStruct` helpers so `cl` can build aggregate LLVM constants without reaching into `ssa` internals.

## Why

Previously pure Go literals such as global arrays and structs were emitted as zero-initialized LLVM globals plus package-init stores. That makes downstream LLVM/LTO passes see the values as runtime initialization, even when they are compile-time literals. Emitting these values as LLVM initializers gives later optimization and analysis passes a normal constant/global shape to consume.

## Validation

- `go test ./ssa`
- `go test ./cl -run '^(TestStaticGlobalLiteralInit|TestRewriteGlobalStrings|TestRewriteSkipsNonConstStores)$' -count=1`
- `go test ./cl -run 'TestRunAndTestFromTestdata/importpkg|TestRunAndTestFromTestdata/method|TestRunAndTestFromTestdata/print|TestRunAndTestFromTestdata/untyped|TestRunAndTestFromTestdata/utf8|TestRunAndTestFromTestrt/gblarray|TestRunAndTestFromTestrt/hello|TestRunAndTestFromTestrt/litdemo|TestRunAndTestFromTestrt/struct' -count=1`

Note: full `go test ./cl` was not used as the final validation because the local Linux run still has an unrelated existing `TestRunAndTestFromTestrt/complex` output mismatch.
