### PR TITLE
Infer LTO MethodByName names through control flow

### DIFF
--- a/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_switch/expect.txt
+++ b/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_switch/expect.txt
@@ -1,0 +1,2 @@
+keep-a
+keep-a

--- a/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_switch/in.go
+++ b/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_switch/in.go
@@ -1,0 +1,63 @@
+// LITTEST
+package main
+
+import (
+	"os"
+	"reflect"
+)
+
+// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_switch{{.*}}S{{.*}}Drop
+// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_switch{{.*}}S{{.*}}KeepA
+// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_switch{{.*}}S{{.*}}KeepB
+// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_switch{{.*}}S{{.*}}KeepC
+// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_switch{{.*}}S{{.*}}Drop
+
+type S struct{}
+
+//go:noinline
+func (S) KeepA() string {
+	return "keep-a"
+}
+
+//go:noinline
+func (S) KeepB() string {
+	return "keep-b"
+}
+
+//go:noinline
+func (S) KeepC() string {
+	return "keep-c"
+}
+
+//go:noinline
+func (S) Drop() string {
+	panic("Drop should be unreachable")
+}
+
+//go:noinline
+func selector() int {
+	return len(os.Args)
+}
+
+func methodName() string {
+	switch selector() {
+	case 1:
+		return "KeepA"
+	case 2:
+		return "KeepB"
+	default:
+		return "KeepC"
+	}
+}
+
+func main() {
+	out := reflect.ValueOf(S{}).MethodByName(methodName()).Call(nil)
+	println(out[0].String())
+
+	m, ok := reflect.TypeOf(S{}).MethodByName(methodName())
+	if !ok {
+		panic("missing method")
+	}
+	out = m.Func.Call([]reflect.Value{reflect.ValueOf(S{})})
+	println(out[0].String())
+}

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -180,6 +180,7 @@ func TestRunAndTestFromTestlto(t *testing.T) {
 	conf.LTO = lto.Full
 	ignore := []string{
 		"./_testlto/globaldce_reflect_method_by_name_ltoplugin",
+		"./_testlto/globaldce_reflect_method_by_name_ltoplugin_switch",
 	}
 	if !buildenv.Dev {
 		ignore = append(ignore,
@@ -210,6 +211,7 @@ var testltoSymbolChecks = []string{
 
 var testltoLTOPluginTests = []string{
 	"globaldce_reflect_method_by_name_ltoplugin",
+	"globaldce_reflect_method_by_name_ltoplugin_switch",
 }
 
 func TestBuildAndCheckSymbolsFromTestlto(t *testing.T) {

--- a/ltoplugin/LLGOLTOPasses.cpp
+++ b/ltoplugin/LLGOLTOPasses.cpp
@@ -39,6 +39,7 @@ static constexpr char ReflectValueMethodTypeIDPrefix[] =
 static constexpr char ReflectTypeMethodTypeIDPrefix[] =
     "go.method.type.reflect.";
 static constexpr unsigned MaxReflectMethodNames = 32;
+static constexpr unsigned MaxStringAnalysisDepth = 12;
 
 // Keep the replacement bounded. The pass is only meant to refine cases where
 // optimization has exposed a small finite set of names. If the set grows too
@@ -87,6 +88,100 @@ std::optional<std::string> readConstantString(Value *Ptr, Value *Len,
   return Bytes.substr(Start, Size).str();
 }
 
+bool collectStringSet(Value *Ptr, Value *Len, const DataLayout &DL,
+                      SmallVectorImpl<std::string> &Names,
+                      unsigned Depth = 0);
+
+bool collectStringSetFromStringValue(Value *StringValue, const DataLayout &DL,
+                                     SmallVectorImpl<std::string> &Names,
+                                     unsigned Depth = 0);
+
+std::optional<unsigned> singleExtractValueIndex(ExtractValueInst *Extract) {
+  if (!Extract || Extract->getNumIndices() != 1)
+    return std::nullopt;
+  return Extract->getIndices()[0];
+}
+
+std::optional<unsigned> singleInsertValueIndex(InsertValueInst *Insert) {
+  if (!Insert || Insert->getNumIndices() != 1)
+    return std::nullopt;
+  return Insert->getIndices()[0];
+}
+
+Value *findInsertedValue(Value *Aggregate, unsigned Index) {
+  for (Value *Cur = Aggregate;;) {
+    auto *Insert = dyn_cast<InsertValueInst>(Cur);
+    if (!Insert)
+      return nullptr;
+    auto InsertIndex = singleInsertValueIndex(Insert);
+    if (InsertIndex && *InsertIndex == Index)
+      return Insert->getInsertedValueOperand();
+    Cur = Insert->getAggregateOperand();
+  }
+}
+
+bool collectStringSetFromStringConstant(Constant *C, const DataLayout &DL,
+                                        SmallVectorImpl<std::string> &Names,
+                                        unsigned Depth) {
+  if (isa<ConstantAggregateZero>(C))
+    return addName(Names, "");
+
+  Constant *Ptr = C->getAggregateElement(0U);
+  Constant *Len = C->getAggregateElement(1U);
+  if (!Ptr || !Len)
+    return false;
+  return collectStringSet(Ptr, Len, DL, Names, Depth + 1);
+}
+
+bool collectStringSetFromStringValue(Value *StringValue, const DataLayout &DL,
+                                     SmallVectorImpl<std::string> &Names,
+                                     unsigned Depth) {
+  if (Depth > MaxStringAnalysisDepth)
+    return false;
+
+  if (auto *C = dyn_cast<Constant>(StringValue))
+    return collectStringSetFromStringConstant(C, DL, Names, Depth);
+
+  if (auto *Insert = dyn_cast<InsertValueInst>(StringValue)) {
+    Value *Ptr = findInsertedValue(Insert, 0);
+    Value *Len = findInsertedValue(Insert, 1);
+    if (!Ptr || !Len)
+      return false;
+    return collectStringSet(Ptr, Len, DL, Names, Depth + 1);
+  }
+
+  if (auto *Sel = dyn_cast<SelectInst>(StringValue)) {
+    return collectStringSetFromStringValue(Sel->getTrueValue(), DL, Names,
+                                           Depth + 1) &&
+           collectStringSetFromStringValue(Sel->getFalseValue(), DL, Names,
+                                           Depth + 1);
+  }
+
+  if (auto *Phi = dyn_cast<PHINode>(StringValue)) {
+    for (Value *Incoming : Phi->incoming_values()) {
+      if (!collectStringSetFromStringValue(Incoming, DL, Names, Depth + 1))
+        return false;
+    }
+    return true;
+  }
+
+  return false;
+}
+
+bool collectExtractedStringSet(Value *Ptr, Value *Len, const DataLayout &DL,
+                               SmallVectorImpl<std::string> &Names,
+                               unsigned Depth) {
+  auto *PtrExtract = dyn_cast<ExtractValueInst>(Ptr);
+  auto *LenExtract = dyn_cast<ExtractValueInst>(Len);
+  auto PtrIndex = singleExtractValueIndex(PtrExtract);
+  auto LenIndex = singleExtractValueIndex(LenExtract);
+  if (!PtrIndex || !LenIndex || *PtrIndex != 0 || *LenIndex != 1 ||
+      PtrExtract->getAggregateOperand() != LenExtract->getAggregateOperand())
+    return false;
+  return collectStringSetFromStringValue(PtrExtract->getAggregateOperand(), DL,
+                                         Names, Depth + 1);
+}
+
 // Collect every possible string from a lowered (ptr, len) pair.
 //
 // The pass is intentionally all-or-nothing: it returns false as soon as any
@@ -95,14 +190,20 @@ std::optional<std::string> readConstantString(Value *Ptr, Value *Len,
 // make GlobalDCE drop a method that may still be reachable at runtime.
 bool collectStringSet(Value *Ptr, Value *Len, const DataLayout &DL,
                       SmallVectorImpl<std::string> &Names,
-                      unsigned Depth = 0) {
-  if (Depth > 8)
+                      unsigned Depth) {
+  if (Depth > MaxStringAnalysisDepth)
     return false;
 
   Ptr = Ptr->stripPointerCasts();
 
+  if (auto *LenC = dyn_cast<ConstantInt>(Len); LenC && LenC->isZero())
+    return addName(Names, "");
+
   if (auto Name = readConstantString(Ptr, Len, DL))
     return addName(Names, *Name);
+
+  if (collectExtractedStringSet(Ptr, Len, DL, Names, Depth))
+    return true;
 
   auto *PtrSel = dyn_cast<SelectInst>(Ptr);
   auto *LenSel = dyn_cast<SelectInst>(Len);


### PR DESCRIPTION
## Summary

This PR extends the LLGo LTO MethodByName refinement pass so it can infer a finite set of reflected method names through optimized control-flow values such as `select` and `phi` nodes.

It adds a focused LTO plugin test that exercises both `reflect.Value.MethodByName` and `reflect.Type.MethodByName` when the name is no longer a direct Go SSA constant but is still provably one of a small fixed set after LLVM optimization.

## Dependency

Stacked on #2029, which adds the base LTO pass plugin infrastructure and MethodByName marker plumbing.

## Validation

- `cmake -S ltoplugin -B /tmp/llgo-ltoplugin-switch-build -DLLVM_DIR=/usr/lib/llvm-19/lib/cmake/llvm && cmake --build /tmp/llgo-ltoplugin-switch-build`
- `LLGO_LTO_PLUGIN=/tmp/llgo-ltoplugin-switch-build/LLGOLTOPlugin.so go test -tags dev ./cl -run '^(TestRunAndTestFromTestltoLTOPlugin|TestBuildAndCheckSymbolsFromTestltoLTOPlugin)$/globaldce_reflect_method_by_name_ltoplugin_switch$' -count=1`
