### PR TITLE
ci: one heavy test suite per runner VM

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,14 +18,22 @@ concurrency:
 
 jobs:
   test:
+    name: test (${{matrix.os}}, ${{matrix.llvm}}, ${{matrix.suite}})
     continue-on-error: true
     timeout-minutes: 60
     strategy:
+      fail-fast: false
       matrix:
         os:
           - macos-latest
           - ubuntu-latest
         llvm: [19]
+        # One heavy test package per runner VM: their compile phases no
+        # longer stack on a single 16GB machine (concurrent clang/lld
+        # bursts were killing ubuntu runners and starving mac runners
+        # into go-list WaitDelay expirations), and wall time drops to the
+        # slowest single suite.
+        suite: [cl, ssa, testgo, rest]
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v7
@@ -69,20 +77,31 @@ jobs:
       - name: Build
         run: go build -v ./...
 
+      - name: Select suite packages
+        id: suite
+        run: |
+          case "${{matrix.suite}}" in
+            cl)     pkgs="./cl" ;;
+            ssa)    pkgs="./ssa ./internal/cabi" ;;
+            testgo) pkgs="./test/..." ;;
+            rest)   pkgs=$(go list ./... | grep -v -E '^github.com/goplus/llgo/(cl$|ssa$|internal/cabi$|test/)' | tr '\n' ' ') ;;
+          esac
+          echo "pkgs=$pkgs" >> "$GITHUB_OUTPUT"
+
       # Both platforms upload coverage: OS-specific paths (ELF vs Mach-O
       # emission, per-OS runtime shims) are otherwise invisible to
       # codecov/patch and fail it on lines only the other OS executes.
       - name: Test with coverage
-        # 45m: the caller-info acceptance suite (test/go) legitimately grew
-        # the covered run past the old 30m budget on macOS runners.
-        run: go test -timeout 45m -coverprofile="coverage.txt" -covermode=atomic ./...
+        run: go test -timeout 45m -coverprofile="coverage.txt" -covermode=atomic ${{steps.suite.outputs.pkgs}}
 
       - name: Test with embedded emulator env
+        if: matrix.suite == 'cl'
         env:
           LLGO_EMBED_TESTS: "1"
         run: go test -v -timeout 60m ./cl -run '^TestRunEmbedEmulator$'
 
       - name: Check std symbol coverage
+        if: matrix.suite == 'rest'
         run: bash doc/_readme/scripts/check_std_cover.sh
 
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,17 +23,20 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
+      # Cap how many heavy, llgo-building test packages share one VM:
+      # their concurrent clang/lld bursts were killing 16GB ubuntu
+      # runners and starving mac runners into go-list WaitDelay
+      # expirations. ubuntu (plentiful runners) gets one suite per VM;
+      # macos (scarce runners) gets two balanced groups of at most two
+      # heavy packages each — the pre-backbone peak, which mac handled.
       matrix:
-        os:
-          - macos-latest
-          - ubuntu-latest
-        llvm: [19]
-        # One heavy test package per runner VM: their compile phases no
-        # longer stack on a single 16GB machine (concurrent clang/lld
-        # bursts were killing ubuntu runners and starving mac runners
-        # into go-list WaitDelay expirations), and wall time drops to the
-        # slowest single suite.
-        suite: [cl, ssa, testgo, rest]
+        include:
+          - { os: ubuntu-latest, llvm: 19, suite: cl }
+          - { os: ubuntu-latest, llvm: 19, suite: ssa }
+          - { os: ubuntu-latest, llvm: 19, suite: testgo }
+          - { os: ubuntu-latest, llvm: 19, suite: rest }
+          - { os: macos-latest, llvm: 19, suite: cl+cabi }
+          - { os: macos-latest, llvm: 19, suite: ssa+testgo+rest }
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v7
@@ -81,10 +84,12 @@ jobs:
         id: suite
         run: |
           case "${{matrix.suite}}" in
-            cl)     pkgs="./cl" ;;
-            ssa)    pkgs="./ssa ./internal/cabi" ;;
-            testgo) pkgs="./test/..." ;;
-            rest)   pkgs=$(go list ./... | grep -v -E '^github.com/goplus/llgo/(cl$|ssa$|internal/cabi$|test/)' | tr '\n' ' ') ;;
+            cl)      pkgs="./cl" ;;
+            ssa)     pkgs="./ssa ./internal/cabi" ;;
+            testgo)  pkgs="./test/..." ;;
+            rest)    pkgs=$(go list ./... | grep -v -E '^github.com/goplus/llgo/(cl$|ssa$|internal/cabi$|test/)' | tr '\n' ' ') ;;
+            cl+cabi) pkgs="./cl ./internal/cabi" ;;
+            ssa+testgo+rest) pkgs="./ssa ./test/... $(go list ./... | grep -v -E '^github.com/goplus/llgo/(cl$|ssa$|internal/cabi$|test/)' | tr '\n' ' ')" ;;
           esac
           echo "pkgs=$pkgs" >> "$GITHUB_OUTPUT"
 
@@ -95,13 +100,13 @@ jobs:
         run: go test -timeout 45m -coverprofile="coverage.txt" -covermode=atomic ${{steps.suite.outputs.pkgs}}
 
       - name: Test with embedded emulator env
-        if: matrix.suite == 'cl'
+        if: contains(matrix.suite, 'cl')
         env:
           LLGO_EMBED_TESTS: "1"
         run: go test -v -timeout 60m ./cl -run '^TestRunEmbedEmulator$'
 
       - name: Check std symbol coverage
-        if: matrix.suite == 'rest'
+        if: contains(matrix.suite, 'rest')
         run: bash doc/_readme/scripts/check_std_cover.sh
 
       - name: Upload coverage reports to Codecov


### PR DESCRIPTION
Structural fix for the post-backbone runner deaths (ubuntu exit-143 "shutdown signal" ~8 minutes into the heavy-package phase, reproduced on main and every stage-5 branch) and the mac go-list `WaitDelay` flakes: the covered run stacks four heavy llgo-building test packages (cl, ssa, internal/cabi, test/go) on one VM, and warm shared caches let their compile phases fully overlap.

## Design (asymmetric, mindful of scarce mac runners)

- **ubuntu** (plentiful runners, where the VMs die): one suite per VM — `cl` / `ssa+cabi` / `test tree` / `rest`. Peak cannot stack by construction.
- **macos** (scarce runners; symptom was slowness, never VM death): two balanced groups of at most two heavy packages each — `cl+cabi` and `ssa+testgo+rest`. That restores the pre-backbone peak scale, which mac handled, at the cost of only +1 mac job.

Rejected alternatives: raising budgets (hides it), `go test -p 2` (lowers probability only).

Wall time drops to the slowest group; coverage uploads from every job and codecov merges per commit. The embedded-emulator step rides with the cl suites, the std-symbol check with the rest suites.

**Branch protection note:** required check names change from `test (os, 19)` to `test (os, 19, <suite>)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
