### PR TITLE
Revert "cltest: share one go-build cache across captured runs"

### DIFF
--- a/cl/cltest/cltest.go
+++ b/cl/cltest/cltest.go
@@ -33,7 +33,6 @@ import (
 	"runtime"
 	"slices"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/goplus/gogen/packages"
@@ -324,21 +323,6 @@ func testRunAndTestFrom(t *testing.T, pkgDir, relPkg, sel string, opts runOption
 	}
 }
 
-// sharedGoCacheDir returns a per-process go-build cache reused by every
-// captured run. Isolation from the developer cache is preserved (fresh
-// temp dir per test process); sharing across tests avoids re-typechecking
-// the whole dependency graph for each of the ~170 golden dirs.
-var goCacheOnce sync.Once
-var goCacheDir string
-var goCacheErr error
-
-func sharedGoCacheDir() (string, error) {
-	goCacheOnce.Do(func() {
-		goCacheDir, goCacheErr = os.MkdirTemp("", "llgo-gocache-*")
-	})
-	return goCacheDir, goCacheErr
-}
-
 func RunAndCapture(relPkg, pkgDir string) ([]byte, error) {
 	conf := build.NewDefaultConf(build.ModeRun)
 	return RunAndCaptureWithConf(relPkg, pkgDir, conf)
@@ -402,10 +386,11 @@ func runWithConf(relPkg, pkgDir string, conf *build.Config) ([]byte, error) {
 }
 
 func doWithConf(relPkg, pkgDir string, conf *build.Config, action string) ([]byte, error) {
-	cacheDir, err := sharedGoCacheDir()
+	cacheDir, err := os.MkdirTemp("", "llgo-gocache-*")
 	if err != nil {
 		return nil, err
 	}
+	defer os.RemoveAll(cacheDir)
 	oldCache := os.Getenv("GOCACHE")
 	if err := os.Setenv("GOCACHE", cacheDir); err != nil {
 		return nil, err


### PR DESCRIPTION
Reverts the #2035 cache sharing. The causal matrix from this week's investigation:

| combination | ubuntu coverage job |
|---|---|
| heavy suite (stage-5 branches, weeks) + fresh per-test GOCACHE | green |
| light suite (pre-backbone main) + shared cache | green |
| **heavy suite + shared cache, one VM** | **runner killed ~8 min into the heavy phase (exit 143), reproduced on main and every stage-5 branch** |
| heavy suite + shared cache, one suite per VM (#2044) | green (4/4 ubuntu, 2/2 mac) |

Same-spec local runs (16GB cgroup) rule out memory (9.9GB peak) and disk (~4GB); the remaining mechanism is platform-level: the per-test fresh cache forced go-loader re-typechecking between llgo compile bursts — a natural stagger. Sharing removed it, the four heavy packages' clang/lld bursts aligned into sustained saturation, and the runner agent starves until GitHub reclaims the VM ("runner has received a shutdown signal").

This revert restores the stagger and unblocks main and the seven stage-5 leaf PRs immediately, at the cost of the measured speedup (mac -30%, ubuntu -43%). #2044 (one heavy suite per VM) is the structural fix that makes the sharing safe again — sharing can be re-landed after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)