### PR TITLE
test(goroot): enable complete Go 1.26 coverage

### DIFF
--- a/dev/test_goroot.sh
+++ b/dev/test_goroot.sh
@@ -72,6 +72,7 @@ for goroot in "${goroots[@]}"; do
 		if [[ "${LLGO_GOROOT_VERBOSE:-0}" != "0" ]]; then
 			go_test_args+=("-v")
 		fi
-		run_with_heartbeat go test ./test/goroot "${go_test_args[@]}" -count=1 -timeout 180m -args -goroot "$goroot" "${runner_args[@]}"
+		goroot_gomaxprocs="${LLGO_GOROOT_GOMAXPROCS:-${GOMAXPROCS:-2}}"
+		run_with_heartbeat env GOMAXPROCS="$goroot_gomaxprocs" go test -p=1 ./test/goroot "${go_test_args[@]}" -count=1 -timeout 180m -args -goroot "$goroot" "${runner_args[@]}"
 	)
 done

--- a/test/goroot/README.md
+++ b/test/goroot/README.md
@@ -3,13 +3,22 @@
 This package runs selected upstream `GOROOT/test` cases against `llgo` without
 copying the upstream source files into this repository.
 
-Current scope:
+The source of truth is an external `GOROOT`. Upstream files stay read-only;
+each case runs in a temporary workspace.
 
-- Source of truth is an external `GOROOT`
-- `legacy` mode runs `// run` cases only
-- CI mode runs `// run`, `// runoutput`, and `// buildrun` cases
-- Cases are compared as `go run <file>` vs `llgo run <file>`
-- Upstream files stay read-only; the runner uses a temporary symlinked work tree
+Directive modes:
+
+- `legacy`: `run`
+- `ci`: `run`, `runoutput`, and `buildrun`
+- `runlike`: all runnable single-file and directory directives
+- `coverage`: recursively discovers and executes `compile`, `errorcheck`,
+  `errorcheckandrundir`, `run`, `runoutput`, `rundir`, `runindir`, `buildrun`,
+  and `buildrundir`
+
+`coverage` follows the upstream test runner's directive and compiler flag
+conventions. Compile-only and diagnostic cases are executed, not omitted from
+the coverage total. Known failures remain executed and are classified through
+`xfail.yaml`; only explicitly host-unsafe cases are skipped.
 
 Basic usage:
 
@@ -19,6 +28,23 @@ go test ./test/goroot -count=1 -args \
   -dirs . \
   -case '^helloworld\.go$'
 ```
+
+Resource-constrained full coverage:
+
+```bash
+GOMAXPROCS=2 go test -p=1 ./test/goroot -count=1 -timeout=180m -args \
+  -goroot "$(go env GOROOT)" \
+  -directive-mode coverage \
+  -max-rss-mib 1536 \
+  -rss-warn-mib 768 \
+  -min-memory-free-percent 20 \
+  -min-swap-free-mib 1024
+```
+
+On Unix, the RSS limit covers the complete process group and terminates the
+group when exceeded. System memory and swap are checked before and during every
+child command. Resource guard failures cannot be converted into expected
+failures by `xfail.yaml`.
 
 Multiple toolchains:
 
@@ -33,10 +59,20 @@ Useful flags:
 - `-llgo`: existing `llgo` binary to use; otherwise one is built from the current checkout
 - `-dirs`: comma-separated `GOROOT/test` subdirectories to scan
 - `-case`: regexp filter on the relative case path
-- `-directive-mode`: case discovery mode: `legacy`, `ci`, or `runlike`
+- `-directive-mode`: case discovery mode: `legacy`, `ci`, `runlike`, or `coverage`
+- `-directives`: comma-separated directive filter within the selected mode
 - `-limit`: stop after N matching cases
 - `-shard-index`: 0-based shard index used to partition matching cases
 - `-shard-total`: total number of shards used to partition matching cases
 - `-keepwork`: keep the temporary symlink work tree for debugging
-- `-run-timeout`: timeout for each child `go`/`llgo` process; `0` disables the timeout
+- `-build-timeout`: timeout for each build or compile step
+- `-run-timeout`: timeout for each compiled program run
+- `-list-cases`: print selected totals without building or running cases
+- `-list-case-paths`: print selected directives and paths without running cases
+- `-max-rss-mib`: hard process-group RSS limit; `0` disables it
+- `-rss-warn-mib`: log commands whose observed peak RSS reaches this value
+- `-rss-poll`: process-group RSS sampling interval
+- `-min-memory-free-percent`: minimum system free-memory percentage
+- `-min-swap-free-mib`: minimum free swap in MiB
+- `-memory-pressure-poll`: system memory and swap sampling interval
 - `-xfail`: xfail YAML file, relative to repo root by default

--- a/test/goroot/memory_darwin_test.go
+++ b/test/goroot/memory_darwin_test.go
@@ -1,0 +1,82 @@
+//go:build darwin
+
+package goroot
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func systemMemoryMonitoringSupported() bool { return true }
+
+func readSystemMemoryState() (systemMemoryState, error) {
+	pressureOutput, err := exec.Command("memory_pressure", "-Q").Output()
+	if err != nil {
+		return systemMemoryState{}, err
+	}
+	const freePrefix = "System-wide memory free percentage: "
+	freePercent := -1
+	for _, line := range strings.Split(string(pressureOutput), "\n") {
+		if !strings.HasPrefix(line, freePrefix) {
+			continue
+		}
+		value := strings.TrimSuffix(strings.TrimSpace(strings.TrimPrefix(line, freePrefix)), "%")
+		freePercent, err = strconv.Atoi(value)
+		if err != nil {
+			return systemMemoryState{}, fmt.Errorf("parse memory_pressure line %q: %w", line, err)
+		}
+		break
+	}
+	if freePercent < 0 {
+		return systemMemoryState{}, fmt.Errorf("memory_pressure did not report a free percentage")
+	}
+
+	swapOutput, err := exec.Command("sysctl", "-n", "vm.swapusage").Output()
+	if err != nil {
+		return systemMemoryState{}, err
+	}
+	fields := strings.Fields(string(swapOutput))
+	var swapFree uint64
+	foundSwapFree := false
+	for i := 0; i+2 < len(fields); i++ {
+		if fields[i] != "free" || fields[i+1] != "=" {
+			continue
+		}
+		swapFree, err = parseDarwinMemorySize(fields[i+2])
+		if err != nil {
+			return systemMemoryState{}, err
+		}
+		foundSwapFree = true
+		break
+	}
+	if !foundSwapFree {
+		return systemMemoryState{}, fmt.Errorf("sysctl vm.swapusage did not report free swap: %q", swapOutput)
+	}
+	return systemMemoryState{freePercent: freePercent, swapFree: swapFree, swapPresent: true}, nil
+}
+
+func parseDarwinMemorySize(value string) (uint64, error) {
+	if len(value) < 2 {
+		return 0, fmt.Errorf("invalid Darwin memory size %q", value)
+	}
+	multiplier := float64(1)
+	switch value[len(value)-1] {
+	case 'K':
+		multiplier = 1 << 10
+	case 'M':
+		multiplier = 1 << 20
+	case 'G':
+		multiplier = 1 << 30
+	case 'T':
+		multiplier = 1 << 40
+	default:
+		return 0, fmt.Errorf("invalid Darwin memory size %q", value)
+	}
+	number, err := strconv.ParseFloat(value[:len(value)-1], 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse Darwin memory size %q: %w", value, err)
+	}
+	return uint64(number * multiplier), nil
+}

--- a/test/goroot/memory_darwin_test.go
+++ b/test/goroot/memory_darwin_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"testing"
 )
 
 func systemMemoryMonitoringSupported() bool { return true }
@@ -37,24 +38,33 @@ func readSystemMemoryState() (systemMemoryState, error) {
 	if err != nil {
 		return systemMemoryState{}, err
 	}
-	fields := strings.Fields(string(swapOutput))
-	var swapFree uint64
-	foundSwapFree := false
+	swapFree, swapPresent, err := parseDarwinSwapUsage(swapOutput)
+	if err != nil {
+		return systemMemoryState{}, err
+	}
+	return systemMemoryState{freePercent: freePercent, swapFree: swapFree, swapPresent: swapPresent}, nil
+}
+
+func parseDarwinSwapUsage(output []byte) (swapFree uint64, swapPresent bool, err error) {
+	fields := strings.Fields(string(output))
+	values := make(map[string]uint64, 2)
 	for i := 0; i+2 < len(fields); i++ {
-		if fields[i] != "free" || fields[i+1] != "=" {
+		name := fields[i]
+		if (name != "total" && name != "free") || fields[i+1] != "=" {
 			continue
 		}
-		swapFree, err = parseDarwinMemorySize(fields[i+2])
-		if err != nil {
-			return systemMemoryState{}, err
+		value, parseErr := parseDarwinMemorySize(fields[i+2])
+		if parseErr != nil {
+			return 0, false, parseErr
 		}
-		foundSwapFree = true
-		break
+		values[name] = value
 	}
-	if !foundSwapFree {
-		return systemMemoryState{}, fmt.Errorf("sysctl vm.swapusage did not report free swap: %q", swapOutput)
+	total, hasTotal := values["total"]
+	free, hasFree := values["free"]
+	if !hasTotal || !hasFree {
+		return 0, false, fmt.Errorf("sysctl vm.swapusage did not report total and free swap: %q", output)
 	}
-	return systemMemoryState{freePercent: freePercent, swapFree: swapFree, swapPresent: true}, nil
+	return free, total > 0, nil
 }
 
 func parseDarwinMemorySize(value string) (uint64, error) {
@@ -79,4 +89,46 @@ func parseDarwinMemorySize(value string) (uint64, error) {
 		return 0, fmt.Errorf("parse Darwin memory size %q: %w", value, err)
 	}
 	return uint64(number * multiplier), nil
+}
+
+func TestParseDarwinSwapUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		output      string
+		wantFree    uint64
+		wantPresent bool
+		wantErr     bool
+	}{
+		{
+			name:        "active swap",
+			output:      "total = 2048.00M  used = 512.00M  free = 1.50G  (encrypted)",
+			wantFree:    1536 << 20,
+			wantPresent: true,
+		},
+		{
+			name:   "runner without swap",
+			output: "total = 0.00M  used = 0.00M  free = 0.00M",
+		},
+		{
+			name:    "missing total",
+			output:  "used = 0.00M free = 0.00M",
+			wantErr: true,
+		},
+		{
+			name:    "invalid free",
+			output:  "total = 1.00G free = unknown",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotFree, gotPresent, err := parseDarwinSwapUsage([]byte(tt.output))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseDarwinSwapUsage() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if gotFree != tt.wantFree || gotPresent != tt.wantPresent {
+				t.Fatalf("parseDarwinSwapUsage() = (%d, %v), want (%d, %v)", gotFree, gotPresent, tt.wantFree, tt.wantPresent)
+			}
+		})
+	}
 }

--- a/test/goroot/memory_linux_test.go
+++ b/test/goroot/memory_linux_test.go
@@ -1,0 +1,42 @@
+//go:build linux
+
+package goroot
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func systemMemoryMonitoringSupported() bool { return true }
+
+func readSystemMemoryState() (systemMemoryState, error) {
+	data, err := os.ReadFile("/proc/meminfo")
+	if err != nil {
+		return systemMemoryState{}, err
+	}
+	values := make(map[string]uint64)
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		key := strings.TrimSuffix(fields[0], ":")
+		value, err := strconv.ParseUint(fields[1], 10, 64)
+		if err != nil {
+			return systemMemoryState{}, fmt.Errorf("parse /proc/meminfo line %q: %w", line, err)
+		}
+		values[key] = value << 10
+	}
+	total := values["MemTotal"]
+	available := values["MemAvailable"]
+	if total == 0 {
+		return systemMemoryState{}, fmt.Errorf("/proc/meminfo did not report MemTotal")
+	}
+	return systemMemoryState{
+		freePercent: int(available * 100 / total),
+		swapFree:    values["SwapFree"],
+		swapPresent: values["SwapTotal"] > 0,
+	}, nil
+}

--- a/test/goroot/memory_other_test.go
+++ b/test/goroot/memory_other_test.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux
+
+package goroot
+
+func systemMemoryMonitoringSupported() bool { return false }
+
+func readSystemMemoryState() (systemMemoryState, error) {
+	return systemMemoryState{}, nil
+}

--- a/test/goroot/proc_other_test.go
+++ b/test/goroot/proc_other_test.go
@@ -12,3 +12,7 @@ func killProcessTree(cmd *exec.Cmd) {
 	}
 	_ = cmd.Process.Kill()
 }
+
+func resourceMonitoringSupported() bool { return false }
+
+func processGroupRSS(int) (uint64, error) { return 0, nil }

--- a/test/goroot/proc_unix_test.go
+++ b/test/goroot/proc_unix_test.go
@@ -3,7 +3,11 @@
 package goroot
 
 import (
+	"bufio"
+	"bytes"
+	"fmt"
 	"os/exec"
+	"strconv"
 	"syscall"
 )
 
@@ -16,4 +20,34 @@ func killProcessTree(cmd *exec.Cmd) {
 		return
 	}
 	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+}
+
+func resourceMonitoringSupported() bool { return true }
+
+func processGroupRSS(processGroupID int) (uint64, error) {
+	output, err := exec.Command("ps", "-axo", "pgid=,rss=").Output()
+	if err != nil {
+		return 0, err
+	}
+	var totalKiB uint64
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	for scanner.Scan() {
+		fields := bytes.Fields(scanner.Bytes())
+		if len(fields) != 2 {
+			continue
+		}
+		pgid, err := strconv.Atoi(string(fields[0]))
+		if err != nil || pgid != processGroupID {
+			continue
+		}
+		rssKiB, err := strconv.ParseUint(string(fields[1]), 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parse RSS from ps output %q: %w", scanner.Text(), err)
+		}
+		totalKiB += rssKiB
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, err
+	}
+	return totalKiB << 10, nil
 }

--- a/test/goroot/runner_test.go
+++ b/test/goroot/runner_test.go
@@ -924,6 +924,9 @@ finished:
 	}
 	elapsed := time.Since(start)
 	if terminationErr != nil {
+		if exitCode == 0 {
+			exitCode = -1
+		}
 		return stdout.Bytes(), stderr.Bytes(), exitCode, elapsed, terminationErr
 	}
 	return stdout.Bytes(), stderr.Bytes(), exitCode, elapsed, nil

--- a/test/goroot/runner_test.go
+++ b/test/goroot/runner_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"go/ast"
 	"go/build"
 	"go/format"
 	"go/parser"
@@ -31,22 +32,31 @@ import (
 )
 
 var (
-	flagGOROOT   = flag.String("goroot", os.Getenv("LLGO_GOROOT"), "Go toolchain root whose GOROOT/test sources should be used")
-	flagGoCmd    = flag.String("go", os.Getenv("LLGO_GO"), "go binary used as baseline (default: <goroot>/bin/go)")
-	flagLLGO     = flag.String("llgo", os.Getenv("LLGO_TEST_LLGO"), "llgo binary used for comparisons (default: build from current checkout)")
-	flagDirs     = flag.String("dirs", strings.Join(defaultGoRootTestDirs, ","), "comma-separated GOROOT/test subdirectories to scan")
-	flagCase     = flag.String("case", os.Getenv("LLGO_GOROOT_CASE"), "regexp selecting cases by relative path")
-	flagLimit    = flag.Int("limit", 0, "maximum number of matching cases to run")
-	flagShardI   = flag.Int("shard-index", 0, "0-based shard index used to partition matching cases")
-	flagShardN   = flag.Int("shard-total", 1, "number of shards used to partition matching cases")
-	flagKeep     = flag.Bool("keepwork", false, "keep temporary work directories for debugging")
-	flagDirMode  = flag.String("directive-mode", "legacy", "case discovery mode: legacy, ci, or runlike")
-	flagXFail    = flag.String("xfail", filepath.Join("test", "goroot", "xfail.yaml"), "xfail configuration path relative to repo root")
-	flagBuildTO  = flag.Duration("build-timeout", 3*time.Minute, "timeout for each go/llgo build step; 0 disables the timeout")
-	flagRunTO    = flag.Duration("run-timeout", time.Minute, "timeout for the compiled program run step; 0 disables the timeout")
-	flagSlowBld  = flag.Duration("slow-build", 10*time.Second, "log build steps that exceed this duration; 0 disables slow-build logging")
-	flagSlowRun  = flag.Duration("slow-run", 5*time.Second, "log run steps that exceed this duration; 0 disables slow-run logging")
-	flagProgress = flag.Duration("progress", 0, "log current GOROOT case progress at this interval; 0 disables progress logging")
+	flagGOROOT     = flag.String("goroot", os.Getenv("LLGO_GOROOT"), "Go toolchain root whose GOROOT/test sources should be used")
+	flagGoCmd      = flag.String("go", os.Getenv("LLGO_GO"), "go binary used as baseline (default: <goroot>/bin/go)")
+	flagLLGO       = flag.String("llgo", os.Getenv("LLGO_TEST_LLGO"), "llgo binary used for comparisons (default: build from current checkout)")
+	flagDirs       = flag.String("dirs", strings.Join(defaultGoRootTestDirs, ","), "comma-separated GOROOT/test subdirectories to scan")
+	flagCase       = flag.String("case", os.Getenv("LLGO_GOROOT_CASE"), "regexp selecting cases by relative path")
+	flagLimit      = flag.Int("limit", 0, "maximum number of matching cases to run")
+	flagShardI     = flag.Int("shard-index", 0, "0-based shard index used to partition matching cases")
+	flagShardN     = flag.Int("shard-total", 1, "number of shards used to partition matching cases")
+	flagKeep       = flag.Bool("keepwork", false, "keep temporary work directories for debugging")
+	flagDirMode    = flag.String("directive-mode", "legacy", "case discovery mode: legacy, ci, runlike, or coverage")
+	flagDirective  = flag.String("directives", "", "comma-separated directive filter within the selected mode")
+	flagXFail      = flag.String("xfail", filepath.Join("test", "goroot", "xfail.yaml"), "xfail configuration path relative to repo root")
+	flagBuildTO    = flag.Duration("build-timeout", 3*time.Minute, "timeout for each go/llgo build step; 0 disables the timeout")
+	flagRunTO      = flag.Duration("run-timeout", time.Minute, "timeout for the compiled program run step; 0 disables the timeout")
+	flagSlowBld    = flag.Duration("slow-build", 10*time.Second, "log build steps that exceed this duration; 0 disables slow-build logging")
+	flagSlowRun    = flag.Duration("slow-run", 5*time.Second, "log run steps that exceed this duration; 0 disables slow-run logging")
+	flagProgress   = flag.Duration("progress", 0, "log current GOROOT case progress at this interval; 0 disables progress logging")
+	flagListCases  = flag.Bool("list-cases", false, "list selected case counts without building or running llgo")
+	flagListPaths  = flag.Bool("list-case-paths", false, "list selected directive and case paths without building or running llgo")
+	flagMaxRSSMiB  = flag.Int64("max-rss-mib", 4096, "maximum RSS in MiB for each spawned process group; 0 disables the limit")
+	flagRSSWarnMiB = flag.Int64("rss-warn-mib", 1024, "log commands whose observed peak process-group RSS reaches this value; 0 disables warnings")
+	flagRSSPoll    = flag.Duration("rss-poll", 100*time.Millisecond, "process-group RSS sampling interval")
+	flagMinMemPct  = flag.Int("min-memory-free-percent", 15, "minimum system-wide free memory percentage required to start and continue a command; 0 disables the check")
+	flagMinSwapMiB = flag.Int64("min-swap-free-mib", 512, "minimum free swap in MiB required to start and continue a command; 0 disables the check")
+	flagMemPoll    = flag.Duration("memory-pressure-poll", time.Second, "system memory pressure sampling interval")
 )
 
 var defaultGoRootTestDirs = []string{
@@ -109,6 +119,7 @@ type directiveMode struct {
 	Name         string
 	Directives   map[string]bool
 	AllowRunArgs bool
+	Recursive    bool
 }
 
 func (m directiveMode) allows(directive string, args []string) bool {
@@ -130,10 +141,13 @@ func (m directiveMode) allows(directive string, args []string) bool {
 
 type directiveOptions struct {
 	BuildFlags     []string
+	CompilerFlags  []string
+	LinkerFlags    []string
 	ProgramArgs    []string
 	ExtraEnv       []string
 	GoModVersion   string
 	SingleFilePkgs bool
+	WantError      bool
 	Timeout        time.Duration
 }
 
@@ -266,13 +280,10 @@ func TestGoRootRunCases(t *testing.T) {
 		t.Fatalf("GOROOT/test root %q is not a directory", testRoot)
 	}
 
-	llgoBin := *flagLLGO
-	if llgoBin == "" {
-		llgoBin = buildLLGOBinary(t, repoRoot, goCmd)
-	}
 	xfails := loadXFailConfig(t, repoRoot, *flagXFail)
 	caseFilter := compileCaseFilter(t, *flagCase)
 	mode := loadDirectiveMode(t, *flagDirMode)
+	mode = filterDirectiveMode(t, mode, *flagDirective)
 	cases := discoverCases(t, testRoot, envInfo, parseDirs(*flagDirs), caseFilter, *flagLimit, mode)
 	if len(cases) == 0 {
 		t.Fatalf("no matching cases found under %s for directive mode %q", testRoot, mode.Name)
@@ -280,6 +291,33 @@ func TestGoRootRunCases(t *testing.T) {
 	cases = shardCases(t, cases, *flagShardI, *flagShardN)
 	if len(cases) == 0 {
 		t.Skipf("no matching cases selected for shard %d/%d", *flagShardI, *flagShardN)
+	}
+	if *flagListCases || *flagListPaths {
+		counts := make(map[string]int)
+		for _, tc := range cases {
+			counts[tc.Directive]++
+		}
+		directives := make([]string, 0, len(counts))
+		for directive := range counts {
+			directives = append(directives, directive)
+		}
+		sort.Strings(directives)
+		fmt.Printf("total=%d\n", len(cases))
+		for _, directive := range directives {
+			fmt.Printf("%s=%d\n", directive, counts[directive])
+		}
+		if *flagListPaths {
+			for _, tc := range cases {
+				fmt.Printf("%s\t%s\n", tc.Directive, tc.RelPath)
+			}
+		}
+		return
+	}
+	t.Setenv("STDLIB_IMPORTCFG", writeStdlibImportCfg(t, goCmd))
+
+	llgoBin := *flagLLGO
+	if llgoBin == "" {
+		llgoBin = buildLLGOBinary(t, repoRoot, goCmd)
 	}
 
 	fmt.Fprintf(os.Stderr, "goroot=%s goversion=%s goos=%s goarch=%s shard=%d/%d cases=%d directive_mode=%s\n", goroot, envInfo.GOVERSION, envInfo.GOOS, envInfo.GOARCH, *flagShardI, *flagShardN, len(cases), mode.Name)
@@ -300,6 +338,10 @@ func TestGoRootRunCases(t *testing.T) {
 			}
 			buildTimeout := effectiveBuildTimeout(*flagBuildTO, runTimeout)
 			err := runCase(t, repoRoot, goroot, goCmd, llgoBin, tc, buildTimeout, runTimeout)
+			var resourceErr *resourceLimitError
+			if errors.As(err, &resourceErr) {
+				t.Fatalf("resource guard stopped case: %v", err)
+			}
 			match, reason := xfails.Match(envInfo.GOVERSION, envInfo.GOOS+"/"+envInfo.GOARCH, tc)
 			flaky, flakyReason := xfails.MatchFlaky(envInfo.GOVERSION, envInfo.GOOS+"/"+envInfo.GOARCH, tc)
 			switch {
@@ -316,6 +358,21 @@ func TestGoRootRunCases(t *testing.T) {
 			}
 		})
 	}
+}
+
+func writeStdlibImportCfg(t *testing.T, goCmd string) string {
+	t.Helper()
+	cmd := exec.Command(goCmd, "list", "-export", "-f", "{{if .Export}}packagefile {{.ImportPath}}={{.Export}}{{end}}", "std")
+	cmd.Env = append(os.Environ(), "GOENV=off", "GOFLAGS=")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("list stdlib exports with %s: %v\n%s", goCmd, err, output)
+	}
+	filePath := filepath.Join(t.TempDir(), "stdlib-importcfg")
+	if err := os.WriteFile(filePath, output, 0o644); err != nil {
+		t.Fatalf("write stdlib importcfg: %v", err)
+	}
+	return filePath
 }
 
 func repoRoot(t *testing.T) string {
@@ -450,10 +507,43 @@ func loadDirectiveMode(t *testing.T, name string) directiveMode {
 			},
 			AllowRunArgs: true,
 		}
+	case "coverage":
+		return directiveMode{
+			Name: "coverage",
+			Directives: map[string]bool{
+				"compile":             true,
+				"errorcheck":          true,
+				"errorcheckandrundir": true,
+				"run":                 true,
+				"runoutput":           true,
+				"rundir":              true,
+				"runindir":            true,
+				"buildrun":            true,
+				"buildrundir":         true,
+			},
+			AllowRunArgs: true,
+			Recursive:    true,
+		}
 	default:
 		t.Fatalf("unknown -directive-mode=%q", name)
 		return directiveMode{}
 	}
+}
+
+func filterDirectiveMode(t *testing.T, mode directiveMode, csv string) directiveMode {
+	t.Helper()
+	if strings.TrimSpace(csv) == "" {
+		return mode
+	}
+	selected := make(map[string]bool)
+	for _, directive := range parseDirs(csv) {
+		if !mode.Directives[directive] {
+			t.Fatalf("directive %q is not enabled by -directive-mode=%s", directive, mode.Name)
+		}
+		selected[directive] = true
+	}
+	mode.Directives = selected
+	return mode
 }
 
 func discoverCases(t *testing.T, testRoot string, envInfo toolchainEnv, dirs []string, filter *regexp.Regexp, limit int, mode directiveMode) []testCase {
@@ -465,6 +555,9 @@ func discoverCases(t *testing.T, testRoot string, envInfo toolchainEnv, dirs []s
 	ctx.GOROOT = filepath.Dir(testRoot)
 	ctx.ReleaseTags = envInfo.ReleaseTags
 
+	if mode.Recursive {
+		dirs = recursiveTestDirs(t, testRoot)
+	}
 	var cases []testCase
 	for _, relDir := range dirs {
 		absDir := filepath.Join(testRoot, filepath.FromSlash(relDir))
@@ -509,6 +602,34 @@ func discoverCases(t *testing.T, testRoot string, envInfo toolchainEnv, dirs []s
 		}
 	}
 	return cases
+}
+
+func recursiveTestDirs(t *testing.T, testRoot string) []string {
+	t.Helper()
+	dirs := []string{"."}
+	err := filepath.WalkDir(testRoot, func(current string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if current == testRoot || !entry.IsDir() {
+			return nil
+		}
+		name := entry.Name()
+		if strings.HasPrefix(name, ".") || name == "testdata" {
+			return filepath.SkipDir
+		}
+		rel, err := filepath.Rel(testRoot, current)
+		if err != nil {
+			return err
+		}
+		dirs = append(dirs, filepath.ToSlash(rel))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk GOROOT/test directories: %v", err)
+	}
+	sort.Strings(dirs)
+	return dirs
 }
 
 func shardCases(t *testing.T, cases []testCase, shardIndex, shardTotal int) []testCase {
@@ -570,6 +691,12 @@ func runCase(t *testing.T, repoRoot, goroot, goCmd, llgoBin string, tc testCase,
 		return err
 	}
 	switch tc.Directive {
+	case "compile":
+		return runCompileCase(t, repoRoot, goroot, llgoBin, tc, opts, buildTimeout)
+	case "errorcheck":
+		return runErrorCheckCase(t, repoRoot, goroot, llgoBin, tc, opts, buildTimeout)
+	case "errorcheckandrundir":
+		return runErrorCheckAndRunCase(t, repoRoot, goroot, goCmd, llgoBin, tc, opts, buildTimeout)
 	case "run", "buildrun":
 		return runSingleFileCase(t, repoRoot, goroot, goCmd, llgoBin, tc, opts, buildTimeout)
 	case "runoutput":
@@ -679,12 +806,29 @@ func upsertEnv(env []string, kv string) []string {
 	return append(env, kv)
 }
 
+func restoreProcessEnv(env []string, key string) []string {
+	prefix := key + "="
+	out := env[:0]
+	for _, item := range env {
+		if !strings.HasPrefix(item, prefix) {
+			out = append(out, item)
+		}
+	}
+	if value, ok := os.LookupEnv(key); ok {
+		out = append(out, prefix+value)
+	}
+	return out
+}
+
 func runProgram(dir, app string, env []string, timeout time.Duration, args ...string) ([]byte, []byte, int, time.Duration, error) {
 	start := time.Now()
+	if err := checkSystemMemoryPressure(); err != nil {
+		return nil, nil, 0, time.Since(start), err
+	}
 	cmd := exec.Command(app, args...)
 	configureProcessGroup(cmd)
 	cmd.Dir = dir
-	cmd.Env = env
+	cmd.Env = upsertEnv(append([]string{}, env...), "PWD="+dir)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -699,17 +843,74 @@ func runProgram(dir, app string, env []string, timeout time.Duration, args ...st
 	}()
 
 	var err error
-	timedOut := false
+	var terminationErr error
+	var timeoutTimer *time.Timer
+	var timeoutCh <-chan time.Time
 	if timeout > 0 {
+		timeoutTimer = time.NewTimer(timeout)
+		timeoutCh = timeoutTimer.C
+		defer timeoutTimer.Stop()
+	}
+	var rssTicker *time.Ticker
+	var rssCh <-chan time.Time
+	if (*flagMaxRSSMiB > 0 || *flagRSSWarnMiB > 0) && resourceMonitoringSupported() {
+		poll := *flagRSSPoll
+		if poll <= 0 {
+			poll = 100 * time.Millisecond
+		}
+		rssTicker = time.NewTicker(poll)
+		rssCh = rssTicker.C
+		defer rssTicker.Stop()
+	}
+	var memoryTicker *time.Ticker
+	var memoryCh <-chan time.Time
+	if systemMemoryMonitoringSupported() && (*flagMinMemPct > 0 || *flagMinSwapMiB > 0) {
+		poll := *flagMemPoll
+		if poll <= 0 {
+			poll = time.Second
+		}
+		memoryTicker = time.NewTicker(poll)
+		memoryCh = memoryTicker.C
+		defer memoryTicker.Stop()
+	}
+	var peakRSS uint64
+	for {
 		select {
 		case err = <-waitCh:
-		case <-time.After(timeout):
-			timedOut = true
+			goto finished
+		case <-timeoutCh:
+			terminationErr = fmt.Errorf("timed out after %s", timeout)
 			killProcessTree(cmd)
 			err = <-waitCh
+			goto finished
+		case <-rssCh:
+			rssBytes, rssErr := processGroupRSS(cmd.Process.Pid)
+			if rssErr != nil {
+				continue
+			}
+			if rssBytes > peakRSS {
+				peakRSS = rssBytes
+			}
+			limitBytes := uint64(*flagMaxRSSMiB) << 20
+			if *flagMaxRSSMiB > 0 && rssBytes > limitBytes {
+				terminationErr = &resourceLimitError{message: fmt.Sprintf("process-group RSS %s exceeded limit %s", formatBytes(rssBytes), formatBytes(limitBytes))}
+				killProcessTree(cmd)
+				err = <-waitCh
+				goto finished
+			}
+		case <-memoryCh:
+			if memoryErr := checkSystemMemoryPressure(); memoryErr != nil {
+				terminationErr = memoryErr
+				killProcessTree(cmd)
+				err = <-waitCh
+				goto finished
+			}
 		}
-	} else {
-		err = <-waitCh
+	}
+
+finished:
+	if *flagRSSWarnMiB > 0 && peakRSS >= uint64(*flagRSSWarnMiB)<<20 {
+		fmt.Fprintf(os.Stderr, "goroot resource warning: %s peak process-group RSS %s\n", filepath.Base(app), formatBytes(peakRSS))
 	}
 	exitCode := 0
 	if err != nil {
@@ -722,10 +923,61 @@ func runProgram(dir, app string, env []string, timeout time.Duration, args ...st
 		}
 	}
 	elapsed := time.Since(start)
-	if timedOut {
-		return stdout.Bytes(), stderr.Bytes(), exitCode, elapsed, fmt.Errorf("timed out after %s", timeout)
+	if terminationErr != nil {
+		return stdout.Bytes(), stderr.Bytes(), exitCode, elapsed, terminationErr
 	}
 	return stdout.Bytes(), stderr.Bytes(), exitCode, elapsed, nil
+}
+
+func formatBytes(bytes uint64) string {
+	const mib = uint64(1 << 20)
+	return fmt.Sprintf("%.1f MiB", float64(bytes)/float64(mib))
+}
+
+type resourceLimitError struct {
+	message string
+}
+
+func (err *resourceLimitError) Error() string { return err.message }
+
+type systemMemoryState struct {
+	freePercent int
+	swapFree    uint64
+	swapPresent bool
+}
+
+func checkSystemMemoryPressure() error {
+	if !systemMemoryMonitoringSupported() || (*flagMinMemPct <= 0 && *flagMinSwapMiB <= 0) {
+		return nil
+	}
+	state, err := readSystemMemoryState()
+	if err != nil {
+		return &resourceLimitError{message: fmt.Sprintf("read system memory pressure: %v", err)}
+	}
+	return validateSystemMemoryState(state)
+}
+
+func validateSystemMemoryState(state systemMemoryState) error {
+	if *flagMinMemPct > 0 && state.freePercent < *flagMinMemPct {
+		return &resourceLimitError{message: fmt.Sprintf("system free memory %d%% is below minimum %d%%", state.freePercent, *flagMinMemPct)}
+	}
+	if *flagMinSwapMiB > 0 && state.swapPresent {
+		minimum := uint64(*flagMinSwapMiB) << 20
+		if state.swapFree < minimum {
+			return &resourceLimitError{message: fmt.Sprintf("free swap %s is below minimum %s", formatBytes(state.swapFree), formatBytes(minimum))}
+		}
+	}
+	return nil
+}
+
+func requireSuccessfulExit(err error, exitCode int) error {
+	if err != nil {
+		return err
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("process exited with code %d", exitCode)
+	}
+	return nil
 }
 
 func commandFailure(prefix string, elapsed time.Duration, err error, stdout, stderr []byte, exitCode int) error {
@@ -741,8 +993,16 @@ func commandFailure(prefix string, elapsed time.Duration, err error, stdout, std
 	if len(stderr) != 0 {
 		fmt.Fprintf(&msg, "\nstderr:\n%s", normalizeOutput(stderr))
 	}
-	return errors.New(msg.String())
+	return &commandFailureError{message: msg.String(), cause: err}
 }
+
+type commandFailureError struct {
+	message string
+	cause   error
+}
+
+func (err *commandFailureError) Error() string { return err.message }
+func (err *commandFailureError) Unwrap() error { return err.cause }
 
 func logSlowCase(t *testing.T, casePath string, goBuildDur, llgoBuildDur, goRunDur, llgoRunDur time.Duration) {
 	t.Helper()
@@ -795,10 +1055,257 @@ func filterNoise(in []byte) []byte {
 			continue
 		case strings.HasPrefix(trimmed, "ld: warning:"):
 			continue
+		case strings.Contains(trimmed, "could not import ") && strings.Contains(trimmed, "(no metadata for "):
+			continue
 		}
 		out.Write(line)
 	}
 	return out.Bytes()
+}
+
+type wantedError struct {
+	regexp  *regexp.Regexp
+	pattern string
+	prefix  string
+	file    string
+	line    int
+	auto    bool
+}
+
+type diagnosticSource struct {
+	full  string
+	short string
+}
+
+var (
+	errorCommentRx = regexp.MustCompile(`// (?:GC_)?ERROR (.*)`)
+	errorAutoRx    = regexp.MustCompile(`// (?:GC_)?ERRORAUTO (.*)`)
+	errorQuotesRx  = regexp.MustCompile(`"([^"]*)"`)
+	errorLineRx    = regexp.MustCompile(`LINE(([+-])(\d+))?`)
+	diagnosticRx   = regexp.MustCompile(`^(.*?):([0-9]+)(?::[0-9]+)?: (.*)$`)
+)
+
+func checkExpectedErrors(output, fullPath, shortPath string) error {
+	return checkExpectedErrorsForFiles(output, []diagnosticSource{{full: fullPath, short: shortPath}})
+}
+
+func checkExpectedErrorsForFiles(output string, sources []diagnosticSource) error {
+	lines := splitCompilerOutput(output, false)
+	for _, source := range sources {
+		for i := range lines {
+			lines[i] = replaceDiagnosticPrefix(lines[i], source.full, source.short)
+		}
+	}
+	lines = preferSpecificDiagnostics(lines)
+	var wanted []wantedError
+	for _, source := range sources {
+		expected, err := wantedErrors(source.full, source.short)
+		if err != nil {
+			return err
+		}
+		wanted = append(wanted, expected...)
+	}
+	var errs []error
+	for _, expected := range wanted {
+		var candidates []string
+		if expected.auto {
+			candidates, lines = partitionCompilerOutput("<autogenerated>", lines)
+		} else {
+			candidates, lines = partitionCompilerOutput(expected.prefix, lines)
+		}
+		if len(candidates) == 0 {
+			errs = append(errs, fmt.Errorf("%s:%d: missing error %q", expected.file, expected.line, expected.pattern))
+			continue
+		}
+		matched := false
+		for _, candidate := range candidates {
+			message := candidate
+			if _, suffix, ok := strings.Cut(message, " "); ok {
+				message = suffix
+			}
+			if expected.regexp.MatchString(message) {
+				matched = true
+			} else {
+				lines = append(lines, candidate)
+			}
+		}
+		if !matched {
+			errs = append(errs, fmt.Errorf("%s:%d: no match for %q", expected.file, expected.line, expected.pattern))
+		}
+	}
+
+	local := lines[:0]
+	for _, line := range lines {
+		if strings.Contains(line, ": \t") {
+			continue
+		}
+		for _, source := range sources {
+			if hasDiagnosticPrefix(line, source.full) || hasDiagnosticPrefix(line, source.short) {
+				local = append(local, line)
+				break
+			}
+		}
+	}
+	if len(local) != 0 {
+		errs = append(errs, fmt.Errorf("unmatched errors:\n%s", strings.Join(local, "\n")))
+	}
+	return errors.Join(errs...)
+}
+
+func preferSpecificDiagnostics(lines []string) []string {
+	discard := make([]bool, len(lines))
+	type parsedDiagnostic struct {
+		location string
+		message  string
+	}
+	parsed := make([]parsedDiagnostic, len(lines))
+	for i, line := range lines {
+		match := diagnosticRx.FindStringSubmatch(line)
+		if match == nil {
+			continue
+		}
+		parsed[i] = parsedDiagnostic{
+			location: filepath.Base(match[1]) + ":" + match[2],
+			message:  match[3],
+		}
+	}
+	for i := range lines {
+		if parsed[i].location == "" || discard[i] {
+			continue
+		}
+		for j := i + 1; j < len(lines); j++ {
+			if parsed[i].location != parsed[j].location || discard[j] {
+				continue
+			}
+			switch {
+			case parsed[i].message == parsed[j].message:
+				discard[j] = true
+			case strings.HasPrefix(parsed[j].message, parsed[i].message):
+				discard[i] = true
+			case strings.HasPrefix(parsed[i].message, parsed[j].message):
+				discard[j] = true
+			}
+		}
+	}
+	out := lines[:0]
+	for i, line := range lines {
+		if !discard[i] {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+func splitCompilerOutput(output string, wantAuto bool) []string {
+	var out []string
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSuffix(line, "\r")
+		switch {
+		case strings.HasPrefix(line, "\t") && len(out) != 0:
+			out[len(out)-1] += "\n" + line
+		case strings.HasPrefix(line, "go tool"), strings.HasPrefix(line, "#"):
+		case !wantAuto && strings.HasPrefix(line, "<autogenerated>"):
+		case strings.TrimSpace(line) != "":
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+func wantedErrors(fullPath, shortPath string) ([]wantedError, error) {
+	src, err := os.ReadFile(fullPath)
+	if err != nil {
+		return nil, err
+	}
+	cache := make(map[string]*regexp.Regexp)
+	var out []wantedError
+	for index, sourceLine := range strings.Split(string(src), "\n") {
+		lineNumber := index + 1
+		if strings.Contains(sourceLine, "////") {
+			continue
+		}
+		auto := false
+		match := errorAutoRx.FindStringSubmatch(sourceLine)
+		if match != nil {
+			auto = true
+		} else {
+			match = errorCommentRx.FindStringSubmatch(sourceLine)
+		}
+		if match == nil {
+			continue
+		}
+		quoted := errorQuotesRx.FindAllStringSubmatch(match[1], -1)
+		if len(quoted) == 0 {
+			return nil, fmt.Errorf("%s:%d: invalid ERROR comment", shortPath, lineNumber)
+		}
+		for _, item := range quoted {
+			pattern := errorLineRx.ReplaceAllStringFunc(item[1], func(marker string) string {
+				line := lineNumber
+				if strings.HasPrefix(marker, "LINE+") {
+					delta, _ := strconv.Atoi(marker[5:])
+					line += delta
+				} else if strings.HasPrefix(marker, "LINE-") {
+					delta, _ := strconv.Atoi(marker[5:])
+					line -= delta
+				}
+				return fmt.Sprintf("%s:%d", shortPath, line)
+			})
+			re := cache[pattern]
+			if re == nil {
+				re, err = regexp.Compile(pattern)
+				if err != nil {
+					return nil, fmt.Errorf("%s:%d: invalid ERROR regexp %q: %w", shortPath, lineNumber, pattern, err)
+				}
+				cache[pattern] = re
+			}
+			out = append(out, wantedError{
+				regexp:  re,
+				pattern: pattern,
+				prefix:  fmt.Sprintf("%s:%d", shortPath, lineNumber),
+				file:    shortPath,
+				line:    lineNumber,
+				auto:    auto,
+			})
+		}
+	}
+	return out, nil
+}
+
+func hasDiagnosticPrefix(line, prefix string) bool {
+	colon := strings.IndexByte(line, ':')
+	if colon < 0 {
+		return false
+	}
+	slash := strings.LastIndex(line[:colon], "/")
+	base := line[slash+1:]
+	if len(base) <= len(prefix) || !strings.HasPrefix(base, prefix) {
+		return false
+	}
+	return base[len(prefix)] == ':' || base[len(prefix)] == '['
+}
+
+func partitionCompilerOutput(prefix string, lines []string) (matched, unmatched []string) {
+	for _, line := range lines {
+		if hasDiagnosticPrefix(line, prefix) {
+			matched = append(matched, line)
+		} else {
+			unmatched = append(unmatched, line)
+		}
+	}
+	return matched, unmatched
+}
+
+func replaceDiagnosticPrefix(value, old, new string) string {
+	if !strings.Contains(value, old) {
+		return value
+	}
+	value = strings.ReplaceAll(value, " "+old, " "+new)
+	value = strings.ReplaceAll(value, "\n"+old, "\n"+new)
+	value = strings.ReplaceAll(value, "\n\t"+old, "\n\t"+new)
+	if strings.HasPrefix(value, old) {
+		value = new + value[len(old):]
+	}
+	return value
 }
 
 func trimLogTimestampPrefix(line string) string {
@@ -983,11 +1490,18 @@ func splitQuoted(s string) ([]string, error) {
 }
 
 func parseDirectiveOptions(directive string, args []string, defaultRunTimeout time.Duration) (directiveOptions, error) {
-	opts := directiveOptions{Timeout: defaultRunTimeout}
+	opts := directiveOptions{
+		Timeout:   defaultRunTimeout,
+		WantError: directive == "errorcheck",
+	}
 	args = append([]string(nil), args...)
 	for len(args) > 0 && strings.HasPrefix(args[0], "-") {
 		switch args[0] {
-		case "-1", "-0":
+		case "-1":
+			opts.WantError = true
+			args = args[1:]
+		case "-0":
+			opts.WantError = false
 			args = args[1:]
 		case "-s":
 			opts.SingleFilePkgs = true
@@ -1027,6 +1541,11 @@ func parseDirectiveOptions(directive string, args []string, defaultRunTimeout ti
 			opts.BuildFlags = append(opts.BuildFlags, args[0], args[1])
 			args = args[2:]
 		case "-ldflags":
+			if usesCompilerFlags(directive) {
+				opts.LinkerFlags = append(opts.LinkerFlags, args[1:]...)
+				args = nil
+				continue
+			}
 			if len(args) < 2 {
 				return directiveOptions{}, fmt.Errorf("%s: missing value for -ldflags", directive)
 			}
@@ -1043,12 +1562,25 @@ func parseDirectiveOptions(directive string, args []string, defaultRunTimeout ti
 		doneLDFlags:
 			opts.BuildFlags = append(opts.BuildFlags, "-ldflags", strings.Join(payload, " "))
 		default:
-			opts.BuildFlags = append(opts.BuildFlags, args[0])
+			if usesCompilerFlags(directive) {
+				opts.CompilerFlags = append(opts.CompilerFlags, args[0])
+			} else {
+				opts.BuildFlags = append(opts.BuildFlags, args[0])
+			}
 			args = args[1:]
 		}
 	}
 	opts.ProgramArgs = append(opts.ProgramArgs, args...)
 	return opts, nil
+}
+
+func usesCompilerFlags(directive string) bool {
+	switch directive {
+	case "compile", "errorcheck", "errorcheckandrundir", "rundir":
+		return true
+	default:
+		return false
+	}
 }
 
 func appendDirectiveEnv(env []string, key, value string) []string {
@@ -1062,6 +1594,196 @@ func appendDirectiveEnv(env []string, key, value string) []string {
 	return append(env, kv)
 }
 
+func runCompileCase(t *testing.T, repoRoot, goroot, llgoBin string, tc testCase, opts directiveOptions, buildTimeout time.Duration) error {
+	t.Helper()
+	stdout, stderr, exitCode, elapsed, err := runLLGOCompiler(repoRoot, goroot, llgoBin, tc, opts, false, buildTimeout)
+	if err != nil {
+		return commandFailure("llgo tool compile", elapsed, err, stdout, stderr, exitCode)
+	}
+	if exitCode != 0 {
+		return commandFailure("llgo tool compile", elapsed, fmt.Errorf("compiler exited unsuccessfully"), stdout, stderr, exitCode)
+	}
+	return nil
+}
+
+func runErrorCheckCase(t *testing.T, repoRoot, goroot, llgoBin string, tc testCase, opts directiveOptions, buildTimeout time.Duration) error {
+	t.Helper()
+	stdout, stderr, exitCode, elapsed, err := runLLGOCompiler(repoRoot, goroot, llgoBin, tc, opts, true, buildTimeout)
+	if err != nil {
+		return commandFailure("llgo tool compile", elapsed, err, stdout, stderr, exitCode)
+	}
+	if opts.WantError && exitCode == 0 {
+		return fmt.Errorf("llgo tool compile succeeded unexpectedly")
+	}
+	if !opts.WantError && exitCode != 0 {
+		return commandFailure("llgo tool compile", elapsed, fmt.Errorf("compiler exited unsuccessfully"), stdout, stderr, exitCode)
+	}
+	output := append(append([]byte(nil), stdout...), stderr...)
+	output = filterNoise(normalizeOutput(output))
+	return checkExpectedErrors(string(output), tc.SourcePath(), tc.FileName)
+}
+
+func (tc testCase) SourcePath() string {
+	return filepath.Join(tc.Dir, tc.FileName)
+}
+
+func runLLGOCompiler(repoRoot, goroot, llgoBin string, tc testCase, opts directiveOptions, errorCheck bool, timeout time.Duration) ([]byte, []byte, int, time.Duration, error) {
+	ws, err := prepareCaseWorkspace(repoRoot)
+	if err != nil {
+		return nil, nil, 0, 0, err
+	}
+	if !*flagKeep {
+		defer ws.cleanup()
+	}
+	importCfg := filepath.Join(ws.rootDir, "importcfg")
+	if err := os.WriteFile(importCfg, nil, 0o644); err != nil {
+		return nil, nil, 0, 0, err
+	}
+	sourcePath := tc.SourcePath()
+	if strings.HasSuffix(filepath.Base(tc.Dir), ".dir") {
+		sourcePath, err = stageNestedCompilerCase(ws.workDir, tc)
+		if err != nil {
+			return nil, nil, 0, 0, err
+		}
+	}
+	args := []string{"tool", "compile", "-e", "-p=p", "-importcfg=" + importCfg}
+	if errorCheck {
+		args = append(args, "-C", "-d=panic", "-o", filepath.Join(ws.rootDir, "a.o"))
+	}
+	args = append(args, opts.CompilerFlags...)
+	if errorCheck && !hasSSACheckFlag(opts.CompilerFlags) {
+		args = append(args, "-d=ssa/check/on")
+	}
+	args = append(args, sourcePath)
+	env := runnerEnv(repoRoot, goroot, ws.gopath, opts.ExtraEnv)
+	return runProgram(ws.workDir, llgoBin, env, timeout, args...)
+}
+
+func stageNestedCompilerCase(workDir string, tc testCase) (string, error) {
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		return "", err
+	}
+	entries, err := os.ReadDir(tc.Dir)
+	if err != nil {
+		return "", err
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || filepath.Ext(name) != ".go" {
+			continue
+		}
+		src := filepath.Join(tc.Dir, name)
+		targetDir := workDir
+		if name != tc.FileName {
+			targetDir = filepath.Join(workDir, strings.TrimSuffix(name, ".go"))
+		}
+		if err := os.MkdirAll(targetDir, 0o755); err != nil {
+			return "", err
+		}
+		data, err := os.ReadFile(src)
+		if err != nil {
+			return "", err
+		}
+		if err := os.WriteFile(filepath.Join(targetDir, name), data, 0o644); err != nil {
+			return "", err
+		}
+	}
+	return filepath.Join(workDir, tc.FileName), nil
+}
+
+func hasSSACheckFlag(flags []string) bool {
+	for _, compilerFlag := range flags {
+		if strings.HasPrefix(compilerFlag, "-d=") && strings.Contains(compilerFlag, "ssa/check/") {
+			return true
+		}
+	}
+	return false
+}
+
+func runErrorCheckAndRunCase(t *testing.T, repoRoot, goroot, goCmd, llgoBin string, tc testCase, opts directiveOptions, buildTimeout time.Duration) error {
+	t.Helper()
+	srcDir := caseSourceDir(tc)
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return err
+	}
+	var goFiles []string
+	for _, entry := range entries {
+		if !entry.IsDir() && !strings.HasPrefix(entry.Name(), ".") && filepath.Ext(entry.Name()) == ".go" {
+			goFiles = append(goFiles, entry.Name())
+		}
+	}
+	sort.Strings(goFiles)
+	pkgs, err := groupDirPackages(srcDir, goFiles, opts.SingleFilePkgs)
+	if err != nil {
+		return err
+	}
+	if len(pkgs) == 0 {
+		return fmt.Errorf("%s: no Go packages in %s", tc.RelPath, srcDir)
+	}
+
+	ws, err := prepareCaseWorkspace(repoRoot)
+	if err != nil {
+		return err
+	}
+	if !*flagKeep {
+		defer ws.cleanup()
+	}
+	if err := stageRundirLayout(ws.workDir, srcDir, opts.SingleFilePkgs); err != nil {
+		return err
+	}
+	modVersion, err := toolchainGoModVersion(goroot)
+	if err != nil {
+		return err
+	}
+	if err := ensureModuleWorkspace(ws.workDir, "test", modVersion); err != nil {
+		return err
+	}
+	importCfg := filepath.Join(ws.rootDir, "importcfg")
+	if err := os.WriteFile(importCfg, nil, 0o644); err != nil {
+		return err
+	}
+	env := runnerEnv(repoRoot, goroot, ws.gopath, append(opts.ExtraEnv, "GO111MODULE=on"))
+	var diagnosticErrs []error
+	for index, pkg := range pkgs {
+		pkgDir := ws.workDir
+		if pkg.name != "main" {
+			pkgDir = filepath.Join(ws.workDir, pkg.dir)
+		}
+		args := []string{"tool", "compile", "-e", "-C", "-d=panic", "-importcfg=" + importCfg}
+		args = append(args, opts.CompilerFlags...)
+		var sources []diagnosticSource
+		for _, fileName := range pkg.files {
+			fullPath := filepath.Join(pkgDir, fileName)
+			args = append(args, fullPath)
+			sources = append(sources, diagnosticSource{full: fullPath, short: fileName})
+		}
+		stdout, stderr, exitCode, elapsed, runErr := runProgram(pkgDir, llgoBin, env, buildTimeout, args...)
+		expectFailure := opts.WantError && index == len(pkgs)-2
+		if runErr != nil {
+			diagnosticErrs = append(diagnosticErrs, commandFailure("llgo tool compile", elapsed, runErr, stdout, stderr, exitCode))
+			continue
+		}
+		if expectFailure && exitCode == 0 {
+			diagnosticErrs = append(diagnosticErrs, fmt.Errorf("%s: package %s compiled successfully, want failure", tc.RelPath, pkg.name))
+		}
+		if !expectFailure && exitCode != 0 {
+			diagnosticErrs = append(diagnosticErrs, commandFailure("llgo tool compile", elapsed, fmt.Errorf("compiler exited unsuccessfully"), stdout, stderr, exitCode))
+		}
+		output := append(append([]byte(nil), stdout...), stderr...)
+		output = filterNoise(normalizeOutput(output))
+		if checkErr := checkExpectedErrorsForFiles(string(output), sources); checkErr != nil {
+			diagnosticErrs = append(diagnosticErrs, fmt.Errorf("%s: package %s diagnostics: %w", tc.RelPath, pkg.name, checkErr))
+		}
+	}
+
+	runErr := runBuildAndCompare(t, tc.RelPath, ws.workDir, ws.rootDir, env, goCmd, llgoBin, nil, nil, opts.ProgramArgs, buildTimeout, opts.Timeout)
+	if runErr != nil {
+		diagnosticErrs = append(diagnosticErrs, runErr)
+	}
+	return errors.Join(diagnosticErrs...)
+}
+
 func runSingleFileCase(t *testing.T, repoRoot, goroot, goCmd, llgoBin string, tc testCase, opts directiveOptions, buildTimeout time.Duration) error {
 	t.Helper()
 	ws, err := prepareCaseWorkspace(repoRoot)
@@ -1071,13 +1793,37 @@ func runSingleFileCase(t *testing.T, repoRoot, goroot, goCmd, llgoBin string, tc
 	if !*flagKeep {
 		defer ws.cleanup()
 	}
-	env := runnerEnv(repoRoot, goroot, ws.gopath, opts.ExtraEnv)
 	goBin := filepath.Join(ws.rootDir, "go.out")
 	llgoOut := filepath.Join(ws.rootDir, "llgo.out")
 	metrics := caseMetrics{}
 	sourceFiles, programArgs := splitSourceFiles(tc.FileName, opts.ProgramArgs)
 	buildTarget := tc.FileName
-	if len(sourceFiles) > 1 {
+	nestedDirCase := strings.HasSuffix(filepath.Base(tc.Dir), ".dir")
+	extraEnv := append([]string{}, opts.ExtraEnv...)
+	if nestedDirCase {
+		preserveLayout, err := directoryHasSubdirectories(tc.Dir)
+		if err != nil {
+			return err
+		}
+		modulePath := "test"
+		if preserveLayout {
+			if err := overlayDir(ws.workDir, tc.Dir); err != nil {
+				return err
+			}
+			modulePath = filepath.Base(tc.Dir)
+		} else if err := stageRundirLayout(ws.workDir, tc.Dir, false); err != nil {
+			return err
+		}
+		modVersion, err := toolchainGoModVersion(goroot)
+		if err != nil {
+			return err
+		}
+		if err := ensureModuleWorkspace(ws.workDir, modulePath, modVersion); err != nil {
+			return err
+		}
+		extraEnv = append(extraEnv, "GO111MODULE=on")
+		buildTarget = "."
+	} else if len(sourceFiles) > 1 {
 		if err := stageSelectedFiles(ws.workDir, tc.Dir, sourceFiles); err != nil {
 			return err
 		}
@@ -1087,33 +1833,40 @@ func runSingleFileCase(t *testing.T, repoRoot, goroot, goCmd, llgoBin string, tc
 			return err
 		}
 	}
+	env := runnerEnv(repoRoot, goroot, ws.gopath, extraEnv)
 
 	goBuildStdout, goBuildStderr, goBuildExit, goBuildDur, err := runProgram(ws.workDir, goCmd, env, buildTimeout, append([]string{"build"}, append(opts.BuildFlags, "-o", goBin, buildTarget)...)...)
 	metrics.goBuild += goBuildDur
-	if err != nil {
-		return commandFailure("baseline go build", goBuildDur, err, goBuildStdout, goBuildStderr, goBuildExit)
+	if cmdErr := requireSuccessfulExit(err, goBuildExit); cmdErr != nil {
+		return commandFailure("baseline go build", goBuildDur, cmdErr, goBuildStdout, goBuildStderr, goBuildExit)
 	}
 	if err := ensureBuiltBinary(goBin, "baseline go build"); err != nil {
 		return err
 	}
 	llgoBuildStdout, llgoBuildStderr, llgoBuildExit, llgoBuildDur, err := runProgram(ws.workDir, llgoBin, env, buildTimeout, append([]string{"build"}, append(opts.BuildFlags, "-o", llgoOut, buildTarget)...)...)
 	metrics.llgoBuild += llgoBuildDur
-	if err != nil {
-		return commandFailure("llgo build", llgoBuildDur, err, llgoBuildStdout, llgoBuildStderr, llgoBuildExit)
+	if cmdErr := requireSuccessfulExit(err, llgoBuildExit); cmdErr != nil {
+		return commandFailure("llgo build", llgoBuildDur, cmdErr, llgoBuildStdout, llgoBuildStderr, llgoBuildExit)
 	}
 	if err := ensureBuiltBinary(llgoOut, "llgo build"); err != nil {
 		return err
 	}
 
-	goStdout, goStderr, goExit, goRunDur, err := runProgram(ws.workDir, goBin, env, opts.Timeout, programArgs...)
-	metrics.goRun += goRunDur
-	if err != nil {
-		return commandFailure("baseline go run", goRunDur, err, goStdout, goStderr, goExit)
+	runDir := ws.workDir
+	if tc.Directive == "run" {
+		runDir = filepath.Join(goroot, "test")
 	}
-	llgoStdout, llgoStderr, llgoExit, llgoRunDur, err := runProgram(ws.workDir, llgoOut, env, opts.Timeout, programArgs...)
+	runEnv := restoreProcessEnv(append([]string{}, env...), "GO111MODULE")
+	runEnv = restoreProcessEnv(runEnv, "GOPATH")
+	goStdout, goStderr, goExit, goRunDur, err := runProgram(runDir, goBin, runEnv, opts.Timeout, programArgs...)
+	metrics.goRun += goRunDur
+	if cmdErr := requireSuccessfulExit(err, goExit); cmdErr != nil {
+		return commandFailure("baseline go run", goRunDur, cmdErr, goStdout, goStderr, goExit)
+	}
+	llgoStdout, llgoStderr, llgoExit, llgoRunDur, err := runProgram(runDir, llgoOut, runEnv, opts.Timeout, programArgs...)
 	metrics.llgoRun += llgoRunDur
-	if err != nil {
-		return commandFailure("llgo run", llgoRunDur, err, llgoStdout, llgoStderr, llgoExit)
+	if cmdErr := requireSuccessfulExit(err, llgoExit); cmdErr != nil {
+		return commandFailure("llgo run", llgoRunDur, cmdErr, llgoStdout, llgoStderr, llgoExit)
 	}
 
 	logSlowCase(t, tc.RelPath, metrics.goBuild, metrics.llgoBuild, metrics.goRun, metrics.llgoRun)
@@ -1222,7 +1975,8 @@ func runInDirCase(t *testing.T, repoRoot, goroot, goCmd, llgoBin string, tc test
 		return err
 	}
 	env := runnerEnv(repoRoot, goroot, ws.gopath, append(opts.ExtraEnv, "GO111MODULE=on"))
-	return runBuildAndCompare(t, tc.RelPath, ws.workDir, ws.rootDir, env, goCmd, llgoBin, append([]string{}, opts.BuildFlags...), opts.ProgramArgs, buildTimeout, opts.Timeout)
+	buildFlags := append([]string{}, opts.BuildFlags...)
+	return runBuildAndCompare(t, tc.RelPath, ws.workDir, ws.rootDir, env, goCmd, llgoBin, buildFlags, buildFlags, opts.ProgramArgs, buildTimeout, opts.Timeout)
 }
 
 func runDirCase(t *testing.T, repoRoot, goroot, goCmd, llgoBin string, tc testCase, opts directiveOptions, preserveLayout bool, buildTimeout time.Duration) error {
@@ -1244,28 +1998,54 @@ func runDirCase(t *testing.T, repoRoot, goroot, goCmd, llgoBin string, tc testCa
 			return err
 		}
 	}
-	env := runnerEnv(repoRoot, goroot, ws.gopath, opts.ExtraEnv)
-	return runBuildAndCompare(t, tc.RelPath, ws.workDir, ws.rootDir, env, goCmd, llgoBin, append([]string{}, opts.BuildFlags...), opts.ProgramArgs, buildTimeout, opts.Timeout)
+	modVersion, err := toolchainGoModVersion(goroot)
+	if err != nil {
+		return err
+	}
+	if err := ensureModuleWorkspace(ws.workDir, "test", modVersion); err != nil {
+		return err
+	}
+	extraEnv := append([]string{}, opts.ExtraEnv...)
+	extraEnv = append(extraEnv, "GO111MODULE=on")
+	env := runnerEnv(repoRoot, goroot, ws.gopath, extraEnv)
+	goBuildFlags, llgoBuildFlags := directoryBuildFlags(opts)
+	return runBuildAndCompare(t, tc.RelPath, ws.workDir, ws.rootDir, env, goCmd, llgoBin, goBuildFlags, llgoBuildFlags, opts.ProgramArgs, buildTimeout, opts.Timeout)
 }
 
-func runBuildAndCompare(t *testing.T, casePath, workDir, rootDir string, env []string, goCmd, llgoBin string, buildFlags, programArgs []string, buildTimeout, runTimeout time.Duration) error {
+func directoryBuildFlags(opts directiveOptions) (goFlags, llgoFlags []string) {
+	goFlags = append(goFlags, opts.BuildFlags...)
+	llgoFlags = append(llgoFlags, opts.BuildFlags...)
+	if len(opts.CompilerFlags) != 0 {
+		value := strings.Join(opts.CompilerFlags, " ")
+		goFlags = append(goFlags, "-gcflags="+value)
+		llgoFlags = append(llgoFlags, "-gcflags="+value)
+	}
+	if len(opts.LinkerFlags) != 0 {
+		value := strings.Join(opts.LinkerFlags, " ")
+		goFlags = append(goFlags, "-ldflags="+value)
+		llgoFlags = append(llgoFlags, "-ldflags="+value)
+	}
+	return goFlags, llgoFlags
+}
+
+func runBuildAndCompare(t *testing.T, casePath, workDir, rootDir string, env []string, goCmd, llgoBin string, goBuildFlags, llgoBuildFlags, programArgs []string, buildTimeout, runTimeout time.Duration) error {
 	t.Helper()
 	goBin := filepath.Join(rootDir, "go.out")
 	llgoOut := filepath.Join(rootDir, "llgo.out")
 	metrics := caseMetrics{}
 
-	goBuildStdout, goBuildStderr, goBuildExit, goBuildDur, err := runProgram(workDir, goCmd, env, buildTimeout, append([]string{"build"}, append(buildFlags, "-o", goBin, ".")...)...)
+	goBuildStdout, goBuildStderr, goBuildExit, goBuildDur, err := runProgram(workDir, goCmd, env, buildTimeout, append([]string{"build"}, append(goBuildFlags, "-o", goBin, ".")...)...)
 	metrics.goBuild += goBuildDur
-	if err != nil {
-		return commandFailure("baseline go build", goBuildDur, err, goBuildStdout, goBuildStderr, goBuildExit)
+	if cmdErr := requireSuccessfulExit(err, goBuildExit); cmdErr != nil {
+		return commandFailure("baseline go build", goBuildDur, cmdErr, goBuildStdout, goBuildStderr, goBuildExit)
 	}
 	if err := ensureBuiltBinary(goBin, "baseline go build"); err != nil {
 		return err
 	}
-	llgoBuildStdout, llgoBuildStderr, llgoBuildExit, llgoBuildDur, err := runProgram(workDir, llgoBin, env, buildTimeout, append([]string{"build"}, append(buildFlags, "-o", llgoOut, ".")...)...)
+	llgoBuildStdout, llgoBuildStderr, llgoBuildExit, llgoBuildDur, err := runProgram(workDir, llgoBin, env, buildTimeout, append([]string{"build"}, append(llgoBuildFlags, "-o", llgoOut, ".")...)...)
 	metrics.llgoBuild += llgoBuildDur
-	if err != nil {
-		return commandFailure("llgo build", llgoBuildDur, err, llgoBuildStdout, llgoBuildStderr, llgoBuildExit)
+	if cmdErr := requireSuccessfulExit(err, llgoBuildExit); cmdErr != nil {
+		return commandFailure("llgo build", llgoBuildDur, cmdErr, llgoBuildStdout, llgoBuildStderr, llgoBuildExit)
 	}
 	if err := ensureBuiltBinary(llgoOut, "llgo build"); err != nil {
 		return err
@@ -1273,13 +2053,13 @@ func runBuildAndCompare(t *testing.T, casePath, workDir, rootDir string, env []s
 
 	goStdout, goStderr, goExit, goRunDur, err := runProgram(workDir, goBin, env, runTimeout, programArgs...)
 	metrics.goRun += goRunDur
-	if err != nil {
-		return commandFailure("baseline go run", goRunDur, err, goStdout, goStderr, goExit)
+	if cmdErr := requireSuccessfulExit(err, goExit); cmdErr != nil {
+		return commandFailure("baseline go run", goRunDur, cmdErr, goStdout, goStderr, goExit)
 	}
 	llgoStdout, llgoStderr, llgoExit, llgoRunDur, err := runProgram(workDir, llgoOut, env, runTimeout, programArgs...)
 	metrics.llgoRun += llgoRunDur
-	if err != nil {
-		return commandFailure("llgo run", llgoRunDur, err, llgoStdout, llgoStderr, llgoExit)
+	if cmdErr := requireSuccessfulExit(err, llgoExit); cmdErr != nil {
+		return commandFailure("llgo run", llgoRunDur, cmdErr, llgoStdout, llgoStderr, llgoExit)
 	}
 
 	logSlowCase(t, casePath, metrics.goBuild, metrics.llgoBuild, metrics.goRun, metrics.llgoRun)
@@ -1301,6 +2081,19 @@ func compareOutputs(goStdout, goStderr []byte, goExit int, llgoStdout, llgoStder
 		return fmt.Errorf("exit code mismatch: llgo=%d go=%d", llgoExit, goExit)
 	}
 	return nil
+}
+
+func directoryHasSubdirectories(dir string) (bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false, err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() && !strings.HasPrefix(entry.Name(), ".") {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func caseSourceDir(tc testCase) string {
@@ -1329,8 +2122,8 @@ func generateRunOutput(ws caseWorkspace, tool string, env []string, sourceFiles,
 		timeout,
 		args...,
 	)
-	if err != nil {
-		return "", runDur, commandFailure(label+" generate run", runDur, err, stdout, stderr, exitCode)
+	if cmdErr := requireSuccessfulExit(err, exitCode); cmdErr != nil {
+		return "", runDur, commandFailure(label+" generate run", runDur, cmdErr, stdout, stderr, exitCode)
 	}
 	genBase := label + "_tmp__.go"
 	genFile := filepath.Join(ws.workDir, genBase)
@@ -1375,15 +2168,15 @@ func runGeneratedProgram(ws caseWorkspace, tool string, env []string, fileName, 
 		out += ".exe"
 	}
 	buildStdout, buildStderr, buildExit, buildDur, err := runProgram(ws.workDir, tool, env, buildTimeout, "build", "-o", out, fileName)
-	if err != nil {
-		return nil, nil, 0, buildDur, 0, commandFailure(label+" generated build", buildDur, err, buildStdout, buildStderr, buildExit)
+	if cmdErr := requireSuccessfulExit(err, buildExit); cmdErr != nil {
+		return nil, nil, 0, buildDur, 0, commandFailure(label+" generated build", buildDur, cmdErr, buildStdout, buildStderr, buildExit)
 	}
 	if err := ensureBuiltBinary(out, label+" generated build"); err != nil {
 		return nil, nil, 0, buildDur, 0, err
 	}
 	stdout, stderr, exitCode, runDur, err := runProgram(ws.workDir, out, env, runTimeout)
-	if err != nil {
-		return nil, nil, 0, buildDur, runDur, commandFailure(label+" generated run", runDur, err, stdout, stderr, exitCode)
+	if cmdErr := requireSuccessfulExit(err, exitCode); cmdErr != nil {
+		return nil, nil, 0, buildDur, runDur, commandFailure(label+" generated run", runDur, cmdErr, stdout, stderr, exitCode)
 	}
 	return stdout, stderr, exitCode, buildDur, runDur, nil
 }
@@ -1495,6 +2288,7 @@ func stageRundirLayout(dstRoot, srcRoot string, singleFilePkgs bool) error {
 	if err != nil {
 		return err
 	}
+	hasMissingBody := false
 	for _, pkg := range pkgs {
 		targetDir := dstRoot
 		if pkg.name != "main" {
@@ -1508,13 +2302,16 @@ func stageRundirLayout(dstRoot, srcRoot string, singleFilePkgs bool) error {
 			if err != nil {
 				return err
 			}
-			if pkg.name != "main" {
-				data, err = rewriteRelativeImports(data)
-				if err != nil {
-					return err
-				}
+			data, err = rewriteRelativeImports(data, "test")
+			if err != nil {
+				return err
 			}
-			if err := os.WriteFile(filepath.Join(targetDir, fileName), data, 0o644); err != nil {
+			missingBody, err := sourceHasMissingFunctionBody(data)
+			if err != nil {
+				return err
+			}
+			hasMissingBody = hasMissingBody || missingBody
+			if err := os.WriteFile(filepath.Join(targetDir, stagedRundirFileName(fileName)), data, 0o644); err != nil {
 				return err
 			}
 		}
@@ -1528,7 +2325,36 @@ func stageRundirLayout(dstRoot, srcRoot string, singleFilePkgs bool) error {
 			return err
 		}
 	}
+	if hasMissingBody && len(auxFiles) == 0 {
+		if err := os.WriteFile(filepath.Join(dstRoot, "testdir_empty.s"), nil, 0o644); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+func stagedRundirFileName(name string) string {
+	if strings.HasSuffix(name, "_test.go") {
+		return strings.TrimSuffix(name, "_test.go") + "_testdir.go"
+	}
+	return name
+}
+
+func sourceHasMissingFunctionBody(src []byte) (bool, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "", src, 0)
+	if err != nil {
+		return false, err
+	}
+	missing := false
+	ast.Inspect(file, func(node ast.Node) bool {
+		if decl, ok := node.(*ast.FuncDecl); ok && decl.Body == nil {
+			missing = true
+			return false
+		}
+		return !missing
+	})
+	return missing, nil
 }
 
 func groupDirPackages(srcRoot string, goFiles []string, singleFilePkgs bool) ([]dirPackage, error) {
@@ -1562,7 +2388,7 @@ func getPackageNameFromSource(filePath string) (string, error) {
 	return file.Name.Name, nil
 }
 
-func rewriteRelativeImports(src []byte) ([]byte, error) {
+func rewriteRelativeImports(src []byte, modulePath string) ([]byte, error) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "", src, parser.ParseComments)
 	if err != nil {
@@ -1575,7 +2401,7 @@ func rewriteRelativeImports(src []byte) ([]byte, error) {
 			return nil, err
 		}
 		if strings.HasPrefix(p, "./") {
-			imp.Path.Value = strconv.Quote("../" + strings.TrimPrefix(p, "./"))
+			imp.Path.Value = strconv.Quote(path.Join(modulePath, strings.TrimPrefix(p, "./")))
 			changed = true
 		}
 	}

--- a/test/goroot/runner_unit_test.go
+++ b/test/goroot/runner_unit_test.go
@@ -200,6 +200,7 @@ func TestRunProgramTimeout(t *testing.T) {
 		time.Sleep(200 * time.Millisecond)
 		return
 	}
+	disableSystemMemoryLimits(t)
 
 	stdout, stderr, exitCode, elapsed, err := runProgram(
 		t.TempDir(),
@@ -241,6 +242,7 @@ func TestRunProgramRSSLimit(t *testing.T) {
 		runtime.KeepAlive(memory)
 		return
 	}
+	disableSystemMemoryLimits(t)
 
 	oldLimit := *flagMaxRSSMiB
 	oldPoll := *flagRSSPoll
@@ -291,6 +293,7 @@ func TestValidateSystemMemoryState(t *testing.T) {
 }
 
 func TestRunGeneratedProgramUsesProvidedTimeout(t *testing.T) {
+	disableSystemMemoryLimits(t)
 	dir := t.TempDir()
 	tool := filepath.Join(dir, "fake-tool.sh")
 	script := `#!/bin/sh
@@ -592,6 +595,7 @@ func TestEnsureModuleWorkspace(t *testing.T) {
 }
 
 func TestRunOutputCaseGeneratesWithBaselineGoOnly(t *testing.T) {
+	disableSystemMemoryLimits(t)
 	if runtime.GOOS == "windows" {
 		t.Skip("fake tool scripts use /bin/sh")
 	}
@@ -646,6 +650,18 @@ func TestRunOutputCaseGeneratesWithBaselineGoOnly(t *testing.T) {
 	if !strings.Contains(log, goTool+" build -o") || !strings.Contains(log, llgoTool+" build -o") {
 		t.Fatalf("generated source was not built by both tools; log:\n%s", log)
 	}
+}
+
+func disableSystemMemoryLimits(t *testing.T) {
+	t.Helper()
+	oldMemory := *flagMinMemPct
+	oldSwap := *flagMinSwapMiB
+	*flagMinMemPct = 0
+	*flagMinSwapMiB = 0
+	t.Cleanup(func() {
+		*flagMinMemPct = oldMemory
+		*flagMinSwapMiB = oldSwap
+	})
 }
 
 func writeRunOutputFakeTool(t *testing.T, path, logPath string, allowRun bool) {

--- a/test/goroot/runner_unit_test.go
+++ b/test/goroot/runner_unit_test.go
@@ -228,6 +228,68 @@ func TestRunProgramTimeout(t *testing.T) {
 	}
 }
 
+func TestRunProgramRSSLimit(t *testing.T) {
+	if !resourceMonitoringSupported() {
+		t.Skip("process-group RSS monitoring is unavailable")
+	}
+	if os.Getenv("LLGO_GOROOT_HELPER") == "allocate" {
+		memory := make([]byte, 64<<20)
+		for i := 0; i < len(memory); i += 4096 {
+			memory[i] = 1
+		}
+		time.Sleep(5 * time.Second)
+		runtime.KeepAlive(memory)
+		return
+	}
+
+	oldLimit := *flagMaxRSSMiB
+	oldPoll := *flagRSSPoll
+	*flagMaxRSSMiB = 24
+	*flagRSSPoll = 10 * time.Millisecond
+	defer func() {
+		*flagMaxRSSMiB = oldLimit
+		*flagRSSPoll = oldPoll
+	}()
+
+	_, _, _, elapsed, err := runProgram(
+		t.TempDir(),
+		os.Args[0],
+		append(os.Environ(), "LLGO_GOROOT_HELPER=allocate"),
+		5*time.Second,
+		"-test.run=^TestRunProgramRSSLimit$",
+	)
+	if err == nil || !strings.Contains(err.Error(), "RSS") {
+		t.Fatalf("err=%v, want RSS limit error", err)
+	}
+	if elapsed >= 5*time.Second {
+		t.Fatalf("elapsed=%s, memory limit did not terminate before timeout", elapsed)
+	}
+}
+
+func TestValidateSystemMemoryState(t *testing.T) {
+	oldMemory := *flagMinMemPct
+	oldSwap := *flagMinSwapMiB
+	*flagMinMemPct = 15
+	*flagMinSwapMiB = 512
+	defer func() {
+		*flagMinMemPct = oldMemory
+		*flagMinSwapMiB = oldSwap
+	}()
+
+	if err := validateSystemMemoryState(systemMemoryState{freePercent: 20, swapFree: 1 << 30, swapPresent: true}); err != nil {
+		t.Fatalf("healthy state rejected: %v", err)
+	}
+	if err := validateSystemMemoryState(systemMemoryState{freePercent: 10, swapFree: 1 << 30, swapPresent: true}); err == nil || !strings.Contains(err.Error(), "free memory") {
+		t.Fatalf("low-memory err=%v", err)
+	}
+	if err := validateSystemMemoryState(systemMemoryState{freePercent: 20, swapFree: 128 << 20, swapPresent: true}); err == nil || !strings.Contains(err.Error(), "free swap") {
+		t.Fatalf("low-swap err=%v", err)
+	}
+	if err := validateSystemMemoryState(systemMemoryState{freePercent: 20, swapPresent: false}); err != nil {
+		t.Fatalf("swapless state rejected: %v", err)
+	}
+}
+
 func TestRunGeneratedProgramUsesProvidedTimeout(t *testing.T) {
 	dir := t.TempDir()
 	tool := filepath.Join(dir, "fake-tool.sh")
@@ -413,6 +475,97 @@ func TestParseDirectiveOptions(t *testing.T) {
 	}
 }
 
+func TestParseCompilerDirectiveOptions(t *testing.T) {
+	opts, err := parseDirectiveOptions("errorcheck", []string{
+		"-0", "-lang=go1.17", "-N", "-goexperiment", "fieldtrack",
+	}, 20*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.WantError {
+		t.Fatal("WantError=true, want false after -0")
+	}
+	if !reflect.DeepEqual(opts.CompilerFlags, []string{"-lang=go1.17", "-N"}) {
+		t.Fatalf("CompilerFlags=%v", opts.CompilerFlags)
+	}
+	if len(opts.BuildFlags) != 0 {
+		t.Fatalf("BuildFlags=%v, want none", opts.BuildFlags)
+	}
+	if !reflect.DeepEqual(opts.ExtraEnv, []string{"GOEXPERIMENT=fieldtrack"}) {
+		t.Fatalf("ExtraEnv=%v", opts.ExtraEnv)
+	}
+}
+
+func TestParseRundirCompilerAndLinkerFlags(t *testing.T) {
+	opts, err := parseDirectiveOptions("rundir", []string{"-N", "-ldflags", "-w", "-strictdups=2"}, 20*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(opts.CompilerFlags, []string{"-N"}) {
+		t.Fatalf("CompilerFlags=%v", opts.CompilerFlags)
+	}
+	if !reflect.DeepEqual(opts.LinkerFlags, []string{"-w", "-strictdups=2"}) {
+		t.Fatalf("LinkerFlags=%v", opts.LinkerFlags)
+	}
+}
+
+func TestDirectoryBuildFlagsMatchGoFlagShape(t *testing.T) {
+	goFlags, llgoFlags := directoryBuildFlags(directiveOptions{
+		CompilerFlags: []string{"-N", "-l=4"},
+		LinkerFlags:   []string{"-strictdups=2", "-w=0"},
+	})
+	want := []string{"-gcflags=-N -l=4", "-ldflags=-strictdups=2 -w=0"}
+	if !reflect.DeepEqual(goFlags, want) {
+		t.Fatalf("goFlags=%v, want %v", goFlags, want)
+	}
+	if !reflect.DeepEqual(llgoFlags, want) {
+		t.Fatalf("llgoFlags=%v, want %v", llgoFlags, want)
+	}
+}
+
+func TestCheckExpectedErrors(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "case.go")
+	src := `package p
+var _ = missing // ERROR "undefined: missing"
+`
+	if err := os.WriteFile(file, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	output := file + ":2:9: undefined: missing\n"
+	if err := checkExpectedErrors(output, file, "case.go"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckExpectedErrorsReportsMissingDiagnostic(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "case.go")
+	src := `package p
+var _ = missing // ERROR "undefined: missing"
+`
+	if err := os.WriteFile(file, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := checkExpectedErrors("", file, "case.go")
+	if err == nil || !strings.Contains(err.Error(), "missing error") {
+		t.Fatalf("err=%v, want missing error", err)
+	}
+}
+
+func TestPreferSpecificDiagnostics(t *testing.T) {
+	got := preferSpecificDiagnostics([]string{
+		"case.go:18:16: requires go1.22 or later (file declares go1.21)",
+		"/tmp/case.go:18: requires go1.22 or later",
+		"case.go:19: a different error",
+	})
+	want := []string{
+		"case.go:18:16: requires go1.22 or later (file declares go1.21)",
+		"case.go:19: a different error",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("preferSpecificDiagnostics()=%v, want %v", got, want)
+	}
+}
+
 func TestSplitSourceFiles(t *testing.T) {
 	files, args := splitSourceFiles("index0.go", []string{"./index.go", "arg1", "arg2"})
 	if !reflect.DeepEqual(files, []string{"index0.go", "index.go"}) {
@@ -579,6 +732,12 @@ func TestStageRundirLayoutRewritesRelativeImports(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(srcDir, "main.go"), []byte("package main\nimport \"./b\"\nfunc main(){_ = b.Y}\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(srcDir, "helper_test.go"), []byte("package main\nfunc helper() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "external.go"), []byte("package external\nfunc Missing()\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	dstDir := t.TempDir()
 	if err := stageRundirLayout(dstDir, srcDir, false); err != nil {
 		t.Fatal(err)
@@ -587,7 +746,20 @@ func TestStageRundirLayoutRewritesRelativeImports(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(got), "\"../a\"") {
-		t.Fatalf("rewritten file=%q, want import ../a", got)
+	if !strings.Contains(string(got), "\"test/a\"") {
+		t.Fatalf("rewritten file=%q, want import test/a", got)
+	}
+	got, err = os.ReadFile(filepath.Join(dstDir, "main.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "\"test/b\"") {
+		t.Fatalf("rewritten file=%q, want import test/b", got)
+	}
+	if _, err := os.Stat(filepath.Join(dstDir, "helper_testdir.go")); err != nil {
+		t.Fatalf("stage _test.go as ordinary source: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dstDir, "testdir_empty.s")); err != nil {
+		t.Fatalf("stage empty assembly source for missing function body: %v", err)
 	}
 }

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1,24 +1,54 @@
 host_skips:
-  - platform: darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
     directive: run
     case: ddd.go
-    reason: host-unsafe concurrency case can destabilize the host
-  - platform: darwin/arm64
+    reason: go1.24 goroot run is host-sensitive on darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
+    directive: run
+    case: ddd.go
+    reason: go1.25 goroot run is host-sensitive on darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
     directive: run
     case: gcgort.go
-    reason: host-unsafe concurrency case can destabilize the host
-  - platform: darwin/arm64
+    reason: go1.24 goroot run is host-sensitive on darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
+    directive: run
+    case: gcgort.go
+    reason: go1.25 goroot run is host-sensitive on darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
     directive: run
     case: fixedbugs/issue25897b.go
-    reason: host-unsafe concurrency case can destabilize the host
-  - platform: darwin/arm64
+    reason: go1.24 goroot run is host-sensitive on darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
+    directive: run
+    case: fixedbugs/issue25897b.go
+    reason: go1.25 goroot run is host-sensitive on darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
     directive: run
     case: fixedbugs/issue27695.go
-    reason: host-unsafe concurrency case can destabilize the host
-  - platform: darwin/arm64
+    reason: go1.24 goroot run is host-sensitive on darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
+    directive: run
+    case: fixedbugs/issue27695.go
+    reason: go1.25 goroot run is host-sensitive on darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
     directive: run
     case: fixedbugs/issue39541.go
-    reason: host-unsafe concurrency case can destabilize the host
+    reason: go1.24 goroot run is host-sensitive on darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
+    directive: run
+    case: fixedbugs/issue39541.go
+    reason: go1.25 goroot run is host-sensitive on darwin/arm64
   - version: go1.24
     platform: linux/amd64
     directive: run
@@ -44,11 +74,6 @@ host_skips:
     directive: run
     case: fixedbugs/issue39541.go
     reason: go1.25 goroot run is host-sensitive on linux/amd64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: fixedbugs/issue39541.go
-    reason: go1.26 goroot run is host-sensitive on linux/amd64
   - version: go1.24
     platform: darwin/arm64
     directive: run
@@ -69,16 +94,6 @@ host_skips:
     directive: run
     case: chan/goroutines.go
     reason: go1.25 goroot run is host-sensitive on linux/amd64
-  - version: go1.26
-    platform: darwin/arm64
-    directive: run
-    case: chan/goroutines.go
-    reason: go1.26 goroot run is host-sensitive on darwin/arm64
-  - version: go1.26
-    platform: linux/amd64
-    directive: run
-    case: chan/goroutines.go
-    reason: go1.26 goroot run is host-sensitive on linux/amd64
   - version: go1.24
     platform: darwin/arm64
     directive: run
@@ -89,11 +104,6 @@ host_skips:
     directive: run
     case: chanlinear.go
     reason: go1.25 goroot run is host-sensitive on darwin/arm64
-  - version: go1.26
-    platform: darwin/arm64
-    directive: run
-    case: chanlinear.go
-    reason: go1.26 goroot run is host-sensitive on darwin/arm64
 timeouts:
   - version: go1.26
     platform: darwin/arm64
@@ -1625,6 +1635,11 @@ flakes:
     directive: run
     case: fixedbugs/issue79186.go
     reason: the RWMutex stress test passes when the host is idle but can exceed its timeout under sustained CPU contention
+  - version: go1.26
+    platform: darwin/arm64
+    directive: run
+    case: chanlinear.go
+    reason: the timing-based linearity check can pass or report chanSelect as too slow on darwin/arm64
   - version: go1.25
     platform: linux/amd64
     directive: run

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -95,6 +95,24 @@ host_skips:
     case: chanlinear.go
     reason: go1.26 goroot run is host-sensitive on darwin/arm64
 timeouts:
+  - version: go1.26
+    platform: darwin/arm64
+    directive: run
+    case: fixedbugs/issue79186.go
+    timeout: 90s
+    reason: the 51.2 million-operation RWMutex stress loop needs load-dependent runtime slack
+  - version: go1.26
+    platform: darwin/arm64
+    directive: run
+    case: fixedbugs/issue19658.go
+    timeout: 2m
+    reason: the test launches 19 nested go run commands and needs load-dependent runtime slack
+  - version: go1.26
+    platform: darwin/arm64
+    directive: runoutput
+    case: fixedbugs/bug449.go
+    timeout: 6m
+    reason: bug449 generated build exceeds the 3m build timeout on darwin/arm64
   - version: go1.24
     platform: darwin/arm64
     directive: run
@@ -1602,6 +1620,11 @@ timeouts:
     timeout: 2m
     reason: nosplit run runs past the default timeout on linux/amd64
 flakes:
+  - version: go1.26
+    platform: darwin/arm64
+    directive: run
+    case: fixedbugs/issue79186.go
+    reason: the RWMutex stress test passes when the host is idle but can exceed its timeout under sustained CPU contention
   - version: go1.25
     platform: linux/amd64
     directive: run
@@ -1735,10 +1758,828 @@ flakes:
     case: goprint.go
     reason: darwin/arm64 goroot run can either pass or fail
 xfails:
+  - version: go1.26
+    directive: errorcheck
+    case: escape_array.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: escape_struct_param2.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: nilptr3.go
+    reason: gc-specific nil-check elimination diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: initloop.go
+    reason: llgo reports an additional initialization-cycle summary diagnostic
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue11362.go
+    reason: llgo uses different non-canonical import-path diagnostic punctuation
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue15611.go
+    reason: llgo scanner recovery emits additional malformed-rune diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue23664.go
+    reason: llgo parser recovery emits additional malformed-declaration diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: syntax/typesw.go
+    reason: llgo reports an additional invalid type-switch syntax-tree diagnostic
+  - version: go1.26
+    directive: errorcheck
+    case: escape6.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: escape_struct_param1.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: nilcheck.go
+    reason: gc-specific nil-check elimination diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue18331.go
+    reason: gc standard-library pragma validation is not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue41635.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue52193.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue33386.go
+    reason: llgo parser recovery emits additional malformed-go/defer diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: escape5.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: escape_slice.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: interface/assertinline.go
+    reason: gc-specific type-assertion optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/bug014.go
+    reason: llgo scanner emits additional malformed-character-constant diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/bug349.go
+    reason: llgo parser recovery emits additional return-value diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue11359.go
+    reason: llgo scanner emits additional illegal-character diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue23587.go
+    reason: llgo parser recovery emits additional invalid-tilde diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: syntax/semi7.go
+    reason: llgo parser recovery emits additional semicolon and else diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue31053.dir/main.go
+    reason: llgo resolves the companion package but uses different unexported-field diagnostic wording
+  - version: go1.26
+    directive: errorcheck
+    case: escape4.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: escape_selfassign.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue14999.go
+    reason: gc runtime heap-allocation diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue27732a.go
+    reason: gc-specific small-frame and optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/bug169.go
+    reason: llgo scanner emits an additional malformed-character-constant diagnostic
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/bug274.go
+    reason: llgo parser recovery emits additional case and label diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue18092.go
+    reason: llgo parser recovery emits additional malformed-channel diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue23586.go
+    reason: llgo reports additional unused variable and import diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue4776.go
+    reason: llgo parser uses a different missing-package-clause diagnostic
+  - version: go1.26
+    directive: errorcheck
+    case: syntax/semi6.go
+    reason: llgo parser emits additional missing-type diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: escape2n.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: escape_runtime_atomic.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: abi/result_live.go
+    reason: gc-specific liveness diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue21709.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue23521.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue18419.dir/test.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/bug388.go
+    reason: gc runtime pseudo-type diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: switch2.go
+    reason: llgo parser recovery emits additional malformed-switch diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue13319.go
+    reason: llgo parser recovery emits additional malformed-call diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue32133.go
+    reason: llgo scanner uses different unterminated-literal diagnostics and emits recovery noise
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue5089.go
+    reason: llgo does not emit the expected non-local method redefinition diagnostic
+  - version: go1.26
+    directive: errorcheck
+    case: syntax/semi5.go
+    reason: llgo parser recovery emits additional semicolon and end-of-file diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: escape2.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: escape_reflect.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: sliceopt.go
+    reason: gc-specific append and slice optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: writebarrier.go
+    reason: gc-specific write-barrier diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue19743.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue27557.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue10700.dir/test.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: import6.go
+    reason: llgo loader does not emit the expected absolute-import-path diagnostic
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/bug163.go
+    reason: llgo scanner emits additional illegal-character diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue13274.go
+    reason: llgo parser emits an additional end-of-file diagnostic
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue4405.go
+    reason: llgo parser recovery emits additional malformed-statement diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue50372.go
+    reason: llgo reports additional expression-count diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: syntax/semi4.go
+    reason: llgo parser recovery emits additional semicolon and brace diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: escape_param.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue31573.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue4099.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue7921.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/notinheap3.go
+    reason: gc runtime write-barrier and notinheap diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: embedvers.go
+    reason: llgo loader reports an embed-pattern error before the expected language-version diagnostic
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue13273.go
+    reason: llgo parser and type checker emit additional channel-direction diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: syntax/semi3.go
+    reason: llgo parser recovery emits additional semicolon and end-of-file diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: escape_mutations.go
+    reason: gc-specific escape-mutation and zerocopy diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/notinheap2.go
+    reason: gc-specific notinheap allocation diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: embedfunc.go
+    reason: llgo loader reports an embed-pattern error instead of the expected local-variable directive error
+  - version: go1.26
+    directive: errorcheck
+    case: shift1.go
+    reason: llgo reports additional shifted-operand diagnostics at different source positions
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/bug136.go
+    reason: llgo reports additional unused-label diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue13266.go
+    reason: llgo parser uses a different malformed-package-clause diagnostic
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue19667.go
+    reason: llgo parser recovery emits additional malformed-call diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: syntax/semi2.go
+    reason: llgo parser recovery emits additional semicolon and brace diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: escape_map.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: runtime.go
+    reason: gc runtime private-symbol compiler diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/notinheap.go
+    reason: gc-specific notinheap allocation diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: goto.go
+    reason: llgo reports goto diagnostics at different source positions
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/bug068.go
+    reason: llgo scanner emits an additional malformed-character-constant diagnostic
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/bug195.go
+    reason: llgo reports an additional recursive-interface diagnostic
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue13248.go
+    reason: llgo parser recovery emits additional malformed-expression diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue14520.go
+    reason: llgo parser emits an additional missing-comma diagnostic
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue17328.go
+    reason: llgo parser recovery emits additional end-of-file diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: syntax/semi1.go
+    reason: llgo parser recovery emits additional semicolon and end-of-file diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: escape_make_non_const.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fuse.go
+    reason: gc-specific SSA late-fuse diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue17318.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue30898.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue39292.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue67329.go
+    reason: gc-specific bounds-check elimination diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: char_lit1.go
+    reason: llgo scanner emits additional malformed-character-constant diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue20789.go
+    reason: llgo parser does not emit the expected malformed-name diagnostic
+  - version: go1.26
+    directive: errorcheck
+    case: syntax/initvar.go
+    reason: llgo parser recovery emits additional invalid-initializer diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: devirtualization_with_type_assertions_interleaved.go
+    reason: gc-specific -m devirtualization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: escape_level.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue12588.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: uintptrkeepalive.go
+    reason: gc-specific go:uintptrkeepalive pragma validation is not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue20780.go
+    reason: gc-specific stack-frame size diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue30722.go
+    reason: llgo scanner emits additional malformed-constant diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue7538a.go
+    reason: llgo reports an additional blank-label resolution diagnostic
+  - version: go1.26
+    directive: errorcheck
+    case: syntax/import.go
+    reason: llgo parser and loader emit different recovery diagnostics for malformed imports
+  - version: go1.26
+    directive: errorcheck
+    case: bounds.go
+    reason: gc-specific -m bounds-check diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: devirtualization.go
+    reason: gc-specific -m devirtualization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: escape_indir.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: live_uintptrkeepalive.go
+    reason: gc-specific liveness and standard-package diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: uintptrescapes2.go
+    reason: gc-specific escape and liveness diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue19168.go
+    reason: gc-specific write-barrier diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue75278.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: typeparam/pragma.go
+    reason: gc-specific pragma optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/bug050.go
+    reason: llgo parser emits an additional malformed-declaration diagnostic
+  - version: go1.26
+    directive: errorcheck
+    case: devirt.go
+    reason: gc-specific SSA devirtualization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: escape_iface_data.go
+    reason: gc-specific escape-debug diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: live2.go
+    reason: gc-specific liveness and write-barrier diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue12006.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue42944.go
+    reason: gc-specific liveness diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: bombad.go
+    reason: llgo parser recovery emits additional byte-order-mark diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/bug435.go
+    reason: llgo parser recovery emits additional end-of-file diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue14006.go
+    reason: llgo parser recovery emits additional malformed-label diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue22581.go
+    reason: llgo parser recovery emits additional malformed-control-clause diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: syntax/else.go
+    reason: llgo parser emits an additional malformed-else diagnostic
+  - version: go1.26
+    directive: errorcheck
+    case: bloop.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: defererrcheck.go
+    reason: gc-specific defer optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: escape_iface.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: prove_popcount.go
+    reason: gc-specific SSA prove diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: typeparam/issue54497.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: syntax/ddd.go
+    reason: llgo parser recovery emits additional malformed-selector diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: escape_hash_maphash.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: prove_invert_loop_with_unused_iterators.go
+    reason: gc-specific SSA prove diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue13799.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue24651b.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: label1.go
+    reason: llgo reports additional invalid-label control-flow diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/bug300.go
+    reason: llgo reports an additional invalid inferred-array diagnostic
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue18915.go
+    reason: llgo parser reports additional malformed control-expression diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue20298.go
+    reason: llgo reports unused imports after the expected import-path validation errors
+  - version: go1.26
+    directive: errorcheck
+    case: syntax/composite.go
+    reason: llgo parser reports an additional missing-comma diagnostic
+  - version: go1.26
+    directive: errorcheck
+    case: escape_goto.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: prove_constant_folding.go
+    reason: gc-specific SSA prove diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue16241_64.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue20250.go
+    reason: gc-specific liveness diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue35518.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: label.go
+    reason: llgo reports additional label declaration and resolution diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/bug121.go
+    reason: llgo parser recovery emits additional malformed-declaration diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/bug228.go
+    reason: llgo parser emits an additional malformed-parameter diagnostic
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/bug299.go
+    reason: llgo parser does not emit the expected parenthesized top-level expression diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: syntax/chan1.go
+    reason: llgo parser recovery emits additional malformed-channel diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: escape_field.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: escape_unsafe.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: intrinsic_atomic.go
+    reason: gc-specific intrinsic substitution diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: prove.go
+    reason: gc-specific SSA prove diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue13587.go
+    reason: gc-specific write-barrier diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue16241.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue18747.go
+    reason: llgo parser recovery emits additional undefined-name diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue20245.go
+    reason: llgo reports an additional interface-type expression diagnostic
+  - version: go1.26
+    directive: errorcheck
+    case: syntax/chan.go
+    reason: llgo parser recovery emits additional malformed-channel diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: escape_closure.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: escape_unique.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: inline_variadic.go
+    reason: gc-specific -m inlining diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: phiopt.go
+    reason: gc-specific SSA phi optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: tighten.go
+    reason: gc-specific SSA tighten diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue35073b.go
+    reason: gc-specific escape and checkptr diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue54159.go
+    reason: gc-specific -m optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: internal/runtime/sys/inlinegcpc.go
+    reason: gc runtime inlining diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/bug179.go
+    reason: llgo reports an additional unused-label diagnostic after invalid branch labels
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue11610.go
+    reason: llgo parser reports additional illegal-character diagnostics
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue20233.go
+    reason: llgo reports an additional invalid function-type expression diagnostic
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue22164.go
+    reason: llgo parser recovery emits additional diagnostics for a malformed argument list
+  - version: go1.26
+    directive: errorcheck
+    case: escape_calls.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: escape_sync_atomic.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: inline_sync.go
+    reason: gc-specific -m inlining diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: nowritebarrier.go
+    reason: gc runtime write-barrier prohibition diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: tailcall.go
+    reason: gc-specific tail-call optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue15747.go
+    reason: gc-specific liveness diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: fixedbugs/issue34723.go
+    reason: gc-specific write-barrier diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: syntax/vareq1.go
+    reason: llgo parser recovery emits an additional diagnostic after the expected syntax error
+  - version: go1.26
+    directive: errorcheck
+    case: escape_bloop.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: escape_struct_return.go
+    reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: inline_big.go
+    reason: gc-specific -m inlining diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: nilptr5.go
+    reason: gc-specific -d=nil optimization diagnostics are not implemented by llgo
+  - version: go1.26
+    directive: errorcheck
+    case: syntax/vareq.go
+    reason: llgo parser recovery emits additional diagnostics after the expected syntax error
+  - version: go1.26
+    directive: compile
+    case: fixedbugs/issue15141.go
+    reason: llgo codegen exceeds the bounded resource budget for 256MiB array return values
+  - version: go1.26
+    directive: compile
+    case: fixedbugs/issue48092.go
+    reason: gc-specific -B bounds-checking backend option is not implemented by llgo
+  - version: go1.26
+    directive: compile
+    case: typeparam/issue50993.go
+    reason: gc-specific -d=checkptr backend option is not implemented by llgo
+  - version: go1.26
+    directive: compile
+    case: fixedbugs/issue26163.go
+    reason: gc-specific -d=softfloat backend option is not implemented by llgo
+  - version: go1.26
+    directive: compile
+    case: fixedbugs/issue56141.go
+    reason: gc-specific -d=libfuzzer backend option is not implemented by llgo
+  - version: go1.26
+    directive: compile
+    case: fixedbugs/issue56105.go
+    reason: gc-specific -d=libfuzzer backend option is not implemented by llgo
+  - version: go1.26
+    directive: compile
+    case: fixedbugs/issue34966.go
+    reason: gc-specific -d=checkptr backend option is not implemented by llgo
+  - version: go1.26
+    directive: compile
+    case: fixedbugs/issue44465.go
+    reason: gc-specific -d=ssa/check/seed option is not implemented by llgo
+  - version: go1.26
+    directive: compile
+    case: fixedbugs/issue58161.go
+    reason: gc-specific -d=ssa/check/seed option is not implemented by llgo
+  - version: go1.26
+    directive: compile
+    case: fixedbugs/issue58826.go
+    reason: gc-specific -dynlink backend mode is not implemented by llgo
+  - version: go1.26
+    directive: compile
+    case: fixedbugs/issue69825.go
+    reason: gc-specific -d=libfuzzer backend option is not implemented by llgo
   - platform: darwin/arm64
     directive: run
     case: init1.go
     reason: current main goroot run failure on darwin/arm64
+  - platform: darwin/arm64
+    directive: run
+    case: finprofiled.go
+    reason: LLGo finalizer profiling run hangs beyond the 1m timeout on darwin/arm64
+  - version: go1.26
+    platform: darwin/arm64
+    directive: run
+    case: fixedbugs/issue25897a.go
+    reason: LLGo makes no progress starting reflect-generated goroutines while a single-P runtime continuously collects
+  - platform: darwin/arm64
+    directive: run
+    case: gcstring.go
+    reason: GC frees a string-backed pointer before its finalizer check on darwin/arm64
+  - platform: darwin/arm64
+    directive: run
+    case: inline_caller.go
+    reason: runtime caller frame reports main instead of runtime.main on darwin/arm64
+  - platform: darwin/arm64
+    directive: run
+    case: nilptr2.go
+    reason: address-of a dereferenced nil pointer does not panic and the run hangs on darwin/arm64
+  - platform: darwin/arm64
+    directive: run
+    case: range4.go
+    reason: range-over-function build exits successfully without producing a binary on darwin/arm64
+  - platform: darwin/arm64
+    directive: run
+    case: fixedbugs/issue31546.go
+    reason: reflection exposes the initializer value of a blank struct field instead of zero on darwin/arm64
+  - platform: darwin/arm64
+    directive: run
+    case: fixedbugs/issue72063.go
+    reason: generic Y-combinator build exits successfully without producing a binary on darwin/arm64
+  - platform: darwin/arm64
+    directive: run
+    case: fixedbugs/issue72844.go
+    reason: dereferencing a nil array pointer for len or range does not panic when required on darwin/arm64
+  - platform: darwin/arm64
+    directive: run
+    case: fixedbugs/issue8047b.go
+    reason: recover interaction panics with value 1 on darwin/arm64
+  - platform: darwin/arm64
+    directive: run
+    case: typeparam/orderedmap.go
+    reason: generic ordered-map iterator dereferences a nil entry on darwin/arm64
+  - platform: darwin/arm64
+    directive: run
+    case: uintptrescapes3.go
+    reason: uintptr escape round trip dereferences a nil pointer on darwin/arm64
+  - version: go1.26
+    platform: darwin/arm64
+    directive: run
+    case: convert5.go
+    reason: out-of-range float-to-uint32 conversions wrap instead of producing zero on darwin/arm64
   - platform: darwin/arm64
     directive: run
     case: noinit.go
@@ -2784,3 +3625,50 @@ xfails:
     directive: runoutput
     case: index0.go
     reason: current main goroot runoutput failure on linux/amd64
+  - version: go1.26
+    directive: errorcheckandrundir
+    case: intrinsic.go
+    reason: gc-specific SSA intrinsic diagnostics are not implemented by llgo; the run stage still executes
+  - version: go1.26
+    directive: errorcheckandrundir
+    case: closure3.go
+    reason: gc-specific escape and inlining diagnostics are not implemented by llgo; the run stage still executes
+  - version: go1.26
+    directive: errorcheckandrundir
+    case: linkname.go
+    reason: gc-specific escape and inlining diagnostics are not implemented by llgo; the run stage still executes
+  - version: go1.26
+    directive: errorcheckandrundir
+    case: fixedbugs/issue37837.go
+    reason: gc-specific escape-analysis diagnostics are not implemented by llgo; the run stage still executes
+  - version: go1.26
+    platform: darwin/arm64
+    directive: rundir
+    case: fixedbugs/issue29919.go
+    reason: runtime CallersFrames reports llgo package names and initialization line metadata differently
+  - version: go1.26
+    platform: darwin/arm64
+    directive: buildrundir
+    case: asmhdr.go
+    reason: llgo build does not implement the Go assembler asmhdr and symabis pipeline
+  - version: go1.26
+    directive: rundir
+    case: fixedbugs/issue31636.go
+    reason: llgo initializes independent imported packages in reverse source order
+  - version: go1.26
+    directive: rundir
+    case: fixedbugs/issue9608.go
+    reason: llgo does not eliminate unreachable references to a bodyless function before linking
+  - version: go1.26
+    directive: runindir
+    case: fixedbugs/issue20014.go
+    reason: gc-specific fieldtrack linker metadata is not implemented by llgo
+  - version: go1.26
+    platform: darwin/arm64
+    directive: buildrundir
+    case: retjmp.go
+    reason: llgo does not preserve Go assembler return-jump ABI behavior
+  - version: go1.26
+    directive: rundir
+    case: fixedbugs/issue24693.go
+    reason: llgo constructs cross-package itabs incorrectly for unexported interface methods

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1936,10 +1936,6 @@ xfails:
     reason: llgo scanner uses different unterminated-literal diagnostics and emits recovery noise
   - version: go1.26
     directive: errorcheck
-    case: fixedbugs/issue5089.go
-    reason: llgo does not emit the expected non-local method redefinition diagnostic
-  - version: go1.26
-    directive: errorcheck
     case: syntax/semi5.go
     reason: llgo parser recovery emits additional semicolon and end-of-file diagnostics
   - version: go1.26
@@ -2336,10 +2332,6 @@ xfails:
     reason: llgo parser emits an additional malformed-parameter diagnostic
   - version: go1.26
     directive: errorcheck
-    case: fixedbugs/bug299.go
-    reason: llgo parser does not emit the expected parenthesized top-level expression diagnostics
-  - version: go1.26
-    directive: errorcheck
     case: syntax/chan1.go
     reason: llgo parser recovery emits additional malformed-channel diagnostics
   - version: go1.26
@@ -2522,11 +2514,23 @@ xfails:
     directive: compile
     case: fixedbugs/issue69825.go
     reason: gc-specific -d=libfuzzer backend option is not implemented by llgo
-  - platform: darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
     directive: run
     case: init1.go
     reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
+    directive: run
+    case: init1.go
+    reason: current main goroot run failure on darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
+    directive: run
+    case: finprofiled.go
+    reason: LLGo finalizer profiling run hangs beyond the 1m timeout on darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
     directive: run
     case: finprofiled.go
     reason: LLGo finalizer profiling run hangs beyond the 1m timeout on darwin/arm64
@@ -2535,7 +2539,13 @@ xfails:
     directive: run
     case: fixedbugs/issue25897a.go
     reason: LLGo makes no progress starting reflect-generated goroutines while a single-P runtime continuously collects
-  - platform: darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
+    directive: run
+    case: gcstring.go
+    reason: GC frees a string-backed pointer before its finalizer check on darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
     directive: run
     case: gcstring.go
     reason: GC frees a string-backed pointer before its finalizer check on darwin/arm64
@@ -2563,15 +2573,33 @@ xfails:
     directive: run
     case: fixedbugs/issue72844.go
     reason: dereferencing a nil array pointer for len or range does not panic when required on darwin/arm64
-  - platform: darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
     directive: run
     case: fixedbugs/issue8047b.go
     reason: recover interaction panics with value 1 on darwin/arm64
-  - platform: darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
+    directive: run
+    case: fixedbugs/issue8047b.go
+    reason: recover interaction panics with value 1 on darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
     directive: run
     case: typeparam/orderedmap.go
     reason: generic ordered-map iterator dereferences a nil entry on darwin/arm64
-  - platform: darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
+    directive: run
+    case: typeparam/orderedmap.go
+    reason: generic ordered-map iterator dereferences a nil entry on darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
+    directive: run
+    case: uintptrescapes3.go
+    reason: uintptr escape round trip dereferences a nil pointer on darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
     directive: run
     case: uintptrescapes3.go
     reason: uintptr escape round trip dereferences a nil pointer on darwin/arm64
@@ -2584,7 +2612,13 @@ xfails:
     directive: run
     case: noinit.go
     reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
+    directive: run
+    case: recover2.go
+    reason: current main goroot run failure on darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
     directive: run
     case: recover2.go
     reason: current main goroot run failure on darwin/arm64
@@ -2592,19 +2626,43 @@ xfails:
     directive: runoutput
     case: rangegen.go
     reason: current main goroot runoutput failure on darwin/arm64
-  - platform: darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
     directive: run
     case: zerodivide.go
     reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
+    directive: run
+    case: zerodivide.go
+    reason: current main goroot run failure on darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
     directive: run
     case: fixedbugs/issue16130.go
     reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
+    directive: run
+    case: fixedbugs/issue16130.go
+    reason: current main goroot run failure on darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
     directive: run
     case: fixedbugs/issue19040.go
     reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
+    directive: run
+    case: fixedbugs/issue19040.go
+    reason: current main goroot run failure on darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
+    directive: run
+    case: fixedbugs/issue37975.go
+    reason: current main goroot run failure on darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
     directive: run
     case: fixedbugs/issue37975.go
     reason: current main goroot run failure on darwin/arm64
@@ -2882,7 +2940,13 @@ xfails:
     directive: runoutput
     case: rangegen.go
     reason: go1.26 goroot ci-mode runoutput failure on linux/amd64
-  - platform: darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
+    directive: run
+    case: deferfin.go
+    reason: latest main goroot run failure on darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
     directive: run
     case: deferfin.go
     reason: latest main goroot run failure on darwin/arm64
@@ -2954,7 +3018,13 @@ xfails:
     directive: run
     case: fixedbugs/issue33724.go
     reason: latest main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
+    directive: run
+    case: fixedbugs/issue45045.go
+    reason: latest main goroot run failure on darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
     directive: run
     case: fixedbugs/issue45045.go
     reason: latest main goroot run failure on darwin/arm64
@@ -2970,7 +3040,13 @@ xfails:
     directive: run
     case: fixedbugs/issue54343.go
     reason: latest main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
+    directive: run
+    case: fixedbugs/issue5493.go
+    reason: latest main goroot run failure on darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
     directive: run
     case: fixedbugs/issue5493.go
     reason: latest main goroot run failure on darwin/arm64
@@ -3487,19 +3563,43 @@ xfails:
     directive: run
     case: fixedbugs/issue5963.go
     reason: go1.26 goroot run failure on linux/amd64
-  - platform: darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
     directive: run
     case: fixedbugs/bug273.go
     reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
+    directive: run
+    case: fixedbugs/bug273.go
+    reason: current main goroot run failure on darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
     directive: run
     case: fixedbugs/issue12133.go
     reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
+    directive: run
+    case: fixedbugs/issue12133.go
+    reason: current main goroot run failure on darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
     directive: run
     case: fixedbugs/issue13169.go
     reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
+    directive: run
+    case: fixedbugs/issue13169.go
+    reason: current main goroot run failure on darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
+    directive: run
+    case: fixedbugs/issue19246.go
+    reason: current main goroot run failure on darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
     directive: run
     case: fixedbugs/issue19246.go
     reason: current main goroot run failure on darwin/arm64
@@ -3507,7 +3607,13 @@ xfails:
     directive: run
     case: fixedbugs/issue26094.go
     reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
+    directive: run
+    case: fixedbugs/issue43835.go
+    reason: current main goroot run failure on darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
     directive: run
     case: fixedbugs/issue43835.go
     reason: current main goroot run failure on darwin/arm64
@@ -3529,19 +3635,43 @@ xfails:
     directive: run
     case: fixedbugs/issue73920.go
     reason: go1.26 goroot run failure on darwin/arm64
-  - platform: darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
     directive: run
     case: fixedbugs/issue8048.go
     reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
+    directive: run
+    case: fixedbugs/issue8048.go
+    reason: current main goroot run failure on darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
     directive: run
     case: fixedbugs/issue8132.go
     reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
+    directive: run
+    case: fixedbugs/issue8132.go
+    reason: current main goroot run failure on darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
     directive: run
     case: nil.go
     reason: current main goroot run failure on darwin/arm64
-  - platform: darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
+    directive: run
+    case: nil.go
+    reason: current main goroot run failure on darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
+    directive: run
+    case: typeparam/chans.go
+    reason: select over unbuffered channel misses final receive on darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
     directive: run
     case: typeparam/chans.go
     reason: select over unbuffered channel misses final receive on darwin/arm64
@@ -3549,7 +3679,13 @@ xfails:
     directive: run
     case: typeparam/mdempsky/15.go
     reason: go:nointerface methods still satisfy interfaces on darwin/arm64
-  - platform: darwin/arm64
+  - version: go1.24
+    platform: darwin/arm64
+    directive: runoutput
+    case: index0.go
+    reason: current main goroot runoutput failure on darwin/arm64
+  - version: go1.25
+    platform: darwin/arm64
     directive: runoutput
     case: index0.go
     reason: current main goroot runoutput failure on darwin/arm64
@@ -3672,3 +3808,23 @@ xfails:
     directive: rundir
     case: fixedbugs/issue24693.go
     reason: llgo constructs cross-package itabs incorrectly for unexported interface methods
+  - version: go1.26
+    directive: runindir
+    case: fixedbugs/issue11656.go
+    reason: llgo traceback metadata cannot resolve the recursive caller after a bad-PC fault
+  - version: go1.26
+    directive: rundir
+    case: fixedbugs/issue18911.go
+    reason: llgo interface-conversion diagnostics omit the same-looking types from different packages detail
+  - version: go1.26
+    directive: runindir
+    case: fixedbugs/issue30862.go
+    reason: llgo does not implement the fieldtrack experiment metadata used by this test
+  - version: go1.26
+    directive: rundir
+    case: interface/embed3.go
+    reason: llgo interface-conversion diagnostics report the import path instead of the package name
+  - version: go1.26
+    directive: run
+    case: fixedbugs/issue52072.go
+    reason: llgo loses the named return value when a deferred nil-receiver method panic is recovered


### PR DESCRIPTION
## Summary

- add a `coverage` GOROOT discovery mode covering all active Go 1.26 test directives;
- execute `compile`, `errorcheck`, and `errorcheckandrundir` through the compiler-facing contract provided by #2066;
- cover directory and nested runnable directives (`rundir`, `runindir`, `buildrundir`) plus compile-only cases;
- add bounded process-group RSS and host-memory/swap guards for local and CI sweeps;
- refresh Go 1.26 expectations from a clean current-main baseline after individual local verification.

## Scope after prerequisite merges

The prerequisite and stabilization PRs are now merged:

- #2066 adds the GOROOT-compatible `llgo tool compile` adapter and frontend option propagation;
- #2068 fixes SSA handling for `unsafe.Offsetof` on generic composite fields;
- #2072 prevents valid concurrent `select` output from being classified as a flaky failure.

This branch was rebuilt on `main` after #2072. The extracted implementations of #2066 and #2068 were removed. The remaining review unit contains four commits and changes only the GOROOT runner, its tests/documentation, resource guards, and `xfail.yaml`: 10 files, 2,466 additions, and 130 deletions.

The former fine-grained PRs #2069, #2070, and #2071 remain closed as superseded. Draft PR #2064 is retained only as comparison data.

## Go 1.26.5 full-sweep baseline

Environment: `go1.26.5 darwin/arm64`.

The full sweep recorded before the prerequisite rebase produced:

- inventory: **2,345 / 2,345 mapped and observed**;
- result after targeted former-skip verification: **2,091 pass / 254 fail / 0 skip**;
- failures: 246 expected failures, 3 failed flakes, 5 reproducible resource-guard stops;
- unexpected unclassified failures: **0**.

Full per-directive statistics and the side-by-side comparison with the merged-stage5 branch are in #2062:
https://github.com/xgo-dev/llgo/issues/2062#issuecomment-4950738613

Resource-constrained sweep settings included `GOMAXPROCS=2`, `go test -p=1`, a 1536 MiB process-group RSS hard limit, minimum 20% free memory, and minimum 1024 MiB free swap.

The rebase preserved the `dev/test_goroot.sh` and `test/goroot` trees byte-for-byte. The focused integration tests below were rerun against the final merged prerequisite implementations.

## Post-rebase verification

Environment: `go1.26.5 darwin/arm64`.

```text
bash -n dev/test_goroot.sh

GOMAXPROCS=2 GOMEMLIMIT=2GiB go test -vet=off -p=1 \
  ./test/goroot ./cmd/internal/compile ./cmd/internal/build ./internal/packages ./cmd/llgo -count=1
```

All focused packages pass. `git diff --check` is clean.

Closes #2062.