### PR TITLE
cmd: add GOROOT compile-test adapter

### DIFF
--- a/cmd/internal/build/build.go
+++ b/cmd/internal/build/build.go
@@ -33,9 +33,11 @@ var Cmd = &base.Command{
 	Short:     "Compile packages and dependencies",
 }
 
+var goBuildFlags *base.PassArgs
+
 func init() {
 	Cmd.Run = runCmd
-	base.PassBuildFlags(Cmd)
+	goBuildFlags = base.PassBuildFlags(Cmd)
 
 	flags.AddCommonFlags(&Cmd.Flag)
 	flags.AddBuildFlags(&Cmd.Flag)
@@ -56,6 +58,7 @@ func runCmd(cmd *base.Command, args []string) {
 		fmt.Fprintln(os.Stderr, err)
 		mockable.Exit(1)
 	}
+	conf.GoBuildFlags = append(conf.GoBuildFlags, goBuildFlags.Args...)
 
 	args = cmd.Flag.Args()
 

--- a/cmd/internal/build/build_test.go
+++ b/cmd/internal/build/build_test.go
@@ -1,0 +1,59 @@
+//go:build !llgo
+
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/goplus/llgo/internal/mockable"
+)
+
+func TestRunCmdPassesGoBuildFlags(t *testing.T) {
+	oldArgs := append([]string(nil), goBuildFlags.Args...)
+	goBuildFlags.Args = nil
+	defer func() { goBuildFlags.Args = oldArgs }()
+
+	stderrFile, err := os.CreateTemp(t.TempDir(), "stderr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldStderr := os.Stderr
+	os.Stderr = stderrFile
+	defer func() { os.Stderr = oldStderr }()
+
+	mockable.EnableMock()
+	defer mockable.DisableMock()
+	exited := false
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				if recovered == "exit" {
+					exited = true
+					return
+				}
+				panic(recovered)
+			}
+		}()
+		runCmd(Cmd, []string{"-gcflags=all=-N", filepath.Join(t.TempDir(), "missing")})
+	}()
+	if !exited || mockable.ExitCode() != 1 {
+		t.Fatalf("runCmd exit = (%v, %d), want (true, 1)", exited, mockable.ExitCode())
+	}
+	if !reflect.DeepEqual(goBuildFlags.Args, []string{"-gcflags=all=-N"}) {
+		t.Fatalf("go build flags = %v", goBuildFlags.Args)
+	}
+	if err := stderrFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(stderrFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "missing") {
+		t.Fatalf("stderr = %q, want missing-package diagnostic", data)
+	}
+}

--- a/cmd/internal/compile/compile.go
+++ b/cmd/internal/compile/compile.go
@@ -1,0 +1,216 @@
+//go:build !llgo
+
+package compile
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/goplus/llgo/cmd/internal/base"
+	"github.com/goplus/llgo/internal/build"
+	"github.com/goplus/llgo/internal/env"
+	"github.com/goplus/llgo/internal/mockable"
+	"github.com/goplus/llgo/internal/optlevel"
+)
+
+// Cmd implements the compiler action used by GOROOT/test. Its option names
+// intentionally follow "go tool compile" rather than the llgo build command.
+var Cmd = &base.Command{
+	UsageLine: "llgo tool compile [options] file.go...",
+	Short:     "Compile Go source files without linking",
+}
+
+type countFlag struct {
+	value int
+	set   bool
+}
+
+func (f *countFlag) String() string { return strconv.Itoa(f.value) }
+
+func (f *countFlag) Set(value string) error {
+	f.set = true
+	if value == "true" {
+		f.value++
+		return nil
+	}
+	if value == "false" {
+		f.value = 0
+		return nil
+	}
+	n, err := strconv.Atoi(value)
+	if err != nil {
+		return err
+	}
+	f.value = n
+	return nil
+}
+
+func (*countFlag) IsBoolFlag() bool { return true }
+
+type stringListFlag []string
+
+func (f *stringListFlag) String() string { return strings.Join(*f, ",") }
+
+func (f *stringListFlag) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+
+type options struct {
+	concurrency int
+	debug       stringListFlag
+	lang        string
+	output      string
+	pkgPath     string
+	importCfg   string
+	localImport string
+	includes    stringListFlag
+
+	noBounds  countFlag
+	noColumns countFlag
+	noOpt     countFlag
+	noInline  countFlag
+	allErrors countFlag
+	showOpt   countFlag
+	writeBar  countFlag
+
+	complete    bool
+	dynlink     bool
+	live        bool
+	race        bool
+	smallFrames bool
+	standard    bool
+	runtimePkg  bool
+	version     bool
+}
+
+func newFlagSet(opts *options) *flag.FlagSet {
+	fs := flag.NewFlagSet("compile", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	fs.Var(&opts.noBounds, "B", "disable bounds checking")
+	fs.Var(&opts.noColumns, "C", "disable printing of columns in error messages")
+	fs.StringVar(&opts.localImport, "D", "", "set relative path for local imports")
+	fs.Var(&opts.includes, "I", "add directory to import search path")
+	fs.Var(&opts.noOpt, "N", "disable optimizations")
+	fs.BoolVar(&opts.runtimePkg, "+", false, "compiling runtime")
+	fs.BoolVar(&opts.version, "V", false, "print version and exit")
+	fs.IntVar(&opts.concurrency, "c", 0, "concurrency during compilation (1 means no concurrency)")
+	fs.BoolVar(&opts.complete, "complete", false, "compiling complete package (no C or assembly)")
+	fs.Var(&opts.debug, "d", "enable debugging settings")
+	fs.BoolVar(&opts.dynlink, "dynlink", false, "support references to Go symbols defined in shared libraries")
+	fs.Var(&opts.allErrors, "e", "no limit on number of errors reported")
+	fs.StringVar(&opts.importCfg, "importcfg", "", "read import configuration from file")
+	fs.StringVar(&opts.lang, "lang", "", "Go language version source code expects")
+	fs.Var(&opts.noInline, "l", "disable inlining")
+	fs.Var(&opts.showOpt, "m", "print optimization decisions")
+	fs.BoolVar(&opts.live, "live", false, "debug liveness analysis")
+	fs.StringVar(&opts.output, "o", "", "write output to file")
+	fs.StringVar(&opts.pkgPath, "p", "", "set expected package import path")
+	fs.BoolVar(&opts.race, "race", false, "enable race detector")
+	fs.BoolVar(&opts.smallFrames, "smallframes", false, "reduce the size limit for stack allocated objects")
+	fs.BoolVar(&opts.standard, "std", false, "compiling standard library")
+	fs.Var(&opts.writeBar, "wb", "enable write barrier")
+	return fs
+}
+
+func init() {
+	Cmd.Run = runCmd
+}
+
+func runCmd(_ *base.Command, args []string) {
+	opts := new(options)
+	fs := newFlagSet(opts)
+	if err := fs.Parse(args); err != nil {
+		mockable.Exit(2)
+		return
+	}
+	if opts.version {
+		fmt.Printf("compile version llgo %s\n", env.Version())
+		return
+	}
+	files := fs.Args()
+	if len(files) == 0 {
+		fmt.Fprintln(os.Stderr, "compile: no Go source files")
+		mockable.Exit(2)
+		return
+	}
+	if unsupported := opts.unsupported(); len(unsupported) != 0 {
+		fmt.Fprintf(os.Stderr, "compile: unsupported llgo compiler option(s): %s\n", strings.Join(unsupported, ", "))
+		mockable.Exit(2)
+		return
+	}
+	if opts.concurrency < 0 {
+		fmt.Fprintln(os.Stderr, "compile: -c must be non-negative")
+		mockable.Exit(2)
+		return
+	}
+	if opts.lang != "" && !strings.HasPrefix(opts.lang, "go1.") {
+		fmt.Fprintf(os.Stderr, "compile: invalid value %q for -lang\n", opts.lang)
+		mockable.Exit(2)
+		return
+	}
+
+	if opts.concurrency > 0 {
+		previous := runtime.GOMAXPROCS(opts.concurrency)
+		defer runtime.GOMAXPROCS(previous)
+	}
+	conf := build.NewDefaultConf(build.ModeGen)
+	conf.GoVersion = opts.lang
+	conf.NoErrorColumn = opts.noColumns.value != 0
+	conf.AllowNoBody = !opts.complete
+	var loaderCompilerFlags []string
+	if opts.allErrors.value != 0 {
+		loaderCompilerFlags = append(loaderCompilerFlags, "-e")
+	}
+	if opts.lang != "" {
+		loaderCompilerFlags = append(loaderCompilerFlags, "-lang="+opts.lang)
+	}
+	if opts.complete {
+		loaderCompilerFlags = append(loaderCompilerFlags, "-complete")
+	}
+	if len(loaderCompilerFlags) != 0 {
+		conf.GoBuildFlags = append(conf.GoBuildFlags, "-gcflags=command-line-arguments="+strings.Join(loaderCompilerFlags, " "))
+	}
+	if opts.noOpt.value != 0 || opts.noInline.value != 0 {
+		conf.OptLevel = optlevel.O0
+	}
+	pkgs, err := build.Do(files, conf)
+	if len(pkgs) != 0 && pkgs[0].LPkg != nil {
+		pkgs[0].LPkg.Prog.Dispose()
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		mockable.Exit(1)
+	}
+}
+
+func (opts *options) unsupported() []string {
+	var out []string
+	appendFlag := func(condition bool, name string) {
+		if condition {
+			out = append(out, name)
+		}
+	}
+	appendFlag(opts.noBounds.value != 0, "-B")
+	appendFlag(opts.dynlink, "-dynlink")
+	appendFlag(opts.showOpt.value != 0, "-m")
+	appendFlag(opts.live, "-live")
+	appendFlag(opts.race, "-race")
+	appendFlag(opts.smallFrames, "-smallframes")
+	appendFlag(opts.standard, "-std")
+	appendFlag(opts.runtimePkg, "-+")
+	appendFlag(opts.writeBar.set, "-wb")
+	for _, setting := range opts.debug {
+		for _, item := range strings.Split(setting, ",") {
+			if item == "panic" || item == "ssa/check/on" {
+				continue
+			}
+			out = append(out, "-d="+item)
+		}
+	}
+	return out
+}

--- a/cmd/internal/compile/compile_test.go
+++ b/cmd/internal/compile/compile_test.go
@@ -1,0 +1,203 @@
+package compile
+
+import (
+	"os"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/goplus/llgo/internal/mockable"
+)
+
+func TestGoCompilerFlagNamesAndTypes(t *testing.T) {
+	opts := new(options)
+	fs := newFlagSet(opts)
+	err := fs.Parse([]string{
+		"-c=2",
+		"-C",
+		"-e",
+		"-l=4",
+		"-lang=go1.17",
+		"-d=panic,ssa/check/on",
+		"-p=p",
+		"-importcfg=importcfg",
+		"case.go",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.concurrency != 2 || opts.noColumns.value != 1 || opts.allErrors.value != 1 || opts.noInline.value != 4 {
+		t.Fatalf("parsed flags: %+v", opts)
+	}
+	if opts.lang != "go1.17" || opts.pkgPath != "p" || opts.importCfg != "importcfg" {
+		t.Fatalf("parsed flags: %+v", opts)
+	}
+	if !reflect.DeepEqual(fs.Args(), []string{"case.go"}) {
+		t.Fatalf("files=%v", fs.Args())
+	}
+	if unsupported := opts.unsupported(); len(unsupported) != 0 {
+		t.Fatalf("unsupported=%v, want none", unsupported)
+	}
+}
+
+func TestGoCompilerSpecificFlagIsExplicitlyUnsupported(t *testing.T) {
+	opts := new(options)
+	fs := newFlagSet(opts)
+	if err := fs.Parse([]string{"-d=libfuzzer", "case.go"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := opts.unsupported(); !reflect.DeepEqual(got, []string{"-d=libfuzzer"}) {
+		t.Fatalf("unsupported=%v", got)
+	}
+}
+
+func TestCountAndListFlags(t *testing.T) {
+	var count countFlag
+	if !count.IsBoolFlag() {
+		t.Fatal("countFlag should accept the bool flag form")
+	}
+	for _, value := range []string{"true", "true", "false", "4"} {
+		if err := count.Set(value); err != nil {
+			t.Fatalf("Set(%q): %v", value, err)
+		}
+	}
+	if got := count.String(); got != "4" || !count.set {
+		t.Fatalf("count flag = %q, set=%v; want 4, true", got, count.set)
+	}
+	if err := count.Set("invalid"); err == nil {
+		t.Fatal("invalid count value was accepted")
+	}
+
+	var list stringListFlag
+	if err := list.Set("one"); err != nil {
+		t.Fatal(err)
+	}
+	if err := list.Set("two"); err != nil {
+		t.Fatal(err)
+	}
+	if got := list.String(); got != "one,two" {
+		t.Fatalf("list flag = %q, want one,two", got)
+	}
+}
+
+func TestUnsupportedCompilerFlags(t *testing.T) {
+	opts := &options{
+		noBounds:    countFlag{value: 1},
+		dynlink:     true,
+		showOpt:     countFlag{value: 1},
+		live:        true,
+		race:        true,
+		smallFrames: true,
+		standard:    true,
+		runtimePkg:  true,
+		writeBar:    countFlag{set: true},
+		debug:       stringListFlag{"panic,libfuzzer", "ssa/check/on,wb"},
+	}
+	want := []string{"-B", "-dynlink", "-m", "-live", "-race", "-smallframes", "-std", "-+", "-wb", "-d=libfuzzer", "-d=wb"}
+	if got := opts.unsupported(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("unsupported=%v, want %v", got, want)
+	}
+}
+
+func TestRunCmdValidationAndVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantCode   int
+		wantOutput string
+	}{
+		{name: "bad flag", args: []string{"-unknown"}, wantCode: 2, wantOutput: "flag provided but not defined"},
+		{name: "no files", wantCode: 2, wantOutput: "no Go source files"},
+		{name: "unsupported", args: []string{"-B", "case.go"}, wantCode: 2, wantOutput: "unsupported llgo compiler option(s): -B"},
+		{name: "negative concurrency", args: []string{"-c=-1", "case.go"}, wantCode: 2, wantOutput: "-c must be non-negative"},
+		{name: "invalid language", args: []string{"-lang=1.22", "case.go"}, wantCode: 2, wantOutput: "invalid value"},
+		{name: "version", args: []string{"-V"}, wantOutput: "compile version llgo"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout, stderr, code := runCompileCommand(t, tt.args)
+			if code != tt.wantCode {
+				t.Fatalf("exit code = %d, want %d; stdout=%q stderr=%q", code, tt.wantCode, stdout, stderr)
+			}
+			if output := stdout + stderr; !strings.Contains(output, tt.wantOutput) {
+				t.Fatalf("output %q does not contain %q", output, tt.wantOutput)
+			}
+		})
+	}
+}
+
+func TestRunCmdBuildsAndReportsErrors(t *testing.T) {
+	dir := t.TempDir()
+	valid := dir + "/valid.go"
+	if err := os.WriteFile(valid, []byte("package compilecase\nfunc F() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	previousProcs := runtime.GOMAXPROCS(0)
+	stdout, stderr, code := runCompileCommand(t, []string{
+		"-c=1", "-C", "-e", "-lang=go1.22", "-N", "-l", "-complete", valid,
+	})
+	if code != 0 {
+		t.Fatalf("valid compile exit code = %d; stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if got := runtime.GOMAXPROCS(0); got != previousProcs {
+		t.Fatalf("GOMAXPROCS = %d after compile, want restored value %d", got, previousProcs)
+	}
+
+	invalid := dir + "/invalid.go"
+	if err := os.WriteFile(invalid, []byte("package compilecase\nvar _ = missing\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, stderr, code = runCompileCommand(t, []string{invalid})
+	if code != 1 || !strings.Contains(stderr, "missing") {
+		t.Fatalf("invalid compile exit code = %d, stderr=%q; want code 1 and diagnostic", code, stderr)
+	}
+}
+
+func runCompileCommand(t *testing.T, args []string) (stdout, stderr string, exitCode int) {
+	t.Helper()
+	outFile, err := os.CreateTemp(t.TempDir(), "stdout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	errFile, err := os.CreateTemp(t.TempDir(), "stderr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldStdout, oldStderr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = outFile, errFile
+	mockable.EnableMock()
+	exited := false
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				if recovered == "exit" {
+					exited = true
+					return
+				}
+				panic(recovered)
+			}
+		}()
+		runCmd(Cmd, args)
+	}()
+	mockable.DisableMock()
+	os.Stdout, os.Stderr = oldStdout, oldStderr
+	if exited {
+		exitCode = mockable.ExitCode()
+	}
+	if err := outFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := errFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+	outData, err := os.ReadFile(outFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	errData, err := os.ReadFile(errFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(outData), string(errData), exitCode
+}

--- a/cmd/llgo/tool_cmd.gox
+++ b/cmd/llgo/tool_cmd.gox
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+use "tool [command]"
+
+short "Run a specified llgo tool"
+
+run => {
+	help
+}

--- a/cmd/llgo/tool_cmd_test.go
+++ b/cmd/llgo/tool_cmd_test.go
@@ -1,0 +1,74 @@
+//go:build !llgo
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestToolCommand(t *testing.T) {
+	cmd := &Cmd_tool{App: new(App)}
+	cmd.Main("tool")
+	if cmd.Command.Command.Use != "tool [command]" || cmd.Command.Command.Short != "Run a specified llgo tool" {
+		t.Fatalf("tool command metadata = (%q, %q)", cmd.Command.Command.Use, cmd.Command.Command.Short)
+	}
+	if got := cmd.Classfname(); got != "tool" {
+		t.Fatalf("Classfname() = %q, want tool", got)
+	}
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	if cmd.Run == nil {
+		t.Fatal("tool command has no run function")
+	}
+	cmd.Run(&cmd.Command.Command, nil)
+	if !strings.Contains(output.String(), "tool [command]") {
+		t.Fatalf("tool help output = %q", output.String())
+	}
+}
+
+func TestToolCompileCommand(t *testing.T) {
+	cmd := &Cmd_tool_compile{App: new(App)}
+	cmd.Main("compile")
+	if cmd.Command.Command.Use != "compile [options] file.go..." || cmd.Command.Command.Short != "Compile Go source files without linking" {
+		t.Fatalf("compile command metadata = (%q, %q)", cmd.Command.Command.Use, cmd.Command.Command.Short)
+	}
+	if !cmd.DisableFlagParsing {
+		t.Fatal("tool compile should pass flags through unchanged")
+	}
+	if got := cmd.Classfname(); got != "tool_compile" {
+		t.Fatalf("Classfname() = %q, want tool_compile", got)
+	}
+	if cmd.Run == nil {
+		t.Fatal("tool compile command has no run function")
+	}
+	output := captureToolStdout(t, func() {
+		cmd.Run(&cmd.Command.Command, []string{"-V"})
+	})
+	if !strings.Contains(output, "compile version llgo") {
+		t.Fatalf("tool compile version output = %q", output)
+	}
+}
+
+func captureToolStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	file, err := os.CreateTemp(t.TempDir(), "stdout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := os.Stdout
+	os.Stdout = file
+	defer func() { os.Stdout = old }()
+	fn()
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(file.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}

--- a/cmd/llgo/tool_compile_cmd.gox
+++ b/cmd/llgo/tool_compile_cmd.gox
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+import (
+	self "github.com/goplus/llgo/cmd/internal/compile"
+)
+
+use "compile [options] file.go..."
+
+short "Compile Go source files without linking"
+
+flagOff
+
+run args => {
+	self.Cmd.Run self.Cmd, args
+}

--- a/cmd/llgo/xgo_autogen.go
+++ b/cmd/llgo/xgo_autogen.go
@@ -7,6 +7,7 @@ import (
 	"github.com/goplus/cobra/xcmd"
 	"github.com/goplus/llgo/cmd/internal/build"
 	"github.com/goplus/llgo/cmd/internal/clean"
+	"github.com/goplus/llgo/cmd/internal/compile"
 	"github.com/goplus/llgo/cmd/internal/install"
 	"github.com/goplus/llgo/cmd/internal/monitor"
 	"github.com/goplus/llgo/cmd/internal/run"
@@ -53,6 +54,14 @@ type Cmd_test struct {
 	xcmd.Command
 	*App
 }
+type Cmd_tool struct {
+	xcmd.Command
+	*App
+}
+type Cmd_tool_compile struct {
+	xcmd.Command
+	*App
+}
 type Cmd_version struct {
 	xcmd.Command
 	*App
@@ -72,8 +81,10 @@ func (this *App) Main() {
 	_xgo_obj5 := &Cmd_monitor{App: this}
 	_xgo_obj6 := &Cmd_run{App: this}
 	_xgo_obj7 := &Cmd_test{App: this}
-	_xgo_obj8 := &Cmd_version{App: this}
-	xcmd.Gopt_App_Main(this, _xgo_obj0, _xgo_obj1, _xgo_obj2, _xgo_obj3, _xgo_obj4, _xgo_obj5, _xgo_obj6, _xgo_obj7, _xgo_obj8)
+	_xgo_obj8 := &Cmd_tool{App: this}
+	_xgo_obj9 := &Cmd_tool_compile{App: this}
+	_xgo_obj10 := &Cmd_version{App: this}
+	xcmd.Gopt_App_Main(this, _xgo_obj0, _xgo_obj1, _xgo_obj2, _xgo_obj3, _xgo_obj4, _xgo_obj5, _xgo_obj6, _xgo_obj7, _xgo_obj8, _xgo_obj9, _xgo_obj10)
 }
 
 //line cmd/llgo/build_cmd.gox:20
@@ -224,6 +235,42 @@ func (this *Cmd_test) Main(_xgo_arg0 string) {
 }
 func (this *Cmd_test) Classfname() string {
 	return "test"
+}
+
+//line cmd/llgo/tool_cmd.gox:16
+func (this *Cmd_tool) Main(_xgo_arg0 string) {
+	this.Command.Main(_xgo_arg0)
+//line cmd/llgo/tool_cmd.gox:16:1
+	this.Use("tool [command]")
+//line cmd/llgo/tool_cmd.gox:18:1
+	this.Short("Run a specified llgo tool")
+//line cmd/llgo/tool_cmd.gox:20:1
+	this.Run__0(func() {
+//line cmd/llgo/tool_cmd.gox:21:1
+		this.Help()
+	})
+}
+func (this *Cmd_tool) Classfname() string {
+	return "tool"
+}
+
+//line cmd/llgo/tool_compile_cmd.gox:20
+func (this *Cmd_tool_compile) Main(_xgo_arg0 string) {
+	this.Command.Main(_xgo_arg0)
+//line cmd/llgo/tool_compile_cmd.gox:20:1
+	this.Use("compile [options] file.go...")
+//line cmd/llgo/tool_compile_cmd.gox:22:1
+	this.Short("Compile Go source files without linking")
+//line cmd/llgo/tool_compile_cmd.gox:24:1
+	this.FlagOff()
+//line cmd/llgo/tool_compile_cmd.gox:26:1
+	this.Run__1(func(args []string) {
+//line cmd/llgo/tool_compile_cmd.gox:27:1
+		compile.Cmd.Run(compile.Cmd, args)
+	})
+}
+func (this *Cmd_tool_compile) Classfname() string {
+	return "tool_compile"
 }
 
 //line cmd/llgo/version_cmd.gox:22

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -31,6 +31,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -156,6 +157,10 @@ type Config struct {
 	SizeFormat    string // size report format: text,json (default text)
 	SizeLevel     string // size aggregation level: full,module,package (default module)
 	CompilerHash  string // metadata hash for the running compiler (development builds only)
+	GoVersion     string // Go language version accepted by the frontend (for example, "go1.22")
+	NoErrorColumn bool   // omit source columns from frontend diagnostics
+	GoBuildFlags  []string
+	AllowNoBody   bool // allow declarations without bodies, as go tool compile does
 
 	// PthreadStackSize sets a custom stack size, in bytes, for pthread-backed
 	// goroutines. A zero value keeps the platform pthread default.
@@ -266,6 +271,7 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	if err := ensureSizeReporting(conf); err != nil {
 		return nil, err
 	}
+	applyFrontendGCFlags(conf)
 	conf.OptLevel = effectiveOptLevel(conf)
 	// Handle crosscompile configuration first to set correct GOOS/GOARCH
 	forceEspClang := conf.ForceEspClang || conf.Target != ""
@@ -298,9 +304,11 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	if len(export.BuildTags) > 0 {
 		tags += "," + strings.Join(export.BuildTags, ",")
 	}
+	goBuildFlags := []string{"-tags=" + tags}
+	goBuildFlags = append(goBuildFlags, conf.GoBuildFlags...)
 	cfg := &packages.Config{
 		Mode:       loadSyntax | packages.NeedDeps | packages.NeedModule | packages.NeedExportFile,
-		BuildFlags: []string{"-tags=" + tags},
+		BuildFlags: goBuildFlags,
 		Fset:       token.NewFileSet(),
 		Tests:      conf.Mode == ModeTest,
 		Env:        append(slices.Clone(os.Environ()), "GOOS="+conf.Goos, "GOARCH="+conf.Goarch),
@@ -376,9 +384,12 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	if err != nil {
 		return nil, err
 	}
-	initial, err := packages.LoadEx(dedup, sizes, cfg, patterns...)
+	initial, err := packages.LoadExWithGoVersion(dedup, sizes, cfg, conf.GoVersion, patterns...)
 	if err != nil {
 		return nil, err
+	}
+	if conf.AllowNoBody {
+		allowMissingFunctionBodies(initial)
 	}
 	mode := conf.Mode
 	if mode == ModeTest {
@@ -575,6 +586,51 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	}
 
 	return allPkgs, nil
+}
+
+func applyFrontendGCFlags(conf *Config) {
+	for _, buildFlag := range conf.GoBuildFlags {
+		value, ok := strings.CutPrefix(buildFlag, "-gcflags=")
+		if !ok {
+			continue
+		}
+		fields := strings.Fields(value)
+		if len(fields) != 0 {
+			if _, compilerFlags, hasPattern := strings.Cut(fields[0], "="); hasPattern {
+				fields[0] = compilerFlags
+			}
+		}
+		for _, compilerFlag := range fields {
+			switch {
+			case strings.HasPrefix(compilerFlag, "-lang="):
+				conf.GoVersion = strings.TrimPrefix(compilerFlag, "-lang=")
+			case compilerFlag == "-N", compilerFlag == "-l", strings.HasPrefix(compilerFlag, "-l="):
+				conf.OptLevel = optlevel.O0
+			}
+		}
+	}
+}
+
+func allowMissingFunctionBodies(initial []*packages.Package) {
+	for _, pkg := range initial {
+		hasMissingBody := false
+		hasOtherError := false
+		for _, pkgErr := range pkg.Errors {
+			switch {
+			case strings.Contains(pkgErr.Msg, "missing function body"):
+				hasMissingBody = true
+			case strings.HasPrefix(pkgErr.Msg, "# "):
+				// go list prefixes compiler diagnostics with the package name.
+			default:
+				hasOtherError = true
+			}
+		}
+		if hasMissingBody && !hasOtherError {
+			pkg.Errors = nil
+			pkg.TypeErrors = nil
+			pkg.IllTyped = false
+		}
+	}
 }
 
 func needLink(pkg *packages.Package, mode Mode) bool {
@@ -1742,13 +1798,36 @@ func buildSSAPkgs(ctx *context, initial []*packages.Package, verbose bool) ([]*a
 	if len(errs) > 0 {
 		for _, errPkg := range errs {
 			for _, err := range errPkg.Errors {
-				fmt.Fprintln(os.Stderr, err)
+				fmt.Fprintln(os.Stderr, formatPackageError(err, ctx.buildConf.NoErrorColumn))
 			}
 			fmt.Fprintln(os.Stderr, "cannot build SSA for package", errPkg)
 		}
 		return nil, fmt.Errorf("cannot build SSA for packages")
 	}
 	return all, nil
+}
+
+func formatPackageError(err packages.Error, noColumn bool) string {
+	if !noColumn || err.Pos == "" || err.Pos == "-" {
+		return err.Error()
+	}
+	pos := err.Pos
+	lastColon := strings.LastIndexByte(pos, ':')
+	if lastColon < 0 {
+		return err.Error()
+	}
+	if _, parseErr := strconv.Atoi(pos[lastColon+1:]); parseErr != nil {
+		return err.Error()
+	}
+	linePos := pos[:lastColon]
+	lineColon := strings.LastIndexByte(linePos, ':')
+	if lineColon < 0 {
+		return err.Error()
+	}
+	if _, parseErr := strconv.Atoi(linePos[lineColon+1:]); parseErr != nil {
+		return err.Error()
+	}
+	return linePos + ": " + err.Msg
 }
 
 func collectRewriteVars(ctx *context, pkgPath string) map[string]string {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1808,26 +1808,51 @@ func buildSSAPkgs(ctx *context, initial []*packages.Package, verbose bool) ([]*a
 }
 
 func formatPackageError(err packages.Error, noColumn bool) string {
-	if !noColumn || err.Pos == "" || err.Pos == "-" {
-		return err.Error()
+	formatted := err.Error()
+	if !noColumn {
+		return formatted
 	}
-	pos := err.Pos
+	if pos, ok := positionWithoutColumn(err.Pos); ok {
+		return pos + ": " + err.Msg
+	}
+	lines := strings.Split(formatted, "\n")
+	for i, line := range lines {
+		if line, ok := diagnosticWithoutColumn(line); ok {
+			lines[i] = line
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func positionWithoutColumn(pos string) (string, bool) {
 	lastColon := strings.LastIndexByte(pos, ':')
 	if lastColon < 0 {
-		return err.Error()
+		return "", false
 	}
 	if _, parseErr := strconv.Atoi(pos[lastColon+1:]); parseErr != nil {
-		return err.Error()
+		return "", false
 	}
 	linePos := pos[:lastColon]
 	lineColon := strings.LastIndexByte(linePos, ':')
 	if lineColon < 0 {
-		return err.Error()
+		return "", false
 	}
 	if _, parseErr := strconv.Atoi(linePos[lineColon+1:]); parseErr != nil {
-		return err.Error()
+		return "", false
 	}
-	return linePos + ": " + err.Msg
+	return linePos, true
+}
+
+func diagnosticWithoutColumn(line string) (string, bool) {
+	separator := strings.Index(line, ": ")
+	if separator < 0 {
+		return "", false
+	}
+	pos, ok := positionWithoutColumn(line[:separator])
+	if !ok {
+		return "", false
+	}
+	return pos + line[separator:], true
 }
 
 func collectRewriteVars(ctx *context, pkgPath string) map[string]string {

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/goplus/llgo/internal/buildenv"
 	"github.com/goplus/llgo/internal/lto"
 	"github.com/goplus/llgo/internal/mockable"
+	"github.com/goplus/llgo/internal/optlevel"
 	"github.com/goplus/llgo/internal/packages"
 	llssa "github.com/goplus/llgo/ssa"
 	"github.com/xgo-dev/llvm"
@@ -500,6 +501,101 @@ func TestDevLTOGlobalDCEDefaultsToFullLTO(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.conf.goGlobalDCEEnabled(); got != tt.want {
 				t.Fatalf("goGlobalDCEEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyFrontendGCFlags(t *testing.T) {
+	conf := &Config{GoBuildFlags: []string{
+		"-tags=integration",
+		"-gcflags=",
+		"-gcflags=-l",
+		"-gcflags=all=-lang=go1.17 -N -l=4",
+	}}
+	applyFrontendGCFlags(conf)
+	if conf.GoVersion != "go1.17" {
+		t.Fatalf("GoVersion=%q, want go1.17", conf.GoVersion)
+	}
+	if conf.OptLevel != optlevel.O0 {
+		t.Fatalf("OptLevel=%v, want O0", conf.OptLevel)
+	}
+}
+
+func TestAllowMissingFunctionBodies(t *testing.T) {
+	pkg := &packages.Package{
+		Errors: []packages.Error{
+			{Msg: "# command-line-arguments"},
+			{Msg: "missing function body"},
+		},
+		IllTyped: true,
+	}
+	allowMissingFunctionBodies([]*packages.Package{pkg})
+	if pkg.IllTyped || len(pkg.Errors) != 0 || len(pkg.TypeErrors) != 0 {
+		t.Fatalf("package remains ill-typed: %+v", pkg.Errors)
+	}
+
+	pkg = &packages.Package{
+		Errors: []packages.Error{
+			{Msg: "missing function body"},
+			{Msg: "undefined: missing"},
+		},
+		IllTyped: true,
+	}
+	allowMissingFunctionBodies([]*packages.Package{pkg})
+	if !pkg.IllTyped || len(pkg.Errors) != 2 {
+		t.Fatalf("mixed errors were incorrectly suppressed: %+v", pkg.Errors)
+	}
+
+	unchanged := &packages.Package{Errors: []packages.Error{{Msg: "# command-line-arguments"}}, IllTyped: true}
+	allowMissingFunctionBodies([]*packages.Package{unchanged})
+	if !unchanged.IllTyped || len(unchanged.Errors) != 1 {
+		t.Fatalf("package without a missing-body diagnostic was changed: %+v", unchanged)
+	}
+}
+
+func TestDoAllowsMissingFunctionBodies(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "nobody.go")
+	if err := os.WriteFile(file, []byte(`package nobody
+
+func External()
+
+func F() {}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	conf := NewDefaultConf(ModeGen)
+	conf.AllowNoBody = true
+	pkgs, err := Do([]string{file}, conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pkgs) != 1 || pkgs[0].LPkg == nil {
+		t.Fatalf("Do returned packages = %+v, want one compiled package", pkgs)
+	}
+	pkgs[0].LPkg.Prog.Dispose()
+}
+
+func TestFormatPackageError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      packages.Error
+		noColumn bool
+		want     string
+	}{
+		{name: "keep columns", err: packages.Error{Pos: "case.go:2:3", Msg: "bad"}, want: "case.go:2:3: bad"},
+		{name: "remove column", err: packages.Error{Pos: "case.go:2:3", Msg: "bad"}, noColumn: true, want: "case.go:2: bad"},
+		{name: "empty position", err: packages.Error{Msg: "bad"}, noColumn: true, want: "-: bad"},
+		{name: "dash position", err: packages.Error{Pos: "-", Msg: "bad"}, noColumn: true, want: "-: bad"},
+		{name: "missing separators", err: packages.Error{Pos: "case.go", Msg: "bad"}, noColumn: true, want: "case.go: bad"},
+		{name: "invalid column", err: packages.Error{Pos: "case.go:2:x", Msg: "bad"}, noColumn: true, want: "case.go:2:x: bad"},
+		{name: "missing line separator", err: packages.Error{Pos: "2:3", Msg: "bad"}, noColumn: true, want: "2:3: bad"},
+		{name: "invalid line", err: packages.Error{Pos: "case.go:x:3", Msg: "bad"}, noColumn: true, want: "case.go:x:3: bad"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatPackageError(tt.err, tt.noColumn); got != tt.want {
+				t.Fatalf("formatPackageError() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -585,6 +585,7 @@ func TestFormatPackageError(t *testing.T) {
 	}{
 		{name: "keep columns", err: packages.Error{Pos: "case.go:2:3", Msg: "bad"}, want: "case.go:2:3: bad"},
 		{name: "remove column", err: packages.Error{Pos: "case.go:2:3", Msg: "bad"}, noColumn: true, want: "case.go:2: bad"},
+		{name: "driver diagnostic", err: packages.Error{Pos: "-", Msg: "# command-line-arguments\ndriver detail\ncase.go:2:3: bad"}, noColumn: true, want: "-: # command-line-arguments\ndriver detail\ncase.go:2: bad"},
 		{name: "empty position", err: packages.Error{Msg: "bad"}, noColumn: true, want: "-: bad"},
 		{name: "dash position", err: packages.Error{Pos: "-", Msg: "bad"}, noColumn: true, want: "-: bad"},
 		{name: "missing separators", err: packages.Error{Pos: "case.go", Msg: "bad"}, noColumn: true, want: "case.go: bad"},

--- a/internal/packages/load.go
+++ b/internal/packages/load.go
@@ -71,6 +71,7 @@ const (
 // The zero value is a valid configuration.
 // Calls to Load do not modify this struct.
 type Config = packages.Config
+type Error = packages.Error
 
 // A Package describes a loaded Go package.
 type Package = packages.Package
@@ -104,6 +105,8 @@ type loader struct {
 	// we need certain modes right.
 	requestedMode LoadMode
 }
+
+var loadGoVersions sync.Map // map[*loader]string
 
 type Cached struct {
 	*packages.Package
@@ -347,13 +350,14 @@ func loadPackageEx(dedup Deduper, ld *loader, lpkg *loaderPackage) {
 	}
 
 	lpkg.TypesInfo = &types.Info{
-		Types:      make(map[ast.Expr]types.TypeAndValue),
-		Defs:       make(map[*ast.Ident]types.Object),
-		Uses:       make(map[*ast.Ident]types.Object),
-		Implicits:  make(map[ast.Node]types.Object),
-		Instances:  make(map[*ast.Ident]types.Instance),
-		Scopes:     make(map[ast.Node]*types.Scope),
-		Selections: make(map[*ast.SelectorExpr]*types.Selection),
+		Types:        make(map[ast.Expr]types.TypeAndValue),
+		Defs:         make(map[*ast.Ident]types.Object),
+		Uses:         make(map[*ast.Ident]types.Object),
+		Implicits:    make(map[ast.Node]types.Object),
+		Instances:    make(map[*ast.Ident]types.Instance),
+		Scopes:       make(map[ast.Node]*types.Scope),
+		Selections:   make(map[*ast.SelectorExpr]*types.Selection),
+		FileVersions: make(map[*ast.File]string),
 	}
 	lpkg.TypesSizes = ld.sizes
 
@@ -398,7 +402,9 @@ func loadPackageEx(dedup Deduper, ld *loader, lpkg *loaderPackage) {
 		Error: appendError,
 		Sizes: ld.sizes, // may be nil
 	}
-	if lpkg.Module != nil && lpkg.Module.GoVersion != "" {
+	if goVersion, ok := loadGoVersions.Load(ld); ok && lpkg.initial {
+		tc.GoVersion = goVersion.(string)
+	} else if lpkg.Module != nil && lpkg.Module.GoVersion != "" {
 		tc.GoVersion = "go" + lpkg.Module.GoVersion
 	}
 	if (ld.Mode & typecheckCgo) != 0 {
@@ -706,7 +712,17 @@ func refineEx(dedup Deduper, ld *loader, response *packages.DriverResponse) ([]*
 // proceeding with further analysis. The PrintErrors function is
 // provided for convenient display of all errors.
 func LoadEx(dedup Deduper, sizes func(sizes types.Sizes, compiler, arch string) types.Sizes, cfg *Config, patterns ...string) ([]*Package, error) {
+	return LoadExWithGoVersion(dedup, sizes, cfg, "", patterns...)
+}
+
+// LoadExWithGoVersion is LoadEx with an optional go/types language version
+// override. The version uses go/types syntax, such as "go1.22".
+func LoadExWithGoVersion(dedup Deduper, sizes func(sizes types.Sizes, compiler, arch string) types.Sizes, cfg *Config, goVersion string, patterns ...string) ([]*Package, error) {
 	ld := newLoader(cfg)
+	if goVersion != "" {
+		loadGoVersions.Store(ld, goVersion)
+		defer loadGoVersions.Delete(ld)
+	}
 	response, external, err := defaultDriver(&ld.Config, patterns...)
 	if err != nil {
 		return nil, err

--- a/internal/packages/load_test.go
+++ b/internal/packages/load_test.go
@@ -1,0 +1,72 @@
+//go:build !llgo
+
+package packages
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadExWithGoVersion(t *testing.T) {
+	dir := t.TempDir()
+	writeLoadTestFile(t, filepath.Join(dir, "go.mod"), "module example.com/loadversion\ngo 1.24\n")
+	writeLoadTestFile(t, filepath.Join(dir, "load.go"), `package loadversion
+
+func identity[T any](value T) T { return value }
+`)
+
+	oldVersion, err := LoadExWithGoVersion(nil, nil, loadTestConfig(dir), "go1.17", ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(oldVersion) != 1 {
+		t.Fatalf("LoadExWithGoVersion returned %d packages, want 1", len(oldVersion))
+	}
+	if !oldVersion[0].IllTyped || !packageErrorsContain(oldVersion[0], "requires go1.18 or later") {
+		t.Fatalf("go1.17 load did not reject generics: %+v", oldVersion[0].Errors)
+	}
+
+	currentVersion, err := LoadEx(nil, nil, loadTestConfig(dir), ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(currentVersion) != 1 {
+		t.Fatalf("LoadEx returned %d packages, want 1", len(currentVersion))
+	}
+	pkg := currentVersion[0]
+	if pkg.IllTyped || len(pkg.Errors) != 0 {
+		t.Fatalf("module-version load failed: %+v", pkg.Errors)
+	}
+	if len(pkg.Syntax) != 1 || pkg.TypesInfo == nil {
+		t.Fatalf("load did not return syntax and type information: %+v", pkg)
+	}
+	if got := pkg.TypesInfo.FileVersions[pkg.Syntax[0]]; got != "go1.24" {
+		t.Fatalf("file language version = %q, want go1.24", got)
+	}
+}
+
+func loadTestConfig(dir string) *Config {
+	return &Config{
+		Dir: dir,
+		Mode: NeedName | NeedFiles | NeedCompiledGoFiles | NeedSyntax |
+			NeedTypes | NeedTypesInfo | NeedTypesSizes | NeedModule,
+	}
+}
+
+func packageErrorsContain(pkg *Package, text string) bool {
+	for _, err := range pkg.Errors {
+		if strings.Contains(err.Msg, text) {
+			return true
+		}
+	}
+	return false
+}
+
+func writeLoadTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/go/tool_compile_compat_test.go
+++ b/test/go/tool_compile_compat_test.go
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gotest
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestToolCompileGoFlagCompatibility(t *testing.T) {
+	t.Run("frontend flags", func(t *testing.T) {
+		dir := t.TempDir()
+		writeToolCompileSource(t, dir, "valid.go", `package compat
+
+type Box[T any] struct{ Value T }
+
+func Identity[T any](v T) T { return v }
+`)
+		writeToolCompileSource(t, dir, "importcfg", "")
+		args := []string{
+			"-c=1", "-C", "-e", "-N", "-l=4", "-lang=go1.22", "-complete",
+			"-d=panic,ssa/check/on", "-p=compat", "-importcfg=importcfg",
+			"-D=.", "-I=.", "-o=compat.o", "valid.go",
+		}
+		compareToolCompileResult(t, dir, args, true, "")
+	})
+
+	t.Run("language version", func(t *testing.T) {
+		dir := t.TempDir()
+		writeToolCompileSource(t, dir, "generic.go", `package compat
+
+func Identity[T any](v T) T { return v }
+`)
+		compareToolCompileResult(t, dir, []string{
+			"-lang=go1.17", "-o=generic.o", "generic.go",
+		}, false, "requires go1.18 or later")
+	})
+
+	t.Run("complete package", func(t *testing.T) {
+		dir := t.TempDir()
+		writeToolCompileSource(t, dir, "nobody.go", `package compat
+
+func External()
+`)
+		compareToolCompileResult(t, dir, []string{
+			"-lang=go1.22", "-complete", "-o=nobody.o", "nobody.go",
+		}, false, "missing function body")
+		compareToolCompileResult(t, dir, []string{
+			"-lang=go1.22", "-o=nobody.o", "nobody.go",
+		}, true, "")
+	})
+
+	t.Run("diagnostic columns", func(t *testing.T) {
+		dir := t.TempDir()
+		writeToolCompileSource(t, dir, "invalid.go", `package compat
+
+var _ = missing
+`)
+		goOutput, llgoOutput := compareToolCompileResult(t, dir, []string{
+			"-C", "-e", "-o=invalid.o", "invalid.go",
+		}, false, "undefined: missing")
+		column := regexp.MustCompile(`invalid\.go:3:[0-9]+:`)
+		for name, output := range map[string]string{"go": goOutput, "llgo": llgoOutput} {
+			if column.MatchString(output) {
+				t.Fatalf("%s -C diagnostic contains a column: %s", name, output)
+			}
+			if !strings.Contains(output, "invalid.go:3:") {
+				t.Fatalf("%s -C diagnostic has no line position: %s", name, output)
+			}
+		}
+	})
+}
+
+func compareToolCompileResult(t *testing.T, dir string, args []string, wantSuccess bool, wantText string) (goOutput, llgoOutput string) {
+	t.Helper()
+
+	goArgs := append([]string{"tool", "compile"}, args...)
+	goCmd := exec.Command("go", goArgs...)
+	goCmd.Dir = dir
+	goCmd.Env = os.Environ()
+	goBytes, goErr := goCmd.CombinedOutput()
+
+	llgoOutput, llgoErr := runLLGoInModule(t, dir, append([]string{"tool", "compile"}, args...)...)
+	goOutput = string(goBytes)
+	if (goErr == nil) != wantSuccess {
+		t.Fatalf("go tool compile success = %v, want %v; output:\n%s", goErr == nil, wantSuccess, goOutput)
+	}
+	if (llgoErr == nil) != wantSuccess {
+		t.Fatalf("llgo tool compile success = %v, want %v; output:\n%s", llgoErr == nil, wantSuccess, llgoOutput)
+	}
+	if wantText != "" {
+		if !strings.Contains(goOutput, wantText) {
+			t.Fatalf("go tool compile output does not contain %q:\n%s", wantText, goOutput)
+		}
+		if !strings.Contains(llgoOutput, wantText) {
+			t.Fatalf("llgo tool compile output does not contain %q:\n%s", wantText, llgoOutput)
+		}
+	}
+	return goOutput, llgoOutput
+}
+
+func writeToolCompileSource(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Problem and impact

GOROOT testdir compile-family recipes invoke a compiler with the `go tool compile` command shape and Go compiler flag names. Before this PR, LLGo had no `llgo tool compile` action and no command path for several frontend options.

Without this PR:

- `compile`, `errorcheck`, and related GOROOT actions cannot exercise LLGo through the same compiler-facing contract used by the Go test driver
- those cases must remain excluded or fail at command dispatch/flag parsing, leaving a material Go compatibility coverage gap
- language-version, complete-package, and diagnostic-column behavior cannot be checked end to end through `test/go`

This PR is an adapter for source compilation and diagnostics. It does not make LLGo a drop-in replacement for the Go object compiler.

## Summary

- add `llgo tool compile [options] file.go...` using the Go flag names and count/value forms needed by GOROOT testdir
- propagate frontend Go version, missing-body, diagnostic-column, optimization, and Go build options through package loading and build configuration
- register and dispatch the generated `llgo tool compile` command
- make `-C` remove columns from both go/types and multiline go-list driver diagnostics
- reject recognized options whose semantics LLGo does not implement instead of silently pretending to support them

## Compatibility with Go 1.26.5

The command intentionally implements a test-runner compatibility subset. The Go compiler parses these flags in `cmd/compile/internal/base` and applies them directly to its noder, optimizer, import archive reader, backend worker pool, and object writer. LLGo parses the matching surface and maps applicable behavior into go/packages, go/types, x/tools SSA, and the LLVM pipeline.

| Flags | LLGo behavior | Difference from `go tool compile` |
| --- | --- | --- |
| `-C` | Removes columns from frontend and go-list diagnostics | Same observable goal; implemented while formatting package-loader errors rather than in the Go compiler diagnostic engine |
| `-lang=go1.x` | Overrides the initial package go/types language version | Same source-language goal; validation and diagnostics come from go/types rather than cmd/compile types2 |
| `-complete` | Requires function bodies; without it, bodyless declarations are allowed | Same tested behavior; LLGo suppresses isolated missing-body load errors after package loading rather than changing the unified-IR writer |
| `-N` | Selects LLVM `O0` | Approximation of the Go compiler no-optimization mode; the optimization pipelines are different |
| `-l[=n]` | Selects LLVM `O0` | Stronger/coarser than Go, where `-l` controls inlining only and count values have compiler-specific meaning |
| `-c=N` | For positive N, temporarily sets process-wide `GOMAXPROCS` during compilation | Go uses N as its backend worker count, defaults it from `GOMAXPROCS`, and requires N >= 1; LLGo currently treats zero as leave unchanged and affects package loading as well as code generation |
| `-e` | Accepted and forwarded in the generated `-gcflags` used by package loading | LLGo does not have the Go compiler diagnostic engine ten-error cutoff, so this is not the same internal control |
| `-d=panic`, `-d=ssa/check/on` | Accepted allowlisted compatibility settings | They do not toggle LLGo pipeline state; LLGo already builds x/tools SSA with sanity checking, and other `-d` settings are rejected |
| `-D`, `-I`, `-p`, `-importcfg` | Parse with Go-compatible names/value forms so the test driver can invoke source-only cases | LLGo resolves package identity and imports through go/packages/go list; it does not consume Go export archives, apply `importmap/packagefile`, or use these values as cmd/compile does |
| `-o` | Accepted for compile-family source checks | `ModeGen` returns an in-memory LLVM module and does not write the requested Go `.o` or `.a` file |
| bare `-V` | Prints an LLGo compile version | Go also supports cache-key forms such as `-V=full`; those are not implemented here |

Recognized but unsupported options fail explicitly: `-B`, `-dynlink`, `-m`, `-live`, `-race`, `-smallframes`, `-std`, `-+`, explicit `-wb`, and non-allowlisted `-d` settings. Other Go compiler flags that are not part of this subset fail normal flag parsing.

The practical boundary is intentional: this command can answer whether LLGo accepts and lowers the source, and can produce frontend diagnostics compatible enough for GOROOT checks. Because it does not emit Go object/export data, it cannot be used as a `-toolexec` compiler or replace `go tool compile` in a normal Go build.

## Compatibility coverage

`test/go/tool_compile_compat_test.go` executes native `go tool compile` and `llgo tool compile` against the same source files and verifies:

- common invocation forms for `-c`, `-C`, `-e`, `-N`, `-l`, `-lang`, `-complete`, allowlisted `-d`, `-p`, `-importcfg`, `-D`, `-I`, and `-o`
- Go language-version rejection
- complete-package missing-body behavior
- compile-only acceptance of declarations without bodies
- column-free diagnostics

The comparison intentionally checks success/failure and relevant diagnostics, not equality or existence of object files. Internal unit tests retain detailed parser, unsupported-option, error-path, and configuration coverage.

## Scope

This PR is the review unit for the GOROOT compile-test adapter and its required frontend option propagation, command registration, and compatibility tests.

The independent `unsafe.Offsetof` frontend fix remains #2068. Both #2066 and #2068 are prerequisites for the complete GOROOT coverage runner in #2065.

Compared with `main`: 13 files, 1,080 additions, 14 deletions.

## Verification

With `GOMAXPROCS=2`, `GOMEMLIMIT=2GiB`, and serial package execution:

- Go 1.24.11 and Go 1.26.5 focused package tests pass
- native Go execution of `TestToolCompileGoFlagCompatibility` passes on both versions
- real `llgo test ./test/go` execution of that compatibility test passes on both versions
- newly added diagnostic helper functions have 100% local statement coverage

GitHub Actions completed with 47 passing checks and 1 expected release skip. Codecov patch coverage is 100.00%.