### PR TITLE
ltoplugin: propagate MethodByName names through function args

### DIFF
--- a/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_param/expect.txt
+++ b/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_param/expect.txt
@@ -1,0 +1,4 @@
+param-value-a
+param-value-b
+param-type-a
+param-type-b

--- a/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_param/in.go
+++ b/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_param/in.go
@@ -1,0 +1,71 @@
+// LITTEST
+package main
+
+import "reflect"
+
+// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_param{{.*}}S{{.*}}Drop
+// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_param{{.*}}S{{.*}}KeepParamValueA
+// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_param{{.*}}S{{.*}}KeepParamValueB
+// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_param{{.*}}S{{.*}}KeepParamTypeA
+// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_param{{.*}}S{{.*}}KeepParamTypeB
+// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_param{{.*}}S{{.*}}Drop
+
+type S struct{}
+
+//go:noinline
+func (S) KeepParamValueA() string {
+	return "param-value-a"
+}
+
+//go:noinline
+func (S) KeepParamValueB() string {
+	return "param-value-b"
+}
+
+//go:noinline
+func (S) KeepParamTypeA() string {
+	return "param-type-a"
+}
+
+//go:noinline
+func (S) KeepParamTypeB() string {
+	return "param-type-b"
+}
+
+//go:noinline
+func (S) Drop() string {
+	panic("Drop should be unreachable")
+}
+
+//go:noinline
+func callValueByName(name string) string {
+	out := reflect.ValueOf(S{}).MethodByName(name).Call(nil)
+	return out[0].String()
+}
+
+//go:noinline
+func forwardValueSuffix(suffix string) string {
+	return callValueByName("Keep" + suffix)
+}
+
+//go:noinline
+func callTypeByName(name string) string {
+	m, ok := reflect.TypeOf(S{}).MethodByName(name)
+	if !ok {
+		panic("missing method")
+	}
+	out := m.Func.Call([]reflect.Value{reflect.ValueOf(S{})})
+	return out[0].String()
+}
+
+//go:noinline
+func forwardTypeName(name string) string {
+	return callTypeByName(name)
+}
+
+func main() {
+	println(forwardValueSuffix("ParamValueA"))
+	println(forwardValueSuffix("ParamValueB"))
+	println(forwardTypeName("KeepParamTypeA"))
+	println(forwardTypeName("KeepParamTypeB"))
+}

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -182,6 +182,7 @@ func TestRunAndTestFromTestlto(t *testing.T) {
 		"./_testlto/globaldce_reflect_method_by_name_ltoplugin",
 		"./_testlto/globaldce_reflect_method_by_name_ltoplugin_concat",
 		"./_testlto/globaldce_reflect_method_by_name_ltoplugin_global",
+		"./_testlto/globaldce_reflect_method_by_name_ltoplugin_param",
 		"./_testlto/globaldce_reflect_method_by_name_ltoplugin_switch",
 	}
 	if !buildenv.Dev {
@@ -215,6 +216,7 @@ var testltoLTOPluginTests = []string{
 	"globaldce_reflect_method_by_name_ltoplugin",
 	"globaldce_reflect_method_by_name_ltoplugin_concat",
 	"globaldce_reflect_method_by_name_ltoplugin_global",
+	"globaldce_reflect_method_by_name_ltoplugin_param",
 	"globaldce_reflect_method_by_name_ltoplugin_switch",
 }
 

--- a/ltoplugin/CMakeLists.txt
+++ b/ltoplugin/CMakeLists.txt
@@ -16,7 +16,8 @@ include(AddLLVM)
 add_definitions(${LLVM_DEFINITIONS})
 
 add_llvm_pass_plugin(LLGOLTOPlugin
-  LLGOLTOPasses.cpp
+  LLGOLTOPlugin.cpp
+  LLGOReflectMethodByNamePass.cpp
 )
 
 target_compile_features(LLGOLTOPlugin PRIVATE cxx_std_17)

--- a/ltoplugin/LLGOLTOPasses.h
+++ b/ltoplugin/LLGOLTOPasses.h
@@ -1,0 +1,18 @@
+#ifndef LLGO_LTO_PASSES_H
+#define LLGO_LTO_PASSES_H
+
+#include "llvm/IR/PassManager.h"
+
+namespace llgo {
+
+inline constexpr char LLGOPreGlobalDCEPassName[] = "llgo-lto-pre-globaldce";
+
+void addLLGOReflectMethodByNamePass(llvm::ModulePassManager &MPM);
+
+inline void addLLGOPreGlobalDCEPipeline(llvm::ModulePassManager &MPM) {
+  addLLGOReflectMethodByNamePass(MPM);
+}
+
+} // namespace llgo
+
+#endif // LLGO_LTO_PASSES_H

--- a/ltoplugin/LLGOLTOPlugin.cpp
+++ b/ltoplugin/LLGOLTOPlugin.cpp
@@ -1,0 +1,31 @@
+#include "LLGOLTOPasses.h"
+
+#include "llvm/Config/llvm-config.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+#include "llvm/Support/Compiler.h"
+
+using namespace llvm;
+
+PassPluginLibraryInfo getLLGOLTOPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, "llgo-lto-plugin", LLVM_VERSION_STRING,
+          [](PassBuilder &PB) {
+            PB.registerPipelineParsingCallback(
+                [](StringRef Name, ModulePassManager &MPM,
+                   ArrayRef<PassBuilder::PipelineElement>) {
+                  if (Name != llgo::LLGOPreGlobalDCEPassName)
+                    return false;
+                  llgo::addLLGOPreGlobalDCEPipeline(MPM);
+                  return true;
+                });
+
+            PB.registerFullLinkTimeOptimizationEarlyEPCallback(
+                [](ModulePassManager &MPM, OptimizationLevel) {
+                  llgo::addLLGOPreGlobalDCEPipeline(MPM);
+                });
+          }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK PassPluginLibraryInfo llvmGetPassPluginInfo() {
+  return getLLGOLTOPluginInfo();
+}

--- a/ltoplugin/LLGOReflectMethodByNamePass.cpp
+++ b/ltoplugin/LLGOReflectMethodByNamePass.cpp
@@ -1,8 +1,9 @@
+#include "LLGOLTOPasses.h"
+
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Analysis/ConstantFolding.h"
 #include "llvm/Analysis/ValueTracking.h"
-#include "llvm/Config/llvm-config.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/IRBuilder.h"
@@ -14,9 +15,6 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Operator.h"
 #include "llvm/IR/PassManager.h"
-#include "llvm/Passes/PassBuilder.h"
-#include "llvm/Passes/PassPlugin.h"
-#include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <cstdlib>
@@ -27,7 +25,6 @@ using namespace llvm;
 
 namespace {
 
-static constexpr char LLGOPreGlobalDCEPassName[] = "llgo-lto-pre-globaldce";
 static constexpr char ReflectMethodByNameCallAttr[] =
     "llgo.reflect.methodbyname";
 static constexpr char ReflectMethodByNameArgAttr[] =
@@ -832,25 +829,10 @@ public:
 
 } // namespace
 
-PassPluginLibraryInfo getLLGOLTOPluginInfo() {
-  return {LLVM_PLUGIN_API_VERSION, "llgo-lto-plugin", LLVM_VERSION_STRING,
-          [](PassBuilder &PB) {
-            PB.registerPipelineParsingCallback(
-                [](StringRef Name, ModulePassManager &MPM,
-                   ArrayRef<PassBuilder::PipelineElement>) {
-                  if (Name != LLGOPreGlobalDCEPassName)
-                    return false;
-                  MPM.addPass(LLGOLTOPreGlobalDCEPass());
-                  return true;
-                });
+namespace llgo {
 
-            PB.registerFullLinkTimeOptimizationEarlyEPCallback(
-                [](ModulePassManager &MPM, OptimizationLevel) {
-                  MPM.addPass(LLGOLTOPreGlobalDCEPass());
-                });
-          }};
+void addLLGOReflectMethodByNamePass(ModulePassManager &MPM) {
+  MPM.addPass(LLGOLTOPreGlobalDCEPass());
 }
 
-extern "C" LLVM_ATTRIBUTE_WEAK PassPluginLibraryInfo llvmGetPassPluginInfo() {
-  return getLLGOLTOPluginInfo();
-}
+} // namespace llgo

--- a/ltoplugin/LLGOReflectMethodByNamePass.cpp
+++ b/ltoplugin/LLGOReflectMethodByNamePass.cpp
@@ -98,6 +98,11 @@ bool collectStringSetFromStringValue(Value *StringValue, const DataLayout &DL,
                                      SmallVectorImpl<std::string> &Names,
                                      unsigned Depth = 0);
 
+bool collectStringSetFromFunctionStringArg(Value *Ptr, Value *Len,
+                                           const DataLayout &DL,
+                                           SmallVectorImpl<std::string> &Names,
+                                           unsigned Depth);
+
 std::optional<unsigned> singleExtractValueIndex(ExtractValueInst *Extract) {
   if (!Extract || Extract->getNumIndices() != 1)
     return std::nullopt;
@@ -432,6 +437,48 @@ bool collectStringSetFromConstantSlots(
   return true;
 }
 
+bool collectStringSetFromFunctionStringArg(Value *Ptr, Value *Len,
+                                           const DataLayout &DL,
+                                           SmallVectorImpl<std::string> &Names,
+                                           unsigned Depth) {
+  auto *PtrArg = dyn_cast<Argument>(Ptr);
+  auto *LenArg = dyn_cast<Argument>(Len);
+  if (!PtrArg || !LenArg)
+    return false;
+
+  Function *F = PtrArg->getParent();
+  if (!F || F != LenArg->getParent())
+    return false;
+
+  unsigned PtrArgNo = PtrArg->getArgNo();
+  unsigned LenArgNo = LenArg->getArgNo();
+  if (LenArgNo != PtrArgNo + 1 || !PtrArg->getType()->isPointerTy() ||
+      !LenArg->getType()->isIntegerTy())
+    return false;
+
+  SmallVector<CallBase *, 8> Callers;
+  for (User *U : F->users()) {
+    auto *CB = dyn_cast<CallBase>(U);
+    if (!CB || CB->getCalledFunction() != F)
+      return false;
+    Callers.push_back(CB);
+  }
+  if (Callers.empty())
+    return false;
+
+  for (CallBase *CB : Callers) {
+    if (LenArgNo >= CB->arg_size())
+      return false;
+    Value *CallPtr = CB->getArgOperand(PtrArgNo);
+    Value *CallLen = CB->getArgOperand(LenArgNo);
+    if (!CallPtr->getType()->isPointerTy() || !CallLen->getType()->isIntegerTy())
+      return false;
+    if (!collectStringSet(CallPtr, CallLen, DL, Names, Depth + 1))
+      return false;
+  }
+  return true;
+}
+
 bool collectStringSetFromStringValue(Value *StringValue, const DataLayout &DL,
                                      SmallVectorImpl<std::string> &Names,
                                      unsigned Depth) {
@@ -520,6 +567,9 @@ bool collectStringSet(Value *Ptr, Value *Len, const DataLayout &DL,
   }
   if (FoldedLoad)
     return collectStringSet(Ptr, Len, DL, Names, Depth + 1);
+
+  if (collectStringSetFromFunctionStringArg(Ptr, Len, DL, Names, Depth))
+    return true;
 
   if (collectStringSetFromConstantSlots(dyn_cast<LoadInst>(Ptr),
                                         dyn_cast<LoadInst>(Len), DL, Names,


### PR DESCRIPTION
## Summary

This PR makes the LTO MethodByName refinement recognize names that are passed through a caller function's string parameter.

- Split LTO plugin registration from the MethodByName implementation, placing the pass registration in `LLGOLTOPlugin.cpp`.
- When the lowered `(ptr, len)` name pair is a function's adjacent string parameters, inspect every direct caller and recursively collect the caller-side candidate strings.
- Remain conservative: analysis succeeds only when every use is a direct call and every caller argument can be resolved. Otherwise the generic reflection marker remains intact.
- Add LTO plugin coverage for both `reflect.Value.MethodByName` and `reflect.Type.MethodByName` through forwarded parameters.

## Scope

The PR is based on `main` and contains two commits:

1. `ltoplugin: split pass registration`
2. `ltoplugin: propagate MethodByName names through function args`

## Validation

- `cmake --build ltoplugin/cmake-build-debug`
- `LLGO_LTO_PLUGIN=$PWD/ltoplugin/cmake-build-debug/LLGOLTOPlugin.so go test -tags dev ./cl -run 'TestBuildAndCheckSymbolsFromTestltoLTOPlugin/globaldce_reflect_method_by_name_ltoplugin_param$' -count=1 -v`
- `LLGO_LTO_PLUGIN=$PWD/ltoplugin/cmake-build-debug/LLGOLTOPlugin.so go test -tags dev ./cl -run 'TestRunAndTestFromTestltoLTOPlugin/globaldce_reflect_method_by_name_ltoplugin_param$' -count=1 -v`
- `LLGO_LTO_PLUGIN=$PWD/ltoplugin/cmake-build-debug/LLGOLTOPlugin.so go test -tags dev ./cl -run TestBuildAndCheckSymbolsFromTestltoLTOPlugin -count=1 -v`