### PR TITLE
cl: handle SSA field values in unsafe.Offsetof

### DIFF
--- a/cl/instr.go
+++ b/cl/instr.go
@@ -711,6 +711,14 @@ func (p *context) pkgNoInit(pkg *types.Package) bool {
 }
 
 func (p *context) offsetOfBuiltinArg(arg ssa.Value) (llssa.Expr, bool) {
+	if field, ok := arg.(*ssa.Field); ok {
+		st, ok := field.X.Type().Underlying().(*types.Struct)
+		if !ok || field.Field < 0 || field.Field >= st.NumFields() {
+			return llssa.Expr{}, false
+		}
+		typ := p.type_(field.X.Type(), llssa.InGo)
+		return p.prog.Val(int(p.prog.OffsetOf(typ, field.Field))), true
+	}
 	load, ok := arg.(*ssa.UnOp)
 	if !ok || load.Op != token.MUL {
 		return llssa.Expr{}, false

--- a/cl/instr_offsetof_test.go
+++ b/cl/instr_offsetof_test.go
@@ -180,6 +180,24 @@ func explicit[T any](v *outer[T]) uintptr {
 	stubStruct := types.NewStruct([]*types.Var{
 		types.NewVar(token.NoPos, nil, "F", types.Typ[types.Int]),
 	}, nil)
+	if _, ok := ctx.offsetOfBuiltinArg(&gossa.Field{
+		X:     fakeSSAValue{typ: types.Typ[types.Int]},
+		Field: 0,
+	}); ok {
+		t.Fatal("offsetOfBuiltinArg returned true for Field of a non-struct value")
+	}
+	if _, ok := ctx.offsetOfBuiltinArg(&gossa.Field{
+		X:     fakeSSAValue{typ: stubStruct},
+		Field: stubStruct.NumFields(),
+	}); ok {
+		t.Fatal("offsetOfBuiltinArg returned true for an out-of-range Field")
+	}
+	if got, ok := ctx.offsetOfBuiltinArg(&gossa.Field{
+		X:     fakeSSAValue{typ: stubStruct},
+		Field: 0,
+	}); !ok || got.IsNil() {
+		t.Fatalf("offsetOfBuiltinArg(Field) = (%v, %v), want zero offset", got, ok)
+	}
 	validSynthetic := &gossa.FieldAddr{
 		X:     fakeSSAValue{typ: types.NewPointer(stubStruct)},
 		Field: 0,
@@ -260,6 +278,7 @@ type level2 struct {
 	C byte
 	level1
 }
+
 type outer[T any] struct {
 	A T
 	level2
@@ -274,6 +293,24 @@ func Offset(v *outer[int]) uintptr {
 }
 `)
 	if fn := m.NamedFunction("foo.Offset"); fn.IsNil() {
+		t.Fatal("missing compiled Offset function")
+	}
+}
+
+func TestCompileOffsetOfGenericCompositeField(t *testing.T) {
+	_, module := mustCompileLLPkgFromSrc(t, `package foo
+
+import "unsafe"
+
+func F[T int](v T) uintptr {
+	return unsafe.Offsetof(struct{ f T }{
+		func(T) T { return v }(v),
+	}.f)
+}
+
+func Offset() uintptr { return F(1) }
+`)
+	if fn := module.NamedFunction("foo.Offset"); fn.IsNil() {
 		t.Fatal("missing compiled Offset function")
 	}
 }

--- a/test/go/promoted_offsetof_test.go
+++ b/test/go/promoted_offsetof_test.go
@@ -17,6 +17,7 @@
 package gotest
 
 import (
+	"reflect"
 	"testing"
 	"unsafe"
 )
@@ -38,5 +39,26 @@ func TestUnsafeOffsetofGenericPromotedFieldIssue53137(t *testing.T) {
 	got, want := promotedOffsets(new(promotedGenericOuter[int]))
 	if got != want {
 		t.Fatalf("unsafe.Offsetof(v.B) = %d, want embedded field offset %d", got, want)
+	}
+}
+
+func offsetofGenericCompositeField[T int](v T) uintptr {
+	return unsafe.Offsetof(struct {
+		Prefix byte
+		Value  T
+	}{0, func(T) T { return v }(v)}.Value)
+}
+
+func TestUnsafeOffsetofGenericCompositeFieldMatchesGoLayout(t *testing.T) {
+	typ := reflect.TypeOf(struct {
+		Prefix byte
+		Value  int
+	}{})
+	field, ok := typ.FieldByName("Value")
+	if !ok {
+		t.Fatal("reflect.Type.FieldByName(Value) failed")
+	}
+	if got, want := offsetofGenericCompositeField(1), field.Offset; got != want {
+		t.Fatalf("unsafe.Offsetof(composite.Value) = %d, want Go layout offset %d", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

- handle `*ssa.Field` operands emitted for `unsafe.Offsetof` on generic composite struct values
- reject non-struct and out-of-range field operands
- retain focused frontend unit coverage for valid and invalid SSA values
- add a `test/go` compatibility regression that compares the LLGo offset with Go layout metadata

## Compatibility coverage

`TestUnsafeOffsetofGenericCompositeFieldMatchesGoLayout` uses a dynamically initialized generic anonymous struct, the source shape that produces `*ssa.Field`. With only the test applied, current `main` panics with `invalid argument for unsafe.Offsetof`; this PR passes under real `llgo test ./test/go`.

## Relationship

Independent prerequisite needed by the complete Go 1.26 GOROOT coverage in #2065. It can merge independently of the compiler-parameter PR #2066.

Compared with `main`: 3 files, 67 additions.

## Verification

Under `GOMAXPROCS=2` and `GOMEMLIMIT=2GiB`, the focused Go and real LLGo test runs pass with Go 1.24.11 and Go 1.26.5.\n\nGitHub Actions completed with 47 passing checks and 1 expected release skip. Codecov patch coverage is 100.00%.