### PR TITLE
packages: allow frontend Go version overrides

### DIFF
--- a/internal/packages/load.go
+++ b/internal/packages/load.go
@@ -71,6 +71,7 @@ const (
 // The zero value is a valid configuration.
 // Calls to Load do not modify this struct.
 type Config = packages.Config
+type Error = packages.Error
 
 // A Package describes a loaded Go package.
 type Package = packages.Package
@@ -104,6 +105,8 @@ type loader struct {
 	// we need certain modes right.
 	requestedMode LoadMode
 }
+
+var loadGoVersions sync.Map // map[*loader]string
 
 type Cached struct {
 	*packages.Package
@@ -347,13 +350,14 @@ func loadPackageEx(dedup Deduper, ld *loader, lpkg *loaderPackage) {
 	}
 
 	lpkg.TypesInfo = &types.Info{
-		Types:      make(map[ast.Expr]types.TypeAndValue),
-		Defs:       make(map[*ast.Ident]types.Object),
-		Uses:       make(map[*ast.Ident]types.Object),
-		Implicits:  make(map[ast.Node]types.Object),
-		Instances:  make(map[*ast.Ident]types.Instance),
-		Scopes:     make(map[ast.Node]*types.Scope),
-		Selections: make(map[*ast.SelectorExpr]*types.Selection),
+		Types:        make(map[ast.Expr]types.TypeAndValue),
+		Defs:         make(map[*ast.Ident]types.Object),
+		Uses:         make(map[*ast.Ident]types.Object),
+		Implicits:    make(map[ast.Node]types.Object),
+		Instances:    make(map[*ast.Ident]types.Instance),
+		Scopes:       make(map[ast.Node]*types.Scope),
+		Selections:   make(map[*ast.SelectorExpr]*types.Selection),
+		FileVersions: make(map[*ast.File]string),
 	}
 	lpkg.TypesSizes = ld.sizes
 
@@ -398,7 +402,9 @@ func loadPackageEx(dedup Deduper, ld *loader, lpkg *loaderPackage) {
 		Error: appendError,
 		Sizes: ld.sizes, // may be nil
 	}
-	if lpkg.Module != nil && lpkg.Module.GoVersion != "" {
+	if goVersion, ok := loadGoVersions.Load(ld); ok && lpkg.initial {
+		tc.GoVersion = goVersion.(string)
+	} else if lpkg.Module != nil && lpkg.Module.GoVersion != "" {
 		tc.GoVersion = "go" + lpkg.Module.GoVersion
 	}
 	if (ld.Mode & typecheckCgo) != 0 {
@@ -706,7 +712,17 @@ func refineEx(dedup Deduper, ld *loader, response *packages.DriverResponse) ([]*
 // proceeding with further analysis. The PrintErrors function is
 // provided for convenient display of all errors.
 func LoadEx(dedup Deduper, sizes func(sizes types.Sizes, compiler, arch string) types.Sizes, cfg *Config, patterns ...string) ([]*Package, error) {
+	return LoadExWithGoVersion(dedup, sizes, cfg, "", patterns...)
+}
+
+// LoadExWithGoVersion is LoadEx with an optional go/types language version
+// override. The version uses go/types syntax, such as "go1.22".
+func LoadExWithGoVersion(dedup Deduper, sizes func(sizes types.Sizes, compiler, arch string) types.Sizes, cfg *Config, goVersion string, patterns ...string) ([]*Package, error) {
 	ld := newLoader(cfg)
+	if goVersion != "" {
+		loadGoVersions.Store(ld, goVersion)
+		defer loadGoVersions.Delete(ld)
+	}
 	response, external, err := defaultDriver(&ld.Config, patterns...)
 	if err != nil {
 		return nil, err

--- a/internal/packages/load_test.go
+++ b/internal/packages/load_test.go
@@ -1,0 +1,72 @@
+//go:build !llgo
+
+package packages
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadExWithGoVersion(t *testing.T) {
+	dir := t.TempDir()
+	writeLoadTestFile(t, filepath.Join(dir, "go.mod"), "module example.com/loadversion\ngo 1.24\n")
+	writeLoadTestFile(t, filepath.Join(dir, "load.go"), `package loadversion
+
+func identity[T any](value T) T { return value }
+`)
+
+	oldVersion, err := LoadExWithGoVersion(nil, nil, loadTestConfig(dir), "go1.17", ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(oldVersion) != 1 {
+		t.Fatalf("LoadExWithGoVersion returned %d packages, want 1", len(oldVersion))
+	}
+	if !oldVersion[0].IllTyped || !packageErrorsContain(oldVersion[0], "requires go1.18 or later") {
+		t.Fatalf("go1.17 load did not reject generics: %+v", oldVersion[0].Errors)
+	}
+
+	currentVersion, err := LoadEx(nil, nil, loadTestConfig(dir), ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(currentVersion) != 1 {
+		t.Fatalf("LoadEx returned %d packages, want 1", len(currentVersion))
+	}
+	pkg := currentVersion[0]
+	if pkg.IllTyped || len(pkg.Errors) != 0 {
+		t.Fatalf("module-version load failed: %+v", pkg.Errors)
+	}
+	if len(pkg.Syntax) != 1 || pkg.TypesInfo == nil {
+		t.Fatalf("load did not return syntax and type information: %+v", pkg)
+	}
+	if got := pkg.TypesInfo.FileVersions[pkg.Syntax[0]]; got != "go1.24" {
+		t.Fatalf("file language version = %q, want go1.24", got)
+	}
+}
+
+func loadTestConfig(dir string) *Config {
+	return &Config{
+		Dir: dir,
+		Mode: NeedName | NeedFiles | NeedCompiledGoFiles | NeedSyntax |
+			NeedTypes | NeedTypesInfo | NeedTypesSizes | NeedModule,
+	}
+}
+
+func packageErrorsContain(pkg *Package, text string) bool {
+	for _, err := range pkg.Errors {
+		if strings.Contains(err.Msg, text) {
+			return true
+		}
+	}
+	return false
+}
+
+func writeLoadTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

- add an optional `go/types` language-version override to `LoadEx`
- keep the override scoped to the loader and initial packages
- initialize per-file version tracking and test override versus module-version behavior

## Relationship

This is the first layer of the command stack and the direct prerequisite for #2070. Merge order: #2069 -> #2070 -> #2071 -> #2066.

## Layer size

Compared with `main`: 2 files, 96 additions, 8 deletions.

## Verification

- Go 1.24.11: `go test ./internal/packages`
- Go 1.26.5: `go test ./internal/packages`