### PR TITLE
cmd/internal/compile: add Go-tool-compatible action

### DIFF
--- a/cmd/internal/build/build.go
+++ b/cmd/internal/build/build.go
@@ -33,9 +33,11 @@ var Cmd = &base.Command{
 	Short:     "Compile packages and dependencies",
 }
 
+var goBuildFlags *base.PassArgs
+
 func init() {
 	Cmd.Run = runCmd
-	base.PassBuildFlags(Cmd)
+	goBuildFlags = base.PassBuildFlags(Cmd)
 
 	flags.AddCommonFlags(&Cmd.Flag)
 	flags.AddBuildFlags(&Cmd.Flag)
@@ -56,6 +58,7 @@ func runCmd(cmd *base.Command, args []string) {
 		fmt.Fprintln(os.Stderr, err)
 		mockable.Exit(1)
 	}
+	conf.GoBuildFlags = append(conf.GoBuildFlags, goBuildFlags.Args...)
 
 	args = cmd.Flag.Args()
 

--- a/cmd/internal/build/build_test.go
+++ b/cmd/internal/build/build_test.go
@@ -1,0 +1,59 @@
+//go:build !llgo
+
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/goplus/llgo/internal/mockable"
+)
+
+func TestRunCmdPassesGoBuildFlags(t *testing.T) {
+	oldArgs := append([]string(nil), goBuildFlags.Args...)
+	goBuildFlags.Args = nil
+	defer func() { goBuildFlags.Args = oldArgs }()
+
+	stderrFile, err := os.CreateTemp(t.TempDir(), "stderr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldStderr := os.Stderr
+	os.Stderr = stderrFile
+	defer func() { os.Stderr = oldStderr }()
+
+	mockable.EnableMock()
+	defer mockable.DisableMock()
+	exited := false
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				if recovered == "exit" {
+					exited = true
+					return
+				}
+				panic(recovered)
+			}
+		}()
+		runCmd(Cmd, []string{"-gcflags=all=-N", filepath.Join(t.TempDir(), "missing")})
+	}()
+	if !exited || mockable.ExitCode() != 1 {
+		t.Fatalf("runCmd exit = (%v, %d), want (true, 1)", exited, mockable.ExitCode())
+	}
+	if !reflect.DeepEqual(goBuildFlags.Args, []string{"-gcflags=all=-N"}) {
+		t.Fatalf("go build flags = %v", goBuildFlags.Args)
+	}
+	if err := stderrFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(stderrFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "missing") {
+		t.Fatalf("stderr = %q, want missing-package diagnostic", data)
+	}
+}

--- a/cmd/internal/compile/compile.go
+++ b/cmd/internal/compile/compile.go
@@ -1,0 +1,216 @@
+//go:build !llgo
+
+package compile
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/goplus/llgo/cmd/internal/base"
+	"github.com/goplus/llgo/internal/build"
+	"github.com/goplus/llgo/internal/env"
+	"github.com/goplus/llgo/internal/mockable"
+	"github.com/goplus/llgo/internal/optlevel"
+)
+
+// Cmd implements the compiler action used by GOROOT/test. Its option names
+// intentionally follow "go tool compile" rather than the llgo build command.
+var Cmd = &base.Command{
+	UsageLine: "llgo tool compile [options] file.go...",
+	Short:     "Compile Go source files without linking",
+}
+
+type countFlag struct {
+	value int
+	set   bool
+}
+
+func (f *countFlag) String() string { return strconv.Itoa(f.value) }
+
+func (f *countFlag) Set(value string) error {
+	f.set = true
+	if value == "true" {
+		f.value++
+		return nil
+	}
+	if value == "false" {
+		f.value = 0
+		return nil
+	}
+	n, err := strconv.Atoi(value)
+	if err != nil {
+		return err
+	}
+	f.value = n
+	return nil
+}
+
+func (*countFlag) IsBoolFlag() bool { return true }
+
+type stringListFlag []string
+
+func (f *stringListFlag) String() string { return strings.Join(*f, ",") }
+
+func (f *stringListFlag) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+
+type options struct {
+	concurrency int
+	debug       stringListFlag
+	lang        string
+	output      string
+	pkgPath     string
+	importCfg   string
+	localImport string
+	includes    stringListFlag
+
+	noBounds  countFlag
+	noColumns countFlag
+	noOpt     countFlag
+	noInline  countFlag
+	allErrors countFlag
+	showOpt   countFlag
+	writeBar  countFlag
+
+	complete    bool
+	dynlink     bool
+	live        bool
+	race        bool
+	smallFrames bool
+	standard    bool
+	runtimePkg  bool
+	version     bool
+}
+
+func newFlagSet(opts *options) *flag.FlagSet {
+	fs := flag.NewFlagSet("compile", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	fs.Var(&opts.noBounds, "B", "disable bounds checking")
+	fs.Var(&opts.noColumns, "C", "disable printing of columns in error messages")
+	fs.StringVar(&opts.localImport, "D", "", "set relative path for local imports")
+	fs.Var(&opts.includes, "I", "add directory to import search path")
+	fs.Var(&opts.noOpt, "N", "disable optimizations")
+	fs.BoolVar(&opts.runtimePkg, "+", false, "compiling runtime")
+	fs.BoolVar(&opts.version, "V", false, "print version and exit")
+	fs.IntVar(&opts.concurrency, "c", 0, "concurrency during compilation (1 means no concurrency)")
+	fs.BoolVar(&opts.complete, "complete", false, "compiling complete package (no C or assembly)")
+	fs.Var(&opts.debug, "d", "enable debugging settings")
+	fs.BoolVar(&opts.dynlink, "dynlink", false, "support references to Go symbols defined in shared libraries")
+	fs.Var(&opts.allErrors, "e", "no limit on number of errors reported")
+	fs.StringVar(&opts.importCfg, "importcfg", "", "read import configuration from file")
+	fs.StringVar(&opts.lang, "lang", "", "Go language version source code expects")
+	fs.Var(&opts.noInline, "l", "disable inlining")
+	fs.Var(&opts.showOpt, "m", "print optimization decisions")
+	fs.BoolVar(&opts.live, "live", false, "debug liveness analysis")
+	fs.StringVar(&opts.output, "o", "", "write output to file")
+	fs.StringVar(&opts.pkgPath, "p", "", "set expected package import path")
+	fs.BoolVar(&opts.race, "race", false, "enable race detector")
+	fs.BoolVar(&opts.smallFrames, "smallframes", false, "reduce the size limit for stack allocated objects")
+	fs.BoolVar(&opts.standard, "std", false, "compiling standard library")
+	fs.Var(&opts.writeBar, "wb", "enable write barrier")
+	return fs
+}
+
+func init() {
+	Cmd.Run = runCmd
+}
+
+func runCmd(_ *base.Command, args []string) {
+	opts := new(options)
+	fs := newFlagSet(opts)
+	if err := fs.Parse(args); err != nil {
+		mockable.Exit(2)
+		return
+	}
+	if opts.version {
+		fmt.Printf("compile version llgo %s\n", env.Version())
+		return
+	}
+	files := fs.Args()
+	if len(files) == 0 {
+		fmt.Fprintln(os.Stderr, "compile: no Go source files")
+		mockable.Exit(2)
+		return
+	}
+	if unsupported := opts.unsupported(); len(unsupported) != 0 {
+		fmt.Fprintf(os.Stderr, "compile: unsupported llgo compiler option(s): %s\n", strings.Join(unsupported, ", "))
+		mockable.Exit(2)
+		return
+	}
+	if opts.concurrency < 0 {
+		fmt.Fprintln(os.Stderr, "compile: -c must be non-negative")
+		mockable.Exit(2)
+		return
+	}
+	if opts.lang != "" && !strings.HasPrefix(opts.lang, "go1.") {
+		fmt.Fprintf(os.Stderr, "compile: invalid value %q for -lang\n", opts.lang)
+		mockable.Exit(2)
+		return
+	}
+
+	if opts.concurrency > 0 {
+		previous := runtime.GOMAXPROCS(opts.concurrency)
+		defer runtime.GOMAXPROCS(previous)
+	}
+	conf := build.NewDefaultConf(build.ModeGen)
+	conf.GoVersion = opts.lang
+	conf.NoErrorColumn = opts.noColumns.value != 0
+	conf.AllowNoBody = !opts.complete
+	var loaderCompilerFlags []string
+	if opts.allErrors.value != 0 {
+		loaderCompilerFlags = append(loaderCompilerFlags, "-e")
+	}
+	if opts.lang != "" {
+		loaderCompilerFlags = append(loaderCompilerFlags, "-lang="+opts.lang)
+	}
+	if opts.complete {
+		loaderCompilerFlags = append(loaderCompilerFlags, "-complete")
+	}
+	if len(loaderCompilerFlags) != 0 {
+		conf.GoBuildFlags = append(conf.GoBuildFlags, "-gcflags=command-line-arguments="+strings.Join(loaderCompilerFlags, " "))
+	}
+	if opts.noOpt.value != 0 || opts.noInline.value != 0 {
+		conf.OptLevel = optlevel.O0
+	}
+	pkgs, err := build.Do(files, conf)
+	if len(pkgs) != 0 && pkgs[0].LPkg != nil {
+		pkgs[0].LPkg.Prog.Dispose()
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		mockable.Exit(1)
+	}
+}
+
+func (opts *options) unsupported() []string {
+	var out []string
+	appendFlag := func(condition bool, name string) {
+		if condition {
+			out = append(out, name)
+		}
+	}
+	appendFlag(opts.noBounds.value != 0, "-B")
+	appendFlag(opts.dynlink, "-dynlink")
+	appendFlag(opts.showOpt.value != 0, "-m")
+	appendFlag(opts.live, "-live")
+	appendFlag(opts.race, "-race")
+	appendFlag(opts.smallFrames, "-smallframes")
+	appendFlag(opts.standard, "-std")
+	appendFlag(opts.runtimePkg, "-+")
+	appendFlag(opts.writeBar.set, "-wb")
+	for _, setting := range opts.debug {
+		for _, item := range strings.Split(setting, ",") {
+			if item == "panic" || item == "ssa/check/on" {
+				continue
+			}
+			out = append(out, "-d="+item)
+		}
+	}
+	return out
+}

--- a/cmd/internal/compile/compile_test.go
+++ b/cmd/internal/compile/compile_test.go
@@ -1,0 +1,203 @@
+package compile
+
+import (
+	"os"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/goplus/llgo/internal/mockable"
+)
+
+func TestGoCompilerFlagNamesAndTypes(t *testing.T) {
+	opts := new(options)
+	fs := newFlagSet(opts)
+	err := fs.Parse([]string{
+		"-c=2",
+		"-C",
+		"-e",
+		"-l=4",
+		"-lang=go1.17",
+		"-d=panic,ssa/check/on",
+		"-p=p",
+		"-importcfg=importcfg",
+		"case.go",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.concurrency != 2 || opts.noColumns.value != 1 || opts.allErrors.value != 1 || opts.noInline.value != 4 {
+		t.Fatalf("parsed flags: %+v", opts)
+	}
+	if opts.lang != "go1.17" || opts.pkgPath != "p" || opts.importCfg != "importcfg" {
+		t.Fatalf("parsed flags: %+v", opts)
+	}
+	if !reflect.DeepEqual(fs.Args(), []string{"case.go"}) {
+		t.Fatalf("files=%v", fs.Args())
+	}
+	if unsupported := opts.unsupported(); len(unsupported) != 0 {
+		t.Fatalf("unsupported=%v, want none", unsupported)
+	}
+}
+
+func TestGoCompilerSpecificFlagIsExplicitlyUnsupported(t *testing.T) {
+	opts := new(options)
+	fs := newFlagSet(opts)
+	if err := fs.Parse([]string{"-d=libfuzzer", "case.go"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := opts.unsupported(); !reflect.DeepEqual(got, []string{"-d=libfuzzer"}) {
+		t.Fatalf("unsupported=%v", got)
+	}
+}
+
+func TestCountAndListFlags(t *testing.T) {
+	var count countFlag
+	if !count.IsBoolFlag() {
+		t.Fatal("countFlag should accept the bool flag form")
+	}
+	for _, value := range []string{"true", "true", "false", "4"} {
+		if err := count.Set(value); err != nil {
+			t.Fatalf("Set(%q): %v", value, err)
+		}
+	}
+	if got := count.String(); got != "4" || !count.set {
+		t.Fatalf("count flag = %q, set=%v; want 4, true", got, count.set)
+	}
+	if err := count.Set("invalid"); err == nil {
+		t.Fatal("invalid count value was accepted")
+	}
+
+	var list stringListFlag
+	if err := list.Set("one"); err != nil {
+		t.Fatal(err)
+	}
+	if err := list.Set("two"); err != nil {
+		t.Fatal(err)
+	}
+	if got := list.String(); got != "one,two" {
+		t.Fatalf("list flag = %q, want one,two", got)
+	}
+}
+
+func TestUnsupportedCompilerFlags(t *testing.T) {
+	opts := &options{
+		noBounds:    countFlag{value: 1},
+		dynlink:     true,
+		showOpt:     countFlag{value: 1},
+		live:        true,
+		race:        true,
+		smallFrames: true,
+		standard:    true,
+		runtimePkg:  true,
+		writeBar:    countFlag{set: true},
+		debug:       stringListFlag{"panic,libfuzzer", "ssa/check/on,wb"},
+	}
+	want := []string{"-B", "-dynlink", "-m", "-live", "-race", "-smallframes", "-std", "-+", "-wb", "-d=libfuzzer", "-d=wb"}
+	if got := opts.unsupported(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("unsupported=%v, want %v", got, want)
+	}
+}
+
+func TestRunCmdValidationAndVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantCode   int
+		wantOutput string
+	}{
+		{name: "bad flag", args: []string{"-unknown"}, wantCode: 2, wantOutput: "flag provided but not defined"},
+		{name: "no files", wantCode: 2, wantOutput: "no Go source files"},
+		{name: "unsupported", args: []string{"-B", "case.go"}, wantCode: 2, wantOutput: "unsupported llgo compiler option(s): -B"},
+		{name: "negative concurrency", args: []string{"-c=-1", "case.go"}, wantCode: 2, wantOutput: "-c must be non-negative"},
+		{name: "invalid language", args: []string{"-lang=1.22", "case.go"}, wantCode: 2, wantOutput: "invalid value"},
+		{name: "version", args: []string{"-V"}, wantOutput: "compile version llgo"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout, stderr, code := runCompileCommand(t, tt.args)
+			if code != tt.wantCode {
+				t.Fatalf("exit code = %d, want %d; stdout=%q stderr=%q", code, tt.wantCode, stdout, stderr)
+			}
+			if output := stdout + stderr; !strings.Contains(output, tt.wantOutput) {
+				t.Fatalf("output %q does not contain %q", output, tt.wantOutput)
+			}
+		})
+	}
+}
+
+func TestRunCmdBuildsAndReportsErrors(t *testing.T) {
+	dir := t.TempDir()
+	valid := dir + "/valid.go"
+	if err := os.WriteFile(valid, []byte("package compilecase\nfunc F() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	previousProcs := runtime.GOMAXPROCS(0)
+	stdout, stderr, code := runCompileCommand(t, []string{
+		"-c=1", "-C", "-e", "-lang=go1.22", "-N", "-l", "-complete", valid,
+	})
+	if code != 0 {
+		t.Fatalf("valid compile exit code = %d; stdout=%q stderr=%q", code, stdout, stderr)
+	}
+	if got := runtime.GOMAXPROCS(0); got != previousProcs {
+		t.Fatalf("GOMAXPROCS = %d after compile, want restored value %d", got, previousProcs)
+	}
+
+	invalid := dir + "/invalid.go"
+	if err := os.WriteFile(invalid, []byte("package compilecase\nvar _ = missing\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, stderr, code = runCompileCommand(t, []string{invalid})
+	if code != 1 || !strings.Contains(stderr, "missing") {
+		t.Fatalf("invalid compile exit code = %d, stderr=%q; want code 1 and diagnostic", code, stderr)
+	}
+}
+
+func runCompileCommand(t *testing.T, args []string) (stdout, stderr string, exitCode int) {
+	t.Helper()
+	outFile, err := os.CreateTemp(t.TempDir(), "stdout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	errFile, err := os.CreateTemp(t.TempDir(), "stderr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldStdout, oldStderr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = outFile, errFile
+	mockable.EnableMock()
+	exited := false
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				if recovered == "exit" {
+					exited = true
+					return
+				}
+				panic(recovered)
+			}
+		}()
+		runCmd(Cmd, args)
+	}()
+	mockable.DisableMock()
+	os.Stdout, os.Stderr = oldStdout, oldStderr
+	if exited {
+		exitCode = mockable.ExitCode()
+	}
+	if err := outFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := errFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+	outData, err := os.ReadFile(outFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	errData, err := os.ReadFile(errFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(outData), string(errData), exitCode
+}

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -31,6 +31,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -156,6 +157,10 @@ type Config struct {
 	SizeFormat    string // size report format: text,json (default text)
 	SizeLevel     string // size aggregation level: full,module,package (default module)
 	CompilerHash  string // metadata hash for the running compiler (development builds only)
+	GoVersion     string // Go language version accepted by the frontend (for example, "go1.22")
+	NoErrorColumn bool   // omit source columns from frontend diagnostics
+	GoBuildFlags  []string
+	AllowNoBody   bool // allow declarations without bodies, as go tool compile does
 
 	// PthreadStackSize sets a custom stack size, in bytes, for pthread-backed
 	// goroutines. A zero value keeps the platform pthread default.
@@ -266,6 +271,7 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	if err := ensureSizeReporting(conf); err != nil {
 		return nil, err
 	}
+	applyFrontendGCFlags(conf)
 	conf.OptLevel = effectiveOptLevel(conf)
 	// Handle crosscompile configuration first to set correct GOOS/GOARCH
 	forceEspClang := conf.ForceEspClang || conf.Target != ""
@@ -298,9 +304,11 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	if len(export.BuildTags) > 0 {
 		tags += "," + strings.Join(export.BuildTags, ",")
 	}
+	goBuildFlags := []string{"-tags=" + tags}
+	goBuildFlags = append(goBuildFlags, conf.GoBuildFlags...)
 	cfg := &packages.Config{
 		Mode:       loadSyntax | packages.NeedDeps | packages.NeedModule | packages.NeedExportFile,
-		BuildFlags: []string{"-tags=" + tags},
+		BuildFlags: goBuildFlags,
 		Fset:       token.NewFileSet(),
 		Tests:      conf.Mode == ModeTest,
 		Env:        append(slices.Clone(os.Environ()), "GOOS="+conf.Goos, "GOARCH="+conf.Goarch),
@@ -376,9 +384,12 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	if err != nil {
 		return nil, err
 	}
-	initial, err := packages.LoadEx(dedup, sizes, cfg, patterns...)
+	initial, err := packages.LoadExWithGoVersion(dedup, sizes, cfg, conf.GoVersion, patterns...)
 	if err != nil {
 		return nil, err
+	}
+	if conf.AllowNoBody {
+		allowMissingFunctionBodies(initial)
 	}
 	mode := conf.Mode
 	if mode == ModeTest {
@@ -575,6 +586,51 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	}
 
 	return allPkgs, nil
+}
+
+func applyFrontendGCFlags(conf *Config) {
+	for _, buildFlag := range conf.GoBuildFlags {
+		value, ok := strings.CutPrefix(buildFlag, "-gcflags=")
+		if !ok {
+			continue
+		}
+		fields := strings.Fields(value)
+		if len(fields) != 0 {
+			if _, compilerFlags, hasPattern := strings.Cut(fields[0], "="); hasPattern {
+				fields[0] = compilerFlags
+			}
+		}
+		for _, compilerFlag := range fields {
+			switch {
+			case strings.HasPrefix(compilerFlag, "-lang="):
+				conf.GoVersion = strings.TrimPrefix(compilerFlag, "-lang=")
+			case compilerFlag == "-N", compilerFlag == "-l", strings.HasPrefix(compilerFlag, "-l="):
+				conf.OptLevel = optlevel.O0
+			}
+		}
+	}
+}
+
+func allowMissingFunctionBodies(initial []*packages.Package) {
+	for _, pkg := range initial {
+		hasMissingBody := false
+		hasOtherError := false
+		for _, pkgErr := range pkg.Errors {
+			switch {
+			case strings.Contains(pkgErr.Msg, "missing function body"):
+				hasMissingBody = true
+			case strings.HasPrefix(pkgErr.Msg, "# "):
+				// go list prefixes compiler diagnostics with the package name.
+			default:
+				hasOtherError = true
+			}
+		}
+		if hasMissingBody && !hasOtherError {
+			pkg.Errors = nil
+			pkg.TypeErrors = nil
+			pkg.IllTyped = false
+		}
+	}
 }
 
 func needLink(pkg *packages.Package, mode Mode) bool {
@@ -1742,13 +1798,36 @@ func buildSSAPkgs(ctx *context, initial []*packages.Package, verbose bool) ([]*a
 	if len(errs) > 0 {
 		for _, errPkg := range errs {
 			for _, err := range errPkg.Errors {
-				fmt.Fprintln(os.Stderr, err)
+				fmt.Fprintln(os.Stderr, formatPackageError(err, ctx.buildConf.NoErrorColumn))
 			}
 			fmt.Fprintln(os.Stderr, "cannot build SSA for package", errPkg)
 		}
 		return nil, fmt.Errorf("cannot build SSA for packages")
 	}
 	return all, nil
+}
+
+func formatPackageError(err packages.Error, noColumn bool) string {
+	if !noColumn || err.Pos == "" || err.Pos == "-" {
+		return err.Error()
+	}
+	pos := err.Pos
+	lastColon := strings.LastIndexByte(pos, ':')
+	if lastColon < 0 {
+		return err.Error()
+	}
+	if _, parseErr := strconv.Atoi(pos[lastColon+1:]); parseErr != nil {
+		return err.Error()
+	}
+	linePos := pos[:lastColon]
+	lineColon := strings.LastIndexByte(linePos, ':')
+	if lineColon < 0 {
+		return err.Error()
+	}
+	if _, parseErr := strconv.Atoi(linePos[lineColon+1:]); parseErr != nil {
+		return err.Error()
+	}
+	return linePos + ": " + err.Msg
 }
 
 func collectRewriteVars(ctx *context, pkgPath string) map[string]string {

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/goplus/llgo/internal/buildenv"
 	"github.com/goplus/llgo/internal/lto"
 	"github.com/goplus/llgo/internal/mockable"
+	"github.com/goplus/llgo/internal/optlevel"
 	"github.com/goplus/llgo/internal/packages"
 	llssa "github.com/goplus/llgo/ssa"
 	"github.com/xgo-dev/llvm"
@@ -500,6 +501,101 @@ func TestDevLTOGlobalDCEDefaultsToFullLTO(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.conf.goGlobalDCEEnabled(); got != tt.want {
 				t.Fatalf("goGlobalDCEEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyFrontendGCFlags(t *testing.T) {
+	conf := &Config{GoBuildFlags: []string{
+		"-tags=integration",
+		"-gcflags=",
+		"-gcflags=-l",
+		"-gcflags=all=-lang=go1.17 -N -l=4",
+	}}
+	applyFrontendGCFlags(conf)
+	if conf.GoVersion != "go1.17" {
+		t.Fatalf("GoVersion=%q, want go1.17", conf.GoVersion)
+	}
+	if conf.OptLevel != optlevel.O0 {
+		t.Fatalf("OptLevel=%v, want O0", conf.OptLevel)
+	}
+}
+
+func TestAllowMissingFunctionBodies(t *testing.T) {
+	pkg := &packages.Package{
+		Errors: []packages.Error{
+			{Msg: "# command-line-arguments"},
+			{Msg: "missing function body"},
+		},
+		IllTyped: true,
+	}
+	allowMissingFunctionBodies([]*packages.Package{pkg})
+	if pkg.IllTyped || len(pkg.Errors) != 0 || len(pkg.TypeErrors) != 0 {
+		t.Fatalf("package remains ill-typed: %+v", pkg.Errors)
+	}
+
+	pkg = &packages.Package{
+		Errors: []packages.Error{
+			{Msg: "missing function body"},
+			{Msg: "undefined: missing"},
+		},
+		IllTyped: true,
+	}
+	allowMissingFunctionBodies([]*packages.Package{pkg})
+	if !pkg.IllTyped || len(pkg.Errors) != 2 {
+		t.Fatalf("mixed errors were incorrectly suppressed: %+v", pkg.Errors)
+	}
+
+	unchanged := &packages.Package{Errors: []packages.Error{{Msg: "# command-line-arguments"}}, IllTyped: true}
+	allowMissingFunctionBodies([]*packages.Package{unchanged})
+	if !unchanged.IllTyped || len(unchanged.Errors) != 1 {
+		t.Fatalf("package without a missing-body diagnostic was changed: %+v", unchanged)
+	}
+}
+
+func TestDoAllowsMissingFunctionBodies(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "nobody.go")
+	if err := os.WriteFile(file, []byte(`package nobody
+
+func External()
+
+func F() {}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	conf := NewDefaultConf(ModeGen)
+	conf.AllowNoBody = true
+	pkgs, err := Do([]string{file}, conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pkgs) != 1 || pkgs[0].LPkg == nil {
+		t.Fatalf("Do returned packages = %+v, want one compiled package", pkgs)
+	}
+	pkgs[0].LPkg.Prog.Dispose()
+}
+
+func TestFormatPackageError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      packages.Error
+		noColumn bool
+		want     string
+	}{
+		{name: "keep columns", err: packages.Error{Pos: "case.go:2:3", Msg: "bad"}, want: "case.go:2:3: bad"},
+		{name: "remove column", err: packages.Error{Pos: "case.go:2:3", Msg: "bad"}, noColumn: true, want: "case.go:2: bad"},
+		{name: "empty position", err: packages.Error{Msg: "bad"}, noColumn: true, want: "-: bad"},
+		{name: "dash position", err: packages.Error{Pos: "-", Msg: "bad"}, noColumn: true, want: "-: bad"},
+		{name: "missing separators", err: packages.Error{Pos: "case.go", Msg: "bad"}, noColumn: true, want: "case.go: bad"},
+		{name: "invalid column", err: packages.Error{Pos: "case.go:2:x", Msg: "bad"}, noColumn: true, want: "case.go:2:x: bad"},
+		{name: "missing line separator", err: packages.Error{Pos: "2:3", Msg: "bad"}, noColumn: true, want: "2:3: bad"},
+		{name: "invalid line", err: packages.Error{Pos: "case.go:x:3", Msg: "bad"}, noColumn: true, want: "case.go:x:3: bad"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatPackageError(tt.err, tt.noColumn); got != tt.want {
+				t.Fatalf("formatPackageError() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/internal/packages/load.go
+++ b/internal/packages/load.go
@@ -71,6 +71,7 @@ const (
 // The zero value is a valid configuration.
 // Calls to Load do not modify this struct.
 type Config = packages.Config
+type Error = packages.Error
 
 // A Package describes a loaded Go package.
 type Package = packages.Package
@@ -104,6 +105,8 @@ type loader struct {
 	// we need certain modes right.
 	requestedMode LoadMode
 }
+
+var loadGoVersions sync.Map // map[*loader]string
 
 type Cached struct {
 	*packages.Package
@@ -347,13 +350,14 @@ func loadPackageEx(dedup Deduper, ld *loader, lpkg *loaderPackage) {
 	}
 
 	lpkg.TypesInfo = &types.Info{
-		Types:      make(map[ast.Expr]types.TypeAndValue),
-		Defs:       make(map[*ast.Ident]types.Object),
-		Uses:       make(map[*ast.Ident]types.Object),
-		Implicits:  make(map[ast.Node]types.Object),
-		Instances:  make(map[*ast.Ident]types.Instance),
-		Scopes:     make(map[ast.Node]*types.Scope),
-		Selections: make(map[*ast.SelectorExpr]*types.Selection),
+		Types:        make(map[ast.Expr]types.TypeAndValue),
+		Defs:         make(map[*ast.Ident]types.Object),
+		Uses:         make(map[*ast.Ident]types.Object),
+		Implicits:    make(map[ast.Node]types.Object),
+		Instances:    make(map[*ast.Ident]types.Instance),
+		Scopes:       make(map[ast.Node]*types.Scope),
+		Selections:   make(map[*ast.SelectorExpr]*types.Selection),
+		FileVersions: make(map[*ast.File]string),
 	}
 	lpkg.TypesSizes = ld.sizes
 
@@ -398,7 +402,9 @@ func loadPackageEx(dedup Deduper, ld *loader, lpkg *loaderPackage) {
 		Error: appendError,
 		Sizes: ld.sizes, // may be nil
 	}
-	if lpkg.Module != nil && lpkg.Module.GoVersion != "" {
+	if goVersion, ok := loadGoVersions.Load(ld); ok && lpkg.initial {
+		tc.GoVersion = goVersion.(string)
+	} else if lpkg.Module != nil && lpkg.Module.GoVersion != "" {
 		tc.GoVersion = "go" + lpkg.Module.GoVersion
 	}
 	if (ld.Mode & typecheckCgo) != 0 {
@@ -706,7 +712,17 @@ func refineEx(dedup Deduper, ld *loader, response *packages.DriverResponse) ([]*
 // proceeding with further analysis. The PrintErrors function is
 // provided for convenient display of all errors.
 func LoadEx(dedup Deduper, sizes func(sizes types.Sizes, compiler, arch string) types.Sizes, cfg *Config, patterns ...string) ([]*Package, error) {
+	return LoadExWithGoVersion(dedup, sizes, cfg, "", patterns...)
+}
+
+// LoadExWithGoVersion is LoadEx with an optional go/types language version
+// override. The version uses go/types syntax, such as "go1.22".
+func LoadExWithGoVersion(dedup Deduper, sizes func(sizes types.Sizes, compiler, arch string) types.Sizes, cfg *Config, goVersion string, patterns ...string) ([]*Package, error) {
 	ld := newLoader(cfg)
+	if goVersion != "" {
+		loadGoVersions.Store(ld, goVersion)
+		defer loadGoVersions.Delete(ld)
+	}
 	response, external, err := defaultDriver(&ld.Config, patterns...)
 	if err != nil {
 		return nil, err

--- a/internal/packages/load_test.go
+++ b/internal/packages/load_test.go
@@ -1,0 +1,72 @@
+//go:build !llgo
+
+package packages
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadExWithGoVersion(t *testing.T) {
+	dir := t.TempDir()
+	writeLoadTestFile(t, filepath.Join(dir, "go.mod"), "module example.com/loadversion\ngo 1.24\n")
+	writeLoadTestFile(t, filepath.Join(dir, "load.go"), `package loadversion
+
+func identity[T any](value T) T { return value }
+`)
+
+	oldVersion, err := LoadExWithGoVersion(nil, nil, loadTestConfig(dir), "go1.17", ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(oldVersion) != 1 {
+		t.Fatalf("LoadExWithGoVersion returned %d packages, want 1", len(oldVersion))
+	}
+	if !oldVersion[0].IllTyped || !packageErrorsContain(oldVersion[0], "requires go1.18 or later") {
+		t.Fatalf("go1.17 load did not reject generics: %+v", oldVersion[0].Errors)
+	}
+
+	currentVersion, err := LoadEx(nil, nil, loadTestConfig(dir), ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(currentVersion) != 1 {
+		t.Fatalf("LoadEx returned %d packages, want 1", len(currentVersion))
+	}
+	pkg := currentVersion[0]
+	if pkg.IllTyped || len(pkg.Errors) != 0 {
+		t.Fatalf("module-version load failed: %+v", pkg.Errors)
+	}
+	if len(pkg.Syntax) != 1 || pkg.TypesInfo == nil {
+		t.Fatalf("load did not return syntax and type information: %+v", pkg)
+	}
+	if got := pkg.TypesInfo.FileVersions[pkg.Syntax[0]]; got != "go1.24" {
+		t.Fatalf("file language version = %q, want go1.24", got)
+	}
+}
+
+func loadTestConfig(dir string) *Config {
+	return &Config{
+		Dir: dir,
+		Mode: NeedName | NeedFiles | NeedCompiledGoFiles | NeedSyntax |
+			NeedTypes | NeedTypesInfo | NeedTypesSizes | NeedModule,
+	}
+}
+
+func packageErrorsContain(pkg *Package, text string) bool {
+	for _, err := range pkg.Errors {
+		if strings.Contains(err.Msg, text) {
+			return true
+		}
+	}
+	return false
+}
+
+func writeLoadTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

- add a Go compiler-compatible compile action in `cmd/internal/compile`
- parse and validate the frontend flags used by `go tool compile`
- cover successful compilation, version/help output, invalid options, and unsupported flags

## Dependency

This PR is stacked on #2070, which provides the build-layer frontend compiler options. Once #2070 merges, this PR will shrink automatically to its own two-file layer.

Merge order: #2069 -> #2070 -> this PR -> #2066. #2068 is independent.

## Layer size

Compared with #2070: 2 files, 419 additions, 0 deletions.

## Verification

Go 1.24.11 and Go 1.26.5 both pass:

`GOMAXPROCS=2 GOMEMLIMIT=2GiB go test -p=1 ./cmd/internal/compile -count=1`