### PR TITLE
cl: accept select output without sender print

### DIFF
--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -325,18 +325,64 @@ func TestRunFromTestgoSelectAllowsKnownInterleavings(t *testing.T) {
 		t.Fatalf("run failed: %v\noutput: %s", err, string(output))
 	}
 	lines := selectOutputLines(string(output))
-	if len(lines) != 3 {
+	if !validSelectOutputLines(lines) {
 		t.Fatalf("unexpected select output lines %q from:\n%s", lines, output)
 	}
-	if lines[0] != "100" && lines[0] != "200" {
-		t.Fatalf("unexpected select send output %q from:\n%s", lines[0], output)
-	}
-	for _, line := range lines[1:] {
+}
+
+func validSelectOutputLines(lines []string) bool {
+	sendCount, recvCount := 0, 0
+	seenCh1, seenCh2 := false, false
+	for _, line := range lines {
 		switch line {
-		case "ch1", "ch2", "exit":
+		case "100", "200":
+			sendCount++
+			if sendCount > 1 {
+				return false
+			}
+		case "ch1":
+			if seenCh1 {
+				return false
+			}
+			seenCh1 = true
+			recvCount++
+		case "ch2":
+			if seenCh2 {
+				return false
+			}
+			seenCh2 = true
+			recvCount++
+		case "exit":
+			recvCount++
 		default:
-			t.Fatalf("unexpected select recv output %q from:\n%s", line, output)
+			return false
 		}
+	}
+	return recvCount == 2
+}
+
+func TestValidSelectOutputLines(t *testing.T) {
+	tests := []struct {
+		name  string
+		lines []string
+		valid bool
+	}{
+		{name: "sender exits before print", lines: []string{"ch1", "ch2"}, valid: true},
+		{name: "both receives default", lines: []string{"exit", "exit"}, valid: true},
+		{name: "send prints first", lines: []string{"100", "ch1", "ch2"}, valid: true},
+		{name: "send print is interleaved", lines: []string{"ch1", "200", "exit"}, valid: true},
+		{name: "duplicate receive", lines: []string{"ch1", "ch1"}},
+		{name: "missing receive", lines: []string{"100", "ch1"}},
+		{name: "extra receive", lines: []string{"ch1", "ch2", "exit"}},
+		{name: "multiple sends", lines: []string{"100", "200", "ch1", "ch2"}},
+		{name: "unknown output", lines: []string{"100", "ch1", "unknown"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validSelectOutputLines(tt.lines); got != tt.valid {
+				t.Fatalf("validSelectOutputLines(%q) = %v, want %v", tt.lines, got, tt.valid)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- accept the legal select fixture outcome where the sender-side goroutine does not print before process exit
- validate the fixture semantically instead of requiring one fixed output length/order
- reject impossible duplicate receives, missing/extra receive outcomes, unknown lines, and multiple sender values

## Root cause

The fixture performs an unbuffered send to a goroutine that prints the received value. The send guarantees that the value was received, but it does not guarantee that the receiver goroutine completes `println` before `main` exits. Therefore this observed output is legal:

```text
ch1
ch2
```

The validator now requires exactly two receive outcomes. `ch1` and `ch2` may each occur at most once, `exit` may occur twice, and the sender value (`100` or `200`) may appear zero or one time in any position.

## Impact without this PR

- `TestRunFromTestgoSelectAllowsKnownInterleavings` can fail nondeterministically on the legal `ch1\nch2\n` outcome
- unrelated pull requests can receive a false-red `go test ./...` result and require a rerun
- if the package failure aborts a Go coverage job before its normal upload, Codecov may calculate patch coverage from incomplete reports; this was observed as 11.11% on the former #2071 run
- the failure is a test-harness false negative, not an LLGo compiler/runtime correctness regression, and it does not change generated programs

## Relationship

This is an independent, test-only CI stability fix. The flake was discovered while monitoring the Ubuntu Go coverage job for the former split PR #2071. That PR has since been closed and consolidated into #2066; this PR does not depend on either PR.

## Verification

Resource-bounded local stress:

- Go 1.24.11: focused tests passed 50 consecutive runs with `GOMAXPROCS=2 GOMEMLIMIT=2GiB go test -p=1`
- Go 1.26.5: focused tests passed 10 consecutive runs with `GOMAXPROCS=2 GOMEMLIMIT=2GiB go test -p=1`
- Go 1.26.5: focused tests passed 100 consecutive runs in 443.596s with `GOMAXPROCS=8 GOMEMLIMIT=2GiB go test ./cl ... -count=100`, without `-p=1`

The `-p` option controls package build/test parallelism; it does not serialize the goroutines inside this fixture. The final stress run raises scheduler parallelism and removes the package-level `-p=1` constraint.

- GitHub Actions: 47 passing checks and 1 expected release skip
- Codecov: `Coverage not affected`, as only test code changes

Scope: 1 file, 53 additions, 7 deletions.