### PR TITLE
ltoplugin: analyze MethodByName names from string slices

### DIFF
--- a/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_param/in.go
+++ b/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_param/in.go
@@ -64,8 +64,8 @@ func forwardTypeName(name string) string {
 }
 
 func main() {
-	println(forwardValueSuffix("ParamValueA"))
-	println(forwardValueSuffix("ParamValueB"))
+	println(forwardValueSuffix("__ParamValueA__"[2:13]))
+	println(forwardValueSuffix("__ParamValueB__"[2:13]))
 	println(forwardTypeName("KeepParamTypeA"))
 	println(forwardTypeName("KeepParamTypeB"))
 }

--- a/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_slice/expect.txt
+++ b/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_slice/expect.txt
@@ -1,0 +1,2 @@
+slice-value
+slice-type

--- a/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_slice/in.go
+++ b/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_slice/in.go
@@ -1,0 +1,47 @@
+// LITTEST
+package main
+
+import "reflect"
+
+// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_slice{{.*}}S{{.*}}Drop
+// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_slice{{.*}}S{{.*}}KeepSliceValue
+// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_slice{{.*}}S{{.*}}KeepSliceType
+// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_slice{{.*}}S{{.*}}Drop
+
+type S struct{}
+
+//go:noinline
+func (S) KeepSliceValue() string {
+	return "slice-value"
+}
+
+//go:noinline
+func (S) KeepSliceType() string {
+	return "slice-type"
+}
+
+//go:noinline
+func (S) Drop() string {
+	panic("Drop should be unreachable")
+}
+
+func valueName() string {
+	return "__KeepSliceValue__"[2:16]
+}
+
+func typeName() string {
+	return "__KeepSliceType__"[2:15]
+}
+
+func main() {
+	v := reflect.ValueOf(S{})
+	out := v.MethodByName(valueName()).Call(nil)
+	println(out[0].String())
+
+	m, ok := reflect.TypeOf(S{}).MethodByName(typeName())
+	if !ok {
+		panic("missing method")
+	}
+	out = m.Func.Call([]reflect.Value{v})
+	println(out[0].String())
+}

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -183,6 +183,7 @@ func TestRunAndTestFromTestlto(t *testing.T) {
 		"./_testlto/globaldce_reflect_method_by_name_ltoplugin_concat",
 		"./_testlto/globaldce_reflect_method_by_name_ltoplugin_global",
 		"./_testlto/globaldce_reflect_method_by_name_ltoplugin_param",
+		"./_testlto/globaldce_reflect_method_by_name_ltoplugin_slice",
 		"./_testlto/globaldce_reflect_method_by_name_ltoplugin_switch",
 	}
 	if !buildenv.Dev {
@@ -217,6 +218,7 @@ var testltoLTOPluginTests = []string{
 	"globaldce_reflect_method_by_name_ltoplugin_concat",
 	"globaldce_reflect_method_by_name_ltoplugin_global",
 	"globaldce_reflect_method_by_name_ltoplugin_param",
+	"globaldce_reflect_method_by_name_ltoplugin_slice",
 	"globaldce_reflect_method_by_name_ltoplugin_switch",
 }
 

--- a/ltoplugin/LLGOReflectMethodByNamePass.cpp
+++ b/ltoplugin/LLGOReflectMethodByNamePass.cpp
@@ -39,6 +39,8 @@ static constexpr char ReflectTypeMethodTypeIDPrefix[] =
     "go.method.type.reflect.";
 static constexpr char RuntimeStringCatSuffix[] =
     "runtime/internal/runtime.StringCat";
+static constexpr char RuntimeStringSlice2Suffix[] =
+    "runtime/internal/runtime.StringSlice2";
 static constexpr unsigned MaxReflectMethodNames = 32;
 static constexpr unsigned MaxStringAnalysisDepth = 12;
 static constexpr unsigned MaxConstantGEPChoices = 32;
@@ -97,6 +99,9 @@ bool collectStringSet(Value *Ptr, Value *Len, const DataLayout &DL,
 bool collectStringSetFromStringValue(Value *StringValue, const DataLayout &DL,
                                      SmallVectorImpl<std::string> &Names,
                                      unsigned Depth = 0);
+
+bool collectIntegerChoices(Value *V, SmallVectorImpl<uint64_t> &Choices,
+                           unsigned Depth = 0);
 
 bool collectStringSetFromFunctionStringArg(Value *Ptr, Value *Len,
                                            const DataLayout &DL,
@@ -159,6 +164,13 @@ bool isRuntimeStringCat(CallBase *CB) {
   return Callee && Callee->getName().ends_with(RuntimeStringCatSuffix);
 }
 
+bool isRuntimeStringSlice2(CallBase *CB) {
+  if (!CB)
+    return false;
+  Function *Callee = CB->getCalledFunction();
+  return Callee && Callee->getName().ends_with(RuntimeStringSlice2Suffix);
+}
+
 bool collectStringSetFromStringCat(CallBase *CB, const DataLayout &DL,
                                    SmallVectorImpl<std::string> &Names,
                                    unsigned Depth) {
@@ -175,6 +187,38 @@ bool collectStringSetFromStringCat(CallBase *CB, const DataLayout &DL,
                         Suffixes, Depth + 1))
     return false;
   return addConcatenatedNames(Names, Prefixes, Suffixes);
+}
+
+bool collectStringSetFromStringSlice2(CallBase *CB, const DataLayout &DL,
+                                      SmallVectorImpl<std::string> &Names,
+                                      unsigned Depth) {
+  if (!isRuntimeStringSlice2(CB))
+    return false;
+  if (CB->arg_size() != 6)
+    return false;
+
+  SmallVector<std::string, 4> Bases;
+  if (!collectStringSet(CB->getArgOperand(0), CB->getArgOperand(1), DL, Bases,
+                        Depth + 1))
+    return false;
+
+  SmallVector<uint64_t, 4> Lows;
+  SmallVector<uint64_t, 4> Highs;
+  if (!collectIntegerChoices(CB->getArgOperand(2), Lows, Depth + 1) ||
+      !collectIntegerChoices(CB->getArgOperand(3), Highs, Depth + 1))
+    return false;
+
+  for (const std::string &Base : Bases) {
+    for (uint64_t I : Lows) {
+      for (uint64_t J : Highs) {
+        if (I > J || J > Base.size())
+          return false;
+        if (!addName(Names, StringRef(Base).substr(I, J - I)))
+          return false;
+      }
+    }
+  }
+  return true;
 }
 
 bool hasOnlyReadUses(User *U, SmallPtrSetImpl<User *> &Seen) {
@@ -299,7 +343,7 @@ bool addIntegerChoice(SmallVectorImpl<uint64_t> &Choices, uint64_t Value) {
 }
 
 bool collectIntegerChoices(Value *V, SmallVectorImpl<uint64_t> &Choices,
-                           unsigned Depth = 0) {
+                           unsigned Depth) {
   if (Depth > MaxStringAnalysisDepth)
     return false;
 
@@ -489,6 +533,8 @@ bool collectStringSetFromStringValue(Value *StringValue, const DataLayout &DL,
     return collectStringSetFromStringConstant(C, DL, Names, Depth);
 
   if (auto *CB = dyn_cast<CallBase>(StringValue)) {
+    if (collectStringSetFromStringSlice2(CB, DL, Names, Depth))
+      return true;
     if (collectStringSetFromStringCat(CB, DL, Names, Depth))
       return true;
   }


### PR DESCRIPTION
## Summary

- Recognize ABI-lowered `runtime/internal/runtime.StringSlice2` calls while resolving `MethodByName` names.
- Collect finite candidates for the source string and slice bounds, validate each range, and feed the resulting substrings into the existing exact-name analysis.
- Add LTO GlobalDCE coverage for sliced names used by both `reflect.Value.MethodByName` and `reflect.Type.MethodByName`.
- Extend the forwarded-parameter test so the caller-provided method names originate from string slices.