### PR TITLE
cmd: make -v Go-compatible and add compiler verbosity flags

### DIFF
--- a/cmd/internal/build/build.go
+++ b/cmd/internal/build/build.go
@@ -40,6 +40,7 @@ func init() {
 	goBuildFlags = base.PassBuildFlags(Cmd)
 
 	flags.AddCommonFlags(&Cmd.Flag)
+	flags.AddCompilerVerboseFlag(&Cmd.Flag)
 	flags.AddBuildFlags(&Cmd.Flag)
 	flags.AddBuildModeFlags(&Cmd.Flag)
 	flags.AddEmulatorFlags(&Cmd.Flag)

--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -30,6 +30,7 @@ func AddOutputFlags(fs *flag.FlagSet) {
 }
 
 var Verbose bool
+var CompilerVerbose bool
 var BuildEnv string
 var BuildMode string
 var Tags string
@@ -167,6 +168,10 @@ const DefaultTestTimeout = "10m" // Matches Go's default test timeout
 
 func AddCommonFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&Verbose, "v", false, "Verbose output")
+}
+
+func AddCompilerVerboseFlag(fs *flag.FlagSet) {
+	fs.BoolVar(&CompilerVerbose, "verbose", false, "Print verbose compiler debug output")
 }
 
 func AddOptLevelFlags(fs *flag.FlagSet) {
@@ -333,6 +338,18 @@ func UpdateConfig(conf *build.Config) error {
 	conf.CompilerHash = compilerhash.Value()
 	conf.Tags = Tags
 	conf.Verbose = Verbose
+	conf.PrintPackages = false
+	switch conf.Mode {
+	case build.ModeBuild:
+		// Match go build -v: print package names as they are compiled. The
+		// legacy LLGo debug output is available separately through -verbose.
+		conf.Verbose = CompilerVerbose
+		conf.PrintPackages = Verbose
+	case build.ModeTest:
+		// For go test, -v controls the test binary only. buildTestArgs forwards
+		// it as -test.v.
+		conf.Verbose = CompilerVerbose
+	}
 	conf.PrintCommands = PrintCommands
 	conf.OptLevel = OptLevel
 	conf.Target = Target

--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -171,7 +171,8 @@ func AddCommonFlags(fs *flag.FlagSet) {
 }
 
 func AddCompilerVerboseFlag(fs *flag.FlagSet) {
-	fs.BoolVar(&CompilerVerbose, "verbose", false, "Print verbose compiler debug output")
+	fs.BoolVar(&CompilerVerbose, "compiler-verbose", false, "Print verbose compiler output")
+	fs.BoolVar(&CompilerVerbose, "cv", false, "Print verbose compiler output (shorthand for -compiler-verbose)")
 }
 
 func AddOptLevelFlags(fs *flag.FlagSet) {
@@ -342,7 +343,7 @@ func UpdateConfig(conf *build.Config) error {
 	switch conf.Mode {
 	case build.ModeBuild:
 		// Match go build -v: print package names as they are compiled. The
-		// legacy LLGo debug output is available separately through -verbose.
+		// legacy LLGo compiler output is available through -compiler-verbose.
 		conf.Verbose = CompilerVerbose
 		conf.PrintPackages = Verbose
 	case build.ModeTest:

--- a/cmd/internal/flags/flags_test.go
+++ b/cmd/internal/flags/flags_test.go
@@ -393,16 +393,20 @@ func TestUpdateConfigVerboseCompatibility(t *testing.T) {
 
 func TestCompilerVerboseFlag(t *testing.T) {
 	oldCompilerVerbose := CompilerVerbose
-	CompilerVerbose = false
 	t.Cleanup(func() { CompilerVerbose = oldCompilerVerbose })
 
-	fs := flag.NewFlagSet("compiler-verbose", flag.ContinueOnError)
-	fs.SetOutput(new(bytes.Buffer))
-	AddCompilerVerboseFlag(fs)
-	if err := fs.Parse([]string{"-verbose"}); err != nil {
-		t.Fatalf("Parse(-verbose) error = %v", err)
-	}
-	if !CompilerVerbose {
-		t.Fatal("-verbose did not enable compiler verbose output")
+	for _, arg := range []string{"-compiler-verbose", "-cv"} {
+		t.Run(arg, func(t *testing.T) {
+			CompilerVerbose = false
+			fs := flag.NewFlagSet("compiler-verbose", flag.ContinueOnError)
+			fs.SetOutput(new(bytes.Buffer))
+			AddCompilerVerboseFlag(fs)
+			if err := fs.Parse([]string{arg}); err != nil {
+				t.Fatalf("Parse(%s) error = %v", arg, err)
+			}
+			if !CompilerVerbose {
+				t.Fatalf("%s did not enable compiler verbose output", arg)
+			}
+		})
 	}
 }

--- a/cmd/internal/flags/flags_test.go
+++ b/cmd/internal/flags/flags_test.go
@@ -348,3 +348,61 @@ func TestUpdateConfigPreservesLTOWhenUnspecified(t *testing.T) {
 		t.Fatalf("conf.LTO = %v, want %v", conf.LTO, lto.Full)
 	}
 }
+
+func TestUpdateConfigVerboseCompatibility(t *testing.T) {
+	oldVerbose := Verbose
+	oldCompilerVerbose := CompilerVerbose
+	t.Cleanup(func() {
+		Verbose = oldVerbose
+		CompilerVerbose = oldCompilerVerbose
+	})
+
+	tests := []struct {
+		name              string
+		mode              build.Mode
+		verbose           bool
+		compilerVerbose   bool
+		wantVerbose       bool
+		wantPrintPackages bool
+	}{
+		{name: "build v prints packages", mode: build.ModeBuild, verbose: true, wantPrintPackages: true},
+		{name: "build verbose prints debug output", mode: build.ModeBuild, compilerVerbose: true, wantVerbose: true},
+		{name: "build flags can be combined", mode: build.ModeBuild, verbose: true, compilerVerbose: true, wantVerbose: true, wantPrintPackages: true},
+		{name: "test v is reserved for test binary", mode: build.ModeTest, verbose: true},
+		{name: "test verbose prints debug output", mode: build.ModeTest, compilerVerbose: true, wantVerbose: true},
+		{name: "other commands keep v behavior", mode: build.ModeRun, verbose: true, wantVerbose: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Verbose = tt.verbose
+			CompilerVerbose = tt.compilerVerbose
+			conf := &build.Config{Mode: tt.mode}
+			if err := UpdateConfig(conf); err != nil {
+				t.Fatalf("UpdateConfig() error = %v", err)
+			}
+			if conf.Verbose != tt.wantVerbose {
+				t.Errorf("Verbose = %v, want %v", conf.Verbose, tt.wantVerbose)
+			}
+			if conf.PrintPackages != tt.wantPrintPackages {
+				t.Errorf("PrintPackages = %v, want %v", conf.PrintPackages, tt.wantPrintPackages)
+			}
+		})
+	}
+}
+
+func TestCompilerVerboseFlag(t *testing.T) {
+	oldCompilerVerbose := CompilerVerbose
+	CompilerVerbose = false
+	t.Cleanup(func() { CompilerVerbose = oldCompilerVerbose })
+
+	fs := flag.NewFlagSet("compiler-verbose", flag.ContinueOnError)
+	fs.SetOutput(new(bytes.Buffer))
+	AddCompilerVerboseFlag(fs)
+	if err := fs.Parse([]string{"-verbose"}); err != nil {
+		t.Fatalf("Parse(-verbose) error = %v", err)
+	}
+	if !CompilerVerbose {
+		t.Fatal("-verbose did not enable compiler verbose output")
+	}
+}

--- a/cmd/internal/test/test.go
+++ b/cmd/internal/test/test.go
@@ -22,6 +22,7 @@ var Cmd = &base.Command{
 func init() {
 	Cmd.Run = runCmd
 	flags.AddCommonFlags(&Cmd.Flag)
+	flags.AddCompilerVerboseFlag(&Cmd.Flag)
 	flags.AddBuildFlags(&Cmd.Flag)
 	flags.AddTestFlags(&Cmd.Flag)
 	flags.AddTestBinaryFlags(&Cmd.Flag)

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -146,6 +146,7 @@ type Config struct {
 	AbiMode       AbiMode
 	GenExpect     bool // only valid for ModeCmpTest
 	Verbose       bool
+	PrintPackages bool // print package paths as they are compiled, like go build -v
 	PrintCommands bool
 	GenLL         bool // generate pkg .ll files
 	CheckLLFiles  bool // check .ll files valid
@@ -1413,6 +1414,8 @@ func buildPkg(ctx *context, aPkg *aPackage, verbose bool) error {
 	pkgPath := pkg.PkgPath
 	if debugBuild || verbose {
 		fmt.Fprintln(os.Stderr, pkgPath)
+	} else {
+		printCompiledPackage(ctx.buildConf, aPkg)
 	}
 	if llruntime.SkipToBuild(pkgPath) {
 		pkg.ExportFile = ""
@@ -1523,6 +1526,12 @@ func buildPkg(ctx *context, aPkg *aPackage, verbose bool) error {
 		}
 	}
 	return nil
+}
+
+func printCompiledPackage(conf *Config, pkg *aPackage) {
+	if conf.PrintPackages && !pkg.CacheHit {
+		fmt.Fprintln(os.Stderr, pkg.PkgPath)
+	}
 }
 
 func exportObject(ctx *context, pkgPath string, exportFile string, pkg llssa.Package) (string, error) {

--- a/internal/build/verbose_test.go
+++ b/internal/build/verbose_test.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package build
+
+import (
+	"os"
+	"testing"
+
+	"github.com/goplus/llgo/internal/packages"
+)
+
+func TestPrintCompiledPackage(t *testing.T) {
+	stderr, err := os.CreateTemp(t.TempDir(), "stderr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldStderr := os.Stderr
+	os.Stderr = stderr
+	t.Cleanup(func() { os.Stderr = oldStderr })
+
+	pkg := &aPackage{Package: &packages.Package{PkgPath: "example.com/rebuilt"}}
+	printCompiledPackage(&Config{PrintPackages: true}, pkg)
+	pkg.CacheHit = true
+	printCompiledPackage(&Config{PrintPackages: true}, pkg)
+	pkg.CacheHit = false
+	printCompiledPackage(&Config{}, pkg)
+
+	if err := stderr.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(stderr.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "example.com/rebuilt\n"; string(got) != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+}

--- a/test/buildcache/test.sh
+++ b/test/buildcache/test.sh
@@ -282,7 +282,7 @@ echo "Snapshots directory: $SNAPSHOTS_DIR"
 echo "Build temp directory: $BUILD_TEMP_DIR"
 
 # Run native tests
-run_test_suite "native" "llgo build -o $BUILD_TEMP_DIR/buildcache.out -v ." ""
+run_test_suite "native" "llgo build -o $BUILD_TEMP_DIR/buildcache.out -compiler-verbose ." ""
 
 # Run WASM tests - always use iwasm from llgo cache directory
 # Determine cache directory based on platform
@@ -311,7 +311,7 @@ if [ -n "$LLGO_IWASM" ] && [ -f "$LLGO_IWASM" ]; then
     echo ""
     echo -e "${BLUE}Using iwasm: $LLGO_IWASM${NC}"
     run_test_suite "wasm" \
-        "GOOS=wasip1 GOARCH=wasm llgo build -o $BUILD_TEMP_DIR/buildcache.wasm -tags=nogc -v ." \
+        "GOOS=wasip1 GOARCH=wasm llgo build -o $BUILD_TEMP_DIR/buildcache.wasm -tags=nogc -compiler-verbose ." \
         "$BUILD_TEMP_DIR/buildcache.wasm" \
         "$LLGO_IWASM --stack-size=819200000 --heap-size=800000000 $BUILD_TEMP_DIR/buildcache.wasm"
 else
@@ -327,7 +327,7 @@ fi
 echo ""
 echo -e "${BLUE}Running ESP32-C3 tests...${NC}"
 run_test_suite "esp32c3" \
-    "llgo build -target=esp32c3 -o $BUILD_TEMP_DIR/buildcache.elf -v ." \
+    "llgo build -target=esp32c3 -o $BUILD_TEMP_DIR/buildcache.elf -compiler-verbose ." \
     "$BUILD_TEMP_DIR/buildcache.elf"
 
 # ===========================================================


### PR DESCRIPTION
Closes #2075

## Summary

- Make llgo build -v print package paths as packages are compiled, without enabling LLGo compiler logs.
- Make llgo test -v control test-binary verbosity only.
- Add -compiler-verbose to preserve the previous compiler/build output, with -cv as a shorthand alias.
- Allow compiler verbosity to be combined with -v.
- Avoid printing cache-hit dependencies for Go-compatible build verbosity.

## Go flag compatibility

- Checked the latest stable Go 1.26.5 and current official compiler source.
- Neither the go command nor cmd/compile defines -compiler-verbose or -cv.
- cmd/compile defines -c and -v separately; Go does not combine -cv into those flags.

## Tests

- macOS arm64, Go 1.24.2: go build ./...
- macOS arm64, Go 1.24.2: go test -p 2 -timeout 45m -coverprofile=coverage.out -covermode=atomic ./...
- macOS arm64, Go 1.24.2: focused flag/build/test tests with coverage after the flag rename
- Linux arm64, Go 1.24.2: focused flag/build/test tests with coverage after the flag rename
- Manual CLI checks for build/test -v, -compiler-verbose, -cv, and removal of -verbose
- Build-cache integration script: 18/18 native, WASM, and ESP32-C3 scenarios passed locally
- Patch coverage: 100%
