### PR TITLE
fix(runtime): decouple wasm from native host services

### DIFF
--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -384,3 +384,36 @@ jobs:
 
           # Run the wasm binary using llgo_wasm
           iwasm --stack-size=819200000 --heap-size=800000000 hello.wasm
+
+  wasm-runtime:
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        go: ["1.24.2", "1.26.5"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install dependencies
+        uses: ./.github/actions/setup-deps
+        with:
+          llvm-version: 19
+
+      - name: Install Emscripten
+        run: sudo apt-get install -y emscripten
+
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
+        with:
+          go-version: ${{matrix.go}}
+
+      - name: Install llgo
+        run: |
+          go install ./...
+          echo "LLGO_ROOT=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+
+      - name: Build standard runtime for wasm
+        shell: bash
+        run: |
+          GOOS=js GOARCH=wasm llgo build -o "$RUNNER_TEMP/runtime-js.wasm" ./internal/build/testdata/wasm-runtime
+          GOOS=wasip1 GOARCH=wasm llgo build -o "$RUNNER_TEMP/runtime-wasip1.wasm" ./internal/build/testdata/wasm-runtime
+          file "$RUNNER_TEMP/runtime-js.wasm" "$RUNNER_TEMP/runtime-wasip1.wasm"

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -388,6 +388,7 @@ jobs:
   wasm-runtime:
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         go: ["1.24.2", "1.26.5"]
     runs-on: ubuntu-latest
@@ -398,8 +399,10 @@ jobs:
         with:
           llvm-version: 19
 
-      - name: Install Emscripten
-        run: sudo apt-get install -y emscripten
+      - name: Set up Emscripten
+        uses: emscripten-core/setup-emsdk@v15
+        with:
+          version: "4.0.21"
 
       - name: Set up Go
         uses: ./.github/actions/setup-go

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -404,15 +404,18 @@ jobs:
         with:
           version: "4.0.21"
 
-      - name: Set up Go
+      - name: Set up Go for building llgo
         uses: ./.github/actions/setup-go
-        with:
-          go-version: ${{matrix.go}}
 
       - name: Install llgo
         run: |
           go install ./...
           echo "LLGO_ROOT=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+
+      - name: Set up Go for testing
+        uses: ./.github/actions/setup-go
+        with:
+          go-version: ${{matrix.go}}
 
       - name: Build standard runtime for wasm
         shell: bash

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -336,7 +336,7 @@ func Do(args []string, conf *Config) ([]Package, error) {
 
 	verbose := conf.Verbose
 	patterns := args
-	tags := "llgo,math_big_pure_go,purego"
+	tags := defaultBuildTags(conf.Goarch, conf.Target)
 	if conf.PCLNMode == PCLNExternal {
 		// Select the optional runtime loader as part of the normal package
 		// cache key. Embedded and none builds do not compile any loader or
@@ -668,6 +668,18 @@ func applyBuildModeCompileFlags(mode BuildMode, export *crosscompile.Export) {
 	if mode == BuildModeCShared && export != nil && !slices.Contains(export.CCFLAGS, "-fPIC") {
 		export.CCFLAGS = append(export.CCFLAGS, "-fPIC")
 	}
+}
+
+func defaultBuildTags(goarch, target string) string {
+	tags := "llgo,math_big_pure_go,purego"
+	// Raw GOOS/GOARCH wasm builds do not have a target configuration that
+	// selects a collector. BDWGC is not available in either wasm host, so use
+	// the supported collector-free runtime unless a named target supplies its
+	// own runtime configuration.
+	if goarch == "wasm" && target == "" {
+		tags += ",nogc"
+	}
+	return tags
 }
 
 func allowMissingFunctionBodies(initial []*packages.Package) {

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -8,6 +8,7 @@ import (
 	"debug/macho"
 	"fmt"
 	"go/ast"
+	gobuild "go/build"
 	"go/parser"
 	"go/token"
 	"io"
@@ -16,11 +17,13 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/goplus/llgo/internal/buildenv"
 	"github.com/goplus/llgo/internal/crosscompile"
+	"github.com/goplus/llgo/internal/env"
 	"github.com/goplus/llgo/internal/lto"
 	"github.com/goplus/llgo/internal/meta"
 	"github.com/goplus/llgo/internal/mockable"
@@ -91,6 +94,74 @@ func TestNeedsLinuxNoPIE(t *testing.T) {
 	ctx.buildConf.Target = "wasi"
 	if needsLinuxNoPIE(ctx, nil) {
 		t.Fatal("named targets should not force host linux -no-pie")
+	}
+}
+
+func TestDefaultBuildTags(t *testing.T) {
+	const base = "llgo,math_big_pure_go,purego"
+	for _, test := range []struct {
+		name   string
+		goarch string
+		target string
+		want   string
+	}{
+		{name: "native", goarch: "arm64", want: base},
+		{name: "raw wasm", goarch: "wasm", want: base + ",nogc"},
+		{name: "configured wasm target", goarch: "wasm", target: "wasip1", want: base},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := defaultBuildTags(test.goarch, test.target); got != test.want {
+				t.Fatalf("defaultBuildTags(%q, %q) = %q, want %q", test.goarch, test.target, got, test.want)
+			}
+		})
+	}
+}
+
+func TestWasmRuntimeAvoidsNativeHostDependencies(t *testing.T) {
+	runtimeDir := filepath.Join(env.LLGoRuntimeDir(), "internal", "lib", "runtime")
+	for _, goos := range []string{"js", "wasip1"} {
+		t.Run(goos, func(t *testing.T) {
+			ctx := gobuild.Default
+			ctx.GOOS = goos
+			ctx.GOARCH = "wasm"
+			ctx.BuildTags = []string{"llgo", "nogc"}
+			pkg, err := ctx.ImportDir(runtimeDir, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			selected := make(map[string]bool)
+			for _, name := range append(pkg.GoFiles, pkg.CgoFiles...) {
+				selected[name] = true
+				file, err := parser.ParseFile(token.NewFileSet(), filepath.Join(runtimeDir, name), nil, parser.ImportsOnly)
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, spec := range file.Imports {
+					path, err := strconv.Unquote(spec.Path.Value)
+					if err != nil {
+						t.Fatal(err)
+					}
+					switch path {
+					case "github.com/goplus/llgo/runtime/internal/clite/libuv",
+						"github.com/goplus/llgo/runtime/internal/clite/bdwgc":
+						t.Fatalf("wasm selected %s, which imports native host dependency %s", name, path)
+					}
+				}
+			}
+
+			for _, name := range []string{
+				"mfinal_nogc.go",
+				"runtime_baremetal.go",
+				"signal_baremetal_llgo.go",
+				"time_wasm_llgo.go",
+				"unwind_wasm_llgo.go",
+			} {
+				if !selected[name] {
+					t.Errorf("wasm runtime did not select %s", name)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/build/testdata/wasm-runtime/main.go
+++ b/internal/build/testdata/wasm-runtime/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "runtime"
+
+func main() {
+	println(runtime.GOOS)
+}

--- a/runtime/internal/clite/debug/debug_wasm.go
+++ b/runtime/internal/clite/debug/debug_wasm.go
@@ -20,11 +20,17 @@ type Info struct {
 }
 
 func Address() unsafe.Pointer {
-	panic("not implemented")
+	return nil
 }
 
 func Addrinfo(addr unsafe.Pointer, info *Info) c.Int {
-	panic("not implemented")
+	_, _ = addr, info
+	return 0
+}
+
+func Symbol(name *c.Char) unsafe.Pointer {
+	_ = name
+	return nil
 }
 
 type Frame struct {
@@ -35,7 +41,7 @@ type Frame struct {
 }
 
 func StackTrace(skip int, fn func(fr *Frame) bool) {
-	panic("not implemented")
+	_, _ = skip, fn
 }
 
 func PrintStack(skip int) {

--- a/runtime/internal/lib/runtime/mfinal.go
+++ b/runtime/internal/lib/runtime/mfinal.go
@@ -1,3 +1,5 @@
+//go:build !nogc
+
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.

--- a/runtime/internal/lib/runtime/mfinal_nogc.go
+++ b/runtime/internal/lib/runtime/mfinal_nogc.go
@@ -1,0 +1,9 @@
+//go:build nogc
+
+package runtime
+
+// SetFinalizer is a no-op when garbage collection is disabled because objects
+// are never discovered as unreachable.
+func SetFinalizer(obj any, finalizer any) {
+	_, _ = obj, finalizer
+}

--- a/runtime/internal/lib/runtime/pprof_runtime_stub_llgo.go
+++ b/runtime/internal/lib/runtime/pprof_runtime_stub_llgo.go
@@ -1,4 +1,4 @@
-//go:build darwin || linux
+//go:build darwin || linux || wasm
 
 package runtime
 

--- a/runtime/internal/lib/runtime/runtime_baremetal.go
+++ b/runtime/internal/lib/runtime/runtime_baremetal.go
@@ -1,4 +1,4 @@
-//go:build baremetal
+//go:build baremetal || wasm
 
 package runtime
 

--- a/runtime/internal/lib/runtime/runtime_default.go
+++ b/runtime/internal/lib/runtime/runtime_default.go
@@ -1,4 +1,4 @@
-//go:build !baremetal
+//go:build !baremetal && !wasm
 
 package runtime
 

--- a/runtime/internal/lib/runtime/signal_baremetal_llgo.go
+++ b/runtime/internal/lib/runtime/signal_baremetal_llgo.go
@@ -1,8 +1,8 @@
-//go:build baremetal
+//go:build baremetal || wasm
 
 package runtime
 
-// Baremetal targets do not provide OS signal delivery.
+// Baremetal and wasm targets do not provide POSIX signal delivery.
 
 func signal_enable(sig uint32) {
 	_ = sig

--- a/runtime/internal/lib/runtime/signal_llgo.go
+++ b/runtime/internal/lib/runtime/signal_llgo.go
@@ -1,4 +1,4 @@
-//go:build !baremetal
+//go:build !baremetal && !wasm
 
 package runtime
 
@@ -9,7 +9,7 @@ import (
 	latomic "github.com/goplus/llgo/runtime/internal/lib/sync/atomic"
 )
 
-// Minimal signal support for stdlib os/signal on llgo/darwin.
+// Minimal signal support for stdlib os/signal on hosted native targets.
 
 type sigState struct {
 	handle  libuv.Signal

--- a/runtime/internal/lib/runtime/time_llgo.go
+++ b/runtime/internal/lib/runtime/time_llgo.go
@@ -1,5 +1,5 @@
-//go:build !go1.23 && !baremetal
-// +build !go1.23,!baremetal
+//go:build !go1.23 && !baremetal && !wasm
+// +build !go1.23,!baremetal,!wasm
 
 package runtime
 

--- a/runtime/internal/lib/runtime/time_llgo_go123.go
+++ b/runtime/internal/lib/runtime/time_llgo_go123.go
@@ -1,5 +1,5 @@
-//go:build go1.23 && !baremetal
-// +build go1.23,!baremetal
+//go:build go1.23 && !baremetal && !wasm
+// +build go1.23,!baremetal,!wasm
 
 package runtime
 

--- a/runtime/internal/lib/runtime/time_wasm_llgo.go
+++ b/runtime/internal/lib/runtime/time_wasm_llgo.go
@@ -1,0 +1,116 @@
+//go:build wasm && go1.23
+
+package runtime
+
+import (
+	"unsafe"
+
+	c "github.com/goplus/llgo/runtime/internal/clite"
+	ct "github.com/goplus/llgo/runtime/internal/clite/time"
+)
+
+// Minimal timer hooks for wasm builds. Host-backed asynchronous timers need
+// scheduler integration; until that is available, keep runtime and time
+// linkable without pulling the native libuv event loop into wasm binaries.
+
+type runtimeTimer struct {
+	pp       uintptr
+	when     int64
+	period   int64
+	f        func(any, uintptr, int64)
+	arg      any
+	seq      uintptr
+	nextwhen int64
+	status   uint32
+}
+
+type timeTimer struct {
+	c    unsafe.Pointer
+	init bool
+	r    runtimeTimer
+}
+
+func startRuntimeTimer(r *runtimeTimer) {
+	if r == nil || r.f == nil {
+		return
+	}
+	if r.period == 0 && r.when <= runtimeNano() {
+		r.f(r.arg, r.seq, runtimeNano())
+	}
+}
+
+func stopRuntimeTimer(r *runtimeTimer) bool {
+	return r != nil
+}
+
+func resetRuntimeTimer(r *runtimeTimer, when, period int64, f func(any, uintptr, int64), arg any, seq uintptr) bool {
+	if r == nil {
+		return false
+	}
+	r.when = when
+	r.period = period
+	r.f = f
+	r.arg = arg
+	r.seq = seq
+	startRuntimeTimer(r)
+	return true
+}
+
+//go:linkname time_now time.now
+func time_now() (sec int64, nsec int32, mono int64) {
+	tv := (*ct.Timespec)(c.Alloca(unsafe.Sizeof(ct.Timespec{})))
+	ct.ClockGettime(ct.CLOCK_REALTIME, tv)
+	return int64(tv.Sec), int32(tv.Nsec), runtimeNano()
+}
+
+//go:linkname time_runtimeNow time.runtimeNow
+func time_runtimeNow() (sec int64, nsec int32, mono int64) {
+	return time_now()
+}
+
+//go:linkname time_runtimeNano time.runtimeNano
+func time_runtimeNano() int64 {
+	return runtimeNano()
+}
+
+//go:linkname time_runtimeIsBubbled time.runtimeIsBubbled
+func time_runtimeIsBubbled() bool {
+	return false
+}
+
+//go:linkname timeSleep time.Sleep
+func timeSleep(ns int64) {
+	if ns <= 0 {
+		return
+	}
+	deadline := runtimeNano() + ns
+	for runtimeNano() < deadline {
+	}
+}
+
+//go:linkname newTimer time.newTimer
+func newTimer(when, period int64, f func(any, uintptr, int64), arg any, cp unsafe.Pointer) *timeTimer {
+	t := &timeTimer{c: cp, init: true}
+	t.r.when = when
+	t.r.period = period
+	t.r.f = f
+	t.r.arg = arg
+	startRuntimeTimer(&t.r)
+	return t
+}
+
+//go:linkname stopTimer time.stopTimer
+func stopTimer(t *timeTimer) bool {
+	if t == nil {
+		return false
+	}
+	return stopRuntimeTimer(&t.r)
+}
+
+//go:linkname resetTimer time.resetTimer
+func resetTimer(t *timeTimer, when, period int64) bool {
+	if t == nil {
+		return false
+	}
+	return resetRuntimeTimer(&t.r, when, period, t.r.f, t.r.arg, t.r.seq)
+}

--- a/runtime/internal/lib/runtime/unwind_wasm_llgo.go
+++ b/runtime/internal/lib/runtime/unwind_wasm_llgo.go
@@ -1,0 +1,12 @@
+//go:build wasm
+
+package runtime
+
+func fpCallers(skip int, pc []uintptr) int {
+	_, _ = skip, pc
+	return 0
+}
+
+func fpUnwindAvailable() bool {
+	return false
+}

--- a/runtime/internal/lib/runtime/zgoos_wasip1.go
+++ b/runtime/internal/lib/runtime/zgoos_wasip1.go
@@ -1,0 +1,24 @@
+//go:build wasip1
+
+package runtime
+
+const GOOS = `wasip1`
+
+const IsAix = 0
+const IsAndroid = 0
+const IsDarwin = 0
+const IsDragonfly = 0
+const IsFreebsd = 0
+const IsHurd = 0
+const IsIllumos = 0
+const IsIos = 0
+const IsJs = 0
+const IsLinux = 0
+const IsNacl = 0
+const IsNetbsd = 0
+const IsOpenbsd = 0
+const IsPlan9 = 0
+const IsSolaris = 0
+const IsWasip1 = 1
+const IsWindows = 0
+const IsZos = 0


### PR DESCRIPTION
## Summary

- default raw GOOS/GOARCH wasm builds to the supported nogc runtime path
- keep wasm timer, signal, unwind, symbol lookup, and platform constants off native host implementations
- stop wasm from compiling or linking libuv, BDWGC, and native fault/unwind wrappers
- add a gating CI matrix for js/wasm and wasip1/wasm with exact Go 1.24.2 and Go 1.26.5 toolchains
- build llgo with the pinned primary Go toolchain before switching to the compatibility toolchain under test
- preserve existing native and named-target selections

Fixes #2080.

## Validation

- macOS arm64, Go 1.26.5:
  - js/wasm and wasip1/wasm builds pass without an explicit nogc tag
  - internal/build: 73.5% statement coverage
- Linux amd64, Emscripten 4.0.21:
  - Go 1.24.2: js/wasm and wasip1/wasm builds pass
  - Go 1.26.5: js/wasm and wasip1/wasm builds pass
  - internal/build: 72.8% statement coverage
- all artifacts are valid WebAssembly modules; inspected artifacts contain no uv_* or GC_* symbols

The issue reproduction is a build failure. Executing raw GOOS artifacts still requires the existing host-runner support for Emscripten imports on js and env.longjmp/shared memory on wasip1, which is outside this PR.
