### PR TITLE
runtime/internal/lib/reflect: fix toRuntimeTypes for bdw-gc

### DIFF
--- a/runtime/internal/lib/reflect/makefunc.go
+++ b/runtime/internal/lib/reflect/makefunc.go
@@ -58,11 +58,11 @@ func makeFunc(typ Type, method bool, fn func(args []Value) (results []Value)) Va
 		ins = append([]*abi.Type{unsafePointerType}, ftyp.In...)
 		off = 1
 	}
-	outs := toRuntimeTypes(ftyp.Out)
-	sig, err := toFFISig(ins, outs)
+	sig, err := toFFISig(ins, ftyp.Out)
 	if err != nil {
 		panic(err)
 	}
+	outs := toRuntimeTypes(ftyp.Out)
 	closure := ffi.NewClosure()
 	userdata := &funcData{ftyp: ftyp, fn: fn, nin: len(ftyp.In), off: off, tout: outs}
 

--- a/runtime/internal/lib/reflect/value.go
+++ b/runtime/internal/lib/reflect/value.go
@@ -2493,6 +2493,10 @@ func (v Value) call(op string, in []Value) (out []Value) {
 		}
 	}
 
+	if fn == nil {
+		panic("reflect.Value.Call: call of nil function")
+	}
+
 	isSlice := op == "CallSlice"
 	n := len(ft.In)
 	isVariadic := ft.Variadic()

--- a/runtime/internal/lib/reflect/value.go
+++ b/runtime/internal/lib/reflect/value.go
@@ -2456,7 +2456,6 @@ func (v Value) call(op string, in []Value) (out []Value) {
 	var (
 		ft   *abi.FuncType
 		tin  []*abi.Type
-		tout []*abi.Type
 		args []unsafe.Pointer
 		fn   unsafe.Pointer
 		ret  unsafe.Pointer
@@ -2465,7 +2464,6 @@ func (v Value) call(op string, in []Value) (out []Value) {
 	if v.typ_.IsClosure() && v.flag&flagMethod == 0 {
 		ft = v.typ_.StructType().Fields[0].Typ.FuncType()
 		tin = append([]*abi.Type{rtypeOf(unsafe.Pointer(nil))}, ft.In...)
-		tout = ft.Out
 		c := (*struct {
 			fn  unsafe.Pointer
 			env unsafe.Pointer
@@ -2480,7 +2478,6 @@ func (v Value) call(op string, in []Value) (out []Value) {
 			)
 			rcvrtype, ft, fn = methodReceiver(op, v, int(v.flag)>>flagMethodShift)
 			tin = append([]*abi.Type{rcvrtype}, ft.In...)
-			tout = ft.Out
 			ioff = 1
 			var ptr unsafe.Pointer
 			storeRcvr(v, unsafe.Pointer(&ptr))
@@ -2493,7 +2490,6 @@ func (v Value) call(op string, in []Value) (out []Value) {
 			}
 			ft = v.typ_.FuncType()
 			tin = ft.In
-			tout = ft.Out
 		}
 	}
 
@@ -2570,8 +2566,7 @@ func (v Value) call(op string, in []Value) (out []Value) {
 		args = append(args, toFFIArg(arg, typ))
 	}
 
-	tout = toRuntimeTypes(tout)
-	sig, err := ffi.NewSignature(toFFIRetType(tout), ffiArgs...)
+	sig, err := ffi.NewSignature(toFFIRetType(ft.Out), ffiArgs...)
 	if err != nil {
 		panic(err)
 	}
@@ -2581,6 +2576,7 @@ func (v Value) call(op string, in []Value) (out []Value) {
 	}
 
 	ffi.Call(sig, fn, ret, args...)
+	tout := toRuntimeTypes(ft.Out)
 	switch n := len(tout); n {
 	case 0:
 	case 1:


### PR DESCRIPTION
fix value.call toRuntimeTypes after ffi.Call to avoid premature bdwgc collection.