### PR TITLE
build: preserve module context for asm file lookup

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -416,8 +416,9 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	}
 
 	altPkgPaths := altPkgs(initial, conf, llssa.PkgRuntime)
-	cfg.Dir = env.LLGoRuntimeDir()
-	altPkgs, err := packages.LoadEx(dedup, sizes, cfg, altPkgPaths...)
+	altCfg := *cfg
+	altCfg.Dir = env.LLGoRuntimeDir()
+	altPkgs, err := packages.LoadEx(dedup, sizes, &altCfg, altPkgPaths...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/build/plan9asm.go
+++ b/internal/build/plan9asm.go
@@ -403,8 +403,16 @@ func pkgSFiles(ctx *context, pkg *packages.Package) ([]string, error) {
 	args = append(args, pkg.PkgPath)
 
 	cmd := exec.Command("go", args...)
-	cmd.Dir = pkg.Dir
-	cmd.Env = append(os.Environ(),
+	// Resolve dependencies from the module or workspace used by packages.Load.
+	// A dependency directory in the module cache may not contain a go.mod.
+	if ctx.conf != nil {
+		cmd.Dir = ctx.conf.Dir
+	}
+	cmdEnv := os.Environ()
+	if ctx.conf != nil && len(ctx.conf.Env) > 0 {
+		cmdEnv = append([]string(nil), ctx.conf.Env...)
+	}
+	cmd.Env = append(cmdEnv,
 		"GOOS="+ctx.buildConf.Goos,
 		"GOARCH="+ctx.buildConf.Goarch,
 	)

--- a/internal/build/plan9asm_sfiles_test.go
+++ b/internal/build/plan9asm_sfiles_test.go
@@ -60,6 +60,10 @@ func TestPkgSFilesUsesPackageLoadDir(t *testing.T) {
 	}
 
 	loadDir := t.TempDir()
+	expectedLoadDir, err := filepath.EvalSymlinks(loadDir)
+	if err != nil {
+		t.Fatal(err)
+	}
 	pkgDir := t.TempDir()
 	sfile := filepath.Join(pkgDir, "asm_amd64.s")
 	if err := os.WriteFile(sfile, nil, 0o644); err != nil {
@@ -83,7 +87,7 @@ printf '{"Dir":"%s","SFiles":["asm_amd64.s"]}\n' "$PACKAGE_DIR"
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	t.Setenv("EXPECTED_GO_LIST_DIR", loadDir)
+	t.Setenv("EXPECTED_GO_LIST_DIR", expectedLoadDir)
 	t.Setenv("PACKAGE_DIR", pkgDir)
 
 	ctx := &context{

--- a/internal/build/plan9asm_sfiles_test.go
+++ b/internal/build/plan9asm_sfiles_test.go
@@ -4,9 +4,13 @@
 package build
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
+
+	"github.com/goplus/llgo/internal/packages"
 )
 
 func TestSelectedSFilesSkipsTestAsm(t *testing.T) {
@@ -47,5 +51,57 @@ func TestShouldSkipPlan9AsmSFilesForTarget(t *testing.T) {
 	}
 	if shouldSkipPlan9AsmSFilesForTarget(&Config{Target: "cortex-m-qemu", Goarch: "arm"}, "internal/bytealg") {
 		t.Fatal("only syscall asm should be skipped by embedded arm rule")
+	}
+}
+
+func TestPkgSFilesUsesPackageLoadDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a shell script as a fake go command")
+	}
+
+	loadDir := t.TempDir()
+	pkgDir := t.TempDir()
+	sfile := filepath.Join(pkgDir, "asm_amd64.s")
+	if err := os.WriteFile(sfile, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	goCmd := filepath.Join(binDir, "go")
+	script := `#!/bin/sh
+if [ "$PWD" != "$EXPECTED_GO_LIST_DIR" ]; then
+	echo "go list ran in $PWD; want $EXPECTED_GO_LIST_DIR" >&2
+	exit 1
+fi
+if [ "$PACKAGE_LOAD_ENV" != "used" ]; then
+	echo "go list did not inherit the package load environment" >&2
+	exit 1
+fi
+printf '{"Dir":"%s","SFiles":["asm_amd64.s"]}\n' "$PACKAGE_DIR"
+`
+	if err := os.WriteFile(goCmd, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("EXPECTED_GO_LIST_DIR", loadDir)
+	t.Setenv("PACKAGE_DIR", pkgDir)
+
+	ctx := &context{
+		conf: &packages.Config{
+			Dir: loadDir,
+			Env: append(os.Environ(), "PACKAGE_LOAD_ENV=used"),
+		},
+		buildConf: &Config{Goos: "linux", Goarch: "amd64"},
+	}
+	got, err := pkgSFiles(ctx, &packages.Package{
+		ID:      "example.com/asm",
+		PkgPath: "example.com/asm",
+		Dir:     pkgDir,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != sfile {
+		t.Fatalf("pkgSFiles = %v, want [%s]", got, sfile)
 	}
 }


### PR DESCRIPTION
## Summary

Keep Plan9 assembly `go list` queries in the same module/workspace and environment used to load Go packages.

The runtime alternate-package load now uses a copy of `packages.Config`, so its runtime directory does not leak into later dependency queries. The asm S-file lookup test also compares canonical paths to cover macOS `/var` to `/private/var` resolution.

## Root cause

The build mutated the main package-load config to load runtime alternatives, leaving its `Dir` set to the llgo runtime directory. `pkgSFiles` then ran `go list` from a dependency package directory or from the leaked runtime directory, where module dependencies such as `github.com/dchest/siphash` were not resolvable.

## Tests

- `GOWORK=off go test ./internal/build -run '^TestPkgSFilesUsesPackageLoadDir$' -count=1`
- the same test with `TMPDIR` through a symbolic link, matching the macOS runner path behavior
