### PR TITLE
cmd/internal/compile: accept SSA check seed

### DIFF
--- a/cmd/internal/compile/compile.go
+++ b/cmd/internal/compile/compile.go
@@ -206,11 +206,21 @@ func (opts *options) unsupported() []string {
 	appendFlag(opts.writeBar.set, "-wb")
 	for _, setting := range opts.debug {
 		for _, item := range strings.Split(setting, ",") {
-			if item == "panic" || item == "ssa/check/on" {
+			if compatibleDebugSetting(item) {
 				continue
 			}
 			out = append(out, "-d="+item)
 		}
 	}
 	return out
+}
+
+func compatibleDebugSetting(setting string) bool {
+	if setting == "panic" || setting == "ssa/check/on" || setting == "ssa/check/seed" {
+		return true
+	}
+	// LLGo's x/tools SSA sanity checking is always enabled. gc uses this seed
+	// for its own randomized checking order, so it needs no additional LLGo
+	// action.
+	return strings.HasPrefix(setting, "ssa/check/seed=")
 }

--- a/cmd/internal/compile/compile_test.go
+++ b/cmd/internal/compile/compile_test.go
@@ -52,6 +52,17 @@ func TestGoCompilerSpecificFlagIsExplicitlyUnsupported(t *testing.T) {
 	}
 }
 
+func TestSSACheckSeedDebugSettingsAreCompatible(t *testing.T) {
+	opts := &options{debug: stringListFlag{
+		"ssa/check/seed,ssa/check/seed=1",
+		"ssa/check/seeded=1",
+	}}
+	want := []string{"-d=ssa/check/seeded=1"}
+	if got := opts.unsupported(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("unsupported=%v, want %v", got, want)
+	}
+}
+
 func TestCountAndListFlags(t *testing.T) {
 	var count countFlag
 	if !count.IsBoolFlag() {
@@ -92,7 +103,7 @@ func TestUnsupportedCompilerFlags(t *testing.T) {
 		standard:    true,
 		runtimePkg:  true,
 		writeBar:    countFlag{set: true},
-		debug:       stringListFlag{"panic,libfuzzer", "ssa/check/on,wb"},
+		debug:       stringListFlag{"panic,libfuzzer", "ssa/check/on,ssa/check/seed=1,wb"},
 	}
 	want := []string{"-B", "-dynlink", "-m", "-live", "-race", "-smallframes", "-std", "-+", "-wb", "-d=libfuzzer", "-d=wb"}
 	if got := opts.unsupported(); !reflect.DeepEqual(got, want) {

--- a/test/go/tool_compile_compat_test.go
+++ b/test/go/tool_compile_compat_test.go
@@ -43,6 +43,23 @@ func Identity[T any](v T) T { return v }
 		compareToolCompileResult(t, dir, args, true, "")
 	})
 
+	t.Run("SSA check seed", func(t *testing.T) {
+		tests := []struct {
+			name string
+			flag string
+		}{
+			{name: "default", flag: "-d=ssa/check/seed"},
+			{name: "explicit", flag: "-d=ssa/check/seed=1"},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				dir := t.TempDir()
+				writeToolCompileSource(t, dir, "valid.go", "package compat\n\nfunc F() {}\n")
+				compareToolCompileResult(t, dir, []string{tt.flag, "-o=compat.o", "valid.go"}, true, "")
+			})
+		}
+	})
+
 	t.Run("language version", func(t *testing.T) {
 		dir := t.TempDir()
 		writeToolCompileSource(t, dir, "generic.go", `package compat

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -2515,14 +2515,6 @@ xfails:
     reason: gc-specific -d=checkptr backend option is not implemented by llgo
   - version: go1.26
     directive: compile
-    case: fixedbugs/issue44465.go
-    reason: gc-specific -d=ssa/check/seed option is not implemented by llgo
-  - version: go1.26
-    directive: compile
-    case: fixedbugs/issue58161.go
-    reason: gc-specific -d=ssa/check/seed option is not implemented by llgo
-  - version: go1.26
-    directive: compile
     case: fixedbugs/issue58826.go
     reason: gc-specific -dynlink backend mode is not implemented by llgo
   - version: go1.26


### PR DESCRIPTION
## Summary

- accept `-d=ssa/check/seed` and `-d=ssa/check/seed=<value>` in the `go tool compile` compatibility adapter
- treat the seed as compatible because LLGo x/tools SSA sanity checking is already always enabled, matching the existing `ssa/check/on` handling
- keep similarly prefixed unknown settings explicitly unsupported
- retire the Go 1.26 compile xfails for `issue44465.go` and `issue58161.go`

## Validation

- Darwin/arm64, Go 1.26.0: focused GOROOT compile cases pass with an empty xfail file
- Linux/amd64, Go 1.26.0 + LLVM 19 under VZ/Rosetta: same focused cases pass with an empty xfail file
- `go test -vet=off -count=1 -coverprofile=... ./cmd/internal/compile`: 100.0% statement coverage on both platforms
- `git diff --check`
