### PR TITLE
test/goroot: normalize scanner recovery diagnostics

### DIFF
--- a/test/goroot/runner_test.go
+++ b/test/goroot/runner_test.go
@@ -1108,6 +1108,7 @@ func checkExpectedErrorsForFiles(output string, sources []diagnosticSource) erro
 		}
 		wanted = append(wanted, expected...)
 	}
+	lexicalLocations := make(map[string]bool)
 	var errs []error
 	for _, expected := range wanted {
 		var candidates []string
@@ -1122,12 +1123,18 @@ func checkExpectedErrorsForFiles(output string, sources []diagnosticSource) erro
 		}
 		matched := false
 		for _, candidate := range candidates {
+			diagnostic, ok := parseCompilerDiagnostic(candidate)
 			message := candidate
-			if _, suffix, ok := strings.Cut(message, " "); ok {
+			if ok {
+				message = diagnostic.message
+			} else if _, suffix, found := strings.Cut(message, " "); found {
 				message = suffix
 			}
-			if expected.regexp.MatchString(message) {
+			if matchesExpectedDiagnostic(expected.regexp, message) {
 				matched = true
+				if ok && isScopedLexicalDiagnostic(message) {
+					lexicalLocations[diagnostic.location] = true
+				}
 			} else {
 				lines = append(lines, candidate)
 			}
@@ -1136,6 +1143,7 @@ func checkExpectedErrorsForFiles(output string, sources []diagnosticSource) erro
 			errs = append(errs, fmt.Errorf("%s:%d: no match for %q", expected.file, expected.line, expected.pattern))
 		}
 	}
+	lines = discardLexicalRecoveryDiagnostics(lines, lexicalLocations)
 
 	local := lines[:0]
 	for _, line := range lines {
@@ -1155,22 +1163,117 @@ func checkExpectedErrorsForFiles(output string, sources []diagnosticSource) erro
 	return errors.Join(errs...)
 }
 
-func preferSpecificDiagnostics(lines []string) []string {
-	discard := make([]bool, len(lines))
-	type parsedDiagnostic struct {
-		location string
-		message  string
+type compilerDiagnostic struct {
+	location string
+	message  string
+}
+
+func parseCompilerDiagnostic(line string) (compilerDiagnostic, bool) {
+	match := diagnosticRx.FindStringSubmatch(line)
+	if match == nil {
+		return compilerDiagnostic{}, false
 	}
-	parsed := make([]parsedDiagnostic, len(lines))
-	for i, line := range lines {
-		match := diagnosticRx.FindStringSubmatch(line)
-		if match == nil {
+	return compilerDiagnostic{
+		location: filepath.Base(match[1]) + ":" + match[2],
+		message:  match[3],
+	}, true
+}
+
+// matchesExpectedDiagnostic accepts the equivalent wording used by the Go
+// scanner for unterminated literals. GOROOT's errorcheck patterns describe gc
+// diagnostics, while llgo's source frontend is go/parser and go/scanner.
+func matchesExpectedDiagnostic(expected *regexp.Regexp, message string) bool {
+	if expected.MatchString(message) {
+		return true
+	}
+	var aliases []string
+	switch message {
+	case "string literal not terminated":
+		aliases = []string{"newline in string", "string not terminated"}
+	case "rune literal not terminated":
+		aliases = []string{"newline in rune literal"}
+	case "raw string literal not terminated":
+		aliases = []string{"string not terminated"}
+	}
+	for _, alias := range aliases {
+		if expected.MatchString(alias) {
+			return true
+		}
+	}
+	return false
+}
+
+// isScopedLexicalDiagnostic identifies primary scanner diagnostics whose
+// follow-up parser and go/types errors are deterministic. A bare invalid
+// character diagnostic is deliberately excluded: without identifier or escape
+// context, a same-line parser error may describe a distinct syntax problem.
+func isScopedLexicalDiagnostic(message string) bool {
+	switch {
+	case strings.HasPrefix(message, "identifier cannot begin with digit"):
+		return true
+	case strings.HasPrefix(message, "invalid character ") &&
+		(strings.Contains(message, " in identifier") || strings.Contains(message, " in octal escape") || strings.Contains(message, " in hexadecimal escape")):
+		return true
+	case strings.HasPrefix(message, "illegal character ") && strings.Contains(message, " in escape sequence"):
+		return true
+	case strings.HasPrefix(message, "unknown escape"):
+		return true
+	case strings.HasPrefix(message, "escape is invalid Unicode code point"),
+		strings.HasPrefix(message, "escape sequence is invalid Unicode code point"):
+		return true
+	case strings.HasPrefix(message, "empty rune literal"),
+		strings.HasPrefix(message, "more than one character in rune literal"),
+		strings.HasPrefix(message, "newline in rune literal"):
+		return true
+	case message == "string literal not terminated", message == "rune literal not terminated", message == "raw string literal not terminated":
+		return true
+	case strings.HasPrefix(message, "'_' must separate successive digits"):
+		return true
+	case strings.Contains(message, " literal has no digits"), strings.Contains(message, "mantissa requires a 'p' exponent"):
+		return true
+	}
+	return false
+}
+
+// discardLexicalRecoveryDiagnostics removes only known secondary diagnostics
+// at a file:line where a scoped lexical diagnostic already satisfied an ERROR
+// expectation. Unrelated diagnostics and recovery on every other line remain
+// unmatched and fail the errorcheck case.
+func discardLexicalRecoveryDiagnostics(lines []string, lexicalLocations map[string]bool) []string {
+	out := lines[:0]
+	for _, line := range lines {
+		diagnostic, ok := parseCompilerDiagnostic(line)
+		if ok && lexicalLocations[diagnostic.location] && isLexicalRecoveryDiagnostic(diagnostic.message) {
 			continue
 		}
-		parsed[i] = parsedDiagnostic{
-			location: filepath.Base(match[1]) + ":" + match[2],
-			message:  match[3],
-		}
+		out = append(out, line)
+	}
+	return out
+}
+
+func isLexicalRecoveryDiagnostic(message string) bool {
+	switch {
+	case strings.HasPrefix(message, "malformed constant: "):
+		return true
+	case message == "illegal rune literal", message == "invalid import path (invalid syntax)":
+		return true
+	case strings.HasPrefix(message, "illegal character U+"):
+		return true
+	case strings.HasPrefix(message, "expected ") && strings.Contains(message, ", found "):
+		return true
+	case strings.HasPrefix(message, "syntax error: unexpected "):
+		return true
+	case strings.HasSuffix(message, " is not used"):
+		return true
+	}
+	return false
+}
+
+func preferSpecificDiagnostics(lines []string) []string {
+	discard := make([]bool, len(lines))
+	parsed := make([]compilerDiagnostic, len(lines))
+	for i, line := range lines {
+		parsed[i], _ = parseCompilerDiagnostic(line)
 	}
 	for i := range lines {
 		if parsed[i].location == "" || discard[i] {

--- a/test/goroot/runner_unit_test.go
+++ b/test/goroot/runner_unit_test.go
@@ -554,6 +554,96 @@ var _ = missing // ERROR "undefined: missing"
 	}
 }
 
+func TestCheckExpectedErrorsNormalizesLexicalDiagnostics(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "case.go")
+	src := `package p
+var _ = 0 // ERROR "newline in string"
+var _ = 0 // ERROR "newline in rune literal"
+var _ = 0 // ERROR "string not terminated"
+var _ = 0 // ERROR "invalid character .* in identifier"
+var _ = 0 // ERROR "identifier cannot begin with digit"
+var _ = 0 // ERROR "oct|char"
+var _ = 0 // ERROR "hexadecimal literal has no digits"
+var _ = 0 // ERROR "empty rune literal"
+var _ = 0 // ERROR "mantissa requires a 'p' exponent"
+`
+	if err := os.WriteFile(file, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	output := strings.Join([]string{
+		file + ":2: string literal not terminated",
+		file + ":2: invalid import path (invalid syntax)",
+		file + ":2: malformed constant: \"",
+		file + ":3: rune literal not terminated",
+		file + ":3: malformed constant: '",
+		file + ":4: raw string literal not terminated",
+		file + ":4: expected '}', found 'EOF'",
+		file + ":4: malformed constant: `",
+		file + ":5: invalid character U+229B '⊛' in identifier",
+		file + ":5: expected type, found 'ILLEGAL'",
+		file + ":5: illegal character U+229B '⊛'",
+		file + ":6: identifier cannot begin with digit U+06F6 '۶'",
+		file + ":6: expected 'IDENT', found 'ILLEGAL'",
+		file + ":6: illegal character U+06F6 '۶'",
+		file + ":7: invalid character '\\'' in octal escape",
+		file + ":7: malformed constant: '\\0'",
+		file + ":8: hexadecimal literal has no digits",
+		file + ":8: malformed constant: 0x",
+		file + ":9: empty rune literal or unescaped '",
+		file + ":9: syntax error: unexpected literal after top level declaration",
+		file + ":9: illegal rune literal",
+		file + ":10: hexadecimal mantissa requires a 'p' exponent",
+		file + ":10: 0x1.0 (untyped float constant 1) is not used",
+	}, "\n")
+	if err := checkExpectedErrors(output, file, "case.go"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckExpectedErrorsKeepsUnrelatedDiagnostics(t *testing.T) {
+	tests := []struct {
+		name   string
+		src    string
+		output func(string) string
+	}{
+		{
+			name: "same line non-recovery",
+			src:  "package p\nvar _ = 0 // ERROR \"unknown escape\"\n",
+			output: func(file string) string {
+				return file + ":2: unknown escape\n" + file + ":2: undefined: still_reported\n"
+			},
+		},
+		{
+			name: "different line recovery",
+			src:  "package p\nvar _ = 0 // ERROR \"unknown escape\"\nvar _ = 0\n",
+			output: func(file string) string {
+				return file + ":2: unknown escape\n" + file + ":3: malformed constant: 0x\n"
+			},
+		},
+		{
+			name: "unscoped invalid character",
+			src:  "package p\nvar _ = 0 // ERROR \"invalid character U\\+003F\"\n",
+			output: func(file string) string {
+				return file + ":2: invalid character U+003F '?'\n" +
+					file + ":2: expected 'IDENT', found 'ILLEGAL'\n" +
+					file + ":2: illegal character U+003F '?'\n"
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file := filepath.Join(t.TempDir(), "case.go")
+			if err := os.WriteFile(file, []byte(tt.src), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			err := checkExpectedErrors(tt.output(file), file, "case.go")
+			if err == nil || !strings.Contains(err.Error(), "unmatched errors") {
+				t.Fatalf("err=%v, want unmatched errors", err)
+			}
+		})
+	}
+}
+
 func TestPreferSpecificDiagnostics(t *testing.T) {
 	got := preferSpecificDiagnostics([]string{
 		"case.go:18:16: requires go1.22 or later (file declares go1.21)",

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1795,10 +1795,6 @@ xfails:
     reason: llgo uses different non-canonical import-path diagnostic punctuation
   - version: go1.26
     directive: errorcheck
-    case: fixedbugs/issue15611.go
-    reason: llgo scanner recovery emits additional malformed-rune diagnostics
-  - version: go1.26
-    directive: errorcheck
     case: fixedbugs/issue23664.go
     reason: llgo parser recovery emits additional malformed-declaration diagnostics
   - version: go1.26
@@ -1847,16 +1843,8 @@ xfails:
     reason: gc-specific type-assertion optimization diagnostics are not implemented by llgo
   - version: go1.26
     directive: errorcheck
-    case: fixedbugs/bug014.go
-    reason: llgo scanner emits additional malformed-character-constant diagnostics
-  - version: go1.26
-    directive: errorcheck
     case: fixedbugs/bug349.go
     reason: llgo parser recovery emits additional return-value diagnostics
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue11359.go
-    reason: llgo scanner emits additional illegal-character diagnostics
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/issue23587.go
@@ -1885,10 +1873,6 @@ xfails:
     directive: errorcheck
     case: fixedbugs/issue27732a.go
     reason: gc-specific small-frame and optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/bug169.go
-    reason: llgo scanner emits an additional malformed-character-constant diagnostic
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/bug274.go
@@ -1947,10 +1931,6 @@ xfails:
     reason: llgo parser recovery emits additional malformed-call diagnostics
   - version: go1.26
     directive: errorcheck
-    case: fixedbugs/issue32133.go
-    reason: llgo scanner uses different unterminated-literal diagnostics and emits recovery noise
-  - version: go1.26
-    directive: errorcheck
     case: syntax/semi5.go
     reason: llgo parser recovery emits additional semicolon and end-of-file diagnostics
   - version: go1.26
@@ -1985,10 +1965,6 @@ xfails:
     directive: errorcheck
     case: import6.go
     reason: llgo loader does not emit the expected absolute-import-path diagnostic
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/bug163.go
-    reason: llgo scanner emits additional illegal-character diagnostics
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/issue13274.go
@@ -2087,10 +2063,6 @@ xfails:
     reason: llgo reports goto diagnostics at different source positions
   - version: go1.26
     directive: errorcheck
-    case: fixedbugs/bug068.go
-    reason: llgo scanner emits an additional malformed-character-constant diagnostic
-  - version: go1.26
-    directive: errorcheck
     case: fixedbugs/bug195.go
     reason: llgo reports an additional recursive-interface diagnostic
   - version: go1.26
@@ -2135,10 +2107,6 @@ xfails:
     reason: gc-specific bounds-check elimination diagnostics are not implemented by llgo
   - version: go1.26
     directive: errorcheck
-    case: char_lit1.go
-    reason: llgo scanner emits additional malformed-character-constant diagnostics
-  - version: go1.26
-    directive: errorcheck
     case: fixedbugs/issue20789.go
     reason: llgo parser does not emit the expected malformed-name diagnostic
   - version: go1.26
@@ -2165,10 +2133,6 @@ xfails:
     directive: errorcheck
     case: fixedbugs/issue20780.go
     reason: gc-specific stack-frame size diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue30722.go
-    reason: llgo scanner emits additional malformed-constant diagnostics
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/issue7538a.go


### PR DESCRIPTION
## Summary

- recognize scoped go/scanner diagnostics that are equivalent to gc errorcheck diagnostics
- discard only known same-location parser/go-types recovery after a lexical diagnostic has satisfied an `ERROR` expectation
- keep unrelated, cross-location, and unscoped invalid-character diagnostics strict
- retire exactly 9 Go 1.26 scanner-related errorcheck xfails

## Validation

- Darwin/arm64, Go 1.26.0: all 9 focused cases pass with an empty xfail file
- Darwin/arm64, Go 1.26.5: complete 650-case errorcheck sweep is functionally 650/650 (the 4 GiB resource-guard case was rechecked alone without the guard)
- Linux/amd64, Go 1.26.0 + LLVM 19 under VZ/Rosetta: unit, race, vet, and all 9 focused cases pass with an empty xfail file
- boundary regression: `fixedbugs/issue11610.go` remains an expected failure and still fails with an empty xfail file
- `git diff --check`

`test/goroot` contains only `_test.go` sources, so Go coverage reports `[no statements]`. The changed branches are covered by 90 lines of positive/negative unit tests plus the complete external errorcheck sweep.
