### PR TITLE
cabi: bound large aggregate return lowering

### DIFF
--- a/internal/cabi/arch.go
+++ b/internal/cabi/arch.go
@@ -192,19 +192,19 @@ func (p *TypeInfoArm64) GetTypeInfo(ctx llvm.Context, ftyp llvm.Type, typ llvm.T
 	info.Align = p.Alignof(typ)
 	switch kind {
 	case llvm.StructTypeKind, llvm.ArrayTypeKind:
-		types := elementTypes(p.td, typ)
-		n := len(types)
+		n := elementTypesCount(typ)
 		if bret && n == 1 {
 			return info
 		}
-		if n == 2 {
-			// skip (i64/ptr,i64/ptr)
-			if (types[0].TypeKind() == llvm.PointerTypeKind || types[0] == ctx.Int64Type()) &&
-				(types[1].TypeKind() == llvm.PointerTypeKind || types[1] == ctx.Int64Type()) {
-				return info
-			}
-		}
 		if n <= 4 {
+			types := elementTypes(p.td, typ)
+			if n == 2 {
+				// skip (i64/ptr,i64/ptr)
+				if (types[0].TypeKind() == llvm.PointerTypeKind || types[0] == ctx.Int64Type()) &&
+					(types[1].TypeKind() == llvm.PointerTypeKind || types[1] == ctx.Int64Type()) {
+					return info
+				}
+			}
 			if checkTypes(types, ctx.FloatType()) || checkTypes(types, ctx.DoubleType()) {
 				return info
 			}

--- a/internal/cabi/arch.go
+++ b/internal/cabi/arch.go
@@ -192,19 +192,24 @@ func (p *TypeInfoArm64) GetTypeInfo(ctx llvm.Context, ftyp llvm.Type, typ llvm.T
 	info.Align = p.Alignof(typ)
 	switch kind {
 	case llvm.StructTypeKind, llvm.ArrayTypeKind:
-		n := elementTypesCount(typ)
+		if info.Size > 16 && elementTypesCount(typ) > 4 {
+			info.Kind = AttrPointer
+			info.Type1 = llvm.PointerType(typ, 0)
+			return info
+		}
+		types := elementTypes(p.td, typ)
+		n := len(types)
 		if bret && n == 1 {
 			return info
 		}
-		if n <= 4 {
-			types := elementTypes(p.td, typ)
-			if n == 2 {
-				// skip (i64/ptr,i64/ptr)
-				if (types[0].TypeKind() == llvm.PointerTypeKind || types[0] == ctx.Int64Type()) &&
-					(types[1].TypeKind() == llvm.PointerTypeKind || types[1] == ctx.Int64Type()) {
-					return info
-				}
+		if n == 2 {
+			// skip (i64/ptr,i64/ptr)
+			if (types[0].TypeKind() == llvm.PointerTypeKind || types[0] == ctx.Int64Type()) &&
+				(types[1].TypeKind() == llvm.PointerTypeKind || types[1] == ctx.Int64Type()) {
+				return info
 			}
+		}
+		if n <= 4 {
 			if checkTypes(types, ctx.FloatType()) || checkTypes(types, ctx.DoubleType()) {
 				return info
 			}

--- a/internal/cabi/cabi.go
+++ b/internal/cabi/cabi.go
@@ -105,6 +105,10 @@ type CallInstr struct {
 	fn   llvm.Value
 }
 
+// LLVM's instruction selector may scalarize larger aggregate copies element by
+// element. Keep such values in memory while adapting indirect C ABI returns.
+const maxDirectAggregateCopySize = 1 << 20
+
 func (p *Transformer) TransformModule(path string, m llvm.Module) {
 	ctx := m.Context()
 	var fns []llvm.Value
@@ -180,6 +184,19 @@ func (p *Transformer) TransformModule(path string, m llvm.Module) {
 	for _, fn := range fns {
 		p.transformFunc(m, fn)
 	}
+}
+
+func (p *Transformer) isLargeAggregate(typ llvm.Type) bool {
+	switch typ.TypeKind() {
+	case llvm.ArrayTypeKind, llvm.StructTypeKind:
+		return p.Sizeof(typ) > maxDirectAggregateCopySize
+	}
+	return false
+}
+
+func hasSingleUse(value, user llvm.Value) bool {
+	use := value.FirstUse()
+	return !use.IsNil() && use.User() == user && use.NextUse().IsNil()
 }
 
 func (p *Transformer) isWrapFunctionType(ctx llvm.Context, ft llvm.Type) bool {
@@ -472,16 +489,28 @@ func (p *Transformer) transformFuncBody(m llvm.Module, ctx llvm.Context, info *F
 
 	if info.Return.Kind >= AttrPointer {
 		var retInstrs []llvm.Value
+		var selfCopies [][2]llvm.Value
 		bb := nfn.FirstBasicBlock()
 		for !bb.IsNil() {
 			instr := bb.FirstInstruction()
 			for !instr.IsNil() {
 				if !instr.IsAReturnInst().IsNil() {
 					retInstrs = append(retInstrs, instr)
+				} else if store := instr.IsAStoreInst(); info.Return.Kind == AttrPointer &&
+					!store.IsNil() && !store.IsVolatile() {
+					load := store.Operand(0).IsALoadInst()
+					if !load.IsNil() && !load.IsVolatile() && p.isLargeAggregate(load.Type()) &&
+						store.Operand(1) == load.Operand(0) && hasSingleUse(load, store) {
+						selfCopies = append(selfCopies, [2]llvm.Value{load, store})
+					}
 				}
 				instr = llvm.NextInstruction(instr)
 			}
 			bb = llvm.NextBasicBlock(bb)
+		}
+		for _, copy := range selfCopies {
+			copy[1].EraseFromParentAsInstruction()
+			copy[0].EraseFromParentAsInstruction()
 		}
 		for _, instr := range retInstrs {
 			ret := instr.Operand(0)
@@ -489,6 +518,19 @@ func (p *Transformer) transformFuncBody(m llvm.Module, ctx llvm.Context, info *F
 			var rv llvm.Value
 			switch info.Return.Kind {
 			case AttrPointer:
+				if load := ret.IsALoadInst(); !load.IsNil() && !load.IsVolatile() &&
+					p.isLargeAggregate(ret.Type()) && hasSingleUse(ret, instr) {
+					// Preserve Go value semantics by copying at the original load,
+					// before the source can be modified (see issue #1608).
+					b.SetInsertPointBefore(load)
+					p.callMemcpy(m, ctx, b, params[0], load.Operand(0), p.Sizeof(ret.Type()))
+					b.SetInsertPointBefore(instr)
+					rv = b.CreateRetVoid()
+					instr.ReplaceAllUsesWith(rv)
+					instr.EraseFromParentAsInstruction()
+					load.EraseFromParentAsInstruction()
+					continue
+				}
 				// %typ @fn()
 				// %2 = load %typ, ptr %1
 				// ret %typ %2
@@ -498,8 +540,8 @@ func (p *Transformer) transformFuncBody(m llvm.Module, ctx llvm.Context, info *F
 				// store %typ %2, ptr %0
 				// ret void
 				//
-				// Note: We don't use memcpy optimization here because the source
-				// address content may be modified between load and ret.
+				// For other values, don't defer a memcpy from a load source: that
+				// source may be modified between the load and ret.
 				// See: https://github.com/goplus/llgo/issues/1608
 				b.CreateStore(ret, params[0])
 				rv = b.CreateRetVoid()
@@ -608,16 +650,16 @@ func (p *Transformer) transformCallInstr(m llvm.Module, ctx llvm.Context, call l
 		}
 	}
 
-	var instr llvm.Value
+	var instr, indirectRet llvm.Value
 	switch info.Return.Kind {
 	case AttrVoid:
 		instr = llvm.CreateCall(b, nft, nfn, nparams)
 		updateCallAttr(instr)
 	case AttrPointer:
-		ret := createAlloca(info.Return.Type)
-		call := llvm.CreateCall(b, nft, nfn, append([]llvm.Value{ret}, nparams...))
+		indirectRet = createAlloca(info.Return.Type)
+		call := llvm.CreateCall(b, nft, nfn, append([]llvm.Value{indirectRet}, nparams...))
 		updateCallAttr(call)
-		instr = b.CreateLoad(info.Return.Type, ret, "")
+		instr = b.CreateLoad(info.Return.Type, indirectRet, "")
 	case AttrWidthType, AttrWidthType2:
 		ret := llvm.CreateCall(b, nft, nfn, nparams)
 		updateCallAttr(ret)
@@ -631,6 +673,24 @@ func (p *Transformer) transformCallInstr(m llvm.Module, ctx llvm.Context, call l
 	}
 	call.ReplaceAllUsesWith(instr)
 	call.EraseFromParentAsInstruction()
+	if !indirectRet.IsNil() && p.isLargeAggregate(info.Return.Type) {
+		var stores []llvm.Value
+		for use := instr.FirstUse(); !use.IsNil(); use = use.NextUse() {
+			store := use.User().IsAStoreInst()
+			if store.IsNil() || store.IsVolatile() || store.Operand(0) != instr {
+				return true
+			}
+			stores = append(stores, store)
+		}
+		for _, store := range stores {
+			b.SetInsertPointBefore(store)
+			p.callMemcpy(m, ctx, b, store.Operand(1), indirectRet, p.Sizeof(info.Return.Type))
+			store.EraseFromParentAsInstruction()
+		}
+		if len(stores) != 0 {
+			instr.EraseFromParentAsInstruction()
+		}
+	}
 	return true
 }
 

--- a/internal/cabi/cabi_large_aggregate_test.go
+++ b/internal/cabi/cabi_large_aggregate_test.go
@@ -1,0 +1,165 @@
+//go:build !llgo
+
+package cabi
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	llssa "github.com/goplus/llgo/ssa"
+	"github.com/xgo-dev/llvm"
+)
+
+func TestArm64LargeArrayUsesIndirectABI(t *testing.T) {
+	llvm.InitializeAllTargets()
+	llvm.InitializeAllTargetMCs()
+	llvm.InitializeAllTargetInfos()
+
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	prog := llssa.NewProgram(nil)
+	defer prog.Dispose()
+	tr := NewTransformer(prog, "arm64-apple-darwin", "", ModeAllFunc, true)
+	if tr.isLargeAggregate(ctx.Int8Type()) {
+		t.Fatal("scalar type was classified as a large aggregate")
+	}
+	if tr.isLargeAggregate(llvm.ArrayType(ctx.Int8Type(), 16)) {
+		t.Fatal("small array was classified as a large aggregate")
+	}
+
+	large := llvm.ArrayType(ctx.Int8Type(), 1<<28)
+	if !tr.isLargeAggregate(large) {
+		t.Fatal("large array was not classified as a large aggregate")
+	}
+	ftyp := llvm.FunctionType(large, nil, false)
+	if info := tr.GetTypeInfo(ctx, ftyp, large, 0); info.Kind != AttrPointer {
+		t.Fatalf("large array ABI kind = %v, want AttrPointer", info.Kind)
+	}
+
+	// A homogeneous floating-point aggregate remains register-returned even
+	// though its size exceeds the ordinary 16-byte aggregate limit.
+	hfa := llvm.ArrayType(ctx.DoubleType(), 4)
+	ftyp = llvm.FunctionType(hfa, nil, false)
+	if info := tr.GetTypeInfo(ctx, ftyp, hfa, 0); info.Kind != AttrNone {
+		t.Fatalf("four-double HFA ABI kind = %v, want AttrNone", info.Kind)
+	}
+}
+
+func TestLargeArrayIndirectReturnStaysInMemory(t *testing.T) {
+	llvm.InitializeAllTargets()
+	llvm.InitializeAllTargetMCs()
+	llvm.InitializeAllTargetInfos()
+
+	const testIR = `
+%Large = type [1048577 x i8]
+
+define %Large @callee(ptr %src) {
+entry:
+  %v = load %Large, ptr %src, align 1
+  %first = getelementptr inbounds %Large, ptr %src, i64 0, i64 0
+  store i8 9, ptr %first, align 1
+  ret %Large %v
+}
+
+define i8 @caller(ptr %src) {
+entry:
+  %v = call %Large @callee(ptr %src)
+  %dst = alloca %Large, align 1
+  store %Large %v, ptr %dst, align 1
+  %first = getelementptr inbounds %Large, ptr %dst, i64 0, i64 0
+  %result = load i8, ptr %first, align 1
+  ret i8 %result
+}
+
+define void @volatile_caller(ptr %src, ptr %dst) {
+entry:
+  %v = call %Large @callee(ptr %src)
+  store volatile %Large %v, ptr %dst, align 1
+  ret void
+}
+
+define %Large @self_copy(ptr %src) {
+entry:
+  %copy = load %Large, ptr %src, align 1
+  store %Large %copy, ptr %src, align 1
+  %result = load %Large, ptr %src, align 1
+  ret %Large %result
+}
+
+define %Large @volatile_copy(ptr %src) {
+entry:
+  %copy = load volatile %Large, ptr %src, align 1
+  store %Large %copy, ptr %src, align 1
+  %result = load %Large, ptr %src, align 1
+  ret %Large %result
+}
+`
+
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	tmpfile := filepath.Join(t.TempDir(), "large_array_return.ll")
+	if err := os.WriteFile(tmpfile, []byte(testIR), 0o644); err != nil {
+		t.Fatalf("write test IR: %v", err)
+	}
+	buf, err := llvm.NewMemoryBufferFromFile(tmpfile)
+	if err != nil {
+		t.Fatalf("read test IR: %v", err)
+	}
+	mod, err := ctx.ParseIR(buf)
+	if err != nil {
+		t.Fatalf("parse test IR: %v", err)
+	}
+	defer mod.Dispose()
+
+	prog := llssa.NewProgram(nil)
+	defer prog.Dispose()
+	tr := NewTransformer(prog, "arm64-apple-darwin", "", ModeAllFunc, true)
+	tr.TransformModule("test", mod)
+
+	calleeIR := mod.NamedFunction("callee").String()
+	if !strings.Contains(calleeIR, "define void @callee(ptr sret([1048577 x i8])") {
+		t.Fatalf("large return was not lowered to sret:\n%s", calleeIR)
+	}
+	if strings.Contains(calleeIR, "load %Large") || strings.Contains(calleeIR, "store %Large") {
+		t.Fatalf("callee retained a direct large aggregate copy:\n%s", calleeIR)
+	}
+	copyAtLoad := strings.Index(calleeIR, "call void @llvm.memcpy")
+	mutation := strings.Index(calleeIR, "store i8 9")
+	if copyAtLoad < 0 || mutation < 0 || copyAtLoad >= mutation {
+		t.Fatalf("return value was not copied before source mutation:\n%s", calleeIR)
+	}
+
+	callerIR := mod.NamedFunction("caller").String()
+	for _, want := range []string{"call void @callee(ptr sret([1048577 x i8])", "call void @llvm.memcpy", "load i8"} {
+		if !strings.Contains(callerIR, want) {
+			t.Fatalf("transformed caller missing %q:\n%s", want, callerIR)
+		}
+	}
+	if strings.Contains(callerIR, "load %Large") || strings.Contains(callerIR, "store %Large") {
+		t.Fatalf("caller reconstructed the large return as an SSA value:\n%s", callerIR)
+	}
+	volatileCallerIR := mod.NamedFunction("volatile_caller").String()
+	if !strings.Contains(volatileCallerIR, "load [1048577 x i8]") ||
+		!strings.Contains(volatileCallerIR, "store volatile [1048577 x i8]") {
+		t.Fatalf("volatile call result store was unexpectedly rewritten:\n%s", volatileCallerIR)
+	}
+
+	selfCopyIR := mod.NamedFunction("self_copy").String()
+	if strings.Contains(selfCopyIR, "load %Large") || strings.Contains(selfCopyIR, "store %Large") {
+		t.Fatalf("exact large self-copy was not removed:\n%s", selfCopyIR)
+	}
+	if got := strings.Count(selfCopyIR, "call void @llvm.memcpy"); got != 1 {
+		t.Fatalf("self-copy function has %d memcpy calls, want 1:\n%s", got, selfCopyIR)
+	}
+
+	volatileIR := mod.NamedFunction("volatile_copy").String()
+	if !strings.Contains(volatileIR, "load volatile [1048577 x i8]") ||
+		!strings.Contains(volatileIR, "store [1048577 x i8]") {
+		t.Fatalf("volatile self-copy was unexpectedly removed:\n%s", volatileIR)
+	}
+	if err := llvm.VerifyModule(mod, llvm.ReturnStatusAction); err != nil {
+		t.Fatalf("transformed module is invalid: %v\n%s", err, mod.String())
+	}
+}

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -2367,10 +2367,6 @@ xfails:
     reason: llgo parser recovery emits additional diagnostics after the expected syntax error
   - version: go1.26
     directive: compile
-    case: fixedbugs/issue15141.go
-    reason: llgo codegen exceeds the bounded resource budget for 256MiB array return values
-  - version: go1.26
-    directive: compile
     case: fixedbugs/issue48092.go
     reason: gc-specific -B bounds-checking backend option is not implemented by llgo
   - version: go1.26


### PR DESCRIPTION
## Summary

- add a minimal ARM64 ABI fast path before flattening aggregates, while preserving HFA register returns
- keep large indirect returns in memory in the existing sret conversion paths instead of materializing giant LLVM SSA loads/stores
- remove only exact, non-volatile large self-copies encountered while transforming sret function bodies
- retire the Go 1.26 `fixedbugs/issue15141.go` compile xfail

## Reproducer

The Go 1.26 `fixedbugs/issue15141.go` case returns a 268,435,455-byte array in several ordinary source forms:

```go
func f(i, y int) (a [0xFFFFFFF]byte) {
    a[i] = byte(y)
    return
}

func g(i, y int) [0xFFFFFFF]byte {
    var a [0xFFFFFFF]byte
    a[i] = byte(y)
    return a
}

func h(i, y int) (a [0xFFFFFFF]byte) {
    a[i] = byte(y)
    return a
}
```

All three forms should compile with an indirect ABI return without constructing the array as an element-by-element LLVM value.

## Root cause

The ARM64 classifier previously flattened every aggregate before checking whether its size required indirect passing:

```go
types := elementTypes(p.td, typ)
n := len(types)
// HFA and other small-aggregate checks...
if info.Size > 16 {
    info.Kind = AttrPointer
    info.Type1 = llvm.PointerType(typ, 0)
}
```

For `[0xFFFFFFF]byte`, `elementTypes` therefore attempted to build a slice containing 268,435,455 LLVM types before the existing `Size > 16` branch could select `AttrPointer`. The ABI result was already correct, but reaching it exhausted the bounded compile-time memory budget.

## Design

The `arch.go` change is limited to a five-line ARM64 fast path: aggregates larger than 16 bytes with more than four scalar elements return `AttrPointer` before flattening. The original classifier remains unchanged for all other values, including ARM64 HFAs with up to four elements. Other ABI classifiers and the existing `elementTypes` implementation are unchanged.

The large-copy handling is also local to C ABI indirect returns; there is no module-wide load/store pass. On the callee side, a single-use return load is copied to sret at the original load position, preserving the value before a later source mutation as required by #1608. On the caller side, store-only uses are copied directly from the stable sret temporary. Exact same-address load/store pairs in an sret body are removed as memory no-ops. Volatile or otherwise unsupported uses retain the existing behavior.

`maxDirectAggregateCopySize` (1 MiB) is an LLGo implementation heuristic, not a Go language, ABI, or compiler requirement. It is deliberately far below the 256 MiB reproducer while remaining above ordinary ABI aggregates, so this resource safeguard fixes the pathological LLVM scalarization without broadly changing existing small-value lowering. The Go compiler instead uses its structural `CanSSA` policy and turns non-SSA aggregate copies into memory `Move` operations; adopting that broader policy in LLGo would affect many smaller arrays and structs and is outside this focused fix.

## Validation

- Darwin/arm64 and Linux/amd64 with Go 1.26.5: `fixedbugs/issue15141.go` passes under a 1536 MiB RSS hard limit without reaching the 256 MiB warning threshold
- complete `go test ./internal/cabi` passes on Darwin/arm64 and Linux/amd64
- Darwin package statement coverage: 96.8%; the new aggregate classification helpers and `transformFuncBody` are 100% covered
- regression IR verifies copy-before-mutation semantics, direct use of the sret temporary, exact self-copy removal, HFA preservation, and unchanged volatile operations
- `go vet ./internal/cabi` and `git diff --check` pass
