### PR TITLE
test/goroot: normalize go/types diagnostics

### DIFF
--- a/test/goroot/runner_test.go
+++ b/test/goroot/runner_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/build"
+	"go/constant"
 	"go/format"
 	"go/parser"
 	"go/token"
@@ -1073,6 +1074,22 @@ type wantedError struct {
 	file    string
 	line    int
 	auto    bool
+	source  string
+}
+
+type compilerDiagnostic struct {
+	file    string
+	line    int
+	message string
+}
+
+func (diagnostic compilerDiagnostic) locationKey() string {
+	return path.Base(diagnostic.file) + ":" + strconv.Itoa(diagnostic.line)
+}
+
+type matchedDiagnostic struct {
+	compilerDiagnostic
+	expected wantedError
 }
 
 type diagnosticSource struct {
@@ -1085,7 +1102,8 @@ var (
 	errorAutoRx    = regexp.MustCompile(`// (?:GC_)?ERRORAUTO (.*)`)
 	errorQuotesRx  = regexp.MustCompile(`"([^"]*)"`)
 	errorLineRx    = regexp.MustCompile(`LINE(([+-])(\d+))?`)
-	diagnosticRx   = regexp.MustCompile(`^(.*?):([0-9]+)(?::[0-9]+)?: (.*)$`)
+	diagnosticRx   = regexp.MustCompile(`^(.*?):([0-9]+)(?:\[[^]]*\])?(?::[0-9]+)?: (.*)$`)
+	gotoOverDeclRx = regexp.MustCompile(`^goto \S+ jumps over variable declaration at line [0-9]+$`)
 )
 
 func checkExpectedErrors(output, fullPath, shortPath string) error {
@@ -1099,19 +1117,27 @@ func checkExpectedErrorsForFiles(output string, sources []diagnosticSource) erro
 			lines[i] = replaceDiagnosticPrefix(lines[i], source.full, source.short)
 		}
 	}
+	lines = normalizeCompilerDiagnostics(lines)
 	lines = preferSpecificDiagnostics(lines)
 	var wanted []wantedError
+	sourceLines := make(map[string][]string, len(sources))
 	for _, source := range sources {
 		expected, err := wantedErrors(source.full, source.short)
 		if err != nil {
 			return err
 		}
 		wanted = append(wanted, expected...)
+		data, err := os.ReadFile(source.full)
+		if err != nil {
+			return err
+		}
+		sourceLines[normalizeDiagnosticPath(source.short)] = strings.Split(string(data), "\n")
 	}
 	pathResolver := newDiagnosticPathResolver(sources)
 	lexicalLocations := make(map[string]bool)
 	var parserRecoveryPairs []parserRecoveryPair
 	var errs []error
+	var matchedDiagnostics []matchedDiagnostic
 	for _, expected := range wanted {
 		var candidates []string
 		if expected.auto {
@@ -1137,7 +1163,7 @@ func checkExpectedErrorsForFiles(output string, sources []diagnosticSource) erro
 			if matchesExpectedDiagnostic(expected.regexp, message) || parserAlias {
 				matched = true
 				if ok && isScopedLexicalDiagnostic(message) {
-					lexicalLocations[diagnostic.location] = true
+					lexicalLocations[diagnostic.locationKey()] = true
 				}
 				if sourceOK {
 					if secondaries := parserRecoverySecondaries(message); len(secondaries) != 0 {
@@ -1146,6 +1172,17 @@ func checkExpectedErrorsForFiles(output string, sources []diagnosticSource) erro
 						})
 					}
 				}
+				if !ok {
+					diagnostic = compilerDiagnostic{
+						file:    normalizeDiagnosticPath(expected.file),
+						line:    expected.line,
+						message: message,
+					}
+				}
+				matchedDiagnostics = append(matchedDiagnostics, matchedDiagnostic{
+					compilerDiagnostic: diagnostic,
+					expected:           expected,
+				})
 			} else {
 				lines = append(lines, candidate)
 			}
@@ -1156,6 +1193,7 @@ func checkExpectedErrorsForFiles(output string, sources []diagnosticSource) erro
 	}
 	lines = discardLexicalRecoveryDiagnostics(lines, lexicalLocations)
 	lines = discardPairedParserDiagnostics(lines, pathResolver, parserRecoveryPairs)
+	lines = filterSecondaryDiagnostics(lines, matchedDiagnostics, sourceLines)
 
 	local := lines[:0]
 	for _, line := range lines {
@@ -1175,9 +1213,323 @@ func checkExpectedErrorsForFiles(output string, sources []diagnosticSource) erro
 	return errors.Join(errs...)
 }
 
-type compilerDiagnostic struct {
-	location string
-	message  string
+// normalizeCompilerDiagnostics maps the go/types spellings emitted by llgo to
+// equivalent gc spellings already accepted by GOROOT's ERROR expressions.
+func normalizeCompilerDiagnostics(lines []string) []string {
+	for i, line := range lines {
+		diagnostic, ok := parseCompilerDiagnostic(line)
+		if !ok {
+			continue
+		}
+		message := normalizeCompilerDiagnosticMessage(diagnostic.message)
+		if message != diagnostic.message {
+			lines[i] = line[:len(line)-len(diagnostic.message)] + message
+		}
+	}
+	return lines
+}
+
+func normalizeCompilerDiagnosticMessage(message string) string {
+	switch message {
+	case "continue not in for statement":
+		return "continue is not in a loop"
+	case "break not in for, switch, or select statement":
+		return "break is not in a loop, switch, or select"
+	case "expected at most 2 expressions":
+		return "range clause permits at most two iteration variables"
+	case "invalid syntax tree: incorrect form of type switch guard":
+		return "invalid variable name in type switch guard"
+	}
+	if gotoOverDeclRx.MatchString(message) {
+		return "goto jumps over declaration"
+	}
+	if strings.HasPrefix(message, "label ") {
+		switch {
+		case strings.HasSuffix(message, " declared and not used"):
+			return strings.TrimSuffix(message, " declared and not used") + " defined and not used"
+		case strings.HasSuffix(message, " already declared"):
+			return strings.TrimSuffix(message, " already declared") + " already defined"
+		case strings.HasSuffix(message, " not declared"):
+			return strings.TrimSuffix(message, " not declared") + " not defined"
+		}
+	}
+	const modernIntAssignment = ") as int value in variable declaration"
+	if strings.Contains(message, modernIntAssignment) {
+		return strings.Replace(message, modernIntAssignment, ") as type int in variable declaration", 1)
+	}
+	return message
+}
+
+func normalizeDiagnosticPath(value string) string {
+	return filepath.ToSlash(filepath.Clean(value))
+}
+
+func diagnosticPathsEqual(left, right string) bool {
+	left = normalizeDiagnosticPath(left)
+	right = normalizeDiagnosticPath(right)
+	if left == right {
+		return true
+	}
+	return !strings.Contains(left, "/") && path.Base(right) == left ||
+		!strings.Contains(right, "/") && path.Base(left) == right
+}
+
+// filterSecondaryDiagnostics removes a go/types follow-on only when its gc-style
+// primary diagnostic was already matched. This keeps every ERROR mandatory and
+// leaves unrelated local diagnostics visible to the unmatched-error check.
+func filterSecondaryDiagnostics(lines []string, matched []matchedDiagnostic, sources map[string][]string) []string {
+	out := lines[:0]
+	for _, line := range lines {
+		diagnostic, ok := parseCompilerDiagnostic(line)
+		if ok && isSecondaryDiagnostic(diagnostic, matched, sources[diagnostic.file]) {
+			continue
+		}
+		out = append(out, line)
+	}
+	return out
+}
+
+func isSecondaryDiagnostic(diagnostic compilerDiagnostic, matched []matchedDiagnostic, source []string) bool {
+	if strings.HasPrefix(diagnostic.message, "initialization cycle for ") &&
+		hasMatchedDiagnostic(matched, diagnostic.file, diagnostic.line, func(item matchedDiagnostic) bool {
+			return strings.Contains(item.expected.pattern, "initialization loop")
+		}) {
+		return true
+	}
+
+	if strings.HasPrefix(diagnostic.message, "invalid recursive type ") &&
+		hasMatchedDiagnostic(matched, diagnostic.file, diagnostic.line, func(item matchedDiagnostic) bool {
+			return strings.Contains(item.expected.pattern, "invalid recursive type")
+		}) {
+		return true
+	}
+
+	if label, ok := unusedLabel(diagnostic.message); ok &&
+		hasMatchedDiagnostic(matched, diagnostic.file, 0, func(item matchedDiagnostic) bool {
+			invalidLabel := item.message == "invalid break label "+label || item.message == "invalid continue label "+label
+			return invalidLabel && sameFunctionScope(source, diagnostic.line, item.line)
+		}) {
+		return true
+	}
+
+	if strings.HasSuffix(diagnostic.message, " (type) is not an expression") &&
+		hasMatchedDiagnostic(matched, diagnostic.file, diagnostic.line, func(item matchedDiagnostic) bool {
+			return strings.HasPrefix(item.message, "undefined: ")
+		}) {
+		return true
+	}
+
+	if diagnostic.message == "invalid use of [...] array (outside a composite literal)" &&
+		hasMatchedDiagnostic(matched, diagnostic.file, diagnostic.line, func(item matchedDiagnostic) bool {
+			return item.message == "cannot parenthesize type in composite literal"
+		}) {
+		return true
+	}
+
+	if diagnostic.message == "range clause permits at most two iteration variables" &&
+		hasMatchedDiagnostic(matched, diagnostic.file, diagnostic.line, func(item matchedDiagnostic) bool {
+			return strings.HasPrefix(item.message, "range over ") && strings.HasSuffix(item.message, " permits only one iteration variable")
+		}) {
+		return true
+	}
+
+	if hasMatchedDiagnostic(matched, diagnostic.file, 0, func(item matchedDiagnostic) bool {
+		return item.message == "too many errors" && diagnostic.line > item.line
+	}) {
+		return true
+	}
+
+	if name, local, ok := unusedName(diagnostic.message); ok &&
+		hasMatchedDiagnostic(matched, diagnostic.file, 0, func(item matchedDiagnostic) bool {
+			code, _, _ := strings.Cut(item.expected.source, "//")
+			if !strings.Contains(item.message, "must be function call") || !containsIdentifier(code, name) {
+				return false
+			}
+			return !local || sameFunctionScope(source, diagnostic.line, item.line)
+		}) {
+		return true
+	}
+
+	return isSpuriousContextualShift(diagnostic, source)
+}
+
+func hasMatchedDiagnostic(matched []matchedDiagnostic, file string, line int, predicate func(matchedDiagnostic) bool) bool {
+	for _, item := range matched {
+		if item.file != file || line != 0 && item.line != line {
+			continue
+		}
+		if predicate(item) {
+			return true
+		}
+	}
+	return false
+}
+
+func unusedLabel(message string) (string, bool) {
+	const prefix = "label "
+	const suffix = " defined and not used"
+	if !strings.HasPrefix(message, prefix) || !strings.HasSuffix(message, suffix) {
+		return "", false
+	}
+	return strings.TrimSuffix(strings.TrimPrefix(message, prefix), suffix), true
+}
+
+func unusedName(message string) (name string, local, ok bool) {
+	const declaredPrefix = "declared and not used: "
+	if strings.HasPrefix(message, declaredPrefix) {
+		return strings.TrimPrefix(message, declaredPrefix), true, true
+	}
+	const importedSuffix = " imported and not used"
+	if !strings.HasSuffix(message, importedSuffix) {
+		return "", false, false
+	}
+	importPath, err := strconv.Unquote(strings.TrimSuffix(message, importedSuffix))
+	if err != nil {
+		return "", false, false
+	}
+	return path.Base(importPath), false, true
+}
+
+func containsIdentifier(source, name string) bool {
+	for index := 0; index < len(source); {
+		for index < len(source) && !isIdentifierByte(source[index]) {
+			index++
+		}
+		start := index
+		for index < len(source) && isIdentifierByte(source[index]) {
+			index++
+		}
+		if source[start:index] == name {
+			return true
+		}
+	}
+	return false
+}
+
+func isIdentifierByte(value byte) bool {
+	return value == '_' || value >= '0' && value <= '9' || value >= 'A' && value <= 'Z' || value >= 'a' && value <= 'z'
+}
+
+type functionScope struct {
+	start int
+	end   int
+}
+
+func sameFunctionScope(source []string, first, second int) bool {
+	firstScope, firstOK := enclosingFunctionScope(source, first)
+	secondScope, secondOK := enclosingFunctionScope(source, second)
+	return firstOK && secondOK && firstScope == secondScope
+}
+
+func enclosingFunctionScope(source []string, line int) (functionScope, bool) {
+	fset := token.NewFileSet()
+	file, _ := parser.ParseFile(fset, "errorcheck.go", strings.Join(source, "\n"), 0)
+	if file == nil {
+		return functionScope{}, false
+	}
+	var best functionScope
+	found := false
+	consider := func(body *ast.BlockStmt) {
+		if body == nil {
+			return
+		}
+		scope := functionScope{
+			start: fset.Position(body.Pos()).Line,
+			end:   fset.Position(body.End()).Line,
+		}
+		if line < scope.start || line > scope.end {
+			return
+		}
+		if !found || scope.end-scope.start < best.end-best.start {
+			best = scope
+			found = true
+		}
+	}
+	ast.Inspect(file, func(node ast.Node) bool {
+		switch node := node.(type) {
+		case *ast.FuncDecl:
+			consider(node.Body)
+		case *ast.FuncLit:
+			consider(node.Body)
+		}
+		return true
+	})
+	return best, found
+}
+
+func isSpuriousContextualShift(diagnostic compilerDiagnostic, source []string) bool {
+	const suffix = " (untyped float value) must be integer"
+	if !strings.HasPrefix(diagnostic.message, "invalid operation: shifted operand (") ||
+		!strings.HasSuffix(diagnostic.message, suffix) || diagnostic.line < 1 || diagnostic.line > len(source) {
+		return false
+	}
+	if strings.Contains(source[diagnostic.line-1], "// ERROR") {
+		return false
+	}
+	fset := token.NewFileSet()
+	file, _ := parser.ParseFile(fset, "errorcheck.go", strings.Join(source, "\n"), 0)
+	if file == nil {
+		return false
+	}
+	spurious := false
+	ast.Inspect(file, func(node ast.Node) bool {
+		assignment, ok := node.(*ast.AssignStmt)
+		if !ok || assignment.Tok != token.ASSIGN || len(assignment.Lhs) != 1 || len(assignment.Rhs) != 1 {
+			return true
+		}
+		if start, end := fset.Position(assignment.Pos()).Line, fset.Position(assignment.End()).Line; diagnostic.line < start || diagnostic.line > end {
+			return true
+		}
+		name, ok := assignment.Lhs[0].(*ast.Ident)
+		if !ok || !isExplicitIntObject(name.Obj) || !isIntegralFloatNestedShift(assignment.Rhs[0]) {
+			return true
+		}
+		spurious = true
+		return false
+	})
+	return spurious
+}
+
+func isExplicitIntObject(object *ast.Object) bool {
+	if object == nil || object.Kind != ast.Var {
+		return false
+	}
+	var expression ast.Expr
+	switch declaration := object.Decl.(type) {
+	case *ast.ValueSpec:
+		expression = declaration.Type
+	case *ast.Field:
+		expression = declaration.Type
+	default:
+		return false
+	}
+	name, ok := expression.(*ast.Ident)
+	return ok && name.Name == "int"
+}
+
+func isIntegralFloatNestedShift(expression ast.Expr) bool {
+	outer, ok := expression.(*ast.BinaryExpr)
+	if !ok || outer.Op != token.SHL {
+		return false
+	}
+	innerExpression := outer.X
+	if paren, ok := innerExpression.(*ast.ParenExpr); ok {
+		innerExpression = paren.X
+	}
+	inner, ok := innerExpression.(*ast.BinaryExpr)
+	if !ok || inner.Op != token.SHL {
+		return false
+	}
+	literal, ok := inner.X.(*ast.BasicLit)
+	if !ok || literal.Kind != token.FLOAT {
+		return false
+	}
+	value := constant.MakeFromLiteral(literal.Value, token.FLOAT, 0)
+	if value.Kind() == constant.Unknown {
+		return false
+	}
+	_, exact := constant.Int64Val(constant.ToInt(value))
+	return exact
 }
 
 type sourceDiagnostic struct {
@@ -1315,9 +1667,14 @@ func parseCompilerDiagnostic(line string) (compilerDiagnostic, bool) {
 	if match == nil {
 		return compilerDiagnostic{}, false
 	}
+	lineNumber, err := strconv.Atoi(match[2])
+	if err != nil {
+		return compilerDiagnostic{}, false
+	}
 	return compilerDiagnostic{
-		location: filepath.Base(match[1]) + ":" + match[2],
-		message:  match[3],
+		file:    normalizeDiagnosticPath(match[1]),
+		line:    lineNumber,
+		message: match[3],
 	}, true
 }
 
@@ -1385,7 +1742,7 @@ func discardLexicalRecoveryDiagnostics(lines []string, lexicalLocations map[stri
 	out := lines[:0]
 	for _, line := range lines {
 		diagnostic, ok := parseCompilerDiagnostic(line)
-		if ok && lexicalLocations[diagnostic.location] && isLexicalRecoveryDiagnostic(diagnostic.message) {
+		if ok && lexicalLocations[diagnostic.locationKey()] && isLexicalRecoveryDiagnostic(diagnostic.message) {
 			continue
 		}
 		out = append(out, line)
@@ -1418,11 +1775,11 @@ func preferSpecificDiagnostics(lines []string) []string {
 		parsed[i], _ = parseCompilerDiagnostic(line)
 	}
 	for i := range lines {
-		if parsed[i].location == "" || discard[i] {
+		if parsed[i].file == "" || discard[i] {
 			continue
 		}
 		for j := i + 1; j < len(lines); j++ {
-			if parsed[i].location != parsed[j].location || discard[j] {
+			if parsed[i].line != parsed[j].line || !diagnosticPathsEqual(parsed[i].file, parsed[j].file) || discard[j] {
 				continue
 			}
 			switch {
@@ -1513,6 +1870,7 @@ func wantedErrors(fullPath, shortPath string) ([]wantedError, error) {
 				file:    shortPath,
 				line:    lineNumber,
 				auto:    auto,
+				source:  sourceLine,
 			})
 		}
 	}
@@ -1520,16 +1878,23 @@ func wantedErrors(fullPath, shortPath string) ([]wantedError, error) {
 }
 
 func hasDiagnosticPrefix(line, prefix string) bool {
-	colon := strings.IndexByte(line, ':')
-	if colon < 0 {
+	firstLine, _, _ := strings.Cut(line, "\n")
+	diagnostic, ok := parseCompilerDiagnostic(firstLine)
+	if !ok {
 		return false
 	}
-	slash := strings.LastIndex(line[:colon], "/")
-	base := line[slash+1:]
-	if len(base) <= len(prefix) || !strings.HasPrefix(base, prefix) {
+	expectedPath := prefix
+	expectedLine := 0
+	if colon := strings.LastIndexByte(prefix, ':'); colon >= 0 {
+		if lineNumber, err := strconv.Atoi(prefix[colon+1:]); err == nil {
+			expectedPath = prefix[:colon]
+			expectedLine = lineNumber
+		}
+	}
+	if expectedLine != 0 && diagnostic.line != expectedLine {
 		return false
 	}
-	return base[len(prefix)] == ':' || base[len(prefix)] == '['
+	return diagnosticPathsEqual(diagnostic.file, expectedPath)
 }
 
 func partitionCompilerOutput(prefix string, lines []string) (matched, unmatched []string) {

--- a/test/goroot/runner_unit_test.go
+++ b/test/goroot/runner_unit_test.go
@@ -717,13 +717,327 @@ func TestPreferSpecificDiagnostics(t *testing.T) {
 		"case.go:18:16: requires go1.22 or later (file declares go1.21)",
 		"/tmp/case.go:18: requires go1.22 or later",
 		"case.go:19: a different error",
+		"/tmp/left/case.go:20: same text",
+		"/tmp/right/case.go:20: same text",
 	})
 	want := []string{
 		"case.go:18:16: requires go1.22 or later (file declares go1.21)",
 		"case.go:19: a different error",
+		"/tmp/left/case.go:20: same text",
+		"/tmp/right/case.go:20: same text",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("preferSpecificDiagnostics()=%v, want %v", got, want)
+	}
+}
+
+func TestNormalizeCompilerDiagnosticMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "continue", in: "continue not in for statement", want: "continue is not in a loop"},
+		{name: "break", in: "break not in for, switch, or select statement", want: "break is not in a loop, switch, or select"},
+		{name: "range count", in: "expected at most 2 expressions", want: "range clause permits at most two iteration variables"},
+		{name: "type switch", in: "invalid syntax tree: incorrect form of type switch guard", want: "invalid variable name in type switch guard"},
+		{name: "initialization", in: "initialization cycle for a", want: "initialization cycle for a"},
+		{name: "goto position", in: "goto L jumps over variable declaration at line 43", want: "goto jumps over declaration"},
+		{name: "unused label", in: "label L declared and not used", want: "label L defined and not used"},
+		{name: "duplicate label", in: "label L already declared", want: "label L already defined"},
+		{name: "missing label", in: "label L not declared", want: "label L not defined"},
+		{
+			name: "assignment type",
+			in:   "cannot use complex(1, 2) (value of type complex128) as int value in variable declaration",
+			want: "cannot use complex(1, 2) (value of type complex128) as type int in variable declaration",
+		},
+		{name: "different range count", in: "expected at most 3 expressions", want: "expected at most 3 expressions"},
+		{name: "goto without position", in: "goto L jumps over variable declaration", want: "goto L jumps over variable declaration"},
+		{name: "non-declaration assignment", in: "cannot use x as int value in argument", want: "cannot use x as int value in argument"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeCompilerDiagnosticMessage(tt.in); got != tt.want {
+				t.Fatalf("normalizeCompilerDiagnosticMessage(%q)=%q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckExpectedErrorsFiltersDeterministicSecondaryDiagnostics(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		output string
+	}{
+		{
+			name: "initialization summary",
+			source: `package p
+var a = b // ERROR "a refers to b\n.*b refers to a|initialization loop"
+var b = a
+`,
+			output: "case.go:2: initialization cycle for a\ncase.go:2: a refers to b\n\tcase.go:3: b refers to a\n",
+		},
+		{
+			name: "unused invalid label",
+			source: `package p
+func f() {
+L:
+	break L // ERROR "invalid break label L"
+}
+`,
+			output: "case.go:4: invalid break label L\ncase.go:3: label L declared and not used\n",
+		},
+		{
+			name: "invalid type expression",
+			source: `package p
+var _ = Missing // ERROR "undefined: Missing"
+`,
+			output: "case.go:2: undefined: Missing\ncase.go:2: Missing (type) is not an expression\n",
+		},
+		{
+			name: "inferred array after parenthesized type",
+			source: `package p
+var _ = ([...]int){} // ERROR "parenthesize"
+`,
+			output: "case.go:2: cannot parenthesize type in composite literal\ncase.go:2: invalid use of [...] array (outside a composite literal)\n",
+		},
+		{
+			name: "channel range arity",
+			source: `package p
+var _ = 0 // ERROR "range over .* permits only one iteration variable"
+`,
+			output: "case.go:2: range over ch (variable of type chan int) permits only one iteration variable\ncase.go:2: expected at most 2 expressions\n",
+		},
+		{
+			name: "recursive type summary",
+			source: `package p
+type I interface{} // ERROR "invalid recursive type I\n\tcase.go:2:.*I refers to I"
+`,
+			output: "case.go:2: invalid recursive type I\ncase.go:2: invalid recursive type I\n\tcase.go:2: I refers to I\n",
+		},
+		{
+			name: "error limit",
+			source: `package p
+var _ = a // ERROR "undefined: a" "too many errors"
+var _ = b
+`,
+			output: "case.go:2: undefined: a\ncase.go:2: too many errors\ncase.go:3: undefined: b\n",
+		},
+		{
+			name: "unused names in invalid go statement",
+			source: `package p
+import "fmt"
+func f() {
+	go func() { fmt.Println() } // ERROR "must be function call"
+}
+`,
+			output: "case.go:4: expression in go must be function call\ncase.go:2: \"fmt\" imported and not used\n",
+		},
+		{
+			name: "unused local in invalid go statement",
+			source: `package p
+func f() {
+	var i int
+	go func() { _ = i } // ERROR "must be function call"
+}
+`,
+			output: "case.go:4: expression in go must be function call\ncase.go:3: declared and not used: i\n",
+		},
+		{
+			name: "contextual integer shift",
+			source: `package p
+var x int
+var _ = missing // ERROR "undefined: missing"
+func f(s uint) {
+	x = (1. << s) << (1 << s)
+}
+`,
+			output: "case.go:3: undefined: missing\ncase.go:5: invalid operation: shifted operand (1. << s) (untyped float value) must be integer\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file := filepath.Join(t.TempDir(), "case.go")
+			if err := os.WriteFile(file, []byte(tt.source), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := checkExpectedErrors(tt.output, file, "case.go"); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestCheckExpectedErrorsKeepsUnrelatedTypeDiagnostics(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		output string
+	}{
+		{
+			name: "unrelated",
+			source: `package p
+var _ = missing // ERROR "undefined: missing"
+var _ = other
+`,
+			output: "case.go:2: undefined: missing\ncase.go:3: unrelated diagnostic\n",
+		},
+		{
+			name: "unused import not referenced by primary",
+			source: `package p
+import "math"
+func f() {
+	go func() { fmt.Println() } // ERROR "must be function call"
+}
+`,
+			output: "case.go:4: expression in go must be function call\ncase.go:2: \"math\" imported and not used\n",
+		},
+		{
+			name: "same label in different functions",
+			source: `package p
+func first() {
+L:
+	break L // ERROR "invalid break label L"
+}
+func second() {
+L:
+}
+`,
+			output: "case.go:4: invalid break label L\ncase.go:7: label L declared and not used\n",
+		},
+		{
+			name: "same local name in different functions",
+			source: `package p
+var i int
+func first() {
+	go func() { _ = i } // ERROR "must be function call"
+}
+func second() {
+	var i int
+}
+`,
+			output: "case.go:4: expression in go must be function call\ncase.go:7: declared and not used: i\n",
+		},
+		{
+			name: "shift without integer context",
+			source: `package p
+var x float64
+var _ = missing // ERROR "undefined: missing"
+func f(s uint) {
+	x = (1. << s) << (1 << s)
+}
+`,
+			output: "case.go:3: undefined: missing\ncase.go:5: invalid operation: shifted operand (1. << s) (untyped float value) must be integer\n",
+		},
+		{
+			name: "shift with integer in different function",
+			source: `package p
+var _ = missing // ERROR "undefined: missing"
+func first() {
+	var x int
+	_ = x
+}
+func second(s uint) {
+	x = (1. << s) << (1 << s)
+}
+`,
+			output: "case.go:2: undefined: missing\ncase.go:8: invalid operation: shifted operand (1. << s) (untyped float value) must be integer\n",
+		},
+		{
+			name: "shift with integer in sibling block",
+			source: `package p
+var _ = missing // ERROR "undefined: missing"
+func f(s uint) {
+	{
+		var x int
+		_ = x
+	}
+	x = (1. << s) << (1 << s)
+}
+`,
+			output: "case.go:2: undefined: missing\ncase.go:8: invalid operation: shifted operand (1. << s) (untyped float value) must be integer\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file := filepath.Join(t.TempDir(), "case.go")
+			if err := os.WriteFile(file, []byte(tt.source), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			err := checkExpectedErrors(tt.output, file, "case.go")
+			if err == nil || !strings.Contains(err.Error(), "unmatched errors") {
+				t.Fatalf("err=%v, want unmatched error", err)
+			}
+		})
+	}
+}
+
+func TestCheckExpectedErrorsSeparatesSameBasenameSources(t *testing.T) {
+	root := t.TempDir()
+	leftDir := filepath.Join(root, "left")
+	rightDir := filepath.Join(root, "right")
+	if err := os.MkdirAll(leftDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(rightDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	left := filepath.Join(leftDir, "case.go")
+	right := filepath.Join(rightDir, "case.go")
+	if err := os.WriteFile(left, []byte("package p\nvar _ = left // ERROR \"undefined: left\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(right, []byte("package p\nvar _ = right // ERROR \"undefined: right\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	output := left + ":2: undefined: left\n" + right + ":2: undefined: right\n"
+	err := checkExpectedErrorsForFiles(output, []diagnosticSource{
+		{full: left, short: "left/case.go"},
+		{full: right, short: "right/case.go"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSecondaryDiagnosticsDoNotCrossSameBasenameSources(t *testing.T) {
+	root := t.TempDir()
+	left := filepath.Join(root, "left", "case.go")
+	right := filepath.Join(root, "right", "case.go")
+	for _, file := range []string{left, right} {
+		if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	leftSource := `package p
+func first() {
+L:
+	break L // ERROR "invalid break label L"
+}
+`
+	rightSource := `package p
+func second() {
+L:
+	_ = 0
+}
+var _ = missing // ERROR "undefined: missing"
+`
+	if err := os.WriteFile(left, []byte(leftSource), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(right, []byte(rightSource), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	output := left + ":4: invalid break label L\n" +
+		right + ":6: undefined: missing\n" +
+		right + ":3: label L declared and not used\n"
+	err := checkExpectedErrorsForFiles(output, []diagnosticSource{
+		{full: left, short: "left/case.go"},
+		{full: right, short: "right/case.go"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "right/case.go:3") {
+		t.Fatalf("err=%v, want unmatched right/case.go diagnostic", err)
 	}
 }
 

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1787,20 +1787,12 @@ xfails:
     reason: gc-specific nil-check elimination diagnostics are not implemented by llgo
   - version: go1.26
     directive: errorcheck
-    case: initloop.go
-    reason: llgo reports an additional initialization-cycle summary diagnostic
-  - version: go1.26
-    directive: errorcheck
     case: fixedbugs/issue11362.go
     reason: llgo uses different non-canonical import-path diagnostic punctuation
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/issue23664.go
     reason: llgo parser recovery emits additional malformed-declaration diagnostics
-  - version: go1.26
-    directive: errorcheck
-    case: syntax/typesw.go
-    reason: llgo reports an additional invalid type-switch syntax-tree diagnostic
   - version: go1.26
     directive: errorcheck
     case: escape6.go
@@ -1881,10 +1873,6 @@ xfails:
     directive: errorcheck
     case: fixedbugs/issue18092.go
     reason: llgo parser recovery emits additional malformed-channel diagnostics
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue23586.go
-    reason: llgo reports additional unused variable and import diagnostics
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/issue4776.go
@@ -1971,10 +1959,6 @@ xfails:
     reason: llgo parser recovery emits additional malformed-statement diagnostics
   - version: go1.26
     directive: errorcheck
-    case: fixedbugs/issue50372.go
-    reason: llgo reports additional expression-count diagnostics
-  - version: go1.26
-    directive: errorcheck
     case: syntax/semi4.go
     reason: llgo parser recovery emits additional semicolon and brace diagnostics
   - version: go1.26
@@ -2023,14 +2007,6 @@ xfails:
     reason: llgo loader reports an embed-pattern error instead of the expected local-variable directive error
   - version: go1.26
     directive: errorcheck
-    case: shift1.go
-    reason: llgo reports additional shifted-operand diagnostics at different source positions
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/bug136.go
-    reason: llgo reports additional unused-label diagnostics
-  - version: go1.26
-    directive: errorcheck
     case: fixedbugs/issue13266.go
     reason: llgo parser uses a different malformed-package-clause diagnostic
   - version: go1.26
@@ -2053,14 +2029,6 @@ xfails:
     directive: errorcheck
     case: fixedbugs/notinheap.go
     reason: gc-specific notinheap allocation diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: goto.go
-    reason: llgo reports goto diagnostics at different source positions
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/bug195.go
-    reason: llgo reports an additional recursive-interface diagnostic
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/issue13248.go
@@ -2129,10 +2097,6 @@ xfails:
     directive: errorcheck
     case: fixedbugs/issue20780.go
     reason: gc-specific stack-frame size diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue7538a.go
-    reason: llgo reports an additional blank-label resolution diagnostic
   - version: go1.26
     directive: errorcheck
     case: bounds.go
@@ -2247,18 +2211,6 @@ xfails:
     reason: gc-specific -m optimization diagnostics are not implemented by llgo
   - version: go1.26
     directive: errorcheck
-    case: label1.go
-    reason: llgo reports additional invalid-label control-flow diagnostics
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/bug300.go
-    reason: llgo reports an additional invalid inferred-array diagnostic
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue20298.go
-    reason: llgo reports unused imports after the expected import-path validation errors
-  - version: go1.26
-    directive: errorcheck
     case: syntax/composite.go
     reason: llgo parser reports an additional missing-comma diagnostic
   - version: go1.26
@@ -2281,10 +2233,6 @@ xfails:
     directive: errorcheck
     case: fixedbugs/issue35518.go
     reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: label.go
-    reason: llgo reports additional label declaration and resolution diagnostics
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/bug121.go
@@ -2327,10 +2275,6 @@ xfails:
     reason: llgo parser recovery emits additional undefined-name diagnostics
   - version: go1.26
     directive: errorcheck
-    case: fixedbugs/issue20245.go
-    reason: llgo reports an additional interface-type expression diagnostic
-  - version: go1.26
-    directive: errorcheck
     case: escape_closure.go
     reason: gc-specific -m escape-analysis diagnostics are not implemented by llgo
   - version: go1.26
@@ -2363,16 +2307,8 @@ xfails:
     reason: gc runtime inlining diagnostics are not implemented by llgo
   - version: go1.26
     directive: errorcheck
-    case: fixedbugs/bug179.go
-    reason: llgo reports an additional unused-label diagnostic after invalid branch labels
-  - version: go1.26
-    directive: errorcheck
     case: fixedbugs/issue11610.go
     reason: llgo parser reports additional illegal-character diagnostics
-  - version: go1.26
-    directive: errorcheck
-    case: fixedbugs/issue20233.go
-    reason: llgo reports an additional invalid function-type expression diagnostic
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/issue22164.go


### PR DESCRIPTION
## Summary

- normalize the narrow set of stable go/types spellings equivalent to gc errorcheck diagnostics
- discard deterministic secondary diagnostics only after the required primary ERROR has matched, with full-path, line, function-scope, or AST-binding guards
- keep same-basename cross-directory diagnostics, same-name cross-function diagnostics, and unrelated shifted operands strict
- retire exactly 16 Go 1.26 type-checker-related errorcheck xfails

## Integration with current main

This branch is rebased onto current `main`, including #2105. Scanner, parser, and go/types compatibility now share one parsed diagnostic representation and one matching pass:

1. normalize only the known go/types message aliases
2. require the source `ERROR` expression to match
3. remove exact scanner/parser recovery diagnostics associated with that match
4. remove only deterministic go/types secondary diagnostics associated with that match

Unmatched and unrelated diagnostics remain errors.

## Validation

- Darwin/arm64, Go 1.26.5 after rebase:
  - complete `test/goroot` package tests pass
  - all 16 focused cases and the `fixedbugs/bug299.go` / `fixedbugs/issue5089.go` negative boundaries pass
  - a full 650-case errorcheck sweep completed 649 cases under a 3 GiB per-process guard; the unrelated existing xfail `fixedbugs/issue20780.go` was stopped only by the guard after exceeding 3 GiB
  - an isolated `issue20780.go` retry was stopped after exceeding a 5 GiB guard, so the limit was not raised further on this host
- Before this rebase, the complete 650-case Darwin sweep passed without an RSS guard.
- Linux/amd64, Go 1.26.0 + LLVM 19 under VZ/Rosetta: unit, race, vet, and all 16 focused cases pass with an empty xfail file.
- `gofmt` and `git diff --check` pass.

`test/goroot` contains only `_test.go` sources, so Go coverage reports `[no statements]`. The changed branches are exercised by positive and negative unit tests plus the focused and full errorcheck sweeps.
