### PR TITLE
abi: lower large aggregate returns indirectly

### DIFF
--- a/internal/abi/large.go
+++ b/internal/abi/large.go
@@ -1,0 +1,245 @@
+// Package abi contains target-independent lowering for LLGo's internal ABI.
+package abi
+
+import "github.com/xgo-dev/llvm"
+
+const (
+	// MaxStackVarSize matches cmd/compile's default limit for explicitly
+	// declared variables. Values larger than this must not live on LLGo's
+	// fixed native stack.
+	MaxStackVarSize uint64 = 128 * 1024
+	// MaxImplicitStackVarSize matches cmd/compile's default limit for
+	// compiler-generated temporaries.
+	MaxImplicitStackVarSize uint64 = 64 * 1024
+
+	runtimeAllocU = "github.com/goplus/llgo/runtime/internal/runtime.AllocU"
+)
+
+// LowerLargeAggregates converts oversized direct aggregate returns to an
+// indirect result pointer before target-specific C ABI lowering runs.
+func LowerLargeAggregates(td llvm.TargetData, m llvm.Module) {
+	l := largeAggregateLowerer{td: td}
+	l.transformModule(m)
+}
+
+type largeAggregateLowerer struct {
+	td llvm.TargetData
+}
+
+func (l largeAggregateLowerer) isLargeAggregate(typ llvm.Type) bool {
+	switch typ.TypeKind() {
+	case llvm.ArrayTypeKind, llvm.StructTypeKind:
+		return l.td.TypeAllocSize(typ) > MaxImplicitStackVarSize
+	}
+	return false
+}
+
+func (l largeAggregateLowerer) indirectType(ctx llvm.Context, typ llvm.Type) llvm.Type {
+	params := append([]llvm.Type{llvm.PointerType(typ.ReturnType(), 0)}, typ.ParamTypes()...)
+	return llvm.FunctionType(ctx.VoidType(), params, typ.IsFunctionVarArg())
+}
+
+func (l largeAggregateLowerer) transformModule(m llvm.Module) {
+	var calls []llvm.Value
+	var funcs []llvm.Value
+	for fn := m.FirstFunction(); !fn.IsNil(); fn = llvm.NextFunction(fn) {
+		if fn.IntrinsicID() == 0 && l.isLargeAggregate(fn.GlobalValueType().ReturnType()) {
+			funcs = append(funcs, fn)
+		}
+		for bb := fn.FirstBasicBlock(); !bb.IsNil(); bb = llvm.NextBasicBlock(bb) {
+			for instr := bb.FirstInstruction(); !instr.IsNil(); instr = llvm.NextInstruction(instr) {
+				if call := instr.IsACallInst(); !call.IsNil() &&
+					call.CalledValue().IntrinsicID() == 0 &&
+					l.isLargeAggregate(call.CalledFunctionType().ReturnType()) {
+					calls = append(calls, call)
+				}
+			}
+		}
+	}
+	for _, call := range calls {
+		l.transformCall(m, call)
+	}
+	for _, fn := range funcs {
+		l.transformFunc(m, fn)
+	}
+}
+
+func (l largeAggregateLowerer) transformCall(m llvm.Module, call llvm.Value) {
+	ctx := m.Context()
+	oldType := call.CalledFunctionType()
+	retType := oldType.ReturnType()
+	newType := l.indirectType(ctx, oldType)
+	b := ctx.NewBuilder()
+	defer b.Dispose()
+	b.SetInsertPointBefore(call)
+
+	result := l.allocResult(m, ctx, b, retType)
+	params := make([]llvm.Value, 1, oldType.ParamTypesCount()+1)
+	params[0] = result
+	reflectMethodByName := call.GetCallSiteStringAttribute(-1, "llgo.reflect.methodbyname")
+	reflectNameParam := -1
+	for i := 0; i < oldType.ParamTypesCount(); i++ {
+		params = append(params, call.Operand(i))
+		if !call.GetCallSiteStringAttribute(i+1, "llgo.reflect.methodbyname.name").IsNil() {
+			reflectNameParam = i + 2
+		}
+	}
+	newCall := llvm.CreateCall(b, newType, call.CalledValue(), params)
+	newCall.AddCallSiteAttribute(1, sretAttribute(ctx, retType))
+	if !reflectMethodByName.IsNil() {
+		newCall.AddCallSiteAttribute(-1, reflectMethodByName)
+	}
+	if reflectNameParam >= 0 {
+		newCall.AddCallSiteAttribute(reflectNameParam, ctx.CreateStringAttribute(
+			"llgo.reflect.methodbyname.name", "1",
+		))
+	}
+	newCall.SetInstructionCallConv(call.InstructionCallConv())
+	newCall.InstructionSetDebugLoc(call.InstructionDebugLoc())
+
+	value := b.CreateLoad(retType, result, "")
+	value.InstructionSetDebugLoc(call.InstructionDebugLoc())
+	call.ReplaceAllUsesWith(value)
+	call.EraseFromParentAsInstruction()
+	l.rewriteStoredResult(ctx, value, result, retType)
+}
+
+func (l largeAggregateLowerer) transformFunc(m llvm.Module, fn llvm.Value) {
+	ctx := m.Context()
+	oldType := fn.GlobalValueType()
+	retType := oldType.ReturnType()
+	newType := l.indirectType(ctx, oldType)
+	name := fn.Name()
+	fn.SetName("")
+	nfn := llvm.AddFunction(m, name, newType)
+	nfn.SetLinkage(fn.Linkage())
+	nfn.SetFunctionCallConv(fn.FunctionCallConv())
+	nfn.AddAttributeAtIndex(1, sretAttribute(ctx, retType))
+	for _, attr := range fn.GetFunctionAttributes() {
+		nfn.AddFunctionAttr(attr)
+	}
+	for i := 0; i < oldType.ParamTypesCount(); i++ {
+		for _, attr := range fn.GetAttributesAtIndex(i + 1) {
+			nfn.AddAttributeAtIndex(i+2, attr)
+		}
+	}
+	if sp := fn.Subprogram(); !sp.IsNil() {
+		nfn.SetSubprogram(sp)
+	}
+
+	if !fn.IsDeclaration() {
+		var blocks []llvm.BasicBlock
+		for bb := fn.FirstBasicBlock(); !bb.IsNil(); bb = llvm.NextBasicBlock(bb) {
+			blocks = append(blocks, bb)
+		}
+		for _, bb := range blocks {
+			bb.RemoveFromParent()
+			llvm.AppendExistingBasicBlock(nfn, bb)
+		}
+		for i := 0; i < oldType.ParamTypesCount(); i++ {
+			fn.Param(i).ReplaceAllUsesWith(nfn.Param(i + 1))
+		}
+		l.rewriteReturns(ctx, nfn, retType)
+	}
+
+	fn.ReplaceAllUsesWith(nfn)
+	fn.EraseFromParentAsFunction()
+}
+
+func (l largeAggregateLowerer) rewriteReturns(ctx llvm.Context, fn llvm.Value, retType llvm.Type) {
+	var returns []llvm.Value
+	var selfCopies [][2]llvm.Value
+	for bb := fn.FirstBasicBlock(); !bb.IsNil(); bb = llvm.NextBasicBlock(bb) {
+		for instr := bb.FirstInstruction(); !instr.IsNil(); instr = llvm.NextInstruction(instr) {
+			if !instr.IsAReturnInst().IsNil() {
+				returns = append(returns, instr)
+				continue
+			}
+			store := instr.IsAStoreInst()
+			if store.IsNil() || store.IsVolatile() {
+				continue
+			}
+			load := store.Operand(0).IsALoadInst()
+			if !load.IsNil() && !load.IsVolatile() && l.isLargeAggregate(load.Type()) &&
+				store.Operand(1) == load.Operand(0) && hasSingleUse(load, store) {
+				selfCopies = append(selfCopies, [2]llvm.Value{load, store})
+			}
+		}
+	}
+	for _, copy := range selfCopies {
+		copy[1].EraseFromParentAsInstruction()
+		copy[0].EraseFromParentAsInstruction()
+	}
+
+	b := ctx.NewBuilder()
+	defer b.Dispose()
+	result := fn.Param(0)
+	for _, ret := range returns {
+		value := ret.Operand(0)
+		load := value.IsALoadInst()
+		if !load.IsNil() && !load.IsVolatile() && hasSingleUse(load, ret) {
+			// Copy at the original load so a later source mutation cannot change
+			// the already-evaluated return value (issue #1608).
+			b.SetInsertPointBefore(load)
+			l.callMemcpy(ctx, b, result, load.Operand(0), retType)
+			b.SetInsertPointBefore(ret)
+			b.CreateRetVoid()
+			ret.EraseFromParentAsInstruction()
+			load.EraseFromParentAsInstruction()
+			continue
+		}
+		b.SetInsertPointBefore(ret)
+		b.CreateStore(value, result)
+		b.CreateRetVoid()
+		ret.EraseFromParentAsInstruction()
+	}
+}
+
+func (l largeAggregateLowerer) rewriteStoredResult(ctx llvm.Context, value, result llvm.Value, typ llvm.Type) {
+	var stores []llvm.Value
+	for use := value.FirstUse(); !use.IsNil(); use = use.NextUse() {
+		store := use.User().IsAStoreInst()
+		if store.IsNil() || store.IsVolatile() || store.Operand(0) != value {
+			return
+		}
+		stores = append(stores, store)
+	}
+	b := ctx.NewBuilder()
+	defer b.Dispose()
+	for _, store := range stores {
+		b.SetInsertPointBefore(store)
+		l.callMemcpy(ctx, b, store.Operand(1), result, typ)
+		store.EraseFromParentAsInstruction()
+	}
+	if len(stores) != 0 || value.FirstUse().IsNil() {
+		value.EraseFromParentAsInstruction()
+	}
+}
+
+func (l largeAggregateLowerer) allocResult(m llvm.Module, ctx llvm.Context, b llvm.Builder, typ llvm.Type) llvm.Value {
+	intType := ctx.IntType(l.td.PointerSize() * 8)
+	ptrType := llvm.PointerType(ctx.Int8Type(), 0)
+	fnType := llvm.FunctionType(ptrType, []llvm.Type{intType}, false)
+	fn := m.NamedFunction(runtimeAllocU)
+	if fn.IsNil() {
+		fn = llvm.AddFunction(m, runtimeAllocU, fnType)
+	}
+	size := llvm.ConstInt(intType, l.td.TypeAllocSize(typ), false)
+	return llvm.CreateCall(b, fnType, fn, []llvm.Value{size})
+}
+
+func (l largeAggregateLowerer) callMemcpy(ctx llvm.Context, b llvm.Builder, dst, src llvm.Value, typ llvm.Type) llvm.Value {
+	size := llvm.ConstInt(ctx.IntType(l.td.PointerSize()*8), l.td.TypeAllocSize(typ), false)
+	return b.CreateIntrinsic(ctx.VoidType(), llvm.LookupIntrinsicID("llvm.memcpy"), []llvm.Value{
+		dst, src, size, llvm.ConstInt(ctx.Int1Type(), 0, false),
+	}, "")
+}
+
+func sretAttribute(ctx llvm.Context, typ llvm.Type) llvm.Attribute {
+	return ctx.CreateTypeAttribute(llvm.AttributeKindID("sret"), typ)
+}
+
+func hasSingleUse(value, user llvm.Value) bool {
+	use := value.FirstUse()
+	return !use.IsNil() && use.User() == user && use.NextUse().IsNil()
+}

--- a/internal/abi/large_test.go
+++ b/internal/abi/large_test.go
@@ -1,0 +1,156 @@
+//go:build !llgo
+
+package abi
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/xgo-dev/llvm"
+)
+
+func TestLargeAggregateThreshold(t *testing.T) {
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	td := llvm.NewTargetData("e-m:o-i64:64-i128:128-n32:64-S128")
+	defer td.Dispose()
+	l := largeAggregateLowerer{td: td}
+
+	if l.isLargeAggregate(ctx.Int64Type()) {
+		t.Fatal("scalar type was classified as a large aggregate")
+	}
+	if l.isLargeAggregate(llvm.ArrayType(ctx.Int8Type(), int(MaxImplicitStackVarSize))) {
+		t.Fatal("aggregate at the implicit stack limit was classified as large")
+	}
+	if !l.isLargeAggregate(llvm.ArrayType(ctx.Int8Type(), int(MaxImplicitStackVarSize+1))) {
+		t.Fatal("aggregate above the implicit stack limit was not classified as large")
+	}
+}
+
+func TestLowerLargeAggregates(t *testing.T) {
+	const testIR = `
+%Large = type [65537 x i8]
+%Small = type [65536 x i8]
+
+define %Large @callee(ptr nonnull %src) #1 {
+entry:
+  %value = load %Large, ptr %src, align 1
+  %first = getelementptr inbounds %Large, ptr %src, i64 0, i64 0
+  store i8 9, ptr %first, align 1
+  ret %Large %value
+}
+
+define i8 @caller(ptr %src) {
+entry:
+  %value = call %Large @callee(ptr "llgo.reflect.methodbyname.name"="1" %src) #0
+  %dst = alloca %Large, align 1
+  store %Large %value, ptr %dst, align 1
+  %first = getelementptr inbounds %Large, ptr %dst, i64 0, i64 0
+  %result = load i8, ptr %first, align 1
+  ret i8 %result
+}
+
+define %Large @wrapper(ptr %src) {
+entry:
+  %value = call %Large @callee(ptr %src)
+  ret %Large %value
+}
+
+define %Large @indirect(ptr %fn, ptr %src) {
+entry:
+  %value = call %Large %fn(ptr %src)
+  ret %Large %value
+}
+
+define %Large @self_copy(ptr %src) {
+entry:
+  %copy = load %Large, ptr %src, align 1
+  store %Large %copy, ptr %src, align 1
+  %result = load %Large, ptr %src, align 1
+  ret %Large %result
+}
+
+define %Small @small(ptr %src) {
+entry:
+  %value = load %Small, ptr %src, align 1
+  ret %Small %value
+}
+
+attributes #0 = { "llgo.reflect.methodbyname"="value" }
+attributes #1 = { noinline }
+`
+
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	path := filepath.Join(t.TempDir(), "large.ll")
+	if err := os.WriteFile(path, []byte(testIR), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	buf, err := llvm.NewMemoryBufferFromFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mod, err := ctx.ParseIR(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mod.Dispose()
+	td := llvm.NewTargetData("e-m:o-i64:64-i128:128-n32:64-S128")
+	defer td.Dispose()
+
+	LowerLargeAggregates(td, mod)
+
+	callee := mod.NamedFunction("callee").String()
+	if !strings.Contains(callee, "define void @callee(ptr sret([65537 x i8])") {
+		t.Fatalf("large return was not lowered to sret:\n%s", callee)
+	}
+	if !strings.Contains(callee, "ptr nonnull %") || !strings.Contains(callee, "noinline") {
+		t.Fatalf("callee attributes were not preserved:\n%s", callee)
+	}
+	copyAtLoad := strings.Index(callee, "call void @llvm.memcpy")
+	mutation := strings.Index(callee, "store i8 9")
+	if copyAtLoad < 0 || mutation < 0 || copyAtLoad >= mutation {
+		t.Fatalf("return value was not copied before source mutation:\n%s", callee)
+	}
+	if strings.Contains(callee, "load [65537 x i8]") || strings.Contains(callee, "store [65537 x i8]") {
+		t.Fatalf("callee retained a direct large aggregate copy:\n%s", callee)
+	}
+
+	caller := mod.NamedFunction("caller").String()
+	for _, want := range []string{
+		`call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocU"(i64 65537)`,
+		"call void @callee(ptr sret([65537 x i8])",
+		`ptr "llgo.reflect.methodbyname.name"="1"`,
+		"call void @llvm.memcpy",
+	} {
+		if !strings.Contains(caller, want) {
+			t.Fatalf("transformed caller missing %q:\n%s", want, caller)
+		}
+	}
+	if strings.Contains(caller, "load [65537 x i8]") || strings.Contains(caller, "store [65537 x i8]") {
+		t.Fatalf("caller reconstructed the large return as an SSA value:\n%s", caller)
+	}
+	if !strings.Contains(mod.String(), `"llgo.reflect.methodbyname"="value"`) {
+		t.Fatalf("reflect MethodByName call marker was not preserved:\n%s", mod.String())
+	}
+
+	for _, name := range []string{"wrapper", "indirect", "self_copy"} {
+		ir := mod.NamedFunction(name).String()
+		if strings.Contains(ir, "load [65537 x i8]") || strings.Contains(ir, "store [65537 x i8]") {
+			t.Fatalf("%s retained a direct large aggregate copy:\n%s", name, ir)
+		}
+	}
+	if got := strings.Count(mod.NamedFunction("self_copy").String(), "call void @llvm.memcpy"); got != 1 {
+		t.Fatalf("self_copy has %d memcpy calls, want 1:\n%s", got, mod.NamedFunction("self_copy").String())
+	}
+
+	small := mod.NamedFunction("small").String()
+	if !strings.Contains(small, "define [65536 x i8] @small") || !strings.Contains(small, "load [65536 x i8]") {
+		t.Fatalf("aggregate at the threshold was unexpectedly lowered:\n%s", small)
+	}
+	if err := llvm.VerifyModule(mod, llvm.ReturnStatusAction); err != nil {
+		t.Fatalf("transformed module is invalid: %v\n%s", err, mod.String())
+	}
+}

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -39,6 +39,7 @@ import (
 	"golang.org/x/tools/go/ssa"
 
 	"github.com/goplus/llgo/cl"
+	llabi "github.com/goplus/llgo/internal/abi"
 	"github.com/goplus/llgo/internal/buildenv"
 	"github.com/goplus/llgo/internal/cabi"
 	"github.com/goplus/llgo/internal/clang"
@@ -1439,6 +1440,7 @@ func buildPkg(ctx *context, aPkg *aPackage, verbose bool) error {
 	}
 
 	ctx.cTransformer.SetSkipFuncs(cabiSkipFuncsForPlan9Asm(ctx, pkgPath, ret.Module()))
+	llabi.LowerLargeAggregates(ctx.prog.TargetData(), ret.Module())
 	ctx.cTransformer.TransformModule(ret.Path(), ret.Module())
 	ctx.cTransformer.SetSkipFuncs(nil)
 

--- a/internal/build/plan9asm.go
+++ b/internal/build/plan9asm.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 
+	llabi "github.com/goplus/llgo/internal/abi"
 	"github.com/goplus/llgo/internal/cabi"
 	"github.com/goplus/llgo/internal/packages"
 	llplan9asm "github.com/goplus/llgo/internal/plan9asm"
@@ -79,6 +80,7 @@ func compilePkgSFiles(ctx *context, aPkg *aPackage, pkg *packages.Package, verbo
 		// runtime asm uses hand-written calling conventions and must stay on
 		// original Go ABI semantics.
 		if pkg.PkgPath != "runtime" {
+			llabi.LowerLargeAggregates(ctx.prog.TargetData(), mod)
 			ctx.cTransformer.TransformModule(pkg.PkgPath, mod)
 		}
 		ll := mod.String()

--- a/internal/cabi/cabi.go
+++ b/internal/cabi/cabi.go
@@ -367,11 +367,15 @@ func (p *Transformer) transformFunc(m llvm.Module, fn llvm.Value) bool {
 		return false
 	}
 	nft, attrs := p.transformFuncType(ctx, &info)
+	preloweredSRet := fn.GetEnumAttributeAtIndex(1, llvm.AttributeKindID("sret"))
 	fname := fn.Name()
 	fn.SetName("")
 	nfn := llvm.AddFunction(m, fname, nft)
 	for i, attr := range attrs {
 		nfn.AddAttributeAtIndex(i, attr)
+	}
+	if !preloweredSRet.IsNil() {
+		nfn.AddAttributeAtIndex(1, preloweredSRet)
 	}
 	nfn.SetLinkage(fn.Linkage())
 	nfn.SetFunctionCallConv(fn.FunctionCallConv())
@@ -537,6 +541,7 @@ func (p *Transformer) transformCallInstr(m llvm.Module, ctx llvm.Context, call l
 		return false
 	}
 	nft, attrs := p.transformFuncType(ctx, &info)
+	preloweredSRet := call.GetCallSiteEnumAttribute(1, llvm.AttributeKindID("sret"))
 	reflectMethodByNameAttr := call.GetCallSiteStringAttribute(-1, "llgo.reflect.methodbyname")
 	b := ctx.NewBuilder()
 	b.SetInsertPointBefore(call)
@@ -597,6 +602,9 @@ func (p *Transformer) transformCallInstr(m llvm.Module, ctx llvm.Context, call l
 	updateCallAttr := func(call llvm.Value) {
 		for i, attr := range attrs {
 			call.AddCallSiteAttribute(i, attr)
+		}
+		if !preloweredSRet.IsNil() {
+			call.AddCallSiteAttribute(1, preloweredSRet)
 		}
 		if !reflectMethodByNameAttr.IsNil() {
 			call.AddCallSiteAttribute(-1, reflectMethodByNameAttr)

--- a/internal/cabi/cabi_patch_test.go
+++ b/internal/cabi/cabi_patch_test.go
@@ -203,3 +203,57 @@ attributes #0 = { "llgo.reflect.methodbyname"="value" }
 		t.Fatalf("reflect MethodByName name marker should not be remapped to string length:\n%s", ir)
 	}
 }
+
+func TestPreloweredSRetAttributePreserved(t *testing.T) {
+	llvm.InitializeAllTargets()
+	llvm.InitializeAllTargetMCs()
+	llvm.InitializeAllTargetInfos()
+
+	const testIR = `
+%Large = type [65537 x i8]
+%Param = type { i64, i64, i64 }
+
+define void @callee(ptr sret(%Large) %result, %Param %param) {
+entry:
+  ret void
+}
+
+define void @caller(ptr %result, %Param %param) {
+entry:
+  call void @callee(ptr sret(%Large) %result, %Param %param)
+  ret void
+}
+`
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	path := filepath.Join(t.TempDir(), "prelowered_sret.ll")
+	if err := os.WriteFile(path, []byte(testIR), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	buf, err := llvm.NewMemoryBufferFromFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mod, err := ctx.ParseIR(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mod.Dispose()
+
+	prog := llssa.NewProgram(nil)
+	defer prog.Dispose()
+	tr := NewTransformer(prog, "arm64-apple-darwin", "", ModeAllFunc, true)
+	tr.TransformModule("test", mod)
+
+	callee := mod.NamedFunction("callee").String()
+	if !strings.Contains(callee, "define void @callee(ptr sret([65537 x i8])") {
+		t.Fatalf("pre-lowered function lost its sret attribute:\n%s", callee)
+	}
+	caller := mod.NamedFunction("caller").String()
+	if !strings.Contains(caller, "call void @callee(ptr sret([65537 x i8])") {
+		t.Fatalf("pre-lowered call lost its sret attribute:\n%s", caller)
+	}
+	if err := llvm.VerifyModule(mod, llvm.ReturnStatusAction); err != nil {
+		t.Fatalf("transformed module is invalid: %v\n%s", err, mod.String())
+	}
+}

--- a/ssa/memory.go
+++ b/ssa/memory.go
@@ -20,6 +20,7 @@ import (
 	"go/token"
 	"go/types"
 
+	llabi "github.com/goplus/llgo/internal/abi"
 	"github.com/xgo-dev/llvm"
 )
 
@@ -114,6 +115,9 @@ func (b Builder) Alloc(elem Type, heap bool) (ret Expr) {
 	prog := b.Prog
 	pkg := b.Pkg
 	size := SizeOf(prog, elem)
+	if !heap && prog.SizeOf(elem) > llabi.MaxStackVarSize {
+		heap = true
+	}
 	if heap {
 		if prog.SizeOf(elem) == 0 {
 			return pkg.moduleZeroSizedAlloc(elem)

--- a/ssa/memory_large_test.go
+++ b/ssa/memory_large_test.go
@@ -1,0 +1,46 @@
+//go:build !llgo
+
+package ssa
+
+import (
+	"go/token"
+	"go/types"
+	"strings"
+	"testing"
+
+	llabi "github.com/goplus/llgo/internal/abi"
+)
+
+func TestAllocLargeLocalOnHeap(t *testing.T) {
+	prog := NewProgram(nil)
+	defer prog.Dispose()
+	runtimePkg := types.NewPackage(PkgRuntime, "runtime")
+	params := types.NewTuple(types.NewVar(token.NoPos, runtimePkg, "size", types.Typ[types.Uintptr]))
+	results := types.NewTuple(types.NewVar(token.NoPos, runtimePkg, "", types.Typ[types.UnsafePointer]))
+	allocZ := types.NewFunc(token.NoPos, runtimePkg, "AllocZ", types.NewSignatureType(nil, nil, nil, params, results, false))
+	runtimePkg.Scope().Insert(allocZ)
+	prog.SetRuntime(runtimePkg)
+
+	pkg := prog.NewPackage("main", "main")
+	b := pkg.NewFunc("main", NoArgsNoRet, InGo).MakeBody(1)
+	small := prog.Type(types.NewArray(types.Typ[types.Byte], int64(llabi.MaxStackVarSize)), InGo)
+	large := prog.Type(types.NewArray(types.Typ[types.Byte], int64(llabi.MaxStackVarSize+1)), InGo)
+	b.Alloc(small, false)
+	b.Alloc(large, false)
+	b.Return()
+	b.EndBuild()
+
+	ir := pkg.String()
+	if !strings.Contains(ir, "alloca [131072 x i8]") {
+		t.Fatalf("local at the explicit stack limit was not kept on the stack:\n%s", ir)
+	}
+	if strings.Contains(ir, "alloca [131073 x i8]") {
+		t.Fatalf("local above the explicit stack limit remained on the stack:\n%s", ir)
+	}
+	if !strings.Contains(ir, `call ptr @"github.com/goplus/llgo/runtime/internal/runtime.AllocZ"(i64 131073)`) {
+		t.Fatalf("large local was not allocated with runtime.AllocZ:\n%s", ir)
+	}
+	if !pkg.NeedRuntime {
+		t.Fatal("large local heap allocation did not mark the runtime as needed")
+	}
+}

--- a/test/go/large_array_return_test.go
+++ b/test/go/large_array_return_test.go
@@ -1,0 +1,111 @@
+//go:build !llgo
+
+package gotest
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+const largeArrayReturnProbe = `package main
+
+const size = 128*1024 + 1
+
+type params struct { x, y, z int }
+
+func main() {
+	a := f(1, 99)
+	b := g(size-1, 98)
+	c := h(size-1, 98)
+	d := withAggregateParam(params{1, 2, 3})
+	println(a[1], b[1], c[1], a[size-1], b[size-1], c[size-1], d[0])
+	println(f(1, 97)[1])
+}
+
+//go:noinline
+func f(i, y int) (a [size]byte) {
+	a[i] = byte(y)
+	return
+}
+
+//go:noinline
+func g(i, y int) [size]byte {
+	var a [size]byte
+	a[i] = byte(y)
+	return a
+}
+
+//go:noinline
+func h(i, y int) (a [size]byte) {
+	a[i] = byte(y)
+	return a
+}
+
+//go:noinline
+func withAggregateParam(p params) (a [size]byte) {
+	a[0] = byte(p.x + p.y + p.z)
+	return
+}
+`
+
+var (
+	largeArrayLLGoOnce sync.Once
+	largeArrayLLGoBin  string
+	largeArrayLLGoErr  string
+)
+
+func largeArrayLLGo(t *testing.T) string {
+	t.Helper()
+	root := findStringConversionRepoRoot(t)
+	t.Setenv("LLGO_ROOT", root)
+	largeArrayLLGoOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "llgo-large-array-bin")
+		if err != nil {
+			largeArrayLLGoErr = err.Error()
+			return
+		}
+		largeArrayLLGoBin = filepath.Join(dir, "llgo")
+		cmd := exec.Command("go", "build", "-tags", "dev", "-o", largeArrayLLGoBin, "./cmd/llgo")
+		cmd.Dir = root
+		if out, err := cmd.CombinedOutput(); err != nil {
+			largeArrayLLGoErr = fmt.Sprintf("%v\n%s", err, out)
+		}
+	})
+	if largeArrayLLGoErr != "" {
+		t.Fatalf("building llgo failed: %s", largeArrayLLGoErr)
+	}
+	return largeArrayLLGoBin
+}
+
+func TestLargeArrayReturnAllABIModes(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module largearray\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(largeArrayReturnProbe), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bin := largeArrayLLGo(t)
+	for mode := 0; mode <= 2; mode++ {
+		t.Run(fmt.Sprintf("abi%d", mode), func(t *testing.T) {
+			cmd := exec.Command(bin, "run", fmt.Sprintf("-abi=%d", mode), ".")
+			cmd.Dir = dir
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("llgo run failed: %v\n%s", err, out)
+			}
+			lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+			if len(lines) < 2 {
+				t.Fatalf("output has fewer than two lines: %q", out)
+			}
+			if got, want := strings.Join(lines[len(lines)-2:], "\n"), "99 0 0 0 98 98 6\n97"; got != want {
+				t.Fatalf("output = %q, want %q", got, want)
+			}
+		})
+	}
+}

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -2367,10 +2367,6 @@ xfails:
     reason: llgo parser recovery emits additional diagnostics after the expected syntax error
   - version: go1.26
     directive: compile
-    case: fixedbugs/issue15141.go
-    reason: llgo codegen exceeds the bounded resource budget for 256MiB array return values
-  - version: go1.26
-    directive: compile
     case: fixedbugs/issue48092.go
     reason: gc-specific -B bounds-checking backend option is not implemented by llgo
   - version: go1.26


### PR DESCRIPTION
## Summary

- move oversized Go values off the native stack using the same default limits as `cmd/compile`: 128 KiB for explicit locals and 64 KiB for compiler-generated result temporaries
- lower large direct aggregate returns to a heap-backed hidden `sret` pointer before target-specific C ABI rewriting, so ABI modes 0, 1, and 2 share the same safe behavior
- keep the return value in memory with `memcpy`, preserving copy-before-mutation semantics and pre-lowered `sret` attributes when CABI must also rewrite aggregate parameters
- retire the Go 1.26 `fixedbugs/issue15141.go` compile xfail and add compile-and-run coverage for all three ABI modes

Supersedes #2103, whose CABI-local fix did not cover ABI mode 0 or the oversized native stack frames that caused the compiled reproducer to fail at runtime.

## Reproducer

Go 1.26's `fixedbugs/issue15141.go` returns a 268,435,455-byte array in three ordinary source forms:

```go
func f(i, y int) (a [0xFFFFFFF]byte) {
    a[i] = byte(y)
    return
}

func g(i, y int) [0xFFFFFFF]byte {
    var a [0xFFFFFFF]byte
    a[i] = byte(y)
    return a
}

func h(i, y int) (a [0xFFFFFFF]byte) {
    a[i] = byte(y)
    return a
}
```

Before this change, the target C ABI classifier could attempt to flatten all 268,435,455 elements, and the LLVM backend could scalarize direct aggregate loads/stores. The CABI-only workaround in #2103 made compilation bounded in ABI mode 2, but each function still reserved a 256 MiB local array on LLGo's native stack; the complete program exhausted the stack and terminated with an illegal-instruction signal. ABI mode 0 also bypassed that workaround entirely.

## Design

The new internal ABI pass runs before CABI and changes only array/struct returns larger than 64 KiB. Callers allocate an uninitialized GC-managed result slot, callees receive it as the hidden first `sret` parameter, and common load/store copies remain in memory as `llvm.memcpy`. Copying a return load at its original evaluation point preserves the value if its source is modified before `return` (#1608).

Separately, SSA locals larger than 128 KiB are promoted to the existing zero-initialized runtime heap allocation path. These limits mirror Go compiler implementation defaults (`MaxImplicitStackVarSize` and `MaxStackVarSize`); they are not language-spec or platform ABI limits.

Small aggregates keep their existing ABI. Target-specific CABI remains responsible only for register/byval classification, and now preserves an already-lowered `sret` attribute if another parameter forces a second signature rewrite.

## Validation

- Darwin/arm64, Go 1.26.5, LLVM 19:
  - full `go test` for `internal/abi`, `internal/cabi`, `internal/build`, and `ssa`
  - ABI 0/1/2 compile-and-run test, including direct result indexing and a large return combined with an aggregate parameter
  - original 256 MiB `issue15141.go`: output `99 0 0 0 98 98`; final ABI 2 build about 1.28 s / 132 MB peak RSS and run about 0.65 s / 1.62 GB peak RSS
- Linux/amd64 under OrbStack, Go 1.26.5, LLVM 19.1.7:
  - ABI 0/1/2 compile-and-run test passes
  - original `fixedbugs/issue15141.go` GOROOT case passes
- atomic package statement coverage: `internal/abi` 96.4%, `internal/cabi` 96.4%, `ssa` 87.8%, `internal/build` 71.7%; all modified integration lines have non-zero execution counts
- `git diff --check`
