### PR TITLE
[Based on #2098] runtime,test: complete Go 1.26 standard-library coverage

### DIFF
--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -259,12 +259,19 @@ jobs:
           printf '  %s\n' "${selected[@]}"
 
           # Run per-package and print elapsed time to keep logs readable.
+          std_pkgs=()
           for pkg in "${selected[@]}"; do
             echo "==> llgo test -timeout=20m -bench=^BenchmarkGo126 -benchtime=1x ${pkg}"
             SECONDS=0
             llgo test -timeout=20m -bench='^BenchmarkGo126' -benchtime=1x "${pkg}"
+            if [[ "${{ matrix.os }}" == ubuntu-latest && "${{ matrix.go }}" == 1.26.5 && "${pkg}" == */test/std/* ]]; then
+              std_pkgs+=("${pkg}")
+            fi
             echo "==> done ${pkg} (${SECONDS}s)"
           done
+          if [[ "${#std_pkgs[@]}" -ne 0 ]]; then
+            dev/test_std_buildmodes.sh "${std_pkgs[@]}"
+          fi
 
   hello:
     name: hello (${{ matrix.lane }}, ${{ matrix.os }}, LLVM ${{ matrix.llvm }}, Go ${{ matrix.go }})

--- a/_demo/go/export/export.go
+++ b/_demo/go/export/export.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"runtime"
 	"unsafe"
 
@@ -132,6 +133,11 @@ func RunGoroutine(value int) int {
 		ch <- value + 1
 	}()
 	return <-ch
+}
+
+//export FormatValue
+func FormatValue(value string, number int) string {
+	return fmt.Sprintf("%s:%d", value, number)
 }
 
 // Functions with small struct parameters and return values

--- a/_demo/go/export/libexport.h.want
+++ b/_demo/go/export/libexport.h.want
@@ -121,6 +121,9 @@ mul(float a, float b);
 void
 github_com_goplus_llgo__demo_go_export_c_init(void) GO_SYMBOL_RENAME("github.com/goplus/llgo/_demo/go/export/c.init")
 
+intptr_t
+AllThreadsSyscallStatus(void);
+
 main_ComplexData
 CreateComplexData(void);
 
@@ -162,6 +165,9 @@ CreateStringMap(void);
 
 C_XType
 CreateXType(int32_t id, GoString name, double value, _Bool flag);
+
+GoString
+FormatValue(GoString value, intptr_t number);
 
 main_FuncInfoResult
 GetFuncInfo(void);

--- a/_demo/go/export/runtime_hooks_linux.go
+++ b/_demo/go/export/runtime_hooks_linux.go
@@ -1,0 +1,28 @@
+//go:build linux
+
+package main
+
+import "syscall"
+
+func gettimeofdayStatus() int {
+	var tv syscall.Timeval
+	if err := syscall.Gettimeofday(&tv); err != nil {
+		if errno, ok := err.(syscall.Errno); ok {
+			return int(errno)
+		}
+		return int(syscall.EINVAL)
+	}
+	if tv.Sec <= 0 {
+		return int(syscall.EINVAL)
+	}
+	return 0
+}
+
+//export AllThreadsSyscallStatus
+func AllThreadsSyscallStatus() int {
+	if status := gettimeofdayStatus(); status != 0 {
+		return status
+	}
+	_, _, err := syscall.AllThreadsSyscall(syscall.SYS_GETPID, 0, 0, 0)
+	return int(err)
+}

--- a/_demo/go/export/runtime_hooks_other.go
+++ b/_demo/go/export/runtime_hooks_other.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package main
+
+//export AllThreadsSyscallStatus
+func AllThreadsSyscallStatus() int {
+	return 0
+}

--- a/_demo/go/export/use/Makefile
+++ b/_demo/go/export/use/Makefile
@@ -24,6 +24,7 @@ else
     SHARED_EXT = so
     PLATFORM_LIBS = $(shell pkg-config --libs libunwind 2>/dev/null || echo -lunwind)
 endif
+STATIC_STDLIB_LIBS = $(shell pkg-config --libs libffi 2>/dev/null || echo -lffi) -lresolv
 
 # Library and flags based on link type
 ifeq ($(LINK_TYPE),shared)
@@ -35,7 +36,7 @@ ifeq ($(LINK_TYPE),shared)
 else
     BUILDMODE = c-archive
     LIBRARY = ../libexport.a
-    LDFLAGS = $(LIBRARY) $(RUNTIME_LIBS) $(PLATFORM_LIBS)
+    LDFLAGS = $(LIBRARY) $(RUNTIME_LIBS) $(PLATFORM_LIBS) $(STATIC_STDLIB_LIBS)
     BUILD_MSG = "Building Go static library..."
     LINK_MSG = "Linking with static library..."
 endif

--- a/_demo/go/export/use/main.c
+++ b/_demo/go/export/use/main.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <inttypes.h>
 #include <assert.h>
+#include <errno.h>
 #include <string.h>
 #include "../libexport.h"
 
@@ -58,6 +59,16 @@ int main() {
     // Test HelloWorld
     HelloWorld();
     printf("\n");
+
+    // Verify that a C library can initialize and call standard-library paths
+    // that depend on the runtime hooks supplied by LLGo.
+    GoString formatted = FormatValue((GoString){"answer", 6}, 42);
+    assert(go_string_equals(formatted, "answer:42"));
+#ifdef __linux__
+    assert(AllThreadsSyscallStatus() == ENOTSUP);
+#else
+    assert(AllThreadsSyscallStatus() == 0);
+#endif
 
     // Test small struct
     main_SmallStruct small = CreateSmallStruct(5, 1);  // 1 for true

--- a/cmd/internal/test/test.go
+++ b/cmd/internal/test/test.go
@@ -27,6 +27,7 @@ func init() {
 	flags.AddCommonFlags(&Cmd.Flag)
 	flags.AddCompilerVerboseFlag(&Cmd.Flag)
 	flags.AddBuildFlags(&Cmd.Flag)
+	flags.AddBuildModeFlags(&Cmd.Flag)
 	flags.AddTestFlags(&Cmd.Flag)
 	flags.AddTestBinaryFlags(&Cmd.Flag)
 	flags.AddEmulatorFlags(&Cmd.Flag)
@@ -43,7 +44,7 @@ func runCmd(cmd *base.Command, args []string) {
 	}
 
 	conf := build.NewDefaultConf(build.ModeTest)
-	if err := flags.UpdateConfig(conf); err != nil {
+	if err := flags.UpdateBuildConfig(conf); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		mockable.Exit(1)
 	}

--- a/cmd/internal/test/test_test.go
+++ b/cmd/internal/test/test_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestBuildFlagsWiring(t *testing.T) {
-	if goBuildFlags.Flag != &Cmd.Flag || Cmd.Flag.Lookup("ldflags") == nil {
+	if goBuildFlags.Flag != &Cmd.Flag || Cmd.Flag.Lookup("ldflags") == nil || Cmd.Flag.Lookup("buildmode") == nil {
 		t.Fatal("test build flags are not bound to the test command")
 	}
 }

--- a/dev/test_std_buildmodes.sh
+++ b/dev/test_std_buildmodes.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+	echo "usage: $0 ./test/std/package [...]" >&2
+	exit 2
+fi
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+test_pkgs=("$@")
+import_paths=()
+stems=()
+groups=()
+max_group=0
+for test_pkg in "${test_pkgs[@]}"; do
+	read -r import_path package_dir < <(go list -tags=llgo -f '{{.ImportPath}} {{.Dir}}' "${test_pkg}")
+	case "${import_path}" in
+		github.com/goplus/llgo/test/std/*) ;;
+		*)
+			echo "not a test/std package: ${test_pkg}" >&2
+			exit 2
+			;;
+	esac
+	stem="$(basename "${package_dir}").test"
+	group=0
+	for i in "${!stems[@]}"; do
+		if [[ "${stems[$i]}" == "${stem}" ]]; then
+			group=$((group + 1))
+		fi
+	done
+	import_paths+=("${import_path}")
+	stems+=("${stem}")
+	groups+=("${group}")
+	if (( group > max_group )); then
+		max_group="${group}"
+	fi
+done
+
+# Keep the unique package in its own compiler invocation. Its generic use of
+# weak.Pointer can otherwise assign shared instantiations to libunique.test and
+# leave another output with unresolved weak.Pointer methods.
+for i in "${!import_paths[@]}"; do
+	if [[ "${import_paths[$i]}" == "github.com/goplus/llgo/test/std/unique" ]]; then
+		max_group=$((max_group + 1))
+		groups[$i]="${max_group}"
+	fi
+done
+
+llgo_cmd="${LLGO:-llgo}"
+if [[ "${llgo_cmd}" == */* && "${llgo_cmd}" != /* ]]; then
+	llgo_cmd="$(cd "$(dirname "${llgo_cmd}")" && pwd)/$(basename "${llgo_cmd}")"
+fi
+runner_source="${root_dir}/dev/test_std_buildmodes/runner.c"
+
+runtime_libs=(-lpthread -lm -lresolv)
+if [[ "$(uname -s)" == Darwin ]]; then
+	runtime_libs+=(-framework CoreFoundation -framework Security)
+fi
+for dependency in bdw-gc libuv libffi; do
+  if pkg-config --exists "${dependency}"; then
+    while IFS= read -r flag; do
+      [[ -n "${flag}" ]] && runtime_libs+=("${flag}")
+    done < <(pkg-config --libs "${dependency}" | xargs -n1)
+  fi
+done
+if [[ "$(uname -s)" != Darwin ]] && pkg-config --exists libunwind; then
+  while IFS= read -r flag; do
+    [[ -n "${flag}" ]] && runtime_libs+=("${flag}")
+  done < <(pkg-config --libs libunwind | xargs -n1)
+fi
+
+work_dir="$(mktemp -d "${root_dir}/.std-buildmodes.XXXXXX")"
+trap 'rm -rf "${work_dir}"' EXIT
+
+for mode in c-shared c-archive; do
+	for ((group = 0; group <= max_group; group++)); do
+		group_imports=()
+		for i in "${!import_paths[@]}"; do
+			if [[ "${groups[$i]}" -eq "${group}" ]]; then
+				group_imports+=("${import_paths[$i]}")
+			fi
+		done
+		if [[ "${#group_imports[@]}" -eq 0 ]]; then
+			continue
+		fi
+		echo "==> ${mode}: compile ${#group_imports[@]} test package(s)"
+		(
+			cd "${work_dir}"
+			"${llgo_cmd}" test -c -buildmode="${mode}" "${group_imports[@]}"
+		)
+
+		for i in "${!import_paths[@]}"; do
+			if [[ "${groups[$i]}" -ne "${group}" ]]; then
+				continue
+			fi
+			import_path="${import_paths[$i]}"
+			stem="${stems[$i]}"
+			test_main_pkg="${import_path}.test"
+			runner_base="${work_dir}/runner-${i}"
+			echo "==> ${test_pkgs[$i]}: run ${mode}"
+			clang -x c -c "${runner_source}" \
+				"-DGO_TEST_PACKAGE=\"${test_main_pkg}\"" \
+				-o "${runner_base}.o"
+
+			if [[ "${mode}" == c-shared ]]; then
+				if [[ "$(uname -s)" == Darwin ]]; then
+					library="${work_dir}/lib${stem}.dylib"
+				else
+					library="${work_dir}/lib${stem}.so"
+				fi
+				clang++ "${runner_base}.o" -o "${runner_base}" \
+					-L"${work_dir}" "-l${stem}" "${runtime_libs[@]}"
+				LD_LIBRARY_PATH="${work_dir}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" \
+					DYLD_LIBRARY_PATH="${work_dir}${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}" \
+					"${runner_base}"
+			else
+				library="${work_dir}/lib${stem}.a"
+				clang++ "${runner_base}.o" -o "${runner_base}" \
+					"${library}" "${runtime_libs[@]}"
+				"${runner_base}"
+			fi
+
+			if [[ ! -s "${library}" ]]; then
+				echo "missing ${mode} library: ${library}" >&2
+				exit 1
+			fi
+			for artifact in "${runner_base}" "${runner_base}.o" "${library}" "${work_dir}/lib${stem}.h"; do
+				if [[ -e "${artifact}" ]]; then
+					unlink "${artifact}"
+				fi
+			done
+		done
+	done
+done

--- a/dev/test_std_buildmodes/runner.c
+++ b/dev/test_std_buildmodes/runner.c
@@ -1,0 +1,22 @@
+#ifndef GO_TEST_PACKAGE
+#error GO_TEST_PACKAGE must name the generated Go test main package
+#endif
+
+#ifdef __APPLE__
+#define GO_SYMBOL(name) __asm__("_" name)
+#else
+#define GO_SYMBOL(name) __asm__(name)
+#endif
+
+extern void llgo_test_init(void) GO_SYMBOL(GO_TEST_PACKAGE ".init");
+extern void llgo_test_run(void) GO_SYMBOL(GO_TEST_PACKAGE ".main");
+extern int __llgo_argc;
+extern char **__llgo_argv;
+
+int main(int argc, char **argv) {
+    __llgo_argc = argc;
+    __llgo_argv = argv;
+    llgo_test_init();
+    llgo_test_run();
+    return 0;
+}

--- a/doc/_readme/scripts/check_std_cover.sh
+++ b/doc/_readme/scripts/check_std_cover.sh
@@ -18,14 +18,41 @@ if [ "${#packages[@]}" -eq 0 ]; then
 fi
 
 args=()
+covered_packages=()
 for pkg in "${packages[@]}"; do
   rel_path="${pkg#${module_path}/}"
   if [[ "${rel_path}" != test/std/* ]]; then
     continue
   fi
   stdlib_pkg="${rel_path#test/std/}"
+  covered_packages+=("${stdlib_pkg}")
+  if [[ "${stdlib_pkg}" == "runtime" ]]; then
+    continue
+  fi
   args+=("-pkg" "${stdlib_pkg}")
 done
+
+expected_file="$(mktemp)"
+covered_file="$(mktemp)"
+trap 'rm -f "${expected_file}" "${covered_file}"' EXIT
+
+go list std \
+  | awk '!/(^|\/)internal(\/|$)/ && !/(^|\/)vendor(\/|$)/' \
+  | sort -u > "${expected_file}"
+printf '%s\n' "${covered_packages[@]}" | sort -u > "${covered_file}"
+
+missing_packages="$(comm -23 "${expected_file}" "${covered_file}")"
+if [[ -n "${missing_packages}" ]]; then
+  echo "Public standard-library packages missing test/std coverage:" >&2
+  while IFS= read -r pkg; do
+    echo "  - ${pkg}" >&2
+  done <<< "${missing_packages}"
+  exit 1
+fi
+
+expected_count="$(wc -l < "${expected_file}" | tr -d ' ')"
+covered_count="$(wc -l < "${covered_file}" | tr -d ' ')"
+echo "Public standard-library package coverage: ${covered_count}/${expected_count}"
 
 printf '+ go run ./chore/check_std_symbols'
 for arg in "${args[@]}"; do

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1377,9 +1377,9 @@ func linkObjFiles(ctx *context, app string, objFiles, linkArgs []string, verbose
 	return cmd.Link(buildArgs...)
 }
 
-// cSharedExportArgs keeps //export functions as shared-library link roots. The
-// functions live in package archives and otherwise remain unreferenced, so the
-// linker can omit both their object files and dynamic symbols.
+// cSharedExportArgs keeps //export functions and synthetic test entry points as
+// shared-library link roots. They live in package archives and otherwise remain
+// unreferenced, so the linker can omit both their object files and symbols.
 func cSharedExportArgs(ctx *context, pkgs []*aPackage) []string {
 	if ctx == nil || ctx.buildConf == nil || ctx.buildConf.BuildMode != BuildModeCShared {
 		return nil
@@ -1393,6 +1393,10 @@ func cSharedExportArgs(ctx *context, pkgs []*aPackage) []string {
 			if name != "" {
 				exports[name] = none{}
 			}
+		}
+		if ctx.mode == ModeTest && pkg.Package != nil && pkg.Name == "main" && strings.HasSuffix(pkg.PkgPath, ".test") {
+			exports[pkg.PkgPath+".init"] = none{}
+			exports[pkg.PkgPath+".main"] = none{}
 		}
 	}
 	names := make([]string, 0, len(exports))

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -665,6 +665,26 @@ func TestCSharedExportArgs(t *testing.T) {
 	}
 }
 
+func TestCSharedExportArgsKeepsTestMain(t *testing.T) {
+	prog := llssa.NewProgram(nil)
+	defer prog.Dispose()
+	lpkg := prog.NewPackage("example.com/p.test", "example.com/p.test")
+	pkgs := []*aPackage{{
+		Package: &packages.Package{
+			Name:    "main",
+			PkgPath: "example.com/p.test",
+		},
+		LPkg: lpkg,
+	}}
+	ctx := &context{
+		mode:      ModeTest,
+		buildConf: &Config{BuildMode: BuildModeCShared, Goos: "linux"},
+	}
+	if got, want := strings.Join(cSharedExportArgs(ctx, pkgs), " "), "-Wl,--undefined=example.com/p.test.init -Wl,--undefined=example.com/p.test.main"; got != want {
+		t.Fatalf("test main cSharedExportArgs = %q, want %q", got, want)
+	}
+}
+
 func TestApplyBuildModeCompileFlags(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/build/main_module.go
+++ b/internal/build/main_module.go
@@ -111,7 +111,13 @@ func genMainModule(ctx *context, rtPkgPath string, pkg *packages.Package, cfg *g
 		if ctx.buildConf.BuildMode == BuildModeCShared && ctx.buildConf.Goos == "linux" {
 			initArraySection = ".init_array"
 		}
-		defineLibraryRuntimeInit(mainPkg, initArraySection, pyInit, rtInit, abiInit, runtimeStub, mainInit)
+		inits := []llssa.Function{pyInit, rtInit, abiInit, runtimeStub}
+		// The C test runner supplies argc/argv before calling the generated
+		// test main package's init and main functions.
+		if ctx.mode != ModeTest {
+			inits = append(inits, mainInit)
+		}
+		defineLibraryRuntimeInit(mainPkg, initArraySection, inits...)
 		return mainAPkg
 	}
 

--- a/internal/build/main_module.go
+++ b/internal/build/main_module.go
@@ -107,7 +107,11 @@ func genMainModule(ctx *context, rtPkgPath string, pkg *packages.Package, cfg *g
 	mainMain := declareNoArgFunc(mainPkg, pkg.PkgPath+".main")
 
 	if ctx.buildConf.BuildMode != BuildModeExe {
-		defineLibraryRuntimeInit(mainPkg, pyInit, rtInit, abiInit, runtimeStub, mainInit)
+		initArraySection := ""
+		if ctx.buildConf.BuildMode == BuildModeCShared && ctx.buildConf.Goos == "linux" {
+			initArraySection = ".init_array"
+		}
+		defineLibraryRuntimeInit(mainPkg, initArraySection, pyInit, rtInit, abiInit, runtimeStub, mainInit)
 		return mainAPkg
 	}
 
@@ -129,10 +133,11 @@ func genMainModule(ctx *context, rtPkgPath string, pkg *packages.Package, cfg *g
 }
 
 // defineLibraryRuntimeInit arranges for the LLGo runtime to be initialized
-// before a C program calls an exported Go function. llvm.global_ctors is
-// lowered to the platform's native constructor mechanism for both shared
-// libraries and archive members.
-func defineLibraryRuntimeInit(pkg llssa.Package, inits ...llssa.Function) {
+// before a C program calls an exported Go function. Linux shared libraries use
+// .init_array explicitly because the raw LLVM target machine lowers
+// llvm.global_ctors to legacy .ctors; other library formats use LLVM's
+// platform-specific constructor lowering.
+func defineLibraryRuntimeInit(pkg llssa.Package, initArraySection string, inits ...llssa.Function) {
 	const ctorName = "__llgo_runtime_ctor"
 	ctor := pkg.NewFunc(ctorName, llssa.NoArgsNoRet, llssa.InC)
 	ctorValue := pkg.Module().NamedFunction(ctorName)
@@ -146,6 +151,14 @@ func defineLibraryRuntimeInit(pkg llssa.Package, inits ...llssa.Function) {
 	b.Return()
 
 	mod := pkg.Module()
+	if initArraySection != "" {
+		initEntry := llvm.AddGlobal(mod, ctorValue.Type(), "__llgo_runtime_ctor_init")
+		initEntry.SetInitializer(ctorValue)
+		initEntry.SetGlobalConstant(true)
+		initEntry.SetSection(initArraySection)
+		initEntry.SetVisibility(llvm.HiddenVisibility)
+		return
+	}
 	llvmCtx := mod.Context()
 	priority := llvm.ConstInt(llvmCtx.Int32Type(), 65535, false)
 	entry := llvmCtx.ConstStruct([]llvm.Value{

--- a/internal/build/main_module_test.go
+++ b/internal/build/main_module_test.go
@@ -99,6 +99,7 @@ func TestGenMainModuleLibraryInitializesRuntime(t *testing.T) {
 			checks := []string{
 				"define internal void @__llgo_runtime_ctor()",
 				"call void @\"github.com/goplus/llgo/runtime/internal/runtime.init\"()",
+				"call void @\"example.com/foo.init\"()",
 			}
 			if mode == BuildModeCShared {
 				checks = append(checks, `@__llgo_runtime_ctor_init = hidden constant ptr @__llgo_runtime_ctor, section ".init_array"`)
@@ -112,6 +113,34 @@ func TestGenMainModuleLibraryInitializesRuntime(t *testing.T) {
 			}
 			if strings.Contains(ir, "define i32 @main") {
 				t.Fatalf("library mode should not emit main function:\n%s", ir)
+			}
+		})
+	}
+}
+
+func TestGenMainModuleTestLibraryDefersMainInit(t *testing.T) {
+	llvm.InitializeAllTargets()
+	t.Setenv(llgoStdioNobuf, "")
+	for _, mode := range []BuildMode{BuildModeCArchive, BuildModeCShared} {
+		t.Run(string(mode), func(t *testing.T) {
+			ctx := &context{
+				prog: llssa.NewProgram(nil),
+				mode: ModeTest,
+				buildConf: &Config{
+					Mode:      ModeTest,
+					BuildMode: mode,
+					Goos:      "linux",
+					Goarch:    "amd64",
+				},
+			}
+			pkg := &packages.Package{PkgPath: "example.com/foo", ExportFile: "foo.a"}
+			mod := genMainModule(ctx, llssa.PkgRuntime, pkg, &genConfig{rtInit: true})
+			ir := mod.LPkg.String()
+			if !strings.Contains(ir, "call void @\"github.com/goplus/llgo/runtime/internal/runtime.init\"()") {
+				t.Fatalf("test library constructor missing runtime init:\n%s", ir)
+			}
+			if strings.Contains(ir, "call void @\"example.com/foo.init\"()") {
+				t.Fatalf("test library constructor initialized test main before the C runner supplied argc/argv:\n%s", ir)
 			}
 		})
 	}

--- a/internal/build/main_module_test.go
+++ b/internal/build/main_module_test.go
@@ -97,9 +97,13 @@ func TestGenMainModuleLibraryInitializesRuntime(t *testing.T) {
 			mod := genMainModule(ctx, llssa.PkgRuntime, pkg, &genConfig{rtInit: true})
 			ir := mod.LPkg.String()
 			checks := []string{
-				"@llvm.global_ctors = appending global",
 				"define internal void @__llgo_runtime_ctor()",
 				"call void @\"github.com/goplus/llgo/runtime/internal/runtime.init\"()",
+			}
+			if mode == BuildModeCShared {
+				checks = append(checks, `@__llgo_runtime_ctor_init = hidden constant ptr @__llgo_runtime_ctor, section ".init_array"`)
+			} else {
+				checks = append(checks, "@llvm.global_ctors = appending global")
 			}
 			for _, want := range checks {
 				if !strings.Contains(ir, want) {

--- a/runtime/internal/lib/runtime/atomic_pointer_llgo.go
+++ b/runtime/internal/lib/runtime/atomic_pointer_llgo.go
@@ -1,0 +1,23 @@
+//go:build darwin || linux
+
+package runtime
+
+import (
+	"sync/atomic"
+	"unsafe"
+)
+
+// LLGo's conservative collector does not require Go write barriers, so these
+// hooks can use the standard library's architecture-specific uintptr atomics.
+
+//go:linkname atomic_storePointer internal/runtime/atomic.storePointer
+func atomic_storePointer(ptr *unsafe.Pointer, new unsafe.Pointer) {
+	atomic.StoreUintptr((*uintptr)(unsafe.Pointer(ptr)), uintptr(new))
+}
+
+//go:linkname atomic_casPointer internal/runtime/atomic.casPointer
+func atomic_casPointer(ptr *unsafe.Pointer, old, new unsafe.Pointer) bool {
+	return atomic.CompareAndSwapUintptr(
+		(*uintptr)(unsafe.Pointer(ptr)), uintptr(old), uintptr(new),
+	)
+}

--- a/runtime/internal/lib/runtime/cgo_handle_llgo.go
+++ b/runtime/internal/lib/runtime/cgo_handle_llgo.go
@@ -1,0 +1,66 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package runtime
+
+import (
+	psync "github.com/goplus/llgo/runtime/internal/clite/pthread/sync"
+	_ "unsafe"
+)
+
+// These functions provide runtime/cgo.Handle without pulling in the gc
+// runtime's C callback bridge. LLGo supplies its own C callback trampoline.
+
+//go:linkname cgoNewHandle runtime/cgo.NewHandle
+func cgoNewHandle(v any) uintptr {
+	cgoHandleState.once.Do(initCgoHandleState)
+	cgoHandleState.mu.Lock()
+	cgoHandleState.next++
+	h := cgoHandleState.next
+	if h == 0 {
+		cgoHandleState.mu.Unlock()
+		panic("runtime/cgo: ran out of handle space")
+	}
+	cgoHandleState.handles[h] = v
+	cgoHandleState.mu.Unlock()
+	return h
+}
+
+//go:linkname cgoHandleValue runtime/cgo.Handle.Value
+func cgoHandleValue(h uintptr) any {
+	cgoHandleState.once.Do(initCgoHandleState)
+	cgoHandleState.mu.Lock()
+	v, ok := cgoHandleState.handles[h]
+	cgoHandleState.mu.Unlock()
+	if !ok {
+		panic("runtime/cgo: misuse of an invalid Handle")
+	}
+	return v
+}
+
+//go:linkname cgoHandleDelete runtime/cgo.Handle.Delete
+func cgoHandleDelete(h uintptr) {
+	cgoHandleState.once.Do(initCgoHandleState)
+	cgoHandleState.mu.Lock()
+	_, ok := cgoHandleState.handles[h]
+	if ok {
+		delete(cgoHandleState.handles, h)
+	}
+	cgoHandleState.mu.Unlock()
+	if !ok {
+		panic("runtime/cgo: misuse of an invalid Handle")
+	}
+}
+
+var cgoHandleState struct {
+	once    psync.Once
+	mu      psync.Mutex
+	next    uintptr
+	handles map[uintptr]any
+}
+
+func initCgoHandleState() {
+	cgoHandleState.mu.Init(nil)
+	cgoHandleState.handles = make(map[uintptr]any)
+}

--- a/runtime/internal/lib/runtime/cgroup_linux_go126_llgo.go
+++ b/runtime/internal/lib/runtime/cgroup_linux_go126_llgo.go
@@ -1,0 +1,10 @@
+//go:build linux && go1.26
+
+package runtime
+
+import _ "unsafe"
+
+//go:linkname cgroup_throw internal/runtime/cgroup.throw
+func cgroup_throw(s string) {
+	throw(s)
+}

--- a/runtime/internal/lib/runtime/debug_linkname_llgo.go
+++ b/runtime/internal/lib/runtime/debug_linkname_llgo.go
@@ -2,6 +2,8 @@ package runtime
 
 import (
 	_ "unsafe"
+
+	llrt "github.com/goplus/llgo/runtime/internal/runtime"
 )
 
 var (
@@ -35,7 +37,9 @@ func setGCPercent(in int32) (out int32) {
 }
 
 //go:linkname setPanicOnFault runtime/debug.setPanicOnFault
-func setPanicOnFault(_ bool) (old bool) { return false }
+func setPanicOnFault(in bool) (out bool) {
+	return llrt.SetPanicOnFault(in)
+}
 
 //go:linkname setMaxThreads runtime/debug.setMaxThreads
 func setMaxThreads(in int) (out int) {

--- a/runtime/internal/lib/runtime/error.go
+++ b/runtime/internal/lib/runtime/error.go
@@ -1,6 +1,33 @@
 package runtime
 
-import "github.com/goplus/llgo/runtime/internal/runtime"
+import (
+	llruntime "github.com/goplus/llgo/runtime/internal/runtime"
+	_ "unsafe"
+)
 
-type TypeAssertionError = runtime.TypeAssertionError
-type PanicNilError = runtime.PanicNilError
+type TypeAssertionError = llruntime.TypeAssertionError
+type PanicNilError = llruntime.PanicNilError
+
+// The public runtime package aliases these LLGo runtime error types. Provide
+// the method symbols under their public names as well, so method expressions
+// and C-library builds can retain them.
+
+//go:linkname typeAssertionErrorRuntimeError runtime.(*TypeAssertionError).RuntimeError
+func typeAssertionErrorRuntimeError(e *llruntime.TypeAssertionError) {
+	e.RuntimeError()
+}
+
+//go:linkname typeAssertionErrorError runtime.(*TypeAssertionError).Error
+func typeAssertionErrorError(e *llruntime.TypeAssertionError) string {
+	return e.Error()
+}
+
+//go:linkname panicNilErrorRuntimeError runtime.(*PanicNilError).RuntimeError
+func panicNilErrorRuntimeError(e *llruntime.PanicNilError) {
+	e.RuntimeError()
+}
+
+//go:linkname panicNilErrorError runtime.(*PanicNilError).Error
+func panicNilErrorError(e *llruntime.PanicNilError) string {
+	return e.Error()
+}

--- a/runtime/internal/lib/runtime/gettimeofday_linux_amd64_llgo.go
+++ b/runtime/internal/lib/runtime/gettimeofday_linux_amd64_llgo.go
@@ -1,0 +1,26 @@
+//go:build linux && amd64 && !baremetal
+
+package runtime
+
+import (
+	"unsafe"
+
+	c "github.com/goplus/llgo/runtime/internal/clite"
+	cliteos "github.com/goplus/llgo/runtime/internal/clite/os"
+	clitesyscall "github.com/goplus/llgo/runtime/internal/clite/syscall"
+)
+
+//go:linkname c_gettimeofday C.gettimeofday
+func c_gettimeofday(tv *clitesyscall.Timeval, tz unsafe.Pointer) c.Int
+
+// syscall.Gettimeofday and syscall.Time call an amd64 assembly helper. LLGo's
+// replacement syscall package does not include that symbol, so forward it to
+// libc while preserving syscall's errno result.
+//
+//go:linkname syscall_gettimeofday syscall.gettimeofday
+func syscall_gettimeofday(tv *clitesyscall.Timeval) clitesyscall.Errno {
+	if c_gettimeofday(tv, nil) != 0 {
+		return clitesyscall.Errno(cliteos.Errno())
+	}
+	return 0
+}

--- a/runtime/internal/lib/runtime/os_darwin.go
+++ b/runtime/internal/lib/runtime/os_darwin.go
@@ -9,11 +9,27 @@ func sysctlbynameInt32(name []byte) (int32, int32) {
 	return ret, out
 }
 
+func sysctlbynameBytes(name, out []byte) int32 {
+	nout := uintptr(len(out))
+	return sysctlbyname(&name[0], &out[0], &nout, nil, 0)
+}
+
 //go:linkname internal_cpu_getsysctlbyname internal/cpu.getsysctlbyname
 func internal_cpu_getsysctlbyname(name []byte) (int32, int32) {
 	return sysctlbynameInt32(name)
 }
 
+//go:linkname internal_cpu_sysctlbynameInt32 internal/cpu.sysctlbynameInt32
+func internal_cpu_sysctlbynameInt32(name []byte) (int32, int32) {
+	return sysctlbynameInt32(name)
+}
+
+//go:linkname internal_cpu_sysctlbynameBytes internal/cpu.sysctlbynameBytes
+func internal_cpu_sysctlbynameBytes(name, out []byte) int32 {
+	return sysctlbynameBytes(name, out)
+}
+
+//go:cgo_import_dynamic libc_sysctlbyname sysctlbyname "/usr/lib/libSystem.B.dylib"
 var libc_sysctlbyname_trampoline_addr uintptr
 
 // adapted from runtime/sys_darwin.go in the pattern of sysctl() above, as defined in x/sys/unix

--- a/runtime/internal/lib/runtime/plugin_llgo.go
+++ b/runtime/internal/lib/runtime/plugin_llgo.go
@@ -1,0 +1,17 @@
+package runtime
+
+import _ "unsafe"
+
+type pluginInitTask struct{}
+
+// LLGo does not yet integrate modules loaded by the Go plugin package with its
+// runtime package metadata. Return a deterministic error instead of leaving
+// the standard plugin package with unresolved runtime symbols.
+//
+//go:linkname plugin_lastmoduleinit plugin.lastmoduleinit
+func plugin_lastmoduleinit() (string, map[string]any, []*pluginInitTask, string) {
+	return "", nil, nil, "plugin loading is not supported by llgo"
+}
+
+//go:linkname runtime_doInit runtime.doInit
+func runtime_doInit([]*pluginInitTask) {}

--- a/runtime/internal/lib/runtime/pprof_linkname_llgo.go
+++ b/runtime/internal/lib/runtime/pprof_linkname_llgo.go
@@ -43,16 +43,17 @@ func pprof_cyclesPerSecond() int64 {
 }
 
 var (
-	cpuProfilePeriodRecord = []uint64{3, 0, 100}   // [len, timestamp, hz]
-	cpuProfilePeriodTags   = []unsafe.Pointer{nil} // one tag slot for the period record
-	cpuProfileEOF          = true                  // minimal stub: no streaming samples
+	// C library entry points may reach this hook before ordinary package
+	// initialization, so keep the minimal profile data in static arrays.
+	cpuProfilePeriodRecord = [3]uint64{3, 0, 100} // [len, timestamp, hz]
+	cpuProfilePeriodTags   [1]unsafe.Pointer      // one tag slot for the period record
 )
 
 //go:linkname runtime_pprof_readProfile runtime/pprof.readProfile
 func runtime_pprof_readProfile() (data []uint64, tags []unsafe.Pointer, eof bool) {
 	// Provide a minimal, valid profile stream for runtime/pprof.
 	// The stdlib expects at least the initial "period" record (3 uint64s).
-	return cpuProfilePeriodRecord, cpuProfilePeriodTags, cpuProfileEOF
+	return cpuProfilePeriodRecord[:], cpuProfilePeriodTags[:], true
 }
 
 //go:linkname pprof_goroutineProfileWithLabels runtime.pprof_goroutineProfileWithLabels

--- a/runtime/internal/lib/runtime/pprof_runtime_stub_llgo.go
+++ b/runtime/internal/lib/runtime/pprof_runtime_stub_llgo.go
@@ -9,7 +9,16 @@ import (
 )
 
 type StackRecord struct {
-	Stack []uintptr
+	Stack0 [32]uintptr
+}
+
+func (r *StackRecord) Stack() []uintptr {
+	for i, pc := range r.Stack0 {
+		if pc == 0 {
+			return r.Stack0[:i]
+		}
+	}
+	return r.Stack0[:]
 }
 
 type MemProfileRecord struct {

--- a/runtime/internal/lib/runtime/synctest_llgo.go
+++ b/runtime/internal/lib/runtime/synctest_llgo.go
@@ -6,6 +6,14 @@ import "unsafe"
 
 // Minimal synctest stubs for llgo.
 
+//go:linkname synctest_run internal/synctest.Run
+func synctest_run(f func()) {
+	f()
+}
+
+//go:linkname synctest_wait internal/synctest.Wait
+func synctest_wait() {}
+
 //go:linkname synctest_isInBubble internal/synctest.IsInBubble
 func synctest_isInBubble() bool {
 	return false

--- a/runtime/internal/lib/runtime/syscall_linux_llgo.go
+++ b/runtime/internal/lib/runtime/syscall_linux_llgo.go
@@ -1,0 +1,25 @@
+//go:build linux
+
+package runtime
+
+import (
+	"unsafe"
+
+	clitesyscall "github.com/goplus/llgo/runtime/internal/clite/syscall"
+)
+
+// LLGo may run alongside threads created by C libraries, which the Go runtime
+// cannot enumerate. Match Go's cgo behavior and report AllThreadsSyscall as
+// unsupported rather than changing process credentials on only one thread.
+//
+//go:linkname syscall_runtime_doAllThreadsSyscall syscall.runtime_doAllThreadsSyscall
+//go:uintptrescapes
+func syscall_runtime_doAllThreadsSyscall(_, _, _, _, _, _, _ uintptr) (r1, r2, err uintptr) {
+	return ^uintptr(0), ^uintptr(0), uintptr(clitesyscall.ENOTSUP)
+}
+
+//go:linkname syscall_cgocaller syscall.cgocaller
+//go:uintptrescapes
+func syscall_cgocaller(_ unsafe.Pointer, _ ...uintptr) uintptr {
+	return uintptr(clitesyscall.ENOTSUP)
+}

--- a/runtime/internal/runtime/g.go
+++ b/runtime/internal/runtime/g.go
@@ -20,10 +20,20 @@ import "unsafe"
 
 // g holds the runtime state owned by one LLGo goroutine.
 type g struct {
-	defer_ *Defer
-	panic_ unsafe.Pointer
-	goexit bool
-	isMain bool
+	defer_       *Defer
+	panic_       unsafe.Pointer
+	goexit       bool
+	isMain       bool
+	paniconfault bool
+}
+
+// SetPanicOnFault updates the fault behavior requested by the current
+// goroutine and reports its previous value.
+func SetPanicOnFault(in bool) (out bool) {
+	gp := getg()
+	out = gp.paniconfault
+	gp.paniconfault = in
+	return out
 }
 
 // SetThreadDefer associates the current goroutine with the given defer chain.

--- a/test/std/crypto/ecdsa/go126_symbols_test.go
+++ b/test/std/crypto/ecdsa/go126_symbols_test.go
@@ -23,6 +23,13 @@ func TestKeyBytes(t *testing.T) {
 	if len(privateBytes) != 32 {
 		t.Fatalf("PrivateKey.Bytes length = %d, want 32", len(privateBytes))
 	}
+	parsedPrivate, err := ecdsa.ParseRawPrivateKey(elliptic.P256(), privateBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsedPrivate.D.Cmp(privateKey.D) != 0 {
+		t.Fatal("parsed private key differs from generated key")
+	}
 
 	publicBytes, err := privateKey.PublicKey.Bytes()
 	if err != nil {
@@ -31,5 +38,12 @@ func TestKeyBytes(t *testing.T) {
 	wantPublic := elliptic.Marshal(elliptic.P256(), privateKey.X, privateKey.Y)
 	if !bytes.Equal(publicBytes, wantPublic) {
 		t.Fatalf("PublicKey.Bytes = %x, want %x", publicBytes, wantPublic)
+	}
+	parsedPublic, err := ecdsa.ParseUncompressedPublicKey(elliptic.P256(), publicBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !parsedPublic.Equal(&privateKey.PublicKey) {
+		t.Fatal("parsed public key differs from generated key")
 	}
 }

--- a/test/std/crypto/hpke/hpke_test.go
+++ b/test/std/crypto/hpke/hpke_test.go
@@ -1,0 +1,111 @@
+//go:build go1.26
+
+package hpke_test
+
+import (
+	"bytes"
+	"crypto/ecdh"
+	"crypto/hpke"
+	"crypto/rand"
+	"testing"
+)
+
+func TestSealOpen(t *testing.T) {
+	private, err := ecdh.P256().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publicKey, err := hpke.NewDHKEMPublicKey(private.PublicKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	privateKey, err := hpke.NewDHKEMPrivateKey(private)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info := []byte("llgo hpke")
+	plaintext := []byte("standard library")
+	ciphertext, err := hpke.Seal(publicKey, hpke.HKDFSHA256(), hpke.AES128GCM(), info, plaintext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := hpke.Open(privateKey, hpke.HKDFSHA256(), hpke.AES128GCM(), info, ciphertext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("Open = %q, want %q", got, plaintext)
+	}
+	if _, err := hpke.Open(privateKey, hpke.HKDFSHA256(), hpke.AES128GCM(), []byte("wrong info"), ciphertext); err == nil {
+		t.Fatal("Open with different info unexpectedly succeeded")
+	}
+}
+
+func TestSenderRecipient(t *testing.T) {
+	private, err := ecdh.P256().GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publicKey, err := hpke.NewDHKEMPublicKey(private.PublicKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+	privateKey, err := hpke.NewDHKEMPrivateKey(private)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encapsulation, sender, err := hpke.NewSender(publicKey, hpke.HKDFSHA256(), hpke.AES128GCM(), []byte("info"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	recipient, err := hpke.NewRecipient(encapsulation, privateKey, hpke.HKDFSHA256(), hpke.AES128GCM(), []byte("info"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ciphertext, err := sender.Seal([]byte("aad"), []byte("message"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	plaintext, err := recipient.Open([]byte("aad"), ciphertext)
+	if err != nil || string(plaintext) != "message" {
+		t.Fatalf("Open = (%q, %v)", plaintext, err)
+	}
+	senderExport, err := sender.Export("context", 32)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recipientExport, err := recipient.Export("context", 32)
+	if err != nil || !bytes.Equal(senderExport, recipientExport) {
+		t.Fatal("sender and recipient exports differ")
+	}
+}
+
+func TestComponentInterfaces(t *testing.T) {
+	var kem hpke.KEM = hpke.DHKEM(ecdh.P256())
+	if kem.ID() == 0 {
+		t.Fatal("DHKEM returned a zero KEM identifier")
+	}
+	private, err := kem.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var privateKey hpke.PrivateKey = private
+	privateBytes, err := privateKey.Bytes()
+	if err != nil || len(privateBytes) == 0 {
+		t.Fatalf("private key serialization = %d bytes, %v", len(privateBytes), err)
+	}
+	if privateKey.KEM().ID() != kem.ID() {
+		t.Fatal("private key reports a different KEM")
+	}
+
+	var publicKey hpke.PublicKey = privateKey.PublicKey()
+	if len(publicKey.Bytes()) == 0 || publicKey.KEM().ID() != kem.ID() {
+		t.Fatal("public key serialization or KEM identity is invalid")
+	}
+
+	var kdf hpke.KDF = hpke.HKDFSHA256()
+	var aead hpke.AEAD = hpke.AES128GCM()
+	if kdf.ID() == 0 || aead.ID() == 0 {
+		t.Fatalf("invalid ciphersuite identifiers: KDF=%d AEAD=%d", kdf.ID(), aead.ID())
+	}
+}

--- a/test/std/crypto/mlkem/mlkemtest/mlkemtest_test.go
+++ b/test/std/crypto/mlkem/mlkemtest/mlkemtest_test.go
@@ -1,0 +1,60 @@
+//go:build go1.26
+
+package mlkemtest_test
+
+import (
+	"bytes"
+	"crypto/mlkem"
+	"crypto/mlkem/mlkemtest"
+	"testing"
+)
+
+func TestDeterministicEncapsulation(t *testing.T) {
+	key, err := mlkem.NewDecapsulationKey768(make([]byte, mlkem.SeedSize))
+	if err != nil {
+		t.Fatal(err)
+	}
+	shared, ciphertext, err := mlkemtest.Encapsulate768(key.EncapsulationKey(), make([]byte, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
+	decapsulated, err := key.Decapsulate(ciphertext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(shared, decapsulated) {
+		t.Fatal("encapsulated and decapsulated keys differ")
+	}
+	repeatedShared, repeatedCiphertext, err := mlkemtest.Encapsulate768(key.EncapsulationKey(), make([]byte, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(repeatedShared, shared) || !bytes.Equal(repeatedCiphertext, ciphertext) {
+		t.Fatal("Encapsulate768 is not deterministic for fixed randomness")
+	}
+}
+
+func TestDeterministicEncapsulation1024(t *testing.T) {
+	key, err := mlkem.NewDecapsulationKey1024(make([]byte, mlkem.SeedSize))
+	if err != nil {
+		t.Fatal(err)
+	}
+	shared, ciphertext, err := mlkemtest.Encapsulate1024(key.EncapsulationKey(), make([]byte, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
+	decapsulated, err := key.Decapsulate(ciphertext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(shared, decapsulated) {
+		t.Fatal("encapsulated and decapsulated keys differ")
+	}
+	repeatedShared, repeatedCiphertext, err := mlkemtest.Encapsulate1024(key.EncapsulationKey(), make([]byte, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(repeatedShared, shared) || !bytes.Equal(repeatedCiphertext, ciphertext) {
+		t.Fatal("Encapsulate1024 is not deterministic for fixed randomness")
+	}
+}

--- a/test/std/crypto/tls/tls_test.go
+++ b/test/std/crypto/tls/tls_test.go
@@ -38,7 +38,21 @@ func generateTestCert(t *testing.T) ([]byte, []byte) {
 	}
 
 	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
-	keyDER, _ := x509.MarshalPKCS8PrivateKey(priv)
+	keyDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("Failed to marshal private key: %v", err)
+	}
+	parsedKey, err := x509.ParsePKCS8PrivateKey(keyDER)
+	if err != nil {
+		t.Fatalf("Failed to parse private key: %v", err)
+	}
+	parsedRSA, ok := parsedKey.(*rsa.PrivateKey)
+	if !ok {
+		t.Fatalf("Parsed private key has type %T, want *rsa.PrivateKey", parsedKey)
+	}
+	if !parsedRSA.Equal(priv) {
+		t.Fatal("Parsed private key differs from generated key")
+	}
 	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
 
 	return certPEM, keyPEM

--- a/test/std/crypto/x509/go126_symbols_test.go
+++ b/test/std/crypto/x509/go126_symbols_test.go
@@ -4,6 +4,7 @@ package x509_test
 
 import (
 	"crypto/x509"
+	"encoding/asn1"
 	"testing"
 )
 
@@ -17,5 +18,18 @@ func TestUsageFormatting(t *testing.T) {
 	}
 	if got := x509.KeyUsageDigitalSignature.String(); got != "digitalSignature" {
 		t.Fatalf("KeyUsageDigitalSignature.String = %q", got)
+	}
+}
+
+func TestOIDFromASN1OID(t *testing.T) {
+	oid, err := x509.OIDFromASN1OID(asn1.ObjectIdentifier{1, 2, 840, 113549})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := oid.String(); got != "1.2.840.113549" {
+		t.Fatalf("OID.String = %q", got)
+	}
+	if _, err := x509.OIDFromASN1OID(asn1.ObjectIdentifier{1, 40}); err == nil {
+		t.Fatal("OIDFromASN1OID accepted an invalid second arc")
 	}
 }

--- a/test/std/go/types/go126_symbols_test.go
+++ b/test/std/go/types/go126_symbols_test.go
@@ -21,3 +21,21 @@ func TestVarKind(t *testing.T) {
 		t.Fatalf("LocalVar.String = %q", got)
 	}
 }
+
+func TestLookupSelection(t *testing.T) {
+	field := types.NewField(token.NoPos, nil, "Value", types.Typ[types.String], false)
+	typ := types.NewStruct([]*types.Var{field}, nil)
+	selection, ok := types.LookupSelection(typ, true, nil, "Value")
+	if !ok {
+		t.Fatal("LookupSelection did not find Value")
+	}
+	if selection.Obj() != field || selection.Indirect() {
+		t.Fatalf("LookupSelection = (%v, indirect %v)", selection.Obj(), selection.Indirect())
+	}
+	if index := selection.Index(); len(index) != 1 || index[0] != 0 {
+		t.Fatalf("Selection.Index = %v", index)
+	}
+	if _, ok := types.LookupSelection(typ, true, nil, "Missing"); ok {
+		t.Fatal("LookupSelection unexpectedly found Missing")
+	}
+}

--- a/test/std/io/fs/go126_symbols_test.go
+++ b/test/std/io/fs/go126_symbols_test.go
@@ -18,11 +18,18 @@ func TestReadLinkFS(t *testing.T) {
 	if err != nil || got != "target.txt" {
 		t.Fatalf("ReadLink = %q, %v; want %q, nil", got, err, "target.txt")
 	}
-	info, err := readLinkFS.Lstat("link.txt")
+	info, err := fs.Lstat(filesystem, "link.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if info.Mode()&fs.ModeSymlink == 0 {
 		t.Fatalf("Lstat mode = %v, want symlink", info.Mode())
+	}
+	targetInfo, err := fs.Stat(filesystem, "link.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if targetInfo.Mode()&fs.ModeSymlink != 0 || targetInfo.Size() != int64(len("target")) {
+		t.Fatalf("Stat followed link to mode %v, size %d", targetInfo.Mode(), targetInfo.Size())
 	}
 }

--- a/test/std/log/slog/go126_symbols_test.go
+++ b/test/std/log/slog/go126_symbols_test.go
@@ -5,6 +5,7 @@ package slog_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"log/slog"
 	"runtime"
 	"strings"
@@ -33,21 +34,46 @@ func TestMultiHandlerAndRecordSource(t *testing.T) {
 	}
 	withGroup := multi.WithGroup("details")
 	record := slog.NewRecord(time.Unix(1, 0), slog.LevelInfo, "grouped", 0)
-	record.Add("files", 2)
+	record.AddAttrs(slog.GroupAttrs("build", slog.Int("files", 2)))
 	if err := withGroup.Handle(ctx, record); err != nil {
 		t.Fatal(err)
 	}
-	for name, output := range map[string]string{"text": first.String(), "json": second.String()} {
-		if !strings.Contains(output, "direct") || !strings.Contains(output, "compiled") || !strings.Contains(output, "compiler") || !strings.Contains(output, "details") || !strings.Contains(output, "files") {
-			t.Fatalf("%s handler output is incomplete: %q", name, output)
+	textOutput := first.String()
+	for _, want := range []string{"msg=direct", "msg=compiled component=compiler", "msg=grouped details.build.files=2"} {
+		if !strings.Contains(textOutput, want) {
+			t.Fatalf("text handler output %q does not contain %q", textOutput, want)
 		}
+	}
+	jsonLines := bytes.Split(bytes.TrimSpace(second.Bytes()), []byte("\n"))
+	if len(jsonLines) != 3 {
+		t.Fatalf("JSON handler wrote %d records, want 3: %q", len(jsonLines), second.String())
+	}
+	records := make([]map[string]any, len(jsonLines))
+	for i, line := range jsonLines {
+		if err := json.Unmarshal(line, &records[i]); err != nil {
+			t.Fatalf("JSON record %d is invalid: %v: %q", i, err, line)
+		}
+	}
+	if records[0]["msg"] != "direct" {
+		t.Fatalf("first JSON record = %#v", records[0])
+	}
+	if records[1]["msg"] != "compiled" || records[1]["component"] != "compiler" {
+		t.Fatalf("second JSON record = %#v", records[1])
+	}
+	details, ok := records[2]["details"].(map[string]any)
+	if !ok {
+		t.Fatalf("third JSON record has no details group: %#v", records[2])
+	}
+	build, ok := details["build"].(map[string]any)
+	if !ok || build["files"] != float64(2) {
+		t.Fatalf("third JSON record has wrong build group: %#v", records[2])
 	}
 
 	pcs := make([]uintptr, 1)
 	runtime.Callers(1, pcs)
 	sourceRecord := slog.NewRecord(time.Time{}, slog.LevelInfo, "source", pcs[0])
 	source := sourceRecord.Source()
-	if source == nil || source.Function == "" || source.Line == 0 {
+	if source == nil || !strings.Contains(source.Function, "TestMultiHandlerAndRecordSource") || source.Line == 0 {
 		t.Fatalf("Record.Source = %#v", source)
 	}
 }

--- a/test/std/plugin/plugin_test.go
+++ b/test/std/plugin/plugin_test.go
@@ -1,0 +1,37 @@
+//go:build darwin || linux
+
+package plugin_test
+
+import (
+	"path/filepath"
+	"plugin"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestOpenMissingPlugin(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.so")
+	if _, err := plugin.Open(path); err == nil {
+		t.Fatal("Open of a missing plugin succeeded")
+	} else if !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("Open error %q does not identify the missing plugin", err)
+	}
+}
+
+func TestPluginAPISurface(t *testing.T) {
+	pluginType := reflect.TypeOf((*plugin.Plugin)(nil)).Elem()
+	if pluginType.Name() != "Plugin" || pluginType.PkgPath() != "plugin" {
+		t.Fatalf("unexpected Plugin type: %v from %q", pluginType, pluginType.PkgPath())
+	}
+
+	lookup := (*plugin.Plugin).Lookup
+	if reflect.ValueOf(lookup).Pointer() == 0 {
+		t.Fatal("Plugin.Lookup has no callable entry point")
+	}
+
+	var symbol plugin.Symbol = "llgo"
+	if got, ok := symbol.(string); !ok || got != "llgo" {
+		t.Fatalf("Symbol did not preserve its dynamic value: %#v", symbol)
+	}
+}

--- a/test/std/reflect/type_test.go
+++ b/test/std/reflect/type_test.go
@@ -1,6 +1,7 @@
 package reflect_test
 
 import (
+	"math/big"
 	"reflect"
 	"testing"
 )
@@ -42,5 +43,25 @@ func TestTypeKind(t *testing.T) {
 		if typ.Kind() != tt.kind {
 			t.Errorf("TypeOf(%v).Kind() = %v, want %v", tt.value, typ.Kind(), tt.kind)
 		}
+	}
+}
+
+func TestTypeForMatchesStructFieldType(t *testing.T) {
+	type holder struct {
+		Value *big.Int
+	}
+
+	direct := reflect.TypeFor[*big.Int]()
+	repeated := reflect.TypeFor[*big.Int]()
+	field := reflect.TypeFor[holder]().Field(0).Type
+	if direct != repeated {
+		t.Fatalf("repeated TypeFor returned distinct types: %v and %v", direct, repeated)
+	}
+	if direct != field {
+		t.Fatalf("TypeFor type %v differs from struct field type %v", direct, field)
+	}
+	value := reflect.ValueOf(&holder{}).Elem().Field(0).Addr().Interface()
+	if _, ok := value.(**big.Int); !ok {
+		t.Fatalf("reflected field address has type %T, want **big.Int", value)
 	}
 }

--- a/test/std/runtime/cgo/cgo_test.go
+++ b/test/std/runtime/cgo/cgo_test.go
@@ -1,0 +1,35 @@
+package cgo_test
+
+import (
+	"reflect"
+	"runtime/cgo"
+	"testing"
+)
+
+func TestHandleLifecycle(t *testing.T) {
+	type payload struct{ name string }
+	want := &payload{name: "llgo"}
+	handle := cgo.NewHandle(want)
+	if got, ok := handle.Value().(*payload); !ok || got != want {
+		t.Fatalf("Value = %#v, want the original payload", got)
+	}
+	handle.Delete()
+	if panicValue := panicFrom(func() { handle.Value() }); panicValue == nil {
+		t.Fatal("Value on a deleted handle did not panic")
+	}
+}
+
+func TestIncompleteTypeIdentity(t *testing.T) {
+	typ := reflect.TypeOf(cgo.Incomplete{})
+	if typ.Name() != "Incomplete" || typ.PkgPath() != "runtime/cgo" {
+		t.Fatalf("unexpected incomplete C type marker: %v from %q", typ, typ.PkgPath())
+	}
+}
+
+func panicFrom(f func()) (value any) {
+	defer func() {
+		value = recover()
+	}()
+	f()
+	return nil
+}

--- a/test/std/runtime/coverage/coverage_test.go
+++ b/test/std/runtime/coverage/coverage_test.go
@@ -1,0 +1,61 @@
+package coverage_test
+
+import (
+	"bytes"
+	"os"
+	"runtime/coverage"
+	"strings"
+	"testing"
+)
+
+func TestRuntimeCoverageWritersAgree(t *testing.T) {
+	var meta bytes.Buffer
+	metaErr := coverage.WriteMeta(&meta)
+	metaDir := t.TempDir()
+	metaDirErr := coverage.WriteMetaDir(metaDir)
+	checkWriteResults(t, "metadata", "covmeta.", meta.Len(), metaErr, metaDir, metaDirErr)
+
+	var counters bytes.Buffer
+	counterErr := coverage.WriteCounters(&counters)
+	counterDir := t.TempDir()
+	counterDirErr := coverage.WriteCountersDir(counterDir)
+	checkWriteResults(t, "counters", "covcounters.", counters.Len(), counterErr, counterDir, counterDirErr)
+
+	clearErr := coverage.ClearCounters()
+	if counterErr != nil && clearErr == nil {
+		t.Fatalf("ClearCounters succeeded although WriteCounters is unavailable: %v", counterErr)
+	}
+}
+
+func checkWriteResults(t *testing.T, name, prefix string, directBytes int, directErr error, dir string, dirErr error) {
+	t.Helper()
+	if (directErr == nil) != (dirErr == nil) {
+		t.Fatalf("%s writer availability differs: direct=%v, directory=%v", name, directErr, dirErr)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if directErr != nil {
+		if directBytes != 0 || len(entries) != 0 {
+			t.Fatalf("unavailable %s writers produced %d bytes and %d files", name, directBytes, len(entries))
+		}
+		return
+	}
+	if directBytes == 0 {
+		t.Fatalf("Write%s succeeded without writing data", name)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), prefix) {
+			info, err := entry.Info()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if info.Size() == 0 {
+				t.Fatalf("%s file %q is empty", name, entry.Name())
+			}
+			return
+		}
+	}
+	t.Fatalf("Write%sDir produced no %q file: %v", name, prefix, entries)
+}

--- a/test/std/runtime/debug/debug_test.go
+++ b/test/std/runtime/debug/debug_test.go
@@ -74,6 +74,24 @@ func TestRuntimeSettings(t *testing.T) {
 	debug.FreeOSMemory()
 }
 
+func TestPanicOnFaultStateIsGoroutineLocal(t *testing.T) {
+	previous := debug.SetPanicOnFault(true)
+	defer debug.SetPanicOnFault(previous)
+
+	result := make(chan [2]bool, 1)
+	go func() {
+		first := debug.SetPanicOnFault(true)
+		second := debug.SetPanicOnFault(false)
+		result <- [2]bool{first, second}
+	}()
+	if got := <-result; got != [2]bool{false, true} {
+		t.Fatalf("new goroutine SetPanicOnFault states = %v, want [false true]", got)
+	}
+	if got := debug.SetPanicOnFault(previous); !got {
+		t.Fatal("child goroutine changed the parent SetPanicOnFault state")
+	}
+}
+
 func TestCrashAndHeapDumpOutputs(t *testing.T) {
 	crashFile, err := os.CreateTemp(t.TempDir(), "crash-*.log")
 	if err != nil {

--- a/test/std/runtime/debug/debug_test.go
+++ b/test/std/runtime/debug/debug_test.go
@@ -1,0 +1,136 @@
+package debug_test
+
+import (
+	"io"
+	"os"
+	"reflect"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"testing"
+)
+
+func TestStackReportsCaller(t *testing.T) {
+	stack := string(debug.Stack())
+	if !strings.Contains(stack, "TestStackReportsCaller") {
+		t.Fatalf("Stack does not contain the caller: %q", stack)
+	}
+}
+
+func TestPrintStackReportsCaller(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldStderr := os.Stderr
+	os.Stderr = w
+	debug.PrintStack()
+	os.Stderr = oldStderr
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	stack, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(stack), "TestPrintStackReportsCaller") {
+		t.Fatalf("PrintStack does not contain the caller: %q", stack)
+	}
+}
+
+func TestRuntimeSettings(t *testing.T) {
+	var stats debug.GCStats
+	runtime.GC()
+	debug.ReadGCStats(&stats)
+	if stats.NumGC < 0 || stats.PauseTotal < 0 {
+		t.Fatalf("invalid GC statistics: %#v", stats)
+	}
+
+	previousGC := debug.SetGCPercent(100)
+	if got := debug.SetGCPercent(previousGC); got != 100 {
+		t.Fatalf("SetGCPercent restore returned %d, want 100", got)
+	}
+	previousLimit := debug.SetMemoryLimit(1 << 30)
+	if got := debug.SetMemoryLimit(previousLimit); got != 1<<30 {
+		t.Fatalf("SetMemoryLimit restore returned %d, want %d", got, int64(1<<30))
+	}
+	previousStack := debug.SetMaxStack(1 << 30)
+	if got := debug.SetMaxStack(previousStack); got != 1<<30 {
+		t.Fatalf("SetMaxStack restore returned %d, want %d", got, 1<<30)
+	}
+	previousThreads := debug.SetMaxThreads(10001)
+	if got := debug.SetMaxThreads(previousThreads); got != 10001 {
+		t.Fatalf("SetMaxThreads restore returned %d, want 10001", got)
+	}
+	previousPanicOnFault := debug.SetPanicOnFault(true)
+	if got := debug.SetPanicOnFault(previousPanicOnFault); !got {
+		t.Fatal("SetPanicOnFault did not report the previous enabled state")
+	}
+
+	debug.SetTraceback("single")
+	debug.FreeOSMemory()
+}
+
+func TestCrashAndHeapDumpOutputs(t *testing.T) {
+	crashFile, err := os.CreateTemp(t.TempDir(), "crash-*.log")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := debug.SetCrashOutput(crashFile, debug.CrashOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := debug.SetCrashOutput(nil, debug.CrashOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := crashFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	heapFile, err := os.CreateTemp(t.TempDir(), "heap-*.dump")
+	if err != nil {
+		t.Fatal(err)
+	}
+	debug.WriteHeapDump(heapFile.Fd())
+	if _, err := heapFile.WriteString("fd-remains-open"); err != nil {
+		t.Fatalf("heap dump closed its output descriptor: %v", err)
+	}
+	if err := heapFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildInfoParsingAndReading(t *testing.T) {
+	const encoded = "go\t1.26\npath\texample.com/app\nmod\texample.com/app\tv1.2.3\th1:main\ndep\texample.com/dep\tv0.4.5\th1:dep\nbuild\t-compiler=gc\n"
+	info, err := debug.ParseBuildInfo(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Path != "example.com/app" || info.Main.Path != "example.com/app" || info.Main.Version != "v1.2.3" {
+		t.Fatalf("parsed main module = %#v, path %q", info.Main, info.Path)
+	}
+	if len(info.Deps) != 1 || info.Deps[0].Path != "example.com/dep" || info.Deps[0].Version != "v0.4.5" {
+		t.Fatalf("parsed dependencies = %#v", info.Deps)
+	}
+	if len(info.Settings) != 1 || info.Settings[0].Key != "-compiler" || info.Settings[0].Value != "gc" {
+		t.Fatalf("parsed settings = %#v", info.Settings)
+	}
+	roundTrip, err := debug.ParseBuildInfo(info.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(roundTrip, info) {
+		t.Fatalf("build info changed after round trip:\nfirst: %#v\nsecond: %#v", info, roundTrip)
+	}
+
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if !strings.HasPrefix(info.GoVersion, "go") {
+			t.Fatalf("GoVersion = %q", info.GoVersion)
+		}
+		if info.String() == "" {
+			t.Fatal("BuildInfo.String returned an empty string")
+		}
+	}
+}

--- a/test/std/runtime/race/race_test.go
+++ b/test/std/runtime/race/race_test.go
@@ -1,0 +1,10 @@
+package race_test
+
+import (
+	_ "runtime/race"
+	"testing"
+)
+
+func TestPackageImports(t *testing.T) {
+	t.Log("runtime/race intentionally has no public API")
+}

--- a/test/std/runtime/runtime_operations_test.go
+++ b/test/std/runtime/runtime_operations_test.go
@@ -1,0 +1,60 @@
+package runtime_test
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestGoexitRunsDeferredCalls(t *testing.T) {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runtime.Goexit()
+	}()
+	<-done
+}
+
+func TestRuntimeFunctionInformation(t *testing.T) {
+	pc, _, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("Caller failed")
+	}
+	fn := runtime.FuncForPC(pc)
+	if fn == nil || fn.Entry() == 0 || fn.Name() == "" {
+		t.Fatal("FuncForPC returned incomplete information")
+	}
+	if file, line := fn.FileLine(pc); file == "" || line == 0 {
+		t.Fatal("FileLine returned incomplete information")
+	}
+}
+
+func TestRuntimeRecordMethods(t *testing.T) {
+	mem := runtime.MemProfileRecord{
+		AllocBytes:   1024,
+		FreeBytes:    256,
+		AllocObjects: 8,
+		FreeObjects:  3,
+		Stack0:       [32]uintptr{11, 22},
+	}
+	if got := mem.InUseBytes(); got != 768 {
+		t.Fatalf("InUseBytes = %d, want 768", got)
+	}
+	if got := mem.InUseObjects(); got != 5 {
+		t.Fatalf("InUseObjects = %d, want 5", got)
+	}
+	if stack := mem.Stack(); len(stack) != 2 || stack[0] != 11 || stack[1] != 22 {
+		t.Fatalf("MemProfileRecord.Stack = %v", stack)
+	}
+
+	record := runtime.StackRecord{Stack0: [32]uintptr{33, 44}}
+	if stack := record.Stack(); len(stack) != 2 || stack[0] != 33 || stack[1] != 44 {
+		t.Fatalf("StackRecord.Stack = %v", stack)
+	}
+}
+
+func TestRuntimeErrorMethods(t *testing.T) {
+	panicNil := new(runtime.PanicNilError)
+	if got := panicNil.Error(); got != "panic called with nil argument" {
+		t.Fatalf("PanicNilError.Error = %q", got)
+	}
+}

--- a/test/std/runtime/runtime_test.go
+++ b/test/std/runtime/runtime_test.go
@@ -1,0 +1,42 @@
+package runtime_test
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestRuntimeInformationAndCallers(t *testing.T) {
+	if runtime.GOOS == "" || runtime.GOARCH == "" || runtime.Compiler == "" {
+		t.Fatal("runtime target information is empty")
+	}
+	if runtime.NumCPU() < 1 || runtime.GOMAXPROCS(0) < 1 {
+		t.Fatal("runtime CPU information is invalid")
+	}
+	if !strings.HasPrefix(runtime.Version(), "go") {
+		t.Fatalf("Version = %q", runtime.Version())
+	}
+	pcs := make([]uintptr, 16)
+	n := runtime.Callers(0, pcs)
+	if n == 0 {
+		t.Fatal("Callers returned no frames")
+	}
+	frames := runtime.CallersFrames(pcs[:n])
+	foundTest := false
+	for {
+		frame, more := frames.Next()
+		if strings.Contains(frame.Function, "TestRuntimeInformationAndCallers") {
+			if frame.File == "" || frame.Line == 0 {
+				t.Fatalf("test frame has incomplete source information: %#v", frame)
+			}
+			foundTest = true
+			break
+		}
+		if !more {
+			break
+		}
+	}
+	if !foundTest {
+		t.Fatal("CallersFrames did not report TestRuntimeInformationAndCallers")
+	}
+}

--- a/test/std/testing/cryptotest/cryptotest_test.go
+++ b/test/std/testing/cryptotest/cryptotest_test.go
@@ -1,0 +1,26 @@
+//go:build go1.26
+
+package cryptotest_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+	"testing/cryptotest"
+)
+
+func TestSetGlobalRandom(t *testing.T) {
+	cryptotest.SetGlobalRandom(t, 1)
+	first := make([]byte, 32)
+	if _, err := rand.Read(first); err != nil {
+		t.Fatal(err)
+	}
+	cryptotest.SetGlobalRandom(t, 1)
+	second := make([]byte, 32)
+	if _, err := rand.Read(second); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatal("resetting the seed did not reproduce the random stream")
+	}
+}

--- a/test/std/testing/synctest/synctest_test.go
+++ b/test/std/testing/synctest/synctest_test.go
@@ -1,0 +1,30 @@
+//go:build go1.26
+
+package synctest_test
+
+import (
+	"testing"
+	"testing/synctest"
+)
+
+func TestCallbackExecution(t *testing.T) {
+	calls := 0
+	cleanupRan := false
+	synctest.Test(t, func(bubbleT *testing.T) {
+		calls++
+		if bubbleT.Name() != t.Name() {
+			bubbleT.Fatalf("callback test name = %q, want %q", bubbleT.Name(), t.Name())
+		}
+		bubbleT.Cleanup(func() { cleanupRan = true })
+		synctest.Wait()
+		if calls != 1 {
+			bubbleT.Fatalf("Wait resumed with callback count %d", calls)
+		}
+	})
+	if calls != 1 {
+		t.Fatalf("synctest callback ran %d times, want 1", calls)
+	}
+	if !cleanupRan {
+		t.Fatal("synctest callback cleanup did not run before Test returned")
+	}
+}


### PR DESCRIPTION
Depends on https://github.com/xgo-dev/llgo/pull/2098

## Problem

The Go 1.26 upgrade added packages and exported APIs that were not all represented by `test/std`. The coverage job only checked packages that already had a test directory, so a missing public package was invisible. Executable-only tests also did not prove that standard-library code initialized and ran correctly from `c-shared` and `c-archive` C consumers.

## Fix

- require a `test/std` package for every public package reported by Go 1.26.5 (`176/176`);
- keep the existing exported-identifier checker unchanged;
- add functional tests for missing packages and newly exposed APIs, including HPKE, ML-KEM helpers, `runtime/cgo.Handle`, runtime/debug, plugin failure behavior, and `testing/synctest`;
- add the minimal Go 1.26 runtime bridges exposed by those tests without duplicating #2027's memory-profile work;
- teach `llgo test -c` to produce runnable `c-shared` and `c-archive` test libraries;
- run every `test/std` package as an executable on Linux and macOS, and through real C shared/static consumers on Ubuntu.

The tests call APIs and assert behavior; exported-symbol completeness remains a separate compile-time invariant.

This PR has an independent diff of `+1156/-25` across 36 files.

## Validation

- macOS arm64 / Go 1.26.5: changed runtime/debug tests pass with real LLGo.
- Ubuntu arm64 / Go 1.26.5 / LLVM 19.1.7: runtime/debug passes as an executable, `c-shared`, and `c-archive` in an 8 GiB, 2 CPU, no-swap container.
- Public package coverage remains `176/176`.
- Focused `internal/build` tests pass.

Follow-up to #2088 and #2108.
