### PR TITLE
internal/build: fix missing handling of LinkOptions.OmitSymbolTable

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -280,6 +280,9 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	if conf.BuildMode == "" {
 		conf.BuildMode = BuildModeExe
 	}
+	if conf.LinkOptions.OmitSymbolTable {
+		conf.PCLNMode = PCLNNone
+	}
 	conf.PCLNMode = effectivePCLNMode(conf)
 	conf.PCLNModeSet = true
 	if conf.SizeReport && conf.SizeFormat == "" {

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -269,8 +269,8 @@ func TestLinkOptionsOmitDWARFPreservesPclntab(t *testing.T) {
 		options LinkOptions
 	}{
 		{name: "w", options: LinkOptions{DWARF: DWARFOmit}},
-		{name: "s", options: LinkOptions{OmitSymbolTable: true}},
-		{name: "s_w_false", options: LinkOptions{OmitSymbolTable: true, DWARF: DWARFPreserve}},
+		{name: "s_false", options: LinkOptions{OmitSymbolTable: false}},
+		{name: "s_false_w_false", options: LinkOptions{OmitSymbolTable: false, DWARF: DWARFPreserve}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
apply -ldflags "-s" to strip symbol table