### PR TITLE
build: run memcpyopt after C ABI lowering

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1618,13 +1618,20 @@ func buildPkg(ctx *context, aPkg *aPackage, verbose bool) error {
 	ctx.cTransformer.TransformModule(ret.Path(), ret.Module())
 	ctx.cTransformer.SetSkipFuncs(nil)
 
+	mod := ret.Module()
+	mod.SetDataLayout(ctx.prog.DataLayout())
+	mod.SetTarget(ctx.prog.Target().Spec().Triple)
+	pbo := gllvm.NewPassBuilderOptions()
+	defer pbo.Dispose()
+
+	// C ABI lowering materializes aggregate copies as load/store pairs. Run
+	// memcpyopt before SROA or code generation can scalarize those aggregates.
+	if err := mod.RunPasses("memcpyopt", ctx.prog.TargetMachine(), pbo); err != nil {
+		return fmt.Errorf("run LLVM memcpyopt pass failed for %v: %v", pkgPath, err)
+	}
+
 	// Run the default LLVM optimization pipeline selected by the requested -O level.
 	if ctx.passOpt {
-		mod := ret.Module()
-		mod.SetDataLayout(ctx.prog.DataLayout())
-		mod.SetTarget(ctx.prog.Target().Spec().Triple)
-		pbo := gllvm.NewPassBuilderOptions()
-		defer pbo.Dispose()
 		if err = gllvm.VerifyModule(mod, gllvm.ReturnStatusAction); err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR fixes #2136 by canonicalizing aggregate copies before LLVM optimization or code generation can expand them.

The implementation includes:

- Initialize the transformed module's data layout and target before running LLVM passes.
- Run `memcpyopt` immediately after `TransformModule`, including in `ModeGen`, so whole-aggregate load/store copies become `llvm.memcpy` before SROA or code generation.
- Reuse the module and pass-builder options for the optional default optimization pipeline.

This prevents unoptimized `ModeGen` builds from sending whole-aggregate copies directly to code generation.


See https://github.com/llvm/llvm-project/pull/210875
