### PR TITLE
debug: establish Go DWARF foundation with stock LLDB support

### DIFF
--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -167,6 +167,12 @@ jobs:
       - name: Show test result
         run: cat result.md
 
+      - name: LLDB integration tests
+        if: ${{ startsWith(matrix.os, 'macos') && matrix.os != 'macos-15-intel' }}
+        run: |
+          echo "Test lldb with llgo plugin on ${{matrix.os}} with LLVM ${{matrix.llvm}}"
+          bash _lldb/runtest.sh -v
+
       - name: DWARF standard tests
         if: ${{ startsWith(matrix.os, 'macos') && matrix.os != 'macos-15-intel' }}
         run: go test -timeout 15m ./internal/build -run '^TestStandardDWARF$' -count=1 -v

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -167,11 +167,9 @@ jobs:
       - name: Show test result
         run: cat result.md
 
-      - name: LLDB tests
+      - name: DWARF standard tests
         if: ${{ startsWith(matrix.os, 'macos') && matrix.os != 'macos-15-intel' }}
-        run: |
-          echo "Test lldb with llgo plugin on ${{matrix.os}} with LLVM ${{matrix.llvm}}"
-          bash _lldb/runtest.sh -v
+        run: go test -timeout 15m ./internal/build -run '^TestStandardDWARF$' -count=1 -v
 
   test:
     name: test (${{ matrix.lane }}, ${{ matrix.os }}, LLVM ${{ matrix.llvm }}, Go ${{ matrix.go }}, shard ${{ matrix.shard }})

--- a/_lldb/README.md
+++ b/_lldb/README.md
@@ -15,6 +15,13 @@ complete local variable inspection in LLDB. The former `LLGO_DEBUG` and
 LLGo's existing runnable DWARF path; improving its metadata quality and making
 it optimization-independent are separate follow-up work.
 
+LLGo currently marks compile units as `DW_LANG_C` because stock LLDB does not
+provide a Go language plugin and otherwise hides valid frame variables.
+`DW_AT_producer` remains `LLGo`, and a versioned debugger marker lets this
+plugin distinguish LLGo binaries from ordinary C targets. Native
+`DW_LANG_Go` support is tracked by
+[issue #2154](https://github.com/xgo-dev/llgo/issues/2154).
+
 ### Debug with lldb
 
 ```shell

--- a/_lldb/lldbtest/main.go
+++ b/_lldb/lldbtest/main.go
@@ -69,8 +69,8 @@ func FuncWithAllTypeStructParam(s StructWithAllTypeFields) {
 	//   s.f32: 11
 	//   s.f64: 12
 	//   s.b: true
-	//   s.c64: complex64{real = 13, imag = 14}
-	//   s.c128: complex128{real = 15, imag = 16}
+	//   s.c64: 13 + 14i
+	//   s.c128: 15 + 16i
 	//   s.slice: []int{21, 22, 23}
 	//   s.arr: [3]int{24, 25, 26}
 	//   s.arr2: [3]lldbtest.E{{i = 27}, {i = 28}, {i = 29}}
@@ -204,8 +204,8 @@ func FuncWithAllTypeParams(
 	//   f32: 19
 	//   f64: 20
 	//   b: false
-	//   c64: complex64{real = 21, imag = 22}
-	//   c128: complex128{real = 23, imag = 24}
+	//   c64: 21 + 22i
+	//   c128: 23 + 24i
 	//   slice: []int{31, 32, 33}
 	//   arr2: [3]lldbtest.E{{i = 37}, {i = 38}, {i = 39}}
 	//   s: "world"
@@ -508,8 +508,8 @@ func main() {
 	//   s.f32: 11
 	//   s.f64: 12
 	//   s.b: true
-	//   s.c64: complex64{real = 13, imag = 14}
-	//   s.c128: complex128{real = 15, imag = 16}
+	//   s.c64: 13 + 14i
+	//   s.c128: 15 + 16i
 	//   s.slice: []int{21, 22, 23}
 	//   s.arr: [3]int{24, 25, 26}
 	//   s.arr2: [3]lldbtest.E{{i = 27}, {i = 28}, {i = 29}}
@@ -521,8 +521,11 @@ func main() {
 	globalStructPtr = &s
 	globalStruct = s
 	println("globalInt:", globalInt)
-	// Expected(skip):
-	//   all variables: globalInt globalStruct globalStructPtr s i err
+	// Expected:
+	//   all variables: s i err
+	//   globalInt: 301
+	//   globalStruct.i8: '\x01'
+	//   (*globalStructPtr).i16: 2
 	println("s:", &s)
 	FuncWithAllTypeStructParam(s)
 	println("called function with struct")

--- a/_lldb/llgo_plugin.py
+++ b/_lldb/llgo_plugin.py
@@ -5,6 +5,9 @@ import re
 import lldb
 
 
+LLGO_DEBUGGER_MARKERS = ("__llgo_debugger_marker_v1",)
+
+
 def log(*args: Any, **kwargs: Any) -> None:
     print(*args, **kwargs, flush=True)
 
@@ -16,8 +19,11 @@ def __lldb_init_module(debugger: lldb.SBDebugger, _: Dict[str, Any]) -> None:
         'command script add -f llgo_plugin.print_all_variables v')
 
 
-def is_llgo_compiler(_target: lldb.SBTarget) -> bool:
-    return True
+def is_llgo_compiler(target: lldb.SBTarget) -> bool:
+    if not target or not target.IsValid():
+        return False
+    return any(target.FindSymbols(marker).GetSize() > 0
+               for marker in LLGO_DEBUGGER_MARKERS)
 
 
 def get_indexed_value(value: lldb.SBValue, index: int) -> Optional[lldb.SBValue]:
@@ -39,6 +45,14 @@ def get_indexed_value(value: lldb.SBValue, index: int) -> Optional[lldb.SBValue]
         return value.GetChildAtIndex(index)
     else:
         return None
+
+
+def find_variable(frame: lldb.SBFrame, name: str) -> lldb.SBValue:
+    value = frame.FindVariable(name)
+    if value and value.IsValid():
+        return value
+    target = frame.GetThread().GetProcess().GetTarget()
+    return target.FindFirstGlobalVariable(name)
 
 
 def evaluate_expression(frame: lldb.SBFrame, expression: str) -> Optional[lldb.SBValue]:
@@ -71,7 +85,7 @@ def evaluate_expression(frame: lldb.SBFrame, expression: str) -> Optional[lldb.S
                 return value, i + 1
             elif part == '.':
                 if value is None:
-                    value = frame.FindVariable(parts[i+1])
+                    value = find_variable(frame, parts[i+1])
                 else:
                     value = value.GetChildMemberWithName(parts[i+1])
                 i += 2
@@ -81,7 +95,7 @@ def evaluate_expression(frame: lldb.SBFrame, expression: str) -> Optional[lldb.S
                 i += 1
             else:
                 if value is None:
-                    value = frame.FindVariable(part)
+                    value = find_variable(frame, part)
                 else:
                     value = value.GetChildMemberWithName(part)
                 i += 1
@@ -126,7 +140,7 @@ def print_all_variables(debugger: lldb.SBDebugger, _command: str, result: lldb.S
 
 
 def is_pointer(frame: lldb.SBFrame, var_name: str) -> bool:
-    var = frame.FindVariable(var_name)
+    var = find_variable(frame, var_name)
     return var.IsValid() and var.GetType().IsPointerType()
 
 

--- a/_lldb/runtest.sh
+++ b/_lldb/runtest.sh
@@ -2,10 +2,12 @@
 
 set -e
 
+script_dir=$(cd "$(dirname "$0")" && pwd)
+
 # Source common functions and variables
 # shellcheck source=./_lldb/common.sh
 # shellcheck disable=SC1091
-source "$(dirname "$0")/common.sh" || exit 1
+source "$script_dir/common.sh" || exit 1
 
 # Parse command-line arguments
 package_path="$DEFAULT_PACKAGE_PATH"
@@ -62,8 +64,20 @@ eval "$LLDB_PATH $lldb_command_string"
 if [ -f "$result_file" ]; then
     exit_code=$(cat "$result_file")
     rm "$result_file"
-    exit "$exit_code"
 else
     echo "Error: Could not find exit code file"
     exit 1
 fi
+
+if [ "$exit_code" -ne 0 ]; then
+    exit "$exit_code"
+fi
+
+# The LLGo formatter must not attach itself to an ordinary C target.
+non_llgo_dir=$(mktemp -d)
+trap 'rm -rf "$non_llgo_dir"' EXIT
+printf 'int main(void) { return 0; }\n' | \
+    "${CC:-cc}" -x c -g -o "$non_llgo_dir/non-llgo" -
+"$LLDB_PATH" --batch "$non_llgo_dir/non-llgo" \
+    -o "command script import \"$script_dir/llgo_plugin.py\"" \
+    -o 'script assert not llgo_plugin.is_llgo_compiler(lldb.target)'

--- a/_lldb/test.py
+++ b/_lldb/test.py
@@ -78,6 +78,10 @@ class LLDBDebugger:
             raise LLDBTestException(
                 f"Failed to create target for {self.executable_path}")
 
+        if not llgo_plugin.is_llgo_compiler(self.target):
+            raise LLDBTestException(
+                "Target does not contain a supported LLGo debugger marker")
+
         self.debugger.HandleCommand(
             'command script add -f llgo_plugin.print_go_expression p')
         self.debugger.HandleCommand(
@@ -107,7 +111,7 @@ class LLDBDebugger:
 
     def get_all_variable_names(self) -> Set[str]:
         frame = self.process.GetSelectedThread().GetFrameAtIndex(0)
-        return set(var.GetName() for var in frame.GetVariables(True, True, True, True))
+        return set(var.GetName() for var in frame.GetVariables(True, True, False, True))
 
     def get_current_function_name(self) -> str:
         frame = self.process.GetSelectedThread().GetFrameAtIndex(0)

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -597,7 +597,7 @@ func (p *context) compileFuncDecl(pkg llssa.Package, f *ssa.Function) (llssa.Fun
 		if f.Recover != nil { // set recover block
 			fn.SetRecover(fn.Block(f.Recover.Index))
 		}
-		dbgEnabled := enableDbg && (f == nil || f.Origin() == nil)
+		dbgEnabled := enableDbg
 		dbgSymsEnabled := enableDbgSyms && (f == nil || f.Origin() == nil)
 		p.inits = append(p.inits, func() {
 			oldFn, oldGoFn, oldMethodNilDerefChecks, oldCallerFrameMark := p.fn, p.goFn, p.methodNilDerefChecks, p.callerFrameMark

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -176,7 +176,8 @@ type context struct {
 	linkOnceFns          map[*ssa.Function]none
 	stackDefers          map[*ssa.Function]bool
 	anonDefers           map[*ssa.Function]bool
-	paramDIVars          map[*types.Var]llssa.DIVar
+	debugDIVars          map[*types.Var]llssa.DIVar
+	debugAllocVars       map[*ssa.Alloc]*types.Var
 	runtimeCallerFuncs   map[*ssa.Function]bool
 	pcLineSeq            uint64
 
@@ -609,9 +610,11 @@ func (p *context) compileFuncDecl(pkg llssa.Package, f *ssa.Function) (llssa.Fun
 			}()
 			p.phis = nil
 			if dbgSymsEnabled {
-				p.paramDIVars = make(map[*types.Var]llssa.DIVar)
+				p.debugDIVars = make(map[*types.Var]llssa.DIVar)
+				p.debugAllocVars = collectDebugAllocVariables(f)
 			} else {
-				p.paramDIVars = nil
+				p.debugDIVars = nil
+				p.debugAllocVars = nil
 			}
 			dbgGoSSADump(f)
 			dbgInstrln("==> FuncBody", name)
@@ -619,7 +622,7 @@ func (p *context) compileFuncDecl(pkg llssa.Package, f *ssa.Function) (llssa.Fun
 			if dbgEnabled {
 				pos := p.goProg.Fset.Position(f.Pos())
 				bodyPos := p.getFuncBodyPos(f)
-				b.DebugFunction(fn, pos, bodyPos)
+				b.DebugFunction(fn, debugFunctionScope(f), pos, bodyPos)
 			}
 			p.bvals = make(map[ssa.Value]llssa.Expr)
 			p.methodNilDerefChecks = collectMethodNilDerefChecks(f)
@@ -787,13 +790,23 @@ func (p *context) debugRef(b llssa.Builder, v *ssa.DebugRef) {
 		return
 	}
 	pos := p.goProg.Fset.Position(v.Pos())
-	value := p.compileValue(b, v.X)
+	var value llssa.Expr
+	if iv, ok := v.X.(instrOrValue); ok {
+		var exists bool
+		value, exists = p.bvals[iv]
+		if !exists {
+			// DebugRef is metadata-only. Do not rematerialize an SSA value that
+			// executable lowering deliberately omitted.
+			return
+		}
+	} else {
+		value = p.compileValue(b, v.X)
+	}
 	fn := v.Parent()
 	dbgVar := p.getLocalVariable(b, fn, variable)
 	scope := variable.Parent()
 	diScope := b.DIScope(p.fn, scope)
 	if v.IsAddr {
-		// *ssa.Alloc
 		b.DIDeclare(variable, value, dbgVar, diScope, pos, b.Func.Block(v.Block().Index))
 	} else {
 		b.DIValue(variable, value, dbgVar, diScope, pos, b.Func.Block(v.Block().Index))
@@ -803,13 +816,16 @@ func (p *context) debugRef(b llssa.Builder, v *ssa.DebugRef) {
 func (p *context) debugParams(b llssa.Builder, f *ssa.Function) {
 	for i, param := range f.Params {
 		variable := param.Object().(*types.Var)
+		if hasDebugAlloc(p.debugAllocVars, variable) {
+			continue
+		}
 		pos := p.goProg.Fset.Position(param.Pos())
 		v := p.compileValue(b, param)
 		ty := param.Type()
 		argNo := i + 1
 		div := b.DIVarParam(p.fn, pos, param.Name(), p.type_(ty, llssa.InGo), argNo)
-		if p.paramDIVars != nil {
-			p.paramDIVars[variable] = div
+		if p.debugDIVars != nil {
+			p.debugDIVars[variable] = div
 		}
 		b.DIParam(variable, v, div, p.fn, pos, p.fn.Block(0))
 	}
@@ -960,8 +976,8 @@ func skipUnusedArrayDeref(v *ssa.UnOp) bool {
 	if block == nil || len(block.Succs) != 1 || !strings.HasPrefix(block.Succs[0].Comment, "rangeindex.") {
 		return false
 	}
-	refs := v.Referrers()
-	if refs == nil || len(*refs) != 0 {
+	refs, ok := nonDebugReferrers(v)
+	if !ok || len(refs) != 0 {
 		return false
 	}
 	if _, ok := v.Type().Underlying().(*types.Array); !ok {
@@ -1059,11 +1075,11 @@ func (p *context) checkVArgs(v *ssa.Alloc, t *types.Pointer) bool {
 }
 
 func (p *context) skipSyntheticMakeSliceAlloc(v *ssa.Alloc) bool {
-	refs := v.Referrers()
-	if refs == nil || len(*refs) != 1 {
+	refs, ok := nonDebugReferrers(v)
+	if !ok || len(refs) != 1 {
 		return false
 	}
-	slice, ok := (*refs)[0].(*ssa.Slice)
+	slice, ok := refs[0].(*ssa.Slice)
 	if !ok {
 		return false
 	}
@@ -1103,11 +1119,14 @@ func (p *context) syntheticMakeSliceCap(v *ssa.Slice) (llssa.Expr, bool) {
 }
 
 func isAllocVargs(ctx *context, v *ssa.Alloc) bool {
-	refs := *v.Referrers()
+	refs, ok := nonDebugReferrers(v)
+	if !ok || len(refs) == 0 {
+		return false
+	}
 	n := len(refs)
 	lastref := refs[n-1]
 	if i, ok := lastref.(*ssa.Slice); ok {
-		if refs = *i.Referrers(); len(refs) == 1 {
+		if refs, _ = nonDebugReferrers(i); len(refs) == 1 {
 			var call *ssa.CallCommon
 			switch ref := refs[0].(type) {
 			case *ssa.Call:
@@ -1216,7 +1235,7 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 				p.recordPanicLocation(b, v.Pos())
 				b.AssertNilDeref(x)
 			}
-			if refs := v.Referrers(); refs != nil && len(*refs) == 0 {
+			if refs, ok := nonDebugReferrers(v); ok && len(refs) == 0 {
 				if t := p.type_(v.Type(), llssa.InGo); t.RawType() != nil {
 					if p.isLargeNonPointerValue(t) {
 						x := p.compileValue(b, v.X)
@@ -1240,8 +1259,8 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 					return
 				}
 			}
-			if refs := v.Referrers(); refs != nil && len(*refs) == 1 {
-				if _, ok := (*refs)[0].(*ssa.MakeInterface); ok {
+			if refs, ok := nonDebugReferrers(v); ok && len(refs) == 1 {
+				if _, ok := refs[0].(*ssa.MakeInterface); ok {
 					if t := p.type_(v.Type(), llssa.InGo); t.RawType() != nil {
 						if p.isLargeNonPointerValue(t) {
 							// Skip the load: the MakeInterface handler below copies
@@ -1318,6 +1337,7 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 		}
 		elem := p.type_(t.Elem(), llssa.InGo)
 		ret = b.Alloc(elem, v.Heap)
+		p.debugAlloc(b, v, ret)
 	case *ssa.IndexAddr:
 		vx := v.X
 		if _, ok := p.isVArgs(vx); ok { // varargs: this is a varargs index
@@ -1368,7 +1388,7 @@ func (p *context) compileInstrOrValue(b llssa.Builder, iv instrOrValue, asValue 
 		ret = b.Slice(x, low, high, max)
 		ret.Type = p.type_(v.Type(), llssa.InGo)
 	case *ssa.MakeInterface:
-		if refs := *v.Referrers(); len(refs) == 1 {
+		if refs, _ := nonDebugReferrers(v); len(refs) == 1 {
 			switch ref := refs[0].(type) {
 			case *ssa.Store:
 				if va, ok := ref.Addr.(*ssa.IndexAddr); ok {
@@ -1485,14 +1505,14 @@ func isEffectfulArrayPointerDeref(v *ssa.UnOp) bool {
 	if !arrayPointerOperandHasEffectAfter(v.X, v.Pos(), nil) {
 		return false
 	}
-	refs := v.Referrers()
-	if refs == nil || len(*refs) == 0 {
-		return refs != nil
+	refs, ok := nonDebugReferrers(v)
+	if !ok || len(refs) == 0 {
+		return ok
 	}
-	if len(*refs) != 1 {
+	if len(refs) != 1 {
 		return false
 	}
-	call, ok := (*refs)[0].(*ssa.Call)
+	call, ok := refs[0].(*ssa.Call)
 	if !ok {
 		return false
 	}
@@ -1543,11 +1563,11 @@ func isInterfaceCompareDeref(v *ssa.UnOp) bool {
 	case *ssa.Alloc, *ssa.Extract, *ssa.FieldAddr, *ssa.FreeVar, *ssa.Global, *ssa.IndexAddr:
 		return false
 	}
-	refs := v.Referrers()
-	if refs == nil || len(*refs) != 1 {
+	refs, ok := nonDebugReferrers(v)
+	if !ok || len(refs) != 1 {
 		return false
 	}
-	bin, ok := (*refs)[0].(*ssa.BinOp)
+	bin, ok := refs[0].(*ssa.BinOp)
 	return ok && (bin.Op == token.EQL || bin.Op == token.NEQ)
 }
 
@@ -1612,17 +1632,19 @@ func (p *context) compileInstr(b llssa.Builder, instr ssa.Instruction) {
 	if _, ok := p.staticInitInstrs[instr]; ok {
 		return
 	}
+	if enableDbg && instr.Parent().Origin() == nil {
+		if _, isDebugRef := instr.(*ssa.DebugRef); !isDebugRef {
+			scope := p.getDebugLocScope(instr.Parent(), instr.Pos())
+			if scope != nil {
+				diScope := b.DIScope(p.fn, scope)
+				pos := p.fset.Position(instr.Pos())
+				b.DISetCurrentDebugLocation(diScope, pos)
+			}
+		}
+	}
 	if iv, ok := instr.(instrOrValue); ok {
 		p.compileInstrOrValue(b, iv, false)
 		return
-	}
-	if enableDbg && instr.Parent().Origin() == nil {
-		scope := p.getDebugLocScope(instr.Parent(), instr.Pos())
-		if scope != nil {
-			diScope := b.DIScope(p.fn, scope)
-			pos := p.fset.Position(instr.Pos())
-			b.DISetCurrentDebugLocation(diScope, pos)
-		}
 	}
 	switch v := instr.(type) {
 	case *ssa.Store:
@@ -1717,15 +1739,19 @@ func (p *context) compileInstr(b llssa.Builder, instr ssa.Instruction) {
 }
 
 func (p *context) getLocalVariable(b llssa.Builder, fn *ssa.Function, v *types.Var) llssa.DIVar {
-	if p.paramDIVars != nil {
-		if div, ok := p.paramDIVars[v]; ok {
+	if p.debugDIVars != nil {
+		if div, ok := p.debugDIVars[v]; ok {
 			return div
 		}
 	}
 	pos := p.fset.Position(v.Pos())
 	t := p.type_(v.Type(), llssa.InGo)
 	scope := b.DIScope(p.fn, v.Parent())
-	return b.DIVarAuto(scope, pos, v.Name(), t)
+	div := b.DIVarAuto(scope, pos, v.Name(), t)
+	if p.debugDIVars != nil {
+		p.debugDIVars[v] = div
+	}
+	return div
 }
 
 func (p *context) compileFunction(v *ssa.Function) (goFn llssa.Function, pyFn llssa.PyObjRef, kind int) {
@@ -2009,6 +2035,7 @@ func newPackageEx(prog llssa.Program, ct *CallerTracking, patches Patches, rewri
 	ret = prog.NewPackage(pkgName, pkgPath)
 	if enableDbg {
 		ret.InitDebug(pkgName, pkgPath, pkgProg.Fset)
+		defer ret.FinalizeDebug()
 	}
 
 	if ct == nil {

--- a/cl/debug_alloc.go
+++ b/cl/debug_alloc.go
@@ -1,0 +1,64 @@
+package cl
+
+import (
+	"go/types"
+
+	llssa "github.com/goplus/llgo/ssa"
+	"golang.org/x/tools/go/ssa"
+)
+
+func collectDebugAllocVariables(fn *ssa.Function) map[*ssa.Alloc]*types.Var {
+	variables := make(map[*ssa.Alloc]*types.Var)
+	for _, block := range fn.Blocks {
+		for _, instr := range block.Instrs {
+			ref, ok := instr.(*ssa.DebugRef)
+			if !ok || !ref.IsAddr {
+				continue
+			}
+			alloc, ok := ref.X.(*ssa.Alloc)
+			if !ok || alloc.Parent() != fn {
+				continue
+			}
+			variable, ok := ref.Object().(*types.Var)
+			if ok && !variable.IsField() {
+				variables[alloc] = variable
+			}
+		}
+	}
+	return variables
+}
+
+func hasDebugAlloc(variables map[*ssa.Alloc]*types.Var, variable *types.Var) bool {
+	for _, candidate := range variables {
+		if candidate == variable {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *context) debugAlloc(b llssa.Builder, alloc *ssa.Alloc, addr llssa.Expr) {
+	variable := p.debugAllocVars[alloc]
+	if variable == nil {
+		return
+	}
+	pos := p.goProg.Fset.Position(variable.Pos())
+	var dbgVar llssa.DIVar
+	if argNo := debugParameterArgNo(p.goFn, variable); argNo != 0 {
+		dbgVar = b.DIVarParam(p.fn, pos, variable.Name(), p.type_(variable.Type(), llssa.InGo), argNo)
+		p.debugDIVars[variable] = dbgVar
+	} else {
+		dbgVar = p.getLocalVariable(b, p.goFn, variable)
+	}
+	diScope := b.DIScope(p.fn, variable.Parent())
+	b.DIDeclare(variable, addr, dbgVar, diScope, pos, b.Func.Block(alloc.Block().Index))
+}
+
+func debugParameterArgNo(fn *ssa.Function, variable *types.Var) int {
+	for i, param := range fn.Params {
+		if param.Object() == variable {
+			return i + 1
+		}
+	}
+	return 0
+}

--- a/cl/debug_alloc_test.go
+++ b/cl/debug_alloc_test.go
@@ -1,0 +1,71 @@
+package cl
+
+import (
+	"go/ast"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"testing"
+
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/ssa/ssautil"
+)
+
+func TestCollectDebugAllocVariables(t *testing.T) {
+	const source = `package debugalloc
+type item struct { value int }
+func named(items [3]item) {
+	items[0].value = 1
+	println(items[0].value)
+}
+var anonymous = func(values [2]int) {
+	values[0] = 1
+	println(values[0])
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "debug_alloc.go", source, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkg, _, err := ssautil.BuildPackage(
+		&types.Config{Importer: importer.Default()},
+		fset,
+		types.NewPackage("debugalloc", "debugalloc"),
+		[]*ast.File{file},
+		ssa.SanityCheckFunctions|ssa.InstantiateGenerics|ssa.GlobalDebug,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertDebugAllocParameter(t, pkg.Func("named"), "items")
+	initFn := pkg.Func("init")
+	for _, fn := range initFn.AnonFuncs {
+		if fn.Syntax() != nil {
+			assertDebugAllocParameter(t, fn, "values")
+			return
+		}
+	}
+	t.Fatal("anonymous function not found")
+}
+
+func assertDebugAllocParameter(t *testing.T, fn *ssa.Function, name string) {
+	t.Helper()
+	variables := collectDebugAllocVariables(fn)
+	if len(fn.Params) != 1 || fn.Params[0].Name() != name {
+		t.Fatalf("unexpected parameters for %s: %v", fn, fn.Params)
+	}
+	variable := fn.Params[0].Object().(*types.Var)
+	if !hasDebugAlloc(variables, variable) {
+		t.Fatalf("%s parameter %q has no debug alloca", fn, name)
+	}
+	if got := debugParameterArgNo(fn, variable); got != 1 {
+		t.Fatalf("debugParameterArgNo(%s) = %d, want 1", name, got)
+	}
+	missing := types.NewVar(token.NoPos, nil, "missing", types.Typ[types.Int])
+	if got := debugParameterArgNo(fn, missing); got != 0 {
+		t.Fatalf("debugParameterArgNo(missing) = %d, want 0", got)
+	}
+}

--- a/cl/debug_compile_test.go
+++ b/cl/debug_compile_test.go
@@ -8,9 +8,12 @@ import (
 	"go/parser"
 	"go/token"
 	"go/types"
+	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/goplus/llgo/internal/optlevel"
+	llssa "github.com/goplus/llgo/ssa"
 	"github.com/xgo-dev/llvm"
 	"golang.org/x/tools/go/ssa"
 	"golang.org/x/tools/go/ssa/ssautil"
@@ -60,9 +63,12 @@ var anonymous = func(seed int) int {
 		EnableDbgSyms(oldDebugSyms)
 	}()
 
-	prog := newLLSSAProg(t)
+	prog := newLLSSAProgForTarget(t, &llssa.Target{
+		GOOS:     runtime.GOOS,
+		GOARCH:   runtime.GOARCH,
+		OptLevel: optlevel.O0,
+	})
 	defer prog.Dispose()
-	prog.SetDebugInfoOptimized(false)
 	pkg, err := NewPackage(prog, ssaPkg, []*ast.File{file})
 	if err != nil {
 		t.Fatal(err)

--- a/cl/debug_compile_test.go
+++ b/cl/debug_compile_test.go
@@ -1,0 +1,89 @@
+//go:build !llgo
+
+package cl
+
+import (
+	"go/ast"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"strings"
+	"testing"
+
+	"github.com/xgo-dev/llvm"
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/ssa/ssautil"
+)
+
+func TestCompileDebugMetadata(t *testing.T) {
+	const source = `package debugcompile
+
+type item struct { value int }
+
+func inspect(items [2]item, seed int) int {
+	x := seed + 1
+	var local [1]item
+	if x > 0 {
+		items[0].value = x
+		local[0].value = x
+	}
+	return items[0].value + local[0].value
+}
+
+var anonymous = func(seed int) int {
+	value := seed + 1
+	return value
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "debug_compile.go", source, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ssaPkg, _, err := ssautil.BuildPackage(
+		&types.Config{Importer: importer.Default()},
+		fset,
+		types.NewPackage("debugcompile", "debugcompile"),
+		[]*ast.File{file},
+		ssa.SanityCheckFunctions|ssa.InstantiateGenerics|ssa.GlobalDebug,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oldDebug, oldDebugSyms := enableDbg, enableDbgSyms
+	EnableDebug(true)
+	EnableDbgSyms(true)
+	defer func() {
+		EnableDebug(oldDebug)
+		EnableDbgSyms(oldDebugSyms)
+	}()
+
+	prog := newLLSSAProg(t)
+	defer prog.Dispose()
+	prog.SetDebugInfoOptimized(false)
+	pkg, err := NewPackage(prog, ssaPkg, []*ast.File{file})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := llvm.VerifyModule(pkg.Module(), llvm.ReturnStatusAction); err != nil {
+		t.Fatalf("debug module is invalid: %v\n%s", err, pkg.Module().String())
+	}
+	ir := pkg.Module().String()
+	for _, want := range []string{
+		"#dbg_declare",
+		"#dbg_value",
+		"DILexicalBlock",
+		`name: "items", arg: 1`,
+		`name: "seed", arg: 2`,
+		`name: "x"`,
+		`name: "local"`,
+		`name: "value"`,
+		"isOptimized: false",
+	} {
+		if !strings.Contains(ir, want) {
+			t.Errorf("debug module is missing %q:\n%s", want, ir)
+		}
+	}
+}

--- a/cl/debug_scope.go
+++ b/cl/debug_scope.go
@@ -1,0 +1,53 @@
+package cl
+
+import (
+	"go/token"
+	"go/types"
+
+	"golang.org/x/tools/go/ssa"
+)
+
+func debugFunctionScope(fn *ssa.Function) *types.Scope {
+	if fn == nil {
+		return nil
+	}
+	if object, ok := fn.Object().(*types.Func); ok && object.Scope() != nil {
+		return object.Scope()
+	}
+	for _, param := range fn.Params {
+		if object := param.Object(); object != nil && object.Parent() != nil {
+			return object.Parent()
+		}
+	}
+
+	syntax := fn.Syntax()
+	if syntax == nil {
+		return nil
+	}
+	for _, block := range fn.Blocks {
+		for _, instr := range block.Instrs {
+			ref, ok := instr.(*ssa.DebugRef)
+			if !ok {
+				continue
+			}
+			variable, ok := ref.Object().(*types.Var)
+			if !ok || variable.Parent() == nil {
+				continue
+			}
+			return outermostScopeWithin(variable.Parent(), syntax.Pos(), syntax.End())
+		}
+	}
+	return nil
+}
+
+func outermostScopeWithin(scope *types.Scope, start, end token.Pos) *types.Scope {
+	result := scope
+	for parent := scope.Parent(); parent != nil; parent = parent.Parent() {
+		if parent.Pos() == token.NoPos || parent.End() == token.NoPos ||
+			parent.Pos() < start || parent.End() > end {
+			break
+		}
+		result = parent
+	}
+	return result
+}

--- a/cl/debug_scope_test.go
+++ b/cl/debug_scope_test.go
@@ -1,0 +1,76 @@
+package cl
+
+import (
+	"go/ast"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"testing"
+
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/ssa/ssautil"
+)
+
+func TestDebugFunctionScope(t *testing.T) {
+	if debugFunctionScope(nil) != nil || debugFunctionScope(new(ssa.Function)) != nil {
+		t.Fatal("function without source scope should return nil")
+	}
+	const source = `package scope
+
+func named(p int) int {
+	if p != 0 {
+		v := p + 1
+		return v
+	}
+	return p
+}
+
+var anonymous = func() int {
+	if true {
+		v := 1
+		return v
+	}
+	return 0
+}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "scope.go", source, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkg, _, err := ssautil.BuildPackage(
+		&types.Config{Importer: importer.Default()},
+		fset,
+		types.NewPackage("scope", "scope"),
+		[]*ast.File{file},
+		ssa.SanityCheckFunctions|ssa.InstantiateGenerics|ssa.GlobalDebug,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	named := pkg.Func("named")
+	if got, want := debugFunctionScope(named), named.Object().(*types.Func).Scope(); got != want {
+		t.Fatalf("named function scope = %p, want %p", got, want)
+	}
+
+	initFn := pkg.Func("init")
+	var anonymous *ssa.Function
+	for _, child := range initFn.AnonFuncs {
+		if child.Syntax() != nil {
+			anonymous = child
+			break
+		}
+	}
+	if anonymous == nil {
+		t.Fatal("anonymous function not found")
+	}
+	root := debugFunctionScope(anonymous)
+	if root == nil {
+		t.Fatal("anonymous function scope is nil")
+	}
+	if root.Pos() < anonymous.Syntax().Pos() || root.End() > anonymous.Syntax().End() {
+		t.Fatalf("anonymous function scope %s is outside function %s", root, anonymous.Syntax())
+	}
+}

--- a/cl/ssa_referrers.go
+++ b/cl/ssa_referrers.go
@@ -1,0 +1,18 @@
+package cl
+
+import "golang.org/x/tools/go/ssa"
+
+// nonDebugReferrers returns the executable users of v. DebugRef is an SSA
+// pseudo-instruction and must not change lowering decisions based on use count.
+func nonDebugReferrers(v ssa.Value) (refs []ssa.Instruction, available bool) {
+	all := v.Referrers()
+	if all == nil {
+		return nil, false
+	}
+	for _, ref := range *all {
+		if _, ok := ref.(*ssa.DebugRef); !ok {
+			refs = append(refs, ref)
+		}
+	}
+	return refs, true
+}

--- a/cl/ssa_referrers_test.go
+++ b/cl/ssa_referrers_test.go
@@ -1,0 +1,76 @@
+package cl
+
+import (
+	"go/ast"
+	"go/constant"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"testing"
+
+	"golang.org/x/tools/go/ssa"
+	"golang.org/x/tools/go/ssa/ssautil"
+)
+
+func TestNonDebugReferrers(t *testing.T) {
+	constantValue := ssa.NewConst(constant.MakeInt64(1), types.Typ[types.Int])
+	if refs, available := nonDebugReferrers(constantValue); available || refs != nil {
+		t.Fatalf("constant referrers = %v, available = %v", refs, available)
+	}
+	const source = `package refs
+func f(p int) int {
+	x := p + 1
+	println(x)
+	return x
+}`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "refs.go", source, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkg, _, err := ssautil.BuildPackage(
+		&types.Config{Importer: importer.Default()},
+		fset,
+		types.NewPackage("refs", "refs"),
+		[]*ast.File{file},
+		ssa.SanityCheckFunctions|ssa.InstantiateGenerics|ssa.GlobalDebug,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var sum *ssa.BinOp
+	for _, block := range pkg.Func("f").Blocks {
+		for _, instr := range block.Instrs {
+			if candidate, ok := instr.(*ssa.BinOp); ok && candidate.Op == token.ADD {
+				sum = candidate
+			}
+		}
+	}
+	if sum == nil {
+		t.Fatal("sum instruction not found")
+	}
+	all := *sum.Referrers()
+	refs, available := nonDebugReferrers(sum)
+	if !available {
+		t.Fatal("referrers unexpectedly unavailable")
+	}
+	debugRefs := 0
+	for _, ref := range all {
+		if _, ok := ref.(*ssa.DebugRef); ok {
+			debugRefs++
+		}
+	}
+	if debugRefs == 0 {
+		t.Fatalf("GlobalDebug produced no DebugRef for %s", sum)
+	}
+	if len(refs) != len(all)-debugRefs {
+		t.Fatalf("filtered referrers = %d, all = %d, debug = %d", len(refs), len(all), debugRefs)
+	}
+	for _, ref := range refs {
+		if _, ok := ref.(*ssa.DebugRef); ok {
+			t.Fatalf("filtered referrers still contain %T", ref)
+		}
+	}
+}

--- a/internal/build/dwarf_standard_test.go
+++ b/internal/build/dwarf_standard_test.go
@@ -1,0 +1,423 @@
+//go:build !llgo
+
+package build
+
+import (
+	"debug/dwarf"
+	"debug/elf"
+	"debug/macho"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/goplus/llgo/internal/optlevel"
+	llvmenv "github.com/goplus/llgo/xtool/env/llvm"
+)
+
+const dwarfLanguageGo = 0x16
+
+type dwarfNode struct {
+	entry    *dwarf.Entry
+	children []*dwarfNode
+}
+
+func TestStandardDWARF(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip("native DWARF integration test requires Mach-O or ELF")
+	}
+
+	for _, level := range []optlevel.Level{optlevel.O0, optlevel.O2} {
+		t.Run(level.String(), func(t *testing.T) {
+			bin := filepath.Join(t.TempDir(), "dwarf-standard")
+			conf := NewDefaultConf(ModeBuild)
+			conf.OutFile = bin
+			conf.OptLevel = level
+			conf.LinkOptions.DWARF = DWARFPreserve
+			if _, err := Do([]string{"./testdata/dwarf"}, conf); err != nil {
+				t.Fatalf("build DWARF fixture at %s: %v", level, err)
+			}
+			if got := runBinary(t, bin); got != "dwarf-ok\n" {
+				t.Fatalf("DWARF fixture output at %s = %q", level, got)
+			}
+
+			data, dwarfPath := openNativeDWARF(t, bin)
+			verifyDWARF(t, dwarfPath)
+			roots := readDWARFTree(t, data)
+			cu := findDWARFNode(roots, dwarf.TagCompileUnit, "main")
+			if cu == nil {
+				t.Fatal("main compile unit not found")
+			}
+			if got, _ := cu.entry.Val(dwarf.AttrLanguage).(int64); got != dwarfLanguageGo {
+				t.Fatalf("DW_AT_language = %#x, want DW_LANG_Go", got)
+			}
+			if got, _ := cu.entry.Val(dwarf.AttrProducer).(string); got != "LLGo" {
+				t.Fatalf("DW_AT_producer = %q, want LLGo", got)
+			}
+
+			assertDWARFCoreTypes(t, data, cu)
+			if level == optlevel.O0 {
+				assertDWARFProgramStructure(t, data, cu)
+			}
+			assertDWARFLines(t, data, cu, "helper.go", markerLineInFile(t, "testdata/dwarf/helper.go", "DWARF_LINE_MARKER"))
+		})
+	}
+}
+
+func openNativeDWARF(t *testing.T, bin string) (*dwarf.Data, string) {
+	t.Helper()
+	switch runtime.GOOS {
+	case "linux":
+		file, err := elf.Open(bin)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = file.Close() })
+		data, err := file.DWARF()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return data, bin
+	case "darwin":
+		dsym := filepath.Join(t.TempDir(), filepath.Base(bin)+".dSYM")
+		if out, err := exec.Command("dsymutil", bin, "-o", dsym).CombinedOutput(); err != nil {
+			t.Fatalf("dsymutil: %v\n%s", err, out)
+		}
+		dwarfPath := filepath.Join(dsym, "Contents", "Resources", "DWARF", filepath.Base(bin))
+		file, err := macho.Open(dwarfPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = file.Close() })
+		data, err := file.DWARF()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return data, dwarfPath
+	default:
+		panic("unreachable")
+	}
+}
+
+func verifyDWARF(t *testing.T, path string) {
+	t.Helper()
+	tool := filepath.Join(llvmenv.New("").BinDir(), "llvm-dwarfdump")
+	if out, err := exec.Command(tool, "--verify", path).CombinedOutput(); err != nil {
+		t.Fatalf("llvm-dwarfdump --verify: %v\n%s", err, out)
+	}
+}
+
+func readDWARFTree(t *testing.T, data *dwarf.Data) []*dwarfNode {
+	t.Helper()
+	reader := data.Reader()
+	var roots []*dwarfNode
+	var stack []*dwarfNode
+	for {
+		entry, err := reader.Next()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if entry == nil {
+			break
+		}
+		if entry.Tag == 0 {
+			if len(stack) == 0 {
+				t.Fatal("unbalanced DWARF child terminator")
+			}
+			stack = stack[:len(stack)-1]
+			continue
+		}
+		node := &dwarfNode{entry: entry}
+		if len(stack) == 0 {
+			roots = append(roots, node)
+		} else {
+			parent := stack[len(stack)-1]
+			parent.children = append(parent.children, node)
+		}
+		if entry.Children {
+			stack = append(stack, node)
+		}
+	}
+	return roots
+}
+
+func findDWARFNode(nodes []*dwarfNode, tag dwarf.Tag, name string) *dwarfNode {
+	for _, node := range nodes {
+		if node.entry.Tag == tag {
+			if got, _ := node.entry.Val(dwarf.AttrName).(string); got == name || strings.HasSuffix(got, "."+name) {
+				return node
+			}
+		}
+		if found := findDWARFNode(node.children, tag, name); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func findDWARFNodes(nodes []*dwarfNode, tag dwarf.Tag, name string) (found []*dwarfNode) {
+	for _, node := range nodes {
+		if node.entry.Tag == tag {
+			if got, _ := node.entry.Val(dwarf.AttrName).(string); got == name {
+				found = append(found, node)
+			}
+		}
+		found = append(found, findDWARFNodes(node.children, tag, name)...)
+	}
+	return found
+}
+
+func dwarfTypeOf(t *testing.T, data *dwarf.Data, entry *dwarf.Entry) dwarf.Type {
+	t.Helper()
+	offset, ok := entry.Val(dwarf.AttrType).(dwarf.Offset)
+	if !ok {
+		t.Fatalf("%v has no DW_AT_type", entry)
+	}
+	typ, err := data.Type(offset)
+	if err != nil {
+		t.Fatalf("read type at %#x: %v", offset, err)
+	}
+	return typ
+}
+
+func unwrapDWARFTypedef(typ dwarf.Type) dwarf.Type {
+	for {
+		typedef, ok := typ.(*dwarf.TypedefType)
+		if !ok {
+			return typ
+		}
+		typ = typedef.Type
+	}
+}
+
+func assertDWARFCoreTypes(t *testing.T, data *dwarf.Data, cu *dwarfNode) {
+	t.Helper()
+	global := findDWARFNode(cu.children, dwarf.TagVariable, "GlobalInt")
+	if global == nil {
+		t.Fatal("GlobalInt DIE not found")
+	}
+	if _, ok := dwarfTypeOf(t, data, global.entry).(*dwarf.TypedefType); !ok {
+		t.Fatalf("GlobalInt type = %T, want source NamedInt without a storage pointer", dwarfTypeOf(t, data, global.entry))
+	}
+	namedInt := findDWARFNode(cu.children, dwarf.TagTypedef, "NamedInt")
+	if namedInt == nil {
+		t.Fatal("NamedInt typedef DIE not found")
+	}
+	if got, _ := namedInt.entry.Val(dwarf.AttrDeclLine).(int64); got != int64(markerLineInFile(t, "testdata/dwarf/main.go", "type NamedInt")) {
+		t.Errorf("NamedInt declaration line = %d, want its type declaration", got)
+	}
+
+	sampleNode := findDWARFNode(cu.children, dwarf.TagTypedef, "Sample")
+	if sampleNode == nil {
+		t.Fatal("Sample typedef DIE not found")
+	}
+	sample, ok := unwrapDWARFTypedef(dwarfTypeOf(t, data, sampleNode.entry)).(*dwarf.StructType)
+	if !ok {
+		t.Fatalf("Sample underlying type = %T, want struct", unwrapDWARFTypedef(dwarfTypeOf(t, data, sampleNode.entry)))
+	}
+	fields := make(map[string]dwarf.Type, len(sample.Field))
+	for _, field := range sample.Field {
+		fields[field.Name] = unwrapDWARFTypedef(field.Type)
+	}
+	checks := map[string]any{
+		"Bool":     (*dwarf.BoolType)(nil),
+		"I64":      (*dwarf.IntType)(nil),
+		"U64":      (*dwarf.UintType)(nil),
+		"F64":      (*dwarf.FloatType)(nil),
+		"C64":      (*dwarf.ComplexType)(nil),
+		"C128":     (*dwarf.ComplexType)(nil),
+		"Text":     (*dwarf.StructType)(nil),
+		"Values":   (*dwarf.StructType)(nil),
+		"Fixed":    (*dwarf.ArrayType)(nil),
+		"Lookup":   (*dwarf.PtrType)(nil),
+		"Queue":    (*dwarf.PtrType)(nil),
+		"Callback": (*dwarf.StructType)(nil),
+		"Any":      (*dwarf.StructType)(nil),
+		"Iface":    (*dwarf.StructType)(nil),
+		"Pointer":  (*dwarf.PtrType)(nil),
+		"Unsafe":   (*dwarf.PtrType)(nil),
+		"Pair":     (*dwarf.StructType)(nil),
+	}
+	for name, want := range checks {
+		got := fields[name]
+		if got == nil || fmt.Sprintf("%T", got) != fmt.Sprintf("%T", want) {
+			t.Errorf("Sample.%s type = %T, want %T", name, got, want)
+		}
+	}
+	if got := fields["C64"].Size(); got != 8 {
+		t.Errorf("complex64 size = %d, want 8", got)
+	}
+	if got := fields["C128"].Size(); got != 16 {
+		t.Errorf("complex128 size = %d, want 16", got)
+	}
+	array := fields["Fixed"].(*dwarf.ArrayType)
+	if array.Count != 3 || array.Type.Size() != 2 {
+		t.Errorf("Fixed = count %d, element size %d; want 3 and 2", array.Count, array.Type.Size())
+	}
+	for _, name := range []string{"Lookup", "Queue", "Pointer", "Unsafe"} {
+		if got := fields[name].Size(); got != int64(dataAddressSize()) {
+			t.Errorf("Sample.%s size = %d, want pointer size %d", name, got, dataAddressSize())
+		}
+	}
+	callback := fields["Callback"].(*dwarf.StructType)
+	var codeType dwarf.Type
+	for _, field := range callback.Field {
+		if field.Name == "$f" {
+			codeType = unwrapDWARFTypedef(field.Type)
+			break
+		}
+	}
+	codePointer, ok := codeType.(*dwarf.PtrType)
+	if !ok {
+		t.Fatalf("function value code field = %T, want pointer", codeType)
+	}
+	if _, ok := codePointer.Type.(*dwarf.FuncType); !ok {
+		t.Errorf("function value code pointee = %T, want subroutine type", codePointer.Type)
+	}
+
+	for _, check := range []struct {
+		name string
+		want any
+	}{
+		{"GlobalMap", (*dwarf.PtrType)(nil)},
+		{"GlobalChan", (*dwarf.PtrType)(nil)},
+		{"GlobalFunc", (*dwarf.StructType)(nil)},
+		{"GlobalInterface", (*dwarf.StructType)(nil)},
+		{"GlobalUnsafe", (*dwarf.PtrType)(nil)},
+	} {
+		node := findDWARFNode(cu.children, dwarf.TagVariable, check.name)
+		if node == nil {
+			t.Errorf("%s DIE not found", check.name)
+			continue
+		}
+		got := unwrapDWARFTypedef(dwarfTypeOf(t, data, node.entry))
+		if fmt.Sprintf("%T", got) != fmt.Sprintf("%T", check.want) {
+			t.Errorf("%s type = %T, want %T", check.name, got, check.want)
+		}
+	}
+
+	recursiveNode := findDWARFNode(cu.children, dwarf.TagTypedef, "Recursive")
+	if recursiveNode == nil {
+		t.Fatal("Recursive typedef DIE not found")
+	}
+	recursive, ok := unwrapDWARFTypedef(dwarfTypeOf(t, data, recursiveNode.entry)).(*dwarf.StructType)
+	if !ok || len(recursive.Field) != 2 {
+		t.Fatalf("Recursive type = %#v, want two-field struct", recursive)
+	}
+	if _, ok := unwrapDWARFTypedef(recursive.Field[1].Type).(*dwarf.PtrType); !ok {
+		t.Fatalf("Recursive.Next = %T, want pointer", recursive.Field[1].Type)
+	}
+}
+
+func assertDWARFProgramStructure(t *testing.T, data *dwarf.Data, cu *dwarfNode) {
+	t.Helper()
+	inspect := findDWARFNode(cu.children, dwarf.TagSubprogram, "inspect")
+	if inspect == nil {
+		t.Fatal("inspect subprogram DIE not found")
+	}
+	if inspect.entry.Val(dwarf.AttrLowpc) == nil || inspect.entry.Val(dwarf.AttrHighpc) == nil {
+		t.Fatal("inspect has no code range")
+	}
+	for _, name := range []string{"input", "pair", "values"} {
+		param := findDWARFNode(inspect.children, dwarf.TagFormalParameter, name)
+		if param == nil || param.entry.Val(dwarf.AttrLocation) == nil {
+			t.Errorf("parameter %s has no located DIE", name)
+		}
+	}
+	for _, name := range []string{"result", "local", "index", "value", "shadow", "closure", "boxed", "typed"} {
+		variables := findDWARFNodes(inspect.children, dwarf.TagVariable, name)
+		if len(variables) == 0 {
+			t.Errorf("local %s DIE not found", name)
+			continue
+		}
+		if variables[0].entry.Val(dwarf.AttrLocation) == nil {
+			t.Errorf("local %s has no location", name)
+		}
+	}
+	if countDWARFTag(inspect.children, dwarf.TagLexDwarfBlock) == 0 {
+		t.Error("inspect has no lexical block DIE")
+	}
+	if findDWARFNodeMatching(cu.children, dwarf.TagSubprogram, func(name string) bool {
+		return strings.Contains(name, ".identity[") && strings.HasSuffix(name, ".NamedInt]")
+	}) == nil {
+		t.Error("instantiated generic identity subprogram DIE not found")
+	}
+	if findDWARFNode(cu.children, dwarf.TagSubprogram, "main.(*Sample).Number") == nil &&
+		findDWARFNode(cu.children, dwarf.TagSubprogram, "Number") == nil {
+		t.Error("method subprogram DIE not found")
+	}
+	_ = data
+}
+
+func findDWARFNodeMatching(nodes []*dwarfNode, tag dwarf.Tag, match func(string) bool) *dwarfNode {
+	for _, node := range nodes {
+		if node.entry.Tag == tag {
+			if name, _ := node.entry.Val(dwarf.AttrName).(string); match(name) {
+				return node
+			}
+		}
+		if found := findDWARFNodeMatching(node.children, tag, match); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func countDWARFTag(nodes []*dwarfNode, tag dwarf.Tag) int {
+	count := 0
+	for _, node := range nodes {
+		if node.entry.Tag == tag {
+			count++
+		}
+		count += countDWARFTag(node.children, tag)
+	}
+	return count
+}
+
+func assertDWARFLines(t *testing.T, data *dwarf.Data, cu *dwarfNode, fileSuffix string, line int) {
+	t.Helper()
+	reader, err := data.LineReader(cu.entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var entry dwarf.LineEntry
+	for {
+		err := reader.Next(&entry)
+		if err != nil {
+			if err != io.EOF {
+				t.Fatal(err)
+			}
+			break
+		}
+		if entry.File != nil && strings.HasSuffix(entry.File.Name, fileSuffix) && entry.Line == line && entry.Address != 0 {
+			return
+		}
+	}
+	t.Errorf("line table has no address for %s:%d", fileSuffix, line)
+}
+
+func markerLineInFile(t *testing.T, path, marker string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, line := range strings.Split(string(data), "\n") {
+		if strings.Contains(line, marker) {
+			return i + 1
+		}
+	}
+	t.Fatalf("marker %q not found in %s", marker, path)
+	return 0
+}
+
+func dataAddressSize() int {
+	if ^uintptr(0)>>32 == 0 {
+		return 4
+	}
+	return 8
+}

--- a/internal/build/dwarf_standard_test.go
+++ b/internal/build/dwarf_standard_test.go
@@ -31,7 +31,14 @@ func TestStandardDWARF(t *testing.T) {
 		t.Skip("native DWARF integration test requires Mach-O or ELF")
 	}
 
-	for _, level := range []optlevel.Level{optlevel.O0, optlevel.O2} {
+	for _, level := range []optlevel.Level{
+		optlevel.O0,
+		optlevel.O1,
+		optlevel.O2,
+		optlevel.O3,
+		optlevel.Os,
+		optlevel.Oz,
+	} {
 		t.Run(level.String(), func(t *testing.T) {
 			bin := filepath.Join(t.TempDir(), "dwarf-standard")
 			conf := NewDefaultConf(ModeBuild)
@@ -105,8 +112,20 @@ func openNativeDWARF(t *testing.T, bin string) (*dwarf.Data, string) {
 
 func verifyDWARF(t *testing.T, path string) {
 	t.Helper()
-	tool := filepath.Join(llvmenv.New("").BinDir(), "llvm-dwarfdump")
-	if out, err := exec.Command(tool, "--verify", path).CombinedOutput(); err != nil {
+	binDir := llvmenv.New("").BinDir()
+	verifyPath := path
+	if runtime.GOOS == "linux" {
+		// ELF section GC leaves BFD tombstones in DIEs for discarded functions.
+		// Normalize a verifier-only copy; semantic assertions still read the
+		// original ELF because dwarfutil intentionally drops global variables.
+		verifyPath = filepath.Join(t.TempDir(), filepath.Base(path)+".dwarf")
+		tool := filepath.Join(binDir, "llvm-dwarfutil")
+		if out, err := exec.Command(tool, "--garbage-collection", path, verifyPath).CombinedOutput(); err != nil {
+			t.Fatalf("llvm-dwarfutil: %v\n%s", err, out)
+		}
+	}
+	tool := filepath.Join(binDir, "llvm-dwarfdump")
+	if out, err := exec.Command(tool, "--verify", verifyPath).CombinedOutput(); err != nil {
 		t.Fatalf("llvm-dwarfdump --verify: %v\n%s", err, out)
 	}
 }

--- a/internal/build/dwarf_standard_test.go
+++ b/internal/build/dwarf_standard_test.go
@@ -21,7 +21,7 @@ import (
 	llvmenv "github.com/goplus/llgo/xtool/env/llvm"
 )
 
-const dwarfLanguageGo = 0x16
+const dwarfLanguageC = 0x02
 
 type dwarfNode struct {
 	entry    *dwarf.Entry
@@ -61,8 +61,8 @@ func TestStandardDWARF(t *testing.T) {
 			if cu == nil {
 				t.Fatal("main compile unit not found")
 			}
-			if got, _ := cu.entry.Val(dwarf.AttrLanguage).(int64); got != dwarfLanguageGo {
-				t.Fatalf("DW_AT_language = %#x, want DW_LANG_Go", got)
+			if got, _ := cu.entry.Val(dwarf.AttrLanguage).(int64); got != dwarfLanguageC {
+				t.Fatalf("DW_AT_language = %#x, want DW_LANG_C", got)
 			}
 			if got, _ := cu.entry.Val(dwarf.AttrProducer).(string); got != "LLGo" {
 				t.Fatalf("DW_AT_producer = %q, want LLGo", got)

--- a/internal/build/dwarf_standard_test.go
+++ b/internal/build/dwarf_standard_test.go
@@ -11,9 +11,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
+	"unsafe"
 
 	"github.com/goplus/llgo/internal/optlevel"
 	llvmenv "github.com/goplus/llgo/xtool/env/llvm"
@@ -238,64 +240,83 @@ func assertDWARFCoreTypes(t *testing.T, data *dwarf.Data, cu *dwarfNode) {
 	if !ok {
 		t.Fatalf("Sample underlying type = %T, want struct", unwrapDWARFTypedef(dwarfTypeOf(t, data, sampleNode.entry)))
 	}
-	fields := make(map[string]dwarf.Type, len(sample.Field))
+	fields := make(map[string]*dwarf.StructField, len(sample.Field))
 	for _, field := range sample.Field {
-		fields[field.Name] = unwrapDWARFTypedef(field.Type)
+		fields[field.Name] = field
 	}
-	checks := map[string]any{
-		"Bool":     (*dwarf.BoolType)(nil),
-		"I64":      (*dwarf.IntType)(nil),
-		"U64":      (*dwarf.UintType)(nil),
-		"F64":      (*dwarf.FloatType)(nil),
-		"C64":      (*dwarf.ComplexType)(nil),
-		"C128":     (*dwarf.ComplexType)(nil),
-		"Text":     (*dwarf.StructType)(nil),
-		"Values":   (*dwarf.StructType)(nil),
-		"Fixed":    (*dwarf.ArrayType)(nil),
-		"Lookup":   (*dwarf.PtrType)(nil),
-		"Queue":    (*dwarf.PtrType)(nil),
-		"Callback": (*dwarf.StructType)(nil),
-		"Any":      (*dwarf.StructType)(nil),
-		"Iface":    (*dwarf.StructType)(nil),
-		"Pointer":  (*dwarf.PtrType)(nil),
-		"Unsafe":   (*dwarf.PtrType)(nil),
-		"Pair":     (*dwarf.StructType)(nil),
+	ptrSize := int64(dataAddressSize())
+	checks := map[string]struct {
+		kind any
+		size int64
+	}{
+		"Bool":     {(*dwarf.BoolType)(nil), 1},
+		"I8":       {(*dwarf.IntType)(nil), 1},
+		"I16":      {(*dwarf.IntType)(nil), 2},
+		"I32":      {(*dwarf.IntType)(nil), 4},
+		"I64":      {(*dwarf.IntType)(nil), 8},
+		"U8":       {(*dwarf.UintType)(nil), 1},
+		"U16":      {(*dwarf.UintType)(nil), 2},
+		"U32":      {(*dwarf.UintType)(nil), 4},
+		"U64":      {(*dwarf.UintType)(nil), 8},
+		"F32":      {(*dwarf.FloatType)(nil), 4},
+		"F64":      {(*dwarf.FloatType)(nil), 8},
+		"C64":      {(*dwarf.ComplexType)(nil), 8},
+		"C128":     {(*dwarf.ComplexType)(nil), 16},
+		"Text":     {(*dwarf.StructType)(nil), 2 * ptrSize},
+		"Values":   {(*dwarf.StructType)(nil), 3 * ptrSize},
+		"Fixed":    {(*dwarf.ArrayType)(nil), 6},
+		"Lookup":   {(*dwarf.PtrType)(nil), ptrSize},
+		"Queue":    {(*dwarf.PtrType)(nil), ptrSize},
+		"Callback": {(*dwarf.StructType)(nil), 2 * ptrSize},
+		"Any":      {(*dwarf.StructType)(nil), 2 * ptrSize},
+		"Iface":    {(*dwarf.StructType)(nil), 2 * ptrSize},
+		"Pointer":  {(*dwarf.PtrType)(nil), ptrSize},
+		"Unsafe":   {(*dwarf.PtrType)(nil), ptrSize},
+		"Pair":     {(*dwarf.StructType)(nil), 16},
 	}
-	for name, want := range checks {
-		got := fields[name]
-		if got == nil || fmt.Sprintf("%T", got) != fmt.Sprintf("%T", want) {
-			t.Errorf("Sample.%s type = %T, want %T", name, got, want)
+	for name, check := range checks {
+		field := fields[name]
+		if field == nil {
+			t.Errorf("Sample.%s field not found", name)
+			continue
+		}
+		got := unwrapDWARFTypedef(field.Type)
+		if fmt.Sprintf("%T", got) != fmt.Sprintf("%T", check.kind) {
+			t.Errorf("Sample.%s type = %T, want %T", name, got, check.kind)
+			continue
+		}
+		if got.Size() != check.size {
+			t.Errorf("Sample.%s size = %d, want %d", name, got.Size(), check.size)
 		}
 	}
-	if got := fields["C64"].Size(); got != 8 {
-		t.Errorf("complex64 size = %d, want 8", got)
-	}
-	if got := fields["C128"].Size(); got != 16 {
-		t.Errorf("complex128 size = %d, want 16", got)
-	}
-	array := fields["Fixed"].(*dwarf.ArrayType)
+	assertDWARFReflectLayout(t, sample, reflect.TypeOf(dwarfFixtureSample{}))
+
+	array := unwrapDWARFTypedef(fields["Fixed"].Type).(*dwarf.ArrayType)
 	if array.Count != 3 || array.Type.Size() != 2 {
 		t.Errorf("Fixed = count %d, element size %d; want 3 and 2", array.Count, array.Type.Size())
 	}
-	for _, name := range []string{"Lookup", "Queue", "Pointer", "Unsafe"} {
-		if got := fields[name].Size(); got != int64(dataAddressSize()) {
-			t.Errorf("Sample.%s size = %d, want pointer size %d", name, got, dataAddressSize())
+	for _, name := range []string{"Lookup", "Queue"} {
+		pointer := unwrapDWARFTypedef(fields[name].Type).(*dwarf.PtrType)
+		if _, ok := pointer.Type.(*dwarf.VoidType); pointer.Type != nil && !ok {
+			t.Errorf("Sample.%s pointee = %T, want void or unspecified", name, pointer.Type)
 		}
 	}
-	callback := fields["Callback"].(*dwarf.StructType)
-	var codeType dwarf.Type
-	for _, field := range callback.Field {
-		if field.Name == "$f" {
-			codeType = unwrapDWARFTypedef(field.Type)
-			break
-		}
-	}
+
+	assertDWARFWordStruct(t, "string", fields["Text"].Type, ptrSize, "data", "len")
+	assertDWARFWordStruct(t, "slice", fields["Values"].Type, ptrSize, "data", "len", "cap")
+	assertDWARFWordStruct(t, "any", fields["Any"].Type, ptrSize, "type", "data")
+	assertDWARFWordStruct(t, "interface", fields["Iface"].Type, ptrSize, "type", "data")
+	callback := assertDWARFWordStruct(t, "function value", fields["Callback"].Type, ptrSize, "$f", "$data")
+	codeType := unwrapDWARFTypedef(callback.Field[0].Type)
 	codePointer, ok := codeType.(*dwarf.PtrType)
 	if !ok {
 		t.Fatalf("function value code field = %T, want pointer", codeType)
 	}
-	if _, ok := codePointer.Type.(*dwarf.FuncType); !ok {
+	functionType, ok := codePointer.Type.(*dwarf.FuncType)
+	if !ok {
 		t.Errorf("function value code pointee = %T, want subroutine type", codePointer.Type)
+	} else {
+		assertDWARFFunctionSignature(t, functionType)
 	}
 
 	for _, check := range []struct {
@@ -432,6 +453,127 @@ func markerLineInFile(t *testing.T, path, marker string) int {
 	}
 	t.Fatalf("marker %q not found in %s", marker, path)
 	return 0
+}
+
+func assertDWARFReflectLayout(t *testing.T, got *dwarf.StructType, want reflect.Type) {
+	t.Helper()
+	if got.Size() != int64(want.Size()) {
+		t.Errorf("%s size = %d, want %d", want.Name(), got.Size(), want.Size())
+	}
+	if len(got.Field) != want.NumField() {
+		t.Fatalf("%s has %d fields, want %d", want.Name(), len(got.Field), want.NumField())
+	}
+	for i, field := range got.Field {
+		wantField := want.Field(i)
+		if field.Name != wantField.Name {
+			t.Errorf("%s field %d name = %q, want %q", want.Name(), i, field.Name, wantField.Name)
+		}
+		if field.ByteOffset != int64(wantField.Offset) {
+			t.Errorf("%s.%s offset = %d, want %d", want.Name(), field.Name, field.ByteOffset, wantField.Offset)
+		}
+	}
+}
+
+func assertDWARFWordStruct(t *testing.T, name string, typ dwarf.Type, wordSize int64, fieldNames ...string) *dwarf.StructType {
+	t.Helper()
+	structure, ok := unwrapDWARFTypedef(typ).(*dwarf.StructType)
+	if !ok {
+		t.Fatalf("%s type = %T, want struct", name, unwrapDWARFTypedef(typ))
+	}
+	if structure.Size() != int64(len(fieldNames))*wordSize {
+		t.Errorf("%s size = %d, want %d", name, structure.Size(), int64(len(fieldNames))*wordSize)
+	}
+	if len(structure.Field) != len(fieldNames) {
+		t.Fatalf("%s has %d fields, want %d", name, len(structure.Field), len(fieldNames))
+	}
+	for i, field := range structure.Field {
+		if field.Name != fieldNames[i] {
+			t.Errorf("%s field %d name = %q, want %q", name, i, field.Name, fieldNames[i])
+		}
+		if field.ByteOffset != int64(i)*wordSize {
+			t.Errorf("%s.%s offset = %d, want %d", name, field.Name, field.ByteOffset, int64(i)*wordSize)
+		}
+		fieldType := unwrapDWARFTypedef(field.Type)
+		if field.Name == "len" || field.Name == "cap" {
+			if _, ok := fieldType.(*dwarf.UintType); !ok {
+				t.Errorf("%s.%s type = %T, want unsigned word", name, field.Name, fieldType)
+			}
+		} else if _, ok := fieldType.(*dwarf.PtrType); !ok {
+			t.Errorf("%s.%s type = %T, want pointer", name, field.Name, fieldType)
+		}
+	}
+	return structure
+}
+
+func assertDWARFFunctionSignature(t *testing.T, function *dwarf.FuncType) {
+	t.Helper()
+	if len(function.ParamType) != 1 {
+		t.Fatalf("function parameter count = %d, want 1", len(function.ParamType))
+	}
+	parameter := unwrapDWARFTypedef(function.ParamType[0])
+	if _, ok := parameter.(*dwarf.IntType); !ok || parameter.Size() != 8 {
+		t.Errorf("function parameter = %T size %d, want NamedInt", parameter, parameter.Size())
+	}
+	results, ok := unwrapDWARFTypedef(function.ReturnType).(*dwarf.StructType)
+	if !ok {
+		t.Fatalf("function result = %T, want two-value tuple", unwrapDWARFTypedef(function.ReturnType))
+	}
+	ptrSize := int64(dataAddressSize())
+	if results.Size() != 8+2*ptrSize || len(results.Field) != 2 {
+		t.Fatalf("function result tuple = size %d, %d fields; want size %d, 2 fields", results.Size(), len(results.Field), 8+2*ptrSize)
+	}
+	if results.Field[0].ByteOffset != 0 || results.Field[1].ByteOffset != 8 {
+		t.Errorf("function result offsets = %d, %d; want 0, 8", results.Field[0].ByteOffset, results.Field[1].ByteOffset)
+	}
+	assertDWARFWordStruct(t, "error interface", results.Field[1].Type, ptrSize, "type", "data")
+}
+
+type dwarfFixtureNamedInt int64
+
+type dwarfFixtureRecursive struct {
+	Value dwarfFixtureNamedInt
+	Next  *dwarfFixtureRecursive
+}
+
+type dwarfFixturePair struct {
+	First  dwarfFixtureNamedInt
+	Second dwarfFixtureNamedInt
+}
+
+type dwarfFixtureFuncValue struct {
+	code    unsafe.Pointer
+	context unsafe.Pointer
+}
+
+type dwarfFixtureNumber interface {
+	Number() dwarfFixtureNamedInt
+}
+
+type dwarfFixtureSample struct {
+	Bool     bool
+	I8       int8
+	I16      int16
+	I32      int32
+	I64      int64
+	U8       uint8
+	U16      uint16
+	U32      uint32
+	U64      uint64
+	F32      float32
+	F64      float64
+	C64      complex64
+	C128     complex128
+	Text     string
+	Values   []dwarfFixtureNamedInt
+	Fixed    [3]uint16
+	Lookup   map[string]dwarfFixtureNamedInt
+	Queue    chan dwarfFixturePair
+	Callback dwarfFixtureFuncValue
+	Any      any
+	Iface    dwarfFixtureNumber
+	Pointer  *dwarfFixtureRecursive
+	Unsafe   unsafe.Pointer
+	Pair     dwarfFixturePair
 }
 
 func dataAddressSize() int {

--- a/internal/build/testdata/dwarf/helper.go
+++ b/internal/build/testdata/dwarf/helper.go
@@ -2,6 +2,6 @@ package main
 
 //go:noinline
 func helper(value NamedInt) NamedInt {
-	intermediate := value + 1 // DWARF_LINE_MARKER
-	return intermediate
+	intermediate := value + 1
+	return intermediate // DWARF_LINE_MARKER
 }

--- a/internal/build/testdata/dwarf/helper.go
+++ b/internal/build/testdata/dwarf/helper.go
@@ -1,0 +1,7 @@
+package main
+
+//go:noinline
+func helper(value NamedInt) NamedInt {
+	intermediate := value + 1 // DWARF_LINE_MARKER
+	return intermediate
+}

--- a/internal/build/testdata/dwarf/main.go
+++ b/internal/build/testdata/dwarf/main.go
@@ -1,0 +1,101 @@
+package main
+
+import "unsafe"
+
+type Alias = uint32
+
+type NamedInt int64
+
+type Recursive struct {
+	Value NamedInt
+	Next  *Recursive
+}
+
+type Pair[T any] struct {
+	First  T
+	Second T
+}
+
+type Number interface {
+	Number() NamedInt
+}
+
+type Sample struct {
+	Bool     bool
+	I8       int8
+	I16      int16
+	I32      int32
+	I64      int64
+	U8       uint8
+	U16      uint16
+	U32      Alias
+	U64      uint64
+	F32      float32
+	F64      float64
+	C64      complex64
+	C128     complex128
+	Text     string
+	Values   []NamedInt
+	Fixed    [3]uint16
+	Lookup   map[string]NamedInt
+	Queue    chan Pair[NamedInt]
+	Callback func(NamedInt) (NamedInt, error)
+	Any      any
+	Iface    Number
+	Pointer  *Recursive
+	Unsafe   unsafe.Pointer
+	Pair     Pair[NamedInt]
+}
+
+var GlobalInt NamedInt = 41
+var GlobalPtr = &Recursive{Value: 1}
+var GlobalSample Sample
+var GlobalMap map[string]NamedInt
+var GlobalChan chan Pair[NamedInt]
+var GlobalFunc func(NamedInt) (NamedInt, error)
+var GlobalInterface Number
+var GlobalUnsafe unsafe.Pointer
+
+func (s *Sample) Number() NamedInt {
+	return NamedInt(s.I64)
+}
+
+func identity[T any](value T) T {
+	return value
+}
+
+//go:noinline
+func inspect(input NamedInt, pair Pair[NamedInt], values ...int) (result NamedInt) {
+	local := helper(input) + pair.First + pair.Second
+	for index, value := range values {
+		local += NamedInt(index + value)
+	}
+	if local > 0 {
+		shadow := local + 1
+		result = shadow // DWARF_SCOPE_MARKER
+	}
+	closure := func(delta NamedInt) NamedInt {
+		return local + delta
+	}
+	boxed := any(result)
+	switch typed := boxed.(type) {
+	case NamedInt:
+		result += typed
+	}
+	result = closure(result)
+	return identity(result)
+}
+
+func main() {
+	GlobalMap = map[string]NamedInt{"answer": GlobalInt}
+	GlobalChan = make(chan Pair[NamedInt], 1)
+	GlobalFunc = func(value NamedInt) (NamedInt, error) { return value + 1, nil }
+	GlobalSample.I64 = int64(GlobalInt)
+	GlobalInterface = &GlobalSample
+	GlobalUnsafe = unsafe.Pointer(GlobalPtr)
+	result := inspect(2, Pair[NamedInt]{First: 3, Second: 4}, 1, 2)
+	if result <= 0 || GlobalInterface.Number() != GlobalInt {
+		panic("bad DWARF fixture result")
+	}
+	println("dwarf-ok")
+}

--- a/internal/debuginfo/builder.go
+++ b/internal/debuginfo/builder.go
@@ -11,10 +11,9 @@ import (
 const (
 	defaultDebugInfoVersion = 3
 	defaultDwarfVersion     = 4
-	// LLDB has no Go language plugin and disables normal frame-variable
-	// inspection for DW_LANG_Go. LLGo's LLDB formatter currently builds on the
-	// C language plugin, so emit the LLVM C API enum index for DW_LANG_C.
-	dwarfSourceLanguageC llvm.DwarfLang = 1
+	// llvm.DwarfLang is passed to LLVMDIBuilderCreateCompileUnit as the ordinal
+	// LLVMDWARFSourceLanguage value, not the encoded DW_LANG_Go value (0x16).
+	dwarfSourceLanguageGo llvm.DwarfLang = 21
 )
 
 // Config describes properties of the generated debug information. Optimized
@@ -91,7 +90,7 @@ func (b *Builder) Finalize() {
 func (b *Builder) CompileUnit(filename, dir string) llvm.Metadata {
 	b.checkOpen()
 	return b.impl.CreateCompileUnit(llvm.DICompileUnit{
-		Language:       dwarfSourceLanguageC,
+		Language:       dwarfSourceLanguageGo,
 		File:           filename,
 		Dir:            dir,
 		Producer:       b.config.Producer,

--- a/internal/debuginfo/builder.go
+++ b/internal/debuginfo/builder.go
@@ -1,0 +1,204 @@
+// Package debuginfo owns the LLVM debug metadata builder and its lifecycle.
+// Source-language type layout and SSA value tracking belong to the caller.
+package debuginfo
+
+import (
+	"path/filepath"
+
+	"github.com/xgo-dev/llvm"
+)
+
+const (
+	defaultDebugInfoVersion = 3
+	defaultDwarfVersion     = 4
+	// LLDB has no Go language plugin and disables normal frame-variable
+	// inspection for DW_LANG_Go. LLGo's LLDB formatter currently builds on the
+	// C language plugin, so emit the LLVM C API enum index for DW_LANG_C.
+	dwarfSourceLanguageC llvm.DwarfLang = 1
+)
+
+// Config describes properties of the generated debug information. Optimized
+// reports what the compilation pipeline does; it does not select any pass.
+type Config struct {
+	Producer  string
+	Optimized bool
+}
+
+// Builder is a package-local owner of an LLVM DIBuilder. Finalize must be
+// called before the module is verified, optimized, serialized, or disposed.
+type Builder struct {
+	impl      *llvm.DIBuilder
+	module    llvm.Module
+	config    Config
+	files     map[string]llvm.Metadata
+	finalized bool
+}
+
+// New creates a debug metadata builder and installs the module metadata LLVM
+// requires for DWARF emission.
+func New(module llvm.Module, config Config) *Builder {
+	if config.Producer == "" {
+		config.Producer = "LLGo"
+	}
+	b := &Builder{
+		impl:   llvm.NewDIBuilder(module),
+		module: module,
+		config: config,
+		files:  make(map[string]llvm.Metadata),
+	}
+	b.addModuleFlag(2, "Debug Info Version", defaultDebugInfoVersion)
+	b.addModuleFlag(7, "Dwarf Version", defaultDwarfVersion)
+	b.addModuleFlag(1, "wchar_size", 4)
+	b.addModuleFlag(8, "PIC Level", 2)
+	b.addModuleFlag(7, "uwtable", 1)
+	b.addModuleFlag(7, "frame-pointer", 1)
+
+	ctx := module.Context()
+	module.AddNamedMetadataOperand("llvm.ident", ctx.MDNode([]llvm.Metadata{
+		ctx.MDString(config.Producer + " Compiler"),
+	}))
+	return b
+}
+
+func (b *Builder) addModuleFlag(behavior int, name string, value int) {
+	ctx := b.module.Context()
+	b.module.AddNamedMetadataOperand("llvm.module.flags", ctx.MDNode([]llvm.Metadata{
+		llvm.ConstInt(ctx.Int32Type(), uint64(behavior), false).ConstantAsMetadata(),
+		ctx.MDString(name),
+		llvm.ConstInt(ctx.Int32Type(), uint64(value), false).ConstantAsMetadata(),
+	}))
+}
+
+func (b *Builder) checkOpen() {
+	if b == nil || b.impl == nil || b.finalized {
+		panic("debuginfo: use after Finalize")
+	}
+}
+
+// Finalize resolves temporary metadata and releases the underlying DIBuilder.
+// It is idempotent so callers can safely defer it across error paths.
+func (b *Builder) Finalize() {
+	if b == nil || b.finalized {
+		return
+	}
+	b.impl.Finalize()
+	b.impl.Destroy()
+	b.impl = nil
+	b.finalized = true
+}
+
+// CompileUnit creates this module's compile unit.
+func (b *Builder) CompileUnit(filename, dir string) llvm.Metadata {
+	b.checkOpen()
+	return b.impl.CreateCompileUnit(llvm.DICompileUnit{
+		Language:       dwarfSourceLanguageC,
+		File:           filename,
+		Dir:            dir,
+		Producer:       b.config.Producer,
+		Optimized:      b.config.Optimized,
+		RuntimeVersion: 1,
+	})
+}
+
+// Optimized reports the code-generation mode recorded in compile units and
+// subprograms.
+func (b *Builder) Optimized() bool {
+	return b != nil && b.config.Optimized
+}
+
+// File returns one metadata node per cleaned source path.
+func (b *Builder) File(filename string) llvm.Metadata {
+	b.checkOpen()
+	key := filename
+	if key != "" {
+		key = filepath.Clean(key)
+	}
+	if file, ok := b.files[key]; ok {
+		return file
+	}
+	dir, file := filepath.Split(key)
+	metadata := b.impl.CreateFile(file, dir)
+	b.files[key] = metadata
+	return metadata
+}
+
+func (b *Builder) CreateLexicalBlock(scope llvm.Metadata, desc llvm.DILexicalBlock) llvm.Metadata {
+	b.checkOpen()
+	return b.impl.CreateLexicalBlock(scope, desc)
+}
+
+func (b *Builder) CreateFunction(scope llvm.Metadata, desc llvm.DIFunction) llvm.Metadata {
+	b.checkOpen()
+	desc.Optimized = b.config.Optimized
+	return b.impl.CreateFunction(scope, desc)
+}
+
+func (b *Builder) CreateGlobalVariableExpression(scope llvm.Metadata, desc llvm.DIGlobalVariableExpression) llvm.Metadata {
+	b.checkOpen()
+	return b.impl.CreateGlobalVariableExpression(scope, desc)
+}
+
+func (b *Builder) CreateAutoVariable(scope llvm.Metadata, desc llvm.DIAutoVariable) llvm.Metadata {
+	b.checkOpen()
+	return b.impl.CreateAutoVariable(scope, desc)
+}
+
+func (b *Builder) CreateParameterVariable(scope llvm.Metadata, desc llvm.DIParameterVariable) llvm.Metadata {
+	b.checkOpen()
+	return b.impl.CreateParameterVariable(scope, desc)
+}
+
+func (b *Builder) CreateBasicType(desc llvm.DIBasicType) llvm.Metadata {
+	b.checkOpen()
+	return b.impl.CreateBasicType(desc)
+}
+
+func (b *Builder) CreatePointerType(desc llvm.DIPointerType) llvm.Metadata {
+	b.checkOpen()
+	return b.impl.CreatePointerType(desc)
+}
+
+func (b *Builder) CreateSubroutineType(desc llvm.DISubroutineType) llvm.Metadata {
+	b.checkOpen()
+	return b.impl.CreateSubroutineType(desc)
+}
+
+func (b *Builder) CreateStructType(scope llvm.Metadata, desc llvm.DIStructType) llvm.Metadata {
+	b.checkOpen()
+	return b.impl.CreateStructType(scope, desc)
+}
+
+func (b *Builder) CreateReplaceableCompositeType(scope llvm.Metadata, desc llvm.DIReplaceableCompositeType) llvm.Metadata {
+	b.checkOpen()
+	return b.impl.CreateReplaceableCompositeType(scope, desc)
+}
+
+func (b *Builder) CreateMemberType(scope llvm.Metadata, desc llvm.DIMemberType) llvm.Metadata {
+	b.checkOpen()
+	return b.impl.CreateMemberType(scope, desc)
+}
+
+func (b *Builder) CreateArrayType(desc llvm.DIArrayType) llvm.Metadata {
+	b.checkOpen()
+	return b.impl.CreateArrayType(desc)
+}
+
+func (b *Builder) CreateTypedef(desc llvm.DITypedef) llvm.Metadata {
+	b.checkOpen()
+	return b.impl.CreateTypedef(desc)
+}
+
+func (b *Builder) CreateExpression(ops []uint64) llvm.Metadata {
+	b.checkOpen()
+	return b.impl.CreateExpression(ops)
+}
+
+func (b *Builder) InsertDeclareAtEnd(value llvm.Value, variable, expression llvm.Metadata, loc llvm.DebugLoc, block llvm.BasicBlock) {
+	b.checkOpen()
+	b.impl.InsertDeclareAtEnd(value, variable, expression, loc, block)
+}
+
+func (b *Builder) InsertValueAtEnd(value llvm.Value, variable, expression llvm.Metadata, loc llvm.DebugLoc, block llvm.BasicBlock) {
+	b.checkOpen()
+	b.impl.InsertValueAtEnd(value, variable, expression, loc, block)
+}

--- a/internal/debuginfo/builder.go
+++ b/internal/debuginfo/builder.go
@@ -11,9 +11,12 @@ import (
 const (
 	defaultDebugInfoVersion = 3
 	defaultDwarfVersion     = 4
-	// llvm.DwarfLang is passed to LLVMDIBuilderCreateCompileUnit as the ordinal
-	// LLVMDWARFSourceLanguage value, not the encoded DW_LANG_Go value (0x16).
-	dwarfSourceLanguageGo llvm.DwarfLang = 21
+	// LLDB has no Go language plugin and limits frame-variable inspection for
+	// DW_LANG_Go. Keep the compile unit on its C language path until the LLDB Go
+	// extension can consume LLGo's otherwise Go-shaped DWARF.
+	dwarfSourceLanguageC llvm.DwarfLang = 1
+
+	debuggerMarkerSymbol = "__llgo_debugger_marker_v1"
 )
 
 // Config describes properties of the generated debug information. Optimized
@@ -51,12 +54,30 @@ func New(module llvm.Module, config Config) *Builder {
 	b.addModuleFlag(8, "PIC Level", 2)
 	b.addModuleFlag(7, "uwtable", 1)
 	b.addModuleFlag(7, "frame-pointer", 1)
+	b.addDebuggerMarker()
 
 	ctx := module.Context()
 	module.AddNamedMetadataOperand("llvm.ident", ctx.MDNode([]llvm.Metadata{
 		ctx.MDString(config.Producer + " Compiler"),
 	}))
 	return b
+}
+
+func (b *Builder) addDebuggerMarker() {
+	ctx := b.module.Context()
+	i8 := ctx.Int8Type()
+	marker := llvm.AddGlobal(b.module, i8, debuggerMarkerSymbol)
+	marker.SetInitializer(llvm.ConstInt(i8, 1, false))
+	marker.SetGlobalConstant(true)
+	marker.SetLinkage(llvm.LinkOnceODRLinkage)
+	marker.SetVisibility(llvm.HiddenVisibility)
+
+	ptr := llvm.PointerType(i8, 0)
+	usedInit := llvm.ConstArray(ptr, []llvm.Value{llvm.ConstBitCast(marker, ptr)})
+	used := llvm.AddGlobal(b.module, usedInit.Type(), "llvm.used")
+	used.SetInitializer(usedInit)
+	used.SetLinkage(llvm.AppendingLinkage)
+	used.SetSection("llvm.metadata")
 }
 
 func (b *Builder) addModuleFlag(behavior int, name string, value int) {
@@ -90,7 +111,7 @@ func (b *Builder) Finalize() {
 func (b *Builder) CompileUnit(filename, dir string) llvm.Metadata {
 	b.checkOpen()
 	return b.impl.CreateCompileUnit(llvm.DICompileUnit{
-		Language:       dwarfSourceLanguageGo,
+		Language:       dwarfSourceLanguageC,
 		File:           filename,
 		Dir:            dir,
 		Producer:       b.config.Producer,

--- a/internal/debuginfo/builder.go
+++ b/internal/debuginfo/builder.go
@@ -99,12 +99,6 @@ func (b *Builder) CompileUnit(filename, dir string) llvm.Metadata {
 	})
 }
 
-// Optimized reports the code-generation mode recorded in compile units and
-// subprograms.
-func (b *Builder) Optimized() bool {
-	return b != nil && b.config.Optimized
-}
-
 // File returns one metadata node per cleaned source path.
 func (b *Builder) File(filename string) llvm.Metadata {
 	b.checkOpen()

--- a/internal/debuginfo/builder_test.go
+++ b/internal/debuginfo/builder_test.go
@@ -1,0 +1,221 @@
+//go:build !llgo
+
+package debuginfo
+
+import (
+	"debug/dwarf"
+	"strings"
+	"testing"
+
+	"github.com/xgo-dev/llvm"
+)
+
+func TestBuilderLifecycleAndModuleMetadata(t *testing.T) {
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	module := ctx.NewModule("debug-test")
+	defer module.Dispose()
+
+	builder := New(module, Config{Producer: "LLGo", Optimized: true})
+	cu := builder.CompileUnit("main.go", "/src/example")
+	file := builder.File("/src/example/main.go")
+	if got := builder.File("/src/example/dir/../main.go"); got != file {
+		t.Fatal("File did not reuse metadata for the same cleaned path")
+	}
+
+	voidType := builder.CreateSubroutineType(llvm.DISubroutineType{File: file})
+	subprogram := builder.CreateFunction(cu, llvm.DIFunction{
+		Name:         "main.main",
+		LinkageName:  "main.main",
+		File:         file,
+		Line:         1,
+		ScopeLine:    1,
+		Type:         voidType,
+		IsDefinition: true,
+	})
+	function := llvm.AddFunction(module, "main.main", llvm.FunctionType(ctx.VoidType(), nil, false))
+	function.SetSubprogram(subprogram)
+	irBuilder := ctx.NewBuilder()
+	defer irBuilder.Dispose()
+	block := llvm.AddBasicBlock(function, "entry")
+	irBuilder.SetInsertPointAtEnd(block)
+	irBuilder.CreateRetVoid()
+
+	builder.Finalize()
+	builder.Finalize()
+	if err := llvm.VerifyModule(module, llvm.ReturnStatusAction); err != nil {
+		t.Fatalf("finalized debug module is invalid: %v\n%s", err, module.String())
+	}
+
+	ir := module.String()
+	for _, want := range []string{
+		`!llvm.dbg.cu`,
+		`!DICompileUnit(language: DW_LANG_C`,
+		`producer: "LLGo"`,
+		`isOptimized: true`,
+		`!{i32 7, !"Dwarf Version", i32 4}`,
+	} {
+		if !strings.Contains(ir, want) {
+			t.Errorf("module is missing %q:\n%s", want, ir)
+		}
+	}
+}
+
+func TestBuilderMetadataOperations(t *testing.T) {
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	module := ctx.NewModule("debug-operations")
+	defer module.Dispose()
+
+	builder := New(module, Config{Optimized: true})
+	if !builder.Optimized() {
+		t.Fatal("Optimized returned false")
+	}
+	cu := builder.CompileUnit("main.go", "/src/example")
+	file := builder.File("/src/example/main.go")
+	basic := builder.CreateBasicType(llvm.DIBasicType{
+		Name:       "int",
+		SizeInBits: 64,
+		Encoding:   llvm.DW_ATE_signed,
+	})
+	pointer := builder.CreatePointerType(llvm.DIPointerType{
+		Pointee:     basic,
+		SizeInBits:  64,
+		AlignInBits: 64,
+		Name:        "*int",
+	})
+	temporary := builder.CreateReplaceableCompositeType(cu, llvm.DIReplaceableCompositeType{
+		Tag:         dwarf.TagStructType,
+		Name:        "pair",
+		File:        file,
+		Line:        1,
+		SizeInBits:  128,
+		AlignInBits: 64,
+	})
+	member := builder.CreateMemberType(temporary, llvm.DIMemberType{
+		Name:        "left",
+		File:        file,
+		Line:        1,
+		SizeInBits:  64,
+		AlignInBits: 64,
+		Type:        basic,
+	})
+	structure := builder.CreateStructType(cu, llvm.DIStructType{
+		Name:        "pair",
+		File:        file,
+		Line:        1,
+		SizeInBits:  128,
+		AlignInBits: 64,
+		Elements:    []llvm.Metadata{member},
+	})
+	temporary.ReplaceAllUsesWith(structure)
+	array := builder.CreateArrayType(llvm.DIArrayType{
+		SizeInBits:  128,
+		AlignInBits: 64,
+		ElementType: basic,
+		Subscripts:  []llvm.DISubrange{{Count: 2}},
+	})
+	typedef := builder.CreateTypedef(llvm.DITypedef{
+		Type:        array,
+		Name:        "ints",
+		File:        file,
+		Line:        1,
+		Context:     cu,
+		AlignInBits: 64,
+	})
+	subroutine := builder.CreateSubroutineType(llvm.DISubroutineType{
+		File:       file,
+		Parameters: []llvm.Metadata{{}, pointer},
+	})
+	subprogram := builder.CreateFunction(cu, llvm.DIFunction{
+		Name:         "main.main",
+		LinkageName:  "main.main",
+		File:         file,
+		Line:         1,
+		ScopeLine:    1,
+		Type:         subroutine,
+		IsDefinition: true,
+	})
+	lexical := builder.CreateLexicalBlock(subprogram, llvm.DILexicalBlock{
+		File: file,
+		Line: 2,
+	})
+	auto := builder.CreateAutoVariable(lexical, llvm.DIAutoVariable{
+		Name:           "local",
+		File:           file,
+		Line:           2,
+		Type:           typedef,
+		AlwaysPreserve: true,
+	})
+	pairAuto := builder.CreateAutoVariable(lexical, llvm.DIAutoVariable{
+		Name:           "pair",
+		File:           file,
+		Line:           2,
+		Type:           structure,
+		AlwaysPreserve: true,
+	})
+	parameter := builder.CreateParameterVariable(subprogram, llvm.DIParameterVariable{
+		Name:           "param",
+		File:           file,
+		Line:           1,
+		Type:           pointer,
+		AlwaysPreserve: true,
+		ArgNo:          1,
+	})
+	expression := builder.CreateExpression(nil)
+	globalExpression := builder.CreateGlobalVariableExpression(cu, llvm.DIGlobalVariableExpression{
+		Name:        "global",
+		LinkageName: "main.global",
+		File:        file,
+		Line:        1,
+		Type:        pointer,
+		Expr:        expression,
+		AlignInBits: 64,
+	})
+	global := llvm.AddGlobal(module, ctx.Int64Type(), "main.global")
+	global.SetInitializer(llvm.ConstInt(ctx.Int64Type(), 0, false))
+	global.AddMetadata(0, globalExpression)
+
+	functionType := llvm.FunctionType(ctx.VoidType(), []llvm.Type{llvm.PointerType(ctx.Int64Type(), 0)}, false)
+	function := llvm.AddFunction(module, "main.main", functionType)
+	function.SetSubprogram(subprogram)
+	irBuilder := ctx.NewBuilder()
+	defer irBuilder.Dispose()
+	block := llvm.AddBasicBlock(function, "entry")
+	irBuilder.SetInsertPointAtEnd(block)
+	home := irBuilder.CreateAlloca(ctx.Int64Type(), "local")
+	pairType := ctx.StructType([]llvm.Type{ctx.Int64Type(), ctx.Int64Type()}, false)
+	pairHome := irBuilder.CreateAlloca(pairType, "pair")
+	loc := llvm.DebugLoc{Line: 2, Scope: lexical}
+	builder.InsertDeclareAtEnd(home, auto, expression, loc, block)
+	builder.InsertDeclareAtEnd(pairHome, pairAuto, expression, loc, block)
+	builder.InsertValueAtEnd(function.Param(0), parameter, expression, loc, block)
+	irBuilder.CreateRetVoid()
+
+	builder.Finalize()
+	if err := llvm.VerifyModule(module, llvm.ReturnStatusAction); err != nil {
+		t.Fatalf("metadata operations produced an invalid module: %v\n%s", err, module.String())
+	}
+	for _, want := range []string{"#dbg_declare", "#dbg_value", `name: "pair"`, `name: "ints"`} {
+		if !strings.Contains(module.String(), want) {
+			t.Errorf("module is missing %q:\n%s", want, module.String())
+		}
+	}
+}
+
+func TestBuilderRejectsUseAfterFinalize(t *testing.T) {
+	ctx := llvm.NewContext()
+	defer ctx.Dispose()
+	module := ctx.NewModule("debug-finalized")
+	defer module.Dispose()
+
+	builder := New(module, Config{})
+	builder.CompileUnit("main.go", ".")
+	builder.Finalize()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("File after Finalize did not panic")
+		}
+	}()
+	builder.File("main.go")
+}

--- a/internal/debuginfo/builder_test.go
+++ b/internal/debuginfo/builder_test.go
@@ -50,7 +50,7 @@ func TestBuilderLifecycleAndModuleMetadata(t *testing.T) {
 	ir := module.String()
 	for _, want := range []string{
 		`!llvm.dbg.cu`,
-		`!DICompileUnit(language: DW_LANG_C`,
+		`!DICompileUnit(language: DW_LANG_Go`,
 		`producer: "LLGo"`,
 		`isOptimized: true`,
 		`!{i32 7, !"Dwarf Version", i32 4}`,

--- a/internal/debuginfo/builder_test.go
+++ b/internal/debuginfo/builder_test.go
@@ -50,9 +50,11 @@ func TestBuilderLifecycleAndModuleMetadata(t *testing.T) {
 	ir := module.String()
 	for _, want := range []string{
 		`!llvm.dbg.cu`,
-		`!DICompileUnit(language: DW_LANG_Go`,
+		`!DICompileUnit(language: DW_LANG_C`,
 		`producer: "LLGo"`,
 		`isOptimized: true`,
+		`@__llgo_debugger_marker_v1 = linkonce_odr hidden constant i8 1`,
+		`@llvm.used = appending global [1 x ptr] [ptr @__llgo_debugger_marker_v1], section "llvm.metadata"`,
 		`!{i32 7, !"Dwarf Version", i32 4}`,
 	} {
 		if !strings.Contains(ir, want) {

--- a/internal/debuginfo/builder_test.go
+++ b/internal/debuginfo/builder_test.go
@@ -68,9 +68,6 @@ func TestBuilderMetadataOperations(t *testing.T) {
 	defer module.Dispose()
 
 	builder := New(module, Config{Optimized: true})
-	if !builder.Optimized() {
-		t.Fatal("Optimized returned false")
-	}
 	cu := builder.CompileUnit("main.go", "/src/example")
 	file := builder.File("/src/example/main.go")
 	basic := builder.CreateBasicType(llvm.DIBasicType{

--- a/ssa/decl.go
+++ b/ssa/decl.go
@@ -357,8 +357,13 @@ func (p Function) NewBuilder() Builder {
 	b := prog.ctx.NewBuilder()
 	// TODO(xsw): Finalize may cause panic, so comment it.
 	// b.Finalize()
-	return &aBuilder{b, nil, p, p.Pkg, prog,
-		make(map[*types.Scope]DIScope)}
+	return &aBuilder{
+		impl:         b,
+		Func:         p,
+		Pkg:          p.Pkg,
+		Prog:         prog,
+		diScopeCache: make(map[*types.Scope]DIScope),
+	}
 }
 
 // HasBody reports whether the function has a body.

--- a/ssa/di.go
+++ b/ssa/di.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"go/token"
 	"go/types"
-	"path/filepath"
-	"unsafe"
 
+	"github.com/goplus/llgo/internal/debuginfo"
 	"github.com/xgo-dev/llvm"
 )
 
@@ -16,41 +15,32 @@ type Positioner interface {
 }
 
 type aDIBuilder struct {
-	di         *llvm.DIBuilder
+	di         *debuginfo.Builder
 	prog       Program
 	types      map[Type]DIType
 	positioner Positioner
-	m          llvm.Module // Add this field
 }
 
 type diBuilder = *aDIBuilder
 
 func newDIBuilder(prog Program, pkg Package, positioner Positioner) diBuilder {
-	m := pkg.mod
-	ctx := m.Context()
-
-	b := &aDIBuilder{
-		di:         llvm.NewDIBuilder(m),
+	return &aDIBuilder{
+		di: debuginfo.New(pkg.mod, debuginfo.Config{
+			Producer:  "LLGo",
+			Optimized: prog.debugInfoOptimized,
+		}),
 		prog:       prog,
 		types:      make(map[*aType]DIType),
 		positioner: positioner,
-		m:          m, // Initialize the m field
 	}
+}
 
-	b.addNamedMetadataOperand("llvm.module.flags", 2, "Debug Info Version", 3)
-	b.addNamedMetadataOperand("llvm.module.flags", 7, "Dwarf Version", 4)
-	b.addNamedMetadataOperand("llvm.module.flags", 1, "wchar_size", 4)
-	b.addNamedMetadataOperand("llvm.module.flags", 8, "PIC Level", 2)
-	b.addNamedMetadataOperand("llvm.module.flags", 7, "uwtable", 1)
-	b.addNamedMetadataOperand("llvm.module.flags", 7, "frame-pointer", 1)
-
-	// Add llvm.ident metadata
-	identNode := ctx.MDNode([]llvm.Metadata{
-		ctx.MDString("LLGo Compiler"),
-	})
-	m.AddNamedMetadataOperand("llvm.ident", identNode)
-
-	return b
+func (b diBuilder) finalize() {
+	if b == nil || b.di == nil {
+		return
+	}
+	b.di.Finalize()
+	b.di = nil
 }
 
 func hasTypeParam(typ types.Type) bool {
@@ -143,18 +133,6 @@ func hasTypeParam(typ types.Type) bool {
 	return visit(typ)
 }
 
-// New method to add named metadata operand
-func (b diBuilder) addNamedMetadataOperand(name string, intValue int, stringValue string, intValue2 int) {
-	ctx := b.m.Context()
-	b.m.AddNamedMetadataOperand(name,
-		ctx.MDNode([]llvm.Metadata{
-			llvm.ConstInt(ctx.Int32Type(), uint64(intValue), false).ConstantAsMetadata(),
-			ctx.MDString(stringValue),
-			llvm.ConstInt(ctx.Int32Type(), uint64(intValue2), false).ConstantAsMetadata(),
-		}),
-	)
-}
-
 // ----------------------------------------------------------------------------
 
 type aCompilationUnit struct {
@@ -167,19 +145,8 @@ func (c CompilationUnit) scopeMeta(b diBuilder, pos token.Position) DIScopeMeta 
 	return &aDIScopeMeta{c.ll}
 }
 
-var DWARF_LANG_C llvm.DwarfLang = 0x2
-var DWARF_LANG_GO llvm.DwarfLang = 0x16
-
 func (b diBuilder) createCompileUnit(filename, dir string) CompilationUnit {
-	return &aCompilationUnit{ll: b.di.CreateCompileUnit(llvm.DICompileUnit{
-		// TODO(lijie): use C language for now, change after Go plugin of LLDB is ready
-		Language:       DWARF_LANG_C - 1,
-		File:           filename,
-		Dir:            dir,
-		Producer:       "LLGo",
-		Optimized:      true,
-		RuntimeVersion: 1,
-	})}
+	return &aCompilationUnit{ll: b.di.CompileUnit(filename, dir)}
 }
 
 // ----------------------------------------------------------------------------
@@ -203,8 +170,7 @@ type aDIFile struct {
 type DIFile = *aDIFile
 
 func (b diBuilder) createFile(filename string) DIFile {
-	dir, file := filepath.Split(filename)
-	return &aDIFile{ll: b.di.CreateFile(file, dir)}
+	return &aDIFile{ll: b.di.File(filename)}
 }
 
 func (f DIFile) scopeMeta(b diBuilder, pos token.Position) DIScopeMeta {
@@ -375,15 +341,31 @@ func (b diBuilder) createAutoVariable(scope DIScope, pos token.Position, name st
 }
 
 func (b diBuilder) createTypedefType(name string, ty Type, pos token.Position) DIType {
+	scope := b.file(pos.Filename)
+	ret := &aDIType{ll: b.di.CreateReplaceableCompositeType(
+		scope.ll,
+		llvm.DIReplaceableCompositeType{
+			Tag:         dwarf.TagStructType,
+			Name:        name,
+			File:        scope.ll,
+			Line:        pos.Line,
+			SizeInBits:  b.prog.SizeOf(ty) * 8,
+			AlignInBits: uint32(b.prog.sizes.Alignof(ty.RawType()) * 8),
+		},
+	)}
+	b.types[ty] = ret
+
 	underlyingType := b.diType(b.prog.rawType(ty.RawType().(*types.Named).Underlying()), pos)
 	typ := b.di.CreateTypedef(llvm.DITypedef{
 		Name:        name,
 		Type:        underlyingType.ll,
-		File:        b.file(pos.Filename).ll,
+		File:        scope.ll,
 		Line:        pos.Line,
 		AlignInBits: uint32(b.prog.sizes.Alignof(ty.RawType()) * 8),
 	})
-	return &aDIType{typ}
+	ret.ll.ReplaceAllUsesWith(typ)
+	ret.ll = typ
+	return ret
 }
 
 func (b diBuilder) createStringType() DIType {
@@ -757,47 +739,39 @@ func (b Builder) DIVarAuto(scope DIScope, pos token.Position, varName string, vt
 	return b.di().varAuto(scope, pos, varName, t)
 }
 
-// hack for types.Scope
-type hackScope struct {
-	parent   *types.Scope
-	children []*types.Scope
-	number   int                     // parent.children[number-1] is this scope; 0 if there is no parent
-	elems    map[string]types.Object // lazily allocated
-	pos, end token.Pos               // scope extent; may be invalid
-	comment  string                  // for debugging only
-	isFunc   bool                    // set if this is a function scope (internal use only)
-}
-
-func isFunc(scope *types.Scope) bool {
-	hs := (*hackScope)(unsafe.Pointer(scope))
-	return hs.isFunc
-}
-
 func (b Builder) DIScope(f Function, scope *types.Scope) DIScope {
+	if scope == nil || b.diFuncScope == nil {
+		return f
+	}
 	if cachedScope, ok := b.diScopeCache[scope]; ok {
 		return cachedScope
 	}
-	pos := b.di().positioner.Position(scope.Pos())
-	// skip package and universe scope
-	// if scope.Parent().Parent() == nil {
-	// 	return b.di().file(pos.Filename)
-	// }
-
-	var result DIScope
-	if isFunc(scope) {
-		// TODO(lijie): should check scope == function scope
-		result = f
-	} else {
-		parentScope := b.DIScope(f, scope.Parent())
-		result = &aDILexicalBlock{b.di().di.CreateLexicalBlock(parentScope.scopeMeta(b.di(), pos).ll, llvm.DILexicalBlock{
-			File:   b.di().file(pos.Filename).ll,
-			Line:   pos.Line,
-			Column: pos.Column,
-		})}
+	if scope == b.diFuncScope {
+		b.diScopeCache[scope] = f
+		return f
+	}
+	if !isScopeWithin(scope, b.diFuncScope) {
+		return f
 	}
 
+	pos := b.di().positioner.Position(scope.Pos())
+	parentScope := b.DIScope(f, scope.Parent())
+	result := &aDILexicalBlock{b.di().di.CreateLexicalBlock(parentScope.scopeMeta(b.di(), pos).ll, llvm.DILexicalBlock{
+		File:   b.di().file(pos.Filename).ll,
+		Line:   pos.Line,
+		Column: pos.Column,
+	})}
 	b.diScopeCache[scope] = result
 	return result
+}
+
+func isScopeWithin(scope, root *types.Scope) bool {
+	for current := scope; current != nil; current = current.Parent() {
+		if current == root {
+			return true
+		}
+	}
+	return false
 }
 
 const (
@@ -829,7 +803,8 @@ func (b Builder) DISetCurrentDebugLocation(diScope DIScope, pos token.Position) 
 	)
 }
 
-func (b Builder) DebugFunction(f Function, pos token.Position, bodyPos token.Position) {
+func (b Builder) DebugFunction(f Function, funcScope *types.Scope, pos token.Position, bodyPos token.Position) {
+	b.diFuncScope = funcScope
 	p := f
 	if p.diFunc == nil {
 		sig := p.Type.raw.Type.(*types.Signature)
@@ -852,7 +827,6 @@ func (b Builder) DebugFunction(f Function, pos token.Position, bodyPos token.Pos
 			ScopeLine:    bodyPos.Line,
 			IsDefinition: true,
 			LocalToUnit:  true,
-			Optimized:    true,
 		}
 		p.diFunc = &aDIFunction{
 			b.di().di.CreateFunction(b.di().file(pos.Filename).ll, dif),

--- a/ssa/di.go
+++ b/ssa/di.go
@@ -208,7 +208,7 @@ func (b diBuilder) createType(name string, ty Type, pos token.Position) DIType {
 		} else if t.Info()&types.IsFloat != 0 {
 			encoding = llvm.DW_ATE_float
 		} else if t.Info()&types.IsComplex != 0 {
-			return b.createComplexType(ty)
+			encoding = llvm.DW_ATE_complex_float
 		} else if t.Info()&types.IsString != 0 {
 			return b.createStringType()
 		} else {
@@ -223,8 +223,7 @@ func (b diBuilder) createType(name string, ty Type, pos token.Position) DIType {
 	case *types.Pointer:
 		return b.createPointerType(name, b.prog.rawType(t.Elem()), pos)
 	case *types.Named:
-		// Create typedef type for named types
-		return b.createTypedefType(name, ty, pos)
+		return b.createTypedefType(name, ty, b.typeDeclarationPosition(t, pos))
 	case *types.Interface:
 		ty := b.prog.rtType("Iface")
 		return b.createInterfaceType(name, ty)
@@ -235,21 +234,28 @@ func (b diBuilder) createType(name string, ty Type, pos token.Position) DIType {
 	case *types.Struct:
 		return b.createStructType(name, ty, pos)
 	case *types.Signature:
-		tyFn := b.prog.Closure(t)
-		return b.createFuncPtrType(name, tyFn, pos)
+		return b.createFuncPtrType(name, ty, pos)
 	case *types.Array:
 		return b.createArrayType(ty, t.Len())
 	case *types.Chan:
-		return b.createChanType(name, ty, pos)
+		return b.createOpaquePointerType(name, ty)
 	case *types.Map:
-		ty := b.prog.rtType("Map")
-		return b.createMapType(name, ty, pos)
+		return b.createOpaquePointerType(name, ty)
 	case *types.Tuple:
 		return b.createTupleType(name, ty, pos)
 	default:
 		panic(fmt.Errorf("can't create debug info of type: %v, %T", ty.RawType(), ty.RawType()))
 	}
 	return &aDIType{typ}
+}
+
+func (b diBuilder) typeDeclarationPosition(typ *types.Named, fallback token.Position) token.Position {
+	if obj := typ.Obj(); obj != nil && obj.Pos().IsValid() {
+		if pos := b.positioner.Position(obj.Pos()); pos.IsValid() {
+			return pos
+		}
+	}
+	return fallback
 }
 
 // ----------------------------------------------------------------------------
@@ -435,40 +441,12 @@ func (b diBuilder) createMemberTypeEx(name string, tyStruct, tyField Type, idxFi
 	)
 }
 
-func (b diBuilder) createMapType(name string, tyMap Type, pos token.Position) DIType {
-	// ty := tyMap.RawType().(*types.Map)
-	// tk := b.prog.rawType(ty.Key())
-	// tv := b.prog.rawType(ty.Elem())
-	tyCount := b.prog.Int()
-	return b.doCreateStructType(name, tyMap, pos, func(ditStruct DIType) []llvm.Metadata {
-		return []llvm.Metadata{
-			b.createMemberType("count", tyMap, tyCount, 0),
-		}
-	})
-}
-
-func (b diBuilder) createChanType(name string, t Type, pos token.Position) DIType {
-	return b.doCreateStructType(name, t, pos, func(ditStruct DIType) []llvm.Metadata {
-		return []llvm.Metadata{}
-	})
-}
-
-func (b diBuilder) createComplexType(t Type) DIType {
-	var tfield Type
-	var tyName string
-	if t.RawType().(*types.Basic).Kind() == types.Complex128 {
-		tfield = b.prog.Float64()
-		tyName = "complex128"
-	} else {
-		tfield = b.prog.Float32()
-		tyName = "complex64"
-	}
-	return b.doCreateStructType(tyName, t, token.Position{}, func(ditStruct DIType) []llvm.Metadata {
-		return []llvm.Metadata{
-			b.createMemberType("real", t, tfield, 0),
-			b.createMemberType("imag", t, tfield, 1),
-		}
-	})
+func (b diBuilder) createOpaquePointerType(name string, ty Type) DIType {
+	return &aDIType{ll: b.di.CreatePointerType(llvm.DIPointerType{
+		Name:        name,
+		SizeInBits:  b.prog.SizeOf(ty) * 8,
+		AlignInBits: uint32(b.prog.sizes.Alignof(ty.RawType()) * 8),
+	})}
 }
 
 func (b diBuilder) createPointerType(name string, ty Type, pos token.Position) DIType {
@@ -552,10 +530,22 @@ func (b diBuilder) createTupleType(name string, ty Type, pos token.Position) DIT
 }
 
 func (b diBuilder) createFuncPtrType(name string, ty Type, pos token.Position) DIType {
+	sig := ty.RawType().(*types.Signature)
+	params := make([]llvm.Metadata, sig.Params().Len()+1)
+	if results := sig.Results(); results.Len() != 0 {
+		params[0] = b.diType(b.prog.rawType(results), pos).ll
+	}
+	for i := 0; i < sig.Params().Len(); i++ {
+		params[i+1] = b.diType(b.prog.rawType(sig.Params().At(i).Type()), pos).ll
+	}
+	subroutine := b.di.CreateSubroutineType(llvm.DISubroutineType{
+		File:       b.file(pos.Filename).ll,
+		Parameters: params,
+	})
 	ptr := b.prog.VoidPtr()
 	return &aDIType{ll: b.di.CreatePointerType(llvm.DIPointerType{
 		Name:        name,
-		Pointee:     b.diType(ptr, pos).ll,
+		Pointee:     subroutine,
 		SizeInBits:  b.prog.SizeOf(ptr) * 8,
 		AlignInBits: uint32(b.prog.sizes.Alignof(ptr.RawType()) * 8),
 	})}
@@ -787,7 +777,7 @@ func (b Builder) DIGlobal(v Expr, name string, pos token.Position) {
 		pos,
 		name,
 		name,
-		v.Type,
+		b.Prog.Elem(v.Type),
 		false,
 	)
 	v.impl.AddMetadata(MD_dbg, gv.ll)

--- a/ssa/di_debug_test.go
+++ b/ssa/di_debug_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/goplus/llgo/internal/optlevel"
 	"github.com/xgo-dev/llvm"
 )
 
@@ -35,10 +36,9 @@ func inspect() {
 		t.Fatal(err)
 	}
 
-	prog := NewProgram(nil)
+	prog := NewProgram(&Target{OptLevel: optlevel.O0})
 	defer prog.Dispose()
 	prog.TypeSizes(types.SizesFor("gc", runtime.GOARCH))
-	prog.SetDebugInfoOptimized(false)
 	pkg := prog.NewPackage("p", "example.com/p")
 	pkg.InitDebug("p", "example.com/p", fset)
 	fn := pkg.NewFunc("debugTypes", NoArgsNoRet, InGo)

--- a/ssa/di_debug_test.go
+++ b/ssa/di_debug_test.go
@@ -102,3 +102,102 @@ func inspect() {
 		}
 	}
 }
+
+func TestDebugGoTypeEncodings(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "types.go", `package p
+type Named int64
+type Recursive struct { Next *Recursive }
+type Shape struct {
+	Complex complex128
+	Text string
+	Values []Named
+	Lookup map[string]Named
+	Queue chan Named
+	Callback func(Named) (Named, error)
+	Any any
+	Recursive *Recursive
+}
+`, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	typesPkg, err := (&types.Config{}).Check("example.com/p", fset, []*ast.File{file}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prog := NewProgram(nil)
+	defer prog.Dispose()
+	prog.TypeSizes(types.SizesFor("gc", runtime.GOARCH))
+	prog.SetRuntime(newDebugRuntimePackage())
+	pkg := prog.NewPackage("p", "example.com/p")
+	pkg.InitDebug("p", "example.com/p", fset)
+
+	shape := typesPkg.Scope().Lookup("Shape").Type()
+	global := pkg.NewVar("example.com/p.GlobalShape", types.NewPointer(shape), InGo)
+	fn := pkg.NewFunc("debugTypes", NoArgsNoRet, InGo)
+	builder := fn.NewBuilder()
+	defer builder.impl.Dispose()
+	builder.DIGlobal(global.Expr, "GlobalShape", fset.Position(typesPkg.Scope().Lookup("Shape").Pos()))
+
+	fallback := token.Position{Filename: "fallback.go", Line: 7}
+	noPos := types.NewNamed(types.NewTypeName(token.NoPos, typesPkg, "NoPos", nil), types.Typ[types.Int], nil)
+	if got := pkg.di.typeDeclarationPosition(noPos, fallback); got != fallback {
+		t.Fatalf("invalid declaration position = %v, want %v", got, fallback)
+	}
+
+	pkg.FinalizeDebug()
+	if err := llvm.VerifyModule(pkg.Module(), llvm.ReturnStatusAction); err != nil {
+		t.Fatalf("Go type debug metadata is invalid: %v\n%s", err, pkg.Module().String())
+	}
+	ir := pkg.Module().String()
+	for _, want := range []string{
+		"DW_LANG_Go",
+		"DW_ATE_complex_float",
+		"!DISubroutineType",
+		`name: "map[string]example.com/p.Named"`,
+		`name: "chan example.com/p.Named"`,
+		`name: "example.com/p.Recursive"`,
+	} {
+		if !strings.Contains(ir, want) {
+			t.Errorf("module is missing %q:\n%s", want, ir)
+		}
+	}
+}
+
+func newDebugRuntimePackage() *types.Package {
+	pkg := types.NewPackage(PkgRuntime, "runtime")
+	unsafePointer := types.Typ[types.UnsafePointer]
+	members := map[string][]*types.Var{
+		"String": {
+			types.NewField(token.NoPos, pkg, "data", unsafePointer, false),
+			types.NewField(token.NoPos, pkg, "len", types.Typ[types.Uint], false),
+		},
+		"Slice": {
+			types.NewField(token.NoPos, pkg, "data", unsafePointer, false),
+			types.NewField(token.NoPos, pkg, "len", types.Typ[types.Uint], false),
+			types.NewField(token.NoPos, pkg, "cap", types.Typ[types.Uint], false),
+		},
+		"Eface": {
+			types.NewField(token.NoPos, pkg, "type", unsafePointer, false),
+			types.NewField(token.NoPos, pkg, "data", unsafePointer, false),
+		},
+		"Iface": {
+			types.NewField(token.NoPos, pkg, "type", unsafePointer, false),
+			types.NewField(token.NoPos, pkg, "data", unsafePointer, false),
+		},
+		"Map": {
+			types.NewField(token.NoPos, pkg, "count", types.Typ[types.Int], false),
+		},
+		"Chan": {
+			types.NewField(token.NoPos, pkg, "count", types.Typ[types.Int], false),
+		},
+	}
+	for name, fields := range members {
+		obj := types.NewTypeName(token.NoPos, pkg, name, nil)
+		types.NewNamed(obj, types.NewStruct(fields, nil), nil)
+		pkg.Scope().Insert(obj)
+	}
+	return pkg
+}

--- a/ssa/di_debug_test.go
+++ b/ssa/di_debug_test.go
@@ -1,0 +1,104 @@
+//go:build !llgo
+
+package ssa
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/xgo-dev/llvm"
+)
+
+func TestDebugRecursiveNamedTypesFinalize(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "recursive.go", `package p
+type Link *Link
+type Peano *Peano
+func inspect() {
+	if true {
+		value := 1
+		_ = value
+	}
+}
+`, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	typesPkg := types.NewPackage("example.com/p", "p")
+	info := &types.Info{Scopes: make(map[ast.Node]*types.Scope)}
+	if err := types.NewChecker(&types.Config{}, fset, typesPkg, info).Files([]*ast.File{file}); err != nil {
+		t.Fatal(err)
+	}
+
+	prog := NewProgram(nil)
+	defer prog.Dispose()
+	prog.TypeSizes(types.SizesFor("gc", runtime.GOARCH))
+	prog.SetDebugInfoOptimized(false)
+	pkg := prog.NewPackage("p", "example.com/p")
+	pkg.InitDebug("p", "example.com/p", fset)
+	fn := pkg.NewFunc("debugTypes", NoArgsNoRet, InGo)
+	builder := fn.NewBuilder()
+	defer builder.impl.Dispose()
+	for _, name := range []string{"Link", "Peano"} {
+		object := typesPkg.Scope().Lookup(name)
+		pos := fset.Position(object.Pos())
+		global := pkg.NewVar("example.com/p."+name, types.NewPointer(object.Type()), InGo)
+		builder.DIGlobal(global.Expr, name, pos)
+	}
+
+	decl := file.Decls[2].(*ast.FuncDecl)
+	object := typesPkg.Scope().Lookup("inspect").(*types.Func)
+	function := pkg.NewFunc("example.com/p.inspect", object.Type().(*types.Signature), InGo)
+	functionBuilder := function.MakeBody(1)
+	defer functionBuilder.Dispose()
+	functionBuilder.DebugFunction(
+		function,
+		object.Scope(),
+		fset.Position(object.Pos()),
+		fset.Position(decl.Body.Lbrace),
+	)
+	if got := functionBuilder.DIScope(function, nil); got != function {
+		t.Fatal("nil scope did not resolve to the function")
+	}
+	if got := functionBuilder.DIScope(function, object.Scope()); got != function {
+		t.Fatal("function scope did not resolve to the function")
+	}
+	if got := functionBuilder.DIScope(function, typesPkg.Scope()); got != function {
+		t.Fatal("package scope did not resolve to the function")
+	}
+	innerBlock := decl.Body.List[0].(*ast.IfStmt).Body
+	innerScope := info.Scopes[innerBlock]
+	if innerScope == nil {
+		t.Fatal("inner lexical scope not found")
+	}
+	lexical := functionBuilder.DIScope(function, innerScope)
+	if lexical == function || functionBuilder.DIScope(function, innerScope) != lexical {
+		t.Fatal("inner lexical scope was not created and cached")
+	}
+	functionBuilder.DISetCurrentDebugLocation(lexical, fset.Position(innerBlock.Lbrace))
+	functionBuilder.Return()
+	functionBuilder.EndBuild()
+
+	pkg.FinalizeDebug()
+	pkg.FinalizeDebug()
+
+	if err := llvm.VerifyModule(pkg.Module(), llvm.ReturnStatusAction); err != nil {
+		t.Fatalf("recursive debug metadata is invalid: %v\n%s", err, pkg.Module().String())
+	}
+	ir := pkg.Module().String()
+	for _, name := range []string{"Link", "Peano"} {
+		if !strings.Contains(ir, `name: "`+name+`"`) {
+			t.Fatalf("module is missing debug type %s:\n%s", name, ir)
+		}
+	}
+	for _, want := range []string{"DILexicalBlock", "isOptimized: false"} {
+		if !strings.Contains(ir, want) {
+			t.Fatalf("module is missing %q:\n%s", want, ir)
+		}
+	}
+}

--- a/ssa/di_debug_test.go
+++ b/ssa/di_debug_test.go
@@ -153,7 +153,7 @@ type Shape struct {
 	}
 	ir := pkg.Module().String()
 	for _, want := range []string{
-		"DW_LANG_Go",
+		"DW_LANG_C",
 		"DW_ATE_complex_float",
 		"!DISubroutineType",
 		`name: "map[string]example.com/p.Named"`,

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -363,12 +363,6 @@ func (p Program) EnableLTOPluginMarkers(enable bool) {
 	p.enableLTOPluginMarker = enable
 }
 
-// SetDebugInfoOptimized records whether optional backend optimization runs.
-// It only controls DWARF's optimized marker and never selects compiler passes.
-func (p Program) SetDebugInfoOptimized(enable bool) {
-	p.debugInfoOptimized = enable
-}
-
 func (p Program) SetNoInterfaceMethod(fullName string) {
 	p.noInterface[fullName] = none{}
 }

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -26,6 +26,7 @@ import (
 	"unsafe"
 
 	"github.com/goplus/llgo/internal/env"
+	"github.com/goplus/llgo/internal/optlevel"
 	"github.com/goplus/llgo/ssa/abi"
 	"github.com/xgo-dev/llvm"
 	"golang.org/x/tools/go/types/typeutil"
@@ -240,6 +241,7 @@ type aProgram struct {
 
 	enableFuncInfoMetadata bool
 	enableFuncInfoSites    bool
+	debugInfoOptimized     bool
 }
 
 type AbiSymbol struct {
@@ -312,6 +314,7 @@ func NewProgram(target *Target) Program {
 		target: target, td: td, tm: tm, is32Bits: is32Bits,
 		ptrSize: td.PointerSize(), named: make(map[string]Type), fnnamed: make(map[string]int),
 		linkname: make(map[string]string), noInterface: make(map[string]none), abiSymbol: make(map[string]*AbiSymbol),
+		debugInfoOptimized: target.effectiveOptLevel() != optlevel.O0,
 	}
 	prog.abi.Init(uintptr(prog.ptrSize), (*goProgram)(unsafe.Pointer(prog)))
 	return prog
@@ -358,6 +361,12 @@ func (p Program) SetPthreadStackSize(size uint64) {
 
 func (p Program) EnableLTOPluginMarkers(enable bool) {
 	p.enableLTOPluginMarker = enable
+}
+
+// SetDebugInfoOptimized records whether optional backend optimization runs.
+// It only controls DWARF's optimized marker and never selects compiler passes.
+func (p Program) SetDebugInfoOptimized(enable bool) {
+	p.debugInfoOptimized = enable
 }
 
 func (p Program) SetNoInterfaceMethod(fullName string) {
@@ -912,6 +921,14 @@ func (p Package) AfterInit(b Builder, ret BasicBlock) {
 func (p Package) InitDebug(name, pkgPath string, positioner Positioner) {
 	p.di = newDIBuilder(p.Prog, p, positioner)
 	p.cu = p.di.createCompileUnit(name, pkgPath)
+}
+
+// FinalizeDebug resolves temporary debug metadata and releases the package's
+// DI builder. No debug records may be added after this call.
+func (p Package) FinalizeDebug() {
+	if p.di != nil {
+		p.di.finalize()
+	}
 }
 
 func (p Package) createGlobalStr(v string) (ret llvm.Value) {

--- a/ssa/stmt_builder.go
+++ b/ssa/stmt_builder.go
@@ -65,6 +65,7 @@ type aBuilder struct {
 	Prog Program
 
 	diScopeCache map[*types.Scope]DIScope // avoid duplicated DILexicalBlock(s)
+	diFuncScope  *types.Scope
 }
 
 // Builder represents a builder for creating instructions in a function.


### PR DESCRIPTION
## Problem

LLGo's existing DWARF path has no standards-based contract. Metadata construction is spread across the compiler, several Go source types are encoded incorrectly, recursive named types cannot be completed safely, and source variables and lexical scopes are not represented consistently.

The result may be malformed or misleading DWARF even when a binary builds successfully. Debugger-only checks do not detect those format and type-system errors. Conversely, valid Go DWARF marked DW_LANG_Go is not sufficient for current LLDB: Apple/LLVM LLDB has no Go language plugin and hides otherwise valid frame variables.

## Foundation design

This PR establishes a Go DWARF foundation with clear ownership:

- internal/debuginfo owns the LLVM DIBuilder lifecycle, module flags, file caching, finalization, and thin metadata operations.
- ssa owns Go source-type lowering and package/function debug metadata.
- cl owns source scopes, variable storage homes, and ssa.DebugRef integration.
- Named and recursive types use replaceable metadata followed by RAUW.
- Globals retain their source type instead of an extra storage pointer.
- Complex values use DW_ATE_complex_float; function values reference a subroutine type; maps and channels are pointer-sized opaque types.
- Parameters, named results, locals, lexical blocks, closures, generic instances, methods, declaration locations, and cross-file line records are emitted.

LLVM builder ownership remains independent from Go semantic lowering, while frontend source-variable bookkeeping stays in cl.

## LLDB compatibility contract

Compile units temporarily use DW_LANG_C so stock LLDB uses its complete C frame-variable path. The emitted type layouts and attributes remain the Go-oriented DWARF validated by the standard tests.

LLGo identity does not depend on the language field:

- DW_AT_producer remains LLGo and is the authoritative DWARF identity.
- A hidden, versioned __llgo_debugger_marker_v1 symbol is emitted only with debug information.
- The marker is a one-byte link-once constant retained through llvm.used, deduplicates to one final Mach-O/ELF symbol, and has no startup or runtime access cost.
- The Python plugin checks the marker instead of attaching to every target.
- Expression lookup now falls back from frame variables to LLGo globals.
- A plain C executable is tested to ensure the plugin rejects non-LLGo targets.

Native DW_LANG_Go support is intentionally a separate LLDB language-extension project described in [#2154](https://github.com/xgo-dev/llgo/issues/2154). LLGo should switch the language field only after that extension passes its cross-platform acceptance matrix.

## Standards coverage

TestStandardDWARF builds and executes a multi-file Go fixture at O0, O1, O2, O3, Os, and Oz, then:

- parses native Mach-O or ELF DWARF with Go's debug/dwarf;
- validates compile-unit language and producer attributes;
- checks aliases, named and recursive types, every primitive width, structs and byte offsets, arrays, strings, slices, maps, channels, interfaces, pointers, globals, scopes, functions, generics, methods, and line tables;
- validates LLGo's runtime layouts for string/slice/interface headers and two-word function values, including the code pointer's subroutine signature;
- runs llvm-dwarfdump --verify;
- runs dsymutil and verifies the produced dSYM on macOS;
- normalizes a verifier-only Linux copy with llvm-dwarfutil to remove linker tombstones left by section GC, while semantic assertions continue to inspect the original ELF.

The macOS LLDB suite runs at O0 because it asserts exact source-variable values and lifetimes. It now passes 198 checks covering parameters, locals, lexical scopes, standard complex values, globals, pointers, aggregates, marker detection, and non-LLGo rejection. Optimized builds legitimately eliminate or merge some locals, so the six optimization levels are validated structurally rather than compared against O0 variable availability.

The requested optimization level still configures LLVM target-machine code generation. Existing main behavior disables LLGo's IR pass pipeline and optimized C ABI mode whenever DWARF is enabled; this PR intentionally does not change that policy. Decoupling those transformations is covered by [#2143](https://github.com/xgo-dev/llgo/pull/2143).

Fixes #2116.

## Verification

Local macOS, Go 1.26.5 / LLVM 19:

- TestStandardDWARF: O0, O1, O2, O3, Os, and Oz pass;
- _lldb/runtest.sh at O0: 198/198 pass, including non-LLGo rejection;
- go test ./internal/debuginfo: pass with 100% statement coverage;
- go test ./ssa: pass;
- the four new cl debug/referrer unit tests: pass;
- shell/Python syntax checks: pass.

The resource-limited full cl package run reached its 15-minute command timeout in the existing _testrt fixture without an assertion failure; CI runs that suite in shards.

Ubuntu arm64 container, Go 1.26.5 / LLVM 19.1.7, limited to 2 CPUs, 15 GiB memory, and 512 PIDs:

- internal/debuginfo tests pass;
- TestStandardDWARF passes at all six optimization levels;
- an O0 LLGo fixture builds and runs;
- the final ELF contains exactly one __llgo_debugger_marker_v1 symbol.

CI keeps both the standards matrix and the existing LLDB integration suite.

## Out of scope

Each area below remains independent from this foundation:

- LLVM IR optimization with DWARF ([#2143](https://github.com/xgo-dev/llgo/pull/2143));
- full-LTO debug locations ([#2144](https://github.com/xgo-dev/llgo/pull/2144));
- C ABI storage rewriting and debug records;
- Python frontend pseudo-variables;
- DWARF-sensitive SSA transformation correctness;
- Go-compatible default -w behavior ([#2142](https://github.com/xgo-dev/llgo/pull/2142));
- pclntab/source-line precision and cold/warm cache consistency;
- native LLDB Go language support ([#2154](https://github.com/xgo-dev/llgo/issues/2154)).

DWARF remains opt-in for linked builds through -ldflags=-w=false in this PR.
