### PR TITLE
debug: keep optimization and SSA rewrites DWARF-safe

### DIFF
--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -258,6 +258,13 @@ var testltoLTOPluginTests = []string{
 	"globaldce_reflect_method_by_name_ltoplugin_switch",
 }
 
+var testltoLTOPluginDWARFTests = []string{
+	"globaldce_reflect_method_by_name_ltoplugin_concat",
+	"globaldce_reflect_method_by_name_ltoplugin_global_slice",
+	"globaldce_reflect_method_by_name_ltoplugin_param",
+	"globaldce_reflect_method_by_name_ltoplugin_slice",
+}
+
 func TestBuildAndCheckSymbolsFromTestlto(t *testing.T) {
 	if !buildenv.Dev {
 		t.Skip("globaldce symbol checks require dev build")
@@ -399,6 +406,15 @@ func TestBuildAndCheckSymbolsFromTestltoLTOPluginAggregateABI(t *testing.T) {
 	if !strings.Contains(unknownResult, `metadata !"go.method.type.reflect"`) {
 		t.Fatalf("aggregate ABI output lost the unknown-name type marker\n%s", unknownResult)
 	}
+}
+
+func TestBuildAndCheckSymbolsFromTestltoLTOPluginDWARF(t *testing.T) {
+	t.Setenv("LLGO_BUILD_CACHE", "off")
+	buildConf := testltoLTOPluginConf(t, build.ModeBuild)
+	buildConf.LinkOptions.DWARF = build.DWARFPreserve
+	cltest.BuildAndCheckSymbolsFromDir(t, "", "./_testlto", testltoLTOPluginDWARFTests,
+		cltest.WithRunConfig(buildConf),
+	)
 }
 
 func TestFilterEmulatorOutput(t *testing.T) {

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -226,6 +226,15 @@ func TestRunAndTestFromTestlto(t *testing.T) {
 	cltest.RunAndTestFromDir(t, "", "./_testlto", ignore, cltest.WithRunConfig(conf))
 }
 
+func TestRunAndTestFromTestltoDWARF(t *testing.T) {
+	t.Setenv("LLGO_BUILD_CACHE", "off")
+	conf := build.NewDefaultConf(build.ModeRun)
+	conf.LTO = lto.Full
+	conf.LinkOptions.DWARF = build.DWARFPreserve
+	cltest.RunAndTestFromDir(t, "reflectmk_runtime", "./_testlto", nil,
+		cltest.WithRunConfig(conf), cltest.WithIRCheck(false))
+}
+
 var testltoSymbolChecks = []string{
 	"globaldce_interface_matrix",
 	"globaldce_interface_slots",
@@ -318,6 +327,14 @@ func TestRunAndTestFromTestltoLTOPlugin(t *testing.T) {
 		cltest.WithRunConfig(conf),
 		cltest.WithIRCheck(false),
 	)
+}
+
+func TestRunAndTestFromTestltoLTOPluginDWARF(t *testing.T) {
+	t.Setenv("LLGO_BUILD_CACHE", "off")
+	conf := testltoLTOPluginConf(t, build.ModeRun)
+	conf.LinkOptions.DWARF = build.DWARFPreserve
+	cltest.RunAndTestFromDir(t, "ltoplugin_switch", "./_testlto", nil,
+		cltest.WithRunConfig(conf), cltest.WithIRCheck(false))
 }
 
 func TestBuildAndCheckSymbolsFromTestltoLTOPlugin(t *testing.T) {

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -226,15 +226,6 @@ func TestRunAndTestFromTestlto(t *testing.T) {
 	cltest.RunAndTestFromDir(t, "", "./_testlto", ignore, cltest.WithRunConfig(conf))
 }
 
-func TestRunAndTestFromTestltoDWARF(t *testing.T) {
-	t.Setenv("LLGO_BUILD_CACHE", "off")
-	conf := build.NewDefaultConf(build.ModeRun)
-	conf.LTO = lto.Full
-	conf.LinkOptions.DWARF = build.DWARFPreserve
-	cltest.RunAndTestFromDir(t, "reflectmk_runtime", "./_testlto", nil,
-		cltest.WithRunConfig(conf), cltest.WithIRCheck(false))
-}
-
 var testltoSymbolChecks = []string{
 	"globaldce_interface_matrix",
 	"globaldce_interface_slots",
@@ -256,13 +247,6 @@ var testltoLTOPluginTests = []string{
 	"globaldce_reflect_method_by_name_ltoplugin_slice",
 	"globaldce_reflect_method_by_name_ltoplugin_string_abi",
 	"globaldce_reflect_method_by_name_ltoplugin_switch",
-}
-
-var testltoLTOPluginDWARFTests = []string{
-	"globaldce_reflect_method_by_name_ltoplugin_concat",
-	"globaldce_reflect_method_by_name_ltoplugin_global_slice",
-	"globaldce_reflect_method_by_name_ltoplugin_param",
-	"globaldce_reflect_method_by_name_ltoplugin_slice",
 }
 
 func TestBuildAndCheckSymbolsFromTestlto(t *testing.T) {
@@ -336,14 +320,6 @@ func TestRunAndTestFromTestltoLTOPlugin(t *testing.T) {
 	)
 }
 
-func TestRunAndTestFromTestltoLTOPluginDWARF(t *testing.T) {
-	t.Setenv("LLGO_BUILD_CACHE", "off")
-	conf := testltoLTOPluginConf(t, build.ModeRun)
-	conf.LinkOptions.DWARF = build.DWARFPreserve
-	cltest.RunAndTestFromDir(t, "ltoplugin_switch", "./_testlto", nil,
-		cltest.WithRunConfig(conf), cltest.WithIRCheck(false))
-}
-
 func TestBuildAndCheckSymbolsFromTestltoLTOPlugin(t *testing.T) {
 	buildConf := testltoLTOPluginConf(t, build.ModeBuild)
 	// See TestBuildAndCheckSymbolsFromTestlto: dynamic main.* exports retain
@@ -406,15 +382,6 @@ func TestBuildAndCheckSymbolsFromTestltoLTOPluginAggregateABI(t *testing.T) {
 	if !strings.Contains(unknownResult, `metadata !"go.method.type.reflect"`) {
 		t.Fatalf("aggregate ABI output lost the unknown-name type marker\n%s", unknownResult)
 	}
-}
-
-func TestBuildAndCheckSymbolsFromTestltoLTOPluginDWARF(t *testing.T) {
-	t.Setenv("LLGO_BUILD_CACHE", "off")
-	buildConf := testltoLTOPluginConf(t, build.ModeBuild)
-	buildConf.LinkOptions.DWARF = build.DWARFPreserve
-	cltest.BuildAndCheckSymbolsFromDir(t, "", "./_testlto", testltoLTOPluginDWARFTests,
-		cltest.WithRunConfig(buildConf),
-	)
 }
 
 func TestFilterEmulatorOutput(t *testing.T) {

--- a/cl/rewrite_internal_test.go
+++ b/cl/rewrite_internal_test.go
@@ -31,6 +31,15 @@ func compileWithRewrites(t *testing.T, src string, rewrites map[string]string) s
 }
 
 func compileWithRewritesTarget(t *testing.T, src string, rewrites map[string]string, target *llssa.Target) string {
+	return compileWithRewritesModeTarget(t, src, rewrites,
+		ssa.SanityCheckFunctions|ssa.InstantiateGenerics, target)
+}
+
+func compileWithRewritesMode(t *testing.T, src string, rewrites map[string]string, mode ssa.BuilderMode) string {
+	return compileWithRewritesModeTarget(t, src, rewrites, mode, nil)
+}
+
+func compileWithRewritesModeTarget(t *testing.T, src string, rewrites map[string]string, mode ssa.BuilderMode, target *llssa.Target) string {
 	t.Helper()
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "rewrite.go", src, parser.ParseComments)
@@ -38,7 +47,6 @@ func compileWithRewritesTarget(t *testing.T, src string, rewrites map[string]str
 		t.Fatalf("parse failed: %v", err)
 	}
 	importer := gpackages.NewImporter(fset)
-	mode := ssa.SanityCheckFunctions | ssa.InstantiateGenerics
 	pkg, _, err := ssautil.BuildPackage(&types.Config{Importer: importer}, fset,
 		types.NewPackage(file.Name.Name, file.Name.Name), []*ast.File{file}, mode)
 	if err != nil {
@@ -231,6 +239,75 @@ func Use() callbackType { return CallbackTypes[1] }
 	assertNoStoreToGlobal(t, ir, "@staticinit.CallbackTypes")
 	if strings.Contains(ir, "runtime.AllocZ") {
 		t.Fatalf("static slice initializer still allocates at runtime:\n%s", ir)
+	}
+}
+
+func TestStaticGlobalSliceLiteralInitWithDebugRefs(t *testing.T) {
+	const src = `package staticinit
+
+var CallbackTypes = []string{"BeforeCreate", "AfterCreate"}
+
+func Use() string { return CallbackTypes[1] }
+`
+	ir := compileWithRewritesMode(t, src, nil,
+		ssa.SanityCheckFunctions|ssa.InstantiateGenerics|ssa.GlobalDebug)
+	for _, want := range []string{
+		`@"staticinit.CallbackTypes$data" = global [2 x %"github.com/goplus/llgo/runtime/internal/runtime.String"]`,
+		`@staticinit.CallbackTypes = global %"github.com/goplus/llgo/runtime/internal/runtime.Slice" { ptr @"staticinit.CallbackTypes$data", i64 2, i64 2 }`,
+		`c"BeforeCreate"`,
+		`c"AfterCreate"`,
+	} {
+		if !strings.Contains(ir, want) {
+			t.Fatalf("missing static slice initializer %q with debug refs:\n%s", want, ir)
+		}
+	}
+	assertNoStoreToGlobal(t, ir, "@staticinit.CallbackTypes")
+	if strings.Contains(ir, "runtime.AllocZ") {
+		t.Fatalf("static slice initializer allocates at runtime with debug refs:\n%s", ir)
+	}
+}
+
+func TestStaticSliceInitRejectsExecutableReferrers(t *testing.T) {
+	const src = `package foo
+
+var Values []int
+
+func useSlice([]int) {}
+func usePointer(*int) {}
+
+func sliceUser() {
+	backing := [2]int{1, 2}
+	values := backing[:]
+	Values = values
+	useSlice(values)
+}
+
+func elementUser() {
+	var backing [2]int
+	elem := &backing[0]
+	*elem = 1
+	usePointer(elem)
+	Values = backing[:]
+}
+`
+	ssapkg := buildSSAPackage(t, src)
+	global := ssapkg.Members["Values"].(*ssa.Global)
+	for _, name := range []string{"sliceUser", "elementUser"} {
+		fn := ssapkg.Func(name)
+		var globalStore *ssa.Store
+		for _, block := range fn.Blocks {
+			for _, instr := range block.Instrs {
+				if store, ok := instr.(*ssa.Store); ok && store.Addr == global {
+					globalStore = store
+				}
+			}
+		}
+		if globalStore == nil {
+			t.Fatalf("%s: store to Values not found", name)
+		}
+		if _, ok := staticSliceInitOf(globalStore); ok {
+			t.Fatalf("%s: static slice init accepted an executable referrer", name)
+		}
 	}
 }
 

--- a/cl/static_init.go
+++ b/cl/static_init.go
@@ -209,16 +209,16 @@ func staticSliceInitOf(store *ssa.Store) (*staticSliceInit, bool) {
 		values: make(map[int]*ssa.Const),
 		instrs: []ssa.Instruction{alloc, slice, store},
 	}
-	sliceRefs := slice.Referrers()
-	if sliceRefs == nil || len(*sliceRefs) != 1 || (*sliceRefs)[0] != store {
+	sliceRefs, ok := nonDebugReferrers(slice)
+	if !ok || len(sliceRefs) != 1 || sliceRefs[0] != store {
 		return nil, false
 	}
-	refs := alloc.Referrers()
-	if refs == nil {
+	refs, ok := nonDebugReferrers(alloc)
+	if !ok {
 		return nil, false
 	}
 	seenSlice := false
-	for _, ref := range *refs {
+	for _, ref := range refs {
 		switch ref := ref.(type) {
 		case *ssa.Slice:
 			if ref != slice || seenSlice {
@@ -233,11 +233,11 @@ func staticSliceInitOf(store *ssa.Store) (*staticSliceInit, bool) {
 			if !ok || index >= int(array.Len()) {
 				return nil, false
 			}
-			indexRefs := ref.Referrers()
-			if indexRefs == nil || len(*indexRefs) != 1 {
+			indexRefs, ok := nonDebugReferrers(ref)
+			if !ok || len(indexRefs) != 1 {
 				return nil, false
 			}
-			elemStore, ok := (*indexRefs)[0].(*ssa.Store)
+			elemStore, ok := indexRefs[0].(*ssa.Store)
 			if !ok || elemStore.Addr != ref {
 				return nil, false
 			}

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -591,10 +591,7 @@ func Build(inv Invocation) ([]Package, error) {
 
 	buildMode := ssaBuildMode
 	cabiOptimize := true
-	passOpt := true
-	if emitDebugInfo || mode == ModeGen {
-		passOpt = false
-	}
+	passOpt := shouldRunLLVMPasses(mode)
 	if emitDebugInfo {
 		buildMode |= ssa.GlobalDebug
 		cabiOptimize = false
@@ -602,6 +599,7 @@ func Build(inv Invocation) ([]Package, error) {
 	if !IsOptimizeEnabled() {
 		buildMode |= ssa.NaiveForm
 	}
+	prog.SetDebugInfoOptimized(passOpt && conf.OptLevel != optlevel.O0)
 	progSSA := ssa.NewProgram(initial[0].Fset, buildMode)
 	patches := make(cl.Patches, len(altPkgPaths))
 	altEntries := registerAltSSAPkgs(progSSA, patches, altPkgs[1:], conf, verbose)
@@ -2611,6 +2609,10 @@ func llvmPassPipeline(level optlevel.Level, ltoMode lto.Mode) string {
 	default:
 		return "default<" + level.Name() + ">"
 	}
+}
+
+func shouldRunLLVMPasses(mode Mode) bool {
+	return mode != ModeGen
 }
 
 func IsWasiThreadsEnabled() bool {

--- a/internal/build/optlevel_test.go
+++ b/internal/build/optlevel_test.go
@@ -71,3 +71,14 @@ func TestLLVMPassPipeline(t *testing.T) {
 		}
 	}
 }
+
+func TestShouldRunLLVMPasses(t *testing.T) {
+	for _, mode := range []Mode{ModeBuild, ModeInstall, ModeRun, ModeTest, ModeCmpTest} {
+		if !shouldRunLLVMPasses(mode) {
+			t.Errorf("shouldRunLLVMPasses(%v) = false, want true", mode)
+		}
+	}
+	if shouldRunLLVMPasses(ModeGen) {
+		t.Fatal("shouldRunLLVMPasses(ModeGen) = true, want false")
+	}
+}

--- a/internal/build/ssa_order_fix.go
+++ b/internal/build/ssa_order_fix.go
@@ -302,11 +302,15 @@ func fixSSAOrderBlock(b *ssa.BasicBlock) {
 			continue
 		}
 
-		// If the loaded value is used by any instruction between its current
-		// position and the return (excluding return itself), moving it may place
-		// its definition after one of those uses and break SSA form.
+		// DebugRefs are metadata-only and move with the value they describe. Any
+		// executable use before Return still makes reordering unsafe.
+		moving := map[ssa.Instruction]struct{}{u: {}}
 		usedBeforeReturn := false
 		for i := loadIdx + 1; i < retIdx; i++ {
+			if ref, ok := b.Instrs[i].(*ssa.DebugRef); ok && instrUsesValue(ref, u) {
+				moving[ref] = struct{}{}
+				continue
+			}
 			if instrUsesValue(b.Instrs[i], u) {
 				usedBeforeReturn = true
 				break
@@ -316,9 +320,7 @@ func fixSSAOrderBlock(b *ssa.BasicBlock) {
 			continue
 		}
 
-		// Move the load right after the last call (but before Return).
-		b.Instrs = moveInstr(b.Instrs, loadIdx, lastCallIdx+1)
-		// Adjust retIdx for subsequent moves in this block.
+		b.Instrs = moveInstrsAfter(b.Instrs, moving, b.Instrs[lastCallIdx])
 		retIdx = indexOfInstr(b.Instrs, ret)
 	}
 }
@@ -391,41 +393,29 @@ func valueDependsOn(v, target ssa.Value, seen map[ssa.Value]struct{}) bool {
 	return false
 }
 
-// moveInstr moves instrs[from] to position to (like inserting before to),
-// preserving relative order of other elements.
-func moveInstr(instrs []ssa.Instruction, from, to int) []ssa.Instruction {
-	if from < 0 || from >= len(instrs) {
+// moveInstrsAfter moves selected instructions as a stable group immediately
+// after anchor.
+func moveInstrsAfter(instrs []ssa.Instruction, moving map[ssa.Instruction]struct{}, anchor ssa.Instruction) []ssa.Instruction {
+	if len(moving) == 0 || anchor == nil {
 		return instrs
 	}
-	if to < 0 {
-		to = 0
+	moved := make([]ssa.Instruction, 0, len(moving))
+	remaining := make([]ssa.Instruction, 0, len(instrs))
+	for _, instr := range instrs {
+		if _, ok := moving[instr]; ok {
+			moved = append(moved, instr)
+			continue
+		}
+		remaining = append(remaining, instr)
 	}
-	if to > len(instrs) {
-		to = len(instrs)
+	for i, instr := range remaining {
+		if instr == anchor {
+			ret := make([]ssa.Instruction, 0, len(instrs))
+			ret = append(ret, remaining[:i+1]...)
+			ret = append(ret, moved...)
+			ret = append(ret, remaining[i+1:]...)
+			return ret
+		}
 	}
-	if from == to || from+1 == to {
-		return instrs
-	}
-
-	ins := instrs[from]
-	// Remove.
-	copy(instrs[from:], instrs[from+1:])
-	instrs = instrs[:len(instrs)-1]
-
-	// Recompute insertion index after removal.
-	if to > from {
-		to--
-	}
-	if to < 0 {
-		to = 0
-	}
-	if to > len(instrs) {
-		to = len(instrs)
-	}
-
-	// Insert.
-	instrs = append(instrs, nil)
-	copy(instrs[to+1:], instrs[to:])
-	instrs[to] = ins
 	return instrs
 }

--- a/internal/build/ssa_order_fix.go
+++ b/internal/build/ssa_order_fix.go
@@ -186,6 +186,9 @@ func moveAssignDepsAfterRecv(b *ssa.BasicBlock, roots []ssa.Value, recv ssa.Valu
 	if len(move) == 0 {
 		return false
 	}
+	// Metadata uses must follow the definitions they describe rather than
+	// blocking an otherwise safe source-order repair.
+	includeDebugRefsForMovedValues(b.Instrs, move, recvIdx)
 	if moveWouldBreakSSA(b.Instrs, move, recvIdx) {
 		return false
 	}
@@ -203,6 +206,30 @@ func moveAssignDepsAfterRecv(b *ssa.BasicBlock, roots []ssa.Value, recv ssa.Valu
 	}
 	b.Instrs = next
 	return true
+}
+
+func includeDebugRefsForMovedValues(instrs []ssa.Instruction, move map[int]struct{}, through int) {
+	moved := make(map[ssa.Value]struct{}, len(move))
+	for i := range move {
+		if v, ok := instrs[i].(ssa.Value); ok && v != nil {
+			moved[v] = struct{}{}
+		}
+	}
+	for i := 0; i <= through && i < len(instrs); i++ {
+		if _, moving := move[i]; moving {
+			continue
+		}
+		ref, ok := instrs[i].(*ssa.DebugRef)
+		if !ok {
+			continue
+		}
+		for v := range moved {
+			if instrUsesValue(ref, v) {
+				move[i] = struct{}{}
+				break
+			}
+		}
+	}
 }
 
 func moveWouldBreakSSA(instrs []ssa.Instruction, move map[int]struct{}, recvIdx int) bool {

--- a/internal/build/ssa_order_fix.go
+++ b/internal/build/ssa_order_fix.go
@@ -189,8 +189,9 @@ func moveAssignDepsAfterRecv(b *ssa.BasicBlock, roots []ssa.Value, recv ssa.Valu
 	}
 	// Metadata uses must follow the definitions they describe rather than
 	// blocking an otherwise safe source-order repair.
-	includeDebugRefsForMovedValues(b.Instrs, move, recvIdx)
-	if moveWouldBreakSSA(b.Instrs, move, recvIdx) {
+	moved := movedValuesForIndices(b.Instrs, move)
+	includeDebugRefsForMovedValues(b.Instrs, move, moved, 0, recvIdx)
+	if moveWouldBreakSSA(b.Instrs, move, recvIdx, moved) {
 		return false
 	}
 	deps := make([]ssa.Instruction, 0, len(move))
@@ -209,14 +210,30 @@ func moveAssignDepsAfterRecv(b *ssa.BasicBlock, roots []ssa.Value, recv ssa.Valu
 	return true
 }
 
-func includeDebugRefsForMovedValues(instrs []ssa.Instruction, move map[int]struct{}, through int) {
+func movedValuesForIndices(instrs []ssa.Instruction, move map[int]struct{}) map[ssa.Value]struct{} {
 	moved := make(map[ssa.Value]struct{}, len(move))
 	for i := range move {
+		if i < 0 || i >= len(instrs) {
+			continue
+		}
 		if v, ok := instrs[i].(ssa.Value); ok && v != nil {
 			moved[v] = struct{}{}
 		}
 	}
-	for i := 0; i < through && i < len(instrs); i++ {
+	return moved
+}
+
+// includeDebugRefsForMovedValues adds metadata-only uses of moved values to
+// move. The moved value set is supplied by the caller so the same set can be
+// reused by the subsequent SSA safety check without rescanning move.
+func includeDebugRefsForMovedValues(instrs []ssa.Instruction, move map[int]struct{}, moved map[ssa.Value]struct{}, from, through int) {
+	if from < 0 {
+		from = 0
+	}
+	if through > len(instrs) {
+		through = len(instrs)
+	}
+	for i := from; i < through; i++ {
 		if _, moving := move[i]; moving {
 			continue
 		}
@@ -233,13 +250,7 @@ func includeDebugRefsForMovedValues(instrs []ssa.Instruction, move map[int]struc
 	}
 }
 
-func moveWouldBreakSSA(instrs []ssa.Instruction, move map[int]struct{}, recvIdx int) bool {
-	moved := make(map[ssa.Value]struct{}, len(move))
-	for i := range move {
-		if v, ok := instrs[i].(ssa.Value); ok && v != nil {
-			moved[v] = struct{}{}
-		}
-	}
+func moveWouldBreakSSA(instrs []ssa.Instruction, move map[int]struct{}, recvIdx int, moved map[ssa.Value]struct{}) bool {
 	for i := 0; i <= recvIdx && i < len(instrs); i++ {
 		if _, moving := move[i]; moving {
 			continue
@@ -332,11 +343,16 @@ func fixSSAOrderBlock(b *ssa.BasicBlock) {
 
 		// DebugRefs are metadata-only and move with the value they describe. Any
 		// executable use before Return still makes reordering unsafe.
-		moving := map[ssa.Instruction]struct{}{u: {}}
+		movingIndices := map[int]struct{}{loadIdx: {}}
+		moved := movedValuesForIndices(b.Instrs, movingIndices)
+		includeDebugRefsForMovedValues(b.Instrs, movingIndices, moved, loadIdx+1, retIdx)
+		moving := make(map[ssa.Instruction]struct{}, len(movingIndices))
+		for i := range movingIndices {
+			moving[b.Instrs[i]] = struct{}{}
+		}
 		usedBeforeReturn := false
 		for i := loadIdx + 1; i < retIdx; i++ {
-			if ref, ok := b.Instrs[i].(*ssa.DebugRef); ok && instrUsesValue(ref, u) {
-				moving[ref] = struct{}{}
+			if _, moving := movingIndices[i]; moving {
 				continue
 			}
 			if instrUsesValue(b.Instrs[i], u) {

--- a/internal/build/ssa_order_fix.go
+++ b/internal/build/ssa_order_fix.go
@@ -21,9 +21,10 @@ import (
 // the first return value as a load before the call, which makes o appear unchanged
 // to the return value in our backend.
 //
-// This pass moves loads of local allocs used only for the final Return results
-// to after any intervening calls that use the same alloc pointer, matching the
-// behavior of the Go compiler for the stdlib cases we rely on (e.g. crypto/x509.ParseOID).
+// This pass moves loads of local allocs that feed a Return result and have no
+// intervening executable use before that Return to after any intervening calls
+// that use the same alloc pointer, matching the behavior of the Go compiler for
+// the stdlib cases we rely on (e.g. crypto/x509.ParseOID).
 func fixSSAOrder(pkg *ssa.Package, files []*ast.File) {
 	if pkg == nil {
 		return
@@ -421,10 +422,14 @@ func valueDependsOn(v, target ssa.Value, seen map[ssa.Value]struct{}) bool {
 }
 
 // moveInstrsAfter moves selected instructions as a stable group immediately
-// after anchor. It returns instrs unchanged when moving is empty or anchor is
-// nil or absent.
+// after anchor. The anchor must not be in moving; callers use an instruction
+// that remains in the block. It returns instrs unchanged when moving is empty,
+// anchor is nil or absent, or the precondition is violated.
 func moveInstrsAfter(instrs []ssa.Instruction, moving map[ssa.Instruction]struct{}, anchor ssa.Instruction) []ssa.Instruction {
 	if len(moving) == 0 || anchor == nil {
+		return instrs
+	}
+	if _, ok := moving[anchor]; ok {
 		return instrs
 	}
 	moved := make([]ssa.Instruction, 0, len(moving))

--- a/internal/build/ssa_order_fix.go
+++ b/internal/build/ssa_order_fix.go
@@ -215,7 +215,7 @@ func includeDebugRefsForMovedValues(instrs []ssa.Instruction, move map[int]struc
 			moved[v] = struct{}{}
 		}
 	}
-	for i := 0; i <= through && i < len(instrs); i++ {
+	for i := 0; i < through && i < len(instrs); i++ {
 		if _, moving := move[i]; moving {
 			continue
 		}
@@ -421,7 +421,8 @@ func valueDependsOn(v, target ssa.Value, seen map[ssa.Value]struct{}) bool {
 }
 
 // moveInstrsAfter moves selected instructions as a stable group immediately
-// after anchor.
+// after anchor. It returns instrs unchanged when moving is empty or anchor is
+// nil or absent.
 func moveInstrsAfter(instrs []ssa.Instruction, moving map[ssa.Instruction]struct{}, anchor ssa.Instruction) []ssa.Instruction {
 	if len(moving) == 0 || anchor == nil {
 		return instrs

--- a/internal/build/ssa_order_fix.go
+++ b/internal/build/ssa_order_fix.go
@@ -440,13 +440,13 @@ func valueDependsOn(v, target ssa.Value, seen map[ssa.Value]struct{}) bool {
 // moveInstrsAfter moves selected instructions as a stable group immediately
 // after anchor. The anchor must not be in moving; callers use an instruction
 // that remains in the block. It returns instrs unchanged when moving is empty,
-// anchor is nil or absent, or the precondition is violated.
+// or anchor is nil or absent.
 func moveInstrsAfter(instrs []ssa.Instruction, moving map[ssa.Instruction]struct{}, anchor ssa.Instruction) []ssa.Instruction {
 	if len(moving) == 0 || anchor == nil {
 		return instrs
 	}
 	if _, ok := moving[anchor]; ok {
-		return instrs
+		panic("moveInstrsAfter: anchor is in moving set")
 	}
 	moved := make([]ssa.Instruction, 0, len(moving))
 	remaining := make([]ssa.Instruction, 0, len(instrs))

--- a/internal/build/ssa_order_fix_test.go
+++ b/internal/build/ssa_order_fix_test.go
@@ -29,11 +29,12 @@ func f() {
 	case *fp(&x, 100) = <-fc(c, 1):
 	}
 }`
-	fn := buildSSAOrderTestPackage(t, src)
-	got := instrOrder(fn, "fc(", "<-", "fp(", "*t")
-	if !inOrder(got, "fc(", "<-", "fp(") {
-		t.Fatalf("single-case select receive assignment order = %v, want fc/receive before fp", got)
-	}
+	testSSAOrderModes(t, src, func(t *testing.T, fn *ssa.Function) {
+		got := instrOrder(fn, "fc(", "<-", "fp(", "*t")
+		if !inOrder(got, "fc(", "<-", "fp(") {
+			t.Fatalf("single-case select receive assignment order = %v, want fc/receive before fp", got)
+		}
+	})
 }
 
 func TestFixSSAOrderPlainRecvAssignKeepsLeftToRight(t *testing.T) {
@@ -67,11 +68,12 @@ func f() {
 	case m[fn(13, 100)] = <-fc(c, 1):
 	}
 }`
-	fn := buildSSAOrderTestPackage(t, src)
-	got := instrOrder(fn, "fc(", "<-", "fn(")
-	if !inOrder(got, "fc(", "<-", "fn(") {
-		t.Fatalf("single-case select map receive assignment order = %v, want fc/receive before fn", got)
-	}
+	testSSAOrderModes(t, src, func(t *testing.T, fn *ssa.Function) {
+		got := instrOrder(fn, "fc(", "<-", "fn(")
+		if !inOrder(got, "fc(", "<-", "fn(") {
+			t.Fatalf("single-case select map receive assignment order = %v, want fc/receive before fn", got)
+		}
+	})
 }
 
 func TestFixSSAOrderSingleCaseSelectTwoValueRecv(t *testing.T) {
@@ -88,11 +90,12 @@ func f() {
 	case *fp(&x, 100), ok = <-fc(c, 1):
 	}
 }`
-	fn := buildSSAOrderTestPackage(t, src)
-	got := instrOrder(fn, "fc(", "<-", "fp(", "*t")
-	if !inOrder(got, "fc(", "<-", "fp(") {
-		t.Fatalf("single-case select two-value receive assignment order = %v, want fc/receive before fp", got)
-	}
+	testSSAOrderModes(t, src, func(t *testing.T, fn *ssa.Function) {
+		got := instrOrder(fn, "fc(", "<-", "fp(", "*t")
+		if !inOrder(got, "fc(", "<-", "fp(") {
+			t.Fatalf("single-case select two-value receive assignment order = %v, want fc/receive before fp", got)
+		}
+	})
 }
 
 func TestFixSSAOrderMultiCaseSelectKeepsLeftToRight(t *testing.T) {
@@ -252,6 +255,22 @@ func checkReturnLoadAfterMutation(t *testing.T, fn *ssa.Function, mutation strin
 
 func buildSSAOrderTestPackage(t *testing.T, src string) *ssa.Function {
 	return buildSSAOrderTestPackageMode(t, src, ssa.SanityCheckFunctions|ssa.InstantiateGenerics)
+}
+
+func testSSAOrderModes(t *testing.T, src string, check func(*testing.T, *ssa.Function)) {
+	t.Helper()
+	base := ssa.SanityCheckFunctions | ssa.InstantiateGenerics
+	for _, test := range []struct {
+		name string
+		mode ssa.BuilderMode
+	}{
+		{name: "default", mode: base},
+		{name: "global-debug", mode: base | ssa.GlobalDebug},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			check(t, buildSSAOrderTestPackageMode(t, src, test.mode))
+		})
+	}
 }
 
 func buildSSAOrderTestPackageMode(t *testing.T, src string, mode ssa.BuilderMode) *ssa.Function {

--- a/internal/build/ssa_order_fix_test.go
+++ b/internal/build/ssa_order_fix_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/go/ssa"
 	"golang.org/x/tools/go/ssa/ssautil"
 )
@@ -115,7 +116,145 @@ func f() {
 	}
 }
 
+func TestFixSSAOrderReturnLoadWithDebugRefs(t *testing.T) {
+	const src = `package p
+type value struct { n int }
+func (v *value) mutate() bool { v.n = 1; return true }
+func f() (value, bool) {
+	var v value
+	return v, v.mutate()
+}`
+	base := ssa.SanityCheckFunctions | ssa.InstantiateGenerics
+	for _, test := range []struct {
+		name string
+		mode ssa.BuilderMode
+	}{
+		{name: "default", mode: base},
+		{name: "global-debug", mode: base | ssa.GlobalDebug},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fn := buildSSAOrderTestPackageMode(t, src, test.mode)
+			checkReturnLoadAfterMutation(t, fn, "mutate")
+		})
+	}
+}
+
+func TestFixSSAOrderCryptoX509ParseOID(t *testing.T) {
+	fset := token.NewFileSet()
+	loaded, err := packages.Load(&packages.Config{
+		Mode: packages.LoadSyntax,
+		Fset: fset,
+	}, "crypto/x509")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if packages.PrintErrors(loaded) != 0 || len(loaded) != 1 {
+		t.Fatal("failed to load crypto/x509")
+	}
+	mode := ssa.SanityCheckFunctions | ssa.InstantiateGenerics | ssa.GlobalDebug
+	prog, ssaPackages := ssautil.Packages(loaded, mode)
+	prog.Build()
+	pkg := ssaPackages[0]
+	fixSSAOrder(pkg, loaded[0].Syntax)
+	checkReturnLoadAfterMutation(t, pkg.Func("ParseOID"), "unmarshalOIDText")
+}
+
+func TestMoveInstrsAfter(t *testing.T) {
+	const src = `package p
+func f() {
+	println(1)
+	println(2)
+	println(3)
+}`
+	fn := buildSSAOrderTestPackage(t, src)
+	instrs := fn.Blocks[0].Instrs
+	if len(instrs) < 4 {
+		t.Fatalf("instructions = %d, want at least 4", len(instrs))
+	}
+
+	assertOrder := func(t *testing.T, got, want []ssa.Instruction) {
+		t.Helper()
+		if len(got) != len(want) {
+			t.Fatalf("instruction count = %d, want %d", len(got), len(want))
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("instruction %d = %v, want %v", i, got[i], want[i])
+			}
+		}
+	}
+
+	t.Run("empty", func(t *testing.T) {
+		assertOrder(t, moveInstrsAfter(instrs, nil, instrs[1]), instrs)
+	})
+	t.Run("nil-anchor", func(t *testing.T) {
+		moving := map[ssa.Instruction]struct{}{instrs[0]: {}}
+		assertOrder(t, moveInstrsAfter(instrs, moving, nil), instrs)
+	})
+	t.Run("missing-anchor", func(t *testing.T) {
+		moving := map[ssa.Instruction]struct{}{instrs[0]: {}}
+		assertOrder(t, moveInstrsAfter(instrs, moving, &ssa.Return{}), instrs)
+	})
+	t.Run("stable", func(t *testing.T) {
+		moving := map[ssa.Instruction]struct{}{
+			instrs[0]: {},
+			instrs[2]: {},
+		}
+		want := []ssa.Instruction{instrs[1], instrs[0], instrs[2]}
+		want = append(want, instrs[3:]...)
+		assertOrder(t, moveInstrsAfter(instrs, moving, instrs[1]), want)
+	})
+}
+
+func checkReturnLoadAfterMutation(t *testing.T, fn *ssa.Function, mutation string) {
+	t.Helper()
+	var ret *ssa.Return
+	var mutationCall ssa.CallInstruction
+	for _, block := range fn.Blocks {
+		for _, instr := range block.Instrs {
+			if candidate, ok := instr.(*ssa.Return); ok {
+				ret = candidate
+			}
+			if call, ok := instr.(ssa.CallInstruction); ok {
+				callee := call.Common().StaticCallee()
+				if callee != nil && callee.Name() == mutation {
+					mutationCall = call
+				}
+			}
+		}
+	}
+	if ret == nil || len(ret.Results) != 2 || mutationCall == nil {
+		t.Fatalf("unexpected return instruction: %v", ret)
+	}
+	callInstr := mutationCall.(ssa.Instruction)
+	callIdx := indexOfInstr(callInstr.Block().Instrs, callInstr)
+	loadIdx := -1
+	debugRefIdx := -1
+	var resultLoad *ssa.UnOp
+	for i, instr := range callInstr.Block().Instrs {
+		if load, ok := instr.(*ssa.UnOp); ok && load.Op == token.MUL {
+			if alloc, ok := load.X.(*ssa.Alloc); ok && callUsesValue(mutationCall, alloc) {
+				loadIdx = i
+				resultLoad = load
+			}
+		}
+		if ref, ok := instr.(*ssa.DebugRef); ok && resultLoad != nil && instrUsesValue(ref, resultLoad) {
+			debugRefIdx = i
+		}
+	}
+	if callIdx < 0 || loadIdx <= callIdx {
+		t.Fatalf("return load index = %d, mutation call index = %d; want load after call\n%s", loadIdx, callIdx, fn)
+	}
+	if debugRefIdx >= 0 && debugRefIdx <= loadIdx {
+		t.Fatalf("DebugRef index = %d, load index = %d; want DebugRef after its load\n%s", debugRefIdx, loadIdx, fn)
+	}
+}
+
 func buildSSAOrderTestPackage(t *testing.T, src string) *ssa.Function {
+	return buildSSAOrderTestPackageMode(t, src, ssa.SanityCheckFunctions|ssa.InstantiateGenerics)
+}
+
+func buildSSAOrderTestPackageMode(t *testing.T, src string, mode ssa.BuilderMode) *ssa.Function {
 	t.Helper()
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "p.go", src, 0)
@@ -129,7 +268,7 @@ func buildSSAOrderTestPackage(t *testing.T, src string) *ssa.Function {
 		fset,
 		pkg,
 		files,
-		ssa.SanityCheckFunctions|ssa.InstantiateGenerics,
+		mode,
 	)
 	if err != nil {
 		t.Fatalf("BuildPackage: %v", err)

--- a/internal/build/ssa_order_fix_test.go
+++ b/internal/build/ssa_order_fix_test.go
@@ -199,8 +199,13 @@ func f() {
 		assertOrder(t, moveInstrsAfter(instrs, moving, &ssa.Return{}), instrs)
 	})
 	t.Run("anchor-in-moving", func(t *testing.T) {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("moveInstrsAfter did not reject an anchor in the moving set")
+			}
+		}()
 		moving := map[ssa.Instruction]struct{}{instrs[1]: {}}
-		assertOrder(t, moveInstrsAfter(instrs, moving, instrs[1]), instrs)
+		moveInstrsAfter(instrs, moving, instrs[1])
 	})
 	t.Run("stable", func(t *testing.T) {
 		moving := map[ssa.Instruction]struct{}{

--- a/internal/build/ssa_order_fix_test.go
+++ b/internal/build/ssa_order_fix_test.go
@@ -162,6 +162,34 @@ func TestFixSSAOrderCryptoX509ParseOID(t *testing.T) {
 	checkReturnLoadAfterMutation(t, pkg.Func("ParseOID"), "unmarshalOIDText")
 }
 
+func TestDebugRefMoveHelpers(t *testing.T) {
+	movedValue := &ssa.BinOp{}
+	instrs := []ssa.Instruction{
+		movedValue,
+		&ssa.DebugRef{X: movedValue},
+		&ssa.Return{Results: []ssa.Value{movedValue}},
+	}
+
+	moved := movedValuesForIndices(instrs, map[int]struct{}{
+		-1:          {},
+		0:           {},
+		2:           {},
+		len(instrs): {},
+	})
+	if len(moved) != 1 {
+		t.Fatalf("moved values = %d, want 1", len(moved))
+	}
+	if _, ok := moved[movedValue]; !ok {
+		t.Fatal("moved values do not contain the selected SSA value")
+	}
+
+	move := map[int]struct{}{0: {}}
+	includeDebugRefsForMovedValues(instrs, move, moved, -1, len(instrs)+1)
+	if _, ok := move[1]; !ok {
+		t.Fatal("DebugRef for the moved value was not included")
+	}
+}
+
 func TestMoveInstrsAfter(t *testing.T) {
 	const src = `package p
 func f() {

--- a/internal/build/ssa_order_fix_test.go
+++ b/internal/build/ssa_order_fix_test.go
@@ -198,6 +198,10 @@ func f() {
 		moving := map[ssa.Instruction]struct{}{instrs[0]: {}}
 		assertOrder(t, moveInstrsAfter(instrs, moving, &ssa.Return{}), instrs)
 	})
+	t.Run("anchor-in-moving", func(t *testing.T) {
+		moving := map[ssa.Instruction]struct{}{instrs[1]: {}}
+		assertOrder(t, moveInstrsAfter(instrs, moving, instrs[1]), instrs)
+	})
 	t.Run("stable", func(t *testing.T) {
 		moving := map[ssa.Instruction]struct{}{
 			instrs[0]: {},

--- a/ssa/di_debug_test.go
+++ b/ssa/di_debug_test.go
@@ -171,6 +171,48 @@ func TestDIGlobalIgnoresStorageLessFrontendVariable(t *testing.T) {
 	builder.DIGlobal(pyVarExpr(Nil, "attribute"), "module.attribute", token.Position{})
 }
 
+func TestDeferInitBuilderInheritsDebugLocation(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "defer.go", `package p
+func f() {}
+`, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	typesPkg, err := (&types.Config{}).Check("example.com/p", fset, []*ast.File{file}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prog := NewProgram(&Target{OptLevel: optlevel.O0})
+	defer prog.Dispose()
+	prog.TypeSizes(types.SizesFor("gc", runtime.GOARCH))
+	pkg := prog.NewPackage("p", "example.com/p")
+	pkg.InitDebug("p", "example.com/p", fset)
+	decl := file.Decls[0].(*ast.FuncDecl)
+	object := typesPkg.Scope().Lookup("f").(*types.Func)
+	fn := pkg.NewFunc("example.com/p.f", object.Type().(*types.Signature), InGo)
+	builder := fn.MakeBody(1)
+	defer builder.Dispose()
+	bodyPos := fset.Position(decl.Body.Lbrace)
+	builder.DebugFunction(fn, object.Scope(), fset.Position(object.Pos()), bodyPos)
+	builder.DISetCurrentDebugLocation(fn, bodyPos)
+	builder.Return()
+
+	deferBuilder, next := fn.deferInitBuilder(builder)
+	defer deferBuilder.Dispose()
+	loc := deferBuilder.impl.GetCurrentDebugLocation()
+	if loc.Line != uint(bodyPos.Line) || loc.Col != uint(bodyPos.Column) || loc.Scope != fn.diFunc.ll {
+		t.Fatalf("defer debug location = %+v, want %s:%d:%d", loc, bodyPos.Filename, bodyPos.Line, bodyPos.Column)
+	}
+	deferBuilder.Jump(next)
+
+	pkg.FinalizeDebug()
+	if err := llvm.VerifyModule(pkg.Module(), llvm.ReturnStatusAction); err != nil {
+		t.Fatalf("defer debug metadata is invalid: %v\n%s", err, pkg.Module().String())
+	}
+}
+
 func newDebugRuntimePackage() *types.Package {
 	pkg := types.NewPackage(PkgRuntime, "runtime")
 	unsafePointer := types.Typ[types.UnsafePointer]

--- a/ssa/eh.go
+++ b/ssa/eh.go
@@ -136,8 +136,14 @@ func (b Builder) Longjmp(jb, retval Expr) {
 
 // -----------------------------------------------------------------------------
 
-func (p Function) deferInitBuilder() (b Builder, next BasicBlock) {
+func (p Function) deferInitBuilder(from Builder) (b Builder, next BasicBlock) {
 	b = p.NewBuilder()
+	if p.diFunc != nil {
+		loc := from.impl.GetCurrentDebugLocation()
+		if !loc.Scope.IsNil() {
+			b.impl.SetCurrentDebugLocation(loc.Line, loc.Col, loc.Scope, loc.InlinedAt)
+		}
+	}
 	next = b.setBlockMoveLast(p.blks[0])
 	p.blks[0].last = next.last
 	return
@@ -197,7 +203,7 @@ func (b Builder) getDefer(kind DoAction) *aDefer {
 		// TODO(xsw): check if in pkg.init
 		var next, panicBlk BasicBlock
 		if kind != DeferAlways {
-			b, next = self.deferInitBuilder()
+			b, next = self.deferInitBuilder(b)
 		}
 
 		blks := self.MakeBlocks(2)

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -382,8 +382,8 @@ func (p Program) EnableLTOPluginMarkers(enable bool) {
 	p.enableLTOPluginMarker = enable
 }
 
-// SetDebugInfoOptimized records whether the LLVM IR optimization pipeline runs.
-// It only controls DWARF's optimized marker and never selects compiler passes.
+// SetDebugInfoOptimized records whether DWARF should mark generated code as
+// optimized. It never selects compiler passes.
 func (p Program) SetDebugInfoOptimized(enable bool) {
 	p.debugInfoOptimized = enable
 }

--- a/ssa/package.go
+++ b/ssa/package.go
@@ -382,6 +382,12 @@ func (p Program) EnableLTOPluginMarkers(enable bool) {
 	p.enableLTOPluginMarker = enable
 }
 
+// SetDebugInfoOptimized records whether the LLVM IR optimization pipeline runs.
+// It only controls DWARF's optimized marker and never selects compiler passes.
+func (p Program) SetDebugInfoOptimized(enable bool) {
+	p.debugInfoOptimized = enable
+}
+
 func (p Program) SetNoInterfaceMethod(fullName string) {
 	p.noInterface[fullName] = none{}
 }

--- a/test/go/caller_acceptance_test.go
+++ b/test/go/caller_acceptance_test.go
@@ -384,7 +384,7 @@ func runLLGoProbe(t *testing.T, dir string) (string, error) {
 
 func runLLGoProbeWithFlags(t *testing.T, dir string, flags ...string) (string, error) {
 	t.Helper()
-	repoRoot := findStringConversionRepoRoot(t)
+	repoRoot := findRepoRoot(t)
 	t.Setenv("LLGO_ROOT", repoRoot)
 	args := append([]string{"run", "./cmd/llgo", "run", "-a"}, flags...)
 	cmd := exec.Command("go", append(args, filepath.Join(dir, "main.go"))...)
@@ -599,7 +599,7 @@ var (
 // its own module).
 func runLLGoInModule(t *testing.T, dir string, args ...string) (string, error) {
 	t.Helper()
-	repoRoot := findStringConversionRepoRoot(t)
+	repoRoot := findRepoRoot(t)
 	t.Setenv("LLGO_ROOT", repoRoot)
 	acceptanceLLGoOnce.Do(func() {
 		tmp, err := os.MkdirTemp("", "llgo-acceptance-bin")

--- a/test/go/dwarf_semantics_acceptance_test.go
+++ b/test/go/dwarf_semantics_acceptance_test.go
@@ -1,0 +1,62 @@
+//go:build !llgo
+
+package gotest
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const dwarfReturnOrderProbe = `package main
+
+type value struct {
+	n int
+}
+
+func (v *value) mutate() bool {
+	v.n = 1
+	return true
+}
+
+func result() (value, bool) {
+	var v value
+	return v, v.mutate()
+}
+
+func main() {
+	v, ok := result()
+	if !ok || v.n != 1 {
+		panic("return value was loaded before mutation")
+	}
+	println("RETURN_ORDER_OK")
+}
+`
+
+func TestDWARFReturnOrderSemantics(t *testing.T) {
+	repoRoot := findStringConversionRepoRoot(t)
+	source := filepath.Join(t.TempDir(), "main.go")
+	if err := os.WriteFile(source, []byte(dwarfReturnOrderProbe), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(
+		"go", "run", "./cmd/llgo", "run", "-ldflags=-w=false", source,
+	)
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"LLGO_ROOT="+repoRoot,
+		"LLGO_BUILD_CACHE=off",
+		"GOMAXPROCS=2",
+		"GOMEMLIMIT=6GiB",
+		"GOFLAGS=-p=1",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("LLGo DWARF return-order acceptance failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "RETURN_ORDER_OK") {
+		t.Fatalf("LLGo DWARF return-order acceptance did not report success:\n%s", out)
+	}
+}

--- a/test/go/dwarf_semantics_acceptance_test.go
+++ b/test/go/dwarf_semantics_acceptance_test.go
@@ -36,7 +36,7 @@ func main() {
 `
 
 func TestDWARFReturnOrderSemantics(t *testing.T) {
-	repoRoot := findStringConversionRepoRoot(t)
+	repoRoot := findRepoRoot(t)
 	source := filepath.Join(t.TempDir(), "main.go")
 	if err := os.WriteFile(source, []byte(dwarfReturnOrderProbe), 0o600); err != nil {
 		t.Fatal(err)

--- a/test/go/fault_unwind_test.go
+++ b/test/go/fault_unwind_test.go
@@ -108,7 +108,7 @@ var (
 
 func faultLLGo(t *testing.T) string {
 	t.Helper()
-	repoRoot := findStringConversionRepoRoot(t)
+	repoRoot := findRepoRoot(t)
 	t.Setenv("LLGO_ROOT", repoRoot)
 	faultLLGoOnce.Do(func() {
 		tmp, err := os.MkdirTemp("", "llgo-fault-bin")

--- a/test/go/float_int_conversion_test.go
+++ b/test/go/float_int_conversion_test.go
@@ -106,7 +106,7 @@ func TestFloatToIntegerConversionSemantics(t *testing.T) {
 	if err := os.WriteFile(file, []byte(floatIntConversionProbe), 0644); err != nil {
 		t.Fatal(err)
 	}
-	repoRoot := findStringConversionRepoRoot(t)
+	repoRoot := findRepoRoot(t)
 	t.Setenv("LLGO_ROOT", repoRoot)
 	runStringConversionProbe(t, repoRoot, "go", "run", "./cmd/llgo", "run", file)
 }

--- a/test/go/large_array_return_test.go
+++ b/test/go/large_array_return_test.go
@@ -61,7 +61,7 @@ var (
 
 func largeArrayLLGo(t *testing.T) string {
 	t.Helper()
-	root := findStringConversionRepoRoot(t)
+	root := findRepoRoot(t)
 	t.Setenv("LLGO_ROOT", root)
 	largeArrayLLGoOnce.Do(func() {
 		dir, err := os.MkdirTemp("", "llgo-large-array-bin")

--- a/test/go/newexpr_go126_test.go
+++ b/test/go/newexpr_go126_test.go
@@ -69,7 +69,7 @@ func TestNewExpressionInitializesAllocatedValue(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	repoRoot := findStringConversionRepoRoot(t)
+	repoRoot := findRepoRoot(t)
 	runStringConversionProbe(t, repoRoot, "go", "run", file)
 	t.Setenv("LLGO_ROOT", repoRoot)
 	runStringConversionProbe(t, repoRoot, "go", "run", "./cmd/llgo", "run", file)

--- a/test/go/runtime_lineinfo_stack_test.go
+++ b/test/go/runtime_lineinfo_stack_test.go
@@ -212,7 +212,7 @@ func TestRuntimeLineInfoAndStack(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	repoRoot := findStringConversionRepoRoot(t)
+	repoRoot := findRepoRoot(t)
 	t.Setenv("LLGO_ROOT", repoRoot)
 	cmd := exec.Command("go", "run", "./cmd/llgo", "run", "-a", file)
 	cmd.Dir = repoRoot
@@ -341,7 +341,7 @@ func TestRuntimeFuncInfoConcurrentFirstUse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	repoRoot := findStringConversionRepoRoot(t)
+	repoRoot := findRepoRoot(t)
 	t.Setenv("LLGO_ROOT", repoRoot)
 	cmd := exec.Command("go", "run", "./cmd/llgo", "run", "-a", file)
 	cmd.Dir = repoRoot

--- a/test/go/runtime_statement_line_test.go
+++ b/test/go/runtime_statement_line_test.go
@@ -205,7 +205,7 @@ func TestRuntimeStatementLineInfo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	repoRoot := findStringConversionRepoRoot(t)
+	repoRoot := findRepoRoot(t)
 	t.Setenv("LLGO_ROOT", repoRoot)
 	cmd := exec.Command("go", "run", "./cmd/llgo", "run", "-a", file)
 	cmd.Dir = repoRoot

--- a/test/go/string_conversion_test.go
+++ b/test/go/string_conversion_test.go
@@ -98,7 +98,7 @@ func TestStringConversionFromWideIntegers(t *testing.T) {
 	if err := os.WriteFile(file, []byte(stringConversionProbe), 0644); err != nil {
 		t.Fatal(err)
 	}
-	repoRoot := findStringConversionRepoRoot(t)
+	repoRoot := findRepoRoot(t)
 	runStringConversionProbe(t, repoRoot, "go", "run", file)
 	t.Setenv("LLGO_ROOT", repoRoot)
 	runStringConversionProbe(t, repoRoot, "go", "run", "./cmd/llgo", "run", file)
@@ -110,7 +110,7 @@ func TestEmptyStringToByteRuneSlicesNonNil(t *testing.T) {
 	if err := os.WriteFile(file, []byte(emptyStringConversionProbe), 0644); err != nil {
 		t.Fatal(err)
 	}
-	repoRoot := findStringConversionRepoRoot(t)
+	repoRoot := findRepoRoot(t)
 	runStringConversionProbe(t, repoRoot, "go", "run", file)
 	t.Setenv("LLGO_ROOT", repoRoot)
 	runStringConversionProbe(t, repoRoot, "go", "run", "./cmd/llgo", "run", file)
@@ -127,7 +127,7 @@ func runStringConversionProbe(t *testing.T, dir, name string, args ...string) {
 	}
 }
 
-func findStringConversionRepoRoot(t *testing.T) string {
+func findRepoRoot(t *testing.T) string {
 	t.Helper()
 	dir, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
This is the consolidated DWARF-safe optimization and SSA-rewrite change.

The effective implementation from [#2183](https://github.com/xgo-dev/llgo/pull/2183)
(return-load ordering) and [#2184](https://github.com/xgo-dev/llgo/pull/2184)
(single-case-select ordering) is included here exactly once. Those PRs are no
longer dependencies of this change; their unrelated CI-only commits are not
carried over.

## Problem

DWARF must not change executable semantics. Enabling the normal optimization pipeline for debug builds exposed four places where debug metadata affected code generation:

- linked builds skipped the configured LLVM pass pipeline whenever DWARF was emitted;
- conditional defer lowering created inlinable runtime calls without `!dbg`, so full LTO verification aborted;
- `ssa.DebugRef` users blocked return-load and single-case-select order repairs;
- `ssa.DebugRef` users blocked valid static global slice folding.

Full LTO with DWARF also exposes aggregate Go strings to the reflect `MethodByName` plugin. #2159, now in `main`, owns that boundary; this PR contains no LTO plugin implementation changes.

## Changes

- run the normal LLVM pass pipeline for linked modes with or without DWARF, while keeping `ModeGen` as raw generated IR;
- derive the compile unit optimized marker from the actual pass decision and optimization level;
- inherit the source location when defer lowering splits the entry block;
- move `ssa.DebugRef` users with repaired return loads and select dependencies, while rejecting executable early uses;
- bound the metadata scan before the receive and document the stable instruction-group fallback;
- ignore `DebugRef` pseudo-users when proving a static slice initializer.

This consolidates the effective changes from #2144, #2146, #2183, and #2184. It does not change the default `-w` policy, Python debugging, pclntab policy, C ABI variable homes, LLDB language behavior, or non-debug optimization policy.

Fixes #2118.
Fixes #2121.
Fixes #2122.

## Verification

- focused `internal/build` SSA-order tests pass in both default and `ssa.GlobalDebug` modes;
- `TestDWARFReturnOrderSemantics` passes with explicit `-w=false`;
- focused `ssa`, `internal/build`, and LTO/DWARF `cl` tests pass on macOS arm64;
- `git diff --check` passes.
