### PR TITLE
debug: preserve defer locations under full LTO

### DIFF
--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -206,6 +206,15 @@ func TestRunAndTestFromTestlto(t *testing.T) {
 	cltest.RunAndTestFromDir(t, "", "./_testlto", ignore, cltest.WithRunConfig(conf))
 }
 
+func TestRunAndTestFromTestltoDWARF(t *testing.T) {
+	t.Setenv("LLGO_BUILD_CACHE", "off")
+	conf := build.NewDefaultConf(build.ModeRun)
+	conf.LTO = lto.Full
+	conf.LinkOptions.DWARF = build.DWARFPreserve
+	cltest.RunAndTestFromDir(t, "reflectmk_runtime", "./_testlto", nil,
+		cltest.WithRunConfig(conf), cltest.WithIRCheck(false))
+}
+
 var testltoSymbolChecks = []string{
 	"globaldce_interface_matrix",
 	"globaldce_interface_slots",
@@ -258,6 +267,14 @@ func TestRunAndTestFromTestltoLTOPlugin(t *testing.T) {
 		cltest.WithRunConfig(conf),
 		cltest.WithIRCheck(false),
 	)
+}
+
+func TestRunAndTestFromTestltoLTOPluginDWARF(t *testing.T) {
+	t.Setenv("LLGO_BUILD_CACHE", "off")
+	conf := testltoLTOPluginConf(t, build.ModeRun)
+	conf.LinkOptions.DWARF = build.DWARFPreserve
+	cltest.RunAndTestFromDir(t, "ltoplugin_switch", "./_testlto", nil,
+		cltest.WithRunConfig(conf), cltest.WithIRCheck(false))
 }
 
 func TestBuildAndCheckSymbolsFromTestltoLTOPlugin(t *testing.T) {

--- a/ssa/di_debug_test.go
+++ b/ssa/di_debug_test.go
@@ -166,6 +166,48 @@ type Shape struct {
 	}
 }
 
+func TestDeferInitBuilderInheritsDebugLocation(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "defer.go", `package p
+func f() {}
+`, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	typesPkg, err := (&types.Config{}).Check("example.com/p", fset, []*ast.File{file}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prog := NewProgram(&Target{OptLevel: optlevel.O0})
+	defer prog.Dispose()
+	prog.TypeSizes(types.SizesFor("gc", runtime.GOARCH))
+	pkg := prog.NewPackage("p", "example.com/p")
+	pkg.InitDebug("p", "example.com/p", fset)
+	decl := file.Decls[0].(*ast.FuncDecl)
+	object := typesPkg.Scope().Lookup("f").(*types.Func)
+	fn := pkg.NewFunc("example.com/p.f", object.Type().(*types.Signature), InGo)
+	builder := fn.MakeBody(1)
+	defer builder.Dispose()
+	bodyPos := fset.Position(decl.Body.Lbrace)
+	builder.DebugFunction(fn, object.Scope(), fset.Position(object.Pos()), bodyPos)
+	builder.DISetCurrentDebugLocation(fn, bodyPos)
+	builder.Return()
+
+	deferBuilder, next := fn.deferInitBuilder(builder)
+	defer deferBuilder.Dispose()
+	loc := deferBuilder.impl.GetCurrentDebugLocation()
+	if loc.Line != uint(bodyPos.Line) || loc.Col != uint(bodyPos.Column) || loc.Scope != fn.diFunc.ll {
+		t.Fatalf("defer debug location = %+v, want %s:%d:%d", loc, bodyPos.Filename, bodyPos.Line, bodyPos.Column)
+	}
+	deferBuilder.Jump(next)
+
+	pkg.FinalizeDebug()
+	if err := llvm.VerifyModule(pkg.Module(), llvm.ReturnStatusAction); err != nil {
+		t.Fatalf("defer debug metadata is invalid: %v\n%s", err, pkg.Module().String())
+	}
+}
+
 func newDebugRuntimePackage() *types.Package {
 	pkg := types.NewPackage(PkgRuntime, "runtime")
 	unsafePointer := types.Typ[types.UnsafePointer]

--- a/ssa/eh.go
+++ b/ssa/eh.go
@@ -136,8 +136,14 @@ func (b Builder) Longjmp(jb, retval Expr) {
 
 // -----------------------------------------------------------------------------
 
-func (p Function) deferInitBuilder() (b Builder, next BasicBlock) {
+func (p Function) deferInitBuilder(from Builder) (b Builder, next BasicBlock) {
 	b = p.NewBuilder()
+	if p.diFunc != nil {
+		loc := from.impl.GetCurrentDebugLocation()
+		if !loc.Scope.IsNil() {
+			b.impl.SetCurrentDebugLocation(loc.Line, loc.Col, loc.Scope, loc.InlinedAt)
+		}
+	}
 	next = b.setBlockMoveLast(p.blks[0])
 	p.blks[0].last = next.last
 	return
@@ -197,7 +203,7 @@ func (b Builder) getDefer(kind DoAction) *aDefer {
 		// TODO(xsw): check if in pkg.init
 		var next, panicBlk BasicBlock
 		if kind != DeferAlways {
-			b, next = self.deferInitBuilder()
+			b, next = self.deferInitBuilder(b)
 		}
 
 		blks := self.MakeBlocks(2)


### PR DESCRIPTION
## Problem

Conditional defer lowering splits the function entry block with a fresh LLVM builder. In a function carrying DWARF, that builder does not inherit the Go source location that triggered defer setup, so synthesized calls such as `GetThreadDefer`, `AllocU`, `SetThreadDefer`, and `Rethrow` have no `!dbg` attachment.

Normal native links may accept that IR, but full LTO verifies the combined debug-bearing module and aborts with `inlinable function call in a function with debug info must have a !dbg location`.

## Changes

- pass the source builder into defer-entry splitting
- copy its current `DebugLoc` to the synthetic builder when the function has debug metadata
- leave non-debug defer lowering unchanged
- add focused location-inheritance coverage
- add separate DWARF acceptance tests for built-in full LTO and the optional LTO pass plugin

The LTO tests disable LLGo's package cache so #2119's cold/warm metadata issue cannot hide or reintroduce this verifier failure.

Fixes #2118.

## Verification

- built-in full LTO DWARF fixture on macOS and Ubuntu arm64
- pass-plugin full LTO DWARF fixture on Ubuntu arm64
- full `ssa` tests on macOS
- standards-based DWARF matrix on macOS and Ubuntu arm64
- changed helper coverage: 100%

Ubuntu validation used 2 CPUs, a 15 GiB memory limit, and 512 PIDs.
