### PR TITLE
debug: handle storage-free Python attributes

### DIFF
--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -412,6 +412,13 @@ func TestRunAndTestFromTestpy(t *testing.T) {
 	cltest.RunAndTestFromDir(t, "", "./_testpy", nil)
 }
 
+func TestRunAndTestFromTestpyDWARF(t *testing.T) {
+	conf := build.NewDefaultConf(build.ModeRun)
+	conf.LinkOptions.DWARF = build.DWARFPreserve
+	cltest.RunAndTestFromDir(t, "", "./_testpy", nil,
+		cltest.WithRunConfig(conf), cltest.WithIRCheck(false))
+}
+
 func TestRunAndTestFromTestlibgo(t *testing.T) {
 	cltest.RunAndTestFromDir(t, "", "./_testlibgo", nil)
 }

--- a/ssa/di.go
+++ b/ssa/di.go
@@ -769,6 +769,11 @@ const (
 )
 
 func (b Builder) DIGlobal(v Expr, name string, pos token.Position) {
+	// Frontend pseudo-variables, such as Python module attributes, have no
+	// native storage to describe or attach metadata to.
+	if v.impl.IsNil() {
+		return
+	}
 	if _, ok := b.Pkg.glbDbgVars[v]; ok {
 		return
 	}

--- a/ssa/di_debug_test.go
+++ b/ssa/di_debug_test.go
@@ -166,6 +166,11 @@ type Shape struct {
 	}
 }
 
+func TestDIGlobalIgnoresStorageLessFrontendVariable(t *testing.T) {
+	var builder Builder
+	builder.DIGlobal(pyVarExpr(Nil, "attribute"), "module.attribute", token.Position{})
+}
+
 func newDebugRuntimePackage() *types.Package {
 	pkg := types.NewPackage(PkgRuntime, "runtime")
 	unsafePointer := types.Typ[types.UnsafePointer]


### PR DESCRIPTION
## Problem

Python module attributes are frontend pseudo-variables. LLGo loads and stores them through Python C API calls, so their `ssa.Expr` has a source-facing type but no native LLVM global or address.

With DWARF enabled, the generic global path tried to derive a native debug type and attach a `DIGlobalVariableExpression` to that absent storage. Compiling `_testpy/list` therefore reached `pyVarTy.Underlying` and panicked with `don't call`.

## Changes

- make `ssa.Builder.DIGlobal` ignore expressions that have no native LLVM storage
- keep ordinary Go and C globals on the existing DWARF path
- do not emit a fake address or misleading `DW_TAG_variable` for dynamically resolved Python attributes
- add a focused unit test using a real storage-free Python variable expression
- run the complete `_testpy` fixture set with DWARF enabled on supported hosts

Fixes #2117.

## Verification

macOS arm64, Go 1.26.5 / LLVM 19:

- all 8 `_testpy` fixtures pass with DWARF
- full `go test ./ssa` passes
- standards-based DWARF matrix passes at `O0`, `O1`, `O2`, `O3`, `Os`, and `Oz`
- the changed `DIGlobal` paths are covered directly

Ubuntu arm64 container, limited to 2 CPUs, 15 GiB memory, and 512 PIDs:

- 7 stable `_testpy` fixtures pass with DWARF
- standards-based DWARF matrix passes at all six optimization levels
- `_testpy/matrix` still reproduces the same existing runtime crash with and without DWARF; this PR does not add a skip or hide that baseline failure
