### PR TITLE
build: separate LTO plugin cache entries

### DIFF
--- a/internal/build/collect.go
+++ b/internal/build/collect.go
@@ -109,6 +109,7 @@ func (c *context) collectCommonInputs(m *manifestBuilder) {
 	m.common.Target = c.buildConf.Target
 	m.common.TargetABI = c.crossCompile.TargetABI
 	m.common.GoGlobalDCE = c.buildConf.goGlobalDCEEnabled()
+	m.common.LTOPluginMarkers = c.buildConf.LTOPlugin.Enabled()
 	m.common.EmitDWARF = shouldEmitDebugInfo(c.buildConf, &c.crossCompile)
 	m.common.PCLNMode = effectivePCLNMode(c.buildConf).String()
 

--- a/internal/build/collect.go
+++ b/internal/build/collect.go
@@ -109,7 +109,7 @@ func (c *context) collectCommonInputs(m *manifestBuilder) {
 	m.common.Target = c.buildConf.Target
 	m.common.TargetABI = c.crossCompile.TargetABI
 	m.common.GoGlobalDCE = c.buildConf.goGlobalDCEEnabled()
-	m.common.LTOPluginMarkers = c.buildConf.LTOPlugin.Enabled()
+	m.common.EnableLTOPlugin = c.buildConf.LTOPlugin.Enabled()
 	m.common.EmitDWARF = shouldEmitDebugInfo(c.buildConf, &c.crossCompile)
 	m.common.PCLNMode = effectivePCLNMode(c.buildConf).String()
 

--- a/internal/build/collect_test.go
+++ b/internal/build/collect_test.go
@@ -415,6 +415,54 @@ func TestDevLTOGlobalDCECollectFingerprint(t *testing.T) {
 	}
 }
 
+func TestCollectFingerprintIncludesLTOPluginMarkers(t *testing.T) {
+	td := t.TempDir()
+	goFile := filepath.Join(td, "main.go")
+	if err := os.WriteFile(goFile, []byte("package main"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	collect := func(plugin lto.PassPlugin) *aPackage {
+		pkg := &aPackage{Package: &packages.Package{
+			PkgPath: "test/pkg",
+			GoFiles: []string{goFile},
+		}}
+		ctx := &context{
+			conf: &packages.Config{},
+			buildConf: &Config{
+				Goos:      "linux",
+				Goarch:    "amd64",
+				LTO:       lto.Full,
+				LTOPlugin: plugin,
+			},
+			crossCompile: crosscompile.Export{LLVMTarget: "x86_64-unknown-linux"},
+		}
+		if err := ctx.collectFingerprint(pkg); err != nil {
+			t.Fatal(err)
+		}
+		return pkg
+	}
+
+	withoutPlugin := collect(lto.PassPlugin{})
+	withPlugin := collect(lto.PassPlugin{Path: "/tmp/LLGOLTOPlugin.so"})
+	withOtherPluginPath := collect(lto.PassPlugin{Path: "/opt/LLGOLTOPlugin.so"})
+
+	if withoutPlugin.Fingerprint == withPlugin.Fingerprint {
+		t.Fatal("plugin and non-plugin builds should not share a cache fingerprint")
+	}
+	if withPlugin.Fingerprint != withOtherPluginPath.Fingerprint {
+		t.Fatal("plugin path should not affect package cache fingerprint")
+	}
+
+	data, err := decodeManifest(withPlugin.Manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if data.Common == nil || !data.Common.LTOPluginMarkers {
+		t.Fatalf("manifest should contain LTO_PLUGIN_MARKERS=true:\n%s", withPlugin.Manifest)
+	}
+}
+
 func TestCollectFingerprintDependencies(t *testing.T) {
 	td := t.TempDir()
 

--- a/internal/build/collect_test.go
+++ b/internal/build/collect_test.go
@@ -415,7 +415,7 @@ func TestDevLTOGlobalDCECollectFingerprint(t *testing.T) {
 	}
 }
 
-func TestCollectFingerprintIncludesLTOPluginMarkers(t *testing.T) {
+func TestCollectFingerprintIncludesLTOPlugin(t *testing.T) {
 	td := t.TempDir()
 	goFile := filepath.Join(td, "main.go")
 	if err := os.WriteFile(goFile, []byte("package main"), 0644); err != nil {
@@ -458,8 +458,8 @@ func TestCollectFingerprintIncludesLTOPluginMarkers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if data.Common == nil || !data.Common.LTOPluginMarkers {
-		t.Fatalf("manifest should contain LTO_PLUGIN_MARKERS=true:\n%s", withPlugin.Manifest)
+	if data.Common == nil || !data.Common.EnableLTOPlugin {
+		t.Fatalf("manifest should contain ENABLE_LTO_PLUGIN=true:\n%s", withPlugin.Manifest)
 	}
 }
 

--- a/internal/build/fingerprint.go
+++ b/internal/build/fingerprint.go
@@ -112,24 +112,25 @@ func (s *envSection) empty() bool {
 }
 
 type commonSection struct {
-	AbiMode     string       `yaml:"ABI_MODE,omitempty"`
-	BuildTags   []string     `yaml:"BUILD_TAGS,omitempty"`
-	Target      string       `yaml:"TARGET,omitempty"`
-	TargetABI   string       `yaml:"TARGET_ABI,omitempty"`
-	GoGlobalDCE bool         `yaml:"GO_GLOBAL_DCE,omitempty"`
-	EmitDWARF   bool         `yaml:"EMIT_DWARF,omitempty"`
-	PCLNMode    string       `yaml:"PCLN_MODE,omitempty"`
-	CC          string       `yaml:"CC,omitempty"`
-	CCFlags     []string     `yaml:"CCFLAGS,omitempty"`
-	CFlags      []string     `yaml:"CFLAGS,omitempty"`
-	LDFlags     []string     `yaml:"LDFLAGS,omitempty"`
-	Linker      string       `yaml:"LINKER,omitempty"`
-	ExtraFiles  []fileDigest `yaml:"EXTRA_FILES,omitempty"`
+	AbiMode          string       `yaml:"ABI_MODE,omitempty"`
+	BuildTags        []string     `yaml:"BUILD_TAGS,omitempty"`
+	Target           string       `yaml:"TARGET,omitempty"`
+	TargetABI        string       `yaml:"TARGET_ABI,omitempty"`
+	GoGlobalDCE      bool         `yaml:"GO_GLOBAL_DCE,omitempty"`
+	LTOPluginMarkers bool         `yaml:"LTO_PLUGIN_MARKERS,omitempty"`
+	EmitDWARF        bool         `yaml:"EMIT_DWARF,omitempty"`
+	PCLNMode         string       `yaml:"PCLN_MODE,omitempty"`
+	CC               string       `yaml:"CC,omitempty"`
+	CCFlags          []string     `yaml:"CCFLAGS,omitempty"`
+	CFlags           []string     `yaml:"CFLAGS,omitempty"`
+	LDFlags          []string     `yaml:"LDFLAGS,omitempty"`
+	Linker           string       `yaml:"LINKER,omitempty"`
+	ExtraFiles       []fileDigest `yaml:"EXTRA_FILES,omitempty"`
 }
 
 func (s *commonSection) empty() bool {
 	return s.AbiMode == "" && len(s.BuildTags) == 0 && s.Target == "" && s.TargetABI == "" &&
-		!s.GoGlobalDCE && !s.EmitDWARF && s.PCLNMode == "" && s.CC == "" && len(s.CCFlags) == 0 && len(s.CFlags) == 0 && len(s.LDFlags) == 0 &&
+		!s.GoGlobalDCE && !s.LTOPluginMarkers && !s.EmitDWARF && s.PCLNMode == "" && s.CC == "" && len(s.CCFlags) == 0 && len(s.CFlags) == 0 && len(s.LDFlags) == 0 &&
 		s.Linker == "" && len(s.ExtraFiles) == 0
 }
 

--- a/internal/build/fingerprint.go
+++ b/internal/build/fingerprint.go
@@ -112,25 +112,25 @@ func (s *envSection) empty() bool {
 }
 
 type commonSection struct {
-	AbiMode          string       `yaml:"ABI_MODE,omitempty"`
-	BuildTags        []string     `yaml:"BUILD_TAGS,omitempty"`
-	Target           string       `yaml:"TARGET,omitempty"`
-	TargetABI        string       `yaml:"TARGET_ABI,omitempty"`
-	GoGlobalDCE      bool         `yaml:"GO_GLOBAL_DCE,omitempty"`
-	LTOPluginMarkers bool         `yaml:"LTO_PLUGIN_MARKERS,omitempty"`
-	EmitDWARF        bool         `yaml:"EMIT_DWARF,omitempty"`
-	PCLNMode         string       `yaml:"PCLN_MODE,omitempty"`
-	CC               string       `yaml:"CC,omitempty"`
-	CCFlags          []string     `yaml:"CCFLAGS,omitempty"`
-	CFlags           []string     `yaml:"CFLAGS,omitempty"`
-	LDFlags          []string     `yaml:"LDFLAGS,omitempty"`
-	Linker           string       `yaml:"LINKER,omitempty"`
-	ExtraFiles       []fileDigest `yaml:"EXTRA_FILES,omitempty"`
+	AbiMode         string       `yaml:"ABI_MODE,omitempty"`
+	BuildTags       []string     `yaml:"BUILD_TAGS,omitempty"`
+	Target          string       `yaml:"TARGET,omitempty"`
+	TargetABI       string       `yaml:"TARGET_ABI,omitempty"`
+	GoGlobalDCE     bool         `yaml:"GO_GLOBAL_DCE,omitempty"`
+	EnableLTOPlugin bool         `yaml:"ENABLE_LTO_PLUGIN,omitempty"`
+	EmitDWARF       bool         `yaml:"EMIT_DWARF,omitempty"`
+	PCLNMode        string       `yaml:"PCLN_MODE,omitempty"`
+	CC              string       `yaml:"CC,omitempty"`
+	CCFlags         []string     `yaml:"CCFLAGS,omitempty"`
+	CFlags          []string     `yaml:"CFLAGS,omitempty"`
+	LDFlags         []string     `yaml:"LDFLAGS,omitempty"`
+	Linker          string       `yaml:"LINKER,omitempty"`
+	ExtraFiles      []fileDigest `yaml:"EXTRA_FILES,omitempty"`
 }
 
 func (s *commonSection) empty() bool {
 	return s.AbiMode == "" && len(s.BuildTags) == 0 && s.Target == "" && s.TargetABI == "" &&
-		!s.GoGlobalDCE && !s.LTOPluginMarkers && !s.EmitDWARF && s.PCLNMode == "" && s.CC == "" && len(s.CCFlags) == 0 && len(s.CFlags) == 0 && len(s.LDFlags) == 0 &&
+		!s.GoGlobalDCE && !s.EnableLTOPlugin && !s.EmitDWARF && s.PCLNMode == "" && s.CC == "" && len(s.CCFlags) == 0 && len(s.CFlags) == 0 && len(s.LDFlags) == 0 &&
 		s.Linker == "" && len(s.ExtraFiles) == 0
 }
 


### PR DESCRIPTION
## Summary

- record whether the LTO pass plugin is enabled in build fingerprints
- rename the fingerprint field and manifest key to `EnableLTOPlugin` / `ENABLE_LTO_PLUGIN`

## Testing

- `go test ./internal/build`