### PR TITLE
runtime: start FP walks from a live caller frame

### DIFF
--- a/runtime/internal/lib/runtime/_wrap/runtime.c
+++ b/runtime/internal/lib/runtime/_wrap/runtime.c
@@ -27,7 +27,9 @@ int llgo_maxprocs()
 __attribute__((noinline)) void *llgo_framepointer(void)
 {
 #if defined(__GNUC__) || defined(__clang__)
-    return __builtin_frame_address(0);
+    /* Read the saved caller FP before this helper's frame becomes invalid. */
+    void **frame = (void **)__builtin_frame_address(0);
+    return frame ? *frame : 0;
 #else
     return 0;
 #endif

--- a/runtime/internal/lib/runtime/unwind_llgo.go
+++ b/runtime/internal/lib/runtime/unwind_llgo.go
@@ -8,6 +8,9 @@ import (
 	rtdebug "github.com/goplus/llgo/runtime/internal/runtime"
 )
 
+// c_framepointer returns its caller's frame pointer while the C helper frame
+// is still alive.
+//
 //go:linkname c_framepointer C.llgo_framepointer
 func c_framepointer() unsafe.Pointer
 
@@ -118,9 +121,8 @@ func fpCallers(skip int, pc []uintptr) int {
 	initRuntimeFuncPCFrames()
 	fp := uintptr(c_framepointer())
 	n := 0
-	// The helper's saved chain starts at our own frame; skip fpCallers
-	// itself so skip counting matches the caller's view.
-	skip++
+	// The helper returns this function's frame pointer, so the first return
+	// address already represents fpCallers' caller.
 	const maxFrames = 4096
 	for i := 0; fp != 0 && n < len(pc) && i < maxFrames; i++ {
 		prev := *(*uintptr)(unsafe.Pointer(fp))

--- a/test/go/caller_acceptance_test.go
+++ b/test/go/caller_acceptance_test.go
@@ -139,6 +139,53 @@ func TestCallerAcceptancePanicTraceback(t *testing.T) {
 	}
 }
 
+// Scenario: the FP walker starts from a live caller frame even when O0 and
+// DWARF make the C helper's returned stack slot easy to overwrite.
+const shallowPanicAcceptanceProbe = `package main
+
+import "runtime"
+
+//go:noinline
+func panicSite() {
+	panic("shallow-panic")
+}
+
+func main() {
+	_ = runtime.NumCPU()
+	panicSite()
+}
+`
+
+func TestCallerAcceptanceShallowPanicBuildModes(t *testing.T) {
+	_, dir := prepareCallerAcceptanceProbe(t, shallowPanicAcceptanceProbe)
+	for _, test := range []struct {
+		name string
+		args []string
+	}{
+		{name: "O0_DWARF", args: []string{"-O0", "-ldflags=-w=false"}},
+		{name: "O0_no_DWARF", args: []string{"-O0", "-ldflags=-w"}},
+		{name: "O2_DWARF", args: []string{"-O2", "-ldflags=-w=false"}},
+		{name: "O2_no_DWARF", args: []string{"-O2", "-ldflags=-w"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			out, err := runLLGoProbeWithFlags(t, dir, test.args...)
+			if err == nil {
+				t.Fatalf("panic probe unexpectedly succeeded:\n%s", out)
+			}
+			for _, want := range []string{
+				"panic: shallow-panic",
+				"goroutine 1 [running]:",
+				"main.panicSite(...)",
+				"main.main(...)",
+			} {
+				if !strings.Contains(out, want) {
+					t.Fatalf("panic traceback missing %q:\n%s", want, out)
+				}
+			}
+		})
+	}
+}
+
 // Scenario: a failing test reports the t.Errorf call's file:line, exactly
 // like `go test` (the whole testing harness runs under llgo).
 func TestCallerAcceptanceTestingFailure(t *testing.T) {
@@ -331,9 +378,15 @@ func markerLineOf(t *testing.T, source, marker string) string {
 
 func runLLGoProbe(t *testing.T, dir string) (string, error) {
 	t.Helper()
+	return runLLGoProbeWithFlags(t, dir)
+}
+
+func runLLGoProbeWithFlags(t *testing.T, dir string, flags ...string) (string, error) {
+	t.Helper()
 	repoRoot := findStringConversionRepoRoot(t)
 	t.Setenv("LLGO_ROOT", repoRoot)
-	cmd := exec.Command("go", "run", "./cmd/llgo", "run", "-a", filepath.Join(dir, "main.go"))
+	args := append([]string{"run", "./cmd/llgo", "run", "-a"}, flags...)
+	cmd := exec.Command("go", append(args, filepath.Join(dir, "main.go"))...)
 	cmd.Dir = repoRoot
 	out, err := cmd.CombinedOutput()
 	return string(out), err


### PR DESCRIPTION
Fixes #2149.

## Problem

A shallow unrecovered panic built with `-O0 -ldflags=-w=false` can fall back to the raw clite address dump instead of LLGo's Go-style traceback. It was first noticed when a logging dependency graph and panic were combined in one probe, but the minimized trigger does not depend on `log`.

Without this PR, output can look like:

```text
panic: shallow-panic

[0x... command-line-arguments.panicSite+0x20, SP = ...]
[0x... command-line-arguments.main+..., SP = ...]
```

## Root cause

`llgo_framepointer` returned the C helper's own `__builtin_frame_address(0)`. The Go walker dereferenced that stack address after the helper returned, so optimized layouts only worked while stale frame bytes happened to remain intact. In the failing O0/DWARF layout, the saved-FP slot was already overwritten and the walk stopped before collecting a frame.

## Change

- Read and return the saved caller FP while the C helper frame is still alive.
- Remove the Go walker's old one-frame skip compensation so existing `Caller`/`Callers` depths remain unchanged.
- Cover a shallow panic under O0/O2 with DWARF both enabled and disabled.

This is independent of #2115: that issue owns precise PCLN statement sites. It also does not rely on #2143; optimization can hide the stale-frame bug but is not the correctness fix.

## Verification

macOS arm64, Go 1.26.5 / LLVM 19:

- `go test -vet=off ./... -count=1 -timeout=20m`
- `cd runtime && go test -vet=off ./... -count=1 -timeout=15m`
- caller/logging/panic/introspection/Stack/line-info acceptance tests
- O0/O2 x DWARF on/off shallow-panic matrix

Ubuntu amd64, Go 1.26.5 / LLVM 19.1.7, offline container limited to 2 CPUs, 15 GiB memory, and 512 PIDs:

- O0/O2 x DWARF on/off shallow-panic matrix