### PR TITLE
internal/build: fix linkname support main.sym

### DIFF
--- a/_demo/go/export/libexport.h.want
+++ b/_demo/go/export/libexport.h.want
@@ -317,7 +317,7 @@ GoString
 TwoParams(intptr_t a, GoString b);
 
 void
-github_com_goplus_llgo__demo_go_export_init(void) GO_SYMBOL_RENAME("github.com/goplus/llgo/_demo/go/export.init")
+main_init(void) GO_SYMBOL_RENAME("main.init")
 
 
 

--- a/_demo/go/export/use/main.c
+++ b/_demo/go/export/use/main.c
@@ -37,7 +37,7 @@ int main() {
     
     // Initialize packages - call init functions first
     github_com_goplus_llgo__demo_go_export_c_init();
-    github_com_goplus_llgo__demo_go_export_init();
+    main_init();
 
     // Verify that funcinfo is not merely linkable: runtime.Callers must yield
     // a symbolized frame and runtime.FuncForPC must resolve that PC's details.

--- a/_demo/go/mainlink/main.go
+++ b/_demo/go/mainlink/main.go
@@ -1,0 +1,14 @@
+package main
+
+import _ "unsafe"
+
+func main() {
+	linkdemo()
+}
+
+func demo() {
+	println("demo")
+}
+
+//go:linkname linkdemo main.demo
+func linkdemo()

--- a/chore/llgen/llgen.go
+++ b/chore/llgen/llgen.go
@@ -26,7 +26,8 @@ import (
 )
 
 var (
-	abi = flag.Int("abi", 0, "ABI mode (default 0). 0 = none, 1 = cfunc, 2 = allfunc.")
+	abi               = flag.Int("abi", 0, "ABI mode (default 0). 0 = none, 1 = cfunc, 2 = allfunc.")
+	rewriteMainPrefix = flag.Bool("rewrite-main-prefix", false, "Rewrite symbol names in the main package from 'pkgpath.sym' to 'main.sym'.")
 )
 
 func main() {
@@ -35,5 +36,5 @@ func main() {
 		fmt.Fprintln(os.Stderr, "Usage: llgen [flags] <pkg>")
 		return
 	}
-	llgen.SmartDoFileEx(flag.Args()[0], build.AbiMode(*abi))
+	llgen.SmartDoFileEx(flag.Args()[0], build.AbiMode(*abi), *rewriteMainPrefix)
 }

--- a/cmd/internal/flags/flags.go
+++ b/cmd/internal/flags/flags.go
@@ -51,6 +51,7 @@ var PrintCommands bool
 var DeadcodeDrop bool
 var PthreadStackSize byteSizeFlag
 var OptLevel optlevel.Level
+var RewriteMainPrefix bool = true
 
 type byteSizeFlag int64
 
@@ -229,6 +230,7 @@ func AddBuildFlags(fs *flag.FlagSet) {
 		fs.BoolVar(&CheckLLFiles, "check-llfiles", false, "check .ll files valid")
 		fs.BoolVar(&GenLLFiles, "gen-llfiles", false, "generate .ll files for pkg export")
 		fs.BoolVar(&ForceEspClang, "force-espclang", false, "force to use esp-clang")
+		fs.BoolVar(&RewriteMainPrefix, "rewrite-main-prefix", true, "Rewrite symbol names in the main package from 'pkgpath.sym' to 'main.sym'")
 	}
 
 	fs.BoolVar(&SizeReport, "size", false, "Print size report after build (default format=text, level=module)")
@@ -423,6 +425,7 @@ func UpdateConfig(conf *build.Config) error {
 		conf.GenLL = GenLLFiles
 		conf.ForceEspClang = ForceEspClang
 	}
+	conf.RewriteMainPrefix = RewriteMainPrefix
 	return nil
 }
 

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -192,6 +192,11 @@ type Config struct {
 	// when it would otherwise be enabled by full LTO.
 	DisableGoGlobalDCE bool
 
+	// RewriteMainPrefix controls whether symbols in the main package
+	// use "main." as their package path prefix instead of the actual
+	// import path. When true, pkgpath.sym is rewritten to main.sym.
+	RewriteMainPrefix bool
+
 	// GlobalRewrites specifies compile-time overrides for global string variables.
 	// Keys are fully qualified package paths (e.g. "main" or "github.com/user/pkg").
 	// Each Rewrites entry maps variable names to replacement string values. Only
@@ -367,6 +372,7 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	if conf.Mode == ModeTest {
 		cfg.Mode |= packages.NeedForTest
 	}
+	abi.SetRewriteMainPrefix(conf.RewriteMainPrefix)
 
 	emitDebugInfo := shouldEmitDebugInfo(conf, &export)
 	cl.EnableDebug(emitDebugInfo)
@@ -445,7 +451,7 @@ func Do(args []string, conf *Config) ([]Package, error) {
 	}
 	mode := conf.Mode
 	if mode == ModeTest {
-		initial, err = filterTestPackages(initial, conf.OutFile)
+		initial, err = filterTestPackages(initial, conf.OutFile, conf.RewriteMainPrefix)
 		if err != nil {
 			return nil, err
 		}
@@ -715,13 +721,13 @@ func needLink(pkg *packages.Package, mode Mode) bool {
 	return pkg.Name == "main"
 }
 
-func filterTestPackages(initial []*packages.Package, outFile string) ([]*packages.Package, error) {
+func filterTestPackages(initial []*packages.Package, outFile string, rewriteMainPrefix bool) ([]*packages.Package, error) {
 	filtered := initial[:0]
 	for _, pkg := range initial {
 		if needLink(pkg, ModeTest) {
 			filtered = append(filtered, pkg)
 		}
-		if pkg.Types != nil && pkg.Types.Name() == "main" {
+		if rewriteMainPrefix && pkg.Types != nil && pkg.Types.Name() == "main" {
 			pkg.Types.SetName("main.test")
 		}
 	}
@@ -1179,7 +1185,7 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, outputPa
 	methodByName := make(map[string]none)
 	allPkgs := []*packages.Package{pkg}
 	for _, v := range pkgs {
-		if v.PkgPath != pkg.PkgPath && v.Types.Name() == "main" {
+		if v.PkgPath != pkg.PkgPath && v.Types != nil && v.Types.Name() == "main" {
 			continue
 		}
 		allPkgs = append(allPkgs, v.Package)

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -721,6 +721,9 @@ func filterTestPackages(initial []*packages.Package, outFile string) ([]*package
 		if needLink(pkg, ModeTest) {
 			filtered = append(filtered, pkg)
 		}
+		if pkg.Types.Name() == "main" {
+			pkg.Types.SetName("main.test")
+		}
 	}
 	if len(filtered) > 1 && outFile != "" {
 		return nil, fmt.Errorf("cannot use -o flag with multiple packages")
@@ -1176,6 +1179,9 @@ func linkMainPkg(ctx *context, pkg *packages.Package, pkgs []*aPackage, outputPa
 	methodByName := make(map[string]none)
 	allPkgs := []*packages.Package{pkg}
 	for _, v := range pkgs {
+		if v.PkgPath != pkg.PkgPath && v.Types.Name() == "main" {
+			continue
+		}
 		allPkgs = append(allPkgs, v.Package)
 	}
 	visitRoots := allPkgs

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -721,7 +721,7 @@ func filterTestPackages(initial []*packages.Package, outFile string) ([]*package
 		if needLink(pkg, ModeTest) {
 			filtered = append(filtered, pkg)
 		}
-		if pkg.Types.Name() == "main" {
+		if pkg.Types != nil && pkg.Types.Name() == "main" {
 			pkg.Types.SetName("main.test")
 		}
 	}

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -308,7 +308,7 @@ func TestFilterTestPackages(t *testing.T) {
 			pkg("github.com/goplus/llgo/chore/ardump"),
 			pkg("github.com/goplus/llgo/chore/ardump [github.com/goplus/llgo/chore/ardump.test]"),
 		}
-		filtered, err := filterTestPackages(initial, "")
+		filtered, err := filterTestPackages(initial, "", false)
 		if err != nil {
 			t.Fatalf("filterTestPackages returned unexpected error: %v", err)
 		}
@@ -322,7 +322,7 @@ func TestFilterTestPackages(t *testing.T) {
 			pkg("foo"),
 			pkg("foo.test"),
 		}
-		filtered, err := filterTestPackages(initial, "")
+		filtered, err := filterTestPackages(initial, "", false)
 		if err != nil {
 			t.Fatalf("filterTestPackages returned unexpected error: %v", err)
 		}
@@ -339,7 +339,7 @@ func TestFilterTestPackages(t *testing.T) {
 			pkg("a.test"),
 			pkg("b.test"),
 		}
-		_, err := filterTestPackages(initial, "/tmp/out")
+		_, err := filterTestPackages(initial, "/tmp/out", false)
 		if err == nil {
 			t.Fatal("expected error for -o with multiple test packages, got nil")
 		}

--- a/internal/build/main_module.go
+++ b/internal/build/main_module.go
@@ -103,8 +103,15 @@ func genMainModule(ctx *context, rtPkgPath string, pkg *packages.Package, cfg *g
 		})
 	}
 
-	mainInit := declareNoArgFunc(mainPkg, pkg.PkgPath+".init")
-	mainMain := declareNoArgFunc(mainPkg, pkg.PkgPath+".main")
+	var pkgPath string
+	if pkg.Types.Name() == "main" {
+		pkgPath = "main"
+	} else {
+		pkgPath = pkg.PkgPath
+	}
+
+	mainInit := declareNoArgFunc(mainPkg, pkgPath+".init")
+	mainMain := declareNoArgFunc(mainPkg, pkgPath+".main")
 
 	if ctx.buildConf.BuildMode != BuildModeExe {
 		initArraySection := ""

--- a/internal/build/main_module.go
+++ b/internal/build/main_module.go
@@ -31,9 +31,8 @@ import (
 	"go/types"
 
 	"github.com/goplus/llgo/internal/packages"
-	llvm "github.com/xgo-dev/llvm"
-
 	llssa "github.com/goplus/llgo/ssa"
+	llvm "github.com/xgo-dev/llvm"
 )
 
 type genConfig struct {
@@ -104,7 +103,7 @@ func genMainModule(ctx *context, rtPkgPath string, pkg *packages.Package, cfg *g
 	}
 
 	var pkgPath string
-	if pkg.Types.Name() == "main" {
+	if ctx.buildConf.RewriteMainPrefix && pkg.Types.Name() == "main" {
 		pkgPath = "main"
 	} else {
 		pkgPath = pkg.PkgPath

--- a/internal/cabi/cabi_test.go
+++ b/internal/cabi/cabi_test.go
@@ -155,7 +155,7 @@ func testModule(t *testing.T, ctx context, td llvm.TargetData, m llvm.Module, c 
 		// check c linkname
 		testFunc(t, ctx, td, m.NamedFunction(fn.Name()), fn)
 		// check go
-		testFunc(t, ctx, td, m.NamedFunction("command-line-arguments."+fn.Name()), fn)
+		testFunc(t, ctx, td, m.NamedFunction("main."+fn.Name()), fn)
 	}
 }
 

--- a/internal/cabi/cabi_test.go
+++ b/internal/cabi/cabi_test.go
@@ -155,7 +155,7 @@ func testModule(t *testing.T, ctx context, td llvm.TargetData, m llvm.Module, c 
 		// check c linkname
 		testFunc(t, ctx, td, m.NamedFunction(fn.Name()), fn)
 		// check go
-		testFunc(t, ctx, td, m.NamedFunction("main."+fn.Name()), fn)
+		testFunc(t, ctx, td, m.NamedFunction("command-line-arguments."+fn.Name()), fn)
 	}
 }
 

--- a/internal/llgen/llgenf.go
+++ b/internal/llgen/llgenf.go
@@ -28,7 +28,7 @@ import (
 )
 
 func GenFrom(fileOrPkg string) string {
-	pkg, err := genFrom(fileOrPkg, 0)
+	pkg, err := genFrom(fileOrPkg, 0, false)
 	check(err)
 	out := pkg.LPkg.String()
 	// Release the compile's LLVM context: golden suites call GenFrom for
@@ -38,11 +38,12 @@ func GenFrom(fileOrPkg string) string {
 	return out
 }
 
-func genFrom(pkgPath string, abiMode build.AbiMode) (build.Package, error) {
+func genFrom(pkgPath string, abiMode build.AbiMode, rewriteMainPrefix bool) (build.Package, error) {
 	conf := &build.Config{
-		Mode:    build.ModeGen,
-		AbiMode: abiMode,
-		GenLL:   true,
+		Mode:              build.ModeGen,
+		AbiMode:           abiMode,
+		GenLL:             true,
+		RewriteMainPrefix: rewriteMainPrefix,
 	}
 	if err := applyGoBuildFlagsFile(conf, filepath.Join(pkgPath, "flags.txt")); err != nil {
 		return nil, err
@@ -87,11 +88,11 @@ func applyGoBuildFlagsFile(conf *build.Config, flagsFile string) error {
 }
 
 func SmartDoFile(pkgPath string) {
-	SmartDoFileEx(pkgPath, 0)
+	SmartDoFileEx(pkgPath, 0, false)
 }
 
-func SmartDoFileEx(pkgPath string, abiMode build.AbiMode) {
-	pkg, err := genFrom(pkgPath, abiMode)
+func SmartDoFileEx(pkgPath string, abiMode build.AbiMode, rewriteMainPrefix bool) {
+	pkg, err := genFrom(pkgPath, abiMode, rewriteMainPrefix)
 	check(err)
 
 	const autgenFile = "llgo_autogen.ll"

--- a/ssa/abi/abi.go
+++ b/ssa/abi/abi.go
@@ -284,6 +284,9 @@ func PathOf(pkg *types.Package) string {
 	if pkg == nil {
 		return ""
 	}
+	if pkg.Name() == "main" {
+		return "main"
+	}
 	return strings.TrimPrefix(pkg.Path(), PatchPathPrefix)
 }
 

--- a/ssa/abi/abi.go
+++ b/ssa/abi/abi.go
@@ -279,12 +279,21 @@ const (
 	PatchPathPrefix = env.LLGoRuntimePkg + "/internal/lib/"
 )
 
+// SetRewriteMainPrefix controls whether symbols in the main package
+// use "main." as their package path prefix instead of the actual
+// import path. When true, pkgpath.sym is rewritten to main.sym.
+func SetRewriteMainPrefix(b bool) {
+	rewriteMainPrefix = b
+}
+
+var rewriteMainPrefix bool
+
 // PathOf returns the package path of the specified package.
 func PathOf(pkg *types.Package) string {
 	if pkg == nil {
 		return ""
 	}
-	if pkg.Name() == "main" {
+	if rewriteMainPrefix && pkg.Name() == "main" {
 		return "main"
 	}
 	return strings.TrimPrefix(pkg.Path(), PatchPathPrefix)

--- a/ssa/abi/abi_test.go
+++ b/ssa/abi/abi_test.go
@@ -407,3 +407,15 @@ func isPaddedField(t reflect.Type, i int) bool {
 	}
 	return field.Offset+field.Type.Size() != t.Size()
 }
+
+func TestRewriteMainPrefix(t *testing.T) {
+	pkg := types.NewPackage("example.com/foo/pkg", "main")
+	if path := abi.PathOf(pkg); path != "example.com/foo/pkg" {
+		t.Fatalf("error %v", path)
+	}
+	abi.SetRewriteMainPrefix(true)
+	if path := abi.PathOf(pkg); path != "main" {
+		t.Fatalf("error %v", path)
+	}
+	abi.SetRewriteMainPrefix(false)
+}

--- a/ssa/abitype.go
+++ b/ssa/abitype.go
@@ -572,7 +572,7 @@ func methodExprSignature(sig *types.Signature) *types.Signature {
 func (b Builder) abiMethodFunc(anonymous bool, mPkg *types.Package, mName string, mSig *types.Signature) Function {
 	var fullName string
 	if anonymous {
-		fullName = b.Pkg.Path() + "." + mSig.Recv().Type().String() + "." + mName
+		fullName = b.Pkg.Path() + "." + types.TypeString(mSig.Recv().Type(), abi.PathOf) + "." + mName
 	} else {
 		fullName = FuncName(mPkg, mName, mSig.Recv(), false)
 	}


### PR DESCRIPTION
fix https://github.com/xgo-dev/llgo/issues/2156

- llgo
default set rewiteMainPrefix = true

    go build -tags dev
```
  -rewrite-main-prefix = true
    	Rewrite symbol names in the main package from 'pkgpath.sym' to 'main.sym' (default true)
```

- llgen 
default set rewiteMainPrefix = false
```
  -rewrite-main-prefix = false
    	Rewrite symbol names in the main package from 'pkgpath.sym' to 'main.sym'.
```