### PR TITLE
lto: analyze aggregate MethodByName string arguments

### DIFF
--- a/cl/_testlto/_globaldce_reflect_method_by_name_ltoplugin_string_abi_unknown/in.go
+++ b/cl/_testlto/_globaldce_reflect_method_by_name_ltoplugin_string_abi_unknown/in.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"os"
+	"reflect"
+)
+
+type Unknown struct{}
+
+//go:noinline
+func (Unknown) UnknownA() {}
+
+//go:noinline
+func (Unknown) UnknownB() {}
+
+func unknownName() string {
+	if len(os.Args) == 0 {
+		return "UnknownA"
+	}
+	return os.Args[0]
+}
+
+func main() {
+	_, _ = reflect.TypeOf(Unknown{}).MethodByName(unknownName())
+}

--- a/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_string_abi/expect.txt
+++ b/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_string_abi/expect.txt
@@ -1,0 +1,4 @@
+direct
+concat
+slice
+forward

--- a/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_string_abi/in.go
+++ b/cl/_testlto/globaldce_reflect_method_by_name_ltoplugin_string_abi/in.go
@@ -1,0 +1,53 @@
+// LITTEST
+package main
+
+import (
+	"reflect"
+)
+
+// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_string_abi{{.*}}Known{{.*}}Drop
+// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_string_abi{{.*}}Known{{.*}}Direct
+// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_string_abi{{.*}}Known{{.*}}Concat
+// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_string_abi{{.*}}Known{{.*}}Slice
+// SYMBOL-DAG: globaldce_reflect_method_by_name_ltoplugin_string_abi{{.*}}Known{{.*}}Forward
+// SYMBOL-NOT: globaldce_reflect_method_by_name_ltoplugin_string_abi{{.*}}Known{{.*}}Drop
+
+type Known struct{}
+
+//go:noinline
+func (Known) Direct() string { return "direct" }
+
+//go:noinline
+func (Known) Concat() string { return "concat" }
+
+//go:noinline
+func (Known) Slice() string { return "slice" }
+
+//go:noinline
+func (Known) Forward() string { return "forward" }
+
+//go:noinline
+func (Known) Drop() string { panic("unreachable") }
+
+func callForward(name string) string {
+	out := reflect.ValueOf(Known{}).MethodByName(name).Call(nil)
+	return out[0].String()
+}
+
+func callConcat(prefix, suffix string) string {
+	out := reflect.ValueOf(Known{}).MethodByName(prefix + suffix).Call(nil)
+	return out[0].String()
+}
+
+func callSlice(source string) string {
+	out := reflect.ValueOf(Known{}).MethodByName(source[2:7]).Call(nil)
+	return out[0].String()
+}
+
+func main() {
+	v := reflect.ValueOf(Known{})
+	println(v.MethodByName("Direct").Call(nil)[0].String())
+	println(callConcat("Con", "cat"))
+	println(callSlice("__Slice__"))
+	println(callForward("Forward"))
+}

--- a/cl/compile_test.go
+++ b/cl/compile_test.go
@@ -21,6 +21,8 @@ package cl_test
 
 import (
 	"os"
+	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -28,8 +30,10 @@ import (
 	"github.com/goplus/llgo/cl/cltest"
 	"github.com/goplus/llgo/internal/build"
 	"github.com/goplus/llgo/internal/buildenv"
+	"github.com/goplus/llgo/internal/cabi"
 	"github.com/goplus/llgo/internal/llgen"
 	"github.com/goplus/llgo/internal/lto"
+	llvmenv "github.com/goplus/llgo/xtool/env/llvm"
 )
 
 func testCompile(t *testing.T, src, expected string) {
@@ -187,6 +191,7 @@ func TestRunAndTestFromTestlto(t *testing.T) {
 		"./_testlto/globaldce_reflect_method_by_name_ltoplugin_param",
 		"./_testlto/globaldce_reflect_method_by_name_ltoplugin_range_literal",
 		"./_testlto/globaldce_reflect_method_by_name_ltoplugin_slice",
+		"./_testlto/globaldce_reflect_method_by_name_ltoplugin_string_abi",
 		"./_testlto/globaldce_reflect_method_by_name_ltoplugin_switch",
 	}
 	if !buildenv.Dev {
@@ -225,6 +230,7 @@ var testltoLTOPluginTests = []string{
 	"globaldce_reflect_method_by_name_ltoplugin_param",
 	"globaldce_reflect_method_by_name_ltoplugin_range_literal",
 	"globaldce_reflect_method_by_name_ltoplugin_slice",
+	"globaldce_reflect_method_by_name_ltoplugin_string_abi",
 	"globaldce_reflect_method_by_name_ltoplugin_switch",
 }
 
@@ -265,6 +271,60 @@ func TestBuildAndCheckSymbolsFromTestltoLTOPlugin(t *testing.T) {
 	cltest.BuildAndCheckSymbolsFromDir(t, "", "./_testlto", testltoLTOPluginTests,
 		cltest.WithRunConfig(buildConf),
 	)
+}
+
+func runTestltoLTOPluginAggregateABI(t *testing.T, fixture string) string {
+	t.Helper()
+	conf := testltoLTOPluginConf(t, build.ModeGen)
+	// Apply a fixed LP64 ABI below so the aggregate form is tested on every host.
+	conf.AbiMode = cabi.ModeNone
+	plugin := conf.LTOPlugin.Path
+	pkgs, err := build.Do([]string{fixture}, conf)
+	if err != nil {
+		t.Fatalf("generate aggregate string module: %v", err)
+	}
+	if len(pkgs) != 1 {
+		t.Fatalf("generate aggregate string module: got %d packages", len(pkgs))
+	}
+	cabi.NewTransformer(pkgs[0].LPkg.Prog, "arm64-unknown-linux", "", cabi.ModeAllFunc, true).
+		TransformModule(pkgs[0].PkgPath, pkgs[0].LPkg.Module())
+	aggregateIR := pkgs[0].LPkg.String()
+	pkgs[0].LPkg.Prog.Dispose()
+	if !strings.Contains(aggregateIR, `runtime.String" "llgo.reflect.methodbyname.name"`) {
+		t.Fatalf("MethodByName string argument was not captured in aggregate form:\n%s", aggregateIR)
+	}
+
+	opt := filepath.Join(llvmenv.New("").BinDir(), "opt")
+	cmd := exec.Command(opt, "-load-pass-plugin="+plugin,
+		"-passes=llgo-lto-pre-globaldce", "-S", "-o", "-")
+	cmd.Stdin = strings.NewReader(aggregateIR)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run LTO plugin for aggregate ABI: %v\n%s", err, out)
+	}
+	return string(out)
+}
+
+func TestBuildAndCheckSymbolsFromTestltoLTOPluginAggregateABI(t *testing.T) {
+	result := runTestltoLTOPluginAggregateABI(t,
+		"./_testlto/globaldce_reflect_method_by_name_ltoplugin_string_abi")
+	for _, name := range []string{"Direct", "Concat", "Slice", "Forward"} {
+		marker := `metadata !"go.method.value.reflect.` + name + `"`
+		if !strings.Contains(result, marker) {
+			t.Fatalf("aggregate ABI output missing %s\n%s", marker, result)
+		}
+	}
+	if strings.Contains(result, `metadata !"go.method.value.reflect"`) {
+		t.Fatalf("aggregate ABI output retained the generic value marker\n%s", result)
+	}
+
+	// A generic marker conservatively retains every matching method, so test
+	// unknown-name fallback in a separate module from the Drop symbol check.
+	unknownResult := runTestltoLTOPluginAggregateABI(t,
+		"./_testlto/_globaldce_reflect_method_by_name_ltoplugin_string_abi_unknown")
+	if !strings.Contains(unknownResult, `metadata !"go.method.type.reflect"`) {
+		t.Fatalf("aggregate ABI output lost the unknown-name type marker\n%s", unknownResult)
+	}
 }
 
 func TestFilterEmulatorOutput(t *testing.T) {

--- a/ltoplugin/LLGOReflectMethodByNamePass.cpp
+++ b/ltoplugin/LLGOReflectMethodByNamePass.cpp
@@ -173,20 +173,40 @@ bool isRuntimeStringSlice2(CallBase *CB) {
   return Callee && Callee->getName().ends_with(RuntimeStringSlice2Suffix);
 }
 
+bool consumeStringCallArgument(CallBase *CB, unsigned &NextArgIndex,
+                               const DataLayout &DL,
+                               SmallVectorImpl<std::string> &Names,
+                               unsigned Depth) {
+  if (NextArgIndex >= CB->arg_size())
+    return false;
+
+  Value *Arg = CB->getArgOperand(NextArgIndex);
+  if (Arg->getType()->isStructTy()) {
+    ++NextArgIndex;
+    return collectStringSetFromStringValue(Arg, DL, Names, Depth + 1);
+  }
+
+  if (NextArgIndex + 1 >= CB->arg_size())
+    return false;
+  Value *Len = CB->getArgOperand(NextArgIndex + 1);
+  if (!Arg->getType()->isPointerTy() || !Len->getType()->isIntegerTy())
+    return false;
+  NextArgIndex += 2;
+  return collectStringSet(Arg, Len, DL, Names, Depth + 1);
+}
+
 bool collectStringSetFromStringCat(CallBase *CB, const DataLayout &DL,
                                    SmallVectorImpl<std::string> &Names,
                                    unsigned Depth) {
   if (!isRuntimeStringCat(CB))
     return false;
-  if (CB->arg_size() != 4)
-    return false;
 
   SmallVector<std::string, 4> Prefixes;
   SmallVector<std::string, 4> Suffixes;
-  if (!collectStringSet(CB->getArgOperand(0), CB->getArgOperand(1), DL,
-                        Prefixes, Depth + 1) ||
-      !collectStringSet(CB->getArgOperand(2), CB->getArgOperand(3), DL,
-                        Suffixes, Depth + 1))
+  unsigned NextArgIndex = 0;
+  if (!consumeStringCallArgument(CB, NextArgIndex, DL, Prefixes, Depth) ||
+      !consumeStringCallArgument(CB, NextArgIndex, DL, Suffixes, Depth) ||
+      NextArgIndex != CB->arg_size())
     return false;
   return addConcatenatedNames(Names, Prefixes, Suffixes);
 }
@@ -196,18 +216,19 @@ bool collectStringSetFromStringSlice2(CallBase *CB, const DataLayout &DL,
                                       unsigned Depth) {
   if (!isRuntimeStringSlice2(CB))
     return false;
-  if (CB->arg_size() != 6)
-    return false;
 
   SmallVector<std::string, 4> Bases;
-  if (!collectStringSet(CB->getArgOperand(0), CB->getArgOperand(1), DL, Bases,
-                        Depth + 1))
+  unsigned NextArgIndex = 0;
+  if (!consumeStringCallArgument(CB, NextArgIndex, DL, Bases, Depth) ||
+      CB->arg_size() != NextArgIndex + 4)
     return false;
 
   SmallVector<uint64_t, 4> Lows;
   SmallVector<uint64_t, 4> Highs;
-  if (!collectIntegerChoices(CB->getArgOperand(2), Lows, Depth + 1) ||
-      !collectIntegerChoices(CB->getArgOperand(3), Highs, Depth + 1))
+  if (!collectIntegerChoices(CB->getArgOperand(NextArgIndex), Lows,
+                             Depth + 1) ||
+      !collectIntegerChoices(CB->getArgOperand(NextArgIndex + 1), Highs,
+                             Depth + 1))
     return false;
 
   for (const std::string &Base : Bases) {
@@ -886,6 +907,37 @@ bool collectStringSetFromFunctionStringArg(Value *Ptr, Value *Len,
   return true;
 }
 
+bool collectStringSetFromFunctionStringValueArg(
+    Value *StringValue, const DataLayout &DL,
+    SmallVectorImpl<std::string> &Names, unsigned Depth) {
+  auto *Arg = dyn_cast<Argument>(StringValue);
+  if (!Arg || !Arg->getType()->isStructTy())
+    return false;
+
+  Function *F = Arg->getParent();
+  if (!F)
+    return false;
+
+  unsigned ArgNo = Arg->getArgNo();
+  SmallVector<CallBase *, 8> Callers;
+  for (User *U : F->users()) {
+    auto *CB = dyn_cast<CallBase>(U);
+    if (!CB || CB->getCalledFunction() != F || ArgNo >= CB->arg_size())
+      return false;
+    Callers.push_back(CB);
+  }
+  if (Callers.empty())
+    return false;
+
+  for (CallBase *CB : Callers) {
+    Value *CallValue = CB->getArgOperand(ArgNo);
+    if (!CallValue->getType()->isStructTy() ||
+        !collectStringSetFromStringValue(CallValue, DL, Names, Depth + 1))
+      return false;
+  }
+  return true;
+}
+
 bool collectStringSetFromStringValue(Value *StringValue, const DataLayout &DL,
                                      SmallVectorImpl<std::string> &Names,
                                      unsigned Depth) {
@@ -906,6 +958,9 @@ bool collectStringSetFromStringValue(Value *StringValue, const DataLayout &DL,
     if (Constant *Folded = foldConstantLoad(Load, DL))
       return collectStringSetFromStringConstant(Folded, DL, Names, Depth + 1);
   }
+
+  if (collectStringSetFromFunctionStringValueArg(StringValue, DL, Names, Depth))
+    return true;
 
   if (auto *Insert = dyn_cast<InsertValueInst>(StringValue)) {
     Value *Ptr = findInsertedValue(Insert, 0);
@@ -1039,23 +1094,18 @@ std::optional<unsigned> findReflectMethodNameArg(CallBase *ReflectCall) {
   return std::nullopt;
 }
 
-// The plugin runs during LTO, after LLGo has applied C ABI lowering to every
-// module that participates in the link. At this point a Go string argument is
-// always split into (ptr, len). LLGo marks the string pointer parameter, and
-// the length is the following parameter produced by the same lowering step.
+// Optimized C ABI lowering splits a Go string into (ptr, len), with the name
+// attribute on the pointer. Debug-preserving builds can retain the original
+// aggregate string argument instead. Accept both representations so enabling
+// DWARF does not change MethodByName reachability.
 bool collectStringSetFromCallArgs(CallBase *ReflectCall, const DataLayout &DL,
                                   SmallVectorImpl<std::string> &Names) {
   std::optional<unsigned> NameArg = findReflectMethodNameArg(ReflectCall);
   if (!NameArg)
     return false;
 
-  if (*NameArg + 1 >= ReflectCall->arg_size())
-    return false;
-  Value *Ptr = ReflectCall->getArgOperand(*NameArg);
-  Value *Len = ReflectCall->getArgOperand(*NameArg + 1);
-  if (!Ptr->getType()->isPointerTy() || !Len->getType()->isIntegerTy())
-    return false;
-  return collectStringSet(Ptr, Len, DL, Names);
+  unsigned NextArgIndex = *NameArg;
+  return consumeStringCallArgument(ReflectCall, NextArgIndex, DL, Names, 0);
 }
 
 bool isTypeCheckedLoad(CallBase *CB) {


### PR DESCRIPTION
Unblocks https://github.com/xgo-dev/llgo/pull/2143.

## Problem

The MethodByName LTO pass assumed that every marked Go string argument had been lowered into separate `(ptr, len)` parameters. LLGo's arm64 LP64 C ABI path can instead keep the 16-byte Go string as a `{ptr, len}` aggregate. In that form the pass could not recover direct, concatenated, sliced, or forwarded constant names, so it left the generic reflect marker in place and prevented the intended named-method pruning.

## Changes

- consume one logical string argument in either aggregate or split ABI form
- reuse that decoding for direct MethodByName calls, `runtime.StringCat`, `runtime.StringSlice2`, and forwarded function parameters
- preserve the generic marker whenever a name cannot be resolved
- add Go fixtures covering direct, concat, slice, forwarding, linked execution, actual unused-method pruning, and unknown-name fallback
- derive the aggregate-ABI assertions from generated Go modules rather than hand-written LLVM IR

The focused aggregate test generates frontend IR with automatic C ABI lowering disabled, applies LLGo's arm64 C ABI transformer, and runs the LTO pass. One module checks the four known-name markers without a generic value marker. A separate module checks conservative unknown-name fallback because a generic marker intentionally retains all matching methods and would invalidate an unused-method symbol assertion. The normal plugin runtime and symbol suites exercise the linked split-ABI path and verify that `Known.Drop` is absent from the final binary.

This PR changes analysis only; it does not change either ABI.

## Validation

- negative check: the Go-generated aggregate test fails with the `main` plugin at the missing `Concat` marker and passes with this PR
- macOS arm64, LLVM 19: clean plugin build and both generated aggregate modules pass
- Ubuntu arm64 container, capped at 2 CPUs / 15 GiB: both generated aggregate modules pass
- Ubuntu arm64: linked runtime fixture passes and the final symbol table excludes `Known.Drop`
- Ubuntu arm64: complete existing LTO-plugin runtime and symbol suites; the new fixture passes in the runtime suite
- Ubuntu arm64: CI-equivalent plugin coverage command, 52.7% aggregate coverage for the instrumented Go packages
- prior CI: `Dev LTO GlobalDCE`, both coverage platforms, and Codecov patch coverage pass
