### PR TITLE
test(goroot): Skip write barrier checks as not applicable

### DIFF
--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -1924,7 +1924,7 @@ xfails:
   - version: go1.26
     directive: errorcheck
     case: writebarrier.go
-    reason: gc-specific write-barrier diagnostics are not implemented by llgo
+    reason: "not applicable: llgo's BDWGC and tinygogc runtimes do not use Go GC write barriers"
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/issue19743.go
@@ -1968,7 +1968,7 @@ xfails:
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/notinheap3.go
-    reason: gc runtime write-barrier and notinheap diagnostics are not implemented by llgo
+    reason: "not applicable: llgo's runtimes do not use Go GC write barriers; notinheap diagnostics are covered separately"
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/issue13273.go
@@ -2100,7 +2100,7 @@ xfails:
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/issue19168.go
-    reason: gc-specific write-barrier diagnostics are not implemented by llgo
+    reason: "not applicable: llgo's BDWGC and tinygogc runtimes do not use Go GC write barriers"
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/issue75278.go
@@ -2124,7 +2124,7 @@ xfails:
   - version: go1.26
     directive: errorcheck
     case: live2.go
-    reason: gc-specific liveness and write-barrier diagnostics are not implemented by llgo
+    reason: "not applicable: llgo's runtimes do not use Go GC write barriers; liveness diagnostics require separate compiler support"
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/issue12006.go
@@ -2244,7 +2244,7 @@ xfails:
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/issue13587.go
-    reason: gc-specific write-barrier diagnostics are not implemented by llgo
+    reason: "not applicable: llgo's BDWGC and tinygogc runtimes do not use Go GC write barriers"
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/issue16241.go
@@ -2308,7 +2308,7 @@ xfails:
   - version: go1.26
     directive: errorcheck
     case: nowritebarrier.go
-    reason: gc runtime write-barrier prohibition diagnostics are not implemented by llgo
+    reason: "not applicable: llgo's BDWGC and tinygogc runtimes do not use Go GC write barriers"
   - version: go1.26
     directive: errorcheck
     case: tailcall.go
@@ -2320,7 +2320,7 @@ xfails:
   - version: go1.26
     directive: errorcheck
     case: fixedbugs/issue34723.go
-    reason: gc-specific write-barrier diagnostics are not implemented by llgo
+    reason: "not applicable: llgo's BDWGC and tinygogc runtimes do not use Go GC write barriers"
   - version: go1.26
     directive: errorcheck
     case: syntax/vareq1.go


### PR DESCRIPTION
Clarify why Go GC write-barrier errorcheck cases remain expected failures under LLGo runtime architectures.

The implementation includes:

- Mark seven Go 1.26 `errorcheck` entries as not applicable because BDWGC and tinygogc do not use Go GC write barriers.
- Keep `fixedbugs/notinheap3.go` scoped so notinheap diagnostics remain tracked separately.
- Keep `live2.go` scoped so liveness diagnostics still require separate compiler support.
- Leave `fixedbugs/issue20780.go` and other unrelated xfails unchanged.

This makes the xfail inventory distinguish architectural non-applicability from missing LLGo compiler functionality.