### PR TITLE
ci: trigger benchmarks after LLGo main updates

### DIFF
--- a/.github/workflows/notify-benchmarks.yml
+++ b/.github/workflows/notify-benchmarks.yml
@@ -1,0 +1,41 @@
+name: Notify binary-size benchmarks
+
+on:
+  # A push to main is the authoritative post-merge state, including squash and
+  # rebase merges. The dispatched SHA is the exact LLGo version to measure.
+  push:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  dispatch:
+    if: github.repository == 'xgo-dev/llgo'
+    runs-on: ubuntu-24.04
+    env:
+      # Set this repository variable to the temporary personal repository
+      # before the migration, then remove it to use xgo-dev/benchmarks.
+      BENCHMARKS_REPOSITORY: ${{ vars.BENCHMARKS_REPOSITORY || 'xgo-dev/benchmarks' }}
+      BENCHMARKS_DISPATCH_TOKEN: ${{ secrets.BENCHMARKS_DISPATCH_TOKEN }}
+    steps:
+      - name: Request a binary-size build for this LLGo revision
+        run: |
+          set -euo pipefail
+          if [[ -z "$BENCHMARKS_DISPATCH_TOKEN" ]]; then
+            echo "BENCHMARKS_DISPATCH_TOKEN is not configured" >&2
+            exit 1
+          fi
+
+          payload="$(jq -cn \
+            --arg source_repository "$GITHUB_REPOSITORY" \
+            --arg llgo_repository "$GITHUB_REPOSITORY" \
+            --arg llgo_commit "$GITHUB_SHA" \
+            --arg source_run_url "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            '{event_type: "llgo-main-updated", client_payload: {source_repository: $source_repository, llgo_repository: $llgo_repository, llgo_commit: $llgo_commit, source_run_url: $source_run_url}}')"
+
+          curl --fail-with-body --location --request POST \
+            --header 'Accept: application/vnd.github+json' \
+            --header "Authorization: Bearer ${BENCHMARKS_DISPATCH_TOKEN}" \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${BENCHMARKS_REPOSITORY}/dispatches" \
+            --data "$payload"


### PR DESCRIPTION
## Summary

- notify `xgo-dev/benchmarks` after every push that advances `xgo-dev/llgo:main`;
- send the exact LLGo commit SHA in a `repository_dispatch` payload so the benchmark run pins that revision;
- default the destination to `xgo-dev/benchmarks`, with `BENCHMARKS_REPOSITORY` available as a temporary migration override;
- fail clearly when the dispatch token is not configured instead of silently skipping a benchmark.

## Required repository setup

Add an Actions secret named `BENCHMARKS_DISPATCH_TOKEN` in `xgo-dev/llgo`. A fine-grained token should be scoped to the target benchmarks repository with repository `Contents: Read and write` permission, which is required for creating a repository dispatch event. The token is used only by this workflow and is never printed.

The receiver workflow is already merged into `xgo-dev/benchmarks:main`. After adding the secret, merge one small change to `llgo:main` and confirm that a `repository_dispatch` run appears in the benchmarks Actions history.

## Validation

- rebased onto `xgo-dev/llgo:main` at `d726187c`;
- workflow YAML parsed successfully;
- generated dispatch JSON was validated with `jq`;
- `git diff --check` passed for the PR diff.
