### PR TITLE
build: keep return-order fix working with DebugRefs

### DIFF
--- a/internal/build/ssa_order_fix.go
+++ b/internal/build/ssa_order_fix.go
@@ -302,11 +302,15 @@ func fixSSAOrderBlock(b *ssa.BasicBlock) {
 			continue
 		}
 
-		// If the loaded value is used by any instruction between its current
-		// position and the return (excluding return itself), moving it may place
-		// its definition after one of those uses and break SSA form.
+		// DebugRefs are metadata-only and move with the value they describe. Any
+		// executable use before Return still makes reordering unsafe.
+		moving := map[ssa.Instruction]struct{}{u: {}}
 		usedBeforeReturn := false
 		for i := loadIdx + 1; i < retIdx; i++ {
+			if ref, ok := b.Instrs[i].(*ssa.DebugRef); ok && instrUsesValue(ref, u) {
+				moving[ref] = struct{}{}
+				continue
+			}
 			if instrUsesValue(b.Instrs[i], u) {
 				usedBeforeReturn = true
 				break
@@ -316,9 +320,7 @@ func fixSSAOrderBlock(b *ssa.BasicBlock) {
 			continue
 		}
 
-		// Move the load right after the last call (but before Return).
-		b.Instrs = moveInstr(b.Instrs, loadIdx, lastCallIdx+1)
-		// Adjust retIdx for subsequent moves in this block.
+		b.Instrs = moveInstrsAfter(b.Instrs, moving, b.Instrs[lastCallIdx])
 		retIdx = indexOfInstr(b.Instrs, ret)
 	}
 }
@@ -391,41 +393,29 @@ func valueDependsOn(v, target ssa.Value, seen map[ssa.Value]struct{}) bool {
 	return false
 }
 
-// moveInstr moves instrs[from] to position to (like inserting before to),
-// preserving relative order of other elements.
-func moveInstr(instrs []ssa.Instruction, from, to int) []ssa.Instruction {
-	if from < 0 || from >= len(instrs) {
+// moveInstrsAfter reinserts selected instructions as an ordered group directly
+// after anchor, preserving the relative order of all other instructions.
+func moveInstrsAfter(instrs []ssa.Instruction, moving map[ssa.Instruction]struct{}, anchor ssa.Instruction) []ssa.Instruction {
+	if len(moving) == 0 || anchor == nil {
 		return instrs
 	}
-	if to < 0 {
-		to = 0
+	moved := make([]ssa.Instruction, 0, len(moving))
+	remaining := make([]ssa.Instruction, 0, len(instrs))
+	for _, instr := range instrs {
+		if _, ok := moving[instr]; ok {
+			moved = append(moved, instr)
+			continue
+		}
+		remaining = append(remaining, instr)
 	}
-	if to > len(instrs) {
-		to = len(instrs)
+	for i, instr := range remaining {
+		if instr == anchor {
+			ret := make([]ssa.Instruction, 0, len(instrs))
+			ret = append(ret, remaining[:i+1]...)
+			ret = append(ret, moved...)
+			ret = append(ret, remaining[i+1:]...)
+			return ret
+		}
 	}
-	if from == to || from+1 == to {
-		return instrs
-	}
-
-	ins := instrs[from]
-	// Remove.
-	copy(instrs[from:], instrs[from+1:])
-	instrs = instrs[:len(instrs)-1]
-
-	// Recompute insertion index after removal.
-	if to > from {
-		to--
-	}
-	if to < 0 {
-		to = 0
-	}
-	if to > len(instrs) {
-		to = len(instrs)
-	}
-
-	// Insert.
-	instrs = append(instrs, nil)
-	copy(instrs[to+1:], instrs[to:])
-	instrs[to] = ins
 	return instrs
 }

--- a/internal/build/ssa_order_fix.go
+++ b/internal/build/ssa_order_fix.go
@@ -394,7 +394,8 @@ func valueDependsOn(v, target ssa.Value, seen map[ssa.Value]struct{}) bool {
 }
 
 // moveInstrsAfter reinserts selected instructions as an ordered group directly
-// after anchor, preserving the relative order of all other instructions.
+// after anchor, preserving the relative order of all other instructions. It
+// returns instrs unchanged when moving is empty or anchor is nil or absent.
 func moveInstrsAfter(instrs []ssa.Instruction, moving map[ssa.Instruction]struct{}, anchor ssa.Instruction) []ssa.Instruction {
 	if len(moving) == 0 || anchor == nil {
 		return instrs

--- a/internal/build/ssa_order_fix_test.go
+++ b/internal/build/ssa_order_fix_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/tools/go/packages"
 	"golang.org/x/tools/go/ssa"
 	"golang.org/x/tools/go/ssa/ssautil"
 )
@@ -115,7 +116,145 @@ func f() {
 	}
 }
 
+func TestFixSSAOrderReturnLoadWithDebugRefs(t *testing.T) {
+	const src = `package p
+type value struct { n int }
+func (v *value) mutate() bool { v.n = 1; return true }
+func f() (value, bool) {
+	var v value
+	return v, v.mutate()
+}`
+	base := ssa.SanityCheckFunctions | ssa.InstantiateGenerics
+	for _, test := range []struct {
+		name string
+		mode ssa.BuilderMode
+	}{
+		{name: "default", mode: base},
+		{name: "global-debug", mode: base | ssa.GlobalDebug},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fn := buildSSAOrderTestPackageMode(t, src, test.mode)
+			checkReturnLoadAfterMutation(t, fn, "mutate")
+		})
+	}
+}
+
+func TestFixSSAOrderCryptoX509ParseOID(t *testing.T) {
+	fset := token.NewFileSet()
+	loaded, err := packages.Load(&packages.Config{
+		Mode: packages.LoadSyntax,
+		Fset: fset,
+	}, "crypto/x509")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if packages.PrintErrors(loaded) != 0 || len(loaded) != 1 {
+		t.Fatal("failed to load crypto/x509")
+	}
+	mode := ssa.SanityCheckFunctions | ssa.InstantiateGenerics | ssa.GlobalDebug
+	prog, ssaPackages := ssautil.Packages(loaded, mode)
+	prog.Build()
+	pkg := ssaPackages[0]
+	fixSSAOrder(pkg, loaded[0].Syntax)
+	checkReturnLoadAfterMutation(t, pkg.Func("ParseOID"), "unmarshalOIDText")
+}
+
+func TestMoveInstrsAfter(t *testing.T) {
+	const src = `package p
+func f() {
+	println(1)
+	println(2)
+	println(3)
+}`
+	fn := buildSSAOrderTestPackage(t, src)
+	instrs := fn.Blocks[0].Instrs
+	if len(instrs) < 4 {
+		t.Fatalf("instructions = %d, want at least 4", len(instrs))
+	}
+
+	assertOrder := func(t *testing.T, got, want []ssa.Instruction) {
+		t.Helper()
+		if len(got) != len(want) {
+			t.Fatalf("instruction count = %d, want %d", len(got), len(want))
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("instruction %d = %v, want %v", i, got[i], want[i])
+			}
+		}
+	}
+
+	t.Run("empty", func(t *testing.T) {
+		assertOrder(t, moveInstrsAfter(instrs, nil, instrs[1]), instrs)
+	})
+	t.Run("nil-anchor", func(t *testing.T) {
+		moving := map[ssa.Instruction]struct{}{instrs[0]: {}}
+		assertOrder(t, moveInstrsAfter(instrs, moving, nil), instrs)
+	})
+	t.Run("missing-anchor", func(t *testing.T) {
+		moving := map[ssa.Instruction]struct{}{instrs[0]: {}}
+		assertOrder(t, moveInstrsAfter(instrs, moving, &ssa.Return{}), instrs)
+	})
+	t.Run("stable", func(t *testing.T) {
+		moving := map[ssa.Instruction]struct{}{
+			instrs[0]: {},
+			instrs[2]: {},
+		}
+		want := []ssa.Instruction{instrs[1], instrs[0], instrs[2]}
+		want = append(want, instrs[3:]...)
+		assertOrder(t, moveInstrsAfter(instrs, moving, instrs[1]), want)
+	})
+}
+
+func checkReturnLoadAfterMutation(t *testing.T, fn *ssa.Function, mutation string) {
+	t.Helper()
+	var ret *ssa.Return
+	var mutationCall ssa.CallInstruction
+	for _, block := range fn.Blocks {
+		for _, instr := range block.Instrs {
+			if candidate, ok := instr.(*ssa.Return); ok {
+				ret = candidate
+			}
+			if call, ok := instr.(ssa.CallInstruction); ok {
+				callee := call.Common().StaticCallee()
+				if callee != nil && callee.Name() == mutation {
+					mutationCall = call
+				}
+			}
+		}
+	}
+	if ret == nil || len(ret.Results) != 2 || mutationCall == nil {
+		t.Fatalf("unexpected return instruction: %v", ret)
+	}
+	callInstr := mutationCall.(ssa.Instruction)
+	callIdx := indexOfInstr(callInstr.Block().Instrs, callInstr)
+	loadIdx := -1
+	debugRefIdx := -1
+	var resultLoad *ssa.UnOp
+	for i, instr := range callInstr.Block().Instrs {
+		if load, ok := instr.(*ssa.UnOp); ok && load.Op == token.MUL {
+			if alloc, ok := load.X.(*ssa.Alloc); ok && callUsesValue(mutationCall, alloc) {
+				loadIdx = i
+				resultLoad = load
+			}
+		}
+		if ref, ok := instr.(*ssa.DebugRef); ok && resultLoad != nil && instrUsesValue(ref, resultLoad) {
+			debugRefIdx = i
+		}
+	}
+	if callIdx < 0 || loadIdx <= callIdx {
+		t.Fatalf("return load index = %d, mutation call index = %d; want load after call\n%s", loadIdx, callIdx, fn)
+	}
+	if debugRefIdx >= 0 && debugRefIdx <= loadIdx {
+		t.Fatalf("DebugRef index = %d, load index = %d; want DebugRef after its load\n%s", debugRefIdx, loadIdx, fn)
+	}
+}
+
 func buildSSAOrderTestPackage(t *testing.T, src string) *ssa.Function {
+	return buildSSAOrderTestPackageMode(t, src, ssa.SanityCheckFunctions|ssa.InstantiateGenerics)
+}
+
+func buildSSAOrderTestPackageMode(t *testing.T, src string, mode ssa.BuilderMode) *ssa.Function {
 	t.Helper()
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "p.go", src, 0)
@@ -129,7 +268,7 @@ func buildSSAOrderTestPackage(t *testing.T, src string) *ssa.Function {
 		fset,
 		pkg,
 		files,
-		ssa.SanityCheckFunctions|ssa.InstantiateGenerics,
+		mode,
 	)
 	if err != nil {
 		t.Fatalf("BuildPackage: %v", err)

--- a/test/llgo/dwarf_semantics_acceptance_test.go
+++ b/test/llgo/dwarf_semantics_acceptance_test.go
@@ -1,0 +1,80 @@
+//go:build !llgo
+
+package llgotest
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const dwarfReturnOrderProbe = `package main
+
+type value struct {
+	n int
+}
+
+func (v *value) mutate() bool {
+	v.n = 1
+	return true
+}
+
+func result() (value, bool) {
+	var v value
+	return v, v.mutate()
+}
+
+func main() {
+	v, ok := result()
+	if !ok || v.n != 1 {
+		panic("return value was loaded before mutation")
+	}
+	println("RETURN_ORDER_OK")
+}
+`
+
+func TestDWARFReturnOrderSemantics(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	source := filepath.Join(t.TempDir(), "main.go")
+	if err := os.WriteFile(source, []byte(dwarfReturnOrderProbe), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(
+		"go", "run", "./cmd/llgo", "run", "-ldflags=-w=false", source,
+	)
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"LLGO_ROOT="+repoRoot,
+		"LLGO_BUILD_CACHE=off",
+		"GOMAXPROCS=2",
+		"GOMEMLIMIT=6GiB",
+		"GOFLAGS=-p=1",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("LLGo DWARF return-order acceptance failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "RETURN_ORDER_OK") {
+		t.Fatalf("LLGo DWARF return-order acceptance did not report success:\n%s", out)
+	}
+}
+
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("repo root not found")
+		}
+		dir = parent
+	}
+}


### PR DESCRIPTION
Follow-up to https://github.com/xgo-dev/llgo/pull/1683.

Related upstream discussions:
- https://github.com/golang/go/issues/48105
- https://github.com/golang/go/issues/77938

## Problem

LLGo already aligns the observable behavior of `return x, x.mutate()` with `cmd/compile`. This compatibility is required by standard-library code such as `crypto/x509.ParseOID`:

```go
var o OID
return o, o.unmarshalOIDText(oid)
```

Without LLGo's existing fix, consuming the `go/ssa` load order literally can return an empty `OID` together with a nil error. `test/std/crypto/x509.TestOID` checks this behavior.

The Go specification leaves the load-before-call versus load-after-call choice unspecified; golang/go#48105 documents that both choices are valid, and golang/go#77938 tracks the `go/ssa`/`cmd/compile` difference. This PR does not redefine that language behavior.

When SSA is built with `ssa.GlobalDebug`, metadata-only `DebugRef` instructions refer to the return load. The existing order repair treats those references as executable pre-return uses and declines to move the load. Enabling DWARF can therefore disable the compatibility fix and regress `crypto/x509.ParseOID`.

## Change

Move related `DebugRef` instructions as a stable group with the reordered return load. Executable users still prevent the transformation. Default SSA and `GlobalDebug` SSA retain the same runtime behavior.

The LLGo-specific end-to-end regression lives under `test/llgo`; shared `test/go` remains usable by both Go and LLGo.

## Verification

- `GOMAXPROCS=2 GOMEMLIMIT=6GiB GOFLAGS=-p=1 go test ./internal/build -run "TestFixSSAOrderReturnLoadWithDebugRefs|TestFixSSAOrderCryptoX509ParseOID|TestMoveInstrsAfter" -count=1`
- `GOMAXPROCS=2 GOMEMLIMIT=6GiB GOFLAGS=-p=1 go test ./test/llgo -run TestDWARFReturnOrderSemantics -count=1`
- `GOMAXPROCS=2 GOMEMLIMIT=6GiB GOFLAGS=-p=1 go test ./internal/build -count=1`
- Focused coverage: `fixSSAOrderBlock` 80.0%, `moveInstrsAfter` 88.2%
- `GOMAXPROCS=2 GOMEMLIMIT=6GiB GOFLAGS=-p=1 LLGO_BUILD_CACHE=off go run ./cmd/llgo test ./test/std/crypto/x509 -run '^TestOID -count=1`
- `git diff --check upstream/main...HEAD`