### PR TITLE
[Based on #2215] build: keep select-order repair working with DebugRefs

### DIFF
--- a/.github/actions/setup-embed-deps/action.yml
+++ b/.github/actions/setup-embed-deps/action.yml
@@ -18,7 +18,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y libsdl2-2.0-0
+        sudo apt-get install -y libsdl2-2.0-0 libslirp0
 
     - name: Install ESP QEMU toolchains
       shell: bash

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -180,7 +180,7 @@ jobs:
   test:
     name: test (${{ matrix.lane }}, ${{ matrix.os }}, LLVM ${{ matrix.llvm }}, Go ${{ matrix.go }}, shard ${{ matrix.shard }})
     continue-on-error: ${{ matrix.lane == 'compatibility' }}
-    timeout-minutes: 30
+    timeout-minutes: ${{ startsWith(matrix.os, 'macos') && 45 || 30 }}
     strategy:
       matrix:
         # Keep compatibility and primary toolchains pinned to exact patches.

--- a/internal/build/ssa_order_fix.go
+++ b/internal/build/ssa_order_fix.go
@@ -186,6 +186,9 @@ func moveAssignDepsAfterRecv(b *ssa.BasicBlock, roots []ssa.Value, recv ssa.Valu
 	if len(move) == 0 {
 		return false
 	}
+	// Metadata uses must follow the definitions they describe rather than
+	// blocking an otherwise safe source-order repair.
+	includeDebugRefsForMovedValues(b.Instrs, move, recvIdx)
 	if moveWouldBreakSSA(b.Instrs, move, recvIdx) {
 		return false
 	}
@@ -205,13 +208,39 @@ func moveAssignDepsAfterRecv(b *ssa.BasicBlock, roots []ssa.Value, recv ssa.Valu
 	return true
 }
 
-func moveWouldBreakSSA(instrs []ssa.Instruction, move map[int]struct{}, recvIdx int) bool {
+func movedValues(instrs []ssa.Instruction, move map[int]struct{}) map[ssa.Value]struct{} {
 	moved := make(map[ssa.Value]struct{}, len(move))
 	for i := range move {
 		if v, ok := instrs[i].(ssa.Value); ok && v != nil {
 			moved[v] = struct{}{}
 		}
 	}
+	return moved
+}
+
+func includeDebugRefsForMovedValues(instrs []ssa.Instruction, move map[int]struct{}, recvIdx int) {
+	moved := movedValues(instrs, move)
+	// DebugRef is metadata, not an ssa.Value, so adding one cannot introduce
+	// another value whose DebugRefs would require a second scan.
+	for i := 0; i <= recvIdx && i < len(instrs); i++ {
+		if _, moving := move[i]; moving {
+			continue
+		}
+		ref, ok := instrs[i].(*ssa.DebugRef)
+		if !ok {
+			continue
+		}
+		for v := range moved {
+			if instrUsesValue(ref, v) {
+				move[i] = struct{}{}
+				break
+			}
+		}
+	}
+}
+
+func moveWouldBreakSSA(instrs []ssa.Instruction, move map[int]struct{}, recvIdx int) bool {
+	moved := movedValues(instrs, move)
 	for i := 0; i <= recvIdx && i < len(instrs); i++ {
 		if _, moving := move[i]; moving {
 			continue

--- a/internal/build/ssa_order_fix.go
+++ b/internal/build/ssa_order_fix.go
@@ -222,7 +222,7 @@ func includeDebugRefsForMovedValues(instrs []ssa.Instruction, move map[int]struc
 	moved := movedValues(instrs, move)
 	// DebugRef is metadata, not an ssa.Value, so adding one cannot introduce
 	// another value whose DebugRefs would require a second scan.
-	for i := 0; i <= recvIdx && i < len(instrs); i++ {
+	for i := 0; i < recvIdx && i < len(instrs); i++ {
 		if _, moving := move[i]; moving {
 			continue
 		}

--- a/internal/build/ssa_order_fix_test.go
+++ b/internal/build/ssa_order_fix_test.go
@@ -28,11 +28,12 @@ func f() {
 	case *fp(&x, 100) = <-fc(c, 1):
 	}
 }`
-	fn := buildSSAOrderTestPackage(t, src)
-	got := instrOrder(fn, "fc(", "<-", "fp(", "*t")
-	if !inOrder(got, "fc(", "<-", "fp(") {
-		t.Fatalf("single-case select receive assignment order = %v, want fc/receive before fp", got)
-	}
+	testSSAOrderModes(t, src, func(t *testing.T, fn *ssa.Function) {
+		got := instrOrder(fn, "fc(", "<-", "fp(", "*t")
+		if !inOrder(got, "fc(", "<-", "fp(") {
+			t.Fatalf("single-case select receive assignment order = %v, want fc/receive before fp", got)
+		}
+	})
 }
 
 func TestFixSSAOrderPlainRecvAssignKeepsLeftToRight(t *testing.T) {
@@ -66,11 +67,12 @@ func f() {
 	case m[fn(13, 100)] = <-fc(c, 1):
 	}
 }`
-	fn := buildSSAOrderTestPackage(t, src)
-	got := instrOrder(fn, "fc(", "<-", "fn(")
-	if !inOrder(got, "fc(", "<-", "fn(") {
-		t.Fatalf("single-case select map receive assignment order = %v, want fc/receive before fn", got)
-	}
+	testSSAOrderModes(t, src, func(t *testing.T, fn *ssa.Function) {
+		got := instrOrder(fn, "fc(", "<-", "fn(")
+		if !inOrder(got, "fc(", "<-", "fn(") {
+			t.Fatalf("single-case select map receive assignment order = %v, want fc/receive before fn", got)
+		}
+	})
 }
 
 func TestFixSSAOrderSingleCaseSelectTwoValueRecv(t *testing.T) {
@@ -87,11 +89,12 @@ func f() {
 	case *fp(&x, 100), ok = <-fc(c, 1):
 	}
 }`
-	fn := buildSSAOrderTestPackage(t, src)
-	got := instrOrder(fn, "fc(", "<-", "fp(", "*t")
-	if !inOrder(got, "fc(", "<-", "fp(") {
-		t.Fatalf("single-case select two-value receive assignment order = %v, want fc/receive before fp", got)
-	}
+	testSSAOrderModes(t, src, func(t *testing.T, fn *ssa.Function) {
+		got := instrOrder(fn, "fc(", "<-", "fp(", "*t")
+		if !inOrder(got, "fc(", "<-", "fp(") {
+			t.Fatalf("single-case select two-value receive assignment order = %v, want fc/receive before fp", got)
+		}
+	})
 }
 
 func TestFixSSAOrderMultiCaseSelectKeepsLeftToRight(t *testing.T) {
@@ -116,6 +119,26 @@ func f() {
 }
 
 func buildSSAOrderTestPackage(t *testing.T, src string) *ssa.Function {
+	return buildSSAOrderTestPackageMode(t, src, ssa.SanityCheckFunctions|ssa.InstantiateGenerics)
+}
+
+func testSSAOrderModes(t *testing.T, src string, check func(*testing.T, *ssa.Function)) {
+	t.Helper()
+	base := ssa.SanityCheckFunctions | ssa.InstantiateGenerics
+	for _, test := range []struct {
+		name string
+		mode ssa.BuilderMode
+	}{
+		{name: "default", mode: base},
+		{name: "global-debug", mode: base | ssa.GlobalDebug},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			check(t, buildSSAOrderTestPackageMode(t, src, test.mode))
+		})
+	}
+}
+
+func buildSSAOrderTestPackageMode(t *testing.T, src string, mode ssa.BuilderMode) *ssa.Function {
 	t.Helper()
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "p.go", src, 0)
@@ -129,7 +152,7 @@ func buildSSAOrderTestPackage(t *testing.T, src string) *ssa.Function {
 		fset,
 		pkg,
 		files,
-		ssa.SanityCheckFunctions|ssa.InstantiateGenerics,
+		mode,
 	)
 	if err != nil {
 		t.Fatalf("BuildPackage: %v", err)


### PR DESCRIPTION
Temporarily based on https://github.com/xgo-dev/llgo/pull/2215 so CI has the current ESP QEMU dependency and macOS test timeout fixes. The dependency will be removed after #2215 merges.

Follow-up to https://github.com/xgo-dev/llgo/pull/1805.

## Problem

A selected receive assignment evaluates its left-hand-side expressions after communication, as specified by https://go.dev/ref/spec#Select_statements. `x/tools/go/ssa` optimizes a blocking one-case select into a plain receive statement, so LLGo already repairs the resulting LHS dependency order for pointer, map, and two-value receive assignments.

With `ssa.GlobalDebug`, metadata-only `DebugRef` instructions use values that the repair must move after the receive. The SSA safety check sees those references before the receive and rejects an otherwise valid move. Enabling debug information can therefore disable the existing select-order repair.

## Change

Include relevant `DebugRef` instructions in the same stable move set as their values before validating SSA uses. Runtime instructions retain the existing safety checks.

The implementation is independent of the return-order compatibility change: relative to #2215, it contains only the select repair and its default/`GlobalDebug` mode tests.

## Verification

- `GOMAXPROCS=2 GOMEMLIMIT=6GiB GOFLAGS=-p=1 go test ./internal/build -run "TestFixSSAOrderSingleCaseSelect|TestFixSSAOrderPlainRecvAssign|TestFixSSAOrderMultiCaseSelect" -count=1`
- `GOMAXPROCS=2 GOMEMLIMIT=6GiB GOFLAGS=-p=1 go test ./internal/build -count=1 -timeout=20m` (`398.643s` after rebase)
- Focused coverage: `includeDebugRefsForMovedValues` 100%, `fixSingleCaseSelectRecvAssignBlock` 93.3%, `moveAssignDepsAfterRecv` 95.8%
- `git diff --check`
