### PR TITLE
cl: run defers before loading named results

### DIFF
--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1681,16 +1681,27 @@ func (p *context) compileInstr(b llssa.Builder, instr ssa.Instruction) {
 		jmpb := p.jumpTo(v)
 		b.Jump(jmpb)
 	case *ssa.Return:
+		runDefers := p.returnNeedsImplicitRunDefers(v)
+		if runDefers {
+			p.recordPanicLocation(b, v.Pos())
+			b.RunDefers()
+		}
 		var results []llssa.Expr
 		if n := len(v.Results); n > 0 {
 			results = make([]llssa.Expr, n)
 			for i, r := range v.Results {
+				// A named result may be changed by a deferred call. Its SSA
+				// load was emitted before the implicit RunDefers above, so
+				// reload it in the continuation block after all defers have
+				// completed.
+				if runDefers && v.Parent().Signature.Results().At(i).Name() != "" {
+					if load, ok := r.(*ssa.UnOp); ok && load.Op == token.MUL {
+						results[i] = p.compileInstrOrValue(b, load, false)
+						continue
+					}
+				}
 				results[i] = p.compileValue(b, r)
 			}
-		}
-		if p.returnNeedsImplicitRunDefers(v) {
-			p.recordPanicLocation(b, v.Pos())
-			b.RunDefers()
 		}
 		if p.shouldTrackCallerFrames() {
 			p.popCallerLocationFrame(b)

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1690,14 +1690,13 @@ func (p *context) compileInstr(b llssa.Builder, instr ssa.Instruction) {
 		if n := len(v.Results); n > 0 {
 			results = make([]llssa.Expr, n)
 			for i, r := range v.Results {
-				// Go SSA forms the named-result tuple with loads from the
-				// result slots. Reload the slot in the RunDefers continuation
-				// so deferred calls can change the value we return. Avoid the
-				// general UnOp path: this plain local load needs neither its
-				// cached value nor any dereference side effects.
-				if runDefers && v.Parent().Signature.Results().At(i).Name() != "" {
-					if load, ok := r.(*ssa.UnOp); ok && load.Op == token.MUL {
-						results[i] = b.Load(p.compileValue(b, load.X))
+				// A deferred call may change a named result independently of
+				// the SSA value in Return.Results. Reload the result's storage
+				// in the RunDefers continuation instead of depending on the
+				// particular SSA node used to form the return tuple.
+				if runDefers {
+					if slot := p.namedResultSlot(i); slot != nil {
+						results[i] = b.Load(p.compileValue(b, slot))
 						continue
 					}
 				}
@@ -1903,6 +1902,30 @@ func (p *context) returnNeedsImplicitRunDefers(ret *ssa.Return) bool {
 		return false
 	}
 	return p.functionHasExplicitStackDeferInAnon(fn)
+}
+
+// namedResultSlot returns the allocation for fn's named result at index.
+// The SSA Function API exposes result variables through their source-level
+// Alloc instructions, while Return.Results only exposes the values currently
+// used to form a particular return tuple.
+func (p *context) namedResultSlot(index int) *ssa.Alloc {
+	fn := p.goFn
+	if fn == nil || index < 0 || index >= fn.Signature.Results().Len() {
+		return nil
+	}
+	result := fn.Signature.Results().At(index)
+	if result.Name() == "" {
+		return nil
+	}
+	for _, block := range fn.Blocks {
+		for _, instr := range block.Instrs {
+			alloc, ok := instr.(*ssa.Alloc)
+			if ok && alloc.Comment == result.Name() && alloc.Pos() == result.Pos() {
+				return alloc
+			}
+		}
+	}
+	return nil
 }
 
 func previousNonDebugInstrIsRunDefers(ret *ssa.Return) bool {

--- a/cl/compile.go
+++ b/cl/compile.go
@@ -1690,13 +1690,14 @@ func (p *context) compileInstr(b llssa.Builder, instr ssa.Instruction) {
 		if n := len(v.Results); n > 0 {
 			results = make([]llssa.Expr, n)
 			for i, r := range v.Results {
-				// A named result may be changed by a deferred call. Its SSA
-				// load was emitted before the implicit RunDefers above, so
-				// reload it in the continuation block after all defers have
-				// completed.
+				// Go SSA forms the named-result tuple with loads from the
+				// result slots. Reload the slot in the RunDefers continuation
+				// so deferred calls can change the value we return. Avoid the
+				// general UnOp path: this plain local load needs neither its
+				// cached value nor any dereference side effects.
 				if runDefers && v.Parent().Signature.Results().At(i).Name() != "" {
 					if load, ok := r.(*ssa.UnOp); ok && load.Op == token.MUL {
-						results[i] = p.compileInstrOrValue(b, load, false)
+						results[i] = b.Load(p.compileValue(b, load.X))
 						continue
 					}
 				}

--- a/cl/rewrite_internal_test.go
+++ b/cl/rewrite_internal_test.go
@@ -796,6 +796,34 @@ func namedResult(stop bool) (result *int) {
 	}
 }
 
+func TestNamedResultSlot(t *testing.T) {
+	ssaPkg, _, _ := buildGoSSAPkg(t, `
+package foo
+
+func seq(yield func(int) bool) { _ = yield(1) }
+
+func f() (result *int) {
+	for v := range seq {
+		defer func() { result = &v }()
+	}
+	return nil
+}
+
+func unnamed() string { return "" }
+`)
+
+	fn := ssaPkg.Func("f")
+	ctx := &context{goFn: fn}
+	slot := ctx.namedResultSlot(0)
+	if slot == nil || slot.Comment != "result" {
+		t.Fatalf("named result slot = %v, want result allocation", slot)
+	}
+	ctx.goFn = ssaPkg.Func("unnamed")
+	if got := ctx.namedResultSlot(0); got != nil {
+		t.Fatalf("unnamed result slot = %v, want nil", got)
+	}
+}
+
 func TestDeferStackOwnerUsesEnclosingSourceFunction(t *testing.T) {
 	const src = `package foo
 

--- a/cl/rewrite_internal_test.go
+++ b/cl/rewrite_internal_test.go
@@ -810,10 +810,20 @@ func f() (result *int) {
 }
 
 func unnamed() string { return "" }
+
+func lifted() (result int) { return }
 `)
 
 	fn := ssaPkg.Func("f")
 	ctx := &context{goFn: fn}
+	if got := (&context{}).namedResultSlot(0); got != nil {
+		t.Fatalf("nil function result slot = %v, want nil", got)
+	}
+	for _, index := range []int{-1, 1} {
+		if got := ctx.namedResultSlot(index); got != nil {
+			t.Fatalf("result slot at index %d = %v, want nil", index, got)
+		}
+	}
 	slot := ctx.namedResultSlot(0)
 	if slot == nil || slot.Comment != "result" {
 		t.Fatalf("named result slot = %v, want result allocation", slot)
@@ -821,6 +831,10 @@ func unnamed() string { return "" }
 	ctx.goFn = ssaPkg.Func("unnamed")
 	if got := ctx.namedResultSlot(0); got != nil {
 		t.Fatalf("unnamed result slot = %v, want nil", got)
+	}
+	ctx.goFn = ssaPkg.Func("lifted")
+	if got := ctx.namedResultSlot(0); got != nil {
+		t.Fatalf("lifted named result slot = %v, want nil", got)
 	}
 }
 

--- a/cl/rewrite_internal_test.go
+++ b/cl/rewrite_internal_test.go
@@ -17,6 +17,7 @@ import (
 	gpackages "github.com/goplus/gogen/packages"
 	llssa "github.com/goplus/llgo/ssa"
 	"github.com/goplus/llgo/ssa/ssatest"
+	"github.com/xgo-dev/llvm"
 	"golang.org/x/tools/go/ssa"
 	"golang.org/x/tools/go/ssa/ssautil"
 )
@@ -771,6 +772,16 @@ func f() {
 		defer func() { _ = v }()
 	}
 }
+
+func namedResult(stop bool) (result *int) {
+	if stop {
+		return nil
+	}
+	for v := range seq {
+		defer func() { result = &v }()
+	}
+	return nil
+}
 `)
 
 	ir := m.String()
@@ -779,6 +790,9 @@ func f() {
 	}
 	if !strings.Contains(ir, "sigsetjmp") && !strings.Contains(ir, "setjmp") {
 		t.Fatalf("expected rangefunc defer stack setup in module, got:\n%s", ir)
+	}
+	if err := llvm.VerifyModule(m, llvm.ReturnStatusAction); err != nil {
+		t.Fatalf("rangefunc defer module is invalid: %v\n%s", err, ir)
 	}
 }
 

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1661,7 +1661,7 @@ func buildPkg(ctx *context, aPkg *aPackage, verbose bool) error {
 			return fmt.Errorf("verify LLVM module for %v failed: %w", pkgPath, err)
 		}
 		if err := mod.RunPasses(llvmPassPipeline(ctx.buildConf.OptLevel, ctx.buildConf.ltoMode()), ctx.prog.TargetMachine(), pbo); err != nil {
-			return fmt.Errorf("run LLVM passes failed for %v: %v", pkgPath, err)
+			return fmt.Errorf("run LLVM passes failed for %v: %w", pkgPath, err)
 		}
 	}
 	emitFuncInfoEntrySites(ctx, ret)

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1658,7 +1658,7 @@ func buildPkg(ctx *context, aPkg *aPackage, verbose bool) error {
 		pbo := gllvm.NewPassBuilderOptions()
 		defer pbo.Dispose()
 		if err = gllvm.VerifyModule(mod, gllvm.ReturnStatusAction); err != nil {
-			return err
+			return fmt.Errorf("verify LLVM module for %v failed: %w", pkgPath, err)
 		}
 		if err := mod.RunPasses(llvmPassPipeline(ctx.buildConf.OptLevel, ctx.buildConf.ltoMode()), ctx.prog.TargetMachine(), pbo); err != nil {
 			return fmt.Errorf("run LLVM passes failed for %v: %v", pkgPath, err)


### PR DESCRIPTION
## Summary

Fix LLVM verifier failures for returns from functions that use explicit defer stacks and named result parameters.

The compiler previously materialized a named-result load before emitting the implicit defer drain. A defer continuation can reach multiple return blocks, so that pre-defer load did not dominate every return use; it also could not observe a deferred update to the named result.

Emit the implicit defer drain before materializing return values, then reload named-result loads in its continuation block. Add a range-over-function defer regression test that verifies the generated LLVM module. LLVM verifier failures now identify the package being compiled.

## Validation

- `go test ./cl -run '^(TestRangeFuncDeferAnalysisHelpers|TestEmitDoWithExplicitDeferStack|TestCompileRangeFuncDeferModule|TestDeferStackOwnerUsesEnclosingSourceFunction|TestRangeFuncDeferHelperNilAndCachePaths|TestEmitDoWithoutExplicitDeferStack|TestNestedRangeFuncDeferAnalysisCombinations|TestDeferStackOwnerCompilesMissingOwner)$'`
- `go test ./ssa -run '^(TestEndDefer|TestDeferToPendingLoopCasesAndFallback|TestTooManyConditionalDefers|TestExplicitDeferStackIR|TestExplicitDeferStackFallbackAndNilBuiltin|TestExplicitDeferStackDrainWithoutLoopCases|TestExplicitDeferStackDrainWithoutRecoverNoop|TestPlainDeferWithoutSavedArgsIR|TestConditionalDeferIR|TestDeferInLoopIR|TestDeferAtomicInLoopIR|TestDeferInLoopMaterializesArgsBeforeFree|TestDeferInLoopContiguousDrainerGeneration)$'`
- `go test ./internal/build`
