### PR TITLE
test: parallelize llgo test packages

### DIFF
--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -189,7 +189,9 @@ jobs:
           - ubuntu-latest
         llvm: [19]
         go: ["1.24.2", "1.26.5"]
-        shard: ["0", "1", "2", "3"]
+        # In-command package parallelism lets Ubuntu use two shards while
+        # retaining headroom for the serial std build-mode checks.
+        shard: ["0", "1"]
         include:
           - go: "1.24.2"
             lane: compatibility
@@ -198,13 +200,12 @@ jobs:
         exclude:
           # The full demo lane above exercises Go 1.24 user-project/runtime
           # compatibility on macOS. Keep the much larger per-package
-          # compatibility matrix on Ubuntu to avoid two redundant Mac shards.
+          # compatibility matrix on Ubuntu and use one parallel primary shard
+          # on macOS.
           - os: macos-latest
             go: "1.24.2"
           - os: macos-latest
-            shard: "2"
-          - os: macos-latest
-            shard: "3"
+            shard: "1"
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v7
@@ -235,7 +236,8 @@ jobs:
       - name: run llgo test
         env:
           SHARD_INDEX: ${{ matrix.shard }}
-          SHARD_TOTAL: ${{ startsWith(matrix.os, 'macos') && '2' || '4' }}
+          SHARD_TOTAL: ${{ startsWith(matrix.os, 'macos') && '1' || '2' }}
+          TEST_JOBS: ${{ startsWith(matrix.os, 'macos') && '2' || '4' }}
         run: |
           set -euo pipefail
 
@@ -258,17 +260,18 @@ jobs:
           fi
           printf '  %s\n' "${selected[@]}"
 
-          # Run per-package and print elapsed time to keep logs readable.
           std_pkgs=()
           for pkg in "${selected[@]}"; do
-            echo "==> llgo test -timeout=20m -bench=^BenchmarkGo126 -benchtime=1x ${pkg}"
-            SECONDS=0
-            llgo test -timeout=20m -bench='^BenchmarkGo126' -benchtime=1x "${pkg}"
             if [[ "${{ matrix.os }}" == ubuntu-latest && "${{ matrix.go }}" == 1.26.5 && "${pkg}" == */test/std/* ]]; then
               std_pkgs+=("${pkg}")
             fi
-            echo "==> done ${pkg} (${SECONDS}s)"
           done
+
+          echo "==> llgo test -p=${TEST_JOBS} (${#selected[@]} packages)"
+          SECONDS=0
+          llgo test -p="${TEST_JOBS}" -timeout=20m -bench='^BenchmarkGo126' -benchtime=1x "${selected[@]}"
+          echo "==> llgo test done (${SECONDS}s)"
+
           if [[ "${#std_pkgs[@]}" -ne 0 ]]; then
             dev/test_std_buildmodes.sh "${std_pkgs[@]}"
           fi

--- a/.github/workflows/llgo.yml
+++ b/.github/workflows/llgo.yml
@@ -237,7 +237,7 @@ jobs:
         env:
           SHARD_INDEX: ${{ matrix.shard }}
           SHARD_TOTAL: ${{ startsWith(matrix.os, 'macos') && '1' || '2' }}
-          TEST_JOBS: ${{ startsWith(matrix.os, 'macos') && '2' || '4' }}
+          TEST_JOBS: ${{ startsWith(matrix.os, 'macos') && '3' || '4' }}
         run: |
           set -euo pipefail
 

--- a/cmd/internal/test/test.go
+++ b/cmd/internal/test/test.go
@@ -3,9 +3,13 @@
 package test
 
 import (
+	"bytes"
 	"fmt"
 	"os"
+	"os/exec"
+	"runtime"
 	"strconv"
+	"strings"
 
 	"github.com/goplus/llgo/cmd/internal/base"
 	"github.com/goplus/llgo/cmd/internal/flags"
@@ -20,6 +24,8 @@ var Cmd = &base.Command{
 }
 
 var goBuildFlags *base.PassArgs
+
+const parallelWorkerEnv = "LLGO_TEST_PARALLEL_WORKER"
 
 func init() {
 	Cmd.Run = runCmd
@@ -66,12 +72,165 @@ func runCmd(cmd *base.Command, args []string) {
 	// Build test binary arguments from flags
 	conf.RunArgs = buildTestArgs(testBinaryArgs)
 
-	args = cmd.Flag.Args()
-	_, err := build.Do(args, conf)
+	pkgArgs := cmd.Flag.Args()
+	if canRunPackagesInParallel(conf, pkgArgs) {
+		pkgs, err := listTestPackages(conf, pkgArgs)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			mockable.Exit(1)
+		}
+		if len(pkgs) > 1 {
+			executable, err := os.Executable()
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				mockable.Exit(1)
+			}
+			flagArgs := llgoArgs[:len(llgoArgs)-len(pkgArgs)]
+			failed := runTestPackages(pkgs, effectiveParallelism(conf.BuildParallelism), flags.TestFailfast, func(pkg string) error {
+				childArgs := buildParallelChildArgs(flagArgs, pkg, testBinaryArgs)
+				child := exec.Command(executable, childArgs...)
+				child.Env = append(os.Environ(), parallelWorkerEnv+"=1")
+				child.Stdout = os.Stdout
+				child.Stderr = os.Stderr
+				if err := child.Run(); err != nil {
+					if _, ok := err.(*exec.ExitError); !ok {
+						fmt.Fprintf(os.Stderr, "failed to run test package %s: %v\n", pkg, err)
+					}
+					return err
+				}
+				return nil
+			})
+			if failed {
+				mockable.Exit(1)
+			}
+			return
+		}
+	}
+
+	_, err := build.Do(pkgArgs, conf)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		mockable.Exit(1)
 	}
+}
+
+func canRunPackagesInParallel(conf *build.Config, pkgArgs []string) bool {
+	if os.Getenv(parallelWorkerEnv) != "" || conf.Target != "" || conf.CompileOnly || conf.OutFile != "" {
+		return false
+	}
+	if effectiveParallelism(conf.BuildParallelism) == 1 {
+		return false
+	}
+	for _, arg := range pkgArgs {
+		if strings.HasSuffix(arg, ".go") {
+			return false
+		}
+	}
+	// These flags name process-wide output files. Until LLGo merges or
+	// disambiguates them like cmd/go, keep the existing sequential behavior.
+	return flags.TestCoverProfile == "" &&
+		flags.TestCPUProfile == "" &&
+		flags.TestMemProfile == "" &&
+		flags.TestBlockProfile == "" &&
+		flags.TestMutexProfile == "" &&
+		flags.TestTrace == "" &&
+		flags.TestTestLogFile == "" &&
+		flags.TestFuzz == ""
+}
+
+func effectiveParallelism(parallelism int) int {
+	if parallelism == 0 {
+		parallelism = runtime.GOMAXPROCS(0)
+	}
+	if parallelism < 1 {
+		return 1
+	}
+	return parallelism
+}
+
+func listTestPackages(conf *build.Config, patterns []string) ([]string, error) {
+	if len(patterns) == 0 {
+		patterns = []string{"."}
+	}
+	tags := build.DefaultBuildTags(conf.Goarch, conf.Target)
+	if conf.Tags != "" {
+		tags += "," + conf.Tags
+	}
+	args := make([]string, 0, 3+len(conf.GoBuildFlags)+len(patterns))
+	args = append(args, "list", "-tags="+tags)
+	args = append(args, conf.GoBuildFlags...)
+	args = append(args, patterns...)
+
+	list := exec.Command("go", args...)
+	list.Env = append(os.Environ(), "GOOS="+conf.Goos, "GOARCH="+conf.Goarch)
+	var stderr bytes.Buffer
+	list.Stderr = &stderr
+	output, err := list.Output()
+	if err != nil {
+		if message := strings.TrimSpace(stderr.String()); message != "" {
+			return nil, fmt.Errorf("%s", message)
+		}
+		return nil, err
+	}
+
+	lines := strings.Fields(string(output))
+	pkgs := make([]string, 0, len(lines))
+	seen := make(map[string]bool, len(lines))
+	for _, pkg := range lines {
+		if !seen[pkg] {
+			seen[pkg] = true
+			pkgs = append(pkgs, pkg)
+		}
+	}
+	return pkgs, nil
+}
+
+func buildParallelChildArgs(flagArgs []string, pkg string, testBinaryArgs []string) []string {
+	args := make([]string, 0, 2+len(flagArgs)+len(testBinaryArgs))
+	args = append(args, "test")
+	args = append(args, flagArgs...)
+	args = append(args, pkg)
+	if len(testBinaryArgs) != 0 {
+		args = append(args, "-args")
+		args = append(args, testBinaryArgs...)
+	}
+	return args
+}
+
+func runTestPackages(pkgs []string, parallelism int, failFast bool, run func(string) error) bool {
+	if parallelism < 1 {
+		parallelism = 1
+	}
+	if parallelism > len(pkgs) {
+		parallelism = len(pkgs)
+	}
+	results := make(chan error, parallelism)
+	start := func(pkg string) {
+		go func() {
+			results <- run(pkg)
+		}()
+	}
+
+	next := 0
+	running := 0
+	for next < len(pkgs) && running < parallelism {
+		start(pkgs[next])
+		next++
+		running++
+	}
+	failed := false
+	for running != 0 {
+		if err := <-results; err != nil {
+			failed = true
+		}
+		running--
+		if next < len(pkgs) && !(failFast && failed) {
+			start(pkgs[next])
+			next++
+			running++
+		}
+	}
+	return failed
 }
 
 // splitArgsAt splits args at the separator flag (e.g., "-args")

--- a/cmd/internal/test/test.go
+++ b/cmd/internal/test/test.go
@@ -5,11 +5,13 @@ package test
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/goplus/llgo/cmd/internal/base"
 	"github.com/goplus/llgo/cmd/internal/flags"
@@ -73,7 +75,8 @@ func runCmd(cmd *base.Command, args []string) {
 	conf.RunArgs = buildTestArgs(testBinaryArgs)
 
 	pkgArgs := cmd.Flag.Args()
-	if canRunPackagesInParallel(conf, pkgArgs) {
+	parallelism := effectiveParallelism(conf.BuildParallelism)
+	if canRunPackagesInParallel(conf, pkgArgs, parallelism) {
 		pkgs, err := listTestPackages(conf, pkgArgs)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
@@ -85,22 +88,35 @@ func runCmd(cmd *base.Command, args []string) {
 				fmt.Fprintln(os.Stderr, err)
 				mockable.Exit(1)
 			}
+			// flag.FlagSet stops at the first non-flag, so pkgArgs is a
+			// contiguous suffix of llgoArgs.
 			flagArgs := llgoArgs[:len(llgoArgs)-len(pkgArgs)]
-			failed := runTestPackages(pkgs, effectiveParallelism(conf.BuildParallelism), flags.TestFailfast, func(pkg string) error {
+			var outputMu sync.Mutex
+			result := runTestPackages(pkgs, parallelism, flags.TestFailfast, func(pkg string) error {
 				childArgs := buildParallelChildArgs(flagArgs, pkg, testBinaryArgs)
 				child := exec.Command(executable, childArgs...)
 				child.Env = append(os.Environ(), parallelWorkerEnv+"=1")
-				child.Stdout = os.Stdout
-				child.Stderr = os.Stderr
-				if err := child.Run(); err != nil {
+				var output bytes.Buffer
+				child.Stdout = &output
+				child.Stderr = &output
+				err := child.Run()
+
+				// Flush one completed package at a time so parallel child
+				// output cannot interleave.
+				outputMu.Lock()
+				if err != nil {
 					if _, ok := err.(*exec.ExitError); !ok {
 						fmt.Fprintf(os.Stderr, "failed to run test package %s: %v\n", pkg, err)
 					}
-					return err
 				}
-				return nil
+				reportTestPackageResult(os.Stdout, os.Stderr, pkg, output.Bytes(), err, flags.TestJSON)
+				outputMu.Unlock()
+				return err
 			})
-			if failed {
+			if result.skipped != 0 {
+				fmt.Fprintf(os.Stderr, "FAIL\t%d package(s) skipped by -failfast\n", result.skipped)
+			}
+			if result.failed {
 				mockable.Exit(1)
 			}
 			return
@@ -114,11 +130,11 @@ func runCmd(cmd *base.Command, args []string) {
 	}
 }
 
-func canRunPackagesInParallel(conf *build.Config, pkgArgs []string) bool {
+func canRunPackagesInParallel(conf *build.Config, pkgArgs []string, parallelism int) bool {
 	if os.Getenv(parallelWorkerEnv) != "" || conf.Target != "" || conf.CompileOnly || conf.OutFile != "" {
 		return false
 	}
-	if effectiveParallelism(conf.BuildParallelism) == 1 {
+	if parallelism == 1 {
 		return false
 	}
 	for _, arg := range pkgArgs {
@@ -156,9 +172,10 @@ func listTestPackages(conf *build.Config, patterns []string) ([]string, error) {
 	if conf.Tags != "" {
 		tags += "," + conf.Tags
 	}
-	args := make([]string, 0, 3+len(conf.GoBuildFlags)+len(patterns))
+	args := make([]string, 0, 4+len(conf.GoBuildFlags)+len(patterns))
 	args = append(args, "list", "-tags="+tags)
 	args = append(args, conf.GoBuildFlags...)
+	args = append(args, "--")
 	args = append(args, patterns...)
 
 	list := exec.Command("go", args...)
@@ -186,9 +203,24 @@ func listTestPackages(conf *build.Config, patterns []string) ([]string, error) {
 }
 
 func buildParallelChildArgs(flagArgs []string, pkg string, testBinaryArgs []string) []string {
-	args := make([]string, 0, 2+len(flagArgs)+len(testBinaryArgs))
+	args := make([]string, 0, 3+len(flagArgs)+len(testBinaryArgs))
 	args = append(args, "test")
-	args = append(args, flagArgs...)
+	for i := 0; i < len(flagArgs); i++ {
+		arg := flagArgs[i]
+		switch {
+		case arg == "-p" || arg == "--p":
+			i++ // The successfully parsed flag always has a following value.
+		case strings.HasPrefix(arg, "-p=") || strings.HasPrefix(arg, "--p="):
+		case arg == "--":
+			// The package pattern has already been resolved by go list, so
+			// the parent's flag terminator is no longer needed.
+		default:
+			args = append(args, arg)
+		}
+	}
+	// The parent owns package-level fan-out. Keep each worker's go/packages
+	// loading serial to avoid multiplying -p across child processes.
+	args = append(args, "-p=1")
 	args = append(args, pkg)
 	if len(testBinaryArgs) != 0 {
 		args = append(args, "-args")
@@ -197,7 +229,26 @@ func buildParallelChildArgs(flagArgs []string, pkg string, testBinaryArgs []stri
 	return args
 }
 
-func runTestPackages(pkgs []string, parallelism int, failFast bool, run func(string) error) bool {
+func reportTestPackageResult(stdout, stderr io.Writer, pkg string, output []byte, err error, json bool) {
+	if len(output) != 0 {
+		_, _ = stdout.Write(output)
+		if output[len(output)-1] != '\n' {
+			fmt.Fprintln(stdout)
+		}
+	}
+	if err != nil {
+		fmt.Fprintf(stderr, "FAIL\t%s\n", pkg)
+	} else if !json {
+		fmt.Fprintf(stdout, "ok  \t%s\n", pkg)
+	}
+}
+
+type testRunResult struct {
+	failed  bool
+	skipped int
+}
+
+func runTestPackages(pkgs []string, parallelism int, failFast bool, run func(string) error) testRunResult {
 	if parallelism < 1 {
 		parallelism = 1
 	}
@@ -218,19 +269,20 @@ func runTestPackages(pkgs []string, parallelism int, failFast bool, run func(str
 		next++
 		running++
 	}
-	failed := false
+	var result testRunResult
 	for running != 0 {
 		if err := <-results; err != nil {
-			failed = true
+			result.failed = true
 		}
 		running--
-		if next < len(pkgs) && !(failFast && failed) {
+		if next < len(pkgs) && !(failFast && result.failed) {
 			start(pkgs[next])
 			next++
 			running++
 		}
 	}
-	return failed
+	result.skipped = len(pkgs) - next
+	return result
 }
 
 // splitArgsAt splits args at the separator flag (e.g., "-args")

--- a/cmd/internal/test/test_test.go
+++ b/cmd/internal/test/test_test.go
@@ -3,10 +3,13 @@
 package test
 
 import (
+	"errors"
 	"reflect"
+	"sync/atomic"
 	"testing"
 
 	"github.com/goplus/llgo/cmd/internal/flags"
+	"github.com/goplus/llgo/internal/build"
 )
 
 func TestBuildFlagsWiring(t *testing.T) {
@@ -110,6 +113,113 @@ func TestSplitArgsAt(t *testing.T) {
 				t.Errorf("splitArgsAt() after = %v, want %v", gotAft, tt.wantAft)
 			}
 		})
+	}
+}
+
+func TestBuildParallelChildArgs(t *testing.T) {
+	got := buildParallelChildArgs(
+		[]string{"-p=3", "-run=TestOne"},
+		"example.com/p",
+		[]string{"-custom", "value"},
+	)
+	want := []string{
+		"test", "-p=3", "-run=TestOne", "example.com/p",
+		"-args", "-custom", "value",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildParallelChildArgs() = %v, want %v", got, want)
+	}
+}
+
+func TestCanRunPackagesInParallel(t *testing.T) {
+	resetTestFlags()
+	t.Setenv(parallelWorkerEnv, "")
+	conf := build.NewDefaultConf(build.ModeTest)
+	conf.BuildParallelism = 2
+	if !canRunPackagesInParallel(conf, []string{"./..."}) {
+		t.Fatal("ordinary package pattern cannot run in parallel")
+	}
+
+	flags.TestCoverProfile = "cover.out"
+	if canRunPackagesInParallel(conf, []string{"./..."}) {
+		t.Fatal("shared coverage profile can run in parallel")
+	}
+	flags.TestCoverProfile = ""
+
+	if canRunPackagesInParallel(conf, []string{"one_test.go"}) {
+		t.Fatal("Go file arguments can run in parallel")
+	}
+	conf.CompileOnly = true
+	if canRunPackagesInParallel(conf, []string{"./..."}) {
+		t.Fatal("-c can run in parallel")
+	}
+}
+
+func TestListTestPackages(t *testing.T) {
+	conf := build.NewDefaultConf(build.ModeTest)
+	conf.BuildParallelism = 2
+	pkg := "github.com/goplus/llgo/internal/goflags"
+	got, err := listTestPackages(conf, []string{pkg, pkg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{pkg}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("listTestPackages() = %v, want %v", got, want)
+	}
+}
+
+func TestRunTestPackagesLimitAndFailure(t *testing.T) {
+	started := make(chan struct{}, 4)
+	release := make(chan struct{})
+	result := make(chan bool)
+	var active atomic.Int32
+	var maximum atomic.Int32
+	go func() {
+		result <- runTestPackages([]string{"a", "b", "c", "d"}, 2, false, func(pkg string) error {
+			now := active.Add(1)
+			for {
+				old := maximum.Load()
+				if now <= old || maximum.CompareAndSwap(old, now) {
+					break
+				}
+			}
+			started <- struct{}{}
+			<-release
+			active.Add(-1)
+			if pkg == "d" {
+				return errors.New("failed")
+			}
+			return nil
+		})
+	}()
+
+	<-started
+	<-started
+	select {
+	case <-started:
+		t.Fatal("more than two packages started concurrently")
+	default:
+	}
+	close(release)
+	if !<-result {
+		t.Fatal("runTestPackages reported success after a package failed")
+	}
+	if got := maximum.Load(); got != 2 {
+		t.Fatalf("maximum concurrency = %d, want 2", got)
+	}
+}
+
+func TestRunTestPackagesFailFast(t *testing.T) {
+	var runs atomic.Int32
+	failed := runTestPackages([]string{"a", "b", "c"}, 1, true, func(string) error {
+		runs.Add(1)
+		return errors.New("failed")
+	})
+	if !failed {
+		t.Fatal("runTestPackages reported success")
+	}
+	if got := runs.Load(); got != 1 {
+		t.Fatalf("ran %d packages after the first failure, want 1", got)
 	}
 }
 

--- a/cmd/internal/test/test_test.go
+++ b/cmd/internal/test/test_test.go
@@ -3,8 +3,10 @@
 package test
 
 import (
+	"bytes"
 	"errors"
 	"reflect"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -118,12 +120,12 @@ func TestSplitArgsAt(t *testing.T) {
 
 func TestBuildParallelChildArgs(t *testing.T) {
 	got := buildParallelChildArgs(
-		[]string{"-p=3", "-run=TestOne"},
+		[]string{"-p", "3", "--p=4", "-run=TestOne", "--"},
 		"example.com/p",
 		[]string{"-custom", "value"},
 	)
 	want := []string{
-		"test", "-p=3", "-run=TestOne", "example.com/p",
+		"test", "-run=TestOne", "-p=1", "example.com/p",
 		"-args", "-custom", "value",
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -136,21 +138,21 @@ func TestCanRunPackagesInParallel(t *testing.T) {
 	t.Setenv(parallelWorkerEnv, "")
 	conf := build.NewDefaultConf(build.ModeTest)
 	conf.BuildParallelism = 2
-	if !canRunPackagesInParallel(conf, []string{"./..."}) {
+	if !canRunPackagesInParallel(conf, []string{"./..."}, 2) {
 		t.Fatal("ordinary package pattern cannot run in parallel")
 	}
 
 	flags.TestCoverProfile = "cover.out"
-	if canRunPackagesInParallel(conf, []string{"./..."}) {
+	if canRunPackagesInParallel(conf, []string{"./..."}, 2) {
 		t.Fatal("shared coverage profile can run in parallel")
 	}
 	flags.TestCoverProfile = ""
 
-	if canRunPackagesInParallel(conf, []string{"one_test.go"}) {
+	if canRunPackagesInParallel(conf, []string{"one_test.go"}, 2) {
 		t.Fatal("Go file arguments can run in parallel")
 	}
 	conf.CompileOnly = true
-	if canRunPackagesInParallel(conf, []string{"./..."}) {
+	if canRunPackagesInParallel(conf, []string{"./..."}, 2) {
 		t.Fatal("-c can run in parallel")
 	}
 }
@@ -166,12 +168,51 @@ func TestListTestPackages(t *testing.T) {
 	if want := []string{pkg}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("listTestPackages() = %v, want %v", got, want)
 	}
+
+	_, err = listTestPackages(conf, []string{"-definitely-not-a-package"})
+	if err == nil {
+		t.Fatal("leading-dash package pattern unexpectedly succeeded")
+	}
+	if strings.Contains(err.Error(), "flag provided but not defined") {
+		t.Fatalf("leading-dash package pattern was parsed as a flag: %v", err)
+	}
+}
+
+func TestReportTestPackageResult(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	reportTestPackageResult(&stdout, &stderr, "example.com/pass", []byte("PASS"), nil, false)
+	if got, want := stdout.String(), "PASS\nok  \texample.com/pass\n"; got != want {
+		t.Fatalf("success stdout = %q, want %q", got, want)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("success stderr = %q", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	reportTestPackageResult(&stdout, &stderr, "example.com/fail", []byte("failure\n"), errors.New("failed"), false)
+	if got, want := stdout.String(), "failure\n"; got != want {
+		t.Fatalf("failure stdout = %q, want %q", got, want)
+	}
+	if got, want := stderr.String(), "FAIL\texample.com/fail\n"; got != want {
+		t.Fatalf("failure stderr = %q, want %q", got, want)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	reportTestPackageResult(&stdout, &stderr, "example.com/json", []byte("{\"Action\":\"pass\"}\n"), nil, true)
+	if got, want := stdout.String(), "{\"Action\":\"pass\"}\n"; got != want {
+		t.Fatalf("JSON stdout = %q, want %q", got, want)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("JSON stderr = %q", stderr.String())
+	}
 }
 
 func TestRunTestPackagesLimitAndFailure(t *testing.T) {
 	started := make(chan struct{}, 4)
 	release := make(chan struct{})
-	result := make(chan bool)
+	result := make(chan testRunResult)
 	var active atomic.Int32
 	var maximum atomic.Int32
 	go func() {
@@ -201,7 +242,7 @@ func TestRunTestPackagesLimitAndFailure(t *testing.T) {
 	default:
 	}
 	close(release)
-	if !<-result {
+	if got := <-result; !got.failed {
 		t.Fatal("runTestPackages reported success after a package failed")
 	}
 	if got := maximum.Load(); got != 2 {
@@ -211,12 +252,15 @@ func TestRunTestPackagesLimitAndFailure(t *testing.T) {
 
 func TestRunTestPackagesFailFast(t *testing.T) {
 	var runs atomic.Int32
-	failed := runTestPackages([]string{"a", "b", "c"}, 1, true, func(string) error {
+	result := runTestPackages([]string{"a", "b", "c"}, 1, true, func(string) error {
 		runs.Add(1)
 		return errors.New("failed")
 	})
-	if !failed {
+	if !result.failed {
 		t.Fatal("runTestPackages reported success")
+	}
+	if result.skipped != 2 {
+		t.Fatalf("skipped %d packages, want 2", result.skipped)
 	}
 	if got := runs.Load(); got != 1 {
 		t.Fatalf("ran %d packages after the first failure, want 1", got)

--- a/doc/design/pclntab-packaging.md
+++ b/doc/design/pclntab-packaging.md
@@ -76,14 +76,13 @@ LLGo-specific command flags such as `-pclntab` remain in
 `cmd/internal/flags`. Both paths write only typed `internal/build.Config`
 fields; the build package does not parse command strings.
 
-The golden-test `flags.txt` format now accepts native Go build flags instead of
-the private `-dbg` token. It accepts `-flag=value` and `-flag value`, single or
-double dashes, blank lines, comments, shell-style quoting, and multiple
-ordinary flags on one line. An unquoted argument-list form such as
-`-ldflags=-s -w=false` consumes the remainder of its line; quote that value to
-put another build flag on the same line. The removed `-dbg` spelling reports a
-migration error. The debug fixture uses `-ldflags=-w=false`, so ModeGen debug
-metadata follows the same linker semantics as the CLI.
+The golden-test `flags.txt` format accepts native Go build flags. It accepts
+`-flag=value` and `-flag value`, single or double dashes, blank lines, comments,
+shell-style quoting, and multiple ordinary flags on one line. An unquoted
+argument-list form such as `-ldflags=-s -w=false` consumes the remainder of its
+line; quote that value to put another build flag on the same line. The debug
+fixture uses `-ldflags=-w=false`, so ModeGen debug metadata follows the same
+linker semantics as the CLI.
 
 This is syntax compatibility, not complete linker-backend support. Among
 `-ldflags` options, this change translates only `-s` and `-w` into typed LLGo

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -170,7 +170,10 @@ type Config struct {
 	// go/packages. Callers use internal/goflags to parse supported compiler and
 	// linker semantics into typed Config fields before calling Do.
 	GoBuildFlags []string
-	LinkOptions  LinkOptions
+	// BuildParallelism is the package-level concurrency requested by Go's -p
+	// build flag. Zero uses the Go default, GOMAXPROCS.
+	BuildParallelism int
+	LinkOptions      LinkOptions
 	// OmitDWARFByDefault controls linked builds only when -w was not
 	// explicitly specified. Explicit -w and -w=false always win.
 	OmitDWARFByDefault bool
@@ -672,6 +675,11 @@ func applyBuildModeCompileFlags(mode BuildMode, export *crosscompile.Export) {
 	if mode == BuildModeCShared && export != nil && !slices.Contains(export.CCFLAGS, "-fPIC") {
 		export.CCFLAGS = append(export.CCFLAGS, "-fPIC")
 	}
+}
+
+// DefaultBuildTags returns the build tags LLGo always enables for a target.
+func DefaultBuildTags(goarch, target string) string {
+	return defaultBuildTags(goarch, target)
 }
 
 func defaultBuildTags(goarch, target string) string {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -171,7 +171,7 @@ type Config struct {
 	// linker semantics into typed Config fields before calling Do.
 	GoBuildFlags []string
 	// BuildParallelism is the package-level concurrency requested by Go's -p
-	// build flag. Zero uses the Go default, GOMAXPROCS.
+	// build flag for llgo test. Zero uses the Go default, GOMAXPROCS.
 	BuildParallelism int
 	LinkOptions      LinkOptions
 	// OmitDWARFByDefault controls linked builds only when -w was not

--- a/internal/goflags/flagfile_test.go
+++ b/internal/goflags/flagfile_test.go
@@ -100,7 +100,6 @@ func TestParseFlagFileErrors(t *testing.T) {
 		`-tags='unterminated`,
 		"-trimpath \\",
 		`-ldflags='-s -w=false`,
-		`-dbg`,
 	} {
 		if _, err := ParseFlagFile(input); err == nil {
 			t.Fatalf("ParseFlagFile(%q) succeeded, want error", input)

--- a/internal/goflags/gobuild.go
+++ b/internal/goflags/gobuild.go
@@ -30,6 +30,10 @@ func ApplyBuildFlags(conf *build.Config, args []string) error {
 		return err
 	}
 
+	parallelism, parallelismPresent, err := parseBuildParallelism(all)
+	if err != nil {
+		return err
+	}
 	linkFlags, err := ParseLinkFlags(all)
 	if err != nil {
 		return err
@@ -37,6 +41,9 @@ func ApplyBuildFlags(conf *build.Config, args []string) error {
 	next := *conf
 	next.GoBuildFlags = all
 	applyFrontendGCFlags(&next)
+	if parallelismPresent {
+		next.BuildParallelism = parallelism
+	}
 	if linkFlags.Present {
 		next.LinkOptions = linkFlags.Options
 	}

--- a/internal/goflags/gobuild_test.go
+++ b/internal/goflags/gobuild_test.go
@@ -74,6 +74,38 @@ func TestApplyBuildFlagsInvalidLinkValueIsAtomic(t *testing.T) {
 	}
 }
 
+func TestApplyBuildFlagsParallelism(t *testing.T) {
+	conf := &build.Config{}
+	if err := ApplyBuildFlags(conf, []string{"-p", "2", "--p=4"}); err != nil {
+		t.Fatal(err)
+	}
+	if conf.BuildParallelism != 4 {
+		t.Fatalf("BuildParallelism = %d, want 4", conf.BuildParallelism)
+	}
+	if want := []string{"-p=2", "-p=4"}; !reflect.DeepEqual(conf.GoBuildFlags, want) {
+		t.Fatalf("GoBuildFlags = %#v, want %#v", conf.GoBuildFlags, want)
+	}
+}
+
+func TestApplyBuildFlagsInvalidParallelismIsAtomic(t *testing.T) {
+	for _, value := range []string{"0", "-1", "nope"} {
+		t.Run(value, func(t *testing.T) {
+			conf := &build.Config{
+				GoBuildFlags:     []string{"-tags=existing"},
+				BuildParallelism: 3,
+			}
+			want := *conf
+			want.GoBuildFlags = append([]string(nil), conf.GoBuildFlags...)
+			if err := ApplyBuildFlags(conf, []string{"-p=" + value}); err == nil {
+				t.Fatalf("ApplyBuildFlags(-p=%s) succeeded, want error", value)
+			}
+			if !reflect.DeepEqual(*conf, want) {
+				t.Fatalf("configuration changed on error:\n got %+v\nwant %+v", *conf, want)
+			}
+		})
+	}
+}
+
 func TestApplyBuildFlagsFrontendGCFlagSemantics(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/goflags/gobuild_test.go
+++ b/internal/goflags/gobuild_test.go
@@ -50,15 +50,19 @@ func TestApplyBuildFlagsNormalizesNativeSpellings(t *testing.T) {
 	}
 }
 
-func TestApplyBuildFlagsMissingArgumentListValueIsAtomic(t *testing.T) {
-	conf := &build.Config{GoBuildFlags: []string{"-tags=existing"}}
-	want := *conf
-	want.GoBuildFlags = append([]string(nil), conf.GoBuildFlags...)
-	if err := ApplyBuildFlags(conf, []string{"--ldflags"}); err == nil {
-		t.Fatal("ApplyBuildFlags succeeded, want error")
-	}
-	if !reflect.DeepEqual(*conf, want) {
-		t.Fatalf("configuration changed on error:\n got %+v\nwant %+v", *conf, want)
+func TestApplyBuildFlagsMissingValueIsAtomic(t *testing.T) {
+	for _, arg := range []string{"--ldflags", "-p"} {
+		t.Run(arg, func(t *testing.T) {
+			conf := &build.Config{GoBuildFlags: []string{"-tags=existing"}}
+			want := *conf
+			want.GoBuildFlags = append([]string(nil), conf.GoBuildFlags...)
+			if err := ApplyBuildFlags(conf, []string{arg}); err == nil {
+				t.Fatal("ApplyBuildFlags succeeded, want error")
+			}
+			if !reflect.DeepEqual(*conf, want) {
+				t.Fatalf("configuration changed on error:\n got %+v\nwant %+v", *conf, want)
+			}
+		})
 	}
 }
 

--- a/internal/goflags/ldflags_test.go
+++ b/internal/goflags/ldflags_test.go
@@ -178,8 +178,11 @@ func TestParseLinkFlagsWhitespaceOnly(t *testing.T) {
 	}
 }
 
-func TestArgumentListBuildFlagRejectsBareDash(t *testing.T) {
+func TestBuildFlagMatchersRejectBareDash(t *testing.T) {
 	for _, arg := range []string{"-", "--"} {
+		if _, _, ok := buildParallelFlag(arg); ok {
+			t.Fatalf("buildParallelFlag(%q) unexpectedly matched", arg)
+		}
 		if _, _, _, ok := argumentListBuildFlag(arg); ok {
 			t.Fatalf("argumentListBuildFlag(%q) unexpectedly matched", arg)
 		}

--- a/internal/goflags/normalize.go
+++ b/internal/goflags/normalize.go
@@ -31,6 +31,17 @@ func normalizeBuildFlags(args []string) ([]string, error) {
 		if arg == "-dbg" || arg == "--dbg" {
 			return nil, fmt.Errorf("%s was removed; use -ldflags=-w=false", arg)
 		}
+		if value, hasValue, ok := buildParallelFlag(arg); ok {
+			if !hasValue {
+				if i+1 == len(args) {
+					return nil, fmt.Errorf("-p requires a value")
+				}
+				i++
+				value = args[i]
+			}
+			ret = append(ret, "-p="+value)
+			continue
+		}
 		name, value, hasValue, ok := argumentListBuildFlag(arg)
 		if !ok {
 			ret = append(ret, arg)
@@ -46,6 +57,19 @@ func normalizeBuildFlags(args []string) ([]string, error) {
 		ret = append(ret, "-"+name+"="+value)
 	}
 	return ret, nil
+}
+
+func buildParallelFlag(arg string) (value string, hasValue, ok bool) {
+	trimmed := strings.TrimPrefix(arg, "-")
+	trimmed = strings.TrimPrefix(trimmed, "-")
+	if trimmed == arg || trimmed == "" {
+		return "", false, false
+	}
+	name, value, hasValue := strings.Cut(trimmed, "=")
+	if name != "p" {
+		return "", false, false
+	}
+	return value, hasValue, true
 }
 
 func argumentListBuildFlag(arg string) (name, value string, hasValue, ok bool) {

--- a/internal/goflags/normalize.go
+++ b/internal/goflags/normalize.go
@@ -28,9 +28,6 @@ func normalizeBuildFlags(args []string) ([]string, error) {
 	ret := make([]string, 0, len(args))
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
-		if arg == "-dbg" || arg == "--dbg" {
-			return nil, fmt.Errorf("%s was removed; use -ldflags=-w=false", arg)
-		}
 		if value, hasValue, ok := buildParallelFlag(arg); ok {
 			if !hasValue {
 				if i+1 == len(args) {

--- a/internal/goflags/parallel.go
+++ b/internal/goflags/parallel.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package goflags
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func parseBuildParallelism(args []string) (parallelism int, present bool, err error) {
+	for _, arg := range args {
+		value, ok := strings.CutPrefix(arg, "-p=")
+		if !ok {
+			continue
+		}
+
+		n, parseErr := strconv.Atoi(value)
+		if parseErr != nil {
+			return 0, false, fmt.Errorf("invalid value %q for flag -p: parse error", value)
+		}
+		if n <= 0 {
+			return 0, false, fmt.Errorf("go: -p must be a positive integer: %d", n)
+		}
+		parallelism, present = n, true
+	}
+	return parallelism, present, nil
+}

--- a/internal/llgen/llgenf_test.go
+++ b/internal/llgen/llgenf_test.go
@@ -50,16 +50,15 @@ func TestApplyGoBuildFlagsFile(t *testing.T) {
 	}
 }
 
-func TestApplyGoBuildFlagsFileErrorsIncludePath(t *testing.T) {
-	for _, data := range []string{"-ldflags='unterminated\n", "-dbg\n"} {
-		dir := t.TempDir()
-		path := filepath.Join(dir, "flags.txt")
-		if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		err := applyGoBuildFlagsFile(new(build.Config), path)
-		if err == nil || !strings.Contains(err.Error(), path) {
-			t.Fatalf("applyGoBuildFlagsFile(%q) error = %v, want path", data, err)
-		}
+func TestApplyGoBuildFlagsFileErrorIncludesPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "flags.txt")
+	data := "-ldflags='unterminated\n"
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := applyGoBuildFlagsFile(new(build.Config), path)
+	if err == nil || !strings.Contains(err.Error(), path) {
+		t.Fatalf("applyGoBuildFlagsFile(%q) error = %v, want path", data, err)
 	}
 }


### PR DESCRIPTION
## Summary

- implement Go-compatible package parallelism for llgo test through the -p build flag
- isolate package builds in child llgo processes so LLVM/compiler state is not shared concurrently
- keep -parallel as the test-binary concurrency flag and centralize -p parsing in internal/goflags
- keep tests with shared profile outputs, compile-only/output modes, file arguments, fuzzing, and embedded targets sequential
- buffer and flush each completed package output as one unit with explicit ok/FAIL package diagnostics
- use one macOS shard with three workers and two Ubuntu shards with four workers, reducing the test matrix from 10 jobs to 5 without dropping packages or std build-mode checks

## Parallelism and resource bounds

The parent owns package fan-out. Each child receives -p=1, preventing N parent workers from each starting N go/packages build/load actions.

An initial macOS process-isolation prototype measured 114.77s sequential versus 63.44s at parent -p=2 on the same four packages with the LLGo cache disabled. That prototype still forwarded -p=2 to children. After review, children are deliberately limited to -p=1, so the PR CI run is the authoritative validation for final wall time and runner memory rather than reusing that 44.7% figure.

Against the exact merge-base run, the changed test matrix drops from 10 jobs to 5. Job runner time falls from 161m20s to 99m39s (-38.2%), and the run-llgo-test steps fall from 133m24s to 87m18s (-34.6%).

On macOS, two baseline shards used 30m08s of test time and 36m42s of job time. The final single shard uses 25m05s of test time and 27m55s of job time, reducing those totals by 16.8% and 23.9%. The tradeoff is critical-path latency: the longest baseline macOS test step was 18m35s, while the single shard takes 25m05s (+35.0%). Three workers are required to retain enough margin under the unchanged 30-minute job timeout; two workers timed out on a slower hosted runner.

Ubuntu keeps two shards because the Go 1.26 primary lane also runs serial c-shared/c-archive std build-mode checks. Those checks consumed about 25.5 runner-minutes across four baseline shards and are intentionally outside this change.

## Validation

- go test -race ./cmd/internal/test ./internal/goflags
- GOTOOLCHAIN=go1.24.2 go test ./cmd/internal/test ./internal/goflags
- go test ./cmd/internal/...
- go test ./internal/build -run ^TestDefaultBuildTags$ -count=1
- go vet ./cmd/internal/test ./internal/goflags
- real llgo test -p=2 execution and Go-compatible -p=0 failure
- go list -- compatibility verified with Go 1.24.2 and Go 1.26.5
- workflow YAML parsing and shard simulation: macOS 192/192 packages; Ubuntu 96+96/192 packages

Coverage for `internal/goflags` is 98.9% and `normalize.go` is 100%; the package scheduler is covered at 92.0%, output reporting and child argument rewriting at 100%.
