### PR TITLE
fix(locality): retain alternate package declaration owners

### DIFF
--- a/cl/compile.go
+++ b/cl/compile.go
@@ -2087,7 +2087,7 @@ func newPackageEx(prog llssa.Program, ct *CallerTracking, patches Patches, rewri
 	if err = ParsePkgSyntax(prog, pkgProg.Fset, pkgTypes, files); err != nil {
 		return nil, nil, err
 	}
-	if err = prog.ValidateLocalities(llssa.PathOf(pkgTypes)); err != nil {
+	if err = prog.ValidateLocalitiesFor(pkgTypes); err != nil {
 		return nil, nil, err
 	}
 	if err = validateLocalInitializers(prog, pkgTypes); err != nil {

--- a/cl/import.go
+++ b/cl/import.go
@@ -788,7 +788,7 @@ func ParsePkgSyntax(prog llssa.Program, fset *token.FileSet, pkg *types.Package,
 						return err
 					}
 					for _, variable := range vars {
-						prog.SetLocalityInfo(llssa.FullName(pkg, variable.Name), variable.Info)
+						prog.DeclareLocality(pkg, variable.Name, variable.Info)
 					}
 					continue
 				}

--- a/cl/locality.go
+++ b/cl/locality.go
@@ -36,14 +36,16 @@ func PrepareLocalVariables(prog llssa.Program, fset *token.FileSet, pkg *types.P
 		return nil
 	}
 	path := llssa.PathOf(pkg)
-	prepared, err := locality.Prepare(fset, path, pkg, info, files, packageLocalities(prog, path))
+	decls := prog.PackageLocalitiesFor(pkg)
+	prepared, err := locality.Prepare(fset, path, pkg, info, files, localityInfos(path, decls))
 	if err != nil {
 		return err
 	}
 	for name, local := range prepared {
 		prog.SetLocalityInfo(llssa.FullName(pkg, name), local)
 	}
-	for fullName := range prog.PackageLocalities(path) {
+	decls = prog.PackageLocalitiesFor(pkg)
+	for fullName := range decls {
 		name := strings.TrimPrefix(fullName, path+".")
 		object, _ := pkg.Scope().Lookup(name).(*types.Var)
 		if object == nil {
@@ -55,7 +57,7 @@ func PrepareLocalVariables(prog llssa.Program, fset *token.FileSet, pkg *types.P
 		}
 		prog.SetLocalStorage(fullName, localitylayout.StorageForType(object.Type()))
 	}
-	_, err = planLocalPackage(prog, pkg)
+	_, err = planLocalPackageWithDecls(prog, pkg, decls)
 	return err
 }
 
@@ -64,9 +66,13 @@ func validateLocalInitializers(prog llssa.Program, pkg *types.Package) error {
 }
 
 func packageLocalities(prog llssa.Program, pkgPath string) map[string]locality.Info {
+	return localityInfos(pkgPath, prog.PackageLocalities(pkgPath))
+}
+
+func localityInfos(pkgPath string, decls map[string]llssa.VariableLocality) map[string]locality.Info {
 	prefix := pkgPath + "."
 	ret := make(map[string]locality.Info)
-	for name, info := range prog.PackageLocalities(pkgPath) {
+	for name, info := range decls {
 		ret[strings.TrimPrefix(name, prefix)] = info.Info
 	}
 	return ret
@@ -77,8 +83,15 @@ func planLocalPackage(prog llssa.Program, pkg *types.Package) (localitylayout.Pa
 		return localitylayout.Package{}, nil
 	}
 	path := llssa.PathOf(pkg)
+	return planLocalPackageWithDecls(prog, pkg, prog.PackageLocalities(path))
+}
+
+func planLocalPackageWithDecls(prog llssa.Program, pkg *types.Package, decls map[string]llssa.VariableLocality) (localitylayout.Package, error) {
+	if pkg == nil {
+		return localitylayout.Package{}, nil
+	}
+	path := llssa.PathOf(pkg)
 	prefix := path + "."
-	decls := prog.PackageLocalities(path)
 	input := make([]localitylayout.Declaration, 0, len(decls))
 	for fullName := range decls {
 		_, info, _, err := prog.ResolveLocality(fullName)

--- a/cl/locality.go
+++ b/cl/locality.go
@@ -32,6 +32,22 @@ import (
 // construction, then records the storage strategy selected by the independent
 // package-layout planner.
 func PrepareLocalVariables(prog llssa.Program, fset *token.FileSet, pkg *types.Package, info *types.Info, files []*ast.File) error {
+	if err := prepareLocalVariables(prog, fset, pkg, info, files); err != nil {
+		return err
+	}
+	prog.ActivateLocalitiesFor(pkg)
+	return nil
+}
+
+// PrepareInactiveLocalVariables prepares declarations from an alternate
+// package without making them affect the program-wide LocalContext decision.
+// The build driver activates an alternate package only when its canonical
+// package participates in the effective dependency graph.
+func PrepareInactiveLocalVariables(prog llssa.Program, fset *token.FileSet, pkg *types.Package, info *types.Info, files []*ast.File) error {
+	return prepareLocalVariables(prog, fset, pkg, info, files)
+}
+
+func prepareLocalVariables(prog llssa.Program, fset *token.FileSet, pkg *types.Package, info *types.Info, files []*ast.File) error {
 	if pkg == nil || info == nil {
 		return nil
 	}

--- a/cl/locality.go
+++ b/cl/locality.go
@@ -42,7 +42,7 @@ func PrepareLocalVariables(prog llssa.Program, fset *token.FileSet, pkg *types.P
 		return err
 	}
 	for name, local := range prepared {
-		prog.SetLocalityInfo(llssa.FullName(pkg, name), local)
+		prog.SetLocalityInfoFor(pkg, llssa.FullName(pkg, name), local)
 	}
 	decls = prog.PackageLocalitiesFor(pkg)
 	for fullName := range decls {
@@ -51,22 +51,26 @@ func PrepareLocalVariables(prog llssa.Program, fset *token.FileSet, pkg *types.P
 		if object == nil {
 			return fmt.Errorf("locality layout: package %s has no variable %s", path, name)
 		}
-		_, _, _, err := prog.ResolveLocality(fullName)
+		_, _, _, err := prog.ResolveLocalityFor(pkg, fullName)
 		if err != nil {
 			return err
 		}
-		prog.SetLocalStorage(fullName, localitylayout.StorageForType(object.Type()))
+		prog.SetLocalStorageFor(pkg, fullName, localitylayout.StorageForType(object.Type()))
 	}
 	_, err = planLocalPackageWithDecls(prog, pkg, decls)
 	return err
 }
 
 func validateLocalInitializers(prog llssa.Program, pkg *types.Package) error {
-	return locality.ValidatePrepared(llssa.PathOf(pkg), packageLocalities(prog, llssa.PathOf(pkg)))
+	return locality.ValidatePrepared(llssa.PathOf(pkg), packageLocalitiesFor(prog, pkg))
 }
 
 func packageLocalities(prog llssa.Program, pkgPath string) map[string]locality.Info {
 	return localityInfos(pkgPath, prog.PackageLocalities(pkgPath))
+}
+
+func packageLocalitiesFor(prog llssa.Program, pkg *types.Package) map[string]locality.Info {
+	return localityInfos(llssa.PathOf(pkg), prog.PackageLocalitiesFor(pkg))
 }
 
 func localityInfos(pkgPath string, decls map[string]llssa.VariableLocality) map[string]locality.Info {
@@ -82,8 +86,7 @@ func planLocalPackage(prog llssa.Program, pkg *types.Package) (localitylayout.Pa
 	if pkg == nil {
 		return localitylayout.Package{}, nil
 	}
-	path := llssa.PathOf(pkg)
-	return planLocalPackageWithDecls(prog, pkg, prog.PackageLocalities(path))
+	return planLocalPackageWithDecls(prog, pkg, prog.PackageLocalitiesFor(pkg))
 }
 
 func planLocalPackageWithDecls(prog llssa.Program, pkg *types.Package, decls map[string]llssa.VariableLocality) (localitylayout.Package, error) {
@@ -94,7 +97,7 @@ func planLocalPackageWithDecls(prog llssa.Program, pkg *types.Package, decls map
 	prefix := path + "."
 	input := make([]localitylayout.Declaration, 0, len(decls))
 	for fullName := range decls {
-		_, info, _, err := prog.ResolveLocality(fullName)
+		_, info, _, err := prog.ResolveLocalityFor(pkg, fullName)
 		if err != nil {
 			return localitylayout.Package{}, err
 		}

--- a/cl/locality.go
+++ b/cl/locality.go
@@ -81,10 +81,6 @@ func validateLocalInitializers(prog llssa.Program, pkg *types.Package) error {
 	return locality.ValidatePrepared(llssa.PathOf(pkg), packageLocalitiesFor(prog, pkg))
 }
 
-func packageLocalities(prog llssa.Program, pkgPath string) map[string]locality.Info {
-	return localityInfos(pkgPath, prog.PackageLocalities(pkgPath))
-}
-
 func packageLocalitiesFor(prog llssa.Program, pkg *types.Package) map[string]locality.Info {
 	return localityInfos(llssa.PathOf(pkg), prog.PackageLocalitiesFor(pkg))
 }

--- a/cl/locality_lower.go
+++ b/cl/locality_lower.go
@@ -66,7 +66,7 @@ type localEnsureCacheKey struct {
 // localityLowering owns all compiler state for TLS/GLS lowering. Only this
 // value is embedded in the general compiler context.
 type localityLowering struct {
-	packages  map[*types.Package]*localPackage
+	packages  map[string]*localPackage
 	variables map[*ssa.Global]*localVariable
 	function  localityFunction
 }
@@ -215,7 +215,8 @@ func (p *context) localPackageFor(typesPkg *types.Package, pkg llssa.Package, de
 	if typesPkg == nil {
 		return nil, nil
 	}
-	if owner := p.locality.packages[typesPkg]; owner != nil {
+	ownerPath := typesPkg.Path()
+	if owner := p.locality.packages[ownerPath]; owner != nil {
 		return owner, nil
 	}
 	plan, err := planLocalPackage(p.prog, typesPkg)
@@ -226,14 +227,14 @@ func (p *context) localPackageFor(typesPkg *types.Package, pkg llssa.Package, de
 		return nil, nil
 	}
 	if p.locality.packages == nil {
-		p.locality.packages = make(map[*types.Package]*localPackage)
+		p.locality.packages = make(map[string]*localPackage)
 	}
 	owner := &localPackage{
 		plan:   plan,
 		direct: make(map[string]llssa.Global),
 		init:   make(map[locality.Kind]*localInitializer),
 	}
-	p.locality.packages[typesPkg] = owner
+	p.locality.packages[ownerPath] = owner
 	p.buildLocalPackage(pkg, owner, define)
 	return owner, nil
 }
@@ -404,7 +405,7 @@ func (p *context) ensureLocalInitializer(b llssa.Builder, owner *localPackage, k
 }
 
 func (p *context) initializeLocalGuards(b llssa.Builder) {
-	owner := p.locality.packages[p.goTyps]
+	owner := p.locality.packages[p.goTyps.Path()]
 	if owner == nil {
 		return
 	}

--- a/cl/locality_lower.go
+++ b/cl/locality_lower.go
@@ -66,7 +66,7 @@ type localEnsureCacheKey struct {
 // localityLowering owns all compiler state for TLS/GLS lowering. Only this
 // value is embedded in the general compiler context.
 type localityLowering struct {
-	packages  map[string]*localPackage
+	packages  map[*types.Package]*localPackage
 	variables map[*ssa.Global]*localVariable
 	function  localityFunction
 }
@@ -138,7 +138,7 @@ func (p *context) prepareLocalVariables(pkg llssa.Package, globals []*ssa.Global
 // aliases and layout validation cannot diverge between lowering cases.
 func (p *context) localVariableFor(pkg llssa.Package, global *ssa.Global, defineCurrent bool) (*localVariable, bool, error) {
 	fullName := llssa.FullName(global.Pkg.Pkg, global.Name())
-	canonical, info, ok, err := p.prog.ResolveLocality(fullName)
+	canonical, info, ok, err := p.prog.ResolveLocalityFor(global.Pkg.Pkg, fullName)
 	if err != nil {
 		return nil, false, err
 	}
@@ -161,7 +161,7 @@ func (p *context) localVariableFor(pkg llssa.Package, global *ssa.Global, define
 }
 
 func (p *context) localityGlobalStorage(pkg llssa.Package, global *ssa.Global, name string, typ types.Type, bg llssa.Background) (llssa.Global, bool) {
-	info, ok := p.resolveLocality(llssa.FullName(global.Pkg.Pkg, global.Name()))
+	info, ok := p.resolveLocality(global.Pkg.Pkg, llssa.FullName(global.Pkg.Pkg, global.Name()))
 	if !ok || info.Locality == locality.None {
 		return pkg.NewVar(name, typ, bg), false
 	}
@@ -215,8 +215,7 @@ func (p *context) localPackageFor(typesPkg *types.Package, pkg llssa.Package, de
 	if typesPkg == nil {
 		return nil, nil
 	}
-	path := llssa.PathOf(typesPkg)
-	if owner := p.locality.packages[path]; owner != nil {
+	if owner := p.locality.packages[typesPkg]; owner != nil {
 		return owner, nil
 	}
 	plan, err := planLocalPackage(p.prog, typesPkg)
@@ -227,14 +226,14 @@ func (p *context) localPackageFor(typesPkg *types.Package, pkg llssa.Package, de
 		return nil, nil
 	}
 	if p.locality.packages == nil {
-		p.locality.packages = make(map[string]*localPackage)
+		p.locality.packages = make(map[*types.Package]*localPackage)
 	}
 	owner := &localPackage{
 		plan:   plan,
 		direct: make(map[string]llssa.Global),
 		init:   make(map[locality.Kind]*localInitializer),
 	}
-	p.locality.packages[path] = owner
+	p.locality.packages[typesPkg] = owner
 	p.buildLocalPackage(pkg, owner, define)
 	return owner, nil
 }
@@ -352,15 +351,15 @@ func (p *context) localVariableAddr(b llssa.Builder, v *ssa.Global, info llssa.V
 }
 
 func (p *context) localVariableAddress(b llssa.Builder, variable *ssa.Global, name string) (llssa.Expr, bool) {
-	info, ok := p.resolveLocality(llssa.FullName(variable.Pkg.Pkg, variable.Name()))
+	info, ok := p.resolveLocality(variable.Pkg.Pkg, llssa.FullName(variable.Pkg.Pkg, variable.Name()))
 	if !ok || info.Locality == locality.None {
 		return llssa.Expr{}, false
 	}
 	return p.localVariableAddr(b, variable, info, name), true
 }
 
-func (p *context) resolveLocality(name string) (llssa.VariableLocality, bool) {
-	_, info, ok, err := p.prog.ResolveLocality(name)
+func (p *context) resolveLocality(pkg *types.Package, name string) (llssa.VariableLocality, bool) {
+	_, info, ok, err := p.prog.ResolveLocalityFor(pkg, name)
 	if err != nil {
 		panic(err)
 	}
@@ -405,7 +404,7 @@ func (p *context) ensureLocalInitializer(b llssa.Builder, owner *localPackage, k
 }
 
 func (p *context) initializeLocalGuards(b llssa.Builder) {
-	owner := p.locality.packages[llssa.PathOf(p.goTyps)]
+	owner := p.locality.packages[p.goTyps]
 	if owner == nil {
 		return
 	}

--- a/cl/locality_lower.go
+++ b/cl/locality_lower.go
@@ -405,6 +405,9 @@ func (p *context) ensureLocalInitializer(b llssa.Builder, owner *localPackage, k
 }
 
 func (p *context) initializeLocalGuards(b llssa.Builder) {
+	if p.goTyps == nil {
+		return
+	}
 	owner := p.locality.packages[p.goTyps.Path()]
 	if owner == nil {
 		return

--- a/cl/locality_lower_test.go
+++ b/cl/locality_lower_test.go
@@ -147,8 +147,8 @@ func TestLocalityLoweringDiagnostics(t *testing.T) {
 	t.Run("stale plan", func(t *testing.T) {
 		prog := newProgram()
 		ctx := &context{prog: prog, goTyps: typesPkg}
-		ctx.locality.packages = map[string]*localPackage{
-			typesPkg.Path(): {plan: localitylayout.Package{Path: typesPkg.Path()}},
+		ctx.locality.packages = map[*types.Package]*localPackage{
+			typesPkg: {plan: localitylayout.Package{Path: typesPkg.Path()}},
 		}
 		if _, _, err := ctx.localVariableFor(nil, global, false); err == nil || !strings.Contains(err.Error(), "missing locality layout") {
 			t.Fatalf("localVariableFor error = %v", err)
@@ -164,7 +164,7 @@ func TestLocalityLoweringDiagnostics(t *testing.T) {
 		if _, _, err := ctx.localVariableFor(nil, global, false); err == nil || !strings.Contains(err.Error(), "cannot use go:linkname") {
 			t.Fatalf("localVariableFor error = %v", err)
 		}
-		assertLocalityPanic(t, "resolveLocality", func() { ctx.resolveLocality(name) })
+		assertLocalityPanic(t, "resolveLocality", func() { ctx.resolveLocality(typesPkg, name) })
 		assertLocalityPanic(t, "prepareLocalVariables", func() { ctx.prepareLocalVariables(nil, nil) })
 		assertLocalityPanic(t, "localVariableAddr", func() {
 			ctx.localVariableAddr(nil, global, llssa.VariableLocality{Info: llssa.LocalityInfo{Locality: llssa.ThreadLocal}}, name)

--- a/cl/locality_lower_test.go
+++ b/cl/locality_lower_test.go
@@ -147,8 +147,8 @@ func TestLocalityLoweringDiagnostics(t *testing.T) {
 	t.Run("stale plan", func(t *testing.T) {
 		prog := newProgram()
 		ctx := &context{prog: prog, goTyps: typesPkg}
-		ctx.locality.packages = map[*types.Package]*localPackage{
-			typesPkg: {plan: localitylayout.Package{Path: typesPkg.Path()}},
+		ctx.locality.packages = map[string]*localPackage{
+			typesPkg.Path(): {plan: localitylayout.Package{Path: typesPkg.Path()}},
 		}
 		if _, _, err := ctx.localVariableFor(nil, global, false); err == nil || !strings.Contains(err.Error(), "missing locality layout") {
 			t.Fatalf("localVariableFor error = %v", err)

--- a/cl/locality_test.go
+++ b/cl/locality_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	llssa "github.com/goplus/llgo/ssa"
+	"github.com/goplus/llgo/ssa/abi"
 	"github.com/goplus/llgo/ssa/ssatest"
 	"golang.org/x/tools/go/ssa"
 )
@@ -493,6 +494,41 @@ func TestValidateLocalInitializers(t *testing.T) {
 	prog.SetLocalityInfo(name, llssa.LocalityInfo{Locality: llssa.ThreadLocal, HasInitializer: true, InitFunc: "example.com/locality.init", InitOrder: 1})
 	if err := validateLocalInitializers(prog, pkg); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestConcretePackageLocalityMetadata(t *testing.T) {
+	std := types.NewPackage("runtime", "runtime")
+	alt := types.NewPackage(abi.PatchPathPrefix+"runtime", "runtime")
+	for _, pkg := range []*types.Package{std, alt} {
+		pkg.Scope().Insert(types.NewVar(token.NoPos, pkg, "state", types.Typ[types.Uintptr]))
+	}
+
+	prog := ssatest.NewProgram(t, nil)
+	name := "runtime.state"
+	prog.DeclareLocality(std, "state", llssa.LocalityInfo{
+		Locality:       llssa.ThreadLocal,
+		HasInitializer: true,
+	})
+	prog.DeclareLocality(alt, "state", llssa.LocalityInfo{
+		Locality: llssa.GoroutineLocal,
+	})
+	prog.SetLocalStorageFor(std, name, llssa.LocalStorageNativeTLS)
+	prog.SetLocalStorageFor(alt, name, llssa.LocalStoragePackage)
+
+	if err := validateLocalInitializers(prog, std); err == nil || !strings.Contains(err.Error(), "inconsistent initializer metadata") {
+		t.Fatalf("standard validation error = %v", err)
+	}
+	if err := validateLocalInitializers(prog, alt); err != nil {
+		t.Fatalf("alternate validation used standard metadata: %v", err)
+	}
+	plan, err := planLocalPackage(prog, alt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, ok := plan.Lookup(name)
+	if !ok || state.Info.Locality != llssa.GoroutineLocal {
+		t.Fatalf("alternate plan state = %+v, %v", state, ok)
 	}
 }
 

--- a/cl/static_init.go
+++ b/cl/static_init.go
@@ -85,7 +85,7 @@ func (p *context) collectStaticGlobalInits(pkg *ssa.Package) {
 			if _, rewritten := p.rewriteValue(globalName); rewritten {
 				continue
 			}
-			if info, ok := p.resolveLocality(llssa.FullName(global.Pkg.Pkg, global.Name())); ok && info.Locality != llssa.LocalityNone {
+			if info, ok := p.resolveLocality(global.Pkg.Pkg, llssa.FullName(global.Pkg.Pkg, global.Name())); ok && info.Locality != llssa.LocalityNone {
 				// Local initializers must remain executable so they can populate the
 				// current context rather than a process-wide LLVM initializer.
 				continue

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1990,10 +1990,31 @@ func prepareLocalVariables(prog llssa.Program, groups ...[]*packages.Package) er
 				return
 			}
 			seen[p.Types] = true
-			firstErr = cl.PrepareLocalVariables(prog, p.Fset, p.Types, p.TypesInfo, p.Syntax)
+			firstErr = cl.PrepareInactiveLocalVariables(prog, p.Fset, p.Types, p.TypesInfo, p.Syntax)
 		})
 		if firstErr != nil {
 			return firstErr
+		}
+	}
+
+	if len(groups) == 0 {
+		return nil
+	}
+	active := make(map[string]bool)
+	activate := func(p *packages.Package) {
+		if p.Types == nil || p.IllTyped {
+			return
+		}
+		active[llssa.PathOf(p.Types)] = true
+		prog.ActivateLocalitiesFor(p.Types)
+	}
+	packages.Visit(groups[0], nil, activate)
+	for _, roots := range groups[1:] {
+		for _, root := range roots {
+			if root == nil || root.Types == nil || !active[llssa.PathOf(root.Types)] {
+				continue
+			}
+			packages.Visit([]*packages.Package{root}, nil, activate)
 		}
 	}
 	return nil

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -713,6 +713,56 @@ func TestPrepareLocalVariables(t *testing.T) {
 	})
 }
 
+func TestPrepareLocalVariablesKeepsAltDeclarationOwners(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "runtime.go", `package runtime
+
+//llgo:gls
+var goroutineState uint32
+
+//llgo:tls
+var threadState uintptr
+`, parser.ParseComments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info := &types.Info{
+		Types:      make(map[ast.Expr]types.TypeAndValue),
+		Defs:       make(map[*ast.Ident]types.Object),
+		Uses:       make(map[*ast.Ident]types.Object),
+		Implicits:  make(map[ast.Node]types.Object),
+		Selections: make(map[*ast.SelectorExpr]*types.Selection),
+		Scopes:     make(map[ast.Node]*types.Scope),
+		Instances:  make(map[*ast.Ident]types.Instance),
+	}
+	alt, err := (&types.Config{}).Check(altPkgPathPrefix+"runtime", fset, []*ast.File{file}, info)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prog := llssa.NewProgram(nil)
+	if err := cl.ParsePkgSyntax(prog, fset, alt, []*ast.File{file}); err != nil {
+		t.Fatal(err)
+	}
+	std := types.NewPackage("runtime", "runtime")
+	err = prepareLocalVariables(prog,
+		[]*packages.Package{{Types: std, TypesInfo: &types.Info{}}},
+		[]*packages.Package{{Types: alt, TypesInfo: info, Syntax: []*ast.File{file}, Fset: fset}},
+	)
+	if err != nil {
+		t.Fatalf("prepareLocalVariables confused standard and alternate runtime packages: %v", err)
+	}
+	for name, kind := range map[string]llssa.Locality{
+		"runtime.goroutineState": llssa.GoroutineLocal,
+		"runtime.threadState":    llssa.ThreadLocal,
+	} {
+		got, ok := prog.VariableLocality(name)
+		if !ok || got.Locality != kind || got.LocalStorage != llssa.LocalStorageNativeTLS {
+			t.Fatalf("%s locality = %+v, %v", name, got, ok)
+		}
+	}
+}
+
 func TestLTOEnabledDefault(t *testing.T) {
 	host := &Config{Target: ""}
 	if host.ltoEnabled() {

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -679,6 +679,12 @@ func TestPrepareLocalVariables(t *testing.T) {
 		return loaded, file
 	}
 
+	t.Run("accepts no package groups", func(t *testing.T) {
+		if err := prepareLocalVariables(llssa.NewProgram(nil)); err != nil {
+			t.Fatal(err)
+		}
+	})
+
 	t.Run("filters and deduplicates packages", func(t *testing.T) {
 		prog := llssa.NewProgram(nil)
 		loaded, file := newLocalPackage("example.com/local", true)
@@ -709,6 +715,19 @@ func TestPrepareLocalVariables(t *testing.T) {
 		err := prepareLocalVariables(prog, []*packages.Package{root})
 		if err == nil || !strings.Contains(err.Error(), "without syntax files") {
 			t.Fatalf("prepareLocalVariables error = %v", err)
+		}
+	})
+
+	t.Run("skips inactive alternate roots", func(t *testing.T) {
+		prog := llssa.NewProgram(nil)
+		active := &packages.Package{Types: types.NewPackage("example.com/active", "active")}
+		inactive := &packages.Package{Types: types.NewPackage("example.com/inactive", "inactive")}
+		err := prepareLocalVariables(prog,
+			[]*packages.Package{active},
+			[]*packages.Package{{}, inactive},
+		)
+		if err != nil {
+			t.Fatal(err)
 		}
 	})
 }

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -718,7 +718,7 @@ func TestPrepareLocalVariablesKeepsAltDeclarationOwners(t *testing.T) {
 	file, err := parser.ParseFile(fset, "runtime.go", `package runtime
 
 //llgo:gls
-var goroutineState uint32
+var goroutineState *uint32
 
 //llgo:tls
 var threadState uintptr
@@ -752,14 +752,23 @@ var threadState uintptr
 	if err != nil {
 		t.Fatalf("prepareLocalVariables confused standard and alternate runtime packages: %v", err)
 	}
-	for name, kind := range map[string]llssa.Locality{
-		"runtime.goroutineState": llssa.GoroutineLocal,
-		"runtime.threadState":    llssa.ThreadLocal,
+	for name, want := range map[string]llssa.VariableLocality{
+		"runtime.goroutineState": {
+			Info:         llssa.LocalityInfo{Locality: llssa.GoroutineLocal},
+			LocalStorage: llssa.LocalStoragePackage,
+		},
+		"runtime.threadState": {
+			Info:         llssa.LocalityInfo{Locality: llssa.ThreadLocal},
+			LocalStorage: llssa.LocalStorageNativeTLS,
+		},
 	} {
 		got, ok := prog.VariableLocality(name)
-		if !ok || got.Locality != kind || got.LocalStorage != llssa.LocalStorageNativeTLS {
+		if !ok || got.Locality != want.Locality || got.LocalStorage != want.LocalStorage {
 			t.Fatalf("%s locality = %+v, %v", name, got, ok)
 		}
+	}
+	if !prog.NeedsLocalContext() {
+		t.Fatal("active alternate runtime package did not require a local context")
 	}
 }
 

--- a/runtime/internal/lib/runtime/fipsbypass_llgo.go
+++ b/runtime/internal/lib/runtime/fipsbypass_llgo.go
@@ -4,28 +4,21 @@ package runtime
 
 import (
 	_ "unsafe"
-
-	"github.com/goplus/llgo/runtime/internal/clite/tls"
 )
-
-// llgo does not currently expose runtime.getg in this compatibility layer.
-// Its goroutines do not migrate between OS threads, so pthread TLS gives the
-// bypass state the same non-process-wide isolation that crypto/fips140 needs.
-var fipsBypassTLS = tls.Alloc[uint32](nil)
 
 //go:linkname fips140_setBypass crypto/fips140.setBypass
 func fips140_setBypass() {
-	fipsBypassTLS.Set(fipsBypassTLS.Get() + 1)
+	fipsBypassDepth++
 }
 
 //go:linkname fips140_unsetBypass crypto/fips140.unsetBypass
 func fips140_unsetBypass() {
-	if n := fipsBypassTLS.Get(); n != 0 {
-		fipsBypassTLS.Set(n - 1)
+	if fipsBypassDepth != 0 {
+		fipsBypassDepth--
 	}
 }
 
 //go:linkname fips140_isBypassed crypto/fips140.isBypassed
 func fips140_isBypassed() bool {
-	return fipsBypassTLS.Get() != 0
+	return fipsBypassDepth != 0
 }

--- a/runtime/internal/lib/runtime/fipsbypass_state_global.go
+++ b/runtime/internal/lib/runtime/fipsbypass_state_global.go
@@ -1,0 +1,7 @@
+//go:build go1.26 && (!llgo || baremetal)
+
+package runtime
+
+// Bare-metal runtimes have one execution context and must not introduce a
+// native TLS relocation for the locality package cache.
+var fipsBypassDepth uint32

--- a/runtime/internal/lib/runtime/fipsbypass_state_gls.go
+++ b/runtime/internal/lib/runtime/fipsbypass_state_gls.go
@@ -1,0 +1,9 @@
+//go:build go1.26 && llgo && !baremetal
+
+package runtime
+
+// fipsBypassDepth is part of the calling goroutine's cryptographic state. It
+// must follow that goroutine if a future scheduler moves it between OS threads.
+//
+//llgo:gls
+var fipsBypassDepth uint32

--- a/ssa/locality.go
+++ b/ssa/locality.go
@@ -55,6 +55,7 @@ type localityInfos struct {
 	entries            map[string]VariableLocality
 	ownerlessEntries   map[string]VariableLocality
 	declarationEntries map[string]map[string]VariableLocality
+	activePackages     map[string]struct{}
 	parsedPackages     map[*types.Package]struct{}
 }
 
@@ -63,6 +64,7 @@ func newLocalityInfos() *localityInfos {
 		entries:            make(map[string]VariableLocality),
 		ownerlessEntries:   make(map[string]VariableLocality),
 		declarationEntries: make(map[string]map[string]VariableLocality),
+		activePackages:     make(map[string]struct{}),
 		parsedPackages:     make(map[*types.Package]struct{}),
 	}
 }
@@ -133,6 +135,19 @@ func (p Program) SetLocalStorage(name string, storage LocalStorage) {
 // declaration.
 func (p Program) SetLocalStorageFor(pkg *types.Package, name string, storage LocalStorage) {
 	p.localities.updateFor(pkg, name, func(info *VariableLocality) { info.LocalStorage = storage })
+}
+
+// ActivateLocalitiesFor marks pkg's concrete import path as part of the
+// effective build graph. Alternate packages are scanned and prepared before
+// link reachability is known; their declarations must not require a
+// LocalContext merely because metadata exists.
+func (p Program) ActivateLocalitiesFor(pkg *types.Package) {
+	if pkg == nil {
+		return
+	}
+	p.localities.mu.Lock()
+	p.localities.activePackages[pkg.Path()] = struct{}{}
+	p.localities.mu.Unlock()
 }
 
 func (p Program) VariableLocality(name string) (VariableLocality, bool) {
@@ -369,8 +384,8 @@ func (p Program) NeedsLocalContext() bool {
 		}
 	}
 	for _, entries := range p.localities.declarationEntries {
-		for _, info := range entries {
-			if needsContext(info) {
+		for owner, info := range entries {
+			if _, active := p.localities.activePackages[owner]; active && needsContext(info) {
 				return true
 			}
 		}

--- a/ssa/locality.go
+++ b/ssa/locality.go
@@ -51,7 +51,9 @@ type VariableLocality struct {
 }
 
 type localityInfos struct {
-	mu                 sync.RWMutex
+	mu sync.RWMutex
+	// entries and ownerlessEntries retain the canonical-only compatibility
+	// view. Production declaration handling uses declarationEntries instead.
 	entries            map[string]VariableLocality
 	ownerlessEntries   map[string]VariableLocality
 	declarationEntries map[string]map[string]VariableLocality
@@ -150,6 +152,9 @@ func (p Program) ActivateLocalitiesFor(pkg *types.Package) {
 	p.localities.mu.Unlock()
 }
 
+// VariableLocality returns the legacy canonical-only metadata view. Its result
+// is unspecified when multiple declaration owners share name; use
+// VariableLocalityFor in owner-aware code.
 func (p Program) VariableLocality(name string) (VariableLocality, bool) {
 	p.localities.mu.RLock()
 	info, ok := p.localities.entries[name]
@@ -185,7 +190,8 @@ func (p Program) ResolveLocality(name string) (string, VariableLocality, bool, e
 }
 
 // ResolveLocalityFor resolves locality metadata using the concrete package's
-// declaration when the canonical package path has multiple owners.
+// declaration when the canonical package path has multiple owners. Owner-less
+// preloaded metadata remains a canonical-name compatibility fallback.
 func (p Program) ResolveLocalityFor(pkg *types.Package, name string) (string, VariableLocality, bool, error) {
 	prefix := PathOf(pkg) + "."
 	lookup := func(name string) (VariableLocality, bool) {
@@ -243,6 +249,9 @@ func hasInitialization(info locality.Info) bool {
 	return info.HasInitializer || info.InitFunc != "" || info.InitOrder != 0
 }
 
+// ValidateLocalities validates the legacy canonical-only metadata view. Its
+// result is unspecified when multiple declaration owners share a canonical
+// path; use ValidateLocalitiesFor in owner-aware code.
 func (p Program) ValidateLocalities(pkgPath string) error {
 	return p.validateLocalities(pkgPath, p.PackageLocalities(pkgPath), p.ResolveLocality)
 }
@@ -333,6 +342,9 @@ func (p Program) MarkPackageSyntaxParsed(pkg *types.Package) {
 	p.localities.mu.Unlock()
 }
 
+// PackageLocalities returns the legacy canonical-only metadata view. Its
+// result is unspecified when a canonical path has multiple declaration
+// owners; use PackageLocalitiesFor in owner-aware code.
 func (p Program) PackageLocalities(pkgPath string) map[string]VariableLocality {
 	prefix := pkgPath + "."
 	ret := make(map[string]VariableLocality)

--- a/ssa/locality.go
+++ b/ssa/locality.go
@@ -51,17 +51,19 @@ type VariableLocality struct {
 }
 
 type localityInfos struct {
-	mu                sync.RWMutex
-	entries           map[string]VariableLocality
-	declarationOwners map[string]map[*types.Package]struct{}
-	parsedPackages    map[*types.Package]struct{}
+	mu                 sync.RWMutex
+	entries            map[string]VariableLocality
+	ownerlessEntries   map[string]VariableLocality
+	declarationEntries map[string]map[*types.Package]VariableLocality
+	parsedPackages     map[*types.Package]struct{}
 }
 
 func newLocalityInfos() *localityInfos {
 	return &localityInfos{
-		entries:           make(map[string]VariableLocality),
-		declarationOwners: make(map[string]map[*types.Package]struct{}),
-		parsedPackages:    make(map[*types.Package]struct{}),
+		entries:            make(map[string]VariableLocality),
+		ownerlessEntries:   make(map[string]VariableLocality),
+		declarationEntries: make(map[string]map[*types.Package]VariableLocality),
+		parsedPackages:     make(map[*types.Package]struct{}),
 	}
 }
 
@@ -70,6 +72,23 @@ func (p *localityInfos) update(name string, update func(*VariableLocality)) {
 	info := p.entries[name]
 	update(&info)
 	p.entries[name] = info
+	ownerless := p.ownerlessEntries[name]
+	update(&ownerless)
+	p.ownerlessEntries[name] = ownerless
+	p.mu.Unlock()
+}
+
+func (p *localityInfos) updateFor(pkg *types.Package, name string, update func(*VariableLocality)) {
+	p.mu.Lock()
+	entries := p.declarationEntries[name]
+	if entries == nil {
+		entries = make(map[*types.Package]VariableLocality)
+		p.declarationEntries[name] = entries
+	}
+	info := entries[pkg]
+	update(&info)
+	entries[pkg] = info
+	p.entries[name] = info
 	p.mu.Unlock()
 }
 
@@ -77,31 +96,49 @@ func (p Program) SetLocalityInfo(name string, info LocalityInfo) {
 	p.localities.update(name, func(current *VariableLocality) { current.Info = info })
 }
 
+// SetLocalityInfoFor updates locality metadata for one concrete package
+// declaration. It preserves distinct metadata for standard and alternate
+// packages whose canonical symbol names are identical.
+func (p Program) SetLocalityInfoFor(pkg *types.Package, name string, info LocalityInfo) {
+	p.localities.updateFor(pkg, name, func(current *VariableLocality) { current.Info = info })
+}
+
 // DeclareLocality records locality metadata found on a declaration in pkg.
 // Alternate packages can share canonical symbol names with the packages they
-// replace, so declaration ownership must retain the concrete types.Package.
+// replace, so both ownership and metadata retain the concrete types.Package.
 func (p Program) DeclareLocality(pkg *types.Package, name string, info LocalityInfo) {
 	fullName := FullName(pkg, name)
-	p.localities.mu.Lock()
-	current := p.localities.entries[fullName]
-	current.Info = info
-	p.localities.entries[fullName] = current
-	owners := p.localities.declarationOwners[fullName]
-	if owners == nil {
-		owners = make(map[*types.Package]struct{})
-		p.localities.declarationOwners[fullName] = owners
-	}
-	owners[pkg] = struct{}{}
-	p.localities.mu.Unlock()
+	p.SetLocalityInfoFor(pkg, fullName, info)
 }
 
 func (p Program) SetLocalStorage(name string, storage LocalStorage) {
 	p.localities.update(name, func(info *VariableLocality) { info.LocalStorage = storage })
 }
 
+// SetLocalStorageFor records the selected storage for one concrete package
+// declaration.
+func (p Program) SetLocalStorageFor(pkg *types.Package, name string, storage LocalStorage) {
+	p.localities.updateFor(pkg, name, func(info *VariableLocality) { info.LocalStorage = storage })
+}
+
 func (p Program) VariableLocality(name string) (VariableLocality, bool) {
 	p.localities.mu.RLock()
 	info, ok := p.localities.entries[name]
+	p.localities.mu.RUnlock()
+	return info, ok
+}
+
+// VariableLocalityFor returns metadata for a concrete declaration, falling
+// back to owner-less preloaded metadata by canonical symbol name.
+func (p Program) VariableLocalityFor(pkg *types.Package, name string) (VariableLocality, bool) {
+	p.localities.mu.RLock()
+	if entries := p.localities.declarationEntries[name]; entries != nil {
+		if info, ok := entries[pkg]; ok {
+			p.localities.mu.RUnlock()
+			return info, true
+		}
+	}
+	info, ok := p.localities.ownerlessEntries[name]
 	p.localities.mu.RUnlock()
 	return info, ok
 }
@@ -113,6 +150,28 @@ func (p Program) ResolveLocality(name string) (string, VariableLocality, bool, e
 		p.localities.mu.RLock()
 		info, ok := p.localities.entries[name]
 		p.localities.mu.RUnlock()
+		return info, ok
+	}
+	return resolveLocality(lookup, p.Linkname, name)
+}
+
+// ResolveLocalityFor resolves locality metadata using the concrete package's
+// declaration when the canonical package path has multiple owners.
+func (p Program) ResolveLocalityFor(pkg *types.Package, name string) (string, VariableLocality, bool, error) {
+	prefix := PathOf(pkg) + "."
+	lookup := func(name string) (VariableLocality, bool) {
+		p.localities.mu.RLock()
+		defer p.localities.mu.RUnlock()
+		if strings.HasPrefix(name, prefix) {
+			if entries := p.localities.declarationEntries[name]; entries != nil {
+				if info, ok := entries[pkg]; ok {
+					return info, true
+				}
+			}
+			info, ok := p.localities.ownerlessEntries[name]
+			return info, ok
+		}
+		info, ok := p.localities.entries[name]
 		return info, ok
 	}
 	return resolveLocality(lookup, p.Linkname, name)
@@ -156,9 +215,21 @@ func hasInitialization(info locality.Info) bool {
 }
 
 func (p Program) ValidateLocalities(pkgPath string) error {
+	return p.validateLocalities(pkgPath, p.PackageLocalities(pkgPath), p.ResolveLocality)
+}
+
+// ValidateLocalitiesFor validates only declarations that belong to pkg, plus
+// owner-less preloaded metadata for its canonical package path.
+func (p Program) ValidateLocalitiesFor(pkg *types.Package) error {
+	return p.validateLocalities(PathOf(pkg), p.PackageLocalitiesFor(pkg), func(name string) (string, VariableLocality, bool, error) {
+		return p.ResolveLocalityFor(pkg, name)
+	})
+}
+
+func (p Program) validateLocalities(pkgPath string, packageEntries map[string]VariableLocality, resolve func(string) (string, VariableLocality, bool, error)) error {
 	prefix := pkgPath + "."
 	p.localities.mu.RLock()
-	if len(p.localities.entries) == 0 {
+	if len(p.localities.entries) == 0 && len(p.localities.declarationEntries) == 0 {
 		p.localities.mu.RUnlock()
 		return nil
 	}
@@ -168,11 +239,19 @@ func (p Program) ValidateLocalities(pkgPath string) error {
 		if info.Locality != locality.None {
 			localNames[name] = true
 		}
-		if strings.HasPrefix(name, prefix) {
-			nameSet[name] = true
+	}
+	for name, entries := range p.localities.declarationEntries {
+		for _, info := range entries {
+			if info.Locality != locality.None {
+				localNames[name] = true
+				break
+			}
 		}
 	}
 	p.localities.mu.RUnlock()
+	for name := range packageEntries {
+		nameSet[name] = true
+	}
 	if len(localNames) == 0 {
 		return nil
 	}
@@ -193,7 +272,7 @@ func (p Program) ValidateLocalities(pkgPath string) error {
 	}
 	sort.Strings(names)
 	for _, name := range names {
-		if _, _, _, err := p.ResolveLocality(name); err != nil {
+		if _, _, _, err := resolve(name); err != nil {
 			return err
 		}
 	}
@@ -239,22 +318,24 @@ func (p Program) PackageLocalities(pkgPath string) map[string]VariableLocality {
 }
 
 // PackageLocalitiesFor returns locality metadata applicable to the concrete
-// package. Metadata discovered on declarations belongs only to its declaration
-// owners. Metadata installed directly through SetLocalityInfo has no owner and
-// remains applicable by canonical package path for compatibility with
-// preloaded metadata.
+// package. Declaration entries retain both their owner and owner-specific
+// metadata. Entries with no declaration owner remain applicable by canonical
+// package path for compatibility with preloaded metadata.
 func (p Program) PackageLocalitiesFor(pkg *types.Package) map[string]VariableLocality {
 	prefix := PathOf(pkg) + "."
 	ret := make(map[string]VariableLocality)
 	p.localities.mu.RLock()
-	for name, info := range p.localities.entries {
+	for name, info := range p.localities.ownerlessEntries {
 		if info.Locality == locality.None || !strings.HasPrefix(name, prefix) {
 			continue
 		}
-		owners := p.localities.declarationOwners[name]
-		if len(owners) == 0 {
-			ret[name] = info
-		} else if _, ok := owners[pkg]; ok {
+		ret[name] = info
+	}
+	for name, entries := range p.localities.declarationEntries {
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		if info, ok := entries[pkg]; ok && info.Locality != locality.None {
 			ret[name] = info
 		}
 	}
@@ -265,8 +346,29 @@ func (p Program) PackageLocalitiesFor(pkg *types.Package) map[string]VariableLoc
 func (p Program) NeedsLocalContext() bool {
 	p.localities.mu.RLock()
 	defer p.localities.mu.RUnlock()
-	for _, info := range p.localities.entries {
-		if info.Locality != locality.None && (info.LocalStorage != LocalStorageNativeTLS || hasInitialization(info.Info)) {
+	needsContext := func(info VariableLocality) bool {
+		return info.Locality != locality.None && (info.LocalStorage != LocalStorageNativeTLS || hasInitialization(info.Info))
+	}
+	for _, info := range p.localities.ownerlessEntries {
+		if needsContext(info) {
+			return true
+		}
+	}
+	for _, entries := range p.localities.declarationEntries {
+		for _, info := range entries {
+			if needsContext(info) {
+				return true
+			}
+		}
+	}
+	for name, info := range p.localities.entries {
+		if _, ownerless := p.localities.ownerlessEntries[name]; ownerless {
+			continue
+		}
+		if _, declared := p.localities.declarationEntries[name]; declared {
+			continue
+		}
+		if needsContext(info) {
 			return true
 		}
 	}

--- a/ssa/locality.go
+++ b/ssa/locality.go
@@ -54,7 +54,7 @@ type localityInfos struct {
 	mu                 sync.RWMutex
 	entries            map[string]VariableLocality
 	ownerlessEntries   map[string]VariableLocality
-	declarationEntries map[string]map[*types.Package]VariableLocality
+	declarationEntries map[string]map[string]VariableLocality
 	parsedPackages     map[*types.Package]struct{}
 }
 
@@ -62,7 +62,7 @@ func newLocalityInfos() *localityInfos {
 	return &localityInfos{
 		entries:            make(map[string]VariableLocality),
 		ownerlessEntries:   make(map[string]VariableLocality),
-		declarationEntries: make(map[string]map[*types.Package]VariableLocality),
+		declarationEntries: make(map[string]map[string]VariableLocality),
 		parsedPackages:     make(map[*types.Package]struct{}),
 	}
 }
@@ -82,12 +82,13 @@ func (p *localityInfos) updateFor(pkg *types.Package, name string, update func(*
 	p.mu.Lock()
 	entries := p.declarationEntries[name]
 	if entries == nil {
-		entries = make(map[*types.Package]VariableLocality)
+		entries = make(map[string]VariableLocality)
 		p.declarationEntries[name] = entries
 	}
-	info := entries[pkg]
+	owner := pkg.Path()
+	info := entries[owner]
 	update(&info)
-	entries[pkg] = info
+	entries[owner] = info
 	p.entries[name] = info
 	p.mu.Unlock()
 }
@@ -105,10 +106,23 @@ func (p Program) SetLocalityInfoFor(pkg *types.Package, name string, info Locali
 
 // DeclareLocality records locality metadata found on a declaration in pkg.
 // Alternate packages can share canonical symbol names with the packages they
-// replace, so both ownership and metadata retain the concrete types.Package.
+// replace, so both ownership and metadata retain the raw import path. Repeated
+// loads of the same raw path preserve metadata enriched during preparation.
 func (p Program) DeclareLocality(pkg *types.Package, name string, info LocalityInfo) {
 	fullName := FullName(pkg, name)
-	p.SetLocalityInfoFor(pkg, fullName, info)
+	owner := pkg.Path()
+	p.localities.mu.Lock()
+	entries := p.localities.declarationEntries[fullName]
+	if entries == nil {
+		entries = make(map[string]VariableLocality)
+		p.localities.declarationEntries[fullName] = entries
+	}
+	if _, exists := entries[owner]; !exists {
+		current := VariableLocality{Info: info}
+		entries[owner] = current
+		p.localities.entries[fullName] = current
+	}
+	p.localities.mu.Unlock()
 }
 
 func (p Program) SetLocalStorage(name string, storage LocalStorage) {
@@ -133,7 +147,7 @@ func (p Program) VariableLocality(name string) (VariableLocality, bool) {
 func (p Program) VariableLocalityFor(pkg *types.Package, name string) (VariableLocality, bool) {
 	p.localities.mu.RLock()
 	if entries := p.localities.declarationEntries[name]; entries != nil {
-		if info, ok := entries[pkg]; ok {
+		if info, ok := entries[pkg.Path()]; ok {
 			p.localities.mu.RUnlock()
 			return info, true
 		}
@@ -164,7 +178,7 @@ func (p Program) ResolveLocalityFor(pkg *types.Package, name string) (string, Va
 		defer p.localities.mu.RUnlock()
 		if strings.HasPrefix(name, prefix) {
 			if entries := p.localities.declarationEntries[name]; entries != nil {
-				if info, ok := entries[pkg]; ok {
+				if info, ok := entries[pkg.Path()]; ok {
 					return info, true
 				}
 			}
@@ -335,7 +349,7 @@ func (p Program) PackageLocalitiesFor(pkg *types.Package) map[string]VariableLoc
 		if !strings.HasPrefix(name, prefix) {
 			continue
 		}
-		if info, ok := entries[pkg]; ok && info.Locality != locality.None {
+		if info, ok := entries[pkg.Path()]; ok && info.Locality != locality.None {
 			ret[name] = info
 		}
 	}

--- a/ssa/locality.go
+++ b/ssa/locality.go
@@ -51,15 +51,17 @@ type VariableLocality struct {
 }
 
 type localityInfos struct {
-	mu             sync.RWMutex
-	entries        map[string]VariableLocality
-	parsedPackages map[*types.Package]struct{}
+	mu                sync.RWMutex
+	entries           map[string]VariableLocality
+	declarationOwners map[string]map[*types.Package]struct{}
+	parsedPackages    map[*types.Package]struct{}
 }
 
 func newLocalityInfos() *localityInfos {
 	return &localityInfos{
-		entries:        make(map[string]VariableLocality),
-		parsedPackages: make(map[*types.Package]struct{}),
+		entries:           make(map[string]VariableLocality),
+		declarationOwners: make(map[string]map[*types.Package]struct{}),
+		parsedPackages:    make(map[*types.Package]struct{}),
 	}
 }
 
@@ -73,6 +75,24 @@ func (p *localityInfos) update(name string, update func(*VariableLocality)) {
 
 func (p Program) SetLocalityInfo(name string, info LocalityInfo) {
 	p.localities.update(name, func(current *VariableLocality) { current.Info = info })
+}
+
+// DeclareLocality records locality metadata found on a declaration in pkg.
+// Alternate packages can share canonical symbol names with the packages they
+// replace, so declaration ownership must retain the concrete types.Package.
+func (p Program) DeclareLocality(pkg *types.Package, name string, info LocalityInfo) {
+	fullName := FullName(pkg, name)
+	p.localities.mu.Lock()
+	current := p.localities.entries[fullName]
+	current.Info = info
+	p.localities.entries[fullName] = current
+	owners := p.localities.declarationOwners[fullName]
+	if owners == nil {
+		owners = make(map[*types.Package]struct{})
+		p.localities.declarationOwners[fullName] = owners
+	}
+	owners[pkg] = struct{}{}
+	p.localities.mu.Unlock()
 }
 
 func (p Program) SetLocalStorage(name string, storage LocalStorage) {
@@ -211,6 +231,30 @@ func (p Program) PackageLocalities(pkgPath string) map[string]VariableLocality {
 	p.localities.mu.RLock()
 	for name, info := range p.localities.entries {
 		if info.Locality != locality.None && strings.HasPrefix(name, prefix) {
+			ret[name] = info
+		}
+	}
+	p.localities.mu.RUnlock()
+	return ret
+}
+
+// PackageLocalitiesFor returns locality metadata applicable to the concrete
+// package. Metadata discovered on declarations belongs only to its declaration
+// owners. Metadata installed directly through SetLocalityInfo has no owner and
+// remains applicable by canonical package path for compatibility with
+// preloaded metadata.
+func (p Program) PackageLocalitiesFor(pkg *types.Package) map[string]VariableLocality {
+	prefix := PathOf(pkg) + "."
+	ret := make(map[string]VariableLocality)
+	p.localities.mu.RLock()
+	for name, info := range p.localities.entries {
+		if info.Locality == locality.None || !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		owners := p.localities.declarationOwners[name]
+		if len(owners) == 0 {
+			ret[name] = info
+		} else if _, ok := owners[pkg]; ok {
 			ret[name] = info
 		}
 	}

--- a/ssa/locality_test.go
+++ b/ssa/locality_test.go
@@ -70,6 +70,10 @@ func TestPackageLocalitiesRetainDeclarationOwners(t *testing.T) {
 
 	prog.DeclareLocality(std, "stdState", LocalityInfo{Locality: ThreadLocal})
 	prog.DeclareLocality(alt, "altState", LocalityInfo{Locality: GoroutineLocal})
+	prog.DeclareLocality(std, "sharedState", LocalityInfo{Locality: ThreadLocal})
+	prog.DeclareLocality(alt, "sharedState", LocalityInfo{Locality: GoroutineLocal})
+	prog.SetLocalStorageFor(std, "runtime.sharedState", LocalStorageNativeTLS)
+	prog.SetLocalStorageFor(alt, "runtime.sharedState", LocalStoragePackage)
 	prog.SetLocalityInfo("runtime.preloadedState", LocalityInfo{Locality: ThreadLocal})
 
 	check := func(pkg *types.Package, wants ...string) {
@@ -84,11 +88,20 @@ func TestPackageLocalitiesRetainDeclarationOwners(t *testing.T) {
 			}
 		}
 	}
-	check(std, "stdState", "preloadedState")
-	check(alt, "altState", "preloadedState")
+	check(std, "stdState", "sharedState", "preloadedState")
+	check(alt, "altState", "sharedState", "preloadedState")
 
-	if got := prog.PackageLocalities("runtime"); len(got) != 3 {
-		t.Fatalf("canonical PackageLocalities(runtime) = %+v, want all three declarations", got)
+	stdShared, ok := prog.VariableLocalityFor(std, "runtime.sharedState")
+	if !ok || stdShared.Locality != ThreadLocal || stdShared.LocalStorage != LocalStorageNativeTLS {
+		t.Fatalf("standard sharedState = %+v, %v", stdShared, ok)
+	}
+	altShared, ok := prog.VariableLocalityFor(alt, "runtime.sharedState")
+	if !ok || altShared.Locality != GoroutineLocal || altShared.LocalStorage != LocalStoragePackage {
+		t.Fatalf("alternate sharedState = %+v, %v", altShared, ok)
+	}
+
+	if got := prog.PackageLocalities("runtime"); len(got) != 4 {
+		t.Fatalf("canonical PackageLocalities(runtime) = %+v, want all four declaration names", got)
 	}
 }
 

--- a/ssa/locality_test.go
+++ b/ssa/locality_test.go
@@ -140,6 +140,30 @@ func TestNeedsLocalContext(t *testing.T) {
 	}
 }
 
+func TestNeedsLocalContextIgnoresInactiveDeclarations(t *testing.T) {
+	prog := NewProgram(nil)
+	std := types.NewPackage("runtime", "runtime")
+	alt := types.NewPackage(abi.PatchPathPrefix+"runtime", "runtime")
+	name := "runtime.state"
+
+	prog.DeclareLocality(std, "state", LocalityInfo{Locality: ThreadLocal})
+	prog.SetLocalStorageFor(std, name, LocalStorageNativeTLS)
+	prog.DeclareLocality(alt, "state", LocalityInfo{Locality: GoroutineLocal})
+	prog.SetLocalStorageFor(alt, name, LocalStoragePackage)
+	if prog.NeedsLocalContext() {
+		t.Fatal("scanned inactive alternate declaration required a local context")
+	}
+
+	prog.ActivateLocalitiesFor(std)
+	if prog.NeedsLocalContext() {
+		t.Fatal("active native-TLS standard declaration used alternate package storage")
+	}
+	prog.ActivateLocalitiesFor(alt)
+	if !prog.NeedsLocalContext() {
+		t.Fatal("active alternate package storage did not require a local context")
+	}
+}
+
 func TestRejectsLinknameLocality(t *testing.T) {
 	prog := NewProgram(nil)
 	target := "example.com/target.value"

--- a/ssa/locality_test.go
+++ b/ssa/locality_test.go
@@ -20,6 +20,8 @@ import (
 	"go/types"
 	"strings"
 	"testing"
+
+	"github.com/goplus/llgo/ssa/abi"
 )
 
 func TestLocalityInfos(t *testing.T) {
@@ -58,6 +60,35 @@ func TestLocalityInfos(t *testing.T) {
 	delete(decls, name)
 	if _, ok := prog.VariableLocality(name); !ok {
 		t.Fatal("mutating PackageLocalities changed program metadata")
+	}
+}
+
+func TestPackageLocalitiesRetainDeclarationOwners(t *testing.T) {
+	prog := NewProgram(nil)
+	std := types.NewPackage("runtime", "runtime")
+	alt := types.NewPackage(abi.PatchPathPrefix+"runtime", "runtime")
+
+	prog.DeclareLocality(std, "stdState", LocalityInfo{Locality: ThreadLocal})
+	prog.DeclareLocality(alt, "altState", LocalityInfo{Locality: GoroutineLocal})
+	prog.SetLocalityInfo("runtime.preloadedState", LocalityInfo{Locality: ThreadLocal})
+
+	check := func(pkg *types.Package, wants ...string) {
+		t.Helper()
+		got := prog.PackageLocalitiesFor(pkg)
+		if len(got) != len(wants) {
+			t.Fatalf("PackageLocalitiesFor(%q) = %+v, want %v", pkg.Path(), got, wants)
+		}
+		for _, name := range wants {
+			if _, ok := got["runtime."+name]; !ok {
+				t.Fatalf("PackageLocalitiesFor(%q) = %+v, missing %q", pkg.Path(), got, name)
+			}
+		}
+	}
+	check(std, "stdState", "preloadedState")
+	check(alt, "altState", "preloadedState")
+
+	if got := prog.PackageLocalities("runtime"); len(got) != 3 {
+		t.Fatalf("canonical PackageLocalities(runtime) = %+v, want all three declarations", got)
 	}
 }
 

--- a/ssa/locality_test.go
+++ b/ssa/locality_test.go
@@ -164,6 +164,63 @@ func TestNeedsLocalContextIgnoresInactiveDeclarations(t *testing.T) {
 	}
 }
 
+func TestLocalityMetadataFallbacks(t *testing.T) {
+	t.Run("owner update and ownerless fallback", func(t *testing.T) {
+		prog := NewProgram(nil)
+		pkg := types.NewPackage("example.com/p", "p")
+		ownedName := "example.com/p.owned"
+		prog.SetLocalityInfoFor(pkg, ownedName, LocalityInfo{Locality: ThreadLocal})
+		owned, ok := prog.VariableLocalityFor(pkg, ownedName)
+		if !ok || owned.Locality != ThreadLocal {
+			t.Fatalf("owner-specific locality = %+v, %v", owned, ok)
+		}
+
+		fallbackName := "example.com/p.fallback"
+		prog.SetLocalityInfo(fallbackName, LocalityInfo{Locality: GoroutineLocal})
+		fallback, ok := prog.VariableLocalityFor(pkg, fallbackName)
+		if !ok || fallback.Locality != GoroutineLocal {
+			t.Fatalf("ownerless fallback locality = %+v, %v", fallback, ok)
+		}
+
+		prog.SetLocalityInfo("example.com/p.ordinary", LocalityInfo{})
+		prog.SetLocalityInfo("example.com/other.local", LocalityInfo{Locality: ThreadLocal})
+		got := prog.PackageLocalitiesFor(pkg)
+		if _, ok := got["example.com/p.ordinary"]; ok {
+			t.Fatalf("ordinary variable returned as local: %+v", got)
+		}
+		if _, ok := got["example.com/other.local"]; ok {
+			t.Fatalf("other package locality returned: %+v", got)
+		}
+
+		// A nil package is intentionally a no-op for callers walking optional
+		// package roots.
+		prog.ActivateLocalitiesFor(nil)
+	})
+
+	t.Run("metadata without local variables", func(t *testing.T) {
+		prog := NewProgram(nil)
+		prog.SetLocalityInfo("example.com/p.ordinary", LocalityInfo{})
+		if err := prog.ValidateLocalities("example.com/p"); err != nil {
+			t.Fatalf("ordinary metadata failed locality validation: %v", err)
+		}
+	})
+
+	t.Run("legacy canonical entry", func(t *testing.T) {
+		prog := NewProgram(nil)
+		// The entries map predates declaration ownership. Keep its compatibility
+		// path covered for callers that preload canonical metadata directly.
+		prog.localities.mu.Lock()
+		prog.localities.entries["example.com/p.legacy"] = VariableLocality{
+			Info:         LocalityInfo{Locality: GoroutineLocal},
+			LocalStorage: LocalStoragePackage,
+		}
+		prog.localities.mu.Unlock()
+		if !prog.NeedsLocalContext() {
+			t.Fatal("legacy canonical locality did not require a context")
+		}
+	})
+}
+
 func TestRejectsLinknameLocality(t *testing.T) {
 	prog := NewProgram(nil)
 	target := "example.com/target.value"

--- a/ssa/locality_test.go
+++ b/ssa/locality_test.go
@@ -99,6 +99,16 @@ func TestPackageLocalitiesRetainDeclarationOwners(t *testing.T) {
 	if !ok || altShared.Locality != GoroutineLocal || altShared.LocalStorage != LocalStoragePackage {
 		t.Fatalf("alternate sharedState = %+v, %v", altShared, ok)
 	}
+	reloadedAlt := types.NewPackage(abi.PatchPathPrefix+"runtime", "runtime")
+	reloadedShared, ok := prog.VariableLocalityFor(reloadedAlt, "runtime.sharedState")
+	if !ok || reloadedShared != altShared {
+		t.Fatalf("reloaded alternate sharedState = %+v, %v; want %+v", reloadedShared, ok, altShared)
+	}
+	prog.DeclareLocality(reloadedAlt, "sharedState", LocalityInfo{Locality: GoroutineLocal})
+	redeclaredShared, ok := prog.VariableLocalityFor(reloadedAlt, "runtime.sharedState")
+	if !ok || redeclaredShared != altShared {
+		t.Fatalf("redeclared alternate sharedState = %+v, %v; want prepared %+v", redeclaredShared, ok, altShared)
+	}
 
 	if got := prog.PackageLocalities("runtime"); len(got) != 4 {
 		t.Fatalf("canonical PackageLocalities(runtime) = %+v, want all four declaration names", got)

--- a/test/llgoext/runtime_fips_locality_test.go
+++ b/test/llgoext/runtime_fips_locality_test.go
@@ -1,0 +1,90 @@
+//go:build llgo && go1.26 && !baremetal
+
+/*
+ * Copyright (c) 2026 The XGo Authors (xgo.dev). All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package llgoext
+
+import (
+	"testing"
+	_ "unsafe"
+)
+
+//go:linkname runtimeFIPSSetBypass crypto/fips140.setBypass
+func runtimeFIPSSetBypass()
+
+//go:linkname runtimeFIPSUnsetBypass crypto/fips140.unsetBypass
+func runtimeFIPSUnsetBypass()
+
+//go:linkname runtimeFIPSIsBypassed crypto/fips140.isBypassed
+func runtimeFIPSIsBypassed() bool
+
+type runtimeFIPSBypassResult struct {
+	id     int
+	before bool
+	set    bool
+	unset  bool
+}
+
+func TestRuntimeFIPSBypassGLSIsolation(t *testing.T) {
+	if runtimeFIPSIsBypassed() {
+		t.Fatal("main goroutine unexpectedly started with FIPS bypass enabled")
+	}
+	runtimeFIPSSetBypass()
+	runtimeFIPSSetBypass()
+	defer func() {
+		runtimeFIPSUnsetBypass()
+		runtimeFIPSUnsetBypass()
+	}()
+
+	ready := make(chan struct{}, 2)
+	release := make(chan struct{})
+	results := make(chan runtimeFIPSBypassResult, 2)
+	for id := 0; id < 2; id++ {
+		go func(id int) {
+			result := runtimeFIPSBypassResult{id: id, before: runtimeFIPSIsBypassed()}
+			runtimeFIPSSetBypass()
+			result.set = runtimeFIPSIsBypassed()
+			ready <- struct{}{}
+			<-release
+			runtimeFIPSUnsetBypass()
+			result.unset = runtimeFIPSIsBypassed()
+			results <- result
+		}(id)
+	}
+	<-ready
+	<-ready
+
+	if !runtimeFIPSIsBypassed() {
+		t.Fatal("child goroutines changed main FIPS bypass state")
+	}
+	close(release)
+	for range 2 {
+		result := <-results
+		if result.before || !result.set || result.unset {
+			t.Fatalf("child %d FIPS bypass states = before:%v set:%v unset:%v", result.id, result.before, result.set, result.unset)
+		}
+	}
+
+	runtimeFIPSUnsetBypass()
+	if !runtimeFIPSIsBypassed() {
+		t.Fatal("nested main FIPS bypass cleared too early")
+	}
+	runtimeFIPSUnsetBypass()
+	if runtimeFIPSIsBypassed() {
+		t.Fatal("main FIPS bypass remained enabled")
+	}
+}


### PR DESCRIPTION
## Summary

- retain locality metadata per uncanonicalized package owner, so standard and overlay packages can share canonical symbol names safely
- key owners by raw import path rather than transient *types.Package identity, preserving prepared metadata across package reloads
- use owner-aware metadata in preparation, initializer validation, planning, and codegen lowering
- prepare overlay declarations eagerly but activate LocalContext only for concrete packages in the effective build graph
- migrate the real runtime FIPS bypass depth from dynamic clite TLS to an overlay-declared `//llgo:gls` variable
- cover distinct-name and same-name/different-locality standard-versus-overlay declarations

## Why

Alternate standard-library packages canonicalize to the paths they replace. Canonical-only metadata mixed declarations from the export-data standard package and the overlay source package. Pointer identity was also insufficient because the build can reload the same overlay raw path into a new *types.Package.

The stable identity is the raw import path: runtime remains distinct from github.com/goplus/llgo/runtime/internal/lib/runtime, while repeated loads of the latter share prepared metadata.

Overlay packages also have to be scanned before final link reachability is known. Scanning is now separate from activation: an inactive alternate declaration cannot make `NeedsLocalContext` true, while an effective alternate and its dependency graph are activated by concrete raw owner. This prevents an unused runtime overlay GLS declaration from pulling the LLGo runtime into a pure C program.

## Tests

- go test ./ssa ./cl ./internal/build -run focused locality/alternate-package coverage
- go test ./ssa
- ./dev/llgo.sh test ./test/llgoext
- real FIPS bypass nesting and goroutine-isolation coverage through canonical runtime linkname APIs
- owner-specific active/inactive LocalContext coverage
- LLGo build of the ESP32 hello target that previously linked spurious EnterLocalContext/LeaveLocalContext references
