### PR TITLE
ci: install libslirp for ESP QEMU

### DIFF
--- a/.github/actions/setup-embed-deps/action.yml
+++ b/.github/actions/setup-embed-deps/action.yml
@@ -18,7 +18,7 @@ runs:
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt-get install -y libsdl2-2.0-0
+        sudo apt-get install -y libsdl2-2.0-0 libslirp0
 
     - name: Install ESP QEMU toolchains
       shell: bash


### PR DESCRIPTION
## Summary

The prebuilt ESP QEMU binaries dynamically link `libslirp.so.0`, but Ubuntu runners do not provide it by default. Install the `libslirp0` runtime package alongside SDL in the existing embedded-dependency setup action.

The missing dependency fails before the build starts:

```text
qemu-system-riscv32: error while loading shared libraries: libslirp.so.0: cannot open shared object file: No such file or directory
```

## Validation

- in an amd64 Ubuntu 24.04 container, the setup downloads both ESP QEMU toolchains, `ldd` reports no missing libraries, and both binaries run `--version`
- the previous CI run passed the Ubuntu LLGo lanes with `libslirp0` installed

## Scope

This PR changes only the Ubuntu package installation. It does not change workflow timeouts, sharding, or job scheduling.