### PR TITLE
test/goroot: match missing-comma recovery diagnostics

### DIFF
--- a/test/goroot/runner_test.go
+++ b/test/goroot/runner_test.go
@@ -1649,7 +1649,7 @@ func parseSourceDiagnostic(line string, resolver diagnosticPathResolver) (source
 }
 
 // parserRecoverySecondaries is deliberately limited to exact diagnostic pairs
-// emitted by the five GOROOT cases enabled with this compatibility shim.
+// emitted by GOROOT cases enabled with this compatibility shim.
 func parserRecoverySecondaries(primary string) []string {
 	switch primary {
 	case "syntax error: cannot use a := 10 as value":
@@ -1664,6 +1664,10 @@ func parserRecoverySecondaries(primary string) []string {
 		return []string{"expected if statement or block, found ';'"}
 	case "syntax error: unexpected newline in type declaration", "syntax error: unexpected EOF in type declaration":
 		return []string{"expected type, found newline"}
+	case "syntax error: unexpected newline in composite literal; possibly missing comma or }":
+		return []string{"missing ',' before newline in composite literal"}
+	case "syntax error: unexpected newline in parameter list; possibly missing comma or )":
+		return []string{"missing ',' before newline in parameter list"}
 	}
 	return nil
 }

--- a/test/goroot/runner_unit_test.go
+++ b/test/goroot/runner_unit_test.go
@@ -607,6 +607,7 @@ func TestCheckExpectedErrorsDiscardsPairedMissingCommaDiagnostics(t *testing.T) 
 	tests := []struct {
 		name      string
 		source    string
+		line      int
 		primary   string
 		secondary string
 	}{
@@ -617,16 +618,18 @@ var _ = []int{
 	3 // ERROR "need trailing comma before newline in composite literal|possibly missing comma or }"
 }
 `,
+			line:      3,
 			primary:   "syntax error: unexpected newline in composite literal; possibly missing comma or }",
 			secondary: "missing ',' before newline in composite literal",
 		},
 		{
 			name: "parameter list",
 			source: `package p
-func f(
-	x int // ERROR "unexpected newline"
-) {}
+func f(x int /* // GC_ERROR "unexpected newline"
+
+*/) // GCCGO_ERROR "expected .*\).*|expected declaration"
 `,
+			line:      2,
 			primary:   "syntax error: unexpected newline in parameter list; possibly missing comma or )",
 			secondary: "missing ',' before newline in parameter list",
 		},
@@ -637,12 +640,16 @@ func f(
 			if err := os.WriteFile(file, []byte(tt.source), 0o644); err != nil {
 				t.Fatal(err)
 			}
-			output := fmt.Sprintf("%s:3: %s\n%s:3: %s\n", file, tt.primary, file, tt.secondary)
+			output := fmt.Sprintf("%s:%d: %s\n%s:%d: %s\n", file, tt.line, tt.primary, file, tt.line, tt.secondary)
 			if err := checkExpectedErrors(output, file, "case.go"); err != nil {
 				t.Fatal(err)
 			}
-			if err := checkExpectedErrors(fmt.Sprintf("%s:3: %s\n", file, tt.secondary), file, "case.go"); err == nil {
+			if err := checkExpectedErrors(fmt.Sprintf("%s:%d: %s\n", file, tt.line, tt.secondary), file, "case.go"); err == nil {
 				t.Fatal("secondary diagnostic passed without its primary")
+			}
+			wrongLine := fmt.Sprintf("%s:%d: %s\n%s:%d: %s\n", file, tt.line, tt.primary, file, tt.line+1, tt.secondary)
+			if err := checkExpectedErrors(wrongLine, file, "case.go"); err == nil || !strings.Contains(err.Error(), tt.secondary) {
+				t.Fatalf("secondary diagnostic on another line was discarded: %v", err)
 			}
 			if got := parserRecoverySecondaries(tt.primary + "."); got != nil {
 				t.Fatalf("near-match primary activated parser recovery: %v", got)

--- a/test/goroot/runner_unit_test.go
+++ b/test/goroot/runner_unit_test.go
@@ -603,6 +603,54 @@ var _ = 0 // ERROR "mantissa requires a 'p' exponent"
 	}
 }
 
+func TestCheckExpectedErrorsDiscardsPairedMissingCommaDiagnostics(t *testing.T) {
+	tests := []struct {
+		name      string
+		source    string
+		primary   string
+		secondary string
+	}{
+		{
+			name: "composite literal",
+			source: `package p
+var _ = []int{
+	3 // ERROR "need trailing comma before newline in composite literal|possibly missing comma or }"
+}
+`,
+			primary:   "syntax error: unexpected newline in composite literal; possibly missing comma or }",
+			secondary: "missing ',' before newline in composite literal",
+		},
+		{
+			name: "parameter list",
+			source: `package p
+func f(
+	x int // ERROR "unexpected newline"
+) {}
+`,
+			primary:   "syntax error: unexpected newline in parameter list; possibly missing comma or )",
+			secondary: "missing ',' before newline in parameter list",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file := filepath.Join(t.TempDir(), "case.go")
+			if err := os.WriteFile(file, []byte(tt.source), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			output := fmt.Sprintf("%s:3: %s\n%s:3: %s\n", file, tt.primary, file, tt.secondary)
+			if err := checkExpectedErrors(output, file, "case.go"); err != nil {
+				t.Fatal(err)
+			}
+			if err := checkExpectedErrors(fmt.Sprintf("%s:3: %s\n", file, tt.secondary), file, "case.go"); err == nil {
+				t.Fatal("secondary diagnostic passed without its primary")
+			}
+			if got := parserRecoverySecondaries(tt.primary + "."); got != nil {
+				t.Fatalf("near-match primary activated parser recovery: %v", got)
+			}
+		})
+	}
+}
+
 func TestCheckExpectedErrorsKeepsUnrelatedDiagnostics(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/test/goroot/xfail.yaml
+++ b/test/goroot/xfail.yaml
@@ -2015,10 +2015,6 @@ xfails:
     reason: llgo parser recovery emits additional malformed-expression diagnostics
   - version: go1.26
     directive: errorcheck
-    case: fixedbugs/issue14520.go
-    reason: llgo parser emits an additional missing-comma diagnostic
-  - version: go1.26
-    directive: errorcheck
     case: fixedbugs/issue17328.go
     reason: llgo parser recovery emits additional end-of-file diagnostics
   - version: go1.26
@@ -2185,10 +2181,6 @@ xfails:
     directive: errorcheck
     case: fixedbugs/issue24651b.go
     reason: gc-specific -m optimization diagnostics are not implemented by llgo
-  - version: go1.26
-    directive: errorcheck
-    case: syntax/composite.go
-    reason: llgo parser reports an additional missing-comma diagnostic
   - version: go1.26
     directive: errorcheck
     case: escape_goto.go


### PR DESCRIPTION
## Summary

- pair the gc-style missing-comma primary with the exact duplicate emitted by go/parser
- keep matching scoped to the same canonical source, line, and exact secondary text
- enable `fixedbugs/issue14520.go` and `syntax/composite.go` in Go 1.26 errorcheck coverage

## Correctness

The secondary is discarded only after the expected primary matched. A secondary by itself, a near-match, a different source/line, or an extra duplicate remains an error.

## Validation

- targeted harness unit tests on Go 1.24.11, 1.25.0, and 1.26.0
- both GOROOT cases on Go 1.24.11, 1.25.0, 1.26.0, and 1.26.5
- original 149 compile/errorcheck xfail cases on Go 1.26.0: 2 pass and the remaining 147 stay expected failures
- `go test ./test/goroot`

## Scope and overlap

No functional dependency on another PR. This does not touch `interface/assertinline.go`, which is handled by #2201, and does not include wasm or DWARF changes.

The Ubuntu Go workflow currently needs #2215 to install `libslirp.so.0` for ESP QEMU verification. This PR does not duplicate that CI fix.

The seven compile xfails remain intentionally unchanged: their `checkptr`, `libfuzzer`, `softfloat`, and `dynlink` flags carry compiler semantics and should not be accepted as no-ops.