### PR TITLE
test(std/os/signal): tolerate signal delivery order

### DIFF
--- a/test/std/os/signal/signal_test.go
+++ b/test/std/os/signal/signal_test.go
@@ -58,13 +58,17 @@ func TestNotifyMultipleSignals(t *testing.T) {
 		t.Fatalf("Signal SIGWINCH error: %v", err)
 	}
 
-	select {
-	case sig := <-c:
-		if sig != syscall.SIGWINCH {
-			t.Errorf("First signal = %v, want SIGWINCH", sig)
+	timeout := time.After(time.Second)
+	for {
+		select {
+		case sig := <-c:
+			// SIGCHLD may arrive first, so wait for the signal sent above.
+			if sig == syscall.SIGWINCH {
+				return
+			}
+		case <-timeout:
+			t.Fatal("Timeout waiting for SIGWINCH")
 		}
-	case <-time.After(time.Second):
-		t.Fatal("Timeout waiting for first signal")
 	}
 }
 


### PR DESCRIPTION
Fixes `TestNotifyMultipleSignals` when a subscribed `SIGCHLD` arrives before the test-generated `SIGWINCH`.

The implementation includes:

- waits specifically for `SIGWINCH` instead of asserting that it is the first delivered signal
- retains a single one-second timeout so other subscribed signals cannot extend the deadline
- validates the focused test with `go test ./test/std/os/signal -run '^TestNotifyMultipleSignals$' -count=100`

This removes the invalid signal-order assumption and fixes #2232.
