### PR TITLE
ci: deploy published benchmark data

### DIFF
--- a/.github/workflows/benchmark-publish.yml
+++ b/.github/workflows/benchmark-publish.yml
@@ -21,5 +21,6 @@ jobs:
       data_repository: >-
         ${{ vars.BENCHMARKS_REPOSITORY ||
             format('{0}/llgo-benchmark-data', github.repository_owner) }}
+      data_dispatch_event: llgo-baseline-published
     secrets:
-      data_token: ${{ secrets.BENCHMARKS_DISPATCH_TOKEN }}
+      data_token: ${{ secrets.BENCHMARK_DATA_TOKEN }}


### PR DESCRIPTION
## Summary

- use the dedicated `BENCHMARK_DATA_TOKEN` for the external benchmark data repository
- notify that repository with `llgo-baseline-published` after data is ready so its existing Pages workflow deploys the updated site
- keep the dispatch inside the reusable publisher, avoiding another LLGo runner job

Forks without the data repository or token now receive an artifact preview and a warning in the benchmark PR comment; data publishing failures do not fail the publisher. Artifact validation, rendering, preview upload, and PR commenting remain hard failures.

## Validation

- reusable publisher CI and self benchmarks passed on `xgo-dev/setup-benchmark-go-action` main
- floating `v1` verified at `b7eae35cb7c3141f9bd4c144c9b1e47c3f9f365f`
- workflow YAML parsed successfully
- `git diff --check`
